### PR TITLE
fix(index): work around rustc nightly ICE in NGramIndexBuilder::stream_spill_reader

### DIFF
--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -966,7 +966,7 @@ impl NGramIndexBuilder {
         Ok(())
     }
 
-    async fn stream_spill_reader(
+    fn stream_spill_reader(
         reader: Arc<dyn IndexReader>,
     ) -> Result<impl Stream<Item = Result<NGramIndexSpillState>>> {
         let num_rows = reader.num_rows();
@@ -996,7 +996,7 @@ impl NGramIndexBuilder {
         let reader = spill_store
             .open_index_file(&Self::spill_filename(id))
             .await?;
-        Self::stream_spill_reader(reader).await
+        Self::stream_spill_reader(reader)
     }
 
     fn merge_spill_states(
@@ -1202,7 +1202,7 @@ impl NGramIndexBuilder {
 
         let left_stream = Self::stream_spill(self.spill_store.clone(), new_data_num).await?;
         let old_reader = old_index.open_index_file(POSTINGS_FILENAME).await?;
-        let right_stream = Self::stream_spill_reader(old_reader).await?;
+        let right_stream = Self::stream_spill_reader(old_reader)?;
 
         Self::merge_spill_streams(left_stream, right_stream, writer.as_mut()).await?;
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1079,7 +1079,7 @@ impl FilteredReadStream {
         mut fragment_read_task: ScopedFragmentRead,
         global_metrics: Arc<FilteredReadGlobalMetrics>,
         fragment_soft_limit: Option<u64>,
-    ) -> Result<impl Stream<Item = Result<ReadBatchFut>>> {
+    ) -> Result<BoxStream<'static, Result<ReadBatchFut>>> {
         let output_schema = Arc::new(fragment_read_task.projection.to_arrow_schema());
 
         if let Some(filter) = &fragment_read_task.filter {

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -218,7 +218,7 @@ impl ExecutionPlan for LancePushdownScanExec {
             )
             .await?;
 
-            frag_scanner.scan().await
+            frag_scanner.scan()
         });
 
         let batch_stream = batch_stream
@@ -325,7 +325,7 @@ impl FragmentScanner {
         })
     }
 
-    pub async fn scan(self) -> Result<impl Stream<Item = Result<RecordBatch>> + 'static + Send> {
+    pub fn scan(self) -> Result<impl Stream<Item = Result<RecordBatch>> + 'static + Send> {
         let batch_readahead = self.config.batch_readahead;
         let simplified_predicates = self.simplified_predicates()?;
         let ordered_output = self.config.ordered_output;


### PR DESCRIPTION
The function was declared `async` but never awaited anything at the top level — `num_rows()` is synchronous and the unfold stream is built synchronously.  The unnecessary `async` triggered an internal compiler error in recent nightly builds:

  error: internal compiler error: Obligation DynCompatible(IndexReader)
  should have been handled by fulfillment already.
  (#0 evaluating async fn body of stream_spill_reader as Future)

Removing `async` and dropping the corresponding `.await` at call sites avoids the ICE while preserving identical runtime behaviour.