### PR TITLE
feat(io): publish object store metrics via the metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4876,8 @@ dependencies = [
  "lance-namespace",
  "lance-testing",
  "log",
+ "metrics",
+ "metrics-util",
  "mock_instant",
  "mockall",
  "moka",
@@ -5459,6 +5467,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "metrics",
+ "ordered-float 4.6.0",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5637,6 +5675,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -6275,6 +6322,15 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -6871,6 +6927,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6998,6 +7069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7115,6 +7196,24 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "rawpointer"
@@ -8247,6 +8346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8630,7 +8735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,8 @@ jieba-rs = { version = "0.10.0", default-features = false }
 jsonb = { version = "0.5.3", default-features = false, features = ["databend"] }
 libm = "0.2.15"
 log = "0.4"
+metrics = { version = "0.24" }
+metrics-util = { version = "0.19" }
 mockall = { version = "0.14.0" }
 mock_instant = { version = "0.6.0" }
 moka = { version = "0.12", features = ["future", "sync"] }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,7 +51,12 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      # Allow snippets to pull in files from the repo root (e.g. shared docs
+      # kept alongside Rust source). Paths are relative to the docs/ dir.
+      base_path:
+        - .
+        - ..
   - pymdownx.tabbed:
       alternate_style: true
   - attr_list

--- a/docs/src/guide/.pages
+++ b/docs/src/guide/.pages
@@ -6,6 +6,7 @@ nav:
   - JSON Support: json.md
   - Tags and Branches: tags_and_branches.md
   - Object Store Configuration: object_store.md
+  - Observability: observability.md
   - Distributed Write: distributed_write.md
   - Distributed Indexing: distributed_indexing.md
   - Migration Guide: migration.md

--- a/docs/src/guide/observability.md
+++ b/docs/src/guide/observability.md
@@ -1,0 +1,8 @@
+# Observability
+
+Lance can publish operational metrics to your monitoring stack. The table below
+is the authoritative catalogue of the metrics Lance emits, shared verbatim with
+the Rust [`lance::metrics`](https://docs.rs/lance/latest/lance/metrics/) module
+documentation.
+
+--8<-- "rust/lance/src/metrics.md"

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -37,6 +37,7 @@ chrono.workspace = true
 futures.workspace = true
 http.workspace = true
 log.workspace = true
+metrics = { workspace = true, optional = true }
 moka.workspace = true
 pin-project.workspace = true
 prost.workspace = true
@@ -60,6 +61,7 @@ rstest.workspace = true
 mock_instant.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-mock = { workspace = true }
+metrics-util = { workspace = true }
 
 [[bench]]
 name = "scheduler"
@@ -67,6 +69,7 @@ harness = false
 
 [features]
 default = ["aws", "azure", "gcp"]
+metrics = ["dep:metrics"]
 gcs-test = []
 goosefs-test = []
 gcp = ["object_store/gcp", "dep:opendal", "opendal/services-gcs", "dep:object_store_opendal"]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -39,6 +39,8 @@ pub(crate) mod dynamic_credentials;
 #[cfg(any(feature = "oss", feature = "huggingface", feature = "tos"))]
 pub(crate) mod dynamic_opendal;
 mod list_retry;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod providers;
 pub mod storage_options;
 #[cfg(test)]

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -10,8 +10,9 @@
 //! Two layers cooperate:
 //!
 //! * [`MeteredObjectStore`] wraps any [`object_store::ObjectStore`] and records
-//!   per-operation request counts, transferred bytes, latency, and errors. It
-//!   works for every store regardless of backend.
+//!   per-operation request counts, transferred bytes, latency, errors, and the
+//!   number of requests currently in flight. It works for every store
+//!   regardless of backend.
 //! * [`MeteringHttpConnector`] wraps the HTTP client used by the native cloud
 //!   stores (S3 / GCS / Azure) and records throttle responses (HTTP 429 / 503)
 //!   per attempt. Because `object_store`'s retry loop re-issues each request
@@ -51,6 +52,9 @@ const METRIC_ERRORS: &str = "lance_object_store_errors_total";
 /// Total number of throttle responses (HTTP 429 / 503) seen at the HTTP layer,
 /// labelled by `status` and `scheme`. Counts every attempt, including retries.
 const METRIC_THROTTLE: &str = "lance_object_store_throttle_total";
+/// Number of object store requests currently in flight, labelled by `operation`
+/// and `scheme`.
+const METRIC_IN_FLIGHT: &str = "lance_object_store_in_flight_requests";
 
 /// Record the outcome of a unary request: count, latency, bytes (on success), and errors.
 fn record_request<T>(
@@ -91,6 +95,32 @@ fn record_error(scheme: &str, operation: &'static str) {
         .increment(1);
 }
 
+/// Raises the in-flight gauge for an operation on creation and lowers it on
+/// drop, so the count stays balanced even if the request future or stream is
+/// cancelled or dropped before completing.
+struct InFlightGuard {
+    scheme: String,
+    operation: &'static str,
+}
+
+impl InFlightGuard {
+    fn new(scheme: &str, operation: &'static str) -> Self {
+        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => operation, "scheme" => scheme.to_owned())
+            .increment(1.0);
+        Self {
+            scheme: scheme.to_owned(),
+            operation,
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => self.operation, "scheme" => self.scheme.clone())
+            .decrement(1.0);
+    }
+}
+
 #[derive(Debug)]
 pub struct MeteredObjectStore {
     target: Arc<dyn object_store::ObjectStore>,
@@ -113,6 +143,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
         opts: PutOptions,
     ) -> OSResult<PutResult> {
         let size = bytes.content_length() as u64;
+        let _in_flight = InFlightGuard::new(&self.scheme, "put");
         let start = Instant::now();
         let result = self.target.put_opts(location, bytes, opts).await;
         record_request(&self.scheme, "put", start, size, &result);
@@ -136,6 +167,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
         // distinguish it here to keep HEAD and GET as separate operations.
         let is_head = options.head;
         let operation = if is_head { "head" } else { "get" };
+        let _in_flight = InFlightGuard::new(&self.scheme, operation);
         let start = Instant::now();
         let result = self.target.get_opts(location, options).await;
         // A HEAD transfers only metadata, so it has no payload bytes.
@@ -148,6 +180,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+        let _in_flight = InFlightGuard::new(&self.scheme, "get");
         let start = Instant::now();
         let result = self.target.get_ranges(location, ranges).await;
         let bytes = match &result {
@@ -163,9 +196,14 @@ impl object_store::ObjectStore for MeteredObjectStore {
         locations: BoxStream<'static, OSResult<Path>>,
     ) -> BoxStream<'static, OSResult<Path>> {
         let scheme = self.scheme.clone();
+        let in_flight = InFlightGuard::new(&self.scheme, "delete");
         self.target
             .delete_stream(locations)
             .map(move |result| {
+                // Reference `in_flight` so this `move` closure captures (owns)
+                // the guard, keeping the gauge raised until the stream is
+                // dropped (a move closure only captures the variables it uses).
+                let _in_flight = &in_flight;
                 // Each yielded path is one delete; failures additionally bump the error counter.
                 record_count(&scheme, "delete");
                 if result.is_err() {
@@ -178,7 +216,11 @@ impl object_store::ObjectStore for MeteredObjectStore {
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
         record_count(&self.scheme, "list");
-        meter_list_stream(self.target.list(prefix), self.scheme.clone())
+        meter_list_stream(
+            self.target.list(prefix),
+            self.scheme.clone(),
+            InFlightGuard::new(&self.scheme, "list"),
+        )
     }
 
     fn list_with_offset(
@@ -190,10 +232,12 @@ impl object_store::ObjectStore for MeteredObjectStore {
         meter_list_stream(
             self.target.list_with_offset(prefix, offset),
             self.scheme.clone(),
+            InFlightGuard::new(&self.scheme, "list"),
         )
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        let _in_flight = InFlightGuard::new(&self.scheme, "list");
         let start = Instant::now();
         let result = self.target.list_with_delimiter(prefix).await;
         record_request(&self.scheme, "list", start, 0, &result);
@@ -201,6 +245,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
     }
 
     async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+        let _in_flight = InFlightGuard::new(&self.scheme, "copy");
         let start = Instant::now();
         let result = self.target.copy_opts(from, to, opts).await;
         record_request(&self.scheme, "copy", start, 0, &result);
@@ -208,6 +253,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
     }
 
     async fn rename_opts(&self, from: &Path, to: &Path, opts: RenameOptions) -> OSResult<()> {
+        let _in_flight = InFlightGuard::new(&self.scheme, "rename");
         let start = Instant::now();
         let result = self.target.rename_opts(from, to, opts).await;
         record_request(&self.scheme, "rename", start, 0, &result);
@@ -220,9 +266,14 @@ impl object_store::ObjectStore for MeteredObjectStore {
 fn meter_list_stream(
     stream: BoxStream<'static, OSResult<ObjectMeta>>,
     scheme: String,
+    in_flight: InFlightGuard,
 ) -> BoxStream<'static, OSResult<ObjectMeta>> {
     stream
         .map(move |result| {
+            // Reference `in_flight` so this `move` closure captures (owns) the
+            // guard: a move closure only captures the variables it uses, and
+            // holding it here keeps the gauge raised until the stream is dropped.
+            let _in_flight = &in_flight;
             if result.is_err() {
                 record_error(&scheme, "list");
             }
@@ -443,7 +494,7 @@ pub use http::MeteringHttpConnector;
 mod tests {
     use super::*;
 
-    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
     use object_store::memory::InMemory;
     use object_store::{ObjectStoreExt, PutPayload};
 
@@ -459,6 +510,17 @@ mod tests {
     /// only once: the snapshotter *drains* histogram samples on every
     /// `snapshot()` call, so a second snapshot would see empty histograms.
     type Metrics = Vec<(metrics::Key, DebugValue)>;
+
+    /// Materialize the current recorder state. Histogram samples are *drained*
+    /// on each call, so a metric must be read from a single snapshot.
+    fn snapshot(snapshotter: &Snapshotter) -> Metrics {
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
+            .collect()
+    }
 
     /// Run an async closure with a thread-local metrics recorder installed and
     /// return the resulting metrics. Uses a current-thread runtime so all polls
@@ -476,12 +538,7 @@ mod tests {
                 .unwrap();
             rt.block_on(f());
         });
-        snapshotter
-            .snapshot()
-            .into_vec()
-            .into_iter()
-            .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
-            .collect()
+        snapshot(&snapshotter)
     }
 
     fn key_matches(key: &metrics::Key, name: &str, labels: &[(&str, &str)]) -> bool {
@@ -513,6 +570,23 @@ mod tests {
             }
         }
         0
+    }
+
+    fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+        for (key, value) in metrics {
+            if key_matches(key, name, labels)
+                && let DebugValue::Gauge(v) = value
+            {
+                return v.0;
+            }
+        }
+        0.0
+    }
+
+    fn has_metric(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> bool {
+        metrics
+            .iter()
+            .any(|(key, _)| key_matches(key, name, labels))
     }
 
     #[test]
@@ -752,6 +826,149 @@ mod tests {
     }
 
     #[test]
+    fn test_in_flight_guard_tracks_and_releases() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        metrics::with_local_recorder(&recorder, || {
+            let g1 = InFlightGuard::new("memory", "get");
+            let g2 = InFlightGuard::new("memory", "get");
+            assert_eq!(
+                gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                2.0
+            );
+            drop(g1);
+            assert_eq!(
+                gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                1.0
+            );
+            drop(g2);
+            assert_eq!(
+                gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                0.0
+            );
+        });
+    }
+
+    #[test]
+    fn test_in_flight_gauge_is_wired_and_balances() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"hello")).await.unwrap();
+            store.get(&path).await.unwrap();
+        });
+
+        // The gauge is emitted for each operation (guard is wired in) and, once
+        // the operation completes, balances back to zero.
+        for operation in ["put", "get"] {
+            let labels = [("operation", operation), ("scheme", "memory")];
+            assert!(has_metric(&recorded, METRIC_IN_FLIGHT, &labels));
+            assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &labels), 0.0);
+        }
+    }
+
+    #[test]
+    fn test_list_stream_holds_in_flight_until_dropped() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "list"), ("scheme", "memory")];
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let store = metered_store();
+                store.put(&Path::from("a/x"), payload(b"x")).await.unwrap();
+
+                // Creating the stream raises the gauge; it stays raised until the
+                // stream is dropped, even before any items are drained.
+                let stream = store.list(Some(&Path::from("a")));
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    1.0
+                );
+                drop(stream);
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    0.0
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn test_delete_stream_holds_in_flight_until_dropped() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "delete"), ("scheme", "memory")];
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let store = metered_store();
+                let locations = futures::stream::iter(vec![Ok(Path::from("a/b"))]).boxed();
+
+                // Like list, creating the delete stream raises the gauge and holds
+                // it until the stream is dropped, before any items are drained.
+                let stream = store.delete_stream(locations);
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    1.0
+                );
+                drop(stream);
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    0.0
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn test_in_flight_released_when_operation_future_dropped() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let started = Arc::new(tokio::sync::Notify::new());
+                // Never signalled: the request stays blocked mid-flight.
+                let release = Arc::new(tokio::sync::Notify::new());
+                let store = (Arc::new(BlockingStore {
+                    started: started.clone(),
+                    release,
+                }) as Arc<dyn object_store::ObjectStore>)
+                    .metered("memory".into());
+
+                let path = Path::from("a/b");
+                let mut fut = Box::pin(store.get(&path));
+                // Drive the request until it is blocked inside the inner store.
+                tokio::select! {
+                    _ = &mut fut => unreachable!("the blocking store never returns"),
+                    _ = started.notified() => {}
+                }
+
+                // The gauge is raised while the request is outstanding, and
+                // dropping the future before it completes releases it.
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    1.0
+                );
+                drop(fut);
+                assert_eq!(
+                    gauge_value(&snapshot(&snapshotter), METRIC_IN_FLIGHT, &labels),
+                    0.0
+                );
+            });
+        });
+    }
+
+    #[test]
     fn test_streaming_errors_are_counted() {
         let recorded = capture_metrics(|| async {
             let delete_store = (Arc::new(FailingStreamStore) as Arc<dyn object_store::ObjectStore>)
@@ -824,6 +1041,82 @@ mod tests {
 
         fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
             futures::stream::once(async { Err(test_error()) }).boxed()
+        }
+
+        fn list_with_offset(
+            &self,
+            _prefix: Option<&Path>,
+            _offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            unimplemented!()
+        }
+
+        async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> OSResult<ListResult> {
+            unimplemented!()
+        }
+
+        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
+            unimplemented!()
+        }
+
+        async fn rename_opts(
+            &self,
+            _from: &Path,
+            _to: &Path,
+            _opts: RenameOptions,
+        ) -> OSResult<()> {
+            unimplemented!()
+        }
+    }
+
+    /// A store whose `get_opts` blocks after signalling `started`, so a request
+    /// can be observed mid-flight and then dropped before it completes.
+    #[derive(Debug)]
+    struct BlockingStore {
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl std::fmt::Display for BlockingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "BlockingStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for BlockingStore {
+        async fn put_opts(
+            &self,
+            _location: &Path,
+            _bytes: PutPayload,
+            _opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            unimplemented!()
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            _location: &Path,
+            _opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            unimplemented!()
+        }
+
+        async fn get_opts(&self, _location: &Path, _options: GetOptions) -> OSResult<GetResult> {
+            self.started.notify_one();
+            self.release.notified().await;
+            unreachable!("release is never signalled in the test")
+        }
+
+        fn delete_stream(
+            &self,
+            _locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            unimplemented!()
+        }
+
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            unimplemented!()
         }
 
         fn list_with_offset(

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -32,8 +32,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
-use futures::StreamExt;
 use futures::stream::BoxStream;
+use futures::{FutureExt, StreamExt};
 use object_store::path::Path;
 use object_store::{
     CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
@@ -291,10 +291,19 @@ struct MeteredMultipartUpload {
 #[async_trait::async_trait]
 impl MultipartUpload for MeteredMultipartUpload {
     fn put_part(&mut self, data: PutPayload) -> UploadPart {
-        record_count(&self.scheme, "put");
-        metrics::counter!(METRIC_BYTES, "operation" => "put", "scheme" => self.scheme.clone())
-            .increment(data.content_length() as u64);
-        self.target.put_part(data)
+        // Each part upload is a distinct `put` request, so it records the same
+        // count / bytes / latency / error set as a unary put.
+        let scheme = self.scheme.clone();
+        let size = data.content_length() as u64;
+        let inner = self.target.put_part(data);
+        async move {
+            let _in_flight = InFlightGuard::new(&scheme, "put");
+            let start = Instant::now();
+            let result = inner.await;
+            record_request(&scheme, "put", start, size, &result);
+            result
+        }
+        .boxed()
     }
 
     async fn complete(&mut self) -> OSResult<PutResult> {
@@ -809,7 +818,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multipart_counts_each_part_as_put_without_latency() {
+    fn test_multipart_records_each_part_as_put() {
         let recorded = capture_metrics(|| async {
             let store = metered_store();
             let mut upload = store.put_multipart(&Path::from("a/big")).await.unwrap();
@@ -821,8 +830,27 @@ mod tests {
         let labels = [("operation", "put"), ("scheme", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 2);
         assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 12);
-        // Individual parts don't record a latency histogram (unlike unary put).
-        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 0);
+        // Each part records its own latency sample, like a unary put.
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 2);
+        // A successful part upload records no error.
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 0);
+    }
+
+    #[test]
+    fn test_multipart_part_error_is_counted() {
+        let recorded = capture_metrics(|| async {
+            let store = (Arc::new(FailingStreamStore) as Arc<dyn object_store::ObjectStore>)
+                .metered("memory".into());
+            let mut upload = store.put_multipart(&Path::from("a/big")).await.unwrap();
+            let _ = upload.put_part(payload(b"data")).await;
+        });
+
+        let labels = [("operation", "put"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 1);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+        // A failed part transfers no counted bytes.
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
     }
 
     #[test]
@@ -1025,7 +1053,7 @@ mod tests {
             _location: &Path,
             _opts: PutMultipartOptions,
         ) -> OSResult<Box<dyn MultipartUpload>> {
-            unimplemented!()
+            Ok(Box::new(FailingUpload))
         }
 
         async fn get_opts(&self, _location: &Path, _options: GetOptions) -> OSResult<GetResult> {
@@ -1065,6 +1093,26 @@ mod tests {
             _to: &Path,
             _opts: RenameOptions,
         ) -> OSResult<()> {
+            unimplemented!()
+        }
+    }
+
+    /// A [`MultipartUpload`] whose part uploads always fail, used to exercise the
+    /// error branch of the metered `put_part`.
+    #[derive(Debug)]
+    struct FailingUpload;
+
+    #[async_trait::async_trait]
+    impl MultipartUpload for FailingUpload {
+        fn put_part(&mut self, _data: PutPayload) -> UploadPart {
+            async { Err(test_error()) }.boxed()
+        }
+
+        async fn complete(&mut self) -> OSResult<PutResult> {
+            unimplemented!()
+        }
+
+        async fn abort(&mut self) -> OSResult<()> {
             unimplemented!()
         }
     }

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -21,16 +21,23 @@
 //! bypass `object_store`'s HTTP client, so there is no place to install the
 //! connector for them.
 //!
-//! All metrics carry a `base` label identifying the store (e.g. `s3$bucket`,
-//! `az$container@account`), so multiple buckets on the same cloud can be told
-//! apart. The metric name constants ([`METRIC_REQUESTS`] etc.) and the recording
+//! Metrics carry a `base` label identifying the store. Its cardinality is
+//! controlled by the `LANCE_OBJECT_STORE_METRICS_LABEL` environment variable
+//! ([`BASE_LABEL_ENV_VAR`]):
+//!
+//! * `scheme` (default) — scheme only, e.g. `s3`; low, bounded cardinality.
+//! * `full` — the full store prefix, e.g. `s3$bucket` or `az$container@account`,
+//!   so multiple buckets on the same cloud can be told apart.
+//! * `off` — omit the `base` label entirely.
+//!
+//! The metric name constants ([`METRIC_REQUESTS`] etc.) and the recording
 //! helpers ([`record_request`], [`record_count`], [`record_error`],
 //! [`InFlightGuard`]) are public so custom object stores can emit the same
 //! metrics.
 
 use std::ops::Range;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -64,6 +71,64 @@ pub const METRIC_RETRYABLE: &str = "lance_object_store_retryable_responses_total
 /// and `base`.
 pub const METRIC_IN_FLIGHT: &str = "lance_object_store_in_flight_requests";
 
+/// Environment variable controlling the cardinality of the `base` label.
+pub const BASE_LABEL_ENV_VAR: &str = "LANCE_OBJECT_STORE_METRICS_LABEL";
+
+/// Controls how much of a store's identity the `base` label carries, traded off
+/// against metric cardinality. Selected via [`BASE_LABEL_ENV_VAR`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BaseLabelMode {
+    /// Full store prefix, e.g. `s3$bucket` or `az$container@account`. Highest
+    /// cardinality: one series family per bucket/container.
+    Full,
+    /// Scheme only, e.g. `s3`. The default: low, bounded cardinality.
+    Scheme,
+    /// Omit the `base` label entirely.
+    Off,
+}
+
+fn parse_base_label_mode(value: Option<&str>) -> BaseLabelMode {
+    match value {
+        Some("full") => BaseLabelMode::Full,
+        Some("off") | Some("none") => BaseLabelMode::Off,
+        Some("scheme") | None => BaseLabelMode::Scheme,
+        Some(other) => {
+            tracing::warn!(
+                "Unrecognized {BASE_LABEL_ENV_VAR}={other:?}; \
+                 expected one of full, scheme, off. Defaulting to scheme."
+            );
+            BaseLabelMode::Scheme
+        }
+    }
+}
+
+/// The label mode is read once from the environment and cached for the process.
+fn base_label_mode() -> BaseLabelMode {
+    static MODE: OnceLock<BaseLabelMode> = OnceLock::new();
+    *MODE.get_or_init(|| parse_base_label_mode(std::env::var(BASE_LABEL_ENV_VAR).ok().as_deref()))
+}
+
+/// Reduce a full store prefix (`scheme$authority`, or just `scheme` for stores
+/// without buckets) to the configured `base` label value, or `None` when the
+/// label should be omitted.
+fn scoped_base(mode: BaseLabelMode, base: &str) -> Option<String> {
+    match mode {
+        BaseLabelMode::Full => Some(base.to_owned()),
+        BaseLabelMode::Scheme => Some(base.split('$').next().unwrap_or(base).to_owned()),
+        BaseLabelMode::Off => None,
+    }
+}
+
+/// Build the `operation` (+ optional `base`) label set shared by all
+/// store-level metrics, honoring the configured label mode.
+fn operation_labels(base: &str, operation: &'static str) -> Vec<metrics::Label> {
+    let mut labels = vec![metrics::Label::new("operation", operation)];
+    if let Some(base) = scoped_base(base_label_mode(), base) {
+        labels.push(metrics::Label::new("base", base));
+    }
+    labels
+}
+
 /// Record the outcome of a unary request: count, latency, bytes (on success), and errors.
 pub fn record_request<T>(
     base: &str,
@@ -86,54 +151,45 @@ pub fn record_outcome(
     is_error: bool,
 ) {
     let elapsed = start.elapsed().as_secs_f64();
-    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "base" => base.to_owned())
-        .increment(1);
-    metrics::histogram!(METRIC_DURATION, "operation" => operation, "base" => base.to_owned())
-        .record(elapsed);
+    let labels = operation_labels(base, operation);
+    metrics::counter!(METRIC_REQUESTS, labels.clone()).increment(1);
+    metrics::histogram!(METRIC_DURATION, labels.clone()).record(elapsed);
     if is_error {
-        record_error(base, operation);
+        metrics::counter!(METRIC_ERRORS, labels).increment(1);
     } else if bytes > 0 {
-        metrics::counter!(METRIC_BYTES, "operation" => operation, "base" => base.to_owned())
-            .increment(bytes);
+        metrics::counter!(METRIC_BYTES, labels).increment(bytes);
     }
 }
 
 /// Record a single request count without latency, used for streaming operations
 /// (list / delete) whose work happens lazily as the stream is polled.
 pub fn record_count(base: &str, operation: &'static str) {
-    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "base" => base.to_owned())
-        .increment(1);
+    metrics::counter!(METRIC_REQUESTS, operation_labels(base, operation)).increment(1);
 }
 
 /// Record a single error for an operation.
 pub fn record_error(base: &str, operation: &'static str) {
-    metrics::counter!(METRIC_ERRORS, "operation" => operation, "base" => base.to_owned())
-        .increment(1);
+    metrics::counter!(METRIC_ERRORS, operation_labels(base, operation)).increment(1);
 }
 
 /// Raises the in-flight gauge for an operation on creation and lowers it on
 /// drop, so the count stays balanced even if the request future or stream is
 /// cancelled or dropped before completing.
 pub struct InFlightGuard {
-    base: String,
-    operation: &'static str,
+    labels: Vec<metrics::Label>,
 }
 
 impl InFlightGuard {
     pub fn new(base: &str, operation: &'static str) -> Self {
-        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => operation, "base" => base.to_owned())
-            .increment(1.0);
-        Self {
-            base: base.to_owned(),
-            operation,
-        }
+        let labels = operation_labels(base, operation);
+        metrics::gauge!(METRIC_IN_FLIGHT, labels.clone()).increment(1.0);
+        Self { labels }
     }
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => self.operation, "base" => self.base.clone())
-            .decrement(1.0);
+        metrics::gauge!(METRIC_IN_FLIGHT, self.labels.clone()).decrement(1.0);
     }
 }
 
@@ -510,23 +566,23 @@ mod http {
             let is_throttle = status == 429 || status == 503;
             let is_retryable = status == 429 || status == 408 || (500..600).contains(&status);
             if is_throttle {
-                metrics::counter!(
-                    METRIC_THROTTLE,
-                    "status" => status.to_string(),
-                    "base" => self.base.clone(),
-                )
-                .increment(1);
+                metrics::counter!(METRIC_THROTTLE, status_labels(&self.base, status)).increment(1);
             }
             if is_retryable {
-                metrics::counter!(
-                    METRIC_RETRYABLE,
-                    "status" => status.to_string(),
-                    "base" => self.base.clone(),
-                )
-                .increment(1);
+                metrics::counter!(METRIC_RETRYABLE, status_labels(&self.base, status)).increment(1);
             }
             Ok(response)
         }
+    }
+
+    /// Build the `status` (+ optional `base`) label set for HTTP-layer metrics,
+    /// honoring the configured label mode.
+    fn status_labels(base: &str, status: u16) -> Vec<metrics::Label> {
+        let mut labels = vec![metrics::Label::new("status", status.to_string())];
+        if let Some(base) = scoped_base(base_label_mode(), base) {
+            labels.push(metrics::Label::new("base", base));
+        }
+        labels
     }
 
     #[cfg(test)]
@@ -592,17 +648,19 @@ mod http {
                 rt.block_on(async {
                     // Each attempt that object_store retries flows through `call`
                     // again; here we simulate that by issuing several responses.
-                    // The base is baked into the connector, so it labels the metric.
+                    // The base is baked into the connector, so it labels the
+                    // metric. Bases here have no `$`, so they are unaffected by
+                    // the label mode and this test isolates status handling.
                     for (base, status) in [
-                        ("s3$bucket", 429u16),
-                        ("s3$bucket", 503),
-                        ("s3$bucket", 503),
-                        ("s3$bucket", 500),
-                        ("s3$bucket", 408),
-                        ("s3$bucket", 409),
-                        ("s3$bucket", 200),
-                        ("s3$bucket", 404),
-                        ("gs$bucket", 429),
+                        ("s3", 429u16),
+                        ("s3", 503),
+                        ("s3", 503),
+                        ("s3", 500),
+                        ("s3", 408),
+                        ("s3", 409),
+                        ("s3", 200),
+                        ("s3", 404),
+                        ("gs", 429),
                     ] {
                         let service = MeteringHttpService {
                             base: base.into(),
@@ -624,27 +682,27 @@ mod http {
             let retryable = |base, status| metric_count(&recorded, METRIC_RETRYABLE, base, status);
 
             // Throttles are only 429 and 503.
-            assert_eq!(throttle("s3$bucket", "429"), 1);
-            assert_eq!(throttle("s3$bucket", "503"), 2);
-            assert_eq!(throttle("s3$bucket", "500"), 0);
-            assert_eq!(throttle("s3$bucket", "408"), 0);
+            assert_eq!(throttle("s3", "429"), 1);
+            assert_eq!(throttle("s3", "503"), 2);
+            assert_eq!(throttle("s3", "500"), 0);
+            assert_eq!(throttle("s3", "408"), 0);
 
             // Retryable is the broader set: 5xx, 429, 408 (but not 409).
-            assert_eq!(retryable("s3$bucket", "429"), 1);
-            assert_eq!(retryable("s3$bucket", "503"), 2);
-            assert_eq!(retryable("s3$bucket", "500"), 1);
-            assert_eq!(retryable("s3$bucket", "408"), 1);
+            assert_eq!(retryable("s3", "429"), 1);
+            assert_eq!(retryable("s3", "503"), 2);
+            assert_eq!(retryable("s3", "500"), 1);
+            assert_eq!(retryable("s3", "408"), 1);
             // 409 conflict is excluded so commit conflicts are not counted as retries.
-            assert_eq!(retryable("s3$bucket", "409"), 0);
+            assert_eq!(retryable("s3", "409"), 0);
 
             // Success and non-retryable client errors count as neither.
-            assert_eq!(throttle("s3$bucket", "200"), 0);
-            assert_eq!(retryable("s3$bucket", "404"), 0);
+            assert_eq!(throttle("s3", "200"), 0);
+            assert_eq!(retryable("s3", "404"), 0);
 
             // The base label is taken from the connector, not shared across stores.
-            assert_eq!(throttle("gs$bucket", "429"), 1);
-            assert_eq!(retryable("gs$bucket", "429"), 1);
-            assert_eq!(throttle("gs$bucket", "503"), 0);
+            assert_eq!(throttle("gs", "429"), 1);
+            assert_eq!(retryable("gs", "429"), 1);
+            assert_eq!(throttle("gs", "503"), 0);
         }
     }
 }
@@ -749,6 +807,69 @@ mod tests {
         metrics
             .iter()
             .any(|(key, _)| key_matches(key, name, labels))
+    }
+
+    #[test]
+    fn test_parse_base_label_mode() {
+        assert_eq!(parse_base_label_mode(None), BaseLabelMode::Scheme);
+        assert_eq!(parse_base_label_mode(Some("scheme")), BaseLabelMode::Scheme);
+        assert_eq!(parse_base_label_mode(Some("full")), BaseLabelMode::Full);
+        assert_eq!(parse_base_label_mode(Some("off")), BaseLabelMode::Off);
+        assert_eq!(parse_base_label_mode(Some("none")), BaseLabelMode::Off);
+        // Unrecognized values fall back to the conservative default.
+        assert_eq!(parse_base_label_mode(Some("bogus")), BaseLabelMode::Scheme);
+    }
+
+    #[test]
+    fn test_scoped_base() {
+        assert_eq!(
+            scoped_base(BaseLabelMode::Full, "s3$bucket").as_deref(),
+            Some("s3$bucket")
+        );
+        assert_eq!(
+            scoped_base(BaseLabelMode::Scheme, "s3$bucket").as_deref(),
+            Some("s3")
+        );
+        // Azure keeps only the scheme even though its prefix carries the account.
+        assert_eq!(
+            scoped_base(BaseLabelMode::Scheme, "az$container@account").as_deref(),
+            Some("az")
+        );
+        // A prefix without `$` (e.g. memory/file) is unchanged by scheme mode.
+        assert_eq!(
+            scoped_base(BaseLabelMode::Scheme, "memory").as_deref(),
+            Some("memory")
+        );
+        assert_eq!(scoped_base(BaseLabelMode::Off, "s3$bucket"), None);
+    }
+
+    #[test]
+    fn test_base_label_defaults_to_scheme() {
+        // No env var is set in the test process, so the default `scheme` mode
+        // applies: the full prefix collapses to just the scheme.
+        let recorded = capture_metrics(|| async {
+            let store = (Arc::new(InMemory::new()) as Arc<dyn object_store::ObjectStore>)
+                .metered("s3$my-bucket".into());
+            store.put(&Path::from("a"), payload(b"x")).await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "put"), ("base", "s3")]
+            ),
+            1
+        );
+        // The full prefix is not emitted as the label under the default mode.
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "put"), ("base", "s3$my-bucket")]
+            ),
+            0
+        );
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -1,0 +1,854 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Publishes object store metrics via the [`metrics`] crate.
+//!
+//! The [`metrics`] facade lets downstream applications install any recorder
+//! (Prometheus, OpenTelemetry, etc.) without Lance depending on a specific
+//! backend. When no recorder is installed the calls are cheap no-ops.
+//!
+//! Two layers cooperate:
+//!
+//! * [`MeteredObjectStore`] wraps any [`object_store::ObjectStore`] and records
+//!   per-operation request counts, transferred bytes, latency, and errors. It
+//!   works for every store regardless of backend.
+//! * [`MeteringHttpConnector`] wraps the HTTP client used by the native cloud
+//!   stores (S3 / GCS / Azure) and records throttle responses (HTTP 429 / 503)
+//!   per attempt. Because `object_store`'s retry loop re-issues each request
+//!   through the [`HttpService`](object_store::client::HttpService), this sees
+//!   every retried throttle, which a store-level wrapper cannot observe.
+//!
+//! The two layers have different coverage: every store gets the request-level
+//! metrics from [`MeteredObjectStore`], but only the native cloud stores get
+//! the HTTP-level throttle metrics. Opendal-backed stores (tos, oss, etc.)
+//! bypass `object_store`'s HTTP client, so there is no place to install the
+//! connector for them.
+//!
+//! All metrics carry a `scheme` label (e.g. `s3`, `gs`, `azure`).
+
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult,
+    UploadPart,
+};
+
+/// Total number of object store requests, labelled by `operation` and `scheme`.
+const METRIC_REQUESTS: &str = "lance_object_store_requests_total";
+/// Total bytes transferred by object store requests, labelled by `operation` and `scheme`.
+const METRIC_BYTES: &str = "lance_object_store_request_bytes_total";
+/// Object store request latency in seconds, labelled by `operation` and `scheme`.
+const METRIC_DURATION: &str = "lance_object_store_request_duration_seconds";
+/// Total number of failed object store requests, labelled by `operation` and `scheme`.
+const METRIC_ERRORS: &str = "lance_object_store_errors_total";
+/// Total number of throttle responses (HTTP 429 / 503) seen at the HTTP layer,
+/// labelled by `status` and `scheme`. Counts every attempt, including retries.
+const METRIC_THROTTLE: &str = "lance_object_store_throttle_total";
+
+/// Record the outcome of a unary request: count, latency, bytes (on success), and errors.
+fn record_request<T>(
+    scheme: &str,
+    operation: &'static str,
+    start: Instant,
+    bytes: u64,
+    result: &OSResult<T>,
+) {
+    let elapsed = start.elapsed().as_secs_f64();
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+    metrics::histogram!(METRIC_DURATION, "operation" => operation, "scheme" => scheme.to_owned())
+        .record(elapsed);
+    match result {
+        Ok(_) => {
+            if bytes > 0 {
+                metrics::counter!(METRIC_BYTES, "operation" => operation, "scheme" => scheme.to_owned())
+                    .increment(bytes);
+            }
+        }
+        Err(_) => {
+            metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
+                .increment(1);
+        }
+    }
+}
+
+/// Record a single request count without latency, used for streaming operations
+/// (list / delete) whose work happens lazily as the stream is polled.
+fn record_count(scheme: &str, operation: &'static str) {
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+}
+
+fn record_error(scheme: &str, operation: &'static str) {
+    metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
+        .increment(1);
+}
+
+#[derive(Debug)]
+pub struct MeteredObjectStore {
+    target: Arc<dyn object_store::ObjectStore>,
+    scheme: String,
+}
+
+impl std::fmt::Display for MeteredObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MeteredObjectStore({})", self.target)
+    }
+}
+
+#[async_trait::async_trait]
+#[deny(clippy::missing_trait_methods)]
+impl object_store::ObjectStore for MeteredObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        bytes: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        let size = bytes.content_length() as u64;
+        let start = Instant::now();
+        let result = self.target.put_opts(location, bytes, opts).await;
+        record_request(&self.scheme, "put", start, size, &result);
+        result
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        let upload = self.target.put_multipart_opts(location, opts).await?;
+        Ok(Box::new(MeteredMultipartUpload {
+            target: upload,
+            scheme: self.scheme.clone(),
+        }))
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        // `head()` is implemented as a `get_opts` call with `head = true`, so we
+        // distinguish it here to keep HEAD and GET as separate operations.
+        let is_head = options.head;
+        let operation = if is_head { "head" } else { "get" };
+        let start = Instant::now();
+        let result = self.target.get_opts(location, options).await;
+        // A HEAD transfers only metadata, so it has no payload bytes.
+        let bytes = match &result {
+            Ok(res) if !is_head => res.range.end - res.range.start,
+            _ => 0,
+        };
+        record_request(&self.scheme, operation, start, bytes, &result);
+        result
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+        let start = Instant::now();
+        let result = self.target.get_ranges(location, ranges).await;
+        let bytes = match &result {
+            Ok(parts) => parts.iter().map(|b| b.len() as u64).sum(),
+            Err(_) => 0,
+        };
+        record_request(&self.scheme, "get", start, bytes, &result);
+        result
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        let scheme = self.scheme.clone();
+        self.target
+            .delete_stream(locations)
+            .map(move |result| {
+                // Each yielded path is one delete; failures additionally bump the error counter.
+                record_count(&scheme, "delete");
+                if result.is_err() {
+                    record_error(&scheme, "delete");
+                }
+                result
+            })
+            .boxed()
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        record_count(&self.scheme, "list");
+        meter_list_stream(self.target.list(prefix), self.scheme.clone())
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        record_count(&self.scheme, "list");
+        meter_list_stream(
+            self.target.list_with_offset(prefix, offset),
+            self.scheme.clone(),
+        )
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        let start = Instant::now();
+        let result = self.target.list_with_delimiter(prefix).await;
+        record_request(&self.scheme, "list", start, 0, &result);
+        result
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+        let start = Instant::now();
+        let result = self.target.copy_opts(from, to, opts).await;
+        record_request(&self.scheme, "copy", start, 0, &result);
+        result
+    }
+
+    async fn rename_opts(&self, from: &Path, to: &Path, opts: RenameOptions) -> OSResult<()> {
+        let start = Instant::now();
+        let result = self.target.rename_opts(from, to, opts).await;
+        record_request(&self.scheme, "rename", start, 0, &result);
+        result
+    }
+}
+
+/// Count errors yielded while draining a list stream. The request itself is
+/// counted once when the stream is created (a single LIST may return many items).
+fn meter_list_stream(
+    stream: BoxStream<'static, OSResult<ObjectMeta>>,
+    scheme: String,
+) -> BoxStream<'static, OSResult<ObjectMeta>> {
+    stream
+        .map(move |result| {
+            if result.is_err() {
+                record_error(&scheme, "list");
+            }
+            result
+        })
+        .boxed()
+}
+
+#[derive(Debug)]
+struct MeteredMultipartUpload {
+    target: Box<dyn MultipartUpload>,
+    scheme: String,
+}
+
+#[async_trait::async_trait]
+impl MultipartUpload for MeteredMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
+        record_count(&self.scheme, "put");
+        metrics::counter!(METRIC_BYTES, "operation" => "put", "scheme" => self.scheme.clone())
+            .increment(data.content_length() as u64);
+        self.target.put_part(data)
+    }
+
+    async fn complete(&mut self) -> OSResult<PutResult> {
+        self.target.complete().await
+    }
+
+    async fn abort(&mut self) -> OSResult<()> {
+        self.target.abort().await
+    }
+}
+
+pub trait ObjectStoreMetricsExt {
+    /// Wrap this store so its operations publish metrics under the given `scheme` label.
+    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore>;
+}
+
+impl ObjectStoreMetricsExt for Arc<dyn object_store::ObjectStore> {
+    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(MeteredObjectStore {
+            target: self,
+            scheme,
+        })
+    }
+}
+
+// --- Layer 2: HTTP-level throttle metrics for native cloud stores ---
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+mod http {
+    use super::*;
+    use object_store::client::{
+        ClientOptions, HttpClient, HttpConnector, HttpError, HttpRequest, HttpResponse,
+        HttpService, ReqwestConnector,
+    };
+
+    /// An [`HttpConnector`] that records throttle responses observed by the
+    /// underlying HTTP client. Install it on the S3 / GCS / Azure builders via
+    /// `with_http_connector`.
+    #[derive(Debug)]
+    pub struct MeteringHttpConnector {
+        scheme: String,
+        inner: ReqwestConnector,
+    }
+
+    impl MeteringHttpConnector {
+        pub fn new(scheme: String) -> Self {
+            Self {
+                scheme,
+                inner: ReqwestConnector::default(),
+            }
+        }
+    }
+
+    impl HttpConnector for MeteringHttpConnector {
+        fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
+            let client = self.inner.connect(options)?;
+            Ok(HttpClient::new(MeteringHttpService {
+                scheme: self.scheme.clone(),
+                inner: client,
+            }))
+        }
+    }
+
+    #[derive(Debug)]
+    struct MeteringHttpService {
+        scheme: String,
+        inner: HttpClient,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpService for MeteringHttpService {
+        async fn call(&self, req: HttpRequest) -> Result<HttpResponse, HttpError> {
+            let response = self.inner.execute(req).await?;
+            let status = response.status();
+            // 429 (throttling) and 5xx (e.g. 503 service unavailable) are the
+            // statuses that drive object_store's retry loop. Each attempt that
+            // hits one is recorded with its numeric status, so 429 and 503 can
+            // be told apart.
+            if status.as_u16() == 429 || status.is_server_error() {
+                metrics::counter!(
+                    METRIC_THROTTLE,
+                    "status" => status.as_u16().to_string(),
+                    "scheme" => self.scheme.clone(),
+                )
+                .increment(1);
+            }
+            Ok(response)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use object_store::client::{HttpRequestBody, HttpResponseBody};
+
+        /// A mock [`HttpService`] that always responds with a fixed status code.
+        #[derive(Debug)]
+        struct StaticStatusService {
+            status: u16,
+        }
+
+        #[async_trait::async_trait]
+        impl HttpService for StaticStatusService {
+            async fn call(&self, _req: HttpRequest) -> Result<HttpResponse, HttpError> {
+                Ok(::http::Response::builder()
+                    .status(self.status)
+                    .body(HttpResponseBody::from(Bytes::new()))
+                    .unwrap())
+            }
+        }
+
+        fn request() -> HttpRequest {
+            ::http::Request::builder()
+                .method("GET")
+                .uri("http://example.com/obj")
+                .body(HttpRequestBody::empty())
+                .unwrap()
+        }
+
+        fn throttle_count(
+            metrics: &[(metrics::Key, DebugValue)],
+            scheme: &str,
+            status: &str,
+        ) -> u64 {
+            for (key, value) in metrics {
+                if key.name() != METRIC_THROTTLE {
+                    continue;
+                }
+                let labels: std::collections::HashMap<&str, &str> =
+                    key.labels().map(|l| (l.key(), l.value())).collect();
+                if labels.get("scheme") == Some(&scheme)
+                    && labels.get("status") == Some(&status)
+                    && let DebugValue::Counter(v) = value
+                {
+                    return *v;
+                }
+            }
+            0
+        }
+
+        #[test]
+        fn test_throttle_responses_counted_by_status() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+                rt.block_on(async {
+                    // Each attempt that object_store retries flows through `call`
+                    // again; here we simulate that by issuing several responses.
+                    // The scheme is baked into the connector, so it labels the metric.
+                    for (scheme, status) in [
+                        ("s3", 429u16),
+                        ("s3", 503),
+                        ("s3", 503),
+                        ("s3", 500),
+                        ("s3", 200),
+                        ("s3", 404),
+                        ("gs", 429),
+                    ] {
+                        let service = MeteringHttpService {
+                            scheme: scheme.into(),
+                            inner: HttpClient::new(StaticStatusService { status }),
+                        };
+                        service.call(request()).await.unwrap();
+                    }
+                });
+            });
+
+            let recorded: Vec<_> = snapshotter
+                .snapshot()
+                .into_vec()
+                .into_iter()
+                .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
+                .collect();
+
+            assert_eq!(throttle_count(&recorded, "s3", "429"), 1);
+            assert_eq!(throttle_count(&recorded, "s3", "503"), 2);
+            // Other server errors (5xx) are retryable and counted by their status.
+            assert_eq!(throttle_count(&recorded, "s3", "500"), 1);
+            // Success and non-retryable client errors are not throttles.
+            assert_eq!(throttle_count(&recorded, "s3", "200"), 0);
+            assert_eq!(throttle_count(&recorded, "s3", "404"), 0);
+            // The scheme label is taken from the connector, not shared across schemes.
+            assert_eq!(throttle_count(&recorded, "gs", "429"), 1);
+            assert_eq!(throttle_count(&recorded, "gs", "503"), 0);
+        }
+    }
+}
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+pub use http::MeteringHttpConnector;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use object_store::memory::InMemory;
+    use object_store::{ObjectStoreExt, PutPayload};
+
+    fn payload(data: &[u8]) -> PutPayload {
+        PutPayload::from_bytes(Bytes::copy_from_slice(data))
+    }
+
+    fn metered_store() -> Arc<dyn object_store::ObjectStore> {
+        (Arc::new(InMemory::new()) as Arc<dyn object_store::ObjectStore>).metered("memory".into())
+    }
+
+    /// A single materialized snapshot of recorded metrics. It must be taken
+    /// only once: the snapshotter *drains* histogram samples on every
+    /// `snapshot()` call, so a second snapshot would see empty histograms.
+    type Metrics = Vec<(metrics::Key, DebugValue)>;
+
+    /// Run an async closure with a thread-local metrics recorder installed and
+    /// return the resulting metrics. Uses a current-thread runtime so all polls
+    /// happen on the thread that holds the recorder guard.
+    fn capture_metrics<F, Fut>(f: F) -> Metrics
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(f());
+        });
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
+            .collect()
+    }
+
+    fn key_matches(key: &metrics::Key, name: &str, labels: &[(&str, &str)]) -> bool {
+        if key.name() != name {
+            return false;
+        }
+        let actual: std::collections::HashSet<(&str, &str)> =
+            key.labels().map(|l| (l.key(), l.value())).collect();
+        labels.len() == actual.len() && labels.iter().all(|l| actual.contains(l))
+    }
+
+    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
+        for (key, value) in metrics {
+            if key_matches(key, name, labels)
+                && let DebugValue::Counter(v) = value
+            {
+                return *v;
+            }
+        }
+        0
+    }
+
+    fn histogram_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> usize {
+        for (key, value) in metrics {
+            if key_matches(key, name, labels)
+                && let DebugValue::Histogram(samples) = value
+            {
+                return samples.len();
+            }
+        }
+        0
+    }
+
+    #[test]
+    fn test_put_records_count_bytes_and_latency() {
+        let data = b"hello world";
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            store
+                .put(&Path::from("a/b.bin"), payload(data))
+                .await
+                .unwrap();
+        });
+
+        let labels = [("operation", "put"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &labels),
+            data.len() as u64
+        );
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+    }
+
+    #[test]
+    fn test_get_records_count_and_bytes() {
+        let data = b"hello world";
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(data)).await.unwrap();
+            store.get(&path).await.unwrap();
+        });
+
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &labels),
+            data.len() as u64
+        );
+    }
+
+    #[test]
+    fn test_head_is_a_separate_operation() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"hello world")).await.unwrap();
+            store.head(&path).await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "head"), ("scheme", "memory")]
+            ),
+            1
+        );
+        // The head call must not be counted as a get.
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "get"), ("scheme", "memory")]
+            ),
+            0
+        );
+        // A HEAD transfers only metadata, so it records no payload bytes.
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_BYTES,
+                &[("operation", "head"), ("scheme", "memory")]
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn test_delete_records_count_per_path() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"x")).await.unwrap();
+            store.delete(&path).await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "delete"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn test_list_counts_one_request_not_per_item() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            for i in 0..3 {
+                store
+                    .put(&Path::from(format!("a/{i}.bin")), payload(b"x"))
+                    .await
+                    .unwrap();
+            }
+            let _: Vec<_> = store.list(Some(&Path::from("a"))).collect().await;
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "list"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn test_error_is_counted() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            // Getting a missing object errors.
+            let _ = store.get(&Path::from("does/not/exist")).await;
+        });
+
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 1);
+        // A failed request is still counted as a request, with latency recorded.
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+        // No bytes are transferred on a failed get.
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
+    }
+
+    #[test]
+    fn test_get_ranges_sums_part_bytes_and_labels_get() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let path = Path::from("a/b.bin");
+            store.put(&path, payload(b"hello world")).await.unwrap();
+            // Two disjoint ranges of 3 bytes each.
+            store.get_ranges(&path, &[2..5, 6..9]).await.unwrap();
+        });
+
+        let labels = [("operation", "get"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 6);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+    }
+
+    #[test]
+    fn test_copy_and_rename_record_zero_bytes() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            store
+                .put(&Path::from("a/src"), payload(b"x"))
+                .await
+                .unwrap();
+            store
+                .copy(&Path::from("a/src"), &Path::from("a/copy"))
+                .await
+                .unwrap();
+            store
+                .rename(&Path::from("a/copy"), &Path::from("a/moved"))
+                .await
+                .unwrap();
+        });
+
+        for operation in ["copy", "rename"] {
+            let labels = [("operation", operation), ("scheme", "memory")];
+            assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+            assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
+            assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+        }
+    }
+
+    #[test]
+    fn test_list_with_delimiter_records_latency() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            store.put(&Path::from("a/b"), payload(b"x")).await.unwrap();
+            store
+                .list_with_delimiter(Some(&Path::from("a")))
+                .await
+                .unwrap();
+        });
+
+        let labels = [("operation", "list"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
+    }
+
+    #[test]
+    fn test_list_with_offset_counts_one_request() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            for i in 0..3 {
+                store
+                    .put(&Path::from(format!("a/{i}")), payload(b"x"))
+                    .await
+                    .unwrap();
+            }
+            let _: Vec<_> = store
+                .list_with_offset(Some(&Path::from("a")), &Path::from("a/0"))
+                .collect()
+                .await;
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "list"), ("scheme", "memory")]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn test_multipart_counts_each_part_as_put_without_latency() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let mut upload = store.put_multipart(&Path::from("a/big")).await.unwrap();
+            upload.put_part(payload(b"hello")).await.unwrap(); // 5 bytes
+            upload.put_part(payload(b"world!!")).await.unwrap(); // 7 bytes
+            upload.complete().await.unwrap();
+        });
+
+        let labels = [("operation", "put"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 2);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 12);
+        // Individual parts don't record a latency histogram (unlike unary put).
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 0);
+    }
+
+    #[test]
+    fn test_streaming_errors_are_counted() {
+        let recorded = capture_metrics(|| async {
+            let delete_store = (Arc::new(FailingStreamStore) as Arc<dyn object_store::ObjectStore>)
+                .metered("memory".into());
+            let _ = delete_store.delete(&Path::from("a/b")).await;
+
+            let list_store = (Arc::new(FailingStreamStore) as Arc<dyn object_store::ObjectStore>)
+                .metered("memory".into());
+            let _: Vec<_> = list_store.list(None).collect().await;
+        });
+
+        // delete_stream counts the item and records an error when it fails.
+        let delete_labels = [("operation", "delete"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &delete_labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &delete_labels), 1);
+
+        // A list request is counted once; a failure while draining records an error.
+        let list_labels = [("operation", "list"), ("scheme", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &list_labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &list_labels), 1);
+    }
+
+    /// A store whose stream-producing operations always yield an error, used to
+    /// exercise the error branches of the streaming wrappers.
+    #[derive(Debug)]
+    struct FailingStreamStore;
+
+    impl std::fmt::Display for FailingStreamStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingStreamStore")
+        }
+    }
+
+    fn test_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "FailingStreamStore",
+            source: "injected failure".into(),
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for FailingStreamStore {
+        async fn put_opts(
+            &self,
+            _location: &Path,
+            _bytes: PutPayload,
+            _opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            unimplemented!()
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            _location: &Path,
+            _opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            unimplemented!()
+        }
+
+        async fn get_opts(&self, _location: &Path, _options: GetOptions) -> OSResult<GetResult> {
+            unimplemented!()
+        }
+
+        fn delete_stream(
+            &self,
+            _locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            futures::stream::once(async { Err(test_error()) }).boxed()
+        }
+
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            futures::stream::once(async { Err(test_error()) }).boxed()
+        }
+
+        fn list_with_offset(
+            &self,
+            _prefix: Option<&Path>,
+            _offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            unimplemented!()
+        }
+
+        async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> OSResult<ListResult> {
+            unimplemented!()
+        }
+
+        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
+            unimplemented!()
+        }
+
+        async fn rename_opts(
+            &self,
+            _from: &Path,
+            _to: &Path,
+            _opts: RenameOptions,
+        ) -> OSResult<()> {
+            unimplemented!()
+        }
+    }
+}

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -3,10 +3,6 @@
 
 //! Publishes object store metrics via the [`metrics`] crate.
 //!
