### PR TITLE
fix(index): accept large_string (LargeUtf8) for BTREE and ZONEMAP scalar indices

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3098,7 +3098,21 @@ class LanceDataset(pa.dataset.Dataset):
             if hasattr(field_type, "storage_type"):
                 field_type = field_type.storage_type
 
-            if index_type in ["BTREE", "BITMAP", "ZONEMAP"]:
+            if index_type in ["BTREE", "ZONEMAP"]:
+                if (
+                    not pa.types.is_integer(field_type)
+                    and not pa.types.is_floating(field_type)
+                    and not pa.types.is_boolean(field_type)
+                    and not pa.types.is_string(field_type)
+                    and not pa.types.is_large_string(field_type)
+                    and not pa.types.is_temporal(field_type)
+                    and not pa.types.is_fixed_size_binary(field_type)
+                ):
+                    raise TypeError(
+                        f"BTREE/ZONEMAP index column {column} must be int",
+                        ", float, bool, str, large_str, fixed-size-binary, or temporal ",
+                    )
+            elif index_type == "BITMAP":
                 if (
                     not pa.types.is_integer(field_type)
                     and not pa.types.is_floating(field_type)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3110,7 +3110,7 @@ class LanceDataset(pa.dataset.Dataset):
                 ):
                     raise TypeError(
                         f"BTREE/ZONEMAP index column {column} must be int",
-                        ", float, bool, str, large_str, fixed-size-binary, or temporal ",
+                        ", float, bool, str, large_str, fixed-size-binary, or temporal",
                     )
             elif index_type == "BITMAP":
                 if (

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3098,7 +3098,7 @@ class LanceDataset(pa.dataset.Dataset):
             if hasattr(field_type, "storage_type"):
                 field_type = field_type.storage_type
 
-            if index_type in ["BTREE", "ZONEMAP"]:
+            if index_type in ["BTREE", "BITMAP", "ZONEMAP"]:
                 if (
                     not pa.types.is_integer(field_type)
                     and not pa.types.is_floating(field_type)
@@ -3109,21 +3109,8 @@ class LanceDataset(pa.dataset.Dataset):
                     and not pa.types.is_fixed_size_binary(field_type)
                 ):
                     raise TypeError(
-                        f"BTREE/ZONEMAP index column {column} must be int",
+                        f"BTREE/BITMAP/ZONEMAP index column {column} must be int",
                         ", float, bool, str, large_str, fixed-size-binary, or temporal",
-                    )
-            elif index_type == "BITMAP":
-                if (
-                    not pa.types.is_integer(field_type)
-                    and not pa.types.is_floating(field_type)
-                    and not pa.types.is_boolean(field_type)
-                    and not pa.types.is_string(field_type)
-                    and not pa.types.is_temporal(field_type)
-                    and not pa.types.is_fixed_size_binary(field_type)
-                ):
-                    raise TypeError(
-                        f"BITMAP index column {column} must be int",
-                        ", float, bool, str, fixed-size-binary, or temporal",
                     )
             elif index_type == "LABEL_LIST":
                 if not pa.types.is_list(field_type):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3122,8 +3122,8 @@ class LanceDataset(pa.dataset.Dataset):
                     and not pa.types.is_fixed_size_binary(field_type)
                 ):
                     raise TypeError(
-                        f"BTREE/BITMAP index column {column} must be int",
-                        ", float, bool, str, fixed-size-binary, or temporal ",
+                        f"BITMAP index column {column} must be int",
+                        ", float, bool, str, fixed-size-binary, or temporal",
                     )
             elif index_type == "LABEL_LIST":
                 if not pa.types.is_list(field_type):

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -5124,7 +5124,7 @@ def test_vector_filter_fts_search(tmp_path):
 
 @pytest.mark.parametrize("index_type", ["BTREE", "BITMAP", "ZONEMAP"])
 def test_large_string_scalar_index(tmp_path, index_type):
