### PR TITLE
docs: document read_blobs for blob payload reads

### DIFF
--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -1,7 +1,9 @@
 # Blob Columns
 
 Lance supports large binary objects (images, videos, audio, model artifacts) through blob columns.
-Blob access is lazy: reads return `BlobFile` handles so callers can stream bytes on demand.
+Blob columns support both planned full-payload reads and lazy file-like access.
+For data loaders and batch processing that need complete byte payloads, use `read_blobs`.
+Use `take_blobs` when you need a `BlobFile` handle for streaming, seeking, or partial reads.
 
 ![Blob](../images/blob.png)
 
@@ -35,9 +37,8 @@ table = pa.table(
 
 ds = lance.write_dataset(table, "./blobs_v22.lance", data_storage_version="2.2")
 
-blob = ds.take_blobs("blob", indices=[0])[0]
-with blob as f:
-    assert f.read() == b"hello blob v2"
+_row_address, payload = ds.read_blobs("blob", indices=[0])[0]
+assert payload == b"hello blob v2"
 ```
 
 ## Version Compatibility (Single Source of Truth)
@@ -160,8 +161,20 @@ ds = lance.write_dataset(
 
 ## Blob v2 Read Patterns
 
-Use `take_blobs` to fetch file-like handles.
-Exactly one selector must be provided: `ids`, `indices`, or `addresses`.
+Choose the read API based on the payload shape you want:
+
+| API | Returns | Use When |
+|---|---|---|
+| `read_blobs` | `List[Tuple[int, bytes]]` | You need complete blob payloads in memory, such as training loaders or batch preprocessing. |
+| `take_blobs` | `List[BlobFile]` | You need file-like objects for streaming, seeking, or partial reads. |
+| `scanner(..., blob_handling="all_binary")` | Arrow binary columns | You want blob columns in a scan result or `pyarrow.Table`. |
+
+Do not wrap `take_blobs` in your own thread pool just to call `read()` or
+`readall()` on every blob. Use `read_blobs` instead; it plans and executes
+batched blob reads through Lance's scheduler.
+
+Exactly one selector must be provided to `read_blobs` or `take_blobs`: `ids`,
+`indices`, or `addresses`.
 
 | Selector | Typical Use | Stability |
 |---|---|---|
@@ -169,7 +182,49 @@ Exactly one selector must be provided: `ids`, `indices`, or `addresses`.
 | `ids` | Logical row-id based reads | Stable logical identity (when row ids are available) |
 | `addresses` | Low-level physical reads and debugging | Unstable physical location |
 
-### Read by row indices
+### Read complete payloads by row indices
+
+```python
+import lance
+
+ds = lance.dataset("./blobs_v22.lance")
+rows = ds.read_blobs("blob", indices=[0, 1])
+payloads = [payload for _row_address, payload in rows]
+```
+
+### Read complete payloads by row ids
+
+```python
+import lance
+
+ds = lance.dataset("./blobs_v22.lance")
+row_ids = ds.to_table(columns=[], with_row_id=True).column("_rowid").to_pylist()
+
+rows = ds.read_blobs("blob", ids=row_ids[:2])
+```
+
+### Read complete payloads by row addresses
+
+```python
+import lance
+
+ds = lance.dataset("./blobs_v22.lance")
+row_addrs = ds.to_table(columns=[], with_row_address=True).column("_rowaddr").to_pylist()
+
+rows = ds.read_blobs("blob", addresses=row_addrs[:2])
+```
+
+### Read blob columns as Arrow binary
+
+```python
+import lance
+
+ds = lance.dataset("./blobs_v22.lance")
+table = ds.scanner(columns=["blob"], blob_handling="all_binary").to_table()
+payloads = table.column("blob").to_pylist()
+```
+
+### Open file-like blob handles lazily
 
 ```python
 import lance
@@ -178,29 +233,7 @@ ds = lance.dataset("./blobs_v22.lance")
 blobs = ds.take_blobs("blob", indices=[0, 1])
 
 with blobs[0] as f:
-    data = f.read()
-```
-
-### Read by row ids
-
-```python
-import lance
-
-ds = lance.dataset("./blobs_v22.lance")
-row_ids = ds.to_table(columns=[], with_row_id=True).column("_rowid").to_pylist()
-
-blobs = ds.take_blobs("blob", ids=row_ids[:2])
-```
-
-### Read by row addresses
-
-```python
-import lance
-
-ds = lance.dataset("./blobs_v22.lance")
-row_addrs = ds.to_table(columns=[], with_row_address=True).column("_rowaddr").to_pylist()
-
-blobs = ds.take_blobs("blob", addresses=row_addrs[:2])
+    header = f.read(1024)
 ```
 
 ### Example: decode video frames lazily
@@ -328,7 +361,7 @@ Fix:
 
 Cause:
 
-- `take_blobs` received none or multiple selectors.
+- `read_blobs` or `take_blobs` received none or multiple selectors.
 
 Fix:
 

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -1,21 +1,24 @@
 # Blob Columns
 
-Lance supports large binary objects (images, videos, audio, model artifacts) through blob columns.
+Lance stores large binary objects (images, videos, audio, model artifacts) in blob columns, where they are treated like any other column payload in the dataset.
 Blob columns support both planned full-payload reads and lazy file-like access.
-For data loaders and batch processing that need complete byte payloads, use `read_blobs`.
-Use `take_blobs` when you need a `BlobFile` handle for streaming, seeking, or partial reads.
+
+!!! tip "Choosing between `read_blobs` and `take_blobs`"
+    - For data loaders and batch processing that need complete byte payloads, use `read_blobs`.
+    - Use `take_blobs` when you need a `BlobFile` handle for streaming, seeking, or partial reads.
+
 
 ![Blob](../images/blob.png)
 
-## What This Page Covers
+See the sections below to explore the read and write access patterns in more detail.
 
-This page focuses on Python blob workflows and uses Lance file format terminology.
+## Quick Start: Blob v2
+
+This page focuses on blob workflows in Python and uses Lance file format terminology.
 
 - `data_storage_version` means the Lance **file format version** of a dataset.
 - A dataset's `data_storage_version` is fixed once the dataset is created.
 - If you need a different file format version, write a **new dataset**.
-
-## Quick Start (Blob v2)
 
 ```python
 import lance
@@ -41,18 +44,23 @@ _row_address, payload = ds.read_blobs("blob", indices=[0])[0]
 assert payload == b"hello blob v2"
 ```
 
-## Version Compatibility (Single Source of Truth)
+## Version Compatibility
+
+Blob support is tied to the dataset's file format version. Earlier file format versions
+(`< 2.2`) stored blobs using the `lance-encoding:blob` metadata field, while Blob
+v2 introduces a new storage layout that requires file format `>= 2.2`.
+
+The two
+schemes are mutually exclusive: for file format `>= 2.2`, legacy blob metadata
+(`lance-encoding:blob`) is rejected on write. The table below is the single
+source of truth for which scheme is supported at each `data_storage_version`.
 
 | Dataset `data_storage_version` | Legacy blob metadata (`lance-encoding:blob`) | Blob v2 (`lance.blob.v2`) |
 |---|---|---|
 | `0.1`, `2.0`, `2.1` | Supported for write/read | Not supported |
 | `2.2+` | Not supported for write | Supported for write/read (recommended) |
 
-Important:
-
-- For file format `>= 2.2`, legacy blob metadata (`lance-encoding:blob`) is rejected on write.
-
-## Blob v2 Write Patterns
+## Blob v2: Write Patterns
 
 Use `blob_field` and `blob_array` to build blob v2 columns.
 
@@ -159,7 +167,7 @@ ds = lance.write_dataset(
 )
 ```
 
-## Blob v2 Read Patterns
+## Blob v2: Read Patterns
 
 Choose the read API based on the payload shape you want:
 
@@ -262,10 +270,10 @@ with av.open(blob) as container:
         pass
 ```
 
-## Legacy Compatibility Appendix (`data_storage_version` <= `2.1`)
+## Legacy Compatibility (`data_storage_version` <= `2.1`)
 
 If you need to keep writing legacy blob columns, use file format `0.1`, `2.0`, or `2.1`
-and mark `LargeBinary` fields with `lance-encoding:blob = true`.
+and mark `LargeBinary` fields with a metadata kwarg `"lance-encoding:blob": true`.
 
 ```python
 import lance
@@ -295,12 +303,12 @@ ds = lance.write_dataset(
 )
 ```
 
-This write pattern is invalid for `data_storage_version >= 2.2`.
-For new datasets, prefer blob v2.
+As mentioned above, this write pattern is invalid for `data_storage_version >= 2.2`.
+For new datasets, it's recommended to use Lance file format 2.2, which uses blob v2 by default.
 
 ## Rewrite to a New Blob v2 Dataset
 
-If your current dataset is legacy blob and you want blob v2, rewrite into a new dataset with `data_storage_version="2.2"`.
+If your current dataset consists of legacy blobs (stored in file formats <2.2) and you want to opt in to blob v2, you must rewrite it as a new dataset with `data_storage_version="2.2"`.
 
 ```python
 import lance
@@ -330,39 +338,23 @@ lance.write_dataset(
 )
 ```
 
-Warning:
-
-- The example above materializes binary payloads in memory (`blob_handling="all_binary"` and `to_pylist()`).
-- For large datasets, prefer chunked/batched rewrite pipelines.
+!!! warning
+    - The example above materializes binary payloads in memory (`blob_handling="all_binary"` and `to_pylist()`).
+    - For large datasets, prefer chunked/batched rewrite pipelines.
 
 ## Troubleshooting
 
-### "Blob v2 requires file version >= 2.2"
+This section contains commonly noticed issues or errors, and explains how to address them.
 
-Cause:
+### Blob v2 requires file version >= 2.2
+**Cause**: You are writing blob v2 values into a dataset/file format below `2.2`.  
+**Fix**: Write to a dataset created with `data_storage_version="2.2"` (or newer).
 
-- You are writing blob v2 values into a dataset/file format below `2.2`.
+### Legacy blob columns ... are not supported for file version >= 2.2
+**Cause**: You are using legacy blob metadata (`lance-encoding:blob`) while writing `2.2+` data.  
+**Fix**: Replace legacy metadata-based columns with blob v2 columns (`blob_field` / `blob_array`).
 
-Fix:
 
-- Write to a dataset created with `data_storage_version="2.2"` (or newer).
-
-### "Legacy blob columns ... are not supported for file version >= 2.2"
-
-Cause:
-
-- You are using legacy blob metadata (`lance-encoding:blob`) while writing `2.2+` data.
-
-Fix:
-
-- Replace legacy metadata-based columns with blob v2 columns (`blob_field` / `blob_array`).
-
-### "Exactly one of ids, indices, or addresses must be specified"
-
-Cause:
-
-- `read_blobs` or `take_blobs` received none or multiple selectors.
-
-Fix:
-
-- Provide exactly one of `ids`, `indices`, or `addresses`.
+### Exactly one of ids, indices, or addresses must be specified
+**Cause**: `read_blobs` or `take_blobs` received none or multiple selectors.  
+**Fix**: Provide exactly one of `ids`, `indices`, or `addresses`.

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -347,11 +347,7 @@ lance.write_dataset(
 Not every binary column needs to be a blob column. Plain Arrow `binary`/`large_binary` stores bytes *inline*, interleaved with your other columns, which is simplest and fastest for really small blobs (e.g., thumbnail images). Using a blob column to store the binary payload makes sense when either of these holds:
 
 - **You need partial or streaming reads.** Inline binary is always read in full; there is no way to fetch a byte range without materializing the entire value. Blob columns expose `take_blobs` → `BlobFile` handles that seek and range-read, so you pay only for the bytes you touch.
-- **Your values are large (roughly 1 MB or more on average).** Large inline values hurt on both reads and writes:
-    - *Read amplification:* the payloads bloat the data file's pages, so scans of *other* columns must read past them to get at the lightweight fields.
-    - *Write amplification:* Lance rewrites data at file/fragment granularity, so any update, delete-and-rewrite, or compaction that touches a fragment copies its large inline payloads forward into the new version — even when those bytes never changed. The bigger the payload, the more bytes you rewrite per logical change.
-
-    A blob column keeps large payloads in separate `.blob` files that are referenced rather than re-copied, so the main column path stays lean and unrelated edits don't rewrite the heavy bytes.
+- **Your values are large (roughly 1 MB or more on average).** Operations that rewrite entire rows, such as compaction or some updates, must copy the large inline payloads forward into the new version — even when those bytes never changed. The bigger the payload, the more bytes you rewrite per logical change (write amplification). A blob column keeps large payloads in separate `.blob` files that are referenced rather than re-copied, so these operations don't rewrite the heavy bytes.
 
 !!! tip
     As a rule of thumb, if average payload size is below a few tens of KB and you only ever read whole values, plain inline binary is fine. Above ~1 MB, or any time you want file-like access, prefer a blob column. Blob v2 also tunes this automatically: by default it keeps payloads under 16 KiB inline, packs mid-sized payloads into shared `.blob` sidecars, and gives payloads over 2 MiB their own dedicated `.blob` file.

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -1,6 +1,6 @@
 # Blob Columns
 
-Lance stores large binary objects (images, videos, audio, model artifacts) in blob columns, where they are treated like any other column payload in the dataset.
+Lance can store large binary objects (images, videos, audio, model artifacts) in blob columns, where they are treated like any other column payload in the dataset.
 Blob columns support both planned full-payload reads and lazy file-like access.
 
 !!! tip "Choosing between `read_blobs` and `take_blobs`"
@@ -10,7 +10,7 @@ Blob columns support both planned full-payload reads and lazy file-like access.
 
 ![Blob](../images/blob.png)
 
-See the sections below to explore the read and write access patterns in more detail.
+If you're unsure about whether you need a blob column in the first place (and why it's useful), read the "[when to use blob column vs. inline binary](#when-to-use-a-blob-column-vs-inline-binary)" section below.
 
 ## Quick Start: Blob v2
 
@@ -341,6 +341,20 @@ lance.write_dataset(
 !!! warning
     - The example above materializes binary payloads in memory (`blob_handling="all_binary"` and `to_pylist()`).
     - For large datasets, prefer chunked/batched rewrite pipelines.
+
+## When to Use a Blob Column vs. Inline Binary
+
+Not every binary column needs to be a blob column. Plain Arrow `binary`/`large_binary` stores bytes *inline*, interleaved with your other columns, which is simplest and fastest for really small blobs (e.g., thumbnail images). Using a blob column to store the binary payload makes sense when either of these holds:
+
+- **You need partial or streaming reads.** Inline binary is always read in full; there is no way to fetch a byte range without materializing the entire value. Blob columns expose `take_blobs` → `BlobFile` handles that seek and range-read, so you pay only for the bytes you touch.
+- **Your values are large (roughly 1 MB or more on average).** Large inline values hurt on both reads and writes:
+    - *Read amplification:* the payloads bloat the data file's pages, so scans of *other* columns must read past them to get at the lightweight fields.
+    - *Write amplification:* Lance rewrites data at file/fragment granularity, so any update, delete-and-rewrite, or compaction that touches a fragment copies its large inline payloads forward into the new version — even when those bytes never changed. The bigger the payload, the more bytes you rewrite per logical change.
+
+    A blob column keeps large payloads in separate `.blob` files that are referenced rather than re-copied, so the main column path stays lean and unrelated edits don't rewrite the heavy bytes.
+
+!!! tip
+    As a rule of thumb, if average payload size is below a few tens of KB and you only ever read whole values, plain inline binary is fine. Above ~1 MB, or any time you want file-like access, prefer a blob column. Blob v2 also tunes this automatically: by default it keeps payloads under 16 KiB inline, packs mid-sized payloads into shared `.blob` sidecars, and gives payloads over 2 MiB their own dedicated `.blob` file.
 
 ## Troubleshooting
 

--- a/docs/src/guide/data_types.md
+++ b/docs/src/guide/data_types.md
@@ -32,7 +32,7 @@ Lance supports the full Apache Arrow type system. When writing data through Pyth
 
 ### Blob Type for Large Binary Objects
 
-Lance provides a specialized **Blob** type for efficiently storing and retrieving very large binary objects such as videos, images, audio files, or other multimedia content. Unlike regular binary columns, blobs support lazy loading, which means you can read portions of the data without loading everything into memory.
+Lance provides a specialized **Blob** type for efficiently storing and retrieving very large binary objects such as videos, images, audio files, or other multimedia content. Blob columns support planned full-payload reads as well as lazy file-like access for streaming, seeking, and partial reads.
 
 For new datasets, use blob v2 (`lance.blob.v2`) via `blob_field` and `blob_array`.
 
@@ -62,9 +62,7 @@ table = pa.table(
 )
 
 ds = lance.write_dataset(table, "./videos_v22.lance", data_storage_version="2.2")
-blob = ds.take_blobs("video", indices=[0])[0]
-with blob as f:
-    payload = f.read()
+_row_address, payload = ds.read_blobs("video", indices=[0])[0]
 ```
 
 For legacy compatibility (`data_storage_version <= 2.1`), you can still write blob columns using `LargeBinary` with `lance-encoding:blob=true`.
@@ -101,11 +99,18 @@ ds = lance.write_dataset(
 )
 ```
 
-To read blob data, use `take_blobs()` which returns file-like objects for lazy reading:
+To read complete blob payloads into memory, use `read_blobs()`:
+
+```python
+rows = ds.read_blobs("video", indices=[0])
+_row_address, payload = rows[0]
+```
+
+Use `take_blobs()` only when you need file-like objects for lazy, partial, or seek-based reading:
 
 ```python
 # Retrieve blob as a file-like object (lazy loading)
-blobs = ds.take_blobs("video", ids=[0])
+blobs = ds.take_blobs("video", indices=[0])
 
 # Use with libraries that accept file-like objects
 import av  # pip install av

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -273,9 +273,11 @@ class BlobColumn:
     file-like objects.
 
     This can be useful for working with medium-to-small binary objects that need
-    to interface with APIs that expect file-like objects.  For very large binary
-    objects (4-8MB or more per value) you might be better off creating a blob column
-    and using :py:meth:`lance.Dataset.take_blobs` to access the blob data.
+    to interface with APIs that expect file-like objects. For very large binary
+    objects (4-8MB or more per value) you might be better off creating a blob
+    column. Use :py:meth:`lance.Dataset.read_blobs` when you need complete blob
+    bytes, or :py:meth:`lance.Dataset.take_blobs` when you need lazy file-like
+    access.
     """
 
     def __init__(self, blob_column: Union[pa.Array, pa.ChunkedArray]):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2122,6 +2122,10 @@ class LanceDataset(pa.dataset.Dataset):
         this API allows you to open binary blob data as a regular Python file-like
         object. For more details, see :py:class:`lance.BlobFile`.
 
+        If you plan to read each selected blob completely with ``read()`` or
+        ``readall()``, use :py:meth:`read_blobs` instead. It materializes blob
+        payloads with Lance's planned batched reader.
+
         Exactly one of ids, addresses, or indices must be specified.
 
         Parameters
@@ -2170,7 +2174,8 @@ class LanceDataset(pa.dataset.Dataset):
 
         Unlike :py:meth:`take_blobs`, which returns file-like :py:class:`lance.BlobFile`
         handles for random access, this API plans and executes batched reads and
-        returns materialized blob payloads.
+        returns materialized blob payloads. Use this API for training loaders,
+        batch preprocessing, and other workflows that need complete blob bytes.
 
         Exactly one of ids, addresses, or indices must be specified.
 


### PR DESCRIPTION
## Summary

This PR updates the blob documentation to make `read_blobs` the recommended path for workflows that need complete blob payloads in memory.

It also clarifies when to use `take_blobs` for lazy file-like access and when to use `scanner(..., blob_handling="all_binary")` for Arrow table scans.

## Context

Blob users were likely to discover `take_blobs` first and then manually parallelize `BlobFile.readall()` calls for batch loaders. Lance already has `read_blobs`, which plans and executes batched materialized blob reads, but the guide did not surface it as the primary API for full-payload reads.

## Validation

- `git diff --check`
- `uv run make lint` partially completed: Ruff format and Ruff lint passed.
- Pyright did not complete locally on macOS because the project installs `tensorflow` only through the Linux tests dependency marker; the remaining errors are existing unresolved `tensorflow` imports in `python/lance/arrow.py`, `python/lance/dependencies.py`, and `python/tests/test_arrow.py`.
- `make install` built the local `pylance` extension successfully, then failed at `pre-commit install` because this checkout inherits an existing `core.hooksPath` configuration.
