### PR TITLE
feat(cache): support batch get-or-insert single-flight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
+ "criterion",
  "datafusion-common",
  "datafusion-sql",
  "futures",

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -51,6 +51,7 @@ log.workspace = true
 libc = { version = "0.2" }
 
 [dev-dependencies]
+criterion.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 
@@ -59,3 +60,7 @@ datafusion = ["dep:datafusion-common", "dep:datafusion-sql"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "cache_batch"
+harness = false

--- a/rust/lance-core/benches/cache_batch.rs
+++ b/rust/lance-core/benches/cache_batch.rs
@@ -1,0 +1,775 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Microbenchmarks for Lance cache get-or-insert paths.
+//!
+//! These benchmarks measure cache primitive overhead and duplicate-load
+//! behavior. They intentionally use small `usize` values plus cheap/yielding
+//! loaders so the cache control flow is visible in the measurements.
+//!
+//! They are not an end-to-end storage read benchmark. They do not model page
+//! bytes, materialization cost, object-store range I/O, or real storage planning.
+//! Use them as evidence for cache-level overhead and single-flight behavior, not
+//! as proof that a higher-level storage read path is faster end to end.
+//!
+//! These benchmarks compare three ways to handle cold overlapping batch reads:
+//! - per-key `get_or_insert_with_key`: keeps single-flight but loses coalesced loading.
+//! - manual `get` + batch load + `insert`: keeps coalesced loading but duplicates
+//!   cold overlapping work.
+//! - `get_or_insert_with_key_batch`: keeps coalesced loading and backend single-flight.
+//!
+//! The no-overlap groups are intentionally included to show the control-flow
+//! cost of the new primitive when there is no duplicate work to avoid. For the
+//! eventual BTree integration, use an end-to-end benchmark with real page bytes,
+//! materialization, and object-store range planning before making storage-path
+//! performance claims.
+//!
+//! The assertions in this file are correctness guards for the measured scenario,
+//! not replacement unit tests. They keep the benchmark from silently measuring a
+//! broken setup after future cache changes.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use lance_core::Result;
+use lance_core::cache::{CacheBatchValue, CacheKey, LanceCache};
+use tokio::sync::Barrier;
+use tokio::task::JoinHandle;
+
+const CACHE_CAPACITY_BYTES: usize = 64 * 1024 * 1024;
+const BATCH_SIZES: [usize; 4] = [1, 8, 64, 512];
+const CONCURRENCIES: [usize; 3] = [1, 8, 32];
+
+// Bench-local typed key. The key string is cached so hot-path measurements do
+// not include repeated integer formatting.
+#[derive(Clone, Debug)]
+struct BenchKey {
+    id: usize,
+    cache_key: Arc<str>,
+}
+
+impl BenchKey {
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            cache_key: Arc::from(id.to_string()),
+        }
+    }
+}
+
+impl CacheKey for BenchKey {
+    type ValueType = usize;
+
+    fn key(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.cache_key.as_ref())
+    }
+
+    fn type_name() -> &'static str {
+        "cache_batch_bench::usize"
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LoaderMode {
+    Cheap,
+    // A single scheduler yield is enough to exercise waiter paths without
+    // making the benchmark mostly a sleep/timer benchmark.
+    YieldOnce,
+}
+
+impl LoaderMode {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Cheap => "cheap",
+            Self::YieldOnce => "yield_once",
+        }
+    }
+
+    async fn wait(self) {
+        match self {
+            Self::Cheap => {}
+            Self::YieldOnce => tokio::task::yield_now().await,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Overlap {
+    Half,
+    Full,
+    None,
+}
+
+impl Overlap {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Half => "50pct",
+            Self::Full => "100pct",
+            Self::None => "0pct",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SingleParams {
+    concurrency: usize,
+    loader_mode: LoaderMode,
+}
+
+impl Display for SingleParams {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "concurrency={},loader={}",
+            self.concurrency,
+            self.loader_mode.name()
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BatchParams {
+    batch_size: usize,
+    concurrency: usize,
+    overlap: Overlap,
+    loader_mode: LoaderMode,
+}
+
+impl Display for BatchParams {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "batch={},concurrency={},overlap={},loader={}",
+            self.batch_size,
+            self.concurrency,
+            self.overlap.name(),
+            self.loader_mode.name()
+        )
+    }
+}
+
+fn criterion_config() -> Criterion {
+    // Keep the default command usable for PR review. For more stable numbers,
+    // run Criterion with a larger sample size and measurement time locally.
+    Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(100))
+        .measurement_time(Duration::from_millis(250))
+}
+
+fn make_cache() -> LanceCache {
+    LanceCache::with_capacity(CACHE_CAPACITY_BYTES)
+}
+
+fn new_counts(count: usize) -> Arc<Vec<AtomicUsize>> {
+    Arc::new((0..count).map(|_| AtomicUsize::new(0)).collect())
+}
+
+fn sum_counts(counts: &[AtomicUsize]) -> usize {
+    counts
+        .iter()
+        .map(|count| count.load(Ordering::SeqCst))
+        .sum()
+}
+
+fn assert_each_key_loaded_once(counts: &[AtomicUsize]) {
+    for (id, count) in counts.iter().enumerate() {
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "key {id} should be loaded exactly once"
+        );
+    }
+}
+
+fn generate_batches(params: BatchParams) -> (Vec<Vec<BenchKey>>, usize) {
+    match params.overlap {
+        Overlap::Full => {
+            // Every task asks for the same logical batch. This is the strongest
+            // duplicate-load pressure on the flight registry.
+            let keys = (0..params.batch_size)
+                .map(BenchKey::new)
+                .collect::<Vec<_>>();
+            (vec![keys; params.concurrency], params.batch_size)
+        }
+        Overlap::Half => {
+            // The first half is shared across all tasks and the second half is
+            // task-local. This models broad range queries with partially
+            // overlapping page windows.
+            let shared_count = params.batch_size.div_ceil(2);
+            let unique_per_task = params.batch_size - shared_count;
+            let mut batches = Vec::with_capacity(params.concurrency);
+
+            for task_idx in 0..params.concurrency {
+                let mut keys = Vec::with_capacity(params.batch_size);
+                keys.extend((0..shared_count).map(BenchKey::new));
+                let unique_start = shared_count + task_idx * unique_per_task;
+                keys.extend((unique_start..unique_start + unique_per_task).map(BenchKey::new));
+                batches.push(keys);
+            }
+
+            (batches, shared_count + params.concurrency * unique_per_task)
+        }
+        Overlap::None => {
+            // Disjoint batches should not benefit from single-flight. This case
+            // isolates the extra registry work when there is no contention.
+            let mut batches = Vec::with_capacity(params.concurrency);
+
+            for task_idx in 0..params.concurrency {
+                let start = task_idx * params.batch_size;
+                batches.push(
+                    (start..start + params.batch_size)
+                        .map(BenchKey::new)
+                        .collect(),
+                );
+            }
+
+            (batches, params.concurrency * params.batch_size)
+        }
+    }
+}
+
+fn overlapping_batch_params() -> Vec<BatchParams> {
+    // This is a representative matrix, not a full Cartesian product. It covers
+    // the requested batch sizes, concurrency levels, overlap levels, and both
+    // loader modes while keeping `cargo bench -- --sample-size 10` practical.
+    vec![
+        BatchParams {
+            batch_size: 1,
+            concurrency: 8,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 8,
+            concurrency: 8,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 64,
+            concurrency: 8,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 512,
+            concurrency: 8,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 8,
+            concurrency: 1,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 8,
+            concurrency: 32,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 64,
+            concurrency: 8,
+            overlap: Overlap::Full,
+            loader_mode: LoaderMode::Cheap,
+        },
+        BatchParams {
+            batch_size: 64,
+            concurrency: 8,
+            overlap: Overlap::Half,
+            loader_mode: LoaderMode::YieldOnce,
+        },
+        BatchParams {
+            batch_size: 64,
+            concurrency: 8,
+            overlap: Overlap::Full,
+            loader_mode: LoaderMode::YieldOnce,
+        },
+    ]
+}
+
+fn no_overlap_batch_params() -> Vec<BatchParams> {
+    // Disjoint batches should not benefit from single-flight. This matrix keeps
+    // the loader cheap so the measured cost is dominated by per-key cache get,
+    // registry claim/complete, validation, and result assembly.
+    let mut params = Vec::new();
+    for batch_size in BATCH_SIZES {
+        for concurrency in CONCURRENCIES {
+            params.push(BatchParams {
+                batch_size,
+                concurrency,
+                overlap: Overlap::None,
+                loader_mode: LoaderMode::Cheap,
+            });
+        }
+    }
+
+    // Retain a yielding case to keep waiter/scheduler overhead visible without
+    // making the no-overlap group mostly a timer benchmark.
+    params.push(BatchParams {
+        batch_size: 64,
+        concurrency: 8,
+        overlap: Overlap::None,
+        loader_mode: LoaderMode::YieldOnce,
+    });
+    params.push(BatchParams {
+        batch_size: 512,
+        concurrency: 32,
+        overlap: Overlap::None,
+        loader_mode: LoaderMode::YieldOnce,
+    });
+
+    params
+}
+
+async fn join_tasks<T>(handles: Vec<JoinHandle<T>>) -> Vec<T> {
+    let mut results = Vec::with_capacity(handles.len());
+    for handle in handles {
+        results.push(handle.await.expect("benchmark task should not panic"));
+    }
+    results
+}
+
+fn assert_arc_values(values: &[Arc<usize>], keys: &[BenchKey]) {
+    assert_eq!(values.len(), keys.len());
+    for (value, key) in values.iter().zip(keys) {
+        assert_eq!(**value, key.id);
+        black_box(**value);
+    }
+}
+
+fn assert_batch_values(values: &[CacheBatchValue<usize>], keys: &[BenchKey]) {
+    assert_eq!(values.len(), keys.len());
+    for (value, key) in values.iter().zip(keys) {
+        assert_eq!(*value.value, key.id);
+        black_box((*value.value, value.was_cached));
+    }
+}
+
+async fn load_keys(
+    keys: Vec<BenchKey>,
+    counts: Arc<Vec<AtomicUsize>>,
+    loader_calls: Arc<AtomicUsize>,
+    loader_mode: LoaderMode,
+) -> Result<Vec<(BenchKey, usize)>> {
+    loader_calls.fetch_add(1, Ordering::SeqCst);
+    loader_mode.wait().await;
+    Ok(keys
+        .into_iter()
+        .map(|key| {
+            counts[key.id].fetch_add(1, Ordering::SeqCst);
+            let value = key.id;
+            (key, value)
+        })
+        .collect())
+}
+
+async fn run_single_cold_concurrent_same_key(params: SingleParams) {
+    let cache = make_cache();
+    let key = BenchKey::new(0);
+    let loader_calls = Arc::new(AtomicUsize::new(0));
+    // Start tasks together so a cold same-key miss actually exercises the
+    // owner/waiter path instead of mostly measuring warm cache hits.
+    let barrier = Arc::new(Barrier::new(params.concurrency));
+    let mut handles = Vec::with_capacity(params.concurrency);
+
+    for _ in 0..params.concurrency {
+        let cache = cache.clone();
+        let key = key.clone();
+        let loader_calls = loader_calls.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            cache
+                .get_or_insert_with_key(key, move || {
+                    let loader_calls = loader_calls.clone();
+                    async move {
+                        loader_calls.fetch_add(1, Ordering::SeqCst);
+                        params.loader_mode.wait().await;
+                        Ok(7usize)
+                    }
+                })
+                .await
+        }));
+    }
+
+    for value in join_tasks(handles).await {
+        assert_eq!(*value.expect("single get_or_insert should succeed"), 7);
+    }
+    assert_eq!(loader_calls.load(Ordering::SeqCst), 1);
+    black_box(loader_calls.load(Ordering::SeqCst));
+}
+
+async fn run_batch_single_loop_overlap(params: BatchParams) {
+    let cache = make_cache();
+    let (batches, unique_key_count) = generate_batches(params);
+    let counts = new_counts(unique_key_count);
+    let loader_calls = Arc::new(AtomicUsize::new(0));
+    let barrier = Arc::new(Barrier::new(params.concurrency));
+    let mut handles = Vec::with_capacity(params.concurrency);
+
+    for keys in batches {
+        let cache = cache.clone();
+        let counts = counts.clone();
+        let loader_calls = loader_calls.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let mut values = Vec::with_capacity(keys.len());
+            for key in &keys {
+                let value = cache
+                    .get_or_insert_with_key(key.clone(), {
+                        let key = key.clone();
+                        let counts = counts.clone();
+                        let loader_calls = loader_calls.clone();
+                        move || {
+                            let counts = counts.clone();
+                            let loader_calls = loader_calls.clone();
+                            let key = key.clone();
+                            async move {
+                                loader_calls.fetch_add(1, Ordering::SeqCst);
+                                params.loader_mode.wait().await;
+                                counts[key.id].fetch_add(1, Ordering::SeqCst);
+                                Ok(key.id)
+                            }
+                        }
+                    })
+                    .await
+                    .expect("single-loop get_or_insert should succeed");
+                values.push(value);
+            }
+            assert_arc_values(&values, &keys);
+        }));
+    }
+
+    join_tasks(handles).await;
+    // The per-key workaround should still deduplicate each key, but it can only
+    // invoke the loader one key at a time, so loader_calls == unique_key_count.
+    assert_each_key_loaded_once(&counts);
+    assert_eq!(loader_calls.load(Ordering::SeqCst), unique_key_count);
+    black_box(loader_calls.load(Ordering::SeqCst));
+}
+
+async fn run_batch_manual_get_load_insert_overlap(params: BatchParams) {
+    run_batch_manual_get_load_insert(params, true).await;
+}
+
+async fn run_batch_manual_get_load_insert_no_overlap(params: BatchParams) {
+    run_batch_manual_get_load_insert(params, false).await;
+}
+
+async fn run_batch_manual_get_load_insert(params: BatchParams, force_all_gets_before_insert: bool) {
+    let cache = make_cache();
+    let (batches, unique_key_count) = generate_batches(params);
+    let counts = new_counts(unique_key_count);
+    let loader_calls = Arc::new(AtomicUsize::new(0));
+    let start_barrier = Arc::new(Barrier::new(params.concurrency));
+    // Overlap benchmarks force all tasks to finish the initial get phase before
+    // any task inserts. This reliably exposes duplicate cold loads without
+    // adding the same synchronization cost to the no-overlap baseline.
+    let after_get_barrier =
+        force_all_gets_before_insert.then(|| Arc::new(Barrier::new(params.concurrency)));
+    let mut handles = Vec::with_capacity(params.concurrency);
+
+    for keys in batches {
+        let cache = cache.clone();
+        let counts = counts.clone();
+        let loader_calls = loader_calls.clone();
+        let start_barrier = start_barrier.clone();
+        let after_get_barrier = after_get_barrier.clone();
+        handles.push(tokio::spawn(async move {
+            start_barrier.wait().await;
+            let mut values = Vec::with_capacity(keys.len());
+            let mut missing = Vec::with_capacity(keys.len());
+
+            for key in &keys {
+                if let Some(value) = cache.get_with_key(key).await {
+                    values.push(Some(value));
+                } else {
+                    values.push(None);
+                    missing.push(key.clone());
+                }
+            }
+
+            if let Some(after_get_barrier) = after_get_barrier {
+                after_get_barrier.wait().await;
+            }
+            let loaded = load_keys(
+                missing,
+                counts.clone(),
+                loader_calls.clone(),
+                params.loader_mode,
+            )
+            .await
+            .expect("manual batch loader should succeed");
+
+            let mut loaded_by_id = HashMap::with_capacity(loaded.len());
+            for (key, value) in loaded {
+                let value = Arc::new(value);
+                cache.insert_with_key(&key, value.clone()).await;
+                loaded_by_id.insert(key.id, value);
+            }
+
+            let values = values
+                .into_iter()
+                .zip(&keys)
+                .map(|(value, key)| {
+                    value.unwrap_or_else(|| {
+                        loaded_by_id
+                            .remove(&key.id)
+                            .expect("manual path should fill each value")
+                    })
+                })
+                .collect::<Vec<_>>();
+            assert_arc_values(&values, &keys);
+        }));
+    }
+
+    join_tasks(handles).await;
+    let loaded_entries = sum_counts(&counts);
+    // In this workaround every task batch loads its own missing set. Overlap
+    // intentionally duplicates shared keys; no-overlap is the coalesced-loader
+    // baseline without backend flight-registry work.
+    assert_eq!(loaded_entries, params.concurrency * params.batch_size);
+    match params.overlap {
+        Overlap::None => assert_eq!(loaded_entries, unique_key_count),
+        Overlap::Half | Overlap::Full if params.concurrency > 1 => {
+            assert!(
+                loaded_entries > unique_key_count,
+                "manual get/load/insert should duplicate overlapping cold loads"
+            );
+        }
+        Overlap::Half | Overlap::Full => {}
+    }
+    black_box((loader_calls.load(Ordering::SeqCst), loaded_entries));
+}
+
+async fn run_batch_get_or_insert_many(params: BatchParams) {
+    let cache = make_cache();
+    let (batches, unique_key_count) = generate_batches(params);
+    let counts = new_counts(unique_key_count);
+    let loader_calls = Arc::new(AtomicUsize::new(0));
+    let barrier = Arc::new(Barrier::new(params.concurrency));
+    let mut handles = Vec::with_capacity(params.concurrency);
+
+    for keys in batches {
+        let cache = cache.clone();
+        let counts = counts.clone();
+        let loader_calls = loader_calls.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let values =
+                cache
+                    .get_or_insert_with_key_batch(keys.clone(), move |owned_keys| {
+                        let counts = counts.clone();
+                        let loader_calls = loader_calls.clone();
+                        async move {
+                            load_keys(owned_keys, counts, loader_calls, params.loader_mode).await
+                        }
+                    })
+                    .await
+                    .expect("batch get_or_insert should succeed");
+            assert_batch_values(&values, &keys);
+        }));
+    }
+
+    join_tasks(handles).await;
+    // New backend-level batch get-or-insert should keep coalesced loading while
+    // still loading each logical key at most once across overlapping tasks.
+    assert_each_key_loaded_once(&counts);
+    assert!(loader_calls.load(Ordering::SeqCst) <= params.concurrency);
+    black_box(loader_calls.load(Ordering::SeqCst));
+}
+
+fn bench_single_get_or_insert_hot(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/single_get_or_insert_hot");
+    let cache = make_cache();
+    let key = BenchKey::new(0);
+
+    runtime.block_on(async {
+        cache.insert_with_key(&key, Arc::new(7usize)).await;
+    });
+
+    group.bench_function("prefilled_key", |b| {
+        b.to_async(&runtime).iter(|| {
+            let cache = cache.clone();
+            let key = key.clone();
+            async move {
+                let value = cache
+                    .get_or_insert_with_key(key, || async {
+                        unreachable!("hot cache benchmark loader should not run")
+                    })
+                    .await
+                    .expect("hot get_or_insert should succeed");
+                assert_eq!(*value, 7);
+                black_box(*value);
+            }
+        });
+    });
+    group.finish();
+}
+
+fn bench_single_get_or_insert_cold_unique_key(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/single_get_or_insert_cold_unique_key");
+
+    for loader_mode in [LoaderMode::Cheap, LoaderMode::YieldOnce] {
+        group.bench_with_input(
+            BenchmarkId::new("loader", loader_mode.name()),
+            &loader_mode,
+            |b, loader_mode| {
+                b.to_async(&runtime).iter_custom(|iters| {
+                    let loader_mode = *loader_mode;
+                    async move {
+                        let iter_count = usize::try_from(iters)
+                            .expect("criterion iteration count should fit usize");
+                        let cache = make_cache();
+                        let keys = (0..iter_count).map(BenchKey::new).collect::<Vec<_>>();
+                        let loader_calls = Arc::new(AtomicUsize::new(0));
+
+                        // Setup above is intentionally outside the measured
+                        // interval. This case isolates an uncontended cold miss:
+                        // cache miss, flight claim/complete, loader execution,
+                        // and cache insert for a key that no other task touches.
+                        let start = Instant::now();
+                        for key in keys {
+                            let expected = key.id;
+                            let value = cache
+                                .get_or_insert_with_key(key, {
+                                    let loader_calls = loader_calls.clone();
+                                    move || {
+                                        let loader_calls = loader_calls.clone();
+                                        async move {
+                                            loader_calls.fetch_add(1, Ordering::SeqCst);
+                                            loader_mode.wait().await;
+                                            Ok(expected)
+                                        }
+                                    }
+                                })
+                                .await
+                                .expect("cold unique get_or_insert should succeed");
+                            assert_eq!(*value, expected);
+                            black_box(*value);
+                        }
+                        let elapsed = start.elapsed();
+
+                        assert_eq!(loader_calls.load(Ordering::SeqCst), iter_count);
+                        black_box(loader_calls.load(Ordering::SeqCst));
+                        elapsed
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_single_get_or_insert_cold_concurrent_same_key(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/single_get_or_insert_cold_concurrent_same_key");
+
+    for concurrency in CONCURRENCIES {
+        for loader_mode in [LoaderMode::Cheap, LoaderMode::YieldOnce] {
+            let params = SingleParams {
+                concurrency,
+                loader_mode,
+            };
+            group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+                b.to_async(&runtime)
+                    .iter(|| run_single_cold_concurrent_same_key(*params));
+            });
+        }
+    }
+    group.finish();
+}
+
+fn bench_batch_single_loop_overlap(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/batch_single_loop_overlap");
+
+    for params in overlapping_batch_params() {
+        group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+            b.to_async(&runtime)
+                .iter(|| run_batch_single_loop_overlap(*params));
+        });
+    }
+    group.finish();
+}
+
+fn bench_batch_manual_get_load_insert_overlap(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/batch_manual_get_load_insert_overlap");
+
+    for params in overlapping_batch_params() {
+        group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+            b.to_async(&runtime)
+                .iter(|| run_batch_manual_get_load_insert_overlap(*params));
+        });
+    }
+    group.finish();
+}
+
+fn bench_batch_manual_get_load_insert_no_overlap(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/batch_manual_get_load_insert_no_overlap");
+
+    for params in no_overlap_batch_params() {
+        group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+            b.to_async(&runtime)
+                .iter(|| run_batch_manual_get_load_insert_no_overlap(*params));
+        });
+    }
+    group.finish();
+}
+
+fn bench_batch_get_or_insert_many_overlap(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/batch_get_or_insert_many_overlap");
+
+    for params in overlapping_batch_params() {
+        group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+            b.to_async(&runtime)
+                .iter(|| run_batch_get_or_insert_many(*params));
+        });
+    }
+    group.finish();
+}
+
+fn bench_batch_get_or_insert_many_no_overlap(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    let mut group = c.benchmark_group("cache_batch/batch_get_or_insert_many_no_overlap");
+
+    for params in no_overlap_batch_params() {
+        group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+            b.to_async(&runtime)
+                .iter(|| run_batch_get_or_insert_many(*params));
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        bench_single_get_or_insert_hot,
+        bench_single_get_or_insert_cold_unique_key,
+        bench_single_get_or_insert_cold_concurrent_same_key,
+        bench_batch_single_loop_overlap,
+        bench_batch_manual_get_load_insert_overlap,
+        bench_batch_manual_get_load_insert_no_overlap,
+        bench_batch_get_or_insert_many_overlap,
+        bench_batch_get_or_insert_many_no_overlap
+}
+criterion_main!(benches);

--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -9,13 +9,14 @@
 //! backends directly.
 
 use std::any::Any;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::Future;
+use futures::{Future, future::BoxFuture};
 
-use crate::Result;
+use crate::{Error, Result};
 
 use super::CacheCodec;
 
@@ -24,6 +25,43 @@ pub type CacheEntry = Arc<dyn Any + Send + Sync>;
 
 /// Iterator over cache keys currently known to a backend.
 pub type CacheKeyIterator<'a> = Box<dyn Iterator<Item = InternalCacheKey> + Send + 'a>;
+
+/// A cache entry loaded by a batch loader.
+pub struct CacheLoadedEntry {
+    /// Cache key for this loaded entry.
+    pub key: InternalCacheKey,
+    /// Loaded value.
+    pub entry: CacheEntry,
+    /// Entry weight in bytes for backend eviction accounting.
+    pub size_bytes: usize,
+}
+
+/// A cache entry returned from a batch lookup.
+pub struct CacheBatchEntry {
+    /// Cache key for this entry.
+    pub key: InternalCacheKey,
+    /// Cached or loaded value.
+    pub entry: CacheEntry,
+    /// True when this call did not run the loader for this key.
+    ///
+    /// This includes ordinary cache hits and values loaded by another
+    /// in-flight owner.
+    pub was_cached: bool,
+}
+
+/// Loader used by [`CacheBackend::get_or_insert_many`].
+///
+/// Backends call this with the subset of missing keys owned by the current
+/// call. The loader must return exactly one [`CacheLoadedEntry`] for each key
+/// it receives and no other keys. A backend may call the loader more than
+/// once during one batch request if keys need to be retried after another
+/// in-flight owner fails or is dropped.
+pub type CacheBatchLoader<'a> = Arc<
+    dyn Fn(Vec<InternalCacheKey>) -> BoxFuture<'a, Result<Vec<CacheLoadedEntry>>>
+        + Send
+        + Sync
+        + 'a,
+>;
 
 /// Structured cache key passed to [`CacheBackend`] methods.
 ///
@@ -99,11 +137,13 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
 
     /// Get an existing entry or compute it from `loader`.
     ///
-    /// Implementations should deduplicate concurrent loads for the same key
-    /// so the loader runs at most once.
+    /// Implementations should deduplicate concurrent successful loads for the
+    /// same key. If an in-flight owner fails or is dropped, a waiting caller
+    /// may retry and invoke its own loader for that key.
     ///
     /// Returns `(entry, was_cached)` where `was_cached` is `true` if the entry
-    /// was already present in the cache (the loader was not invoked).
+    /// was already present in the cache or was loaded by another in-flight
+    /// owner, so this call did not invoke its loader.
     ///
     /// See [`get`](Self::get) for codec semantics.
     async fn get_or_insert<'a>(
@@ -113,10 +153,103 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
         codec: Option<CacheCodec>,
     ) -> Result<(CacheEntry, bool)>;
 
