### PR TITLE
fix(dataset): support updating JSON columns via update_columns

### DIFF
--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -617,6 +617,69 @@ def test_fragment_update_columns_with_custom_join_key(tmp_path):
     assert result["name"][2] == "Chase"  # id=3 should have name Chase
 
 
+def test_fragment_update_columns_json(tmp_path):
+    """Backfill an existing JSON column via fragment update_columns (hash join).
+
+    Regression test: the stored JSON column is physically ``lance.json``
+    (LargeBinary), while the right-hand input arrives as Arrow JSON (Utf8).
+    The hash join used to interleave the two physical representations and fail
+    with "It is not possible to interleave arrays of different data types
+    (Utf8 and LargeBinary)".
+    """
+    base = pa.table(
+        {
+            "save_path": ["a.jpg", "b.jpg"],
+            "dt": ["2026-06-03", "2026-06-03"],
+        }
+    )
+    dataset_uri = tmp_path / "test_dataset_update_columns_json"
+    dataset = lance.write_dataset(base, dataset_uri, max_rows_per_file=2)
+
+    # Add an (all-null) JSON column to backfill later.
+    dataset.add_columns(pa.schema([pa.field("detection", pa.json_())]))
+    dataset = lance.dataset(dataset_uri)
+    assert dataset.schema.field("detection").type == pa.json_()
+
+    right = pa.table(
+        {
+            "save_path": ["a.jpg", "b.jpg"],
+            "detection": pa.array(
+                [
+                    json.dumps({"result": {"score": 0.1}, "res_status": 1}),
+                    json.dumps({"result": {"score": 0.2}, "res_status": 1}),
+                ],
+                type=pa.json_(),
+            ),
+        }
+    )
+
+    fragment = dataset.get_fragment(0)
+    updated_fragment, fields_modified = fragment.update_columns(
+        right, left_on="save_path", right_on="save_path"
+    )
+    assert len(fields_modified) > 0
+
+    op = LanceOperation.Update(
+        updated_fragments=[updated_fragment],
+        fields_modified=fields_modified,
+    )
+    updated_dataset = lance.LanceDataset.commit(
+        str(dataset_uri), op, read_version=dataset.version
+    )
+
+    # JSON type is preserved and the backfilled values round-trip.
+    assert updated_dataset.schema.field("detection").type == pa.json_()
+    result = updated_dataset.to_table(
+        filter="json_get_int(detection, 'res_status') = 1"
+    )
+    assert result.num_rows == 2
+    scores = sorted(
+        json.loads(v)["result"]["score"]
+        for v in result.column("detection").to_pylist()
+    )
+    assert scores == [0.1, 0.2]
+
+
 def test_fragment_update_columns_with_nulls(tmp_path):
     """Test fragment update columns with null values."""
     # Create initial dataset

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -15,7 +15,8 @@ use arrow::compute::concat_batches;
 use arrow_array::cast::as_primitive_array;
 use arrow_array::types::UInt64Type;
 use arrow_array::{
-    Array, RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array, new_null_array,
+    Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StructArray, UInt32Array,
+    UInt64Array, new_null_array,
 };
 use arrow_schema::Schema as ArrowSchema;
 use datafusion::logical_expr::Expr;
@@ -64,6 +65,7 @@ use super::updater::Updater;
 use super::{NewColumnTransform, WriteParams, schema_evolution};
 use crate::dataset::Dataset;
 use crate::dataset::fragment::session::FragmentSession;
+use crate::dataset::utils::SchemaAdapter;
 use crate::io::deletion::read_dataset_deletion_file;
 
 /// Result of [`FileFragment::update_columns_with_offsets`]: updated fragment metadata, modified field ids,
@@ -1891,6 +1893,31 @@ impl FileFragment {
                 None,
             )
             .await?;
