### PR TITLE
feat: support cross-store (cross-account) deep_clone

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2663,7 +2663,7 @@ impl Dataset {
     /// copies are written through the target object store built from `store_params`.
     /// This makes the clone work across accounts/stores (e.g. between two abfss
     /// accounts): when the source and target stores are the same the copy stays
-    /// server-side, otherwise the data is streamed source -> target.
+    /// server-side, otherwise the data is streamed through this process.
     ///
     /// Parameters:
     /// - `target_path`: the URI string to clone the dataset into.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -37,6 +37,7 @@ use lance_io::object_store::{
     WrappingObjectStore,
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::traits::{WriteExt, Writer};
 use lance_io::utils::{
     CachedFileSize, read_last_block, read_message, read_metadata_offset, read_struct,
 };
@@ -2655,14 +2656,24 @@ impl Dataset {
     }
 
     /// Deep clone the target version into a new dataset at target_path.
-    /// This performs a server-side copy of all relevant dataset files (data files,
-    /// deletion files, and any external row-id files) into the target dataset
-    /// without loading data into memory.
+    /// This copies all relevant dataset files (data files, deletion files, and
+    /// index files) into the target dataset without loading data into memory.
+    ///
+    /// The source files are read through this dataset's own object store while the
+    /// copies are written through the target object store built from `store_params`.
+    /// This makes the clone work across accounts/stores (e.g. between two abfss
+    /// accounts): when the source and target stores are the same the copy stays
+    /// server-side, otherwise the data is streamed source -> target.
     ///
     /// Parameters:
     /// - `target_path`: the URI string to clone the dataset into.
     /// - `version`: the version cloned from, could be a version number, branch head, or tag.
-    /// - `store_params`: the object store params to use for the new dataset.
+    /// - `store_params`: the object store params for the target dataset (e.g. the
+    ///   credentials of the target account).
+    ///
+    /// Note: external `base_paths` referenced by the source manifest are read through
+    /// this dataset's object store; per-base distinct source credentials are not yet
+    /// supported (see <https://github.com/lance-format/lance/issues/6093>).
     pub async fn deep_clone(
         &mut self,
         target_path: &str,
@@ -2703,7 +2714,12 @@ impl Dataset {
             path
         };
 
-        // TODO: Leverage object store bulk copy for efficient deep_clone
+        // When the source and target live in the same store we can keep the copy
+        // server-side. Otherwise (e.g. cloning across accounts) we stream each file
+        // from the source store to the target store.
+        let same_store = src_ds.object_store.store_prefix == target_store.store_prefix;
+
+        // TODO: Leverage object store bulk copy for efficient same-store deep_clone.
         //
         // All cloud storage providers support batch copy APIs that would provide significant
         // performance improvements. We use single file copy before we have upstream support.
@@ -2713,10 +2729,21 @@ impl Dataset {
         let copy_futures = src_paths
             .iter()
             .map(|(relative_path, base)| {
-                let store = Arc::clone(&target_store);
+                let source_store = Arc::clone(&src_ds.object_store);
+                let target_store = Arc::clone(&target_store);
                 let src_path = build_absolute_path(relative_path, base);
                 let target_path = build_absolute_path(relative_path, &target_base);
-                async move { store.copy(&src_path, &target_path).await.map(|_| ()) }
+                async move {
+                    if same_store {
+                        target_store.copy(&src_path, &target_path).await?;
+                    } else {
+                        let reader = source_store.open(&src_path).await?;
+                        let mut writer = target_store.create(&target_path).await?;
+                        writer.copy_from_reader(reader.as_ref()).await?;
+                        writer.shutdown().await?;
+                    }
+                    Result::Ok(())
+                }
             })
             .collect::<Vec<_>>();
 
@@ -2741,6 +2768,7 @@ impl Dataset {
         let builder = CommitBuilder::new(WriteDestination::Uri(target_path))
             .with_store_params(store_params.clone().unwrap_or_default())
             .with_object_store(target_store.clone())
+            .with_source_store(src_ds.object_store.clone())
             .with_commit_handler(self.commit_handler.clone())
             .with_storage_format(self.manifest.data_storage_format.lance_file_version()?);
         let new_ds = builder.execute(txn).await?;

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1124,6 +1124,70 @@ async fn test_deep_clone(
     assert_eq!(count_files(store, &dst_root, "_deletions").await, 0);
 }
 
+#[rstest]
+#[tokio::test]
+async fn test_deep_clone_cross_store(
+    #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
+    data_storage_version: LanceFileVersion,
+) {
+    // Source lives in an in-memory store while the target is a local directory, so the
+    // two stores have different `store_prefix`es and `deep_clone` must stream files from
+    // the source store to the target store (the cross-account code path).
+    let session = Arc::new(Session::default());
+    let test_dir = TempStdDir::default();
+    let clone_dir = test_dir.join("clone_ds");
+    let cloned_uri = clone_dir.to_str().unwrap();
+
+    // 64 rows across 4 files exercises the multi-fragment copy path.
+    let data_reader = gen_batch()
+        .col("id", array::step::<Int32Type>())
+        .col("val", array::fill_utf8("deep".to_string()))
+        .into_reader_rows(RowCount::from(64), BatchCount::from(1));
+
+    let mut dataset = Dataset::write(
+        data_reader,
+        "memory://cross_store_src",
+        Some(WriteParams {
+            max_rows_per_file: 16,
+            max_rows_per_group: 16,
+            data_storage_version: Some(data_storage_version),
+            session: Some(session.clone()),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_ne!(dataset.object_store.store_prefix, "");
+
+    // Delete some rows so a deletion file is also streamed across stores.
+    dataset.delete("id < 10").await.unwrap();
+    let cloned_dataset = dataset
+        .deep_clone(cloned_uri, dataset.version().version, None)
+        .await
+        .unwrap();
+
+    // The clone targets a local store, distinct from the in-memory source.
+    assert_ne!(
+        cloned_dataset.object_store.store_prefix,
+        dataset.object_store.store_prefix
+    );
+    assert!(cloned_dataset.manifest().base_paths.is_empty());
+
+    // Re-open the clone from a fresh session to prove the files were physically copied
+    // into the target store and the clone is fully independent of the source store.
+    let reopened = DatasetBuilder::from_uri(cloned_uri).load().await.unwrap();
+    let batches = reopened
+        .scan()
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 54); // 64 rows - 10 deletions
+}
+
 // Helper: count files under a dataset directory (data/_indices/_deletions)
 async fn count_files(store: &ObjectStore, root: &Path, prefix: &str) -> usize {
     use futures::StreamExt;

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1124,6 +1124,12 @@ async fn test_deep_clone(
     assert_eq!(count_files(store, &dst_root, "_deletions").await, 0);
 }
 
+// Uses an in-memory source store to force a cross-store copy. The in-memory store has
+// known platform-specific quirks on Windows (it reads back empty there; see the note in
+// tests/resource_tests.rs), so this test is gated to non-Windows. The local write side is
+// covered on Windows by `test_deep_clone` (same-store), and the cross-store streaming path
+// against real cloud stores is platform-agnostic std/tokio I/O.
+#[cfg(not(windows))]
 #[rstest]
 #[tokio::test]
 async fn test_deep_clone_cross_store(

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1159,6 +1159,19 @@ async fn test_deep_clone_cross_store(
     .unwrap();
     assert_ne!(dataset.object_store.store_prefix, "");
 
+    // Create a scalar index so the index files and the manifest index section are also
+    // copied across stores (the index section is read through the source store at commit).
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::Scalar,
+            Some("id_idx".to_string()),
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
     // Delete some rows so a deletion file is also streamed across stores.
     dataset.delete("id < 10").await.unwrap();
     let cloned_dataset = dataset
@@ -1186,6 +1199,13 @@ async fn test_deep_clone_cross_store(
         .unwrap();
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(total_rows, 54); // 64 rows - 10 deletions
+
+    // The scalar index must have been copied and resolve against the target store, with its
+    // base reference normalized to local (no external base_paths).
+    let cloned_indices = reopened.load_indices().await.unwrap();
+    assert_eq!(cloned_indices.len(), 1);
+    assert_eq!(cloned_indices.first().unwrap().name, "id_idx");
+    assert!(cloned_indices.iter().all(|idx| idx.base_id.is_none()));
 }
 
 // Helper: count files under a dataset directory (data/_indices/_deletions)

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -43,6 +43,7 @@ pub struct CommitBuilder<'a> {
     commit_handler: Option<Arc<dyn CommitHandler>>,
     store_params: Option<ObjectStoreParams>,
     object_store: Option<Arc<ObjectStore>>,
+    source_store: Option<Arc<ObjectStore>>,
     session: Option<Arc<Session>>,
     detached: bool,
     commit_config: CommitConfig,
@@ -64,6 +65,7 @@ impl<'a> CommitBuilder<'a> {
             commit_handler: None,
             store_params: None,
             object_store: None,
+            source_store: None,
             session: None,
             detached: false,
             commit_config: Default::default(),
@@ -100,6 +102,18 @@ impl<'a> CommitBuilder<'a> {
     /// Pass an object store to use.
     pub fn with_object_store(mut self, object_store: Arc<ObjectStore>) -> Self {
         self.object_store = Some(object_store);
+        self
+    }
+
+    /// Pass the object store of the dataset being cloned from.
+    ///
+    /// Only used by `Operation::Clone`: the source manifest is read through this store
+    /// while the new dataset is written through the destination store. This lets a clone
+    /// cross object stores/accounts (e.g. between two Azure accounts), where the source
+    /// is not reachable with the destination's credentials. Defaults to the destination
+    /// store when not set, preserving same-store behavior.
+    pub fn with_source_store(mut self, source_store: Arc<ObjectStore>) -> Self {
+        self.source_store = Some(source_store);
         self
     }
 
@@ -240,6 +254,9 @@ impl<'a> CommitBuilder<'a> {
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
             .unwrap_or_default();
+
+        // Store used to read the source manifest for a clone (see with_source_store).
+        let source_store = self.source_store.clone();
 
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
@@ -405,6 +422,7 @@ impl<'a> CommitBuilder<'a> {
         } else {
             commit_new_dataset(
                 object_store.as_ref(),
+                source_store.as_deref(),
                 commit_handler.as_ref(),
                 &base_path,
                 &transaction,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -140,6 +140,7 @@ pub(crate) async fn write_transaction_file(
 #[allow(clippy::too_many_arguments)]
 async fn do_commit_new_dataset(
     object_store: &ObjectStore,
+    source_store: Option<&ObjectStore>,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
     transaction: &Transaction,
@@ -163,15 +164,19 @@ async fn do_commit_new_dataset(
         ..
     } = &transaction.operation
     {
+        // The source manifest must be read through the source store, which may differ
+        // from the destination store when cloning across object stores/accounts. Falls
+        // back to the destination store for same-store clones.
+        let source_store = source_store.unwrap_or(object_store);
         let source_base_path =
             ObjectStore::extract_path_from_uri(store_registry, ref_path.as_str())?;
         let source_manifest_location = commit_handler
-            .resolve_version_location(&source_base_path, *ref_version, &object_store.inner)
+            .resolve_version_location(&source_base_path, *ref_version, &source_store.inner)
             .await?;
         let source_manifest = Dataset::load_manifest(
-            object_store,
+            source_store,
             &source_manifest_location,
-            base_path.to_string().as_str(),
+            ref_path.as_str(),
             &Session::default(),
         )
         .await?;
@@ -192,7 +197,7 @@ async fn do_commit_new_dataset(
             );
 
             let updated_indices = if let Some(index_section_pos) = source_manifest.index_section {
-                let reader = object_store.open(&source_manifest_location.path).await?;
+                let reader = source_store.open(&source_manifest_location.path).await?;
                 let section: pb::IndexSection =
                     lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
                 section
@@ -229,7 +234,7 @@ async fn do_commit_new_dataset(
             // Indices: keep metadata but normalize base to local
             let mut updated_indices = Vec::new();
             if let Some(index_section_pos) = source_manifest.index_section {
-                let reader = object_store.open(&source_manifest_location.path).await?;
+                let reader = source_store.open(&source_manifest_location.path).await?;
                 let section: pb::IndexSection =
                     lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
                 updated_indices = section
@@ -300,6 +305,7 @@ async fn do_commit_new_dataset(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn commit_new_dataset(
     object_store: &ObjectStore,
+    source_store: Option<&ObjectStore>,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
     transaction: &Transaction,
@@ -310,6 +316,7 @@ pub(crate) async fn commit_new_dataset(
 ) -> Result<(Manifest, ManifestLocation)> {
     do_commit_new_dataset(
         object_store,
+        source_store,
         commit_handler,
         base_path,
         transaction,


### PR DESCRIPTION
### Problem

`Dataset::deep_clone` could not clone into a different object store / account
(e.g. one Azure account to another). The data files were copied, but the commit
failed: the `Operation::Clone` handler read the **source** manifest (and its index
section) through the **destination** object store, which cannot see the source.
Same-store clones worked only because the two stores coincided. Fixes #7543.

### Change

Read the source manifest through the source dataset's own object store while
writing the new dataset through the destination store:

- **Per-file copy** streams source → target when the stores differ, and keeps the
  server-side `ObjectStore::copy` fast-path when they match (`store_prefix`
  equality).
- **`CommitBuilder::with_source_store`** (new, optional): `commit_new_dataset` /
  `do_commit_new_dataset` thread it into the `Operation::Clone` arm so the source
  manifest **and the index section** are read through it. Defaults to the
  destination store, so same-store clones (and shallow/branch clones) are
  unchanged.
- **`deep_clone`** passes `src_ds.object_store` as the source store and documents
  that external `base_paths` are read through the source store (per-base source
  credentials remain out of scope, see #6093).

No public API break: `with_source_store` is additive; `commit_new_dataset` is
`pub(crate)`.

### Tests

- New `test_deep_clone_cross_store` (in `dataset_io.rs`): in-memory source → local
  target so the two stores have different `store_prefix`es and the streaming path
  runs. Covers a **scalar index** (exercises the source-store index-section read
  and index-file copy) **and** a deletion file; re-opens the clone from a fresh
  session to prove the files were physically copied and the clone is independent,
  and asserts the index resolves with its base normalized to local.
  Verified as a real guard: reverting the index-section read to the destination
  store makes this test fail.
- Existing `test_deep_clone` (same-store) and the shallow/branch clone suite
  continue to pass (12 clone tests green).

### Verification

- Unit: `cargo test -p lance clone` (12 pass), `cargo fmt --all`, `cargo clippy -p
  lance --tests` clean.
- Real cloud e2e (manual, out of CI — no cloud creds in CI): wrote a small table
  to `abfss://…` (with a deletion), `deep_clone`'d **abfss → local** (distinct
  stores), then re-opened the local clone **with no Azure credentials** and
  verified the row count. As a negative control, reverting the source-store read
  reproduces the original failure on the real account
  (`DatasetNotFound: …/_versions/N.manifest` resolved against the destination
  store), confirming the fix is what enables the cross-store clone.

### Notes

- Complementary to #6559 (exposing `deep_clone` to the Python API); this is the
  core correctness fix that lets such a clone cross accounts at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