+    /// Get existing entries or compute missing entries from `loader`.
+    ///
+    /// Input keys must be unique. The returned entries must follow the same
+    /// order as `keys`. Implementations should deduplicate concurrent loads
+    /// per key. The loader receives only keys this call owns, preserving their
+    /// input order, and must return exactly one entry for each owned key.
+    ///
+    /// This API is intended for callers whose loader can load missing keys more
+    /// efficiently as a batch. It is not a general replacement for
+    /// [`get_or_insert`](Self::get_or_insert): for isolated keys, cheap loaders,
+    /// or disjoint concurrent batches, the per-key coordination and result maps
+    /// can make it slower than simpler cache access patterns. Use it when
+    /// preserving batched loading is worth that overhead.
+    ///
+    /// The default implementation is a compatibility fallback: it calls
+    /// [`get_or_insert`](Self::get_or_insert) one key at a time. It preserves
+    /// the backend's single-key get-or-insert semantics, but it does not
+    /// preserve coalesced batch I/O. Backends that can preserve true batch
+    /// loading should override this method. The fallback is not atomic: if
+    /// loading a later key fails, earlier keys may already have been inserted
+    /// into the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use lance_core::Result;
+    /// # use lance_core::cache::{
+    /// #     CacheBackend, CacheBatchEntry, CacheBatchLoader, CacheEntry,
+    /// #     CacheLoadedEntry, InternalCacheKey,
+    /// # };
+    /// # async fn example(
+    /// #     backend: &dyn CacheBackend,
+    /// #     keys: Vec<InternalCacheKey>,
+    /// # ) -> Result<Vec<CacheBatchEntry>> {
+    /// let loader: CacheBatchLoader<'_> = Arc::new(|owned_keys| {
+    ///     Box::pin(async move {
+    ///         Ok(owned_keys
+    ///             .into_iter()
+    ///             .map(|key| CacheLoadedEntry {
+    ///                 key,
+    ///                 entry: Arc::new(42_usize) as CacheEntry,
+    ///                 size_bytes: std::mem::size_of::<usize>(),
+    ///             })
+    ///             .collect())
+    ///     })
+    /// });
+    ///
+    /// let entries = backend.get_or_insert_many(keys, loader, None).await?;
+    /// # Ok(entries)
+    /// # }
+    /// ```
+    async fn get_or_insert_many<'a>(
+        &self,
+        keys: Vec<InternalCacheKey>,
+        loader: CacheBatchLoader<'a>,
+        codec: Option<CacheCodec>,
+    ) -> Result<Vec<CacheBatchEntry>> {
+        validate_unique_keys(&keys)?;
+
+        let mut entries = Vec::with_capacity(keys.len());
+        for key in keys {
+            let loader = loader.clone();
+            let loader_key = key.clone();
+            let single_loader = Box::pin(async move {
+                let loaded = loader(vec![loader_key.clone()]).await?;
+                let mut loaded =
+                    validate_loaded_entries(std::slice::from_ref(&loader_key), loaded)?;
+                let loaded = loaded.remove(&loader_key).ok_or_else(|| {
+                    Error::internal("validated batch loader result missing single fallback key")
+                })?;
+                Ok((loaded.entry, loaded.size_bytes))
+            });
+            let (entry, was_cached) = self.get_or_insert(&key, single_loader, codec).await?;
+            entries.push(CacheBatchEntry {
+                key,
+                entry,
+                was_cached,
+            });
+        }
+
+        Ok(entries)
+    }
+
     /// Remove all entries whose prefix starts with the given string.
