### PR TITLE
fix(mem-wal): fence writer on WAL persistence failure

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -51,31 +51,20 @@ pub fn box_error(e: impl std::error::Error + Send + Sync + 'static) -> BoxedErro
     Box::new(e)
 }
 
-/// Why a writer is fenced — i.e. why it must stop accepting writes.
-///
-/// Both reasons are terminal for the affected writer, but the recovery
-/// differs, so callers (and downstream HTTP layers) need to tell them apart
-/// rather than parsing an error string:
-///
-/// - [`FenceReason::PeerClaimedEpoch`]: another writer legitimately took
-///   ownership of the shard by claiming a higher epoch. This writer lost the
-///   race and should give up for good.
-/// - [`FenceReason::PersistenceFailure`]: this writer's own WAL persistence
-///   failed (after retries), so its in-memory state may have advanced past the
-///   durable WAL. Continuing would corrupt reads and partial-row updates that
-///   rely on prior values. The writer must be reopened so WAL replay can
-///   re-synchronize memory with durable storage.
+/// Why a writer is fenced. Both reasons are terminal, but callers must tell them
+/// apart (a peer takeover vs. our own failure) rather than parse the message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FenceReason {
-    /// A successor writer claimed a higher epoch.
+    /// A successor writer claimed a higher epoch; this writer lost ownership.
     PeerClaimedEpoch,
-    /// Our own WAL persistence failed; in-memory state may diverge from the WAL.
+    /// Our own WAL persistence failed, so in-memory state may have diverged from
+    /// the durable WAL. The writer must be reopened to replay.
     PersistenceFailure,
 }
 
 impl std::fmt::Display for FenceReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Stable strings — surfaced in error messages and may be matched.