-    """large_string (Arrow LargeUtf8) columns must be accepted by BTREE and ZONEMAP."""
+    """large_string (LargeUtf8) must be accepted by BTREE, BITMAP, and ZONEMAP."""
     table = pa.table(
         {
             "id": pa.array([1, 2, 3], pa.int32()),

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -5122,7 +5122,7 @@ def test_vector_filter_fts_search(tmp_path):
         scanner.to_table()
 
 
-@pytest.mark.parametrize("index_type", ["BTREE", "ZONEMAP"])
+@pytest.mark.parametrize("index_type", ["BTREE", "BITMAP", "ZONEMAP"])
 def test_large_string_scalar_index(tmp_path, index_type):
     """large_string (Arrow LargeUtf8) columns must be accepted by BTREE and ZONEMAP."""
     table = pa.table(

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -5120,3 +5120,28 @@ def test_vector_filter_fts_search(tmp_path):
     )
     with pytest.raises(ValueError):
         scanner.to_table()
+
+
+@pytest.mark.parametrize("index_type", ["BTREE", "ZONEMAP"])
+def test_large_string_scalar_index(tmp_path, index_type):
+    """large_string (Arrow LargeUtf8) columns must be accepted by BTREE and ZONEMAP."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], pa.int32()),
+            "category": pa.array(["alpha", "beta", "alpha"], pa.large_string()),
+        }
+    )
+    ds = lance.write_dataset(table, tmp_path)
+    assert ds.schema.field("category").type == pa.large_string()
+
+    # Must not raise TypeError
+    ds.create_scalar_index("category", index_type=index_type)
+
+    indices = ds.describe_indices()
+    assert any(
+        "category" in idx.field_names for idx in indices
+    ), f"{index_type} index for large_string column not found in describe_indices()"
+
+    result = ds.scanner(filter="category = 'alpha'").to_table()
+    assert result.num_rows == 2
+    assert set(result.column("id").to_pylist()) == {1, 3}

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -5138,9 +5138,9 @@ def test_large_string_scalar_index(tmp_path, index_type):
     ds.create_scalar_index("category", index_type=index_type)
 
     indices = ds.describe_indices()
-    assert any(
-        "category" in idx.field_names for idx in indices
-    ), f"{index_type} index for large_string column not found in describe_indices()"
+    assert any("category" in idx.field_names for idx in indices), (
+        f"{index_type} index for large_string column not found in describe_indices()"
+    )
 
     result = ds.scanner(filter="category = 'alpha'").to_table()
     assert result.num_rows == 2


### PR DESCRIPTION
## Summary

Fixes #7524

Daft's `DataType::Utf8` always exports to Arrow `LargeUtf8`, so Lance tables written by Daft have `large_string` columns. The Python type-guard in `create_scalar_index()` only called `pa.types.is_string()` (Arrow `Utf8`), causing a `TypeError` before the Rust layer was reached:

```
TypeError: ('BTREE/BITMAP index column category must be int',
            ', float, bool, str, fixed-size-binary, or temporal ')
```

The Lance Rust layer already handles `LargeUtf8` for both index types:
- `lance-index/src/scalar/btree.rs` – explicit `LargeUtf8` branch in query path (with dedicated test at line 3825)
- `lance-index/src/scalar/zonemap.rs` – `LargeUtf8` handled in scan path

**Changes:**

- Split the combined `BTREE/BITMAP/ZONEMAP` validation block:
  - `BTREE` and `ZONEMAP`: add `pa.types.is_large_string()` to accepted types
  - `BITMAP`: keep existing stricter check (Rust-side `LargeUtf8` support not yet verified)
- Update the `TypeError` message for `BTREE/ZONEMAP` to mention `large_str`
- Add `test_large_string_scalar_index` parametrized over `["BTREE", "ZONEMAP"]`:
  - Writes a `pa.large_string()` column via `lance.write_dataset`
  - Asserts index creation succeeds
  - Asserts `describe_indices()` lists the index
  - Asserts `scanner(filter=...)` returns correct rows

## Test plan

- [x] `uv run pytest python/tests/test_scalar_index.py::test_large_string_scalar_index -v` — 2 passed
- [x] End-to-end with Daft 0.7.16: Daft writes `large_string` column → `create_scalar_index("BTREE")` / `create_scalar_index("ZONEMAP")` → filter query returns correct results
- [x] `uv run make lint` (no new warnings)