### PR TITLE
fix(lance-encoding): rebase nested-list offsets correctly across pages

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -466,10 +466,14 @@ mod tests {
             let total_inner = num_rows * inner_per_row;
             let total_values = total_inner * inner_len;
             let values = Float32Array::from(
-                (0..total_values).map(|i| (start_row + i) as f32).collect::<Vec<_>>(),
+                (0..total_values)
+                    .map(|i| (start_row + i) as f32)
+                    .collect::<Vec<_>>(),
             );
             let inner_offsets = ScalarBuffer::<i32>::from(
-                (0..=total_inner).map(|i| (i * inner_len) as i32).collect::<Vec<_>>(),
+                (0..=total_inner)
+                    .map(|i| (i * inner_len) as i32)
+                    .collect::<Vec<_>>(),
             );
             let inner_list = ListArray::new(
                 Arc::new(Field::new("item", DataType::Float32, true)),
@@ -478,7 +482,9 @@ mod tests {
                 None,
             );
             let outer_offsets = ScalarBuffer::<i32>::from(
-                (0..=num_rows).map(|i| (i * inner_per_row) as i32).collect::<Vec<_>>(),
+                (0..=num_rows)
+                    .map(|i| (i * inner_per_row) as i32)
+                    .collect::<Vec<_>>(),
             );
             Arc::new(ListArray::new(
                 Arc::new(Field::new(

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -428,6 +428,90 @@ mod tests {
         check_basic_random(field).await;
     }
 
+    /// Regression test: a `List<List<Float32>>` column written as MULTIPLE
+    /// batches (chunks) whose flattened leaf values cross a value-page boundary
+    /// fails to decode with "Max offset N exceeds length of values M" (Arrow
+    /// error raised by `ListArray::try_new` in `StructuralListDecodeTask::decode`).
+    ///
+    /// The trigger (verified against the production file and pylance 7.0.0b12 /
+    /// 7.0.0 / 9.0.0-beta.10) requires ALL of:
+    ///   1. >= 2 list layers (`List<List<..>>`),
+    ///   2. a leaf large enough to be chunked into multiple value pages,
+    ///   3. the column written as more than one batch.
+    /// A single batch of the identical data round-trips fine — which is why the
+    /// earlier single-chunk version of this test (and the small `test_nested_list`
+    /// cases) did not catch it. Found in production on the gaming TransNet
+    /// `dino_embedding_per_frame` column (rectangular 3 x 768 float per row).
+    ///
+    /// Each element of the `vec![..]` passed to `check_round_trip_encoding_of_data`
+    /// is encoded as a separate batch (its own `RepDefBuilder`), so we split the
+    /// rows into two chunks to exercise the multi-batch repdef accumulation path.
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_multipage_nested_float_list(
+        #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
+        structural_encoding: &str,
+    ) {
+        use arrow_array::Float32Array;
+
+        // Production shape: 3 inner lists per row, 768 floats each.
+        let inner_per_row: usize = 3;
+        let inner_len: usize = 768;
+        // Two chunks (batches) -> two pages; a read batch that spans the page
+        // boundary is where the multi-page outer-offset bug triggered. A single
+        // [2731] chunk (one page) decodes fine, which is why this needs >= 2.
+        let chunk_rows: &[usize] = &[1366, 1365];
+
+        let make_chunk = |start_row: usize, num_rows: usize| -> Arc<dyn Array> {
+            let total_inner = num_rows * inner_per_row;
+            let total_values = total_inner * inner_len;
+            let values = Float32Array::from(
+                (0..total_values).map(|i| (start_row + i) as f32).collect::<Vec<_>>(),
+            );
+            let inner_offsets = ScalarBuffer::<i32>::from(
+                (0..=total_inner).map(|i| (i * inner_len) as i32).collect::<Vec<_>>(),
+            );
+            let inner_list = ListArray::new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                OffsetBuffer::new(inner_offsets),
+                Arc::new(values),
+                None,
+            );
+            let outer_offsets = ScalarBuffer::<i32>::from(
+                (0..=num_rows).map(|i| (i * inner_per_row) as i32).collect::<Vec<_>>(),
+            );
+            Arc::new(ListArray::new(
+                Arc::new(Field::new(
+                    "item",
+                    DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                    true,
+                )),
+                OffsetBuffer::new(outer_offsets),
+                Arc::new(inner_list),
+                None,
+            ))
+        };
+
+        let mut start = 0;
+        let chunks: Vec<Arc<dyn Array>> = chunk_rows
+            .iter()
+            .map(|&n| {
+                let c = make_chunk(start, n);
+                start += n;
+                c
+            })
+            .collect();
+
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert(
+            STRUCTURAL_ENCODING_META_KEY.to_string(),
+            structural_encoding.into(),
+        );
+
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
+        check_round_trip_encoding_of_data(chunks, &test_cases, field_metadata).await;
+    }
+
     #[test_log::test(tokio::test)]
     async fn test_list_struct_list() {
         let struct_type = DataType::Struct(Fields::from(vec![Field::new(

--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -1743,7 +1743,11 @@ impl RepDefUnraveler {
             }
             let num_new_lists = offsets.len() - old_offsets_len;
             offsets.push(to_offset(curlen)?);
-            rep_levels.truncate(offsets.len() - 1);
+            // Truncate to the number of lists THIS unraveler produced (write_idx),
+            // not `offsets.len() - 1` — the latter includes offsets contributed by
+            // earlier unravelers in a multi-page read, which would leave too many
+            // rep levels for the next (outer) layer and over-count its lists.
+            rep_levels.truncate(write_idx);
             if let Some(validity) = validity {
                 // Even though we don't have validity it is possible another unraveler did and so we need
                 // to push all valids
@@ -2957,6 +2961,40 @@ mod tests {
         let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
         assert_eq!(off.inner(), offsets_32(&[0, 2, 3, 5]).inner());
         assert_eq!(val, None);
+    }
+
+    #[test]
+    fn test_repdef_nested_list_multibatch_matches_single() {
+        // Single builder: List<List<i32>>, 3 rows.
+        //   outer [0,2,3,5] -> rows have 2,1,2 inner lists
+        //   inner [0,1,3,5,7,9] -> 5 inner lists, lengths 1,2,2,2,2 (9 leaf)
+        let mut single = RepDefBuilder::default();
+        single.add_offsets(offsets_64(&[0, 2, 3, 5]), None);
+        single.add_offsets(offsets_64(&[0, 1, 3, 5, 7, 9]), None);
+        single.add_no_null(9);
+        let single_rep = RepDefBuilder::serialize(vec![single])
+            .repetition_levels
+            .unwrap();
+
+        // Same logical data split into two batches:
+        //   batch0 = rows 0,1 : outer [0,2,3], inner [0,1,3,5] (3 inner, 5 leaf)
+        //   batch1 = row 2    : outer [0,2],   inner [0,2,4]   (2 inner, 4 leaf)
+        let mut b0 = RepDefBuilder::default();
+        b0.add_offsets(offsets_64(&[0, 2, 3]), None);
+        b0.add_offsets(offsets_64(&[0, 1, 3, 5]), None);
+        b0.add_no_null(5);
+        let mut b1 = RepDefBuilder::default();
+        b1.add_offsets(offsets_64(&[0, 2]), None);
+        b1.add_offsets(offsets_64(&[0, 2, 4]), None);
+        b1.add_no_null(4);
+        let multi_rep = RepDefBuilder::serialize(vec![b0, b1])
+            .repetition_levels
+            .unwrap();
+
+        assert_eq!(
+            *single_rep, *multi_rep,
+            "multi-batch nested-list rep levels must equal single-batch"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #7538.

A `List<List<T>>` (nested list) column written as **multiple batches** is silently corrupted: the write succeeds and `count_rows()` is correct, but reads fail with

```
Invalid argument error: Max offset of N exceeds length of values M
  (ListArray::try_new in StructuralListDecodeTask::decode, encodings/logical/list.rs)
```

once a read batch spans a page boundary. A single batch of the identical data round-trips fine, which is why this slipped past the existing nested-list tests.

## Root cause (decode-side)

The on-disk rep/def levels are correct — multi-batch and single-batch serialization produce byte-identical levels. The bug is in the reader.

Each write batch becomes its own page. A read batch that spans two pages builds a `CompositeRepDefUnraveler` with one `RepDefUnraveler` per page and unravels each layer across them into a **shared** `offsets` vec. In the all-valid branch of `RepDefUnraveler::unravel_offsets`, the rep-level buffer was truncated to:

```rust
rep_levels.truncate(offsets.len() - 1);
```

`offsets` already contains the entries contributed by earlier unravelers, so for the 2nd+ page this keeps too many rep levels. The next (outer) list layer then iterates those extra levels and over-counts its lists, yielding offsets that exceed the decoded child array.

The parallel with-def-levels branch already truncates to the local `write_idx`. The fix makes the all-valid branch consistent:

```rust
rep_levels.truncate(write_idx);
```

Single-page reads are unaffected because `old_offsets_len == 0` makes the two expressions equal — which is exactly why only multi-page nested-list columns were hit.

Because the fix is purely on the reader and the on-disk bytes were always valid, **existing affected files become readable with no rewrite**.

## Tests

- `encodings::logical::list::tests::test_multipage_nested_float_list` — full round-trip of a multi-batch `List<List<Float32>>` (3×768 per row, the production shape), parametrized over miniblock and fullzip. Fails before the fix (`Max offset … exceeds …`), passes after.
- `repdef::tests::test_repdef_nested_list_multibatch_matches_single` — asserts multi-batch and single-batch nested-list rep levels are byte-identical (documents that the encode side is correct).

Full `lance-encoding` suite passes (395 tests). Verified end to end via a from-source pylance build: the minimal Python reproducer and a real previously-unreadable file both read correctly after the fix.
