### PR TITLE
perf(lance): honor unordered filtered reads

### DIFF
--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,6 +62,7 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
+  optional bool ordered_output = 13;
 }
 
 // Serializable form of FilteredReadPlan (planned/distributed mode).

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2858,9 +2858,23 @@ impl Scanner {
         fragments: Option<Arc<Vec<Fragment>>>,
         scan_range: Option<Range<u64>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let ordered_output = if self.ordering.is_some() || self.nearest.is_some() {
+            // If a later plan node sorts the results then the scan does not need
+            // to preserve fragment order.
+            false
+        } else if projection.with_row_last_updated_at_version
+            || projection.with_row_created_at_version
+        {
+            // Version columns require ordered scanning because version metadata
+            // is indexed by position within each fragment.
+            true
+        } else {
+            self.ordered
+        };
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
-            .with_projection(projection);
+            .with_projection(projection)
+            .with_ordered_output(ordered_output);
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -12240,6 +12254,12 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "Schema should include _row_created_at_version"
         );
 
+        scanner.scan_in_order(false);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(filtered.options().ordered_output);
+
         // Actually read the data to ensure version columns are materialized
         let batches = scanner
             .try_into_stream()
@@ -12369,6 +12389,28 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert_eq!(filtered.options().io_buffer_size_bytes, Some(7777));
+    }
+
+    #[tokio::test]
+    async fn test_scan_in_order_propagated_to_filtered_read() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_scan_in_order_propagated", None)
+            .await
+            .unwrap();
+
+        let plan = dataset.scan().create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(filtered.options().ordered_output);
+
+        let mut scanner = dataset.scan();
+        scanner.scan_in_order(false);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(!filtered.options().ordered_output);
     }
 
     // The env var key scopes serial_test's lock so this test only blocks others

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -326,6 +326,8 @@ struct FilteredReadStream {
     active_partitions_counter: Arc<AtomicUsize>,
     /// The threading mode for the scan
     threading_mode: FilteredReadThreadingMode,
+    /// If true, output batches preserve fragment/task order.
+    ordered_output: bool,
     /// Range to apply to the result stream if not already pushed down in planning phase
     scan_range_after_filter: Option<Range<u64>>,
 }