+        // The updater reads the left-hand columns in their physical form (e.g. JSON is
+        // stored as `lance.json`/`LargeBinary`). Convert the right-hand stream to the same
+        // physical form so the hash join's `interleave` sees matching types on both sides;
+        // otherwise an existing JSON column (LargeBinary) clashes with the logical Arrow
+        // JSON input (Utf8). New-column paths (`merge`/`merge_columns`) don't hit this
+        // because they have no left-hand fallback to interleave against.
+        let adapter = SchemaAdapter::new(right_schema.clone());
+        let needs_physical_conversion = adapter.requires_physical_conversion();
+        let right_stream: Box<dyn RecordBatchReader + Send> = if needs_physical_conversion {
+            let mut physical_batches = Vec::new();
+            let mut reader = right_stream;
+            while let Some(batch) = reader.next().transpose()? {
+                physical_batches.push(adapter.to_physical_batch(batch)?);
+            }
+            let physical_schema = physical_batches
+                .first()
+                .map(|b| b.schema())
+                .unwrap_or_else(|| right_schema.clone());
+            Box::new(RecordBatchIterator::new(
+                physical_batches.into_iter().map(Ok),
+                physical_schema,
+            ))
+        } else {
+            right_stream
+        };
         // Hash join: rows matched on the right-hand stream rewrite columns; track physical offsets via `_rowaddr`.
         let joiner = Arc::new(HashJoiner::try_new(right_stream, right_on).await?);
         let mut matched_offsets = RoaringBitmap::new();


### PR DESCRIPTION
## Problem

Updating an **existing** JSON column with `LanceFragment.update_columns` (the hash-join backfill path) crashes:

```
ValueError: Invalid user input: HashJoiner: Invalid argument error:
It is not possible to interleave arrays of different data types
(Utf8 and LargeBinary), rust/lance/src/dataset/hash_joiner.rs:...
```

Minimal repro (Python):

```python
import tempfile
import lance
import pyarrow as pa

path = tempfile.mkdtemp() + "/json_update"

# Dataset that already has a JSON column (stored physically as lance.json / LargeBinary).
ds = lance.write_dataset(
    pa.table({"key": ["a"], "detection": pa.array(['{"v": 0}'], type=pa.json_())}),
    path,
)
# Right-hand input carries the same column as logical Arrow JSON (Utf8).
right = pa.table({"key": ["a"], "detection": pa.array(['{"v": 1}'], type=pa.json_())})

# Hash-join update of the existing JSON column — a single fully-matched row is enough.
ds.get_fragment(0).update_columns(right, left_on="key", right_on="key")  # raises
```

## Root cause

JSON columns are stored physically as `lance.json` (Arrow `LargeBinary`, JSONB), while the right-hand stream passed to `update_columns` carries JSON in its logical Arrow form (`arrow.json` / `Utf8`). When updating an existing column, `HashJoiner::collect_with_fallback` builds each output column with `arrow::compute::interleave`, feeding it **both**:

- the right-hand (new) values — `Utf8`, and
- the left-hand fallback (on-disk) values — `LargeBinary`.

`interleave` requires all candidate arrays to share one data type and rejects the mix before it even looks at the indices, so the call fails even when every row matches the join key.

The new-column path (`HashJoiner::collect`, used by `merge` / `merge_columns`) is unaffected: its fallback is a null array built with the right-hand type, so both sides always match. `collect_with_fallback` has a single caller — `update_columns_with_offsets` — so this is the only affected path. The same class of mismatch applies to view types (`Utf8View` / `BinaryView`).

## Fix

In `FileFragment::update_columns_with_offsets`, before building the `HashJoiner`, convert the right-hand stream to its physical form via `SchemaAdapter::to_physical_batch` — the same logical→physical conversion the write path already applies on ingest (`write.rs`). Both sides are then `LargeBinary`, `interleave` succeeds, and the `lance.json` extension metadata is preserved so the column round-trips as JSON. Non-JSON / non-view streams are untouched (`requires_physical_conversion()` returns `false`), so existing paths are unchanged.

```rust
let adapter = SchemaAdapter::new(right_schema.clone());
let right_stream: Box<dyn RecordBatchReader + Send> = if adapter.requires_physical_conversion() {
    // Convert each batch (arrow.json/Utf8 -> lance.json/LargeBinary, view -> classic) then rewrap.
    ...
} else {
    right_stream
};
let joiner = Arc::new(HashJoiner::try_new(right_stream, right_on).await?);
```
