### PR TITLE
feat(io): publish object store metrics via the metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4876,8 @@ dependencies = [
  "lance-namespace",
  "lance-testing",
  "log",
+ "metrics",
+ "metrics-util",
  "mock_instant",
  "mockall",
  "moka",
@@ -5459,6 +5467,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "metrics",
+ "ordered-float 4.6.0",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5637,6 +5675,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -6275,6 +6322,15 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -6871,6 +6927,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6998,6 +7069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7115,6 +7196,24 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "rawpointer"
@@ -8247,6 +8346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8630,7 +8735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,8 @@ jieba-rs = { version = "0.10.0", default-features = false }
 jsonb = { version = "0.5.3", default-features = false, features = ["databend"] }
 libm = "0.2.15"
 log = "0.4"
+metrics = { version = "0.24" }
+metrics-util = { version = "0.19" }
 mockall = { version = "0.14.0" }
 mock_instant = { version = "0.6.0" }
 moka = { version = "0.12", features = ["future", "sync"] }

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -37,6 +37,7 @@ chrono.workspace = true
 futures.workspace = true
 http.workspace = true
 log.workspace = true
+metrics = { workspace = true, optional = true }
 moka.workspace = true
 pin-project.workspace = true
 prost.workspace = true
@@ -60,6 +61,7 @@ rstest.workspace = true
 mock_instant.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-mock = { workspace = true }
+metrics-util = { workspace = true }
 
 [[bench]]
 name = "scheduler"
@@ -67,6 +69,7 @@ harness = false
 
 [features]
 default = ["aws", "azure", "gcp"]
+metrics = ["dep:metrics"]
 gcs-test = []
 goosefs-test = []
 gcp = ["object_store/gcp", "dep:opendal", "opendal/services-gcs", "dep:object_store_opendal"]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -39,6 +39,8 @@ pub(crate) mod dynamic_credentials;
 #[cfg(any(feature = "oss", feature = "huggingface", feature = "tos"))]
 pub(crate) mod dynamic_opendal;
 mod list_retry;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod providers;
 pub mod storage_options;
 #[cfg(test)]

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -1,0 +1,625 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Publishes object store metrics via the [`metrics`] crate.
+//!
+//! The [`metrics`] facade lets downstream applications install any recorder
+//! (Prometheus, OpenTelemetry, etc.) without Lance depending on a specific
+//! backend. When no recorder is installed the calls are cheap no-ops.
+//!
+//! Two layers cooperate:
+//!
+//! * [`MeteredObjectStore`] wraps any [`object_store::ObjectStore`] and records
+//!   per-operation request counts, transferred bytes, latency, and errors. It
+//!   works for every store regardless of backend.
+//! * [`MeteringHttpConnector`] wraps the HTTP client used by the native cloud
+//!   stores (S3 / GCS / Azure) and records throttle responses (HTTP 429 / 503)
+//!   per attempt. Because `object_store`'s retry loop re-issues each request
+//!   through the [`HttpService`](object_store::client::HttpService), this sees
+//!   every retried throttle, which a store-level wrapper cannot observe.
+//!
+//! All metrics carry a `scheme` label (e.g. `s3`, `gs`, `azure`).
+
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult,
+    UploadPart,
+};
+
+/// Total number of object store requests, labelled by `operation` and `scheme`.
+const METRIC_REQUESTS: &str = "lance_object_store_requests_total";
+/// Total bytes transferred by object store requests, labelled by `operation` and `scheme`.
+const METRIC_BYTES: &str = "lance_object_store_request_bytes_total";
+/// Object store request latency in seconds, labelled by `operation` and `scheme`.
+const METRIC_DURATION: &str = "lance_object_store_request_duration_seconds";
+/// Total number of failed object store requests, labelled by `operation` and `scheme`.
+const METRIC_ERRORS: &str = "lance_object_store_errors_total";
+/// Total number of throttle responses (HTTP 429 / 503) seen at the HTTP layer,
+/// labelled by `status` and `scheme`. Counts every attempt, including retries.
+const METRIC_THROTTLE: &str = "lance_object_store_throttle_total";
+
+/// Record the outcome of a unary request: count, latency, bytes (on success), and errors.
+fn record_request<T>(
+    scheme: &str,
+    operation: &'static str,
+    start: Instant,
+    bytes: u64,
+    result: &OSResult<T>,
+) {
+    let elapsed = start.elapsed().as_secs_f64();
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+    metrics::histogram!(METRIC_DURATION, "operation" => operation, "scheme" => scheme.to_owned())
+        .record(elapsed);
+    match result {
+        Ok(_) => {
+            if bytes > 0 {
+                metrics::counter!(METRIC_BYTES, "operation" => operation, "scheme" => scheme.to_owned())
+                    .increment(bytes);
+            }
+        }
+        Err(_) => {
+            metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
+                .increment(1);
+        }
+    }
+}
+
+/// Record a single request count without latency, used for streaming operations
+/// (list / delete) whose work happens lazily as the stream is polled.
+fn record_count(scheme: &str, operation: &'static str) {
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+}
+
+fn record_error(scheme: &str, operation: &'static str) {
+    metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+}
+
+#[derive(Debug)]
+pub struct MeteredObjectStore {
+    target: Arc<dyn object_store::ObjectStore>,
+    scheme: String,
+}
+
+impl std::fmt::Display for MeteredObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MeteredObjectStore({})", self.target)
+    }
+}
+
+#[async_trait::async_trait]
+#[deny(clippy::missing_trait_methods)]
+impl object_store::ObjectStore for MeteredObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        bytes: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        let size = bytes.content_length() as u64;
+        let start = Instant::now();
+        let result = self.target.put_opts(location, bytes, opts).await;
+        record_request(&self.scheme, "put", start, size, &result);
+        result
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        let upload = self.target.put_multipart_opts(location, opts).await?;
+        Ok(Box::new(MeteredMultipartUpload {
+            target: upload,
+            scheme: self.scheme.clone(),
+        }))
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        // `head()` is implemented as a `get_opts` call with `head = true`, so we
+        // distinguish it here to keep HEAD and GET as separate operations.
+        let is_head = options.head;
+        let operation = if is_head { "head" } else { "get" };
+        let start = Instant::now();
+        let result = self.target.get_opts(location, options).await;
+        // A HEAD transfers only metadata, so it has no payload bytes.
+        let bytes = match &result {
+            Ok(res) if !is_head => res.range.end - res.range.start,
+            _ => 0,
+        };
+        record_request(&self.scheme, operation, start, bytes, &result);
+        result
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+        let start = Instant::now();
+        let result = self.target.get_ranges(location, ranges).await;
+        let bytes = match &result {
+            Ok(parts) => parts.iter().map(|b| b.len() as u64).sum(),
+            Err(_) => 0,
+        };
+        record_request(&self.scheme, "get", start, bytes, &result);
+        result
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        let scheme = self.scheme.clone();
+        self.target
+            .delete_stream(locations)
+            .map(move |result| {
+                match &result {
+                    Ok(_) => record_count(&scheme, "delete"),
+                    Err(_) => {
+                        record_count(&scheme, "delete");
+                        record_error(&scheme, "delete");
+                    }
+                }
+                result
+            })
+            .boxed()
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        record_count(&self.scheme, "list");
+        meter_list_stream(self.target.list(prefix), self.scheme.clone())
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        record_count(&self.scheme, "list");
+        meter_list_stream(
+            self.target.list_with_offset(prefix, offset),
+            self.scheme.clone(),
+        )
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        let start = Instant::now();
+        let result = self.target.list_with_delimiter(prefix).await;
+        record_request(&self.scheme, "list", start, 0, &result);
+        result
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+        let start = Instant::now();
+        let result = self.target.copy_opts(from, to, opts).await;
+        record_request(&self.scheme, "copy", start, 0, &result);
+        result
+    }
+
+    async fn rename_opts(&self, from: &Path, to: &Path, opts: RenameOptions) -> OSResult<()> {
+        let start = Instant::now();
+        let result = self.target.rename_opts(from, to, opts).await;
+        record_request(&self.scheme, "rename", start, 0, &result);
+        result
+    }
+}
+
+/// Count errors yielded while draining a list stream. The request itself is
+/// counted once when the stream is created (a single LIST may return many items).
+fn meter_list_stream(
+    stream: BoxStream<'static, OSResult<ObjectMeta>>,
+    scheme: String,
+) -> BoxStream<'static, OSResult<ObjectMeta>> {
+    stream
+        .map(move |result| {
+            if result.is_err() {
+                record_error(&scheme, "list");
+            }
+            result
+        })
+        .boxed()
+}
+
+#[derive(Debug)]
+struct MeteredMultipartUpload {
+    target: Box<dyn MultipartUpload>,
+    scheme: String,
+}
+
+#[async_trait::async_trait]
+impl MultipartUpload for MeteredMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
+        record_count(&self.scheme, "put");
+        metrics::counter!(METRIC_BYTES, "operation" => "put", "scheme" => self.scheme.clone())
+            .increment(data.content_length() as u64);
+        self.target.put_part(data)
+    }
+
+    async fn complete(&mut self) -> OSResult<PutResult> {
+        self.target.complete().await
+    }
+
+    async fn abort(&mut self) -> OSResult<()> {
+        self.target.abort().await
+    }
+}
+
+pub trait ObjectStoreMetricsExt {
+    /// Wrap this store so its operations publish metrics under the given `scheme` label.
+    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore>;
+}
+
+impl ObjectStoreMetricsExt for Arc<dyn object_store::ObjectStore> {
+    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(MeteredObjectStore {
+            target: self,
+            scheme,
+        })
+    }
+}
+
+// --- Layer 2: HTTP-level throttle metrics for native cloud stores ---
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+mod http {
+    use super::*;
+    use object_store::client::{
+        ClientOptions, HttpClient, HttpConnector, HttpError, HttpRequest, HttpResponse,
+        HttpService, ReqwestConnector,
+    };
+
+    /// An [`HttpConnector`] that records throttle responses observed by the
+    /// underlying HTTP client. Install it on the S3 / GCS / Azure builders via
+    /// `with_http_connector`.
+    #[derive(Debug)]
+    pub struct MeteringHttpConnector {
+        scheme: String,
+        inner: ReqwestConnector,
+    }
+
+    impl MeteringHttpConnector {
+        pub fn new(scheme: String) -> Self {
+            Self {
+                scheme,
+                inner: ReqwestConnector::default(),
+            }
+        }
+    }
+
+    impl HttpConnector for MeteringHttpConnector {
+        fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
+            let client = self.inner.connect(options)?;
+            Ok(HttpClient::new(MeteringHttpService {
+                scheme: self.scheme.clone(),
+                inner: client,
+            }))
+        }
+    }
+
+    #[derive(Debug)]
+    struct MeteringHttpService {
+        scheme: String,
+        inner: HttpClient,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpService for MeteringHttpService {
+        async fn call(&self, req: HttpRequest) -> Result<HttpResponse, HttpError> {
+            let response = self.inner.execute(req).await?;
+            let status = response.status();
+            // 429 (throttling) and 5xx (e.g. 503 service unavailable) are the
+            // statuses that drive object_store's retry loop. Each attempt that
+            // hits one is recorded with its numeric status, so 429 and 503 can
+            // be told apart.
+            if status.as_u16() == 429 || status.is_server_error() {
+                metrics::counter!(
+                    METRIC_THROTTLE,
+                    "status" => status.as_u16().to_string(),
+                    "scheme" => self.scheme.clone(),
+                )
+                .increment(1);
+            }
+            Ok(response)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use object_store::client::{HttpRequestBody, HttpResponseBody};
+
+        /// A mock [`HttpService`] that always responds with a fixed status code.
+        #[derive(Debug)]
+        struct StaticStatusService {
+            status: u16,
+        }
+
+        #[async_trait::async_trait]
+        impl HttpService for StaticStatusService {
+            async fn call(&self, _req: HttpRequest) -> Result<HttpResponse, HttpError> {
+                Ok(::http::Response::builder()
+                    .status(self.status)
+                    .body(HttpResponseBody::from(Bytes::new()))
+                    .unwrap())
+            }
+        }
+
+        fn request() -> HttpRequest {
+            ::http::Request::builder()
+                .method("GET")
+                .uri("http://example.com/obj")
+                .body(HttpRequestBody::empty())
+                .unwrap()
+        }
+
+        fn throttle_count(
+            metrics: &[(metrics::Key, DebugValue)],
+            scheme: &str,
+            status: &str,
+        ) -> u64 {
+            for (key, value) in metrics {
+                if key.name() != METRIC_THROTTLE {
+                    continue;
+                }
+                let labels: std::collections::HashMap<&str, &str> =
+                    key.labels().map(|l| (l.key(), l.value())).collect();
+                if labels.get("scheme") == Some(&scheme)
+                    && labels.get("status") == Some(&status)
+                    && let DebugValue::Counter(v) = value
+                {
+                    return *v;
+                }
+            }
+            0
+        }
+
+        #[test]
+        fn test_throttle_responses_counted_by_status() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+                rt.block_on(async {
+                    // Each attempt that object_store retries flows through `call`
+                    // again; here we simulate that by issuing several responses.
+                    for status in [429u16, 503, 503, 200, 404] {
+                        let service = MeteringHttpService {
+                            scheme: "s3".into(),
+                            inner: HttpClient::new(StaticStatusService { status }),
+                        };
+                        service.call(request()).await.unwrap();
+                    }
+                });
+            });
+
+            let recorded: Vec<_> = snapshotter
+                .snapshot()
+                .into_vec()
+                .into_iter()
+                .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
+                .collect();
+
+            assert_eq!(throttle_count(&recorded, "s3", "429"), 1);
+            assert_eq!(throttle_count(&recorded, "s3", "503"), 2);
+            // Success and non-retryable client errors are not throttles.
+            assert_eq!(throttle_count(&recorded, "s3", "200"), 0);
+            assert_eq!(throttle_count(&recorded, "s3", "404"), 0);
+        }
+    }
+}
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+pub use http::MeteringHttpConnector;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use object_store::memory::InMemory;
+    use object_store::{ObjectStoreExt, PutPayload};
+
+    fn payload(data: &[u8]) -> PutPayload {
+        PutPayload::from_bytes(Bytes::copy_from_slice(data))
+    }
+
+    fn metered_store() -> Arc<dyn object_store::ObjectStore> {
+        (Arc::new(InMemory::new()) as Arc<dyn object_store::ObjectStore>).metered("memory".into())
+    }
+
+    /// A single materialized snapshot of recorded metrics. It must be taken
+    /// only once: the snapshotter *drains* histogram samples on every
+    /// `snapshot()` call, so a second snapshot would see empty histograms.
+    type Metrics = Vec<(metrics::Key, DebugValue)>;
+
+    /// Run an async closure with a thread-local metrics recorder installed and
+    /// return the resulting metrics. Uses a current-thread runtime so all polls
+    /// happen on the thread that holds the recorder guard.
+    fn capture_metrics<F, Fut>(f: F) -> Metrics
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(f());
+        });
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
+            .collect()
+    }
+
+    fn key_matches(key: &metrics::Key, name: &str, labels: &[(&str, &str)]) -> bool {
+        if key.name() != name {
+            return false;
+        }
+        let actual: std::collections::HashSet<(&str, &str)> =
+            key.labels().map(|l| (l.key(), l.value())).collect();
+        labels.len() == actual.len() && labels.iter().all(|l| actual.contains(l))
+    }
+
+    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
+        for (key, value) in metrics {
+            if key_matches(key, name, labels)
+                && let DebugValue::Counter(v) = value
+            {
+                return *v;
+            }
+        }
+        0
+    }
+
+    fn histogram_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> usize {
+        for (key, value) in metrics {
+            if key_matches(key, name, labels)
+                && let DebugValue::Histogram(samples) = value
+            {
+                return samples.len();
+            }
+        }
+        0
+    }
+
+    #[test]
+    fn test_put_records_count_bytes_and_latency() {
+        let data = b"hello world";
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            store
+                .put(&Path::from("a/b.bin"), payload(data))
+                .await
+                .unwrap();
+        });
+
+        let labels = [("operation", "put"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &labels),
+            data.len() as u64
+        );
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+    }
+
+    #[test]
+    fn test_get_records_count_and_bytes() {
+        let data = b"hello world";
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(data)).await.unwrap();
+            store.get(&path).await.unwrap();
+        });
+
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &labels),
+            data.len() as u64
+        );
+    }
+
+    #[test]
+    fn test_head_is_a_separate_operation() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"hello world")).await.unwrap();
+            store.head(&path).await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "head"), ("scheme", "memory")]
+            ),
+            1
+        );
+        // The head call must not be counted as a get.
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "get"), ("scheme", "memory")]
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn test_delete_records_count_per_path() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"x")).await.unwrap();
+            store.delete(&path).await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "delete"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn test_list_counts_one_request_not_per_item() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            for i in 0..3 {
+                store
+                    .put(&Path::from(format!("a/{i}.bin")), payload(b"x"))
+                    .await
+                    .unwrap();
+            }
+            let _: Vec<_> = store.list(Some(&Path::from("a"))).collect().await;
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "list"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn test_error_is_counted() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            // Getting a missing object errors.
+            let _ = store.get(&Path::from("does/not/exist")).await;
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_ERRORS,
+                &[("operation", "get"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+}

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -259,6 +259,12 @@ impl ObjectStoreRegistry {
 
         store.inner = store.inner.traced();
 
+        #[cfg(feature = "metrics")]
+        {
+            use crate::object_store::metrics::ObjectStoreMetricsExt;
+            store.inner = store.inner.metered(store.scheme.clone());
+        }
+
         if let Some(wrapper) = &params.object_store_wrapper {
             store.inner = wrapper.wrap(&cache_path, store.inner);
         }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -89,6 +89,15 @@ impl AwsStoreProvider {
             .with_retry(retry_config)
             .with_region(region);
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -192,6 +192,15 @@ impl AzureBlobStoreProvider {
             builder = builder.with_credentials(credentials);
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -89,6 +89,15 @@ impl GcsStoreProvider {
             builder = builder.with_credentials(credential_provider);
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -160,6 +160,8 @@ tencent = ["lance-io/tencent"]
 goosefs = ["lance-io/goosefs"]
 tos = ["lance-io/tos"]
 huggingface = ["lance-io/huggingface"]
+# Publish object store metrics via the `metrics` crate.
+metrics = ["lance-io/metrics"]
 geo = ["lance-datafusion/geo", "lance-index/geo"]
 # Enable slow integration tests (disabled by default in CI)
 slow_tests = []


### PR DESCRIPTION
Adds an optional `metrics` feature to `lance-io` that publishes object store metrics through the [`metrics`](https://docs.rs/metrics) crate facade, so applications can wire them to Prometheus, OpenTelemetry, etc. without Lance depending on a specific backend. The feature is **off by default**.

Two layers cooperate:

- **`MeteredObjectStore`** wraps any `ObjectStore` and records per-operation request counts, transferred bytes, latency, and errors, labelled by `operation` (get/put/head/list/delete/copy/rename) and `scheme`. Works for every store regardless of backend.
  - `lance_object_store_requests_total{operation, scheme}`
  - `lance_object_store_request_bytes_total{operation, scheme}`
  - `lance_object_store_request_duration_seconds{operation, scheme}` (histogram)
  - `lance_object_store_errors_total{operation, scheme}`
- **`MeteringHttpConnector`** wraps the HTTP client used by the native cloud stores (S3 / GCS / Azure) via `with_http_connector`, and records throttle responses per attempt:
  - `lance_object_store_throttle_total{status, scheme}` — counts 429 / 5xx responses.

  Because object_store's retry loop re-issues each request through the `HttpService`, this observes **every retried 429/503 with its precise status code** — something a store-level wrapper cannot see, since object_store retries internally below the `ObjectStore` trait.

### Success criteria
- [x] Requests measured with counts, bytes, latency, and error count, across `operation` and `scheme` labels.
- [x] Retry/throttle counts separated by reason (429 vs 503) — stretch goal.
- [x] `metrics` is an optional dependency.

### Notes
- Opendal-backed stores (tos/oss/goosefs/tencent/hf) get the store-level metrics but not the HTTP-level throttle metrics, since they bypass object_store's HTTP client.
- Enable with `lance-io`'s (or `lance`'s) `metrics` feature.

Closes #7504

🤖 Generated with [Claude Code](https://claude.com/claude-code)