+    ///
+    /// This only invalidates entries currently stored in the backend.
+    /// Implementations are not required to cancel in-flight loaders, and an
+    /// in-flight `get_or_insert` may insert a matching entry after this call
+    /// returns.
     async fn invalidate_prefix(&self, prefix: &str);
 
     /// Remove all entries.
+    ///
+    /// This only invalidates entries currently stored in the backend.
+    /// Implementations are not required to cancel in-flight loaders, and an
+    /// in-flight `get_or_insert` may insert an entry after this call returns.
     async fn clear(&self);
 
     /// Return an iterator over cache keys currently known to this backend.
@@ -149,4 +282,60 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     fn approx_size_bytes(&self) -> usize {
         0
     }
+}
+
+pub(crate) fn validate_unique_keys(keys: &[InternalCacheKey]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(keys.len());
+    for key in keys {
+        if !seen.insert(key) {
+            return Err(Error::invalid_input(format!(
+                "duplicate cache key in get_or_insert_many: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_loaded_entries(
+    expected: &[InternalCacheKey],
+    loaded: Vec<CacheLoadedEntry>,
+) -> Result<HashMap<InternalCacheKey, CacheLoadedEntry>> {
+    let expected_keys = expected.iter().cloned().collect::<HashSet<_>>();
+    let mut loaded_by_key = HashMap::with_capacity(loaded.len());
+
+    for entry in loaded {
+        if !expected_keys.contains(&entry.key) {
+            return Err(Error::invalid_input(format!(
+                "batch cache loader returned unexpected key: prefix='{}', key='{}', type='{}'",
+                entry.key.prefix(),
+                entry.key.key(),
+                entry.key.type_name()
+            )));
+        }
+        let key = entry.key.clone();
+        if loaded_by_key.insert(key.clone(), entry).is_some() {
+            return Err(Error::invalid_input(format!(
+                "batch cache loader returned duplicate keys: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            )));
+        }
+    }
+
+    for key in expected {
+        if !loaded_by_key.contains_key(key) {
+            return Err(Error::invalid_input(format!(
+                "batch cache loader did not return expected key: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            )));
+        }
+    }
+
+    Ok(loaded_by_key)
 }

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -50,7 +50,10 @@ pub mod codec;
 mod entry_io;
 mod moka;
 
-pub use backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
+pub use backend::{
+    CacheBackend, CacheBatchEntry, CacheBatchLoader, CacheEntry, CacheKeyIterator,
+    CacheLoadedEntry, InternalCacheKey,
+};
 pub use codec::{
     CacheCodec, CacheCodecImpl, CacheDecode, CacheMissReason, MAGIC, has_cache_envelope,
 };
@@ -58,6 +61,7 @@ pub use entry_io::{CacheEntryReader, CacheEntryWriter};
 pub use moka::MokaCacheBackend;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
@@ -65,7 +69,7 @@ use std::sync::{
 
 use futures::{Future, FutureExt};
 
-use crate::Result;
+use crate::{Error, Result};
 
 pub use crate::deepsize::{Context, DeepSizeOf};
 
@@ -149,6 +153,182 @@ fn cache_entry_size<T: DeepSizeOf + ?Sized>(value: &T) -> usize {
 /// and a type name.
 fn build_key(prefix: &Arc<str>, key: &str, type_name: &'static str) -> InternalCacheKey {
     InternalCacheKey::new(prefix.clone(), Arc::from(key), type_name)
+}
+
+fn build_batch_keys<K>(
+    prefix: &Arc<str>,
+    cache_keys: &[K],
+) -> Result<(Vec<InternalCacheKey>, HashMap<InternalCacheKey, K>)>
+where
+    K: CacheKey + Clone,
+{
+    let mut keys = Vec::with_capacity(cache_keys.len());
+    let mut typed_keys = HashMap::with_capacity(cache_keys.len());
+
+    for cache_key in cache_keys {
+        let key = build_key(prefix, &cache_key.key(), K::type_name());
+        if typed_keys.insert(key.clone(), cache_key.clone()).is_some() {
+            return Err(Error::invalid_input(format!(
+                "duplicate cache key in get_or_insert_with_key_batch: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            )));
+        }
+        keys.push(key);
+    }
+
+    Ok((keys, typed_keys))
+}
+
+/// Converts typed batch requests into the backend's type-erased batch API while
+/// keeping cache coordination and single-flight ownership inside the backend.
+async fn get_or_insert_batch_with_backend<K, F, Fut>(
+    cache: &dyn CacheBackend,
+    prefix: &Arc<str>,
+    hits: &AtomicU64,
+    misses: &AtomicU64,
+    cache_keys: Vec<K>,
+    loader: F,
+) -> Result<Vec<CacheBatchValue<K::ValueType>>>
+where
+    K: CacheKey + Clone + Send + Sync,
+    K::ValueType: DeepSizeOf + Send + Sync + 'static,
+    F: Fn(Vec<K>) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Vec<(K, K::ValueType)>>> + Send,
+{
+    let (keys, typed_keys) = build_batch_keys(prefix, &cache_keys)?;
+    let typed_keys = Arc::new(typed_keys);
+    let loader = Arc::new(loader);
+    let prefix = prefix.clone();
+
+    let typed_loader: CacheBatchLoader<'_> = Arc::new(move |owned_keys| {
+        let typed_keys = typed_keys.clone();
+        let loader = loader.clone();
+        let prefix = prefix.clone();
+
+        async move {
+            let mut loader_keys = Vec::with_capacity(owned_keys.len());
+            for key in &owned_keys {
+                loader_keys.push(
+                    typed_keys
+                        .get(key)
+                        .ok_or_else(|| {
+                            Error::internal(format!(
+                                "backend requested unknown cache key: prefix='{}', key='{}', type='{}'",
+                                key.prefix(),
+                                key.key(),
+                                key.type_name()
+                            ))
+                        })?
+                        .clone(),
+                );
+            }
+
+            loader(loader_keys)
+                .await?
+                .into_iter()
+                .map(|(cache_key, value)| {
+                    let key = build_key(&prefix, &cache_key.key(), K::type_name());
+                    let entry = Arc::new(value);
+                    let size_bytes = cache_entry_size(&*entry);
+                    Ok(CacheLoadedEntry {
+                        key,
+                        entry: entry as CacheEntry,
+                        size_bytes,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()
+        }
+        .boxed()
+    });
+
+    let entries = cache
+        .get_or_insert_many(keys, typed_loader, K::codec())
+        .await?;
+
+    let mut values = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let CacheBatchEntry {
+            key,
+            entry,
+            was_cached,
+        } = entry;
+        if was_cached {
+            hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            misses.fetch_add(1, Ordering::Relaxed);
+        }
+        let value = entry.downcast::<K::ValueType>().map_err(|_| {
+            Error::internal(format!(
+                "cache entry type mismatch for key: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            ))
+        })?;
+        values.push(CacheBatchValue { value, was_cached });
+    }
+
+    Ok(values)
+}
+
+/// Preserves the typed batch contract when a WeakLanceCache has lost its
+/// backend: no cache coordination, exact loader validation, input-order output.
+async fn load_batch_without_cache<K, F, Fut>(
+    prefix: &Arc<str>,
+    cache_keys: Vec<K>,
+    loader: F,
+) -> Result<Vec<CacheBatchValue<K::ValueType>>>
+where
+    K: CacheKey + Clone + Send + Sync,
+    K::ValueType: DeepSizeOf + Send + Sync + 'static,
+    F: FnOnce(Vec<K>) -> Fut + Send,
+    Fut: Future<Output = Result<Vec<(K, K::ValueType)>>> + Send,
+{
+    if cache_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let (keys, expected_keys) = build_batch_keys(prefix, &cache_keys)?;
+    let mut loaded = HashMap::with_capacity(keys.len());
+    for (cache_key, value) in loader(cache_keys).await? {
+        let key = build_key(prefix, &cache_key.key(), K::type_name());
+        if !expected_keys.contains_key(&key) {
+            return Err(Error::invalid_input(format!(
+                "batch cache loader returned unexpected key: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            )));
+        }
+        let loaded_key = key.clone();
+        if loaded.insert(key, Arc::new(value)).is_some() {
+            return Err(Error::invalid_input(format!(
+                "batch cache loader returned duplicate keys: prefix='{}', key='{}', type='{}'",
+                loaded_key.prefix(),
+                loaded_key.key(),
+                loaded_key.type_name()
+            )));
+        }
+    }
+
+    let mut values = Vec::with_capacity(keys.len());
+    for key in keys {
+        let value = loaded.remove(&key).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "batch cache loader did not return expected key: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            ))
+        })?;
+        values.push(CacheBatchValue {
+            value,
+            was_cached: false,
+        });
+    }
+    Ok(values)
 }
 
 // ---------------------------------------------------------------------------
@@ -394,7 +574,94 @@ impl LanceCache {
             self.misses.fetch_add(1, Ordering::Relaxed);
         }
 
-        Ok(entry.downcast::<K::ValueType>().unwrap())
+        entry.downcast::<K::ValueType>().map_err(|_| {
+            Error::internal(format!(
+                "cache entry type mismatch for key: prefix='{}', key='{}', type='{}'",
+                key.prefix(),
+                key.key(),
+                key.type_name()
+            ))
+        })
+    }
+
+    /// Get or insert a batch of typed cache entries.
+    ///
+    /// `cache_keys` must be unique. The returned entries follow the same order
+    /// as `cache_keys`. The loader receives only missing keys owned by this
+    /// call, preserving their input order, and must return exactly one value
+    /// for each received key.
+    ///
+    /// The loader is `Fn`, not `FnOnce`, because a backend may call it more
+    /// than once during one batch request if keys need to be retried after
+    /// another in-flight owner fails or is dropped. Custom backends that do
+    /// not override [`CacheBackend::get_or_insert_many`] use a compatibility
+    /// fallback that invokes the loader one key at a time.
+    ///
+    /// Use this when the loader can benefit from receiving multiple missing
+    /// keys at once, for example by coalescing adjacent reads. This is not a
+    /// general faster path: for isolated keys, cheap loaders, or disjoint
+    /// concurrent batches, [`get_or_insert_with_key`](Self::get_or_insert_with_key)
+    /// avoids the batch result maps and per-key coordination needed to preserve
+    /// ordering and single-flight behavior.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::borrow::Cow;
+    /// # use lance_core::{Result, cache::{CacheKey, LanceCache}};
+    /// #
+    /// # #[derive(Clone)]
+    /// # struct PageKey(u32);
+    /// #
+    /// # impl CacheKey for PageKey {
+    /// #     type ValueType = usize;
+    /// #
+    /// #     fn key(&self) -> Cow<'_, str> {
+    /// #         Cow::Owned(self.0.to_string())
+    /// #     }
+    /// #
+    /// #     fn type_name() -> &'static str {
+    /// #         "PageKey"
+    /// #     }
+    /// # }
+    /// #
+    /// # async fn example(cache: LanceCache) -> Result<()> {
+    /// let values = cache
+    ///     .get_or_insert_with_key_batch(vec![PageKey(1), PageKey(2)], |keys| async move {
+    ///         Ok(keys
+    ///             .into_iter()
+    ///             .map(|key| {
+    ///                 let value = key.0 as usize;
+    ///                 (key, value)
+    ///             })
+    ///             .collect())
+    ///     })
+    ///     .await?;
+    ///
+    /// assert_eq!(*values[0].value, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_or_insert_with_key_batch<K, F, Fut>(
+        &self,
+        cache_keys: Vec<K>,
+        loader: F,
+    ) -> Result<Vec<CacheBatchValue<K::ValueType>>>
+    where
+        K: CacheKey + Clone + Send + Sync,
+        K::ValueType: DeepSizeOf + Send + Sync + 'static,
+        F: Fn(Vec<K>) -> Fut + Send + Sync,
+        Fut: Future<Output = Result<Vec<(K, K::ValueType)>>> + Send,
+    {
+        get_or_insert_batch_with_backend(
+            self.cache.as_ref(),
+            &self.prefix,
+            &self.hits,
+            &self.misses,
+            cache_keys,
+            loader,
+        )
+        .await
     }
 
     pub async fn insert_unsized_with_key<K>(&self, cache_key: &K, metadata: Arc<K::ValueType>)
@@ -466,8 +733,22 @@ impl WeakLanceCache {
         let cache = self.inner.upgrade()?;
         let key = build_key(&self.prefix, &cache_key.key(), K::type_name());
         if let Some(entry) = cache.get(&key, K::codec()).await {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            Some(entry.downcast::<K::ValueType>().unwrap())
+            match entry.downcast::<K::ValueType>() {
+                Ok(value) => {
+                    self.hits.fetch_add(1, Ordering::Relaxed);
+                    Some(value)
+                }
+                Err(_) => {
+                    self.misses.fetch_add(1, Ordering::Relaxed);
+                    log::warn!(
+                        "cache entry type mismatch for key: prefix='{}', key='{}', type='{}'",
+                        key.prefix(),
+                        key.key(),
+                        key.type_name()
+                    );
+                    None
+                }
+            }
         } else {
             self.misses.fetch_add(1, Ordering::Relaxed);
             None
@@ -518,10 +799,51 @@ impl WeakLanceCache {
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
             }
-            Ok(entry.downcast::<K::ValueType>().unwrap())
+            entry.downcast::<K::ValueType>().map_err(|_| {
+                Error::internal(format!(
+                    "cache entry type mismatch for key: prefix='{}', key='{}', type='{}'",
+                    key.prefix(),
+                    key.key(),
+                    key.type_name()
+                ))
+            })
         } else {
             log::warn!("WeakLanceCache: cache no longer available, computing without caching");
             loader().await.map(Arc::new)
+        }
+    }
+
+    /// Get or insert a batch of typed cache entries.
+    ///
+    /// If the backing cache is still available, this has the same semantics as
+    /// [`LanceCache::get_or_insert_with_key_batch`]. If the backing cache has
+    /// been dropped, the loader runs without caching and all returned entries
+    /// are validated, reordered to match the input keys, and marked as not
+    /// cached.
+    pub async fn get_or_insert_with_key_batch<K, F, Fut>(
+        &self,
+        cache_keys: Vec<K>,
+        loader: F,
+    ) -> Result<Vec<CacheBatchValue<K::ValueType>>>
+    where
+        K: CacheKey + Clone + Send + Sync,
+        K::ValueType: DeepSizeOf + Send + Sync + 'static,
+        F: Fn(Vec<K>) -> Fut + Send + Sync,
+        Fut: Future<Output = Result<Vec<(K, K::ValueType)>>> + Send,
+    {
+        if let Some(cache) = self.inner.upgrade() {
+            get_or_insert_batch_with_backend(
+                cache.as_ref(),
+                &self.prefix,
+                &self.hits,
+                &self.misses,
+                cache_keys,
+                loader,
+            )
+            .await
+        } else {
+            log::warn!("WeakLanceCache: cache no longer available, computing without caching");
+            load_batch_without_cache(&self.prefix, cache_keys, loader).await
         }
     }
 
@@ -564,14 +886,45 @@ impl WeakLanceCache {
 
 #[derive(Debug, Clone)]
 pub struct CacheStats {
-    /// Number of times `get`, `get_unsized`, or `get_or_insert` found an item in the cache.
+    /// Number of cache operations satisfied without running this call's loader.
+    ///
+    /// For `get`/`get_unsized`, this means the entry was found in the cache.
+    /// For `get_or_insert`/batch get-or-insert, this means the entry was
+    /// either already cached or was loaded by another in-flight owner. A
+    /// get-or-insert caller that initially missed but waited for another owner
+    /// is counted here, not in `misses`.
+    ///
+    /// Batch get-or-insert calls count each returned key independently, not the
+    /// batch request as a single operation.
     pub hits: u64,
-    /// Number of times `get`, `get_unsized`, or `get_or_insert` did not find an item in the cache.
+    /// Number of cache operations that were not satisfied from cache/owner.
+    ///
+    /// For `get`/`get_unsized`, this means the entry was not found. For
+    /// `get_or_insert`/batch get-or-insert, this means the current call
+    /// executed the loader for that entry.
+    ///
+    /// Batch get-or-insert calls count each returned key independently, not the
+    /// batch request as a single operation.
     pub misses: u64,
     /// Number of entries currently in the cache.
     pub num_entries: usize,
     /// Total size in bytes of all entries in the cache.
     pub size_bytes: usize,
+}
+
+/// A typed value returned by batch get-or-insert.
+///
+/// Includes both the cache value and whether this call avoided running its
+/// loader for the key.
+#[derive(Debug, Clone)]
+pub struct CacheBatchValue<T> {
+    /// Cached or loaded value.
+    pub value: Arc<T>,
+    /// True when this call did not run the loader for this key.
+    ///
+    /// This includes ordinary cache hits and values loaded by another
+    /// in-flight owner.
+    pub was_cached: bool,
 }
 
 impl CacheStats {
@@ -595,9 +948,11 @@ impl CacheStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::collections::{BTreeSet, HashMap};
     use std::marker::PhantomData;
 
+    #[derive(Clone)]
     struct TestKey<T: 'static> {
         key: String,
         _phantom: PhantomData<T>,
@@ -657,6 +1012,90 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn assert_invalid_input_contains(err: Error, snippets: &[&str]) {
+        assert!(matches!(err, Error::InvalidInput { .. }));
+        let message = err.to_string();
+        for snippet in snippets {
+            assert!(
+                message.contains(snippet),
+                "expected error message to contain '{snippet}', got: {message}"
+            );
+        }
+    }
+
+    #[derive(Debug)]
+    struct HashMapBackend {
+        map: tokio::sync::Mutex<HashMap<InternalCacheKey, (CacheEntry, usize)>>,
+    }
+
+    impl HashMapBackend {
+        fn new() -> Self {
+            Self {
+                map: tokio::sync::Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CacheBackend for HashMapBackend {
+        async fn get(
+            &self,
+            key: &InternalCacheKey,
+            _codec: Option<CacheCodec>,
+        ) -> Option<CacheEntry> {
+            self.map.lock().await.get(key).map(|(e, _)| e.clone())
+        }
+
+        async fn insert(
+            &self,
+            key: &InternalCacheKey,
+            entry: CacheEntry,
+            size_bytes: usize,
+            _codec: Option<CacheCodec>,
+        ) {
+            self.map
+                .lock()
+                .await
+                .insert(key.clone(), (entry, size_bytes));
+        }
+
+        async fn get_or_insert<'a>(
+            &self,
+            key: &InternalCacheKey,
+            loader: std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>,
+            >,
+            _codec: Option<CacheCodec>,
+        ) -> Result<(CacheEntry, bool)> {
+            if let Some((entry, _)) = self.map.lock().await.get(key) {
+                Ok((entry.clone(), true))
+            } else {
+                let (entry, size) = loader.await?;
+                self.map
+                    .lock()
+                    .await
+                    .insert(key.clone(), (entry.clone(), size));
+                Ok((entry, false))
+            }
+        }
+
+        async fn invalidate_prefix(&self, prefix: &str) {
+            self.map.lock().await.retain(|k, _| !k.starts_with(prefix));
+        }
+
+        async fn clear(&self) {
+            self.map.lock().await.clear();
+        }
+
+        async fn num_entries(&self) -> usize {
+            self.map.lock().await.len()
+        }
+
+        async fn size_bytes(&self) -> usize {
+            self.map.lock().await.values().map(|(_, s)| *s).sum()
+        }
     }
 
     #[tokio::test]
@@ -862,6 +1301,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_clear_does_not_cancel_in_flight_get_or_insert() {
+        let cache = LanceCache::with_capacity(1000);
+        let loader_started = Arc::new(tokio::sync::Notify::new());
+        let finish_loader = Arc::new(tokio::sync::Notify::new());
+
+        let task_cache = cache.clone();
+        let loader_started_clone = loader_started.clone();
+        let finish_loader_clone = finish_loader.clone();
+        let load = tokio::spawn(async move {
+            task_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("k"), move || {
+                    let loader_started = loader_started_clone;
+                    let finish_loader = finish_loader_clone;
+                    async move {
+                        loader_started.notify_waiters();
+                        finish_loader.notified().await;
+                        Ok(vec![1, 2, 3])
+                    }
+                })
+                .await
+        });
+
+        loader_started.notified().await;
+        cache.clear().await;
+        assert_eq!(cache.size().await, 0);
+
+        finish_loader.notify_waiters();
+        let loaded = load.await.unwrap().unwrap();
+        assert_eq!(*loaded, vec![1, 2, 3]);
+
+        let cached = cache
+            .get_with_key(&TestKey::<Vec<i32>>::new("k"))
+            .await
+            .unwrap();
+        assert_eq!(*cached, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
     async fn test_cache_get_or_insert() {
         let cache = LanceCache::with_capacity(1000);
 
@@ -888,76 +1365,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_custom_backend() {
-        use async_trait::async_trait;
-        use tokio::sync::Mutex;
-
-        #[derive(Debug)]
-        struct HashMapBackend {
-            map: Mutex<HashMap<InternalCacheKey, (CacheEntry, usize)>>,
-        }
-
-        impl HashMapBackend {
-            fn new() -> Self {
-                Self {
-                    map: Mutex::new(HashMap::new()),
-                }
-            }
-        }
-
-        #[async_trait]
-        impl CacheBackend for HashMapBackend {
-            async fn get(
-                &self,
-                key: &InternalCacheKey,
-                _codec: Option<CacheCodec>,
-            ) -> Option<CacheEntry> {
-                self.map.lock().await.get(key).map(|(e, _)| e.clone())
-            }
-            async fn insert(
-                &self,
-                key: &InternalCacheKey,
-                entry: CacheEntry,
-                size_bytes: usize,
-                _codec: Option<CacheCodec>,
-            ) {
-                self.map
-                    .lock()
-                    .await
-                    .insert(key.clone(), (entry, size_bytes));
-            }
-            async fn get_or_insert<'a>(
-                &self,
-                key: &InternalCacheKey,
-                loader: std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>,
-                >,
-                _codec: Option<CacheCodec>,
-            ) -> Result<(CacheEntry, bool)> {
-                if let Some((entry, _)) = self.map.lock().await.get(key) {
-                    Ok((entry.clone(), true))
-                } else {
-                    let (entry, size) = loader.await?;
-                    self.map
-                        .lock()
-                        .await
-                        .insert(key.clone(), (entry.clone(), size));
-                    Ok((entry, false))
-                }
-            }
-            async fn invalidate_prefix(&self, prefix: &str) {
-                self.map.lock().await.retain(|k, _| !k.starts_with(prefix));
-            }
-            async fn clear(&self) {
-                self.map.lock().await.clear();
-            }
-            async fn num_entries(&self) -> usize {
-                self.map.lock().await.len()
-            }
-            async fn size_bytes(&self) -> usize {
-                self.map.lock().await.values().map(|(_, s)| *s).sum()
-            }
-        }
-
         let cache = LanceCache::with_backend(Arc::new(HashMapBackend::new()));
 
         cache
@@ -977,6 +1384,165 @@ mod tests {
                 .is_none()
         );
         assert!(cache.keys().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_uses_backend_default_fallback() {
+        let cache = LanceCache::with_backend(Arc::new(HashMapBackend::new()));
+        let loader_calls = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let values = cache
+            .get_or_insert_with_key_batch(
+                vec![
+                    TestKey::<Vec<i32>>::new("1"),
+                    TestKey::<Vec<i32>>::new("2"),
+                    TestKey::<Vec<i32>>::new("3"),
+                ],
+                {
+                    let loader_calls = loader_calls.clone();
+                    move |owned_keys| {
+                        let loader_calls = loader_calls.clone();
+                        async move {
+                            loader_calls.lock().await.push(
+                                owned_keys
+                                    .iter()
+                                    .map(|key| key.key.clone())
+                                    .collect::<Vec<_>>(),
+                            );
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    (key, vec![value])
+                                })
+                                .collect())
+                        }
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![1], vec![2], vec![3]]
+        );
+        assert_eq!(
+            values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![false, false, false]
+        );
+        assert_eq!(
+            *loader_calls.lock().await,
+            vec![
+                vec!["1".to_string()],
+                vec!["2".to_string()],
+                vec!["3".to_string()]
+            ]
+        );
+
+        let cached_values = cache
+            .get_or_insert_with_key_batch(
+                vec![TestKey::<Vec<i32>>::new("2"), TestKey::<Vec<i32>>::new("3")],
+                |_| async { panic!("cached fallback keys should not call loader") },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            cached_values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![true, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_weak_get_or_insert_batch_empty_after_cache_drop_skips_loader() {
+        let weak_cache = {
+            let cache = LanceCache::with_capacity(10000);
+            WeakLanceCache::from(&cache)
+        };
+
+        let values: Vec<CacheBatchValue<Vec<i32>>> = weak_cache
+            .get_or_insert_with_key_batch(Vec::<TestKey<Vec<i32>>>::new(), |_| async {
+                panic!("empty weak-cache batch should not call loader")
+            })
+            .await
+            .unwrap();
+
+        assert!(values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_weak_get_or_insert_batch_after_cache_drop_loads_without_cache() {
+        let weak_cache = {
+            let cache = LanceCache::with_capacity(10000);
+            WeakLanceCache::from(&cache)
+        };
+
+        let values = weak_cache
+            .get_or_insert_with_key_batch(
+                vec![
+                    TestKey::<Vec<i32>>::new("2"),
+                    TestKey::<Vec<i32>>::new("1"),
+                    TestKey::<Vec<i32>>::new("3"),
+                ],
+                |keys| async move {
+                    assert_eq!(
+                        keys.iter().map(|key| key.key.as_str()).collect::<Vec<_>>(),
+                        vec!["2", "1", "3"]
+                    );
+                    Ok(vec![
+                        (keys[2].clone(), vec![3]),
+                        (keys[1].clone(), vec![1]),
+                        (keys[0].clone(), vec![2]),
+                    ])
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![2], vec![1], vec![3]]
+        );
+        assert_eq!(
+            values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![false, false, false]
+        );
+
+        let err = weak_cache
+            .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], |_| async {
+                Ok(vec![(TestKey::<Vec<i32>>::new("2"), vec![2])])
+            })
+            .await
+            .unwrap_err();
+
+        assert_invalid_input_contains(err, &["unexpected key", "key='2'"]);
+
+        let err = weak_cache
+            .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], |_| async {
+                Ok(vec![
+                    (TestKey::<Vec<i32>>::new("1"), vec![1]),
+                    (TestKey::<Vec<i32>>::new("1"), vec![10]),
+                ])
+            })
+            .await
+            .unwrap_err();
+
+        assert_invalid_input_contains(err, &["duplicate keys", "key='1'"]);
     }
 
     #[tokio::test]
@@ -1013,5 +1579,790 @@ mod tests {
         }
 
         assert_eq!(load_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_dedups_overlapping_keys() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, sleep};
+
+        let cache = LanceCache::with_capacity(10000);
+        let load_counts = Arc::new(
+            (0..5)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<AtomicUsize>>(),
+        );
+
+        let (barrier_tx, _) = tokio::sync::broadcast::channel::<()>(1);
+        let mut handles = Vec::new();
+        for keys in [
+            vec![
+                TestKey::<Vec<i32>>::new("1"),
+                TestKey::<Vec<i32>>::new("2"),
+                TestKey::<Vec<i32>>::new("3"),
+            ],
+            vec![
+                TestKey::<Vec<i32>>::new("2"),
+                TestKey::<Vec<i32>>::new("3"),
+                TestKey::<Vec<i32>>::new("4"),
+            ],
+        ] {
+            let cache = cache.clone();
+            let load_counts = load_counts.clone();
+            let mut barrier_rx = barrier_tx.subscribe();
+            handles.push(tokio::spawn(async move {
+                barrier_rx.recv().await.ok();
+                cache
+                    .get_or_insert_with_key_batch(keys.clone(), move |owned_keys| {
+                        let load_counts = load_counts.clone();
+                        async move {
+                            sleep(Duration::from_millis(20)).await;
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    load_counts[value as usize].fetch_add(1, Ordering::SeqCst);
+                                    (key, vec![value])
+                                })
+                                .collect::<Vec<_>>())
+                        }
+                    })
+                    .await
+            }));
+        }
+
+        barrier_tx.send(()).unwrap();
+        let first = handles.remove(0).await.unwrap().unwrap();
+        let second = handles.remove(0).await.unwrap().unwrap();
+
+        assert_eq!(
+            first
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![1], vec![2], vec![3]]
+        );
+        assert_eq!(
+            second
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![2], vec![3], vec![4]]
+        );
+        let mut cached_by_value = HashMap::new();
+        for entry in first.iter().chain(second.iter()) {
+            cached_by_value
+                .entry(entry.value[0])
+                .or_insert_with(Vec::new)
+                .push(entry.was_cached);
+        }
+        assert_eq!(cached_by_value.get(&1).unwrap(), &vec![false]);
+        assert_eq!(cached_by_value.get(&4).unwrap(), &vec![false]);
+        assert_eq!(
+            cached_by_value
+                .get(&2)
+                .unwrap()
+                .iter()
+                .filter(|was_cached| **was_cached)
+                .count(),
+            1
+        );
+        assert_eq!(
+            cached_by_value
+                .get(&3)
+                .unwrap()
+                .iter()
+                .filter(|was_cached| **was_cached)
+                .count(),
+            1
+        );
+        for key in 1..=4 {
+            assert_eq!(load_counts[key].load(Ordering::SeqCst), 1);
+        }
+        assert_eq!(cache.stats().await.misses, 4);
+        assert_eq!(cache.stats().await.hits, 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_waits_on_in_flight_batch_owner() {
+        use std::sync::atomic::AtomicUsize;
+
+        let cache = LanceCache::with_capacity(10000);
+        let first_load_count = Arc::new(AtomicUsize::new(0));
+        let second_load_count = Arc::new(AtomicUsize::new(0));
+        let owner_started = Arc::new(tokio::sync::Notify::new());
+        let finish_owner = Arc::new(tokio::sync::Notify::new());
+        let second_loader_started = Arc::new(tokio::sync::Notify::new());
+
+        let first_cache = cache.clone();
+        let first_load_count_clone = first_load_count.clone();
+        let owner_started_clone = owner_started.clone();
+        let finish_owner_clone = finish_owner.clone();
+        let first = tokio::spawn(async move {
+            first_cache
+                .get_or_insert_with_key_batch(
+                    vec![
+                        TestKey::<Vec<i32>>::new("1"),
+                        TestKey::<Vec<i32>>::new("2"),
+                        TestKey::<Vec<i32>>::new("3"),
+                    ],
+                    move |owned_keys| {
+                        let first_load_count = first_load_count_clone.clone();
+                        let owner_started = owner_started_clone.clone();
+                        let finish_owner = finish_owner_clone.clone();
+                        async move {
+                            assert_eq!(
+                                owned_keys
+                                    .iter()
+                                    .map(|key| key.key.as_str())
+                                    .collect::<Vec<_>>(),
+                                vec!["1", "2", "3"]
+                            );
+                            first_load_count.fetch_add(owned_keys.len(), Ordering::SeqCst);
+                            owner_started.notify_waiters();
+                            finish_owner.notified().await;
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    (key, vec![value])
+                                })
+                                .collect::<Vec<_>>())
+                        }
+                    },
+                )
+                .await
+        });
+
+        owner_started.notified().await;
+
+        let second_cache = cache.clone();
+        let second_load_count_clone = second_load_count.clone();
+        let second_loader_started_clone = second_loader_started.clone();
+        let second = tokio::spawn(async move {
+            second_cache
+                .get_or_insert_with_key_batch(
+                    vec![
+                        TestKey::<Vec<i32>>::new("2"),
+                        TestKey::<Vec<i32>>::new("3"),
+                        TestKey::<Vec<i32>>::new("4"),
+                    ],
+                    move |owned_keys| {
+                        let second_load_count = second_load_count_clone.clone();
+                        let second_loader_started = second_loader_started_clone.clone();
+                        async move {
+                            second_loader_started.notify_waiters();
+                            assert_eq!(
+                                owned_keys
+                                    .iter()
+                                    .map(|key| key.key.as_str())
+                                    .collect::<Vec<_>>(),
+                                vec!["4"]
+                            );
+                            second_load_count.fetch_add(owned_keys.len(), Ordering::SeqCst);
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    (key, vec![value])
+                                })
+                                .collect::<Vec<_>>())
+                        }
+                    },
+                )
+                .await
+        });
+
+        second_loader_started.notified().await;
+        finish_owner.notify_waiters();
+
+        let first_values = first.await.unwrap().unwrap();
+        let second_values = second.await.unwrap().unwrap();
+
+        assert_eq!(
+            first_values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![1], vec![2], vec![3]]
+        );
+        assert_eq!(
+            first_values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![false, false, false]
+        );
+        assert_eq!(
+            second_values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![2], vec![3], vec![4]]
+        );
+        assert_eq!(
+            second_values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![true, true, false]
+        );
+        assert_eq!(first_load_count.load(Ordering::SeqCst), 3);
+        assert_eq!(second_load_count.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.stats().await.misses, 4);
+        assert_eq!(cache.stats().await.hits, 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_dedups_high_fanout_overlap() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, sleep};
+
+        let cache = LanceCache::with_capacity(10000);
+        let key_count = 64;
+        let concurrency = 8;
+        let load_counts = Arc::new(
+            (0..key_count)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<_>>(),
+        );
+        let (barrier_tx, _) = tokio::sync::broadcast::channel::<()>(1);
+        let mut handles = Vec::new();
+
+        for _ in 0..concurrency {
+            let cache = cache.clone();
+            let load_counts = load_counts.clone();
+            let mut barrier_rx = barrier_tx.subscribe();
+            handles.push(tokio::spawn(async move {
+                let keys = (0..key_count)
+                    .map(|idx| TestKey::<Vec<i32>>::new(&idx.to_string()))
+                    .collect::<Vec<_>>();
+                barrier_rx.recv().await.ok();
+                cache
+                    .get_or_insert_with_key_batch(keys, move |owned_keys| {
+                        let load_counts = load_counts.clone();
+                        async move {
+                            sleep(Duration::from_millis(10)).await;
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    load_counts[value as usize].fetch_add(1, Ordering::SeqCst);
+                                    (key, vec![value])
+                                })
+                                .collect::<Vec<_>>())
+                        }
+                    })
+                    .await
+            }));
+        }
+
+        barrier_tx.send(()).unwrap();
+        for handle in handles {
+            let values = handle.await.unwrap().unwrap();
+            assert_eq!(
+                values
+                    .iter()
+                    .map(|entry| entry.value[0])
+                    .collect::<Vec<_>>(),
+                (0..key_count).collect::<Vec<_>>()
+            );
+        }
+
+        for key in 0..key_count {
+            assert_eq!(load_counts[key as usize].load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_shares_flights_with_single_key_get_or_insert() {
+        use std::sync::atomic::AtomicUsize;
+
+        let cache = LanceCache::with_capacity(10000);
+        let batch_load_count = Arc::new(AtomicUsize::new(0));
+        let single_load_count = Arc::new(AtomicUsize::new(0));
+        let loader_started = Arc::new(tokio::sync::Notify::new());
+        let finish_loader = Arc::new(tokio::sync::Notify::new());
+
+        let batch_cache = cache.clone();
+        let batch_load_count_clone = batch_load_count.clone();
+        let loader_started_clone = loader_started.clone();
+        let finish_loader_clone = finish_loader.clone();
+        let batch = tokio::spawn(async move {
+            batch_cache
+                .get_or_insert_with_key_batch(
+                    vec![TestKey::<Vec<i32>>::new("1"), TestKey::<Vec<i32>>::new("2")],
+                    move |owned_keys| {
+                        let batch_load_count = batch_load_count_clone.clone();
+                        let loader_started = loader_started_clone.clone();
+                        let finish_loader = finish_loader_clone.clone();
+                        async move {
+                            batch_load_count.fetch_add(owned_keys.len(), Ordering::SeqCst);
+                            loader_started.notify_waiters();
+                            finish_loader.notified().await;
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    (key, vec![value])
+                                })
+                                .collect::<Vec<_>>())
+                        }
+                    },
+                )
+                .await
+        });
+
+        loader_started.notified().await;
+
+        let single_cache = cache.clone();
+        let single_load_count_clone = single_load_count.clone();
+        let single = tokio::spawn(async move {
+            single_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("2"), move || {
+                    let single_load_count = single_load_count_clone;
+                    async move {
+                        single_load_count.fetch_add(1, Ordering::SeqCst);
+                        Ok(vec![20])
+                    }
+                })
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(single_load_count.load(Ordering::SeqCst), 0);
+        finish_loader.notify_waiters();
+
+        let batch_values = batch.await.unwrap().unwrap();
+        let single_value = single.await.unwrap().unwrap();
+
+        assert_eq!(
+            batch_values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![1], vec![2]]
+        );
+        assert_eq!(
+            batch_values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![false, false]
+        );
+        assert_eq!(*single_value, vec![2]);
+        assert_eq!(batch_load_count.load(Ordering::SeqCst), 2);
+        assert_eq!(single_load_count.load(Ordering::SeqCst), 0);
+        assert_eq!(cache.stats().await.misses, 2);
+        assert_eq!(cache.stats().await.hits, 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_single_key_shares_flights_with_batch_get_or_insert() {
+        use std::sync::atomic::AtomicUsize;
+
+        let cache = LanceCache::with_capacity(10000);
+        let single_load_count = Arc::new(AtomicUsize::new(0));
+        let batch_load_count = Arc::new(AtomicUsize::new(0));
+        let loader_started = Arc::new(tokio::sync::Notify::new());
+        let finish_loader = Arc::new(tokio::sync::Notify::new());
+        let batch_loader_started = Arc::new(tokio::sync::Notify::new());
+
+        let single_cache = cache.clone();
+        let single_load_count_clone = single_load_count.clone();
+        let loader_started_clone = loader_started.clone();
+        let finish_loader_clone = finish_loader.clone();
+        let single = tokio::spawn(async move {
+            single_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("2"), move || {
+                    let single_load_count = single_load_count_clone.clone();
+                    let loader_started = loader_started_clone.clone();
+                    let finish_loader = finish_loader_clone;
+                    async move {
+                        single_load_count.fetch_add(1, Ordering::SeqCst);
+                        loader_started.notify_waiters();
+                        finish_loader.notified().await;
+                        Ok(vec![2])
+                    }
+                })
+                .await
+        });
+
+        loader_started.notified().await;
+
+        let batch_cache = cache.clone();
+        let batch_load_count_clone = batch_load_count.clone();
+        let batch_loader_started_clone = batch_loader_started.clone();
+        let batch = tokio::spawn(async move {
+            batch_cache
+                .get_or_insert_with_key_batch(
+                    vec![TestKey::<Vec<i32>>::new("1"), TestKey::<Vec<i32>>::new("2")],
+                    move |owned_keys| {
+                        let batch_load_count = batch_load_count_clone.clone();
+                        let batch_loader_started = batch_loader_started_clone.clone();
+                        async move {
+                            batch_loader_started.notify_waiters();
+                            assert_eq!(
+                                owned_keys
+                                    .iter()
+                                    .map(|key| key.key.as_str())
+                                    .collect::<Vec<_>>(),
+                                vec!["1"]
+                            );
+                            batch_load_count.fetch_add(owned_keys.len(), Ordering::SeqCst);
+                            Ok(owned_keys
+                                .into_iter()
+                                .map(|key| {
+                                    let value = key.key.parse::<i32>().unwrap();
+                                    (key, vec![value])
+                                })
+                                .collect())
+                        }
+                    },
+                )
+                .await
+        });
+
+        batch_loader_started.notified().await;
+        finish_loader.notify_waiters();
+
+        let single_value = single.await.unwrap().unwrap();
+        let batch_values = batch.await.unwrap().unwrap();
+
+        assert_eq!(*single_value, vec![2]);
+        assert_eq!(
+            batch_values
+                .iter()
+                .map(|entry| entry.value.as_ref().clone())
+                .collect::<Vec<_>>(),
+            vec![vec![1], vec![2]]
+        );
+        assert_eq!(
+            batch_values
+                .iter()
+                .map(|entry| entry.was_cached)
+                .collect::<Vec<_>>(),
+            vec![false, true]
+        );
+        assert_eq!(single_load_count.load(Ordering::SeqCst), 1);
+        assert_eq!(batch_load_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_loader_receives_owned_keys_in_input_order() {
+        let cache = LanceCache::with_capacity(10000);
+        cache
+            .insert_with_key(&TestKey::new("key-03"), Arc::new(vec![3]))
+            .await;
+        cache
+            .insert_with_key(&TestKey::new("key-07"), Arc::new(vec![7]))
+            .await;
+
+        let keys = (0..16)
+            .map(|idx| TestKey::<Vec<i32>>::new(&format!("key-{idx:02}")))
+            .collect::<Vec<_>>();
+        let expected_owned_keys = keys
+            .iter()
+            .filter(|key| key.key != "key-03" && key.key != "key-07")
+            .map(|key| key.key.clone())
+            .collect::<Vec<_>>();
+        let observed_owned_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed_owned_keys_clone = observed_owned_keys.clone();
+
+        let values = cache
+            .get_or_insert_with_key_batch(keys, move |owned_keys| {
+                let observed_owned_keys = observed_owned_keys_clone.clone();
+                async move {
+                    *observed_owned_keys.lock().unwrap() =
+                        owned_keys.iter().map(|key| key.key.clone()).collect();
+                    Ok(owned_keys
+                        .into_iter()
+                        .map(|key| {
+                            let value = key.key.strip_prefix("key-").unwrap().parse().unwrap();
+                            (key, vec![value])
+                        })
+                        .collect())
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(*observed_owned_keys.lock().unwrap(), expected_owned_keys);
+        assert_eq!(
+            values
+                .iter()
+                .map(|entry| entry.value[0])
+                .collect::<Vec<_>>(),
+            (0..16).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_rejects_duplicate_input_keys() {
+        let cache = LanceCache::with_capacity(10000);
+
+        let err = cache
+            .get_or_insert_with_key_batch(
+                vec![TestKey::<Vec<i32>>::new("1"), TestKey::<Vec<i32>>::new("1")],
+                |_| async { Ok(Vec::<(TestKey<Vec<i32>>, Vec<i32>)>::new()) },
+            )
+            .await
+            .unwrap_err();
+
+        assert_invalid_input_contains(err, &["duplicate cache key", "key='1'"]);
+        assert_eq!(cache.stats().await.hits, 0);
+        assert_eq!(cache.stats().await.misses, 0);
+    }
+
+    #[rstest]
+    #[case::unexpected_key(
+        vec![(TestKey::<Vec<i32>>::new("2"), vec![2])],
+        &["unexpected key", "key='2'"]
+    )]
+    #[case::missing_key(
+        Vec::<(TestKey<Vec<i32>>, Vec<i32>)>::new(),
+        &["did not return expected key", "key='1'"]
+    )]
+    #[case::extra_key(vec![
+        (TestKey::<Vec<i32>>::new("1"), vec![1]),
+        (TestKey::<Vec<i32>>::new("2"), vec![2]),
+    ], &["unexpected key", "key='2'"])]
+    #[case::duplicate_key(vec![
+        (TestKey::<Vec<i32>>::new("1"), vec![1]),
+        (TestKey::<Vec<i32>>::new("1"), vec![10]),
+    ], &["duplicate keys", "key='1'"])]
+    #[tokio::test]
+    async fn test_get_or_insert_batch_rejects_loader_key_validation(
+        #[case] loaded: Vec<(TestKey<Vec<i32>>, Vec<i32>)>,
+        #[case] expected_message: &[&str],
+    ) {
+        let cache = LanceCache::with_capacity(10000);
+
+        let err = cache
+            .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], move |_| {
+                let loaded = loaded.clone();
+                async move { Ok(loaded) }
+            })
+            .await
+            .unwrap_err();
+
+        assert_invalid_input_contains(err, expected_message);
+        assert!(
+            cache
+                .get_with_key(&TestKey::<Vec<i32>>::new("1"))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_single_key_waiter_retries_after_owner_error() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, timeout};
+
+        let cache = LanceCache::with_capacity(10000);
+        let owner_started = Arc::new(tokio::sync::Notify::new());
+        let fail_owner = Arc::new(tokio::sync::Notify::new());
+        let retry_load_count = Arc::new(AtomicUsize::new(0));
+
+        let owner_cache = cache.clone();
+        let owner_started_clone = owner_started.clone();
+        let fail_owner_clone = fail_owner.clone();
+        let owner = tokio::spawn(async move {
+            owner_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("1"), move || async move {
+                    owner_started_clone.notify_waiters();
+                    fail_owner_clone.notified().await;
+                    Err(Error::io("owner load failed"))
+                })
+                .await
+        });
+
+        owner_started.notified().await;
+
+        let waiter_cache = cache.clone();
+        let retry_load_count_clone = retry_load_count.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("1"), move || async move {
+                    retry_load_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![1])
+                })
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+        fail_owner.notify_waiters();
+
+        let owner_err = owner.await.unwrap().unwrap_err();
+        assert!(matches!(owner_err, Error::IO { .. }));
+
+        let waiter_value = timeout(Duration::from_secs(5), waiter)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(*waiter_value, vec![1]);
+        assert_eq!(retry_load_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_single_key_waiter_retries_after_owner_cancel() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, sleep, timeout};
+
+        let cache = LanceCache::with_capacity(10000);
+        let owner_started = Arc::new(tokio::sync::Notify::new());
+        let retry_load_count = Arc::new(AtomicUsize::new(0));
+
+        let owner_cache = cache.clone();
+        let owner_started_clone = owner_started.clone();
+        let owner = tokio::spawn(async move {
+            owner_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("1"), move || async move {
+                    owner_started_clone.notify_waiters();
+                    std::future::pending::<Result<Vec<i32>>>().await
+                })
+                .await
+        });
+
+        owner_started.notified().await;
+
+        let waiter_cache = cache.clone();
+        let retry_load_count_clone = retry_load_count.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_cache
+                .get_or_insert_with_key(TestKey::<Vec<i32>>::new("1"), move || async move {
+                    retry_load_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![1])
+                })
+                .await
+        });
+
+        sleep(Duration::from_millis(10)).await;
+        assert!(!waiter.is_finished());
+        owner.abort();
+
+        let waiter_value = timeout(Duration::from_secs(5), waiter)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(*waiter_value, vec![1]);
+        assert_eq!(retry_load_count.load(Ordering::SeqCst), 1);
+        assert!(owner.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_waiter_retries_after_owner_error() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, timeout};
+
+        let cache = LanceCache::with_capacity(10000);
+        let owner_started = Arc::new(tokio::sync::Notify::new());
+        let fail_owner = Arc::new(tokio::sync::Notify::new());
+        let retry_load_count = Arc::new(AtomicUsize::new(0));
+
+        let owner_cache = cache.clone();
+        let owner_started_clone = owner_started.clone();
+        let fail_owner_clone = fail_owner.clone();
+        let owner = tokio::spawn(async move {
+            owner_cache
+                .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], move |_| {
+                    let owner_started = owner_started_clone.clone();
+                    let fail_owner = fail_owner_clone.clone();
+                    async move {
+                        owner_started.notify_waiters();
+                        fail_owner.notified().await;
+                        Err(Error::io("owner load failed"))
+                    }
+                })
+                .await
+        });
+
+        owner_started.notified().await;
+
+        let waiter_cache = cache.clone();
+        let retry_load_count_clone = retry_load_count.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_cache
+                .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], move |keys| {
+                    let retry_load_count = retry_load_count_clone.clone();
+                    async move {
+                        retry_load_count.fetch_add(keys.len(), Ordering::SeqCst);
+                        Ok(keys.into_iter().map(|key| (key, vec![1])).collect())
+                    }
+                })
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+        fail_owner.notify_waiters();
+
+        let owner_err = owner.await.unwrap().unwrap_err();
+        assert!(matches!(owner_err, Error::IO { .. }));
+
+        let waiter_values = timeout(Duration::from_secs(5), waiter)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(*waiter_values[0].value, vec![1]);
+        assert_eq!(retry_load_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_batch_waiter_retries_after_owner_cancel() {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::time::{Duration, sleep, timeout};
+
+        let cache = LanceCache::with_capacity(10000);
+        let owner_started = Arc::new(tokio::sync::Notify::new());
+        let retry_load_count = Arc::new(AtomicUsize::new(0));
+
+        let owner_cache = cache.clone();
+        let owner_started_clone = owner_started.clone();
+        let owner = tokio::spawn(async move {
+            owner_cache
+                .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], move |_| {
+                    let owner_started = owner_started_clone.clone();
+                    async move {
+                        owner_started.notify_waiters();
+                        std::future::pending::<Result<Vec<(TestKey<Vec<i32>>, Vec<i32>)>>>().await
+                    }
+                })
+                .await
+        });
+
+        owner_started.notified().await;
+
+        let waiter_cache = cache.clone();
+        let retry_load_count_clone = retry_load_count.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_cache
+                .get_or_insert_with_key_batch(vec![TestKey::<Vec<i32>>::new("1")], move |keys| {
+                    let retry_load_count = retry_load_count_clone.clone();
+                    async move {
+                        retry_load_count.fetch_add(keys.len(), Ordering::SeqCst);
+                        Ok(keys.into_iter().map(|key| (key, vec![1])).collect())
+                    }
+                })
+                .await
+        });
+
+        sleep(Duration::from_millis(10)).await;
+        assert!(!waiter.is_finished());
+        owner.abort();
+
+        let waiter_values = timeout(Duration::from_secs(5), waiter)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(*waiter_values[0].value, vec![1]);
+        assert_eq!(retry_load_count.load(Ordering::SeqCst), 1);
+        assert!(owner.await.unwrap_err().is_cancelled());
     }
 }

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use futures::Future;
+use tokio::sync::Notify;
 
