### PR TITLE
fix: recover from stale cached manifest size on read

### DIFF
--- a/rust/lance-io/src/utils.rs
+++ b/rust/lance-io/src/utils.rs
@@ -84,7 +84,11 @@ pub async fn read_fixed_stride_array(
 /// followed by the message itself.
 pub async fn read_message<M: Message + Default>(reader: &dyn Reader, pos: usize) -> Result<M> {
     let file_size = reader.size().await?;
-    if pos > file_size {
+    // A message is a u32 length prefix followed by its body; both must lie before
+    // the end. A `pos` too close to the end means the reader size is too small
+    // (e.g. a stale cached size). Reject it rather than slice a short buffer and
+    // panic.
+    if pos + 4 > file_size {
         return Err(Error::io("file size is too small".to_string()));
     }
 
@@ -96,7 +100,9 @@ pub async fn read_message<M: Message + Default>(reader: &dyn Reader, pos: usize)
         let remaining_range = range.end..min(4 + pos + msg_len, file_size);
         let remaining_bytes = reader.get_range(remaining_range).await?;
         let buf = [buf, remaining_bytes].concat();
-        assert!(buf.len() >= msg_len + 4);
+        if buf.len() < msg_len + 4 {
+            return Err(Error::io("file size is too small".to_string()));
+        }
         Ok(M::decode(&buf[4..4 + msg_len])?)
     } else {
         Ok(M::decode(&buf[4..4 + msg_len])?)

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -115,14 +115,18 @@ pub async fn read_manifest_indexes(
     manifest: &Manifest,
 ) -> Result<Vec<IndexMetadata>> {
     if let Some(pos) = manifest.index_section.as_ref() {
-        let reader = if let Some(size) = location.size {
-            object_store
-                .open_with_size(&location.path, size as usize)
-                .await?
-        } else {
-            object_store.open(&location.path).await?
+        let result = read_index_section(object_store, &location.path, location.size, *pos).await;
+        // A stale cached size makes the index offset fall outside the sized view,
+        // so the read fails as "file size is too small". Retry once with the true
+        // size; surface any other error unchanged.
+        let section = match result {
+            Err(e)
+                if location.size.is_some() && e.to_string().contains("file size is too small") =>
+            {
+                read_index_section(object_store, &location.path, None, *pos).await?
+            }
+            other => other?,
         };
-        let section: pb::IndexSection = read_message(reader.as_ref(), *pos).await?;
 
         let indices = section
             .indices
@@ -133,6 +137,22 @@ pub async fn read_manifest_indexes(
     } else {
         Ok(vec![])
     }
+}
+
+/// Read the index section message at `pos`, opening the manifest with a known
+/// size when one is provided.
+async fn read_index_section(
+    object_store: &ObjectStore,
+    path: &Path,
+    size: Option<u64>,
+    pos: usize,
+) -> Result<pb::IndexSection> {
+    let reader = if let Some(size) = size {
+        object_store.open_with_size(path, size as usize).await?
+    } else {
+        object_store.open(path).await?
+    };
+    read_message(reader.as_ref(), pos).await
 }
 
 async fn do_write_manifest(

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -42,7 +42,8 @@ use lance_io::utils::{
 };
 use lance_namespace::LanceNamespace;
 use lance_table::format::{
-    DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest, RowIdMeta, pb,
+    DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, MAGIC, Manifest, RowIdMeta,
+    pb,
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, CommitLock, ManifestLocation, ManifestNamingScheme,
@@ -654,6 +655,24 @@ impl Dataset {
                     }
                     _ => Error::io_source(err.into()),
                 })?;
+
+        // A stale cached size yields a bogus footer offset. Detect it (the block
+        // lacks the trailing magic) and retry with the true size, like
+        // read_manifest.
+        if manifest_location.size.is_some() && !last_block.ends_with(MAGIC) {
+            let manifest_location = ManifestLocation {
+                size: None,
+                ..manifest_location.clone()
+            };
+            return Box::pin(Self::load_manifest(
+                object_store,
+                &manifest_location,
+                uri,
+                session,
+            ))
+            .await;
+        }
+
         let offset = read_metadata_offset(&last_block)?;
 
         // If manifest is in the last block, we can decode directly from memory.

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -3679,3 +3679,68 @@ async fn test_legacy_dataset_uses_v2_0_for_indexes() {
         "Index files should never use legacy format, even for legacy datasets"
     );
 }
+
+#[tokio::test]
+async fn test_manifest_read_recovers_from_stale_size() {
+    // A cached `ManifestLocation.size` can lag the real object: a reader may pick
+    // up a size from a stale listing/hint while another writer is committing
+    // concurrently. Reading the manifest (or its index section) with that stale
+    // size must not fail with a spurious "file size is too small" error. The
+    // reader should drop the cached size, fetch the true size, and succeed.
+    use crate::session::Session;
+    use lance_table::io::commit::ManifestLocation;
+    use lance_table::io::manifest::read_manifest_indexes;
+
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from((0..100).collect::<Vec<i32>>()))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+    let mut dataset = Dataset::write(reader, &test_uri, None).await.unwrap();
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            Some("id_idx".to_string()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let real_location = dataset.manifest_location().clone();
+    assert!(real_location.size.is_some());
+
+    // A deliberately-too-small size stands in for a stale cached size. Without the
+    // retry, both reads below decode a bogus footer offset and fail with
+    // "file size is too small".
+    let stale_location = ManifestLocation {
+        size: Some(1),
+        ..real_location.clone()
+    };
+
+    let session = Session::default();
+    let manifest = Dataset::load_manifest(
+        dataset.object_store.as_ref(),
+        &stale_location,
+        test_uri.as_ref(),
+        &session,
+    )
+    .await
+    .expect("load_manifest should recover from a stale manifest size");
+    assert_eq!(manifest.version, real_location.version);
+
+    let indices = read_manifest_indexes(dataset.object_store.as_ref(), &stale_location, &manifest)
+        .await
+        .expect("read_manifest_indexes should recover from a stale manifest size");
+    assert_eq!(indices.len(), 1);
+    assert_eq!(indices[0].name, "id_idx");
+}


### PR DESCRIPTION
ManifestLocation caches a file size to skip a metadata call, but it can lag the real object under concurrent commits. read_manifest already retries without the cached size; the open path did not, so a stale size surfaced as a spurious "file size is too small" error.

Apply the same fallback in load_manifest and read_manifest_indexes, and guard read_message's length-prefix slice against a truncated read.