+        // Stable strings — surfaced in error messages.
         let s = match self {
             Self::PeerClaimedEpoch => "peer claimed epoch",
             Self::PersistenceFailure => "persistence failure",
@@ -281,10 +270,9 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-    /// A writer has been fenced and must stop. See [`FenceReason`] for the
-    /// distinction between a peer takeover and a local persistence failure.
-    /// The message retains the `Writer fenced` prefix so legacy string-based
-    /// consumers keep working; new code should match on [`Error::fence_reason`].
+    /// A writer has been fenced and must stop (see [`FenceReason`]). The message
+    /// keeps the `Writer fenced` prefix for legacy string consumers; new code
+    /// should match on [`Error::fence_reason`].
     #[snafu(display("Writer fenced ({reason}): {message}, {location}"))]
     Fenced {
         reason: FenceReason,
@@ -325,8 +313,8 @@ impl Error {
         .build()
     }
 
-    /// This writer's WAL persistence failed, so its in-memory state may have
-    /// diverged from the durable WAL. The writer must be reopened (replay).
+    /// Our WAL persistence failed; in-memory state may have diverged from the
+    /// durable WAL, so the writer must be reopened to replay.
     #[track_caller]
     pub fn writer_poisoned(message: impl Into<String>) -> Self {
         FencedSnafu {
@@ -336,9 +324,8 @@ impl Error {
         .build()
     }
 
-    /// The [`FenceReason`] if this is a [`Error::Fenced`], else `None`. Prefer
-    /// this over matching on the error message when deciding how to react to a
-    /// fence (e.g. retry vs. reopen, or HTTP status mapping).
+    /// The [`FenceReason`] if this is [`Error::Fenced`], else `None`. Prefer this
+    /// over matching the error message to decide how to react to a fence.
     pub fn fence_reason(&self) -> Option<FenceReason> {
         match self {
             Self::Fenced { reason, .. } => Some(*reason),

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -51,6 +51,39 @@ pub fn box_error(e: impl std::error::Error + Send + Sync + 'static) -> BoxedErro
     Box::new(e)
 }
 
+/// Why a writer is fenced — i.e. why it must stop accepting writes.
+///
+/// Both reasons are terminal for the affected writer, but the recovery
+/// differs, so callers (and downstream HTTP layers) need to tell them apart
+/// rather than parsing an error string:
+///
+/// - [`FenceReason::PeerClaimedEpoch`]: another writer legitimately took
+///   ownership of the shard by claiming a higher epoch. This writer lost the
+///   race and should give up for good.
+/// - [`FenceReason::PersistenceFailure`]: this writer's own WAL persistence
+///   failed (after retries), so its in-memory state may have advanced past the
+///   durable WAL. Continuing would corrupt reads and partial-row updates that
+///   rely on prior values. The writer must be reopened so WAL replay can
+///   re-synchronize memory with durable storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FenceReason {
+    /// A successor writer claimed a higher epoch.
+    PeerClaimedEpoch,
+    /// Our own WAL persistence failed; in-memory state may diverge from the WAL.
+    PersistenceFailure,
+}
+
+impl std::fmt::Display for FenceReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Stable strings — surfaced in error messages and may be matched.
+        let s = match self {
+            Self::PeerClaimedEpoch => "peer claimed epoch",
+            Self::PersistenceFailure => "persistence failure",
+        };
+        f.write_str(s)
+    }
+}
+
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
@@ -248,6 +281,17 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    /// A writer has been fenced and must stop. See [`FenceReason`] for the
+    /// distinction between a peer takeover and a local persistence failure.
+    /// The message retains the `Writer fenced` prefix so legacy string-based
+    /// consumers keep working; new code should match on [`Error::fence_reason`].
+    #[snafu(display("Writer fenced ({reason}): {message}, {location}"))]
+    Fenced {
+        reason: FenceReason,
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl Error {
@@ -269,6 +313,37 @@ impl Error {
     #[track_caller]
     pub fn io(message: impl Into<String>) -> Self {
         IOSnafu.into_error(message.into().into())
+    }
+
+    /// A successor writer claimed a higher epoch; this writer lost ownership.
+    #[track_caller]
+    pub fn fenced_by_peer(message: impl Into<String>) -> Self {
+        FencedSnafu {
+            reason: FenceReason::PeerClaimedEpoch,
+            message: message.into(),
+        }
+        .build()
+    }
+
+    /// This writer's WAL persistence failed, so its in-memory state may have
+    /// diverged from the durable WAL. The writer must be reopened (replay).
+    #[track_caller]
+    pub fn writer_poisoned(message: impl Into<String>) -> Self {
+        FencedSnafu {
+            reason: FenceReason::PersistenceFailure,
+            message: message.into(),
+        }
+        .build()
+    }
+
+    /// The [`FenceReason`] if this is a [`Error::Fenced`], else `None`. Prefer
+    /// this over matching on the error message when deciding how to react to a
+    /// fence (e.g. retry vs. reopen, or HTTP status mapping).
+    pub fn fence_reason(&self) -> Option<FenceReason> {
+        match self {
+            Self::Fenced { reason, .. } => Some(*reason),
+            _ => None,
+        }
     }
 
     #[track_caller]

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -17,7 +17,7 @@ pub mod levenshtein;
 pub mod traits;
 pub mod utils;
 
-pub use error::{ArrowResult, Error, Result, box_error};
+pub use error::{ArrowResult, Error, FenceReason, Result, box_error};
 
 /// Wildcard to indicate all non-system columns
 pub const WILDCARD: &str = "*";

--- a/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
@@ -684,6 +684,8 @@ async fn run_search(args: &Args) -> Result<serde_json::Value> {
     let batches_per_gen = (args.max_memtable_rows / args.batch_rows).max(1);
     let config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write: false,
         sync_indexed_write: false,

--- a/rust/lance/benches/mem_wal/kv/mem_wal_kv_point_lookup.rs
+++ b/rust/lance/benches/mem_wal/kv/mem_wal_kv_point_lookup.rs
@@ -788,6 +788,8 @@ async fn run_lance(
     let big = args.rows.saturating_mul(args.value_size + 256).max(1 << 30);
     let config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write: true,
         sync_indexed_write: true,
@@ -817,8 +819,12 @@ async fn run_lance(
         };
         while lo < part_end {
             let hi = (lo + args.batch_rows).min(part_end);
-            let batch =
-                make_batch(schema.clone(), &insert_order[lo..hi], args.value_size, key_type);
+            let batch = make_batch(
+                schema.clone(),
+                &insert_order[lo..hi],
+                args.value_size,
+                key_type,
+            );
             writer.put(vec![batch]).await?;
             lo = hi;
         }
@@ -1519,7 +1525,14 @@ async fn run_lance_flushed(
     let peak_rss_mb = sampler.stop();
     println!(
         "[lance] read p50={:.2}us p95={:.2}us p99={:.2}us mean={:.2}us qps_1t={:.0} qps_{}t={:.0} (hits={hits} miss={misses_resolved}) peak_rss={:.0}MB",
-        stats.p50_us, stats.p95_us, stats.p99_us, stats.mean_us, read_qps_1t, args.threads, read_qps_nt, peak_rss_mb
+        stats.p50_us,
+        stats.p95_us,
+        stats.p99_us,
+        stats.mean_us,
+        read_qps_1t,
+        args.threads,
+        read_qps_nt,
+        peak_rss_mb
     );
 
     Ok(EngineResult {

--- a/rust/lance/benches/mem_wal/point_lookup/mem_wal_point_lookup_bench.rs
+++ b/rust/lance/benches/mem_wal/point_lookup/mem_wal_point_lookup_bench.rs
@@ -334,6 +334,8 @@ async fn run_lookup(args: &Args) -> Result<serde_json::Value> {
     let max_memtable_rows = args.max_memtable_rows;
     let config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write: false,
         sync_indexed_write: false,

--- a/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
@@ -385,6 +385,8 @@ async fn run_checkpoint(
     }
     let writer_config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write: false,
         sync_indexed_write: true,

--- a/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
@@ -208,6 +208,8 @@ async fn main() -> lance_core::Result<()> {
     let total_batches_max = max_rows.div_ceil(batch_size);
     let writer_config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write,
         sync_indexed_write: true,

--- a/rust/lance/benches/mem_wal/vector/mem_wal_vector_bench.rs
+++ b/rust/lance/benches/mem_wal/vector/mem_wal_vector_bench.rs
@@ -516,6 +516,8 @@ async fn run_search(args: &Args) -> Result<serde_json::Value> {
     let row_bytes = VECTOR_DIM * 4 + 8; // embedding + id
     let config = ShardWriterConfig {
         shard_id,
+        max_wal_persist_retries: 3,
+        wal_persist_retry_base_delay: std::time::Duration::from_millis(50),
         shard_spec_id: 0,
         durable_write: false,
         sync_indexed_write: false,

--- a/rust/lance/benches/mem_wal/write/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal/write/mem_wal_write.rs
@@ -630,6 +630,9 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                                 let config = ShardWriterConfig {
                                     shard_id,
                                     shard_spec_id: 0,
+                                    max_wal_persist_retries: 3,
+                                    wal_persist_retry_base_delay:
+                                        std::time::Duration::from_millis(50),
                                     durable_write: durable,
                                     sync_indexed_write: indexed,
                                     max_wal_buffer_size: max_wal_buffer_size

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -39,6 +39,8 @@ mod manifest;
 pub mod memtable;
 pub mod scanner;
 pub mod sharding;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod util;
 mod wal;
 pub mod write;

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -401,6 +401,14 @@ fn writer_config_to_defaults(config: &ShardWriterConfig) -> HashMap<String, Stri
             config.max_wal_buffer_size.to_string(),
         ),
         (
+            "max_wal_persist_retries".to_string(),
+            config.max_wal_persist_retries.to_string(),
+        ),
+        (
+            "wal_persist_retry_base_delay_ms".to_string(),
+            config.wal_persist_retry_base_delay.as_millis().to_string(),
+        ),
+        (
             "max_memtable_size".to_string(),
             config.max_memtable_size.to_string(),
         ),

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -519,8 +519,8 @@ impl ShardManifestStore {
         shard_id: Uuid,
     ) -> Result<()> {
         match manifest {
-            Some(m) if m.writer_epoch > local_epoch => Err(Error::io(format!(
-                "Writer fenced: local epoch {} < stored epoch {} for shard {}",
+            Some(m) if m.writer_epoch > local_epoch => Err(Error::fenced_by_peer(format!(
+                "local epoch {} < stored epoch {} for shard {}",
                 local_epoch, m.writer_epoch, shard_id
             ))),
             _ => Ok(()),

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use super::index::IndexStore;
 use super::util::{WatchableOnceCell, WatchableOnceCellReader};
+use super::wal::WalFlushFailure;
 use super::write::{DurabilityResult, WalFlushResult};
 use crate::Dataset;
 use batch_store::BatchStore;
@@ -103,9 +104,10 @@ pub struct MemTable {
     /// Set when the memtable is frozen and a WAL flush request is sent.
     /// The reader can be awaited to know when WAL flush is complete.
     /// Uses Mutex for interior mutability since the MemTable is wrapped in Arc when frozen.
-    /// Uses Result<WalFlushResult, String> since lance_core::Error doesn't implement Clone.
+    /// Uses `WalFlushFailure` (not `Error`) since `lance_core::Error` doesn't
+    /// implement Clone; the carrier preserves the fence reason for the waiter.
     wal_flush_completion: std::sync::Mutex<
-        Option<WatchableOnceCellReader<std::result::Result<WalFlushResult, String>>>,
+        Option<WatchableOnceCellReader<std::result::Result<WalFlushResult, WalFlushFailure>>>,
     >,
 
     /// Cell for memtable flush completion notification.
@@ -266,7 +268,7 @@ impl MemTable {
     /// the WAL flush is complete.
     pub fn set_wal_flush_completion(
         &self,
-        reader: WatchableOnceCellReader<std::result::Result<WalFlushResult, String>>,
+        reader: WatchableOnceCellReader<std::result::Result<WalFlushResult, WalFlushFailure>>,
     ) {
         *self.wal_flush_completion.lock().unwrap() = Some(reader);
     }
@@ -278,7 +280,7 @@ impl MemTable {
     /// Thread-safe via interior mutability.
     pub fn take_wal_flush_completion(
         &self,
-    ) -> Option<WatchableOnceCellReader<std::result::Result<WalFlushResult, String>>> {
+    ) -> Option<WatchableOnceCellReader<std::result::Result<WalFlushResult, WalFlushFailure>>> {
         self.wal_flush_completion.lock().unwrap().take()
     }
 

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Test-only object store that injects WAL-write failures, for exercising the
+//! WAL persistence-failure fencing path.
+
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::Range;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    RenameOptions, Result as OSResult,
+};
+
+use lance_io::object_store::{
+    ObjectStore, ObjectStoreParams, ObjectStoreRegistry, WrappingObjectStore,
+};
+
+/// Knobs controlling injected WAL-entry write failures, shared with the test.
+#[derive(Debug, Default)]
+pub struct FailControls {
+    /// Remaining WAL-entry `put_opts` calls to fail; saturates at 0. Set high to
+    /// "always fail", set to 0 to "recover".
+    wal_put_failures: AtomicUsize,
+    /// When failing, write to the inner store anyway before reporting the error,
+    /// simulating a lost acknowledgement (the PUT actually landed).
+    simulate_lost_ack: AtomicBool,
+    /// WAL-entry `put_opts` attempts observed, for assertions.
+    wal_put_attempts: AtomicUsize,
+}
+
+impl FailControls {
+    pub fn fail_wal_puts(&self, n: usize) {
+        self.wal_put_failures.store(n, Ordering::SeqCst);
+    }
+    pub fn recover(&self) {
+        self.wal_put_failures.store(0, Ordering::SeqCst);
+    }
+    pub fn set_lost_ack(&self, v: bool) {
+        self.simulate_lost_ack.store(v, Ordering::SeqCst);
+    }
+    pub fn attempts(&self) -> usize {
+        self.wal_put_attempts.load(Ordering::SeqCst)
+    }
+}
+
+/// Wraps the inner store with [`FailingObjectStore`] at construction.
+#[derive(Debug)]
+struct FailingWrapper {
+    controls: Arc<FailControls>,
+}
+
+impl WrappingObjectStore for FailingWrapper {
+    fn wrap(&self, _prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
+        Arc::new(FailingObjectStore {
+            inner: original,
+            controls: self.controls.clone(),
+        })
+    }
+}
+
+/// Delegates everything to `inner`, failing WAL-entry PUTs per [`FailControls`].
+#[derive(Debug)]
+struct FailingObjectStore {
+    inner: Arc<dyn OSObjectStore>,
+    controls: Arc<FailControls>,
+}
+
+impl FailingObjectStore {
+    /// WAL entries live under `.../wal/`; manifests (`.../manifest/`) are never
+    /// failed so `ShardWriter::open`/`claim_epoch` still work.
+    fn is_wal_entry(location: &Path) -> bool {
+        location.as_ref().contains("/wal/")
+    }
+
+    fn injected_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "failing-test-store",
+            source: "injected transient WAL put failure".to_string().into(),
+        }
+    }
+}
+
+impl Display for FailingObjectStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FailingObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait::async_trait]
+impl OSObjectStore for FailingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        if Self::is_wal_entry(location) {
+            self.controls
+                .wal_put_attempts
+                .fetch_add(1, Ordering::SeqCst);
+            if self.controls.wal_put_failures.load(Ordering::SeqCst) > 0 {
+                self.controls
+                    .wal_put_failures
+                    .fetch_sub(1, Ordering::SeqCst);
+                if self.controls.simulate_lost_ack.load(Ordering::SeqCst) {
+                    // The write lands but we still report failure (lost ack).
+                    let _ = self.inner.put_opts(location, payload, opts).await;
+                }
+                return Err(Self::injected_error());
+            }
+        }
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+        self.inner.copy_opts(from, to, opts).await
+    }
+
+    async fn rename_opts(&self, from: &Path, to: &Path, opts: RenameOptions) -> OSResult<()> {
+        self.inner.rename_opts(from, to, opts).await
+    }
+}
+
+/// Build an in-memory `ObjectStore` whose WAL-entry writes can be failed on
+/// demand. Returns the store, its base path, and the shared controls.
+pub async fn failing_memory_store() -> (Arc<ObjectStore>, Path, Arc<FailControls>) {
+    let controls = Arc::new(FailControls::default());
+    let params = ObjectStoreParams {
+        object_store_wrapper: Some(Arc::new(FailingWrapper {
+            controls: controls.clone(),
+        })),
+        ..Default::default()
+    };
+    let (store, base) = ObjectStore::from_uri_and_params(
+        Arc::new(ObjectStoreRegistry::default()),
+        "memory:///",
+        &params,
+    )
+    .await
+    .unwrap();
+    (store, base, controls)
+}

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -873,15 +873,6 @@ pub struct WalAppender {
     retry: WalRetryConfig,
 }
 
-/// Result of attempting to persist a WAL entry at a single position.
-enum SlotOutcome {
-    /// The entry was created by this writer (or a lost-ack retry confirmed our
-    /// own entry already landed at this position).
-    Written,
-    /// The position is occupied by another writer; the caller advances.
-    Conflict,
-}
-
 impl WalAppender {
     /// Open a WAL appender and claim a new writer epoch.
     pub async fn open(
@@ -993,7 +984,13 @@ impl WalAppender {
             *next_pos = Some(self.discover_next_position().await?);
         }
 
+        // `conflicts` counts position races across the whole append (advancing
+        // past slots others hold). `io_attempts` is the per-position retry
+        // budget for transient PUT failures; it only ever grows while we sit on
+        // one position, since the only path that advances resets it implicitly
+        // by living in the `io_attempts == 0` branch.
         let mut conflicts = 0;
+        let mut io_attempts = 0;
         loop {
             let pos = next_pos.ok_or_else(|| {
                 Error::internal(format!(
@@ -1001,8 +998,15 @@ impl WalAppender {
                     self.shard_id
                 ))
             })?;
-            match self.put_at_position(pos, &wal_data).await? {
-                SlotOutcome::Written => {
+            match atomic_put(
+                self.object_store.as_ref(),
+                &self.wal_dir,
+                &wal_entry_filename(pos),
+                wal_data.clone(),
+            )
+            .await
+            {
+                Ok(()) => {
                     let next = pos.checked_add(1).ok_or_else(|| {
                         Error::io(format!("WAL position overflow for shard {}", self.shard_id))
                     })?;
@@ -1016,8 +1020,26 @@ impl WalAppender {
                         wal_bytes,
                     });
                 }
-                SlotOutcome::Conflict => {
+                Err(AtomicPutError::AlreadyExists) => {
                     self.check_fenced().await?;
+                    // If we had already failed to PUT this exact slot, its now
+                    // being occupied is ambiguous: our own lost acknowledgement
+                    // (the PUT landed but errored) or a peer that grabbed the
+                    // slot. We can neither advance-and-rewrite (that would
+                    // duplicate the entry) nor blindly accept it, so we poison
+                    // the writer — reopening replays the WAL and reconciles the
+                    // in-memory state with durable storage before writes resume.
+                    // `check_fenced` above already surfaced the peer case as a
+                    // typed peer fence.
+                    if io_attempts > 0 {
+                        return Err(Error::writer_poisoned(format!(
+                            "WAL position {} for shard {} was taken after a failed PUT; \
+                             in-memory state may diverge from the durable WAL, reopen to replay",
+                            pos, self.shard_id
+                        )));
+                    }
+                    // First touch of this slot: an ordinary position conflict
+                    // (stale cursor, our own earlier entries, or contention).
                     conflicts += 1;
                     if conflicts >= MAX_APPEND_CREATE_CONFLICTS {
                         return Err(Error::io(format!(
@@ -1033,49 +1055,6 @@ impl WalAppender {
                         })?);
                     }
                 }
-            }
-        }
-    }
-
-    /// Persist `wal_data` at exactly `pos`, retrying transient object-store
-    /// failures at the *same* position per [`WalRetryConfig`].
-    ///
-    /// Retrying the same position (rather than advancing on every error) is what
-    /// keeps the WAL free of duplicates under ambiguous failures: if a PUT that
-    /// reported an error had actually landed (a lost acknowledgement), the retry
-    /// sees `AlreadyExists` and confirms our own entry via its writer epoch
-    /// instead of rewriting the data at a new position.
-    ///
-    /// Returns `Conflict` when the slot belongs to another writer (the caller
-    /// advances), `Err(fenced_by_peer)` if a successor fenced us, or
-    /// `Err(writer_poisoned)` once the retry budget is exhausted — at which
-    /// point the writer must be reopened so WAL replay can re-synchronize the
-    /// in-memory state with durable storage.
-    async fn put_at_position(&self, pos: u64, wal_data: &Bytes) -> Result<SlotOutcome> {
-        let mut io_attempts = 0;
-        loop {
-            match atomic_put(
-                self.object_store.as_ref(),
-                &self.wal_dir,
-                &wal_entry_filename(pos),
-                wal_data.clone(),
-            )
-            .await
-            {
-                Ok(()) => return Ok(SlotOutcome::Written),
-                Err(AtomicPutError::AlreadyExists) => {
-                    // A first-attempt conflict is a genuine race for the slot.
-                    // After a transient error, the slot may instead hold our own
-                    // PUT that actually landed — confirm via the entry's writer
-                    // epoch before treating it as someone else's.
-                    if io_attempts == 0 {
-                        return Ok(SlotOutcome::Conflict);
-                    }
-                    return match self.entry_writer_epoch(pos).await? {
-                        Some(epoch) if epoch == self.writer_epoch => Ok(SlotOutcome::Written),
-                        _ => Ok(SlotOutcome::Conflict),
-                    };
-                }
                 Err(AtomicPutError::Other(error)) => {
                     // A successor fence is terminal — don't waste the retry budget.
                     self.check_fenced().await?;
@@ -1088,35 +1067,10 @@ impl WalAppender {
                     }
                     io_attempts += 1;
                     tokio::time::sleep(self.retry.backoff(io_attempts)).await;
+                    // Retry the same position (next_pos unchanged).
                 }
             }
         }
-    }
-
-    /// Read just the writer epoch recorded in the WAL entry at `pos`, or `None`
-    /// if no entry exists. Used by [`Self::put_at_position`] to detect a
-    /// lost-ack: an `AlreadyExists` after a transient PUT failure may be our own
-    /// entry that actually landed.
-    async fn entry_writer_epoch(&self, pos: u64) -> Result<Option<u64>> {
-        let path = self.wal_dir.clone().join(wal_entry_filename(pos));
-        let data = match self.object_store.inner.get(&path).await {
-            Ok(d) => d,
-            Err(object_store::Error::NotFound { .. }) => return Ok(None),
-            Err(e) => {
-                return Err(Error::io(format!(
-                    "failed to read WAL entry {} for shard {}: {}",
-                    pos, self.shard_id, e
-                )));
-            }
-        };
-        let bytes = data.bytes().await.map_err(|e| {
-            Error::io(format!(
-                "failed to read WAL entry bytes at {} for shard {}: {}",
-                pos, self.shard_id, e
-            ))
-        })?;
-        let (writer_epoch, _batches) = deserialize_appender_batches(bytes)?;
-        Ok(Some(writer_epoch))
     }
 
     /// Check that this writer's epoch has not been fenced.

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -65,6 +65,7 @@ fn is_terminal_failure(error: &Error) -> bool {
 pub struct WalFlushFailure {
     /// The fence reason if terminal; `None` for an ordinary flush error.
     pub fence_reason: Option<FenceReason>,
+    /// The error message carrying details about the flush failure.
     pub message: String,
 }
 
@@ -787,7 +788,10 @@ const MAX_CURSOR_PROBE: u64 = 4096;
 /// ([`Error::writer_poisoned`]).
 #[derive(Debug, Clone, Copy)]
 pub struct WalRetryConfig {
+    /// Maximum number of retries for a transient WAL write failure before the
+    /// writer self-fences.
     pub max_retries: usize,
+    /// Base duration for exponential backoff between retry attempts.
     pub base_delay: Duration,
 }
 

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -45,30 +45,25 @@ pub const WRITER_EPOCH_KEY: &str = "writer_epoch";
 /// replay skips sentinels via their empty batch list).
 pub const FENCE_SENTINEL_KEY: &str = "fence_sentinel";
 
-/// True if `error` is a peer fence (a successor claimed a higher epoch). This
-/// is the legitimate-takeover case, distinct from a local persistence failure.
+/// True if `error` is a peer fence (a successor claimed a higher epoch).
 #[cfg(test)]
 fn is_fence_error(error: &Error) -> bool {
     error.fence_reason() == Some(FenceReason::PeerClaimedEpoch)
 }
 
-/// True if `error` is terminal for the writer — either kind of fence. A
-/// terminal failure means the WAL will never advance for this writer, so
-/// durability waiters must be woken with the error instead of blocking, and
-/// subsequent writes must be rejected.
+/// True if `error` is terminal for the writer (either fence kind): the WAL will
+/// never advance, so durability waiters must be woken and later writes rejected.
 fn is_terminal_failure(error: &Error) -> bool {
     error.fence_reason().is_some()
 }
 
-/// Cloneable carrier for a terminal flush failure, used to pass the error
-/// across the async boundaries (`WalFlusher::terminal_error` and the per-flush
-/// `done` cell) where `lance_core::Error` cannot travel because it is not
-/// `Clone`. Preserves the [`FenceReason`] so the typed [`Error::Fenced`] can be
-/// rebuilt for the caller rather than collapsing to a string.
+/// Cloneable carrier that ferries a flush error across the async completion
+/// channels (`WalFlusher::terminal_error` and the per-flush `done` cell), since
+/// `lance_core::Error` is not `Clone`. Preserves the [`FenceReason`] so the typed
+/// [`Error::Fenced`] can be rebuilt rather than flattened to a string.
 #[derive(Clone, Debug)]
 pub struct WalFlushFailure {
-    /// The fence reason when this failure is terminal (peer or persistence).
-    /// `None` for a non-terminal flush error that is merely reported back.
+    /// The fence reason if terminal; `None` for an ordinary flush error.
     pub fence_reason: Option<FenceReason>,
     pub message: String,
 }
@@ -101,10 +96,9 @@ pub struct BatchDurableWatcher {
     rx: watch::Receiver<usize>,
     /// Target batch ID to wait for.
     target_batch_position: usize,
-    /// Terminal flush failure (a peer fence or a persistence-failure self-fence)
-    /// shared with the flusher. When set, the watermark will never advance to
-    /// the target, so `wait` returns this (typed) error instead of blocking
-    /// forever.
+    /// Terminal flush failure shared with the flusher. When set, the watermark
+    /// can never reach the target, so `wait` returns this typed error instead of
+    /// blocking forever.
     terminal_error: Arc<StdMutex<Option<WalFlushFailure>>>,
 }
 
@@ -382,11 +376,9 @@ pub struct WalFlusher {
     /// Created at construction and recreated after each flush.
     /// Used by backpressure to wait for WAL flushes.
     wal_flush_cell: std::sync::Mutex<Option<WatchableOnceCell<super::write::DurabilityResult>>>,
-    /// First terminal flush failure — a peer fence or a persistence-failure
-    /// self-fence. Shared with every `BatchDurableWatcher` so a terminally
-    /// failed flush — which never advances the watermark — wakes durability
-    /// waiters with the typed error instead of hanging them forever, and read
-    /// by `check_poisoned` so the write path fails fast.
+    /// First terminal flush failure, shared with every `BatchDurableWatcher`. It
+    /// wakes durability waiters (the watermark never advances) and is read by
+    /// `check_poisoned` so the write path fails fast.
     terminal_error: Arc<StdMutex<Option<WalFlushFailure>>>,
 }
 
@@ -437,11 +429,9 @@ impl WalFlusher {
         )
     }
 
-    /// Record a terminal flush failure (a peer fence or a persistence-failure
-    /// self-fence) and wake every pending durability waiter. A terminal failure
-    /// is permanent — the watermark will never advance — so waiters must observe
-    /// the error rather than block forever. Idempotent: only the first failure
-    /// is retained.
+    /// Latch a terminal flush failure and wake every durability waiter (the
+    /// watermark never advances, so they must observe the error, not block).
+    /// Idempotent: only the first failure is retained.
     fn mark_terminal_failure(&self, error: &Error) {
         {
             let mut slot = self.terminal_error.lock().unwrap();
@@ -454,11 +444,10 @@ impl WalFlusher {
         self.durable_watermark_tx.send_modify(|_| {});
     }
 
-    /// Fail fast if this writer has been fenced — by a peer or by its own WAL
-    /// persistence failing. Once terminally failed, the in-memory state may no
-    /// longer match the durable WAL, so the write path calls this before
-    /// touching the memtable to reject writes with the typed error instead of
-    /// silently diverging. Recovery is to reopen the shard (replay the WAL).
+    /// Fail fast with the typed error if this writer has been fenced (by a peer
+    /// or its own persistence failure). The write path calls this before touching
+    /// the memtable so a poisoned writer can't diverge further. Recovery is to
+    /// reopen the shard (replay the WAL).
     pub fn check_poisoned(&self) -> Result<()> {
         if let Some(failure) = self.terminal_error.lock().unwrap().clone() {
             return Err(failure.into_error());
@@ -546,11 +535,8 @@ impl WalFlusher {
             }
             WalFlushSource::WalOnly { state } => self.flush_from_wal_only(state).await,
         };
-        // A terminal failure (peer fence or persistence-failure self-fence)
-        // means the append will never succeed, so the durability watermark can
-        // never advance. Wake any waiter (e.g. a `durable_write` put) with the
-        // typed error instead of hanging it, and latch the poison so later
-        // writes fail fast via `check_poisoned`.
+        // A terminal failure means the watermark can never advance; latch the
+        // poison so waiters wake with the typed error and later writes fail fast.
         if let Err(e) = &result
             && is_terminal_failure(e)
         {
@@ -795,14 +781,10 @@ const APPEND_CONFLICT_REFRESH_INTERVAL: usize = 16;
 const MAX_CURSOR_PROBE: u64 = 4096;
 
 /// Retry policy for transient WAL persistence failures before the writer
-/// self-fences.
-///
-/// On a non-conflict object-store error, the appender retries the *same* WAL
-/// position up to `max_retries` more times with exponential backoff starting at
-/// `base_delay`. Retrying the same position (rather than advancing) keeps the
-/// WAL free of duplicate entries: if the failed PUT had actually landed (a lost
-/// acknowledgement), the retry observes our own entry and treats it as success.
-/// Exhausting the budget poisons the writer with [`Error::writer_poisoned`].
+/// self-fences. On a non-conflict object-store error the appender retries the
+/// *same* WAL position up to `max_retries` times with exponential backoff from
+/// `base_delay`; exhausting the budget poisons the writer
+/// ([`Error::writer_poisoned`]).
 #[derive(Debug, Clone, Copy)]
 pub struct WalRetryConfig {
     pub max_retries: usize,
@@ -984,11 +966,10 @@ impl WalAppender {
             *next_pos = Some(self.discover_next_position().await?);
         }
 
-        // `conflicts` counts position races across the whole append (advancing
-        // past slots others hold). `io_attempts` is the per-position retry
-        // budget for transient PUT failures; it only ever grows while we sit on
-        // one position, since the only path that advances resets it implicitly
-        // by living in the `io_attempts == 0` branch.
+        // `conflicts` counts position races across the append; `io_attempts` is
+        // the per-position retry budget for transient PUT failures. The latter
+        // only grows while we sit on one position — the sole advancing branch is
+        // `io_attempts == 0`, so it never carries across positions.
         let mut conflicts = 0;
         let mut io_attempts = 0;
         loop {
@@ -1021,16 +1002,11 @@ impl WalAppender {
                     });
                 }
                 Err(AtomicPutError::AlreadyExists) => {
-                    self.check_fenced().await?;
-                    // If we had already failed to PUT this exact slot, its now
-                    // being occupied is ambiguous: our own lost acknowledgement
-                    // (the PUT landed but errored) or a peer that grabbed the
-                    // slot. We can neither advance-and-rewrite (that would
-                    // duplicate the entry) nor blindly accept it, so we poison
-                    // the writer — reopening replays the WAL and reconciles the
-                    // in-memory state with durable storage before writes resume.
-                    // `check_fenced` above already surfaced the peer case as a
-                    // typed peer fence.
+                    self.check_fenced().await?; // surfaces a peer takeover as a typed fence
+                    // A slot we already failed to PUT is now occupied — ambiguous
+                    // (our lost-ack, or a peer). We can't advance-and-rewrite (would
+                    // duplicate) nor blindly accept it, so poison and let replay
+                    // reconcile on reopen.
                     if io_attempts > 0 {
                         return Err(Error::writer_poisoned(format!(
                             "WAL position {} for shard {} was taken after a failed PUT; \
@@ -1514,6 +1490,7 @@ async fn best_effort_cursor_update(manifest_store: &ShardManifestStore, entry_po
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::mem_wal::test_util::failing_memory_store;
     use arrow_array::{Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use std::sync::Arc;
@@ -1835,18 +1812,13 @@ mod tests {
         second.append(vec![batch.clone()]).await.unwrap();
 
         let err = first.check_fenced().await.unwrap_err();
-        assert!(
-            err.to_string().contains("Writer fenced"),
-            "expected fence error, got: {err}"
-        );
+        // A peer takeover is a typed peer fence, distinct from a self-poison.
+        assert_eq!(err.fence_reason(), Some(FenceReason::PeerClaimedEpoch));
 
         // Fenced writer's cached next_pos still points at 2; the conflict path
         // must surface the fence error rather than silently advance.
         let err = first.append(vec![batch]).await.unwrap_err();
-        assert!(
-            err.to_string().contains("Writer fenced"),
-            "expected fence error from append, got: {err}"
-        );
+        assert_eq!(err.fence_reason(), Some(FenceReason::PeerClaimedEpoch));
     }
 
     #[tokio::test]
@@ -2004,5 +1976,138 @@ mod tests {
         // next_position must still resolve to one past the last appended entry.
         // Three entries from a fresh shard land at 1, 2, 3, so next is 4.
         assert_eq!(tailer.next_position().await.unwrap(), 4);
+    }
+
+    // A transient PUT failure is retried at the same position and then succeeds.
+    #[tokio::test]
+    async fn test_append_retries_transient_failure_then_succeeds() {
+        let (store, base, controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        controls.fail_wal_puts(2); // 2 failures, under the default budget of 3
+        let appender = WalAppender::open(store, base, shard_id, 0).await.unwrap();
+
+        let schema = create_test_schema();
+        let res = appender
+            .append(vec![create_test_batch(&schema, 1)])
+            .await
+            .unwrap();
+        assert_eq!(res.entry_position, FIRST_WAL_ENTRY_POSITION);
+        assert_eq!(controls.attempts(), 3); // 2 failed + 1 succeeded
+    }
+
+    // Exhausting the retry budget poisons the writer with a typed persistence
+    // failure (distinct from a peer fence).
+    #[tokio::test]
+    async fn test_append_poisons_after_exhausting_retries() {
+        let (store, base, controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        controls.fail_wal_puts(usize::MAX);
+        let manifest_store = Arc::new(ShardManifestStore::new(store.clone(), &base, shard_id, 2));
+        let (epoch, _) = manifest_store.claim_epoch(0).await.unwrap();
+        let appender = WalAppender::with_claimed_epoch(
+            store,
+            base,
+            shard_id,
+            manifest_store,
+            epoch,
+            0,
+            WalRetryConfig {
+                max_retries: 2,
+                base_delay: Duration::from_millis(1),
+            },
+        );
+
+        let schema = create_test_schema();
+        let err = appender
+            .append(vec![create_test_batch(&schema, 1)])
+            .await
+            .unwrap_err();
+        assert_eq!(err.fence_reason(), Some(FenceReason::PersistenceFailure));
+        assert_eq!(controls.attempts(), 3); // io_attempts 0,1,2 then poison
+    }
+
+    // A lost acknowledgement (PUT errored but landed) poisons the writer without
+    // ever writing a duplicate entry at the next position.
+    #[tokio::test]
+    async fn test_append_lost_ack_poisons_without_duplicate() {
+        let (store, base, controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        controls.set_lost_ack(true);
+        controls.fail_wal_puts(1);
+        let appender = WalAppender::open(store.clone(), base.clone(), shard_id, 0)
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let err = appender
+            .append(vec![create_test_batch(&schema, 1)])
+            .await
+            .unwrap_err();
+        assert_eq!(err.fence_reason(), Some(FenceReason::PersistenceFailure));
+
+        // The entry landed exactly once; the next slot stays empty.
+        let tailer = WalTailer::new(store, base, shard_id);
+        assert!(
+            tailer
+                .read_entry(FIRST_WAL_ENTRY_POSITION)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            tailer
+                .read_entry(FIRST_WAL_ENTRY_POSITION + 1)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // A persistence failure during flush latches the poison: the flush result,
+    // `check_poisoned`, and the durability watcher all report the typed error
+    // (rather than the watcher hanging on a watermark that never advances).
+    #[tokio::test]
+    async fn test_flush_persistence_failure_poisons_and_wakes_waiter() {
+        let (store, base, controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        controls.fail_wal_puts(usize::MAX);
+        let manifest_store = Arc::new(ShardManifestStore::new(store.clone(), &base, shard_id, 2));
+        let (epoch, _) = manifest_store.claim_epoch(0).await.unwrap();
+        let appender = Arc::new(WalAppender::with_claimed_epoch(
+            store,
+            base,
+            shard_id,
+            manifest_store,
+            epoch,
+            0,
+            WalRetryConfig {
+                max_retries: 1,
+                base_delay: Duration::from_millis(1),
+            },
+        ));
+        let flusher = WalFlusher::new(appender);
+
+        let schema = create_test_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
+        batch_store.append(create_test_batch(&schema, 1)).unwrap();
+        let mut watcher = flusher.track_batch(0);
+
+        let source = batch_store_source(&batch_store);
+        let flush_err = flusher.flush(&source, batch_store.len()).await.unwrap_err();
+        assert_eq!(
+            flush_err.fence_reason(),
+            Some(FenceReason::PersistenceFailure)
+        );
+
+        assert_eq!(
+            flusher.check_poisoned().unwrap_err().fence_reason(),
+            Some(FenceReason::PersistenceFailure)
+        );
+
+        let waited = tokio::time::timeout(Duration::from_secs(5), watcher.wait())
+            .await
+            .expect("watcher hung after a poisoning flush")
+            .expect_err("watcher must surface the poison");
+        assert_eq!(waited.fence_reason(), Some(FenceReason::PersistenceFailure));
     }
 }

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -12,13 +12,15 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use std::time::Duration;
+
 use arrow_array::RecordBatch;
 use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::Schema as ArrowSchema;
 use bytes::Bytes;
 use futures::StreamExt;
-use lance_core::{Error, Result};
+use lance_core::{Error, FenceReason, Result};
 use lance_io::object_store::ObjectStore;
 use object_store::ObjectStoreExt;
 use object_store::path::Path;
@@ -43,11 +45,50 @@ pub const WRITER_EPOCH_KEY: &str = "writer_epoch";
 /// replay skips sentinels via their empty batch list).
 pub const FENCE_SENTINEL_KEY: &str = "fence_sentinel";
 
-/// True if `error` is the terminal fence emitted by `ManifestStore::check_fenced`
-/// (a successor claimed a higher epoch). Matches the message it formats, since
-/// fences surface as a plain `Error::io` rather than a typed variant.
+/// True if `error` is a peer fence (a successor claimed a higher epoch). This
+/// is the legitimate-takeover case, distinct from a local persistence failure.
+#[cfg(test)]
 fn is_fence_error(error: &Error) -> bool {
-    error.to_string().contains("Writer fenced")
+    error.fence_reason() == Some(FenceReason::PeerClaimedEpoch)
+}
+
+/// True if `error` is terminal for the writer — either kind of fence. A
+/// terminal failure means the WAL will never advance for this writer, so
+/// durability waiters must be woken with the error instead of blocking, and
+/// subsequent writes must be rejected.
+fn is_terminal_failure(error: &Error) -> bool {
+    error.fence_reason().is_some()
+}
+
+/// Cloneable carrier for a terminal flush failure, used to pass the error
+/// across the async boundaries (`WalFlusher::terminal_error` and the per-flush
+/// `done` cell) where `lance_core::Error` cannot travel because it is not
+/// `Clone`. Preserves the [`FenceReason`] so the typed [`Error::Fenced`] can be
+/// rebuilt for the caller rather than collapsing to a string.
+#[derive(Clone, Debug)]
+pub struct WalFlushFailure {
+    /// The fence reason when this failure is terminal (peer or persistence).
+    /// `None` for a non-terminal flush error that is merely reported back.
+    pub fence_reason: Option<FenceReason>,
+    pub message: String,
+}
+
+impl WalFlushFailure {
+    pub(crate) fn from_error(error: &Error) -> Self {
+        Self {
+            fence_reason: error.fence_reason(),
+            message: error.to_string(),
+        }
+    }
+
+    /// Rebuild a typed `Error`, restoring the fence reason when present.
+    pub(crate) fn into_error(self) -> Error {
+        match self.fence_reason {
+            Some(FenceReason::PeerClaimedEpoch) => Error::fenced_by_peer(self.message),
+            Some(FenceReason::PersistenceFailure) => Error::writer_poisoned(self.message),
+            None => Error::io(self.message),
+        }
+    }
 }
 
 /// Watcher for batch durability using watermark-based tracking.
@@ -60,10 +101,11 @@ pub struct BatchDurableWatcher {
     rx: watch::Receiver<usize>,
     /// Target batch ID to wait for.
     target_batch_position: usize,
-    /// Terminal flush failure (e.g. a fence) shared with the flusher. When
-    /// set, the watermark will never advance to the target, so `wait`
-    /// returns this error instead of blocking forever.
-    terminal_error: Arc<StdMutex<Option<String>>>,
+    /// Terminal flush failure (a peer fence or a persistence-failure self-fence)
+    /// shared with the flusher. When set, the watermark will never advance to
+    /// the target, so `wait` returns this (typed) error instead of blocking
+    /// forever.
+    terminal_error: Arc<StdMutex<Option<WalFlushFailure>>>,
 }
 
 impl BatchDurableWatcher {
@@ -71,7 +113,7 @@ impl BatchDurableWatcher {
     pub fn new(
         rx: watch::Receiver<usize>,
         target_batch_position: usize,
-        terminal_error: Arc<StdMutex<Option<String>>>,
+        terminal_error: Arc<StdMutex<Option<WalFlushFailure>>>,
     ) -> Self {
         Self {
             rx,
@@ -87,8 +129,8 @@ impl BatchDurableWatcher {
     /// never reach the target.
     pub async fn wait(&mut self) -> Result<()> {
         loop {
-            if let Some(msg) = self.terminal_error.lock().unwrap().clone() {
-                return Err(Error::io(msg));
+            if let Some(failure) = self.terminal_error.lock().unwrap().clone() {
+                return Err(failure.into_error());
             }
             let current = *self.rx.borrow();
             if current >= self.target_batch_position {
@@ -186,8 +228,10 @@ pub struct TriggerWalFlush {
     /// this flush. Use `usize::MAX` to flush all pending batches.
     pub end_batch_position: usize,
     /// Optional cell to write completion result.
-    /// Uses Result<WalFlushResult, String> since Error doesn't implement Clone.
-    pub done: Option<WatchableOnceCell<std::result::Result<WalFlushResult, String>>>,
+    /// Uses `WalFlushFailure` (not `Error`) since `Error` doesn't implement
+    /// `Clone`; the carrier preserves the fence reason so callers waiting on
+    /// this cell still get a typed error.
+    pub done: Option<WatchableOnceCell<std::result::Result<WalFlushResult, WalFlushFailure>>>,
 }
 
 impl std::fmt::Debug for TriggerWalFlush {
@@ -338,11 +382,12 @@ pub struct WalFlusher {
     /// Created at construction and recreated after each flush.
     /// Used by backpressure to wait for WAL flushes.
     wal_flush_cell: std::sync::Mutex<Option<WatchableOnceCell<super::write::DurabilityResult>>>,
-    /// First terminal flush failure (a fence). Shared with every
-    /// `BatchDurableWatcher` so a fenced flush — which never advances the
-    /// watermark — wakes durability waiters with the error instead of
-    /// hanging them forever.
-    terminal_error: Arc<StdMutex<Option<String>>>,
+    /// First terminal flush failure — a peer fence or a persistence-failure
+    /// self-fence. Shared with every `BatchDurableWatcher` so a terminally
+    /// failed flush — which never advances the watermark — wakes durability
+    /// waiters with the typed error instead of hanging them forever, and read
+    /// by `check_poisoned` so the write path fails fast.
+    terminal_error: Arc<StdMutex<Option<WalFlushFailure>>>,
 }
 
 impl WalFlusher {
@@ -392,20 +437,33 @@ impl WalFlusher {
         )
     }
 
-    /// Record a terminal flush failure (a fence) and wake every pending
-    /// durability waiter. A fence is permanent — the watermark will never
-    /// advance — so waiters must observe the error rather than block forever.
-    /// Idempotent: only the first failure is retained.
+    /// Record a terminal flush failure (a peer fence or a persistence-failure
+    /// self-fence) and wake every pending durability waiter. A terminal failure
+    /// is permanent — the watermark will never advance — so waiters must observe
+    /// the error rather than block forever. Idempotent: only the first failure
+    /// is retained.
     fn mark_terminal_failure(&self, error: &Error) {
         {
             let mut slot = self.terminal_error.lock().unwrap();
             if slot.is_none() {
-                *slot = Some(error.to_string());
+                *slot = Some(WalFlushFailure::from_error(error));
             }
         }
         // Wake `wait`ers without advancing the watermark; each re-checks
         // `terminal_error` and returns the error.
         self.durable_watermark_tx.send_modify(|_| {});
+    }
+
+    /// Fail fast if this writer has been fenced — by a peer or by its own WAL
+    /// persistence failing. Once terminally failed, the in-memory state may no
+    /// longer match the durable WAL, so the write path calls this before
+    /// touching the memtable to reject writes with the typed error instead of
+    /// silently diverging. Recovery is to reopen the shard (replay the WAL).
+    pub fn check_poisoned(&self) -> Result<()> {
+        if let Some(failure) = self.terminal_error.lock().unwrap().clone() {
+            return Err(failure.into_error());
+        }
+        Ok(())
     }
 
     /// Get the current durable watermark.
@@ -452,7 +510,7 @@ impl WalFlusher {
         &self,
         source: WalFlushSource,
         end_batch_position: usize,
-        done: Option<WatchableOnceCell<std::result::Result<WalFlushResult, String>>>,
+        done: Option<WatchableOnceCell<std::result::Result<WalFlushResult, WalFlushFailure>>>,
     ) -> Result<()> {
         if let Some(tx) = &self.flush_tx {
             tx.send(TriggerWalFlush {
@@ -488,11 +546,13 @@ impl WalFlusher {
             }
             WalFlushSource::WalOnly { state } => self.flush_from_wal_only(state).await,
         };
-        // A fence is terminal: the append will never succeed, so the
-        // durability watermark can never advance. Wake any waiter (e.g. a
-        // `durable_write` put) with the fence error instead of hanging it.
+        // A terminal failure (peer fence or persistence-failure self-fence)
+        // means the append will never succeed, so the durability watermark can
+        // never advance. Wake any waiter (e.g. a `durable_write` put) with the
+        // typed error instead of hanging it, and latch the poison so later
+        // writes fail fast via `check_poisoned`.
         if let Err(e) = &result
-            && is_fence_error(e)
+            && is_terminal_failure(e)
         {
             self.mark_terminal_failure(e);
         }
@@ -734,6 +794,43 @@ const MAX_APPEND_CREATE_CONFLICTS: usize = 1024;
 const APPEND_CONFLICT_REFRESH_INTERVAL: usize = 16;
 const MAX_CURSOR_PROBE: u64 = 4096;
 
+/// Retry policy for transient WAL persistence failures before the writer
+/// self-fences.
+///
+/// On a non-conflict object-store error, the appender retries the *same* WAL
+/// position up to `max_retries` more times with exponential backoff starting at
+/// `base_delay`. Retrying the same position (rather than advancing) keeps the
+/// WAL free of duplicate entries: if the failed PUT had actually landed (a lost
+/// acknowledgement), the retry observes our own entry and treats it as success.
+/// Exhausting the budget poisons the writer with [`Error::writer_poisoned`].
+#[derive(Debug, Clone, Copy)]
+pub struct WalRetryConfig {
+    pub max_retries: usize,
+    pub base_delay: Duration,
+}
+
+impl Default for WalRetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay: Duration::from_millis(50),
+        }
+    }
+}
+
+impl WalRetryConfig {
+    /// Backoff before retry `attempt` (1-based), capped so a wedged store can't
+    /// block the flush task indefinitely.
+    fn backoff(&self, attempt: usize) -> Duration {
+        const MAX_BACKOFF: Duration = Duration::from_secs(5);
+        let shift = attempt.saturating_sub(1).min(16) as u32;
+        self.base_delay
+            .checked_mul(1u32 << shift)
+            .unwrap_or(MAX_BACKOFF)
+            .min(MAX_BACKOFF)
+    }
+}
+
 /// Result of appending a WAL entry.
 #[derive(Debug, Clone)]
 pub struct WalAppendResult {
@@ -772,6 +869,17 @@ pub struct WalAppender {
     /// so reopened shards report the post-recovery cursor immediately;
     /// updated after each successful append.
     next_entry_position_hint: AtomicU64,
+    /// Retry budget for transient persistence failures before self-fencing.
+    retry: WalRetryConfig,
+}
+
+/// Result of attempting to persist a WAL entry at a single position.
+enum SlotOutcome {
+    /// The entry was created by this writer (or a lost-ack retry confirmed our
+    /// own entry already landed at this position).
+    Written,
+    /// The position is occupied by another writer; the caller advances.
+    Conflict,
 }
 
 impl WalAppender {
@@ -800,6 +908,7 @@ impl WalAppender {
             manifest_store,
             writer_epoch,
             position_hint,
+            WalRetryConfig::default(),
         ))
     }
 
@@ -821,6 +930,7 @@ impl WalAppender {
         manifest_store: Arc<ShardManifestStore>,
         writer_epoch: u64,
         next_entry_position_hint_seed: u64,
+        retry: WalRetryConfig,
     ) -> Self {
         Self {
             object_store,
@@ -830,6 +940,7 @@ impl WalAppender {
             writer_epoch,
             next_entry_position: Mutex::new(None),
             next_entry_position_hint: AtomicU64::new(next_entry_position_hint_seed),
+            retry,
         }
     }
 
@@ -890,15 +1001,8 @@ impl WalAppender {
                     self.shard_id
                 ))
             })?;
-            match atomic_put(
-                self.object_store.as_ref(),
-                &self.wal_dir,
-                &wal_entry_filename(pos),
-                wal_data.clone(),
-            )
-            .await
-            {
-                Ok(()) => {
+            match self.put_at_position(pos, &wal_data).await? {
+                SlotOutcome::Written => {
                     let next = pos.checked_add(1).ok_or_else(|| {
                         Error::io(format!("WAL position overflow for shard {}", self.shard_id))
                     })?;
@@ -912,7 +1016,7 @@ impl WalAppender {
                         wal_bytes,
                     });
                 }
-                Err(AtomicPutError::AlreadyExists) => {
+                SlotOutcome::Conflict => {
                     self.check_fenced().await?;
                     conflicts += 1;
                     if conflicts >= MAX_APPEND_CREATE_CONFLICTS {
@@ -929,12 +1033,90 @@ impl WalAppender {
                         })?);
                     }
                 }
+            }
+        }
+    }
+
+    /// Persist `wal_data` at exactly `pos`, retrying transient object-store
+    /// failures at the *same* position per [`WalRetryConfig`].
+    ///
+    /// Retrying the same position (rather than advancing on every error) is what
+    /// keeps the WAL free of duplicates under ambiguous failures: if a PUT that
+    /// reported an error had actually landed (a lost acknowledgement), the retry
+    /// sees `AlreadyExists` and confirms our own entry via its writer epoch
+    /// instead of rewriting the data at a new position.
+    ///
+    /// Returns `Conflict` when the slot belongs to another writer (the caller
+    /// advances), `Err(fenced_by_peer)` if a successor fenced us, or
+    /// `Err(writer_poisoned)` once the retry budget is exhausted — at which
+    /// point the writer must be reopened so WAL replay can re-synchronize the
+    /// in-memory state with durable storage.
+    async fn put_at_position(&self, pos: u64, wal_data: &Bytes) -> Result<SlotOutcome> {
+        let mut io_attempts = 0;
+        loop {
+            match atomic_put(
+                self.object_store.as_ref(),
+                &self.wal_dir,
+                &wal_entry_filename(pos),
+                wal_data.clone(),
+            )
+            .await
+            {
+                Ok(()) => return Ok(SlotOutcome::Written),
+                Err(AtomicPutError::AlreadyExists) => {
+                    // A first-attempt conflict is a genuine race for the slot.
+                    // After a transient error, the slot may instead hold our own
+                    // PUT that actually landed — confirm via the entry's writer
+                    // epoch before treating it as someone else's.
+                    if io_attempts == 0 {
+                        return Ok(SlotOutcome::Conflict);
+                    }
+                    return match self.entry_writer_epoch(pos).await? {
+                        Some(epoch) if epoch == self.writer_epoch => Ok(SlotOutcome::Written),
+                        _ => Ok(SlotOutcome::Conflict),
+                    };
+                }
                 Err(AtomicPutError::Other(error)) => {
+                    // A successor fence is terminal — don't waste the retry budget.
                     self.check_fenced().await?;
-                    return Err(error);
+                    if io_attempts >= self.retry.max_retries {
+                        return Err(Error::writer_poisoned(format!(
+                            "WAL persistence failed for shard {} at position {} after {} retries; \
+                             in-memory state may diverge from the durable WAL, reopen to replay: {}",
+                            self.shard_id, pos, self.retry.max_retries, error
+                        )));
+                    }
+                    io_attempts += 1;
+                    tokio::time::sleep(self.retry.backoff(io_attempts)).await;
                 }
             }
         }
+    }
+
+    /// Read just the writer epoch recorded in the WAL entry at `pos`, or `None`
+    /// if no entry exists. Used by [`Self::put_at_position`] to detect a
+    /// lost-ack: an `AlreadyExists` after a transient PUT failure may be our own
+    /// entry that actually landed.
+    async fn entry_writer_epoch(&self, pos: u64) -> Result<Option<u64>> {
+        let path = self.wal_dir.clone().join(wal_entry_filename(pos));
+        let data = match self.object_store.inner.get(&path).await {
+            Ok(d) => d,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => {
+                return Err(Error::io(format!(
+                    "failed to read WAL entry {} for shard {}: {}",
+                    pos, self.shard_id, e
+                )));
+            }
+        };
+        let bytes = data.bytes().await.map_err(|e| {
+            Error::io(format!(
+                "failed to read WAL entry bytes at {} for shard {}: {}",
+                pos, self.shard_id, e
+            ))
+        })?;
+        let (writer_epoch, _batches) = deserialize_appender_batches(bytes)?;
+        Ok(Some(writer_epoch))
     }
 
     /// Check that this writer's epoch has not been fenced.
@@ -1430,6 +1612,7 @@ mod tests {
             writer_epoch,
             // Tests start with no entries, so seed the hint at 0.
             0,
+            WalRetryConfig::default(),
         ));
         WalFlusher::new(appender)
     }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -109,14 +109,10 @@ pub struct ShardWriterConfig {
     /// Default: 100ms
     pub max_wal_flush_interval: Option<Duration>,
 
-    /// Number of times a failed WAL persistence PUT is retried (at the same
-    /// position, with exponential backoff) before the writer self-fences.
-    ///
-    /// A persistence failure means the in-memory state may have advanced past
-    /// the durable WAL, so once the budget is exhausted the writer is poisoned
-    /// (`Error::writer_poisoned`) and must be reopened to replay. Retries absorb
-    /// transient object-store errors that `object_store`'s own retry layer does
-    /// not. Default: 3.
+    /// Times a failed WAL PUT is retried (same position, exponential backoff)
+    /// before the writer self-fences. On exhaustion the writer is poisoned
+    /// (`Error::writer_poisoned`) and must be reopened to replay. Absorbs
+    /// transient errors beyond `object_store`'s own retries. Default: 3.
     pub max_wal_persist_retries: usize,
 
     /// Base backoff before the first WAL persistence retry; subsequent retries
@@ -1831,9 +1827,8 @@ impl ShardWriter {
         writer_state: &Arc<SharedWriterState>,
         backpressure: &BackpressureController,
     ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
-        // Reject writes on a fenced writer (peer takeover or a persistence
-        // failure that poisoned us) before mutating the memtable — continuing
-        // would let in-memory state drift further from the durable WAL.
+        // Reject writes on a fenced writer before mutating the memtable, so a
+        // poisoned writer can't drift further from the durable WAL.
         self.wal_flusher.check_poisoned()?;
 
         // Apply backpressure if needed (before acquiring main lock)
@@ -1907,8 +1902,8 @@ impl ShardWriter {
         trigger: &StdRwLock<WalOnlyTriggerState>,
         backpressure: &BackpressureController,
     ) -> Result<WriteResult> {
-        // Reject writes on a fenced writer (peer takeover or persistence-failure
-        // self-fence) before enqueuing — see `put_memtable_no_wait`.
+        // Reject writes on a fenced writer before enqueuing — see
+        // `put_memtable_no_wait`.
         self.wal_flusher.check_poisoned()?;
 
         // Apply backpressure against the pending queue before pushing. The
@@ -3053,8 +3048,10 @@ pub fn new_shared_stats() -> SharedWriteStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::mem_wal::test_util::failing_memory_store;
     use arrow_array::{Int32Array, StringArray};
     use arrow_schema::{DataType, Field};
+    use lance_core::FenceReason;
     use tempfile::TempDir;
 
     async fn create_local_store() -> (Arc<ObjectStore>, Path, String, TempDir) {
@@ -4779,6 +4776,60 @@ mod tests {
             id_field,
             Field::new("name", DataType::Utf8, true),
         ]))
+    }
+
+    // A durable write whose WAL PUT keeps failing poisons the writer with a
+    // typed persistence failure; the next write fails fast with the same reason;
+    // and once storage heals, reopening replays the WAL and writes resume.
+    #[tokio::test]
+    async fn test_writer_poisons_on_persistence_failure_and_recovers_on_reopen() {
+        let (store, base_path, controls) = failing_memory_store().await;
+        let base_uri = "memory:///";
+        let shard_id = Uuid::new_v4();
+        let schema = schema_with_pk();
+        controls.fail_wal_puts(usize::MAX);
+
+        let config = ShardWriterConfig {
+            max_wal_persist_retries: 1,
+            wal_persist_retry_base_delay: Duration::from_millis(1),
+            ..memtable_config_with_pk(shard_id)
+        };
+
+        let writer = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri,
+            config.clone(),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // The durable put waits on the flush, which poisons after its retries.
+        let err = writer
+            .put(vec![create_test_batch(&schema, 0, 1)])
+            .await
+            .unwrap_err();
+        assert_eq!(err.fence_reason(), Some(FenceReason::PersistenceFailure));
+
+        // A poisoned writer rejects further writes fast, same typed reason.
+        let err = writer
+            .put(vec![create_test_batch(&schema, 1, 1)])
+            .await
+            .unwrap_err();
+        assert_eq!(err.fence_reason(), Some(FenceReason::PersistenceFailure));
+        drop(writer);
+
+        // Storage heals: reopening replays the WAL and accepts writes again.
+        controls.recover();
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+        writer
+            .put(vec![create_test_batch(&schema, 2, 1)])
+            .await
+            .unwrap();
     }
 
     /// Replay-on-open recovers durable WAL entries that were never flushed

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -5092,6 +5092,15 @@ mod tests {
         let Err(err) = result else {
             panic!("expected open to fail with fence error during replay");
         };
+        // Assert the *typed* fence reason, not just the message: a regression
+        // reverting this to `Error::io` would still carry a message containing
+        // "fenced" and slip past a string check, but must not report a
+        // `FenceReason`.
+        assert_eq!(
+            err.fence_reason(),
+            Some(FenceReason::PeerClaimedEpoch),
+            "replay must abort with a typed peer-fence error, got: {err}"
+        );
         let msg = err.to_string();
         assert!(
             msg.contains("WAL replay aborted") && msg.contains("fenced"),

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -44,13 +44,13 @@ pub use super::memtable::batch_store::{BatchStore, StoreFull, StoredBatch};
 pub use super::memtable::flush::MemTableFlusher;
 pub use super::memtable::scanner::MemTableScanner;
 pub use super::util::{WatchableOnceCell, WatchableOnceCellReader};
-pub use super::wal::{WalEntry, WalEntryData, WalFlushResult, WalFlusher};
+pub use super::wal::{WalEntry, WalEntryData, WalFlushFailure, WalFlushResult, WalFlusher};
 
 use super::memtable::flush::TriggerMemTableFlush;
 use super::scanner::GenerationWarmer;
 use super::wal::{
-    BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, WalTailer,
-    empty_flush_result,
+    BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState,
+    WalRetryConfig, WalTailer, empty_flush_result,
 };
 use super::{TOMBSTONE, schema_with_tombstone};
 
@@ -108,6 +108,20 @@ pub struct ShardWriterConfig {
     /// and prevents accumulating too much data before flushing to object storage.
     /// Default: 100ms
     pub max_wal_flush_interval: Option<Duration>,
+
+    /// Number of times a failed WAL persistence PUT is retried (at the same
+    /// position, with exponential backoff) before the writer self-fences.
+    ///
+    /// A persistence failure means the in-memory state may have advanced past
+    /// the durable WAL, so once the budget is exhausted the writer is poisoned
+    /// (`Error::writer_poisoned`) and must be reopened to replay. Retries absorb
+    /// transient object-store errors that `object_store`'s own retry layer does
+    /// not. Default: 3.
+    pub max_wal_persist_retries: usize,
+
+    /// Base backoff before the first WAL persistence retry; subsequent retries
+    /// back off exponentially (capped). Default: 50ms.
+    pub wal_persist_retry_base_delay: Duration,
 
     /// Maximum MemTable size in bytes before triggering a flush to storage.
     ///
@@ -250,9 +264,11 @@ impl Default for ShardWriterConfig {
             sync_indexed_write: true,
             max_wal_buffer_size: 10 * 1024 * 1024, // 10MB
             max_wal_flush_interval: Some(Duration::from_millis(100)), // 100ms
-            max_memtable_size: 256 * 1024 * 1024,  // 256MB
-            max_memtable_rows: 100_000,            // 100k rows
-            max_memtable_batches: 8_000,           // 8k batches
+            max_wal_persist_retries: 3,
+            wal_persist_retry_base_delay: Duration::from_millis(50),
+            max_memtable_size: 256 * 1024 * 1024, // 256MB
+            max_memtable_rows: 100_000,           // 100k rows
+            max_memtable_batches: 8_000,          // 8k batches
             manifest_scan_batch_size: 2,
             max_unflushed_memtable_bytes: 1024 * 1024 * 1024, // 1GB
             backpressure_log_interval: Duration::from_secs(30),
@@ -303,6 +319,20 @@ impl ShardWriterConfig {
     /// Set maximum flush interval.
     pub fn with_max_wal_flush_interval(mut self, interval: Duration) -> Self {
         self.max_wal_flush_interval = Some(interval);
+        self
+    }
+
+    /// Set the number of WAL persistence retries before the writer self-fences.
+    /// See [`ShardWriterConfig::max_wal_persist_retries`].
+    pub fn with_max_wal_persist_retries(mut self, retries: usize) -> Self {
+        self.max_wal_persist_retries = retries;
+        self
+    }
+
+    /// Set the base backoff before the first WAL persistence retry.
+    /// See [`ShardWriterConfig::wal_persist_retry_base_delay`].
+    pub fn with_wal_persist_retry_base_delay(mut self, delay: Duration) -> Self {
+        self.wal_persist_retry_base_delay = delay;
         self
     }
 
@@ -843,7 +873,7 @@ async fn replay_memtable_from_wal(
             None => break,
             Some(entry) => {
                 if entry.writer_epoch > our_epoch {
-                    return Err(Error::io(format!(
+                    return Err(Error::fenced_by_peer(format!(
                         "WAL replay aborted: entry at position {} has writer_epoch {} > our claimed epoch {} for shard {} (writer was fenced during open)",
                         position, entry.writer_epoch, our_epoch, shard_id
                     )));
@@ -1054,8 +1084,9 @@ impl SharedWriterState {
         let _memtable_flush_watcher = old_memtable.create_memtable_flush_completion();
 
         if pending_wal_range.is_some() {
-            let completion_cell: WatchableOnceCell<std::result::Result<WalFlushResult, String>> =
-                WatchableOnceCell::new();
+            let completion_cell: WatchableOnceCell<
+                std::result::Result<WalFlushResult, WalFlushFailure>,
+            > = WatchableOnceCell::new();
             let completion_reader = completion_cell.reader();
             old_memtable.set_wal_flush_completion(completion_reader);
 
@@ -1349,6 +1380,10 @@ impl ShardWriter {
             manifest_store.clone(),
             epoch,
             position_hint_seed,
+            WalRetryConfig {
+                max_retries: config.max_wal_persist_retries,
+                base_delay: config.wal_persist_retry_base_delay,
+            },
         ));
 
         // Fence the predecessor before replay (see `write_fence_sentinel`).
@@ -1796,6 +1831,11 @@ impl ShardWriter {
         writer_state: &Arc<SharedWriterState>,
         backpressure: &BackpressureController,
     ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
+        // Reject writes on a fenced writer (peer takeover or a persistence
+        // failure that poisoned us) before mutating the memtable — continuing
+        // would let in-memory state drift further from the durable WAL.
+        self.wal_flusher.check_poisoned()?;
+
         // Apply backpressure if needed (before acquiring main lock)
         backpressure
             .maybe_apply_backpressure(|| {
@@ -1867,6 +1907,10 @@ impl ShardWriter {
         trigger: &StdRwLock<WalOnlyTriggerState>,
         backpressure: &BackpressureController,
     ) -> Result<WriteResult> {
+        // Reject writes on a fenced writer (peer takeover or persistence-failure
+        // self-fence) before enqueuing — see `put_memtable_no_wait`.
+        self.wal_flusher.check_poisoned()?;
+
         // Apply backpressure against the pending queue before pushing. The
         // budget reuses `max_unflushed_memtable_bytes` since WAL-only mode
         // shares the same "in-memory bytes waiting for durable storage"
@@ -1920,7 +1964,9 @@ impl ShardWriter {
             let mut reader = reader;
             match reader.await_value().await {
                 Some(Ok(_)) => {}
-                Some(Err(msg)) => return Err(Error::io(msg)),
+                // Rebuild the typed error (peer fence vs. persistence-failure
+                // self-fence) so a WAL-only durable caller can tell them apart.
+                Some(Err(failure)) => return Err(failure.into_error()),
                 None => {
                     return Err(Error::io(
                         "WAL flush handler exited before reporting durability",
@@ -2135,6 +2181,7 @@ impl ShardWriter {
                 ..
             } => {
                 self.check_fenced().await?;
+                self.wal_flusher.check_poisoned()?;
                 let mut state = state.write().await;
                 if state.memtable.batch_count() == 0 {
                     return Ok(());
@@ -2412,9 +2459,10 @@ impl MessageHandler<TriggerWalFlush> for WalFlushHandler {
                 state.last_flushed_wal_entry_position.max(entry.position);
         }
 
-        // Notify completion if requested
+        // Notify completion if requested. Carry the typed fence reason through
+        // the cell (not just a string) so a waiter rebuilds the right error.
         if let Some(cell) = done {
-            cell.write(result.map_err(|e| e.to_string()));
+            cell.write(result.map_err(|e| WalFlushFailure::from_error(&e)));
         }
 
         Ok(())
@@ -2614,7 +2662,9 @@ impl MemTableFlushHandler {
                 if let Some(mut completion_reader) = memtable.take_wal_flush_completion() {
                     match completion_reader.await_value().await {
                         Some(Ok(flush_result)) => flush_result.entry.map(|e| e.position),
-                        Some(Err(e)) => return Err(Error::io(format!("WAL flush failed: {}", e))),
+                        // Rebuild the typed error so a fence/poison reason
+                        // propagates to the memtable-flush caller too.
+                        Some(Err(e)) => return Err(e.into_error()),
                         None => {
                             return Err(Error::io(
                                 "WAL flush handler exited before reporting completion",
@@ -4969,6 +5019,7 @@ mod tests {
             // hint seed irrelevant; the real position counter is discovered
             // lazily on the first append.
             0,
+            WalRetryConfig::default(),
         );
         high_epoch_appender
             .append(vec![create_test_batch(&schema, 999, 1)])


### PR DESCRIPTION
## Summary

A WAL writer must stop accepting writes the moment its in-memory state can no longer be proven to match the durable WAL — otherwise partial-row updates that read prior values compute against state that may be lost on crash/replay.

Today a genuine object-store write failure (`AtomicPutError::Other`) in `WalAppender::append` is returned to the caller but leaves the writer fully usable, even though `put_memtable_no_wait` has **already** inserted the batch into the in-memory memtable. The in-memory state then diverges from the durable WAL while writes keep flowing. Only a *peer* fence was treated as terminal, and it was detected by string-matching `"Writer fenced"`.

## Changes

- **Retry before fencing.** A failing WAL PUT is retried at the *same* position with exponential backoff, configurable via `ShardWriterConfig::max_wal_persist_retries` / `wal_persist_retry_base_delay` (defaults 3 / 50ms). `object_store`'s own retry layer doesn't cover everything; this absorbs the rest before giving up.
- **Self-fence on exhaustion.** Once the retry budget is spent the flush latches a terminal failure that wakes durability waiters and makes every subsequent `put`/`delete` fail fast (`check_poisoned`). Recovery is **reopen-only**: `ShardWriter::open` re-claims an epoch and replays the WAL to re-synchronize memory with durable storage.
- **No duplicate entries under a lost acknowledgement.** Retries reuse the *same* WAL position. If a retry then finds the slot already occupied (our own PUT landed but its ack was lost, or a peer grabbed it), the writer poisons and lets replay reconcile on reopen — it never advances-and-rewrites, so the WAL cannot gain a duplicate entry. Steady-state writes remain a single CAS; the only added requests are on the error path.
- **Typed fence errors.** New `lance_core::Error::Fenced { reason: FenceReason }` distinguishes `PeerClaimedEpoch` (a successor legitimately took over) from `PersistenceFailure` (our own WAL write failed). Constructors `fenced_by_peer` / `writer_poisoned`, accessor `fence_reason()`. The `Display` keeps the `Writer fenced` prefix for back-compat with existing string consumers (e.g. the downstream 410 mapping). A cloneable `WalFlushFailure` carrier preserves the reason across the async done-cell and terminal-error channels (since `Error` is not `Clone`).

## Tests

A failure-injecting object store (`test_util::failing_memory_store`) fails WAL-entry PUTs on demand (optionally simulating a lost ack). Coverage:

- [x] append retries a transient failure then succeeds
- [x] append poisons with `PersistenceFailure` once retries are exhausted
- [x] a lost acknowledgement poisons **without** a duplicate WAL entry
- [x] a peer takeover stays a typed `PeerClaimedEpoch`
- [x] a poisoning flush latches the error: flush result, `check_poisoned`, and the durability watcher all report it (no hang)
- [x] `ShardWriter` poisons, rejects further writes fast, and recovers on reopen once storage heals

`cargo fmt --all` clean; `cargo clippy -p lance -p lance-core --tests --benches -- -D warnings` clean; `dataset::mem_wal` unit suite passes (430 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)