-use crate::Result;
+use crate::{Error, Result};
 
 use super::CacheCodec;
-use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
+use super::backend::{
+    CacheBackend, CacheBatchEntry, CacheBatchLoader, CacheEntry, CacheKeyIterator,
+    InternalCacheKey, validate_loaded_entries, validate_unique_keys,
+};
 
 /// Internal record stored in the moka cache.
 #[derive(Clone, Debug)]
@@ -23,15 +27,119 @@ struct MokaCacheEntry {
 /// Default [`CacheBackend`] backed by a [moka](https://crates.io/crates/moka) cache.
 ///
 /// Provides weighted-capacity eviction and concurrent-load deduplication
-/// via moka's built-in `optionally_get_with`.
+/// via a shared in-flight registry. Single-key and batch get-or-insert calls
+/// use the same registry, so mixed callers still coalesce on the same key.
+/// Hot hits return from the moka cache before touching the registry; cold
+/// misses allocate short-lived per-key flight state until the owner completes.
+/// This in-flight state is not counted against the weighted cache capacity; it
+/// is bounded by currently live cold misses and slow loaders.
 pub struct MokaCacheBackend {
     cache: moka::future::Cache<InternalCacheKey, MokaCacheEntry>,
+    flights: FlightRegistry,
+}
+
+type FlightRegistry = Arc<Mutex<HashMap<InternalCacheKey, Arc<CacheFlight>>>>;
+
+struct CacheFlight {
+    state: Mutex<FlightState>,
+    notify: Notify,
+}
+
+#[derive(Clone)]
+enum FlightState {
+    Loading,
+    Ready(MokaCacheEntry),
+    Retry,
+}
+
+enum FlightClaim {
+    Owner(FlightOwner),
+    Waiter(Arc<CacheFlight>),
+}
+
+struct FlightOwner {
+    key: InternalCacheKey,
+    flight: Arc<CacheFlight>,
+    flights: FlightRegistry,
+    completed: bool,
+}
+
+impl CacheFlight {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(FlightState::Loading),
+            notify: Notify::new(),
+        }
+    }
+
+    async fn wait(&self) -> Result<FlightState> {
+        loop {
+            let notified = self.notify.notified();
+            {
+                let state = self.state.lock().map_err(|_| {
+                    Error::internal("cache flight state mutex poisoned while waiting")
+                })?;
+                match &*state {
+                    FlightState::Loading => {}
+                    FlightState::Ready(entry) => return Ok(FlightState::Ready(entry.clone())),
+                    FlightState::Retry => return Ok(FlightState::Retry),
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+impl FlightOwner {
+    fn complete(&mut self, entry: MokaCacheEntry) -> Result<()> {
+        self.set_state(FlightState::Ready(entry))
+    }
+
+    fn retry(&mut self) -> Result<()> {
+        self.set_state(FlightState::Retry)
+    }
+
+    fn set_state(&mut self, state: FlightState) -> Result<()> {
+        {
+            let mut guard = self.flight.state.lock().map_err(|_| {
+                Error::internal("cache flight state mutex poisoned while completing owner")
+            })?;
+            *guard = state;
+        }
+        let remove_result = self.remove_from_registry();
+        self.completed = true;
+        self.flight.notify.notify_waiters();
+        remove_result
+    }
+
+    fn remove_from_registry(&self) -> Result<()> {
+        let mut flights = self.flights.lock().map_err(|_| {
+            Error::internal("cache flight registry mutex poisoned while removing owner")
+        })?;
+        if flights
+            .get(&self.key)
+            .is_some_and(|flight| Arc::ptr_eq(flight, &self.flight))
+        {
+            flights.remove(&self.key);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for FlightOwner {
+    fn drop(&mut self) {
+        if !self.completed {
+            let _ = self.retry();
+        }
+    }
 }
 
 impl std::fmt::Debug for MokaCacheBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let in_flight_entries = self.flights.lock().map(|flights| flights.len()).ok();
         f.debug_struct("MokaCacheBackend")
             .field("entry_count", &self.cache.entry_count())
+            .field("in_flight_entries", &in_flight_entries)
             .finish()
     }
 }
@@ -43,13 +151,38 @@ impl MokaCacheBackend {
             .weigher(|_, v: &MokaCacheEntry| v.size_bytes.try_into().unwrap_or(u32::MAX))
             .support_invalidation_closures()
             .build();
-        Self { cache }
+        Self {
+            cache,
+            flights: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 
     pub fn no_cache() -> Self {
         Self {
             cache: moka::future::Cache::new(0),
+            flights: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    fn claim_flight(&self, key: InternalCacheKey) -> Result<FlightClaim> {
+        let mut flights = self.flights.lock().map_err(|_| {
+            Error::internal("cache flight registry mutex poisoned while claiming owner")
+        })?;
+        // Do not inspect flight.state while holding the registry lock. Owners
+        // complete with state -> registry order, so claim must only take the
+        // registry lock to avoid lock-order inversions.
+        if let Some(flight) = flights.get(&key).cloned() {
+            return Ok(FlightClaim::Waiter(flight));
+        }
+
+        let flight = Arc::new(CacheFlight::new());
+        flights.insert(key.clone(), flight.clone());
+        Ok(FlightClaim::Owner(FlightOwner {
+            key,
+            flight,
+            flights: self.flights.clone(),
+            completed: false,
+        }))
     }
 }
 
@@ -77,38 +210,212 @@ impl CacheBackend for MokaCacheBackend {
         loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
         _codec: Option<CacheCodec>,
     ) -> Result<(CacheEntry, bool)> {
-        // Use moka's built-in dedup: optionally_get_with runs the init future
-        // at most once per key, even under concurrent access.
-        let (error_tx, error_rx) = tokio::sync::oneshot::channel();
+        let mut loader = Some(loader);
 
-        // Track whether the loader actually ran (= cache miss).
-        let was_miss = Arc::new(AtomicBool::new(false));
-        let was_miss_clone = was_miss.clone();
+        loop {
+            if let Some(record) = self.cache.get(key).await {
+                return Ok((record.entry, true));
+            }
 
-        let init = async move {
-            was_miss_clone.store(true, Ordering::Relaxed);
-            match loader.await {
-                Ok((entry, size_bytes)) => Some(MokaCacheEntry { entry, size_bytes }),
-                Err(e) => {
-                    let _ = error_tx.send(e);
-                    None
+            match self.claim_flight(key.clone())? {
+                FlightClaim::Owner(mut owner) => {
+                    if let Some(record) = self.cache.get(key).await {
+                        owner.complete(record.clone())?;
+                        return Ok((record.entry, true));
+                    }
+
+                    let Some(loader) = loader.take() else {
+                        owner.retry()?;
+                        return Err(crate::Error::internal(
+                            "single-key cache loader already consumed",
+                        ));
+                    };
+                    let (entry, size_bytes) = match loader.await {
+                        Ok(loaded) => loaded,
+                        Err(err) => {
+                            owner.retry()?;
+                            return Err(err);
+                        }
+                    };
+                    let record = MokaCacheEntry { entry, size_bytes };
+                    self.cache.insert(key.clone(), record.clone()).await;
+                    owner.complete(record.clone())?;
+                    return Ok((record.entry, false));
+                }
+                FlightClaim::Waiter(flight) => match flight.wait().await? {
+                    FlightState::Ready(record) => return Ok((record.entry, true)),
+                    FlightState::Retry => {}
+                    FlightState::Loading => {
+                        return Err(Error::internal(format!(
+                            "cache flight wait returned loading state for key: prefix='{}', key='{}', type='{}'",
+                            key.prefix(),
+                            key.key(),
+                            key.type_name()
+                        )));
+                    }
+                },
+            }
+        }
+    }
+
+    async fn get_or_insert_many<'a>(
+        &self,
+        keys: Vec<InternalCacheKey>,
+        loader: CacheBatchLoader<'a>,
+        _codec: Option<CacheCodec>,
+    ) -> Result<Vec<CacheBatchEntry>> {
+        validate_unique_keys(&keys)?;
+
+        // This override keeps the loader batched for owned missing keys while
+        // still coordinating per-key single-flight with single-key callers. The
+        // HashMaps/Vectors below are per-request state bounded by the input
+        // batch and current in-flight overlap; they are not retained in the
+        // cache after this call completes and are not part of cache capacity
+        // accounting.
+        let mut remaining = keys.clone();
+        let mut results = HashMap::with_capacity(keys.len());
+
+        while !remaining.is_empty() {
+            let remaining_len = remaining.len();
+            let mut owners = HashMap::with_capacity(remaining_len);
+            let mut owner_keys = Vec::with_capacity(remaining_len);
+            let mut waiters = Vec::with_capacity(remaining_len);
+
+            for key in remaining {
+                if let Some(record) = self.cache.get(&key).await {
+                    results.insert(
+                        key.clone(),
+                        CacheBatchEntry {
+                            key,
+                            entry: record.entry,
+                            was_cached: true,
+                        },
+                    );
+                    continue;
+                }
+
+                match self.claim_flight(key.clone())? {
+                    FlightClaim::Owner(owner) => {
+                        owner_keys.push(key.clone());
+                        owners.insert(key, owner);
+                    }
+                    FlightClaim::Waiter(flight) => {
+                        waiters.push((key, flight));
+                    }
                 }
             }
-        };
 
-        let owned_key = key.clone();
-        match self.cache.optionally_get_with(owned_key, init).await {
-            Some(record) => {
-                let was_cached = !was_miss.load(Ordering::Relaxed);
-                Ok((record.entry, was_cached))
+            let mut loader_keys = Vec::with_capacity(owner_keys.len());
+            for key in owner_keys {
+                if let Some(record) = self.cache.get(&key).await {
+                    let mut owner = owners.remove(&key).ok_or_else(|| {
+                        Error::internal(format!(
+                            "owned cache flight missing for cache-hit owner key: prefix='{}', key='{}', type='{}'",
+                            key.prefix(),
+                            key.key(),
+                            key.type_name()
+                        ))
+                    })?;
+                    owner.complete(record.clone())?;
+                    results.insert(
+                        key.clone(),
+                        CacheBatchEntry {
+                            key,
+                            entry: record.entry,
+                            was_cached: true,
+                        },
+                    );
+                } else {
+                    loader_keys.push(key);
+                }
             }
-            None => match error_rx.await {
-                Ok(err) => Err(err),
-                Err(_) => Err(crate::Error::internal(
-                    "Failed to retrieve error from cache loader",
-                )),
-            },
+
+            if !loader_keys.is_empty() {
+                match loader(loader_keys.clone()).await {
+                    Ok(loaded) => {
+                        let mut loaded = validate_loaded_entries(&loader_keys, loaded)?;
+                        for key in loader_keys {
+                            let loaded = loaded.remove(&key).ok_or_else(|| {
+                                Error::internal(format!(
+                                    "validated batch loader result missing owner key: prefix='{}', key='{}', type='{}'",
+                                    key.prefix(),
+                                    key.key(),
+                                    key.type_name()
+                                ))
+                            })?;
+                            let record = MokaCacheEntry {
+                                entry: loaded.entry,
+                                size_bytes: loaded.size_bytes,
+                            };
+                            self.cache.insert(key.clone(), record.clone()).await;
+                            let mut owner = owners.remove(&key).ok_or_else(|| {
+                                Error::internal(format!(
+                                    "owned cache flight missing for loaded key: prefix='{}', key='{}', type='{}'",
+                                    key.prefix(),
+                                    key.key(),
+                                    key.type_name()
+                                ))
+                            })?;
+                            owner.complete(record.clone())?;
+                            results.insert(
+                                key.clone(),
+                                CacheBatchEntry {
+                                    key,
+                                    entry: record.entry,
+                                    was_cached: false,
+                                },
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        for (_, mut owner) in owners {
+                            owner.retry()?;
+                        }
+                        return Err(err);
+                    }
+                }
+            }
+
+            let mut retry_keys = Vec::new();
+            for (key, flight) in waiters {
+                match flight.wait().await? {
+                    FlightState::Ready(record) => {
+                        results.insert(
+                            key.clone(),
+                            CacheBatchEntry {
+                                key,
+                                entry: record.entry,
+                                was_cached: true,
+                            },
+                        );
+                    }
+                    FlightState::Retry => retry_keys.push(key),
+                    FlightState::Loading => {
+                        return Err(Error::internal(format!(
+                            "cache flight wait returned loading state for key: prefix='{}', key='{}', type='{}'",
+                            key.prefix(),
+                            key.key(),
+                            key.type_name()
+                        )));
+                    }
+                }
+            }
+
+            remaining = retry_keys;
         }
+
+        keys.into_iter()
+            .map(|key| {
+                results.remove(&key).ok_or_else(|| {
+                    Error::internal(format!(
+                        "batch cache result missing for input key: prefix='{}', key='{}', type='{}'",
+                        key.prefix(),
+                        key.key(),
+                        key.type_name()
+                    ))
+                })
+            })
+            .collect()
     }
 
     async fn invalidate_prefix(&self, prefix: &str) {


### PR DESCRIPTION
## Feature

### What is the new feature?

This adds backend-level batch get-or-insert support to Lance cache primitives.

The new API allows callers to provide one batch loader for multiple missing keys while preserving backend-owned per-key single-flight semantics. This is intended as cache-layer groundwork for callers such as coalesced BTree page reads, where we need both:

- coalesced loading: one loader can load multiple missing pages together
- single-flight: concurrent cold overlapping requests do not duplicate loading for the same key

Related to #6759.

### Why do we need this feature?

`CacheBackend::get_or_insert` currently supports one key at a time. That works for single-key cache misses because the backend can deduplicate concurrent loaders for the same key.

For batch-oriented callers, neither existing pattern provides both desired properties:

- calling single-key `get_or_insert` in a loop preserves single-flight, but loses batch/coalesced loading
- doing manual `get` + batch load + `insert` preserves batch loading, but bypasses backend single-flight

Under concurrent cold overlapping range reads, the manual batch pattern can duplicate page IO and materialization for the same logical cache keys.

### How does it work?

- Adds low-level batch cache types and API:
  - `CacheLoadedEntry`
  - `CacheBatchEntry`
  - `CacheBatchLoader`
  - `CacheBackend::get_or_insert_many`
- Adds typed cache APIs:
  - `LanceCache::get_or_insert_with_key_batch`
  - `WeakLanceCache::get_or_insert_with_key_batch`
  - `CacheBatchValue<T>`
- Implements true batch single-flight in `MokaCacheBackend`.
- Uses one shared in-flight registry for both single-key and batch get-or-insert paths, so mixed callers still coalesce on the same key.
- Ensures the batch loader only receives missing keys currently owned by this caller.
- Preserves input key order in returned values.
- Rejects duplicate input keys with `InvalidInput`.
- Validates loader output exactly:
  - missing returned key => `InvalidInput`
  - extra returned key => `InvalidInput`
  - duplicate returned key => `InvalidInput`
- Clarifies `was_cached` semantics:
  - `true` means this call did not run the loader for that key
  - this includes ordinary cache hits and values produced by another in-flight owner
- Keeps the default trait implementation as a compatibility fallback that calls single-key `get_or_insert` one key at a time.

### Compatibility

This is an additive cache API change.

Existing single-key `get_or_insert` behavior remains compatible. The default `get_or_insert_many` implementation preserves existing backend single-key semantics for custom backends, but does not preserve coalesced batch loading unless a backend overrides it.

This PR does not change BTree query logic directly. It only adds the cache primitive needed by future multi-page miss paths.

## Testing

Local verification run on commit `50dd286d2`:

- `cargo fmt --all -- --check`
- `cargo test -p lance-core cache`
  - 38 passed
- `cargo test -p lance-core --doc cache`
  - 3 passed, 2 ignored
- `cargo test -p lance-core --bench cache_batch -- --test`
  - all benchmark scenarios reported `Success`
- `cargo clippy -p lance-core --all-targets -- -D warnings`
- `cargo bench -p lance-core --bench cache_batch -- --noplot`

## Benchmarks

These are cache primitive microbenchmarks, not end-to-end BTree or object-store benchmarks. They intentionally use small `usize` values and cheap / yielding loaders so the cache coordination overhead and duplicate-load behavior are visible.

Benchmark environment:

- MacBook Pro, Apple M1 Pro, 16 GiB memory
- macOS 15.6, arm64
- Rust 1.94.0
- Command: `cargo bench -p lance-core --bench cache_batch -- --noplot`
- Criterion config: sample size 10, 100 ms warmup, 250 ms measurement time

Each row runs multiple concurrent tasks against the same cache. `Batch size`
is the number of keys requested by each task. `Concurrent tasks` is the number
of simultaneous cache callers. `Key overlap` controls how many keys are shared
across those concurrent callers.

`Actual loads` counts how many entries were actually produced by loaders across
all concurrent tasks. Lower load counts indicate less duplicate cold-miss work.

| Batch size | Concurrent tasks | Key overlap | Loader | Actual loads: single / manual / new batch | Single-key loop | Manual get + batch load + insert | Batch get_or_insert_many | New vs manual |
|---:|---:|---:|---|---:|---:|---:|---:|---:|
| 64 | 8 | 50% | cheap | 288 / 512 / 288 | 0.961 ms | 0.843 ms | 1.258 ms | 1.49x |
| 64 | 8 | 100% | cheap | 64 / 512 / 64 | 0.395 ms | 0.851 ms | 0.702 ms | 0.82x |
| 64 | 8 | 50% | yield_once | 288 / 512 / 288 | 1.269 ms | 0.827 ms | 1.335 ms | 1.61x |
| 64 | 8 | 100% | yield_once | 64 / 512 / 64 | 0.660 ms | 0.936 ms | 0.718 ms | 0.77x |
| 8 | 32 | 50% | cheap | 132 / 256 / 132 | 0.523 ms | 0.532 ms | 0.625 ms | 1.18x |
| 64 | 8 | 0% | cheap | n/a / 512 / 512 | n/a | 0.671 ms | 1.815 ms | 2.71x |
| 64 | 8 | 0% | yield_once | n/a / 512 / 512 | n/a | 0.700 ms | 1.894 ms | 2.71x |
| 512 | 32 | 0% | cheap | n/a / 16384 / 16384 | n/a | 20.414 ms | 61.045 ms | 2.99x |

Interpretation:

- The new batch API is not intended to be a universal faster path for cheap disjoint misses.
- In no-overlap scenarios, it has expected overhead from per-key flight coordination, validation, and result ordering.
- The value is semantic: overlapping cold batch requests preserve batch/coalesced loading while avoiding duplicate loads for shared keys.
- In full-overlap scenarios, the new batch API avoids the duplicate work in the manual `get` + load + `insert` pattern and is faster in this microbenchmark.
- The single-key loop still has strong single-flight behavior, but it cannot give a multi-key loader the full missing-key set for coalesced IO.