-//! The [`metrics`] facade lets downstream applications install any recorder
-//! (Prometheus, OpenTelemetry, etc.) without Lance depending on a specific
-//! backend. When no recorder is installed the calls are cheap no-ops.
-//!
 //! Two layers cooperate:
 //!
 //! * [`MeteredObjectStore`] wraps any [`object_store::ObjectStore`] and records
@@ -14,10 +10,10 @@
 //!   number of requests currently in flight. It works for every store
 //!   regardless of backend.
 //! * [`MeteringHttpConnector`] wraps the HTTP client used by the native cloud
-//!   stores (S3 / GCS / Azure) and records throttle responses (HTTP 429 / 503)
-//!   per attempt. Because `object_store`'s retry loop re-issues each request
+//!   stores (S3 / GCS / Azure) and records throttle / retryable responses per
+//!   attempt. Because `object_store`'s retry loop re-issues each request
 //!   through the [`HttpService`](object_store::client::HttpService), this sees
-//!   every retried throttle, which a store-level wrapper cannot observe.
+//!   every retried response, which a store-level wrapper cannot observe.
 //!
 //! The two layers have different coverage: every store gets the request-level
 //! metrics from [`MeteredObjectStore`], but only the native cloud stores get
@@ -25,90 +21,110 @@
 //! bypass `object_store`'s HTTP client, so there is no place to install the
 //! connector for them.
 //!