@@ -414,20 +416,28 @@ impl FilteredReadStream {
 
         let global_metrics_clone = global_metrics.clone();
 
-        let fragment_streams = futures::stream::iter(scoped_fragments)
-            .map({
-                let scan_range_after_filter = scan_range_after_filter.clone();
-                move |scoped_fragment| {
-                    let metrics = global_metrics_clone.clone();
-                    let limit = scan_range_after_filter.as_ref().map(|r| r.end);
-                    SpawnedTask::spawn(
-                        Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
-                    )
-                    .map(|thread_result| thread_result.unwrap())
-                }
-            })
-            .buffered(fragment_readahead);
-        let task_stream = fragment_streams.try_flatten().boxed();
+        let fragment_tasks = futures::stream::iter(scoped_fragments).map({
+            let scan_range_after_filter = scan_range_after_filter.clone();
+            move |scoped_fragment| {
+                let metrics = global_metrics_clone.clone();
+                let limit = scan_range_after_filter.as_ref().map(|r| r.end);
+                SpawnedTask::spawn(
+                    Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
+                )
+                .map(|thread_result| thread_result.unwrap())
+            }
+        });
+        let task_stream = if options.ordered_output {
+            fragment_tasks
+                .buffered(fragment_readahead)
+                .try_flatten()
+                .boxed()
+        } else {
+            fragment_tasks
+                .buffer_unordered(fragment_readahead)
+                .try_flatten_unordered(Some(fragment_readahead))
+                .boxed()
+        };
 
         Ok(Self {
             output_schema,
@@ -436,6 +446,7 @@ impl FilteredReadStream {
             metrics: global_metrics,
             active_partitions_counter: Arc::new(AtomicUsize::new(0)),
             threading_mode,
+            ordered_output: options.ordered_output,
             scan_range_after_filter,
         })
     }
@@ -963,10 +974,10 @@ impl FilteredReadStream {
                 assert_eq!(partition, 0);
                 let output_schema = self.output_schema.clone();
                 let task_stream = self.task_stream.clone();
-                let partition_metrics_clone = partition_metrics.clone();
+                let partition_metrics_for_tasks = partition_metrics.clone();
                 let futures_stream = futures::stream::try_unfold(task_stream, {
                     move |task_stream| {
-                        let partition_metrics = partition_metrics_clone.clone();
+                        let partition_metrics = partition_metrics_for_tasks.clone();
                         async move {
                             // There is no compute we can meaningfully measure here.  The actual work is
                             // done by spawned background threads.
@@ -978,17 +989,18 @@ impl FilteredReadStream {
                         }
                     }
                 });
-                let partition_metrics_clone = partition_metrics.clone();
-                let base_batch_stream =
-                    futures_stream
-                        .try_buffered(num_threads)
-                        .try_filter_map(move |batch| {
-                            std::future::ready(Ok(if batch.num_rows() == 0 {
-                                None
-                            } else {
-                                Some(batch)
-                            }))
-                        });
+                let base_batch_stream = if self.ordered_output {
+                    futures_stream.try_buffered(num_threads).boxed()
+                } else {
+                    futures_stream.try_buffer_unordered(num_threads).boxed()
+                }
+                .try_filter_map(move |batch| {
+                    std::future::ready(Ok(if batch.num_rows() == 0 {
+                        None
+                    } else {
+                        Some(batch)
+                    }))
+                });
 
                 let batch_stream = if let Some(ref range) = self.scan_range_after_filter {
                     Self::apply_hard_range(base_batch_stream, range.clone()).boxed()
@@ -1001,9 +1013,10 @@ impl FilteredReadStream {
                 // no output batches were produced (inspect_ok never fires in that case).
                 let global_metrics_final = global_metrics.clone();
                 let scan_scheduler_final = scan_scheduler.clone();
+                let partition_metrics_for_batches = partition_metrics.clone();
                 let batch_stream = batch_stream
                     .inspect_ok(move |batch| {
-                        partition_metrics_clone
+                        partition_metrics_for_batches
                             .baseline_metrics
                             .record_output(batch.num_rows());
                         global_metrics.io_metrics.record(&scan_scheduler);
@@ -1291,6 +1304,8 @@ pub struct FilteredReadOptions {
     pub full_filter: Option<Expr>,
     /// The threading mode to use for the scan
     pub threading_mode: FilteredReadThreadingMode,
+    /// If true, emit fragment tasks in fragment order.
+    pub ordered_output: bool,
     /// The size of the I/O buffer to use for the scan
     pub io_buffer_size_bytes: Option<u64>,
     /// If true, skip fragments that are not covered by the scalar index result.
@@ -1324,6 +1339,7 @@ impl FilteredReadOptions {
             full_filter: None,
             io_buffer_size_bytes: None,
             only_indexed_fragments: false,
+            ordered_output: true,
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
                 get_num_compute_intensive_cpus(),
             ),
@@ -1420,6 +1436,12 @@ impl FilteredReadOptions {
     /// scheduler.
     pub fn with_fragment_readahead(mut self, fragment_readahead: usize) -> Self {
         self.fragment_readahead = Some(fragment_readahead);
+        self
+    }
+
+    /// Set whether output batches should preserve fragment order.
+    pub fn with_ordered_output(mut self, ordered_output: bool) -> Self {
+        self.ordered_output = ordered_output;
         self
     }
 
@@ -2518,6 +2540,29 @@ mod tests {
 
         // Some batches will be smaller because we don't coalesce batches across fragments
         assert_eq!(batch_sizes, vec![35, 35, 30, 35, 15, 35, 35, 30]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_unordered_output_preserves_rows() {
+        let fixture = TestFixture::new().await;
+        let options = FilteredReadOptions::basic_full_read(&fixture.dataset)
+            .with_batch_size(35)
+            .with_ordered_output(false);
+
+        let plan = fixture.make_plan(options).await;
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+        let mut values = batch
+            .column(0)
+            .as_primitive::<UInt32Type>()
+            .values()
+            .to_vec();
+        values.sort_unstable();
+
+        let expected = (0..100).chain(250..400).collect::<Vec<u32>>();
+        assert_eq!(values, expected);
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance/src/io/exec/filtered_read_proto.rs
+++ b/rust/lance/src/io/exec/filtered_read_proto.rs
@@ -145,6 +145,7 @@ fn fr_options_to_proto(
         threading_mode: Some(threading_mode_to_proto(&options.threading_mode)),
         io_buffer_size_bytes: options.io_buffer_size_bytes,
         filter_schema_ipc,
+        ordered_output: Some(options.ordered_output),
     })
 }
 
@@ -196,6 +197,9 @@ async fn fr_options_from_proto(
     }
     if let Some(mode) = proto.threading_mode {
         options.threading_mode = threading_mode_from_proto(&mode)?;
+    }
+    if let Some(ordered_output) = proto.ordered_output {
+        options = options.with_ordered_output(ordered_output);
     }
 
     // Filters — require filter_schema_ipc when filters are present
@@ -615,6 +619,7 @@ mod tests {
         assert_eq!(options.fragment_readahead, back.fragment_readahead);
         assert_eq!(options.io_buffer_size_bytes, back.io_buffer_size_bytes);
         assert_eq!(options.threading_mode, back.threading_mode);
+        assert_eq!(options.ordered_output, back.ordered_output);
         assert_eq!(options.with_deleted_rows, back.with_deleted_rows);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);
         assert_eq!(options.projection.with_row_id, back.projection.with_row_id);
@@ -622,6 +627,24 @@ mod tests {
             options.projection.with_row_addr,
             back.projection.with_row_addr
         );
+    }
+
+    #[tokio::test]
+    async fn test_options_from_old_proto_defaults_to_ordered_output() {
+        let dataset = make_test_dataset().await;
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let filter_schema = Arc::new(prune_schema_for_substrait(&dataset.schema().into()));
+
+        let options = FilteredReadOptions::basic_full_read(&dataset).with_ordered_output(false);
+        let mut proto = fr_options_to_proto(&options, &filter_schema, &state).unwrap();
+        proto.ordered_output = None;
+
+        let back = fr_options_from_proto(proto, &dataset, &state)
+            .await
+            .unwrap();
+
+        assert!(back.ordered_output);
     }
 
     #[tokio::test]
@@ -644,6 +667,7 @@ mod tests {
         options.full_filter = Some(filter_expr);
         options.refine_filter = Some(refine_expr);
         options.threading_mode = FilteredReadThreadingMode::MultiplePartitions(4);
+        options = options.with_ordered_output(false);
 
         let proto = fr_options_to_proto(&options, &filter_schema, &state).unwrap();
 
@@ -660,6 +684,7 @@ mod tests {
         assert!(back.refine_filter.is_some());
         assert!(back.with_deleted_rows);
         assert_eq!(options.threading_mode, back.threading_mode);
+        assert_eq!(options.ordered_output, back.ordered_output);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);
         assert!(back.projection.with_row_id);
     }


### PR DESCRIPTION
## Why

The final goal of this stack is to let large S3/cloud scans approach the raw scheduler bandwidth limit without regressing point reads or small scans. This PR fixes one prerequisite: v2 `FilteredReadExec` now honors unordered scan output instead of forcing ordered fragment and batch draining.

## What

- Adds an internal `ordered_output` option to `FilteredReadOptions`.
- Propagates `Scanner::scan_in_order(false)` into v2 filtered reads.
- Uses unordered fragment/task draining when ordered output is not required.
- Keeps ordered output as the default.
- Keeps version-column scans ordered when position-sensitive metadata is requested.
- Preserves old serialized filtered-read options by decoding missing `ordered_output` as ordered.

## Boundaries

This PR does not change scheduler capacity, I/O buffer sizing, fragment readahead defaults, structural page loading, fullzip decode, or high-bandwidth scan policy. It is not expected to provide the main throughput gain by itself; it makes the unordered scan contract observable for later cloud scan scaling work.

## Validation

- `cargo test -p lance --lib filtered_read -- --nocapture --test-threads=1`
- `cargo test -p lance --features substrait --lib filtered_read_proto -- --nocapture`
- `cargo check -p lance --bench s3_file_reader_diagnostics`
- `cargo fmt --all --check`
- `git diff --check`

S3 smoke on `lance-over-100gbps` showed the PR2 scanner path behaving correctly, with no meaningful standalone throughput gain versus PR1 (`21.77Gbps` vs `21.72Gbps` logical on the vector smoke). This keeps the performance attribution with later stack layers.
