### PR TITLE
docs: add FTS v2 migration note

### DIFF
--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -6,6 +6,27 @@ stable and breaking changes should generally be communicated (via warnings) for 
 give users a chance to migrate.  This page documents the breaking changes between releases and gives advice on how to
 migrate.
 
+## 9.0.0
+
+* Newly created FTS / inverted indexes now default to format v2 instead of v1.
+  The `LANCE_FTS_FORMAT_VERSION` environment variable no longer controls the
+  format used for newly created indexes. Users who need a specific index layout
+  should pass the index creation parameter `format_version` explicitly.
+
+* This affects users who create FTS / inverted indexes and need those indexes to
+  be readable by older Lance versions, or who depend on the v1 index layout. In
+  those cases, pass `format_version=1` when creating the index. Otherwise, newly
+  created indexes will use v2 by default, and older Lance readers may not be able
+  to read them.
+
+  ```python
+  dataset.create_scalar_index("text", "INVERTED", format_version=1)
+  ```
+
+* Existing v1 FTS indexes remain queryable. Operations that maintain an existing
+  v1 index, including append, incremental indexing, optimize, and mem-wal
+  maintained-index flush, should continue preserving the v1 format.
+
 ## 7.2.0
 
 * The `IndexSegmentBuilder` API has been removed from Rust, Python, and Java.


### PR DESCRIPTION
## Summary

Docs-only follow-up to https://github.com/lance-format/lance/pull/7512.

This adds a migration guide note for the FTS / inverted index format default changing from v1 to v2. The note explains who is affected, how to keep creating v1 indexes with `format_version=1`, and the compatibility boundary for existing v1 indexes and older Lance readers.

## Validation

- `git diff --check -- docs/src/guide/migration.md`
- `cd docs && uv sync --all-extras`
- `cd docs && uv run mkdocs build`
- `cd docs && uv run mkdocs-linkcheck src`

`mkdocs build` completed successfully with existing warnings about unrelated missing documentation links outside `docs/src/guide/migration.md`.