-//! All metrics carry a `scheme` label (e.g. `s3`, `gs`, `azure`).
+//! All metrics carry a `base` label identifying the store (e.g. `s3$bucket`,
+//! `az$container@account`), so multiple buckets on the same cloud can be told
+//! apart. The metric name constants ([`METRIC_REQUESTS`] etc.) and the recording
+//! helpers ([`record_request`], [`record_count`], [`record_error`],
+//! [`InFlightGuard`]) are public so custom object stores can emit the same
+//! metrics.
 
 use std::ops::Range;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use futures::{FutureExt, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use object_store::path::Path;
 use object_store::{
-    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult,
     UploadPart,
 };
 
-/// Total number of object store requests, labelled by `operation` and `scheme`.
-const METRIC_REQUESTS: &str = "lance_object_store_requests_total";
-/// Total bytes transferred by object store requests, labelled by `operation` and `scheme`.
-const METRIC_BYTES: &str = "lance_object_store_request_bytes_total";
-/// Object store request latency in seconds, labelled by `operation` and `scheme`.
-const METRIC_DURATION: &str = "lance_object_store_request_duration_seconds";
-/// Total number of failed object store requests, labelled by `operation` and `scheme`.
-const METRIC_ERRORS: &str = "lance_object_store_errors_total";
+/// Total number of object store requests, labelled by `operation` and `base`.
+pub const METRIC_REQUESTS: &str = "lance_object_store_requests_total";
+/// Total bytes transferred by object store requests, labelled by `operation` and `base`.
+pub const METRIC_BYTES: &str = "lance_object_store_request_bytes_total";
+/// Object store request latency in seconds, labelled by `operation` and `base`.
+pub const METRIC_DURATION: &str = "lance_object_store_request_duration_seconds";
+/// Total number of failed object store requests, labelled by `operation` and `base`.
+pub const METRIC_ERRORS: &str = "lance_object_store_errors_total";
 /// Total number of throttle responses (HTTP 429 / 503) seen at the HTTP layer,
-/// labelled by `status` and `scheme`. Counts every attempt, including retries.
-const METRIC_THROTTLE: &str = "lance_object_store_throttle_total";
+/// labelled by `status` and `base`. Counts every attempt, including retries.
+pub const METRIC_THROTTLE: &str = "lance_object_store_throttle_total";
+/// Total number of retryable responses (HTTP 5xx / 429 / 408) seen at the HTTP
+/// layer, labelled by `status` and `base`. Counts every attempt, including
+/// retries. This is a superset of [`METRIC_THROTTLE`]; 409 (conflict) is
+/// deliberately excluded so commit conflicts are not counted as retries.
+pub const METRIC_RETRYABLE: &str = "lance_object_store_retryable_responses_total";
 /// Number of object store requests currently in flight, labelled by `operation`
-/// and `scheme`.
-const METRIC_IN_FLIGHT: &str = "lance_object_store_in_flight_requests";
+/// and `base`.
+pub const METRIC_IN_FLIGHT: &str = "lance_object_store_in_flight_requests";
 
 /// Record the outcome of a unary request: count, latency, bytes (on success), and errors.
-fn record_request<T>(
-    scheme: &str,
+pub fn record_request<T>(
+    base: &str,
     operation: &'static str,
     start: Instant,
     bytes: u64,
     result: &OSResult<T>,
 ) {
+    record_outcome(base, operation, start, bytes, result.is_err());
+}
+
+/// Record count, latency, and either transferred bytes or an error for a
+/// completed request. Used both for unary requests and for streamed GETs whose
+/// bytes are only known once the body finishes.
+pub fn record_outcome(
+    base: &str,
+    operation: &'static str,
+    start: Instant,
+    bytes: u64,
+    is_error: bool,
+) {
     let elapsed = start.elapsed().as_secs_f64();
-    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "base" => base.to_owned())
         .increment(1);
-    metrics::histogram!(METRIC_DURATION, "operation" => operation, "scheme" => scheme.to_owned())
+    metrics::histogram!(METRIC_DURATION, "operation" => operation, "base" => base.to_owned())
         .record(elapsed);
-    match result {
-        Ok(_) => {
-            if bytes > 0 {
-                metrics::counter!(METRIC_BYTES, "operation" => operation, "scheme" => scheme.to_owned())
-                    .increment(bytes);
-            }
-        }
-        Err(_) => {
-            metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
-                .increment(1);
-        }
+    if is_error {
+        record_error(base, operation);
+    } else if bytes > 0 {
+        metrics::counter!(METRIC_BYTES, "operation" => operation, "base" => base.to_owned())
+            .increment(bytes);
     }
 }
 
 /// Record a single request count without latency, used for streaming operations
 /// (list / delete) whose work happens lazily as the stream is polled.
-fn record_count(scheme: &str, operation: &'static str) {
-    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "scheme" => scheme.to_owned())
+pub fn record_count(base: &str, operation: &'static str) {
+    metrics::counter!(METRIC_REQUESTS, "operation" => operation, "base" => base.to_owned())
         .increment(1);
 }
 
-fn record_error(scheme: &str, operation: &'static str) {
-    metrics::counter!(METRIC_ERRORS, "operation" => operation, "scheme" => scheme.to_owned())
+/// Record a single error for an operation.
+pub fn record_error(base: &str, operation: &'static str) {
+    metrics::counter!(METRIC_ERRORS, "operation" => operation, "base" => base.to_owned())
         .increment(1);
 }
 
 /// Raises the in-flight gauge for an operation on creation and lowers it on
 /// drop, so the count stays balanced even if the request future or stream is
 /// cancelled or dropped before completing.
-struct InFlightGuard {
-    scheme: String,
+pub struct InFlightGuard {
+    base: String,
     operation: &'static str,
 }
 
 impl InFlightGuard {
-    fn new(scheme: &str, operation: &'static str) -> Self {
-        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => operation, "scheme" => scheme.to_owned())
+    pub fn new(base: &str, operation: &'static str) -> Self {
+        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => operation, "base" => base.to_owned())
             .increment(1.0);
         Self {
-            scheme: scheme.to_owned(),
+            base: base.to_owned(),
             operation,
         }
     }
@@ -116,7 +132,7 @@ impl InFlightGuard {
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => self.operation, "scheme" => self.scheme.clone())
+        metrics::gauge!(METRIC_IN_FLIGHT, "operation" => self.operation, "base" => self.base.clone())
             .decrement(1.0);
     }
 }
@@ -124,7 +140,7 @@ impl Drop for InFlightGuard {
 #[derive(Debug)]
 pub struct MeteredObjectStore {
     target: Arc<dyn object_store::ObjectStore>,
-    scheme: String,
+    base: String,
 }
 
 impl std::fmt::Display for MeteredObjectStore {
@@ -143,10 +159,10 @@ impl object_store::ObjectStore for MeteredObjectStore {
         opts: PutOptions,
     ) -> OSResult<PutResult> {
         let size = bytes.content_length() as u64;
-        let _in_flight = InFlightGuard::new(&self.scheme, "put");
+        let _in_flight = InFlightGuard::new(&self.base, "put");
         let start = Instant::now();
         let result = self.target.put_opts(location, bytes, opts).await;
-        record_request(&self.scheme, "put", start, size, &result);
+        record_request(&self.base, "put", start, size, &result);
         result
     }
 
@@ -158,7 +174,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
         let upload = self.target.put_multipart_opts(location, opts).await?;
         Ok(Box::new(MeteredMultipartUpload {
             target: upload,
-            scheme: self.scheme.clone(),
+            base: self.base.clone(),
         }))
     }
 
@@ -167,27 +183,37 @@ impl object_store::ObjectStore for MeteredObjectStore {
         // distinguish it here to keep HEAD and GET as separate operations.
         let is_head = options.head;
         let operation = if is_head { "head" } else { "get" };
-        let _in_flight = InFlightGuard::new(&self.scheme, operation);
+        let in_flight = InFlightGuard::new(&self.base, operation);
         let start = Instant::now();
         let result = self.target.get_opts(location, options).await;
-        // A HEAD transfers only metadata, so it has no payload bytes.
-        let bytes = match &result {
-            Ok(res) if !is_head => res.range.end - res.range.start,
-            _ => 0,
-        };
-        record_request(&self.scheme, operation, start, bytes, &result);
-        result
+
+        // A HEAD transfers only metadata, and errors carry no payload, so both
+        // are recorded immediately. `get_opts` only resolves once the response
+        // headers arrive; the body is streamed afterwards, so for a successful
+        // GET we defer recording until the body has been drained (see below).
+        if is_head || result.is_err() {
+            record_request(&self.base, operation, start, 0, &result);
+            return result;
+        }
+
+        let result = result.expect("checked to be Ok above");
+        Ok(meter_get_result(
+            result,
+            self.base.clone(),
+            start,
+            in_flight,
+        ))
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
-        let _in_flight = InFlightGuard::new(&self.scheme, "get");
+        let _in_flight = InFlightGuard::new(&self.base, "get");
         let start = Instant::now();
         let result = self.target.get_ranges(location, ranges).await;
         let bytes = match &result {
             Ok(parts) => parts.iter().map(|b| b.len() as u64).sum(),
             Err(_) => 0,
         };
-        record_request(&self.scheme, "get", start, bytes, &result);
+        record_request(&self.base, "get", start, bytes, &result);
         result
     }
 
@@ -195,8 +221,13 @@ impl object_store::ObjectStore for MeteredObjectStore {
         &self,
         locations: BoxStream<'static, OSResult<Path>>,
     ) -> BoxStream<'static, OSResult<Path>> {
-        let scheme = self.scheme.clone();
-        let in_flight = InFlightGuard::new(&self.scheme, "delete");
+        let base = self.base.clone();
+        // Count one logical delete request per call, matching `list`: a single
+        // `delete_stream` maps to one batched request on stores that support it
+        // (e.g. S3's `DeleteObjects`), so counting per yielded path would
+        // over-count. Errors are still recorded per failing path.
+        record_count(&self.base, "delete");
+        let in_flight = InFlightGuard::new(&self.base, "delete");
         self.target
             .delete_stream(locations)
             .map(move |result| {
@@ -204,10 +235,8 @@ impl object_store::ObjectStore for MeteredObjectStore {
                 // the guard, keeping the gauge raised until the stream is
                 // dropped (a move closure only captures the variables it uses).
                 let _in_flight = &in_flight;
-                // Each yielded path is one delete; failures additionally bump the error counter.
-                record_count(&scheme, "delete");
                 if result.is_err() {
-                    record_error(&scheme, "delete");
+                    record_error(&base, "delete");
                 }
                 result
             })
@@ -215,11 +244,11 @@ impl object_store::ObjectStore for MeteredObjectStore {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
-        record_count(&self.scheme, "list");
+        record_count(&self.base, "list");
         meter_list_stream(
             self.target.list(prefix),
-            self.scheme.clone(),
-            InFlightGuard::new(&self.scheme, "list"),
+            self.base.clone(),
+            InFlightGuard::new(&self.base, "list"),
         )
     }
 
@@ -228,35 +257,35 @@ impl object_store::ObjectStore for MeteredObjectStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, OSResult<ObjectMeta>> {
-        record_count(&self.scheme, "list");
+        record_count(&self.base, "list");
         meter_list_stream(
             self.target.list_with_offset(prefix, offset),
-            self.scheme.clone(),
-            InFlightGuard::new(&self.scheme, "list"),
+            self.base.clone(),
+            InFlightGuard::new(&self.base, "list"),
         )
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
-        let _in_flight = InFlightGuard::new(&self.scheme, "list");
+        let _in_flight = InFlightGuard::new(&self.base, "list");
         let start = Instant::now();
         let result = self.target.list_with_delimiter(prefix).await;
-        record_request(&self.scheme, "list", start, 0, &result);
+        record_request(&self.base, "list", start, 0, &result);
         result
     }
 
     async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
-        let _in_flight = InFlightGuard::new(&self.scheme, "copy");
+        let _in_flight = InFlightGuard::new(&self.base, "copy");
         let start = Instant::now();
         let result = self.target.copy_opts(from, to, opts).await;
-        record_request(&self.scheme, "copy", start, 0, &result);
+        record_request(&self.base, "copy", start, 0, &result);
         result
     }
 
     async fn rename_opts(&self, from: &Path, to: &Path, opts: RenameOptions) -> OSResult<()> {
-        let _in_flight = InFlightGuard::new(&self.scheme, "rename");
+        let _in_flight = InFlightGuard::new(&self.base, "rename");
         let start = Instant::now();
         let result = self.target.rename_opts(from, to, opts).await;
-        record_request(&self.scheme, "rename", start, 0, &result);
+        record_request(&self.base, "rename", start, 0, &result);
         result
     }
 }
@@ -265,7 +294,7 @@ impl object_store::ObjectStore for MeteredObjectStore {
 /// counted once when the stream is created (a single LIST may return many items).
 fn meter_list_stream(
     stream: BoxStream<'static, OSResult<ObjectMeta>>,
-    scheme: String,
+    base: String,
     in_flight: InFlightGuard,
 ) -> BoxStream<'static, OSResult<ObjectMeta>> {
     stream
@@ -275,57 +304,152 @@ fn meter_list_stream(
             // holding it here keeps the gauge raised until the stream is dropped.
             let _in_flight = &in_flight;
             if result.is_err() {
-                record_error(&scheme, "list");
+                record_error(&base, "list");
             }
             result
         })
         .boxed()
 }
 
+/// Wrap a successful GET so the request is recorded once its body has been
+/// fully read, capturing the true transfer duration and byte count rather than
+/// the time-to-first-byte and declared range. For payloads without a body
+/// stream (e.g. a local file handle) the request is recorded immediately.
+fn meter_get_result(
+    mut result: GetResult,
+    base: String,
+    start: Instant,
+    in_flight: InFlightGuard,
+) -> GetResult {
+    match result.payload {
+        GetResultPayload::Stream(stream) => {
+            result.payload = GetResultPayload::Stream(
+                MeteredGetStream {
+                    inner: stream,
+                    base,
+                    start,
+                    bytes: 0,
+                    errored: false,
+                    recorded: false,
+                    _in_flight: in_flight,
+                }
+                .boxed(),
+            );
+            result
+        }
+        // No body stream to observe (e.g. a local file), so record now.
+        other => {
+            let bytes = result.range.end - result.range.start;
+            record_outcome(&base, "get", start, bytes, false);
+            result.payload = other;
+            result
+        }
+    }
+}
+
+/// Stream wrapper over a GET body that records the request (count, duration,
+/// bytes, errors) once the body is fully drained or the stream is dropped.
+struct MeteredGetStream {
+    inner: BoxStream<'static, OSResult<Bytes>>,
+    base: String,
+    start: Instant,
+    bytes: u64,
+    errored: bool,
+    recorded: bool,
+    _in_flight: InFlightGuard,
+}
+
+impl MeteredGetStream {
+    fn record(&mut self) {
+        if self.recorded {
+            return;
+        }
+        self.recorded = true;
+        record_outcome(&self.base, "get", self.start, self.bytes, self.errored);
+    }
+}
+
+impl Stream for MeteredGetStream {
+    type Item = OSResult<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                self.bytes += chunk.len() as u64;
+                Poll::Ready(Some(Ok(chunk)))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                self.errored = true;
+                Poll::Ready(Some(Err(e)))
+            }
+            Poll::Ready(None) => {
+                self.record();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for MeteredGetStream {
+    fn drop(&mut self) {
+        // Records the partial transfer if the body was dropped before it drained.
+        self.record();
+    }
+}
+
 #[derive(Debug)]
 struct MeteredMultipartUpload {
     target: Box<dyn MultipartUpload>,
-    scheme: String,
+    base: String,
 }
 
 #[async_trait::async_trait]
 impl MultipartUpload for MeteredMultipartUpload {
     fn put_part(&mut self, data: PutPayload) -> UploadPart {
-        // Each part upload is a distinct `put` request, so it records the same
-        // count / bytes / latency / error set as a unary put.
-        let scheme = self.scheme.clone();
+        // Each part upload is a distinct request, recorded under the `put_part`
+        // operation with the same count / bytes / latency / error set as a
+        // unary put.
+        let base = self.base.clone();
         let size = data.content_length() as u64;
         let inner = self.target.put_part(data);
         async move {
-            let _in_flight = InFlightGuard::new(&scheme, "put");
+            let _in_flight = InFlightGuard::new(&base, "put_part");
             let start = Instant::now();
             let result = inner.await;
-            record_request(&scheme, "put", start, size, &result);
+            record_request(&base, "put_part", start, size, &result);
             result
         }
         .boxed()
     }
 
     async fn complete(&mut self) -> OSResult<PutResult> {
-        self.target.complete().await
+        // Completing a multipart upload issues its own request that can throttle
+        // or fail, so it is metered like any other operation.
+        let _in_flight = InFlightGuard::new(&self.base, "complete_multipart");
+        let start = Instant::now();
+        let result = self.target.complete().await;
+        record_request(&self.base, "complete_multipart", start, 0, &result);
+        result
     }
 
     async fn abort(&mut self) -> OSResult<()> {
-        self.target.abort().await
+        let _in_flight = InFlightGuard::new(&self.base, "abort_multipart");
+        let start = Instant::now();
+        let result = self.target.abort().await;
+        record_request(&self.base, "abort_multipart", start, 0, &result);
+        result
     }
 }
 
 pub trait ObjectStoreMetricsExt {
-    /// Wrap this store so its operations publish metrics under the given `scheme` label.
-    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore>;
+    /// Wrap this store so its operations publish metrics under the given `base` label.
+    fn metered(self, base: String) -> Arc<dyn object_store::ObjectStore>;
 }
 
 impl ObjectStoreMetricsExt for Arc<dyn object_store::ObjectStore> {
-    fn metered(self, scheme: String) -> Arc<dyn object_store::ObjectStore> {
-        Arc::new(MeteredObjectStore {
-            target: self,
-            scheme,
-        })
+    fn metered(self, base: String) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(MeteredObjectStore { target: self, base })
     }
 }
 
@@ -339,19 +463,19 @@ mod http {
         HttpService, ReqwestConnector,
     };
 
-    /// An [`HttpConnector`] that records throttle responses observed by the
-    /// underlying HTTP client. Install it on the S3 / GCS / Azure builders via
-    /// `with_http_connector`.
+    /// An [`HttpConnector`] that records throttle and retryable responses
+    /// observed by the underlying HTTP client. Install it on the S3 / GCS /
+    /// Azure builders via `with_http_connector`.
     #[derive(Debug)]
     pub struct MeteringHttpConnector {
-        scheme: String,
+        base: String,
         inner: ReqwestConnector,
     }
 
     impl MeteringHttpConnector {
-        pub fn new(scheme: String) -> Self {
+        pub fn new(base: String) -> Self {
             Self {
-                scheme,
+                base,
                 inner: ReqwestConnector::default(),
             }
         }
@@ -361,7 +485,7 @@ mod http {
         fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
             let client = self.inner.connect(options)?;
             Ok(HttpClient::new(MeteringHttpService {
-                scheme: self.scheme.clone(),
+                base: self.base.clone(),
                 inner: client,
             }))
         }
@@ -369,7 +493,7 @@ mod http {
 
     #[derive(Debug)]
     struct MeteringHttpService {
-        scheme: String,
+        base: String,
         inner: HttpClient,
     }
 
@@ -377,16 +501,27 @@ mod http {
     impl HttpService for MeteringHttpService {
         async fn call(&self, req: HttpRequest) -> Result<HttpResponse, HttpError> {
             let response = self.inner.execute(req).await?;
-            let status = response.status();
-            // 429 (throttling) and 5xx (e.g. 503 service unavailable) are the
-            // statuses that drive object_store's retry loop. Each attempt that
-            // hits one is recorded with its numeric status, so 429 and 503 can
-            // be told apart.
-            if status.as_u16() == 429 || status.is_server_error() {
+            let status = response.status().as_u16();
+            // Each attempt that object_store may retry is recorded with its
+            // numeric status. Throttles (429 / 503) are a distinct, narrower
+            // signal than the broader set of retryable responses, so they get
+            // their own counter. 409 (conflict) is intentionally excluded from
+            // the retryable set so commit conflicts are not counted as retries.
+            let is_throttle = status == 429 || status == 503;
+            let is_retryable = status == 429 || status == 408 || (500..600).contains(&status);
+            if is_throttle {
                 metrics::counter!(
                     METRIC_THROTTLE,
-                    "status" => status.as_u16().to_string(),
-                    "scheme" => self.scheme.clone(),
+                    "status" => status.to_string(),
+                    "base" => self.base.clone(),
+                )
+                .increment(1);
+            }
+            if is_retryable {
+                metrics::counter!(
+                    METRIC_RETRYABLE,
+                    "status" => status.to_string(),
+                    "base" => self.base.clone(),
                 )
                 .increment(1);
             }
@@ -424,18 +559,19 @@ mod http {
                 .unwrap()
         }
 
-        fn throttle_count(
+        fn metric_count(
             metrics: &[(metrics::Key, DebugValue)],
-            scheme: &str,
+            name: &str,
+            base: &str,
             status: &str,
         ) -> u64 {
             for (key, value) in metrics {
-                if key.name() != METRIC_THROTTLE {
+                if key.name() != name {
                     continue;
                 }
                 let labels: std::collections::HashMap<&str, &str> =
                     key.labels().map(|l| (l.key(), l.value())).collect();
-                if labels.get("scheme") == Some(&scheme)
+                if labels.get("base") == Some(&base)
                     && labels.get("status") == Some(&status)
                     && let DebugValue::Counter(v) = value
                 {
@@ -446,7 +582,7 @@ mod http {
         }
 
         #[test]
-        fn test_throttle_responses_counted_by_status() {
+        fn test_throttle_and_retryable_responses_counted_by_status() {
             let recorder = DebuggingRecorder::new();
             let snapshotter = recorder.snapshotter();
             metrics::with_local_recorder(&recorder, || {
@@ -456,18 +592,20 @@ mod http {
                 rt.block_on(async {
                     // Each attempt that object_store retries flows through `call`
                     // again; here we simulate that by issuing several responses.
-                    // The scheme is baked into the connector, so it labels the metric.
-                    for (scheme, status) in [
-                        ("s3", 429u16),
-                        ("s3", 503),
-                        ("s3", 503),
-                        ("s3", 500),
-                        ("s3", 200),
-                        ("s3", 404),
-                        ("gs", 429),
+                    // The base is baked into the connector, so it labels the metric.
+                    for (base, status) in [
+                        ("s3$bucket", 429u16),
+                        ("s3$bucket", 503),
+                        ("s3$bucket", 503),
+                        ("s3$bucket", 500),
+                        ("s3$bucket", 408),
+                        ("s3$bucket", 409),
+                        ("s3$bucket", 200),
+                        ("s3$bucket", 404),
+                        ("gs$bucket", 429),
                     ] {
                         let service = MeteringHttpService {
-                            scheme: scheme.into(),
+                            base: base.into(),
                             inner: HttpClient::new(StaticStatusService { status }),
                         };
                         service.call(request()).await.unwrap();
@@ -482,16 +620,31 @@ mod http {
                 .map(|(ck, _unit, _desc, value)| (ck.key().clone(), value))
                 .collect();
 
-            assert_eq!(throttle_count(&recorded, "s3", "429"), 1);
-            assert_eq!(throttle_count(&recorded, "s3", "503"), 2);
-            // Other server errors (5xx) are retryable and counted by their status.
-            assert_eq!(throttle_count(&recorded, "s3", "500"), 1);
-            // Success and non-retryable client errors are not throttles.
-            assert_eq!(throttle_count(&recorded, "s3", "200"), 0);
-            assert_eq!(throttle_count(&recorded, "s3", "404"), 0);
-            // The scheme label is taken from the connector, not shared across schemes.
-            assert_eq!(throttle_count(&recorded, "gs", "429"), 1);
-            assert_eq!(throttle_count(&recorded, "gs", "503"), 0);
+            let throttle = |base, status| metric_count(&recorded, METRIC_THROTTLE, base, status);
+            let retryable = |base, status| metric_count(&recorded, METRIC_RETRYABLE, base, status);
+
+            // Throttles are only 429 and 503.
+            assert_eq!(throttle("s3$bucket", "429"), 1);
+            assert_eq!(throttle("s3$bucket", "503"), 2);
+            assert_eq!(throttle("s3$bucket", "500"), 0);
+            assert_eq!(throttle("s3$bucket", "408"), 0);
+
+            // Retryable is the broader set: 5xx, 429, 408 (but not 409).
+            assert_eq!(retryable("s3$bucket", "429"), 1);
+            assert_eq!(retryable("s3$bucket", "503"), 2);
+            assert_eq!(retryable("s3$bucket", "500"), 1);
+            assert_eq!(retryable("s3$bucket", "408"), 1);
+            // 409 conflict is excluded so commit conflicts are not counted as retries.
+            assert_eq!(retryable("s3$bucket", "409"), 0);
+
+            // Success and non-retryable client errors count as neither.
+            assert_eq!(throttle("s3$bucket", "200"), 0);
+            assert_eq!(retryable("s3$bucket", "404"), 0);
+
+            // The base label is taken from the connector, not shared across stores.
+            assert_eq!(throttle("gs$bucket", "429"), 1);
+            assert_eq!(retryable("gs$bucket", "429"), 1);
+            assert_eq!(throttle("gs$bucket", "503"), 0);
         }
     }
 }
@@ -609,7 +762,7 @@ mod tests {
                 .unwrap();
         });
 
-        let labels = [("operation", "put"), ("scheme", "memory")];
+        let labels = [("operation", "put"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
         assert_eq!(
             counter_value(&recorded, METRIC_BYTES, &labels),
@@ -625,15 +778,52 @@ mod tests {
             let store = metered_store();
             let path = Path::from("a/b.bin");
             store.put(&path, payload(data)).await.unwrap();
-            store.get(&path).await.unwrap();
+            // The GET is only recorded once its body has been fully drained.
+            store.get(&path).await.unwrap().bytes().await.unwrap();
         });
 
-        let labels = [("operation", "get"), ("scheme", "memory")];
+        let labels = [("operation", "get"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
         assert_eq!(
             counter_value(&recorded, METRIC_BYTES, &labels),
             data.len() as u64
         );
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+    }
+
+    #[test]
+    fn test_get_not_recorded_until_body_drained() {
+        let data = b"hello world";
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "get"), ("base", "memory")];
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let store = metered_store();
+                let path = Path::from("a/b.bin");
+                store.put(&path, payload(data)).await.unwrap();
+
+                // Holding the result without reading the body records nothing yet.
+                let result = store.get(&path).await.unwrap();
+                assert_eq!(
+                    counter_value(&snapshot(&snapshotter), METRIC_REQUESTS, &labels),
+                    0
+                );
+
+                // Draining the body records the request with the true byte count.
+                let bytes = result.bytes().await.unwrap();
+                assert_eq!(bytes.len(), data.len());
+                let recorded = snapshot(&snapshotter);
+                assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+                assert_eq!(
+                    counter_value(&recorded, METRIC_BYTES, &labels),
+                    data.len() as u64
+                );
+            });
+        });
     }
 
     #[test]
@@ -649,7 +839,7 @@ mod tests {
             counter_value(
                 &recorded,
                 METRIC_REQUESTS,
-                &[("operation", "head"), ("scheme", "memory")]
+                &[("operation", "head"), ("base", "memory")]
             ),
             1
         );
@@ -658,7 +848,7 @@ mod tests {
             counter_value(
                 &recorded,
                 METRIC_REQUESTS,
-                &[("operation", "get"), ("scheme", "memory")]
+                &[("operation", "get"), ("base", "memory")]
             ),
             0
         );
@@ -667,26 +857,34 @@ mod tests {
             counter_value(
                 &recorded,
                 METRIC_BYTES,
-                &[("operation", "head"), ("scheme", "memory")]
+                &[("operation", "head"), ("base", "memory")]
             ),
             0
         );
     }
 
     #[test]
-    fn test_delete_records_count_per_path() {
+    fn test_delete_records_one_request_per_call() {
         let recorded = capture_metrics(|| async {
             let store = metered_store();
-            let path = Path::from("a/b.bin");
-            store.put(&path, payload(b"x")).await.unwrap();
-            store.delete(&path).await.unwrap();
+            for i in 0..3 {
+                store
+                    .put(&Path::from(format!("a/{i}.bin")), payload(b"x"))
+                    .await
+                    .unwrap();
+            }
+            // `delete` drives `delete_stream`; deleting three paths is still one
+            // logical delete request (a single batched request on real stores).
+            let paths =
+                futures::stream::iter((0..3).map(|i| Ok(Path::from(format!("a/{i}.bin"))))).boxed();
+            let _: Vec<_> = store.delete_stream(paths).collect().await;
         });
 
         assert_eq!(
             counter_value(
                 &recorded,
                 METRIC_REQUESTS,
-                &[("operation", "delete"), ("scheme", "memory")]
+                &[("operation", "delete"), ("base", "memory")]
             ),
             1
         );
@@ -709,7 +907,7 @@ mod tests {
             counter_value(
                 &recorded,
                 METRIC_REQUESTS,
-                &[("operation", "list"), ("scheme", "memory")]
+                &[("operation", "list"), ("base", "memory")]
             ),
             1
         );
@@ -723,7 +921,7 @@ mod tests {
             let _ = store.get(&Path::from("does/not/exist")).await;
         });
 
-        let labels = [("operation", "get"), ("scheme", "memory")];
+        let labels = [("operation", "get"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 1);
         // A failed request is still counted as a request, with latency recorded.
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
@@ -742,7 +940,7 @@ mod tests {
             store.get_ranges(&path, &[2..5, 6..9]).await.unwrap();
         });
 
-        let labels = [("operation", "get"), ("scheme", "memory")];
+        let labels = [("operation", "get"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 6);
         assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
@@ -767,7 +965,7 @@ mod tests {
         });
 
         for operation in ["copy", "rename"] {
-            let labels = [("operation", operation), ("scheme", "memory")];
+            let labels = [("operation", operation), ("base", "memory")];
             assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
             assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
             assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
@@ -785,7 +983,7 @@ mod tests {
                 .unwrap();
         });
 
-        let labels = [("operation", "list"), ("scheme", "memory")];
+        let labels = [("operation", "list"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
         assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
@@ -811,14 +1009,14 @@ mod tests {
             counter_value(
                 &recorded,
                 METRIC_REQUESTS,
-                &[("operation", "list"), ("scheme", "memory")]
+                &[("operation", "list"), ("base", "memory")]
             ),
             1
         );
     }
 
     #[test]
-    fn test_multipart_records_each_part_as_put() {
+    fn test_multipart_records_each_part_and_complete() {
         let recorded = capture_metrics(|| async {
             let store = metered_store();
             let mut upload = store.put_multipart(&Path::from("a/big")).await.unwrap();
@@ -827,13 +1025,38 @@ mod tests {
             upload.complete().await.unwrap();
         });
 
-        let labels = [("operation", "put"), ("scheme", "memory")];
-        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 2);
-        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 12);
+        let part_labels = [("operation", "put_part"), ("base", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &part_labels), 2);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &part_labels), 12);
         // Each part records its own latency sample, like a unary put.
-        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 2);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &part_labels), 2);
         // A successful part upload records no error.
-        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 0);
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &part_labels), 0);
+
+        // Completing the upload is its own metered request.
+        let complete_labels = [("operation", "complete_multipart"), ("base", "memory")];
+        assert_eq!(
+            counter_value(&recorded, METRIC_REQUESTS, &complete_labels),
+            1
+        );
+        assert_eq!(
+            histogram_count(&recorded, METRIC_DURATION, &complete_labels),
+            1
+        );
+    }
+
+    #[test]
+    fn test_multipart_abort_is_recorded() {
+        let recorded = capture_metrics(|| async {
+            let store = metered_store();
+            let mut upload = store.put_multipart(&Path::from("a/big")).await.unwrap();
+            upload.put_part(payload(b"hello")).await.unwrap();
+            upload.abort().await.unwrap();
+        });
+
+        let labels = [("operation", "abort_multipart"), ("base", "memory")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
     }
 
     #[test]
@@ -845,7 +1068,7 @@ mod tests {
             let _ = upload.put_part(payload(b"data")).await;
         });
 
-        let labels = [("operation", "put"), ("scheme", "memory")];
+        let labels = [("operation", "put_part"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 1);
         assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
@@ -857,7 +1080,7 @@ mod tests {
     fn test_in_flight_guard_tracks_and_releases() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
-        let labels = [("operation", "get"), ("scheme", "memory")];
+        let labels = [("operation", "get"), ("base", "memory")];
         metrics::with_local_recorder(&recorder, || {
             let g1 = InFlightGuard::new("memory", "get");
             let g2 = InFlightGuard::new("memory", "get");
@@ -890,7 +1113,7 @@ mod tests {
         // The gauge is emitted for each operation (guard is wired in) and, once
         // the operation completes, balances back to zero.
         for operation in ["put", "get"] {
-            let labels = [("operation", operation), ("scheme", "memory")];
+            let labels = [("operation", operation), ("base", "memory")];
             assert!(has_metric(&recorded, METRIC_IN_FLIGHT, &labels));
             assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &labels), 0.0);
         }
@@ -900,7 +1123,7 @@ mod tests {
     fn test_list_stream_holds_in_flight_until_dropped() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
-        let labels = [("operation", "list"), ("scheme", "memory")];
+        let labels = [("operation", "list"), ("base", "memory")];
         metrics::with_local_recorder(&recorder, || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -929,7 +1152,7 @@ mod tests {
     fn test_delete_stream_holds_in_flight_until_dropped() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
-        let labels = [("operation", "delete"), ("scheme", "memory")];
+        let labels = [("operation", "delete"), ("base", "memory")];
         metrics::with_local_recorder(&recorder, || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -958,7 +1181,7 @@ mod tests {
     fn test_in_flight_released_when_operation_future_dropped() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
-        let labels = [("operation", "get"), ("scheme", "memory")];
+        let labels = [("operation", "get"), ("base", "memory")];
         metrics::with_local_recorder(&recorder, || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1009,12 +1232,12 @@ mod tests {
         });
 
         // delete_stream counts the item and records an error when it fails.
-        let delete_labels = [("operation", "delete"), ("scheme", "memory")];
+        let delete_labels = [("operation", "delete"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &delete_labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_ERRORS, &delete_labels), 1);
 
         // A list request is counted once; a failure while draining records an error.
-        let list_labels = [("operation", "list"), ("scheme", "memory")];
+        let list_labels = [("operation", "list"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &list_labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_ERRORS, &list_labels), 1);
     }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -261,8 +261,10 @@ impl ObjectStoreRegistry {
 
         #[cfg(feature = "metrics")]
         {
+            // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
+            // `az$container@account`) so multiple stores on one cloud differ.
             use crate::object_store::metrics::ObjectStoreMetricsExt;
-            store.inner = store.inner.metered(store.scheme.clone());
+            store.inner = store.inner.metered(cache_path.clone());
         }
 
         if let Some(wrapper) = &params.object_store_wrapper {

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -259,6 +259,12 @@ impl ObjectStoreRegistry {
 
         store.inner = store.inner.traced();
 
+        #[cfg(feature = "metrics")]
+        {
+            use crate::object_store::metrics::ObjectStoreMetricsExt;
+            store.inner = store.inner.metered(store.scheme.clone());
+        }
+
         if let Some(wrapper) = &params.object_store_wrapper {
             store.inner = wrapper.wrap(&cache_path, store.inner);
         }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -89,6 +89,15 @@ impl AwsStoreProvider {
             .with_retry(retry_config)
             .with_region(region);
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -73,6 +73,12 @@ impl AwsStoreProvider {
             s3_storage_options.insert(AmazonS3ConfigKey::S3Express, true.to_string());
         }
 
+        // Compute the metrics label before rewriting the url below, so it
+        // matches the prefix the registry uses to key this store.
+        #[cfg(feature = "metrics")]
+        let store_prefix =
+            self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?;
+
         // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
         base_path.set_scheme("s3").unwrap();
         base_path.set_query(None);
@@ -92,9 +98,7 @@ impl AwsStoreProvider {
         #[cfg(feature = "metrics")]
         {
             builder = builder.with_http_connector(
-                crate::object_store::metrics::MeteringHttpConnector::new(
-                    base_path.scheme().to_string(),
-                ),
+                crate::object_store::metrics::MeteringHttpConnector::new(store_prefix),
             );
         }
 

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -196,7 +196,7 @@ impl AzureBlobStoreProvider {
         {
             builder = builder.with_http_connector(
                 crate::object_store::metrics::MeteringHttpConnector::new(
-                    base_path.scheme().to_string(),
+                    self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?,
                 ),
             );
         }

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -192,6 +192,15 @@ impl AzureBlobStoreProvider {
             builder = builder.with_credentials(credentials);
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -89,6 +89,15 @@ impl GcsStoreProvider {
             builder = builder.with_credentials(credential_provider);
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            builder = builder.with_http_connector(
+                crate::object_store::metrics::MeteringHttpConnector::new(
+                    base_path.scheme().to_string(),
+                ),
+            );
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
 }

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -93,7 +93,7 @@ impl GcsStoreProvider {
         {
             builder = builder.with_http_connector(
                 crate::object_store::metrics::MeteringHttpConnector::new(
-                    base_path.scheme().to_string(),
+                    self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?,
                 ),
             );
         }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -160,6 +160,8 @@ tencent = ["lance-io/tencent"]
 goosefs = ["lance-io/goosefs"]
 tos = ["lance-io/tos"]
 huggingface = ["lance-io/huggingface"]
+# Publish object store metrics via the `metrics` crate.
+metrics = ["lance-io/metrics"]
 geo = ["lance-datafusion/geo", "lance-index/geo"]
 # Enable slow integration tests (disabled by default in CI)
 slow_tests = []

--- a/rust/lance/src/lib.rs
+++ b/rust/lance/src/lib.rs
@@ -81,6 +81,8 @@ pub mod datafusion;
 pub mod dataset;
 pub mod index;
 pub mod io;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod session;
 pub mod table;
 pub mod utils;

--- a/rust/lance/src/metrics.md
+++ b/rust/lance/src/metrics.md
@@ -6,13 +6,19 @@ is a cheap no-op. Metrics are only emitted when Lance is built with the
 
 ## Object store metrics
 
-These track I/O against the underlying object store. The `base` label is the
-store's unique prefix: `s3$my-bucket` / `gs$my-bucket` for bucketed stores,
-`az$container@account` for Azure (where the account also matters), or just
-`file` / `memory` for stores without buckets — so multiple buckets on the same
-cloud can be told apart. `operation` is one of `get`, `put`, `put_part`,
-`head`, `list`, `delete`, `copy`, `rename`, `complete_multipart`, or
-`abort_multipart`.
+These track I/O against the underlying object store. The `base` label
+identifies the store; its cardinality is controlled by the
+`LANCE_OBJECT_STORE_METRICS_LABEL` environment variable:
+
+- `scheme` (default) — the scheme only (`s3`, `gs`, `az`, `file`, `memory`);
+  low, bounded cardinality.
+- `full` — the store's unique prefix (`s3$my-bucket`, `az$container@account`
+  where Azure's account also matters), so multiple buckets on the same cloud
+  can be told apart. Cardinality grows with the number of stores accessed.
+- `off` — omit the `base` label entirely.
+
+`operation` is one of `get`, `put`, `put_part`, `head`, `list`, `delete`,
+`copy`, `rename`, `complete_multipart`, or `abort_multipart`.
 
 Request counts are per logical operation: a `list` or `delete` that spans many
 objects is one request, matching how backends batch them.

--- a/rust/lance/src/metrics.md
+++ b/rust/lance/src/metrics.md
@@ -16,6 +16,7 @@ store scheme (`s3`, `gs`, `azure`, `file`, …), and `operation` is one of
 | `lance_object_store_request_bytes_total` | counter | `operation`, `scheme` | Bytes transferred by `get`/`put` requests. |
 | `lance_object_store_request_duration_seconds` | histogram | `operation`, `scheme` | Per-request latency, in seconds. |
 | `lance_object_store_errors_total` | counter | `operation`, `scheme` | Requests that returned an error. |
+| `lance_object_store_in_flight_requests` | gauge | `operation`, `scheme` | Requests currently in flight. |
 | `lance_object_store_throttle_total` | counter | `status`, `scheme` | Throttle responses (HTTP 429 / 5xx) seen at the HTTP layer, counted per attempt including retries. The `status` label is the numeric HTTP status (e.g. `429`, `503`). |
 
 `lance_object_store_throttle_total` is recorded only for the native cloud

--- a/rust/lance/src/metrics.md
+++ b/rust/lance/src/metrics.md
@@ -1,0 +1,24 @@
+Lance publishes metrics through the [`metrics`](https://docs.rs/metrics) crate
+facade. Install any recorder (Prometheus, OpenTelemetry, etc.) in your
+application and Lance will emit into it; when no recorder is installed, emission
+is a cheap no-op. Metrics are only emitted when Lance is built with the
+`metrics` feature.
+
+## Object store metrics
+
+These track I/O against the underlying object store. The `scheme` label is the
+store scheme (`s3`, `gs`, `azure`, `file`, …), and `operation` is one of
+`get`, `put`, `head`, `list`, `delete`, `copy`, or `rename`.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `lance_object_store_requests_total` | counter | `operation`, `scheme` | Object store requests issued. |
+| `lance_object_store_request_bytes_total` | counter | `operation`, `scheme` | Bytes transferred by `get`/`put` requests. |
+| `lance_object_store_request_duration_seconds` | histogram | `operation`, `scheme` | Per-request latency, in seconds. |
+| `lance_object_store_errors_total` | counter | `operation`, `scheme` | Requests that returned an error. |
+| `lance_object_store_throttle_total` | counter | `status`, `scheme` | Throttle responses (HTTP 429 / 5xx) seen at the HTTP layer, counted per attempt including retries. The `status` label is the numeric HTTP status (e.g. `429`, `503`). |
+
+`lance_object_store_throttle_total` is recorded only for the native cloud
+stores (S3, GCS, Azure); Opendal-backed stores bypass the HTTP client where the
+counter is installed, so they report the other object store metrics but not
+throttle counts.

--- a/rust/lance/src/metrics.md
+++ b/rust/lance/src/metrics.md
@@ -6,20 +6,29 @@ is a cheap no-op. Metrics are only emitted when Lance is built with the
 
 ## Object store metrics
 
-These track I/O against the underlying object store. The `scheme` label is the
-store scheme (`s3`, `gs`, `azure`, `file`, …), and `operation` is one of
-`get`, `put`, `head`, `list`, `delete`, `copy`, or `rename`.
+These track I/O against the underlying object store. The `base` label is the
+store's unique prefix: `s3$my-bucket` / `gs$my-bucket` for bucketed stores,
+`az$container@account` for Azure (where the account also matters), or just
+`file` / `memory` for stores without buckets — so multiple buckets on the same
+cloud can be told apart. `operation` is one of `get`, `put`, `put_part`,
+`head`, `list`, `delete`, `copy`, `rename`, `complete_multipart`, or
+`abort_multipart`.
+
+Request counts are per logical operation: a `list` or `delete` that spans many
+objects is one request, matching how backends batch them.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `lance_object_store_requests_total` | counter | `operation`, `scheme` | Object store requests issued. |
-| `lance_object_store_request_bytes_total` | counter | `operation`, `scheme` | Bytes transferred by `get`/`put` requests. |
-| `lance_object_store_request_duration_seconds` | histogram | `operation`, `scheme` | Per-request latency, in seconds. |
-| `lance_object_store_errors_total` | counter | `operation`, `scheme` | Requests that returned an error. |
-| `lance_object_store_in_flight_requests` | gauge | `operation`, `scheme` | Requests currently in flight. |
-| `lance_object_store_throttle_total` | counter | `status`, `scheme` | Throttle responses (HTTP 429 / 5xx) seen at the HTTP layer, counted per attempt including retries. The `status` label is the numeric HTTP status (e.g. `429`, `503`). |
+| `lance_object_store_requests_total` | counter | `operation`, `base` | Object store requests issued. |
+| `lance_object_store_request_bytes_total` | counter | `operation`, `base` | Bytes transferred by `get`/`put` requests. A `get` is counted once its response body has been fully read. |
+| `lance_object_store_request_duration_seconds` | histogram | `operation`, `base` | Per-request latency, in seconds. For `get` this covers the full body transfer, not just time-to-first-byte. |
+| `lance_object_store_errors_total` | counter | `operation`, `base` | Requests that returned an error. |
+| `lance_object_store_in_flight_requests` | gauge | `operation`, `base` | Requests currently in flight. |
+| `lance_object_store_throttle_total` | counter | `status`, `base` | Throttle responses (HTTP 429 / 503) seen at the HTTP layer, counted per attempt including retries. The `status` label is the numeric HTTP status. |
+| `lance_object_store_retryable_responses_total` | counter | `status`, `base` | Retryable responses (HTTP 5xx / 429 / 408) seen at the HTTP layer, counted per attempt including retries. A superset of `throttle_total`; 409 (conflict) is excluded so commit conflicts are not counted. |
 
-`lance_object_store_throttle_total` is recorded only for the native cloud
-stores (S3, GCS, Azure); Opendal-backed stores bypass the HTTP client where the
-counter is installed, so they report the other object store metrics but not
-throttle counts.
+`lance_object_store_throttle_total` and
+`lance_object_store_retryable_responses_total` are recorded only for the native
+cloud stores (S3, GCS, Azure); Opendal-backed stores bypass the HTTP client
+where the counters are installed, so they report the other object store metrics
+but not throttle/retryable counts.

--- a/rust/lance/src/metrics.rs
+++ b/rust/lance/src/metrics.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Metrics published by Lance.
+#![doc = include_str!("metrics.md")]
+//!
+//! The metrics themselves are emitted from the relevant subsystems (for
+//! example object store I/O is instrumented in
+//! [`lance_io::object_store::metrics`]); this module exists to document the
+//! full catalogue of metric names, types, and labels in one place.


### PR DESCRIPTION
Adds an optional `metrics` feature to `lance-io` that publishes object store metrics through the [`metrics`](https://docs.rs/metrics) crate facade, so applications can wire them to Prometheus, OpenTelemetry, etc. without Lance depending on a specific backend. The feature is **off by default**.

Two layers cooperate:

- **`MeteredObjectStore`** wraps any `ObjectStore` and records per-operation request counts, transferred bytes, latency, errors, and in-flight count, labelled by `operation` (get/put/head/list/delete/copy/rename) and `scheme`. Works for every store regardless of backend.
  - `lance_object_store_requests_total{operation, scheme}`
  - `lance_object_store_request_bytes_total{operation, scheme}`
  - `lance_object_store_request_duration_seconds{operation, scheme}` (histogram)
  - `lance_object_store_errors_total{operation, scheme}`
  - `lance_object_store_in_flight_requests{operation, scheme}` (gauge) — requests currently outstanding, tracked by an RAII guard so the count stays balanced even if a request future or a list/delete stream is dropped before finishing.
- **`MeteringHttpConnector`** wraps the HTTP client used by the native cloud stores (S3 / GCS / Azure) via `with_http_connector`, and records throttle responses per attempt:
  - `lance_object_store_throttle_total{status, scheme}` — counts 429 / 5xx responses.

  Because object_store's retry loop re-issues each request through the `HttpService`, this observes **every retried 429/503 with its precise status code** — something a store-level wrapper cannot see, since object_store retries internally below the `ObjectStore` trait.

Multipart part uploads (`put_part`) record the same count / bytes / latency / errors / in-flight set as a unary `put`, so multipart writes are consistent with the rest of the object store metrics.

### Success criteria
- [x] Requests measured with counts, bytes, latency, and error count, across `operation` and `scheme` labels.
- [x] Retry/throttle counts separated by reason (429 vs 503) — stretch goal.
- [x] `metrics` is an optional dependency.

### Notes
- Opendal-backed stores (tos/oss/goosefs/tencent/hf) get the store-level metrics but not the HTTP-level throttle metrics, since they bypass object_store's HTTP client.
- Enable with `lance-io`'s (or `lance`'s) `metrics` feature.

Closes #7504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Documentation
Available metrics are catalogued in one shared table (`rust/lance/src/metrics.md`), surfaced both in the Rust `lance::metrics` module docs and a new **Observability** docs-site page (`docs/src/guide/observability.md`) via an mkdocs snippet include — single source of truth for Rust and Python.
