### PR TITLE
perf(io): allow scheduler capacity override

### DIFF
--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,6 +62,7 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
+  optional bool ordered_output = 13;
 }
 
 // Serializable form of FilteredReadPlan (planned/distributed mode).

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -79,11 +79,23 @@ impl PrioritiesInFlight {
             self.in_flight.remove(pos);
         }
     }
+
+    fn len(&self) -> usize {
+        self.in_flight.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.in_flight.is_empty()
+    }
 }
 
 struct IoQueueState {
+    // The configured number of IOPS that can be issued concurrently.
+    io_capacity: u32,
     // Number of IOPS we can issue concurrently before pausing I/O
     iops_avail: u32,
+    // The configured byte budget for unread I/O.
+    io_buffer_size: u64,
     // Number of bytes we are allowed to buffer in memory before pausing I/O
     //
     // This can dip below 0 due to I/O prioritization
@@ -106,7 +118,9 @@ struct IoQueueState {
 impl IoQueueState {
     fn new(io_capacity: u32, io_buffer_size: u64) -> Self {
         Self {
+            io_capacity,
             iops_avail: io_capacity,
+            io_buffer_size,
             bytes_avail: io_buffer_size as i64,
             pending_requests: BinaryHeap::new(),
             priorities_in_flight: PrioritiesInFlight::new(io_capacity),
@@ -114,6 +128,60 @@ impl IoQueueState {
             start: Instant::now(),
             last_warn: AtomicU64::from(0),
             no_backpressure: io_buffer_size == 0,
+        }
+    }
+
+    fn diagnostics(&self) -> SchedulerDiagnostics {
+        let pending_bytes = self
+            .pending_requests
+            .iter()
+            .map(IoTask::num_bytes)
+            .sum::<u64>();
+        let head_task = self.pending_requests.peek();
+        let min_in_flight_priority = if self.priorities_in_flight.is_empty() {
+            None
+        } else {
+            Some(self.priorities_in_flight.min_in_flight())
+        };
+        let head_task_priority_bypass = head_task.map(|task| {
+            self.no_backpressure
+                || task.bypass_backpressure
+                || task.priority <= self.priorities_in_flight.min_in_flight()
+        });
+        let head_task_blocked_by_iops = head_task.map(|_| self.iops_avail == 0);
+        let head_task_blocked_by_bytes = head_task.map(|task| {
+            let bypasses_bytes = self.no_backpressure
+                || task.bypass_backpressure
+                || task.priority <= self.priorities_in_flight.min_in_flight();
+            !bypasses_bytes && task.num_bytes() as i64 > self.bytes_avail
+        });
+        let head_task_can_deliver = head_task.map(|task| self.can_deliver_without_warning(task));
+        let (head_task_priority_high, head_task_priority_low) =
+            split_priority(head_task.map(|task| task.priority));
+        let (min_in_flight_priority_high, min_in_flight_priority_low) =
+            split_priority(min_in_flight_priority);
+        SchedulerDiagnostics {
+            kind: SchedulerQueueKind::Standard,
+            stats: ScanStats::default(),
+            io_capacity: u64::from(self.io_capacity),
+            iops_available: u64::from(self.iops_avail),
+            active_iops: u64::from(self.io_capacity.saturating_sub(self.iops_avail)),
+            pending_iops: self.pending_requests.len() as u64,
+            pending_bytes,
+            bytes_available: self.bytes_avail,
+            bytes_reserved: self.io_buffer_size as i64 - self.bytes_avail,
+            io_buffer_size_bytes: self.io_buffer_size,
+            priorities_in_flight: self.priorities_in_flight.len() as u64,
+            no_backpressure: self.no_backpressure,
+            head_task_bytes: head_task.map(IoTask::num_bytes),
+            head_task_priority_high,
+            head_task_priority_low,
+            min_in_flight_priority_high,
+            min_in_flight_priority_low,
+            head_task_can_deliver,
+            head_task_priority_bypass,
+            head_task_blocked_by_iops,
+            head_task_blocked_by_bytes,
         }
     }
 
@@ -136,6 +204,20 @@ impl IoQueueState {
     }
 
     fn can_deliver(&self, task: &IoTask) -> bool {
+        let can_deliver = self.can_deliver_without_warning(task);
+        if !can_deliver
+            && self.iops_avail > 0
+            && !(self.no_backpressure
+                || task.bypass_backpressure
+                || task.priority <= self.priorities_in_flight.min_in_flight())
+            && task.num_bytes() as i64 > self.bytes_avail
+        {
+            self.warn_if_needed();
+        }
+        can_deliver
+    }
+
+    fn can_deliver_without_warning(&self, task: &IoTask) -> bool {
         if self.iops_avail == 0 {
             false
         } else if self.no_backpressure
@@ -143,11 +225,8 @@ impl IoQueueState {
             || task.priority <= self.priorities_in_flight.min_in_flight()
         {
             true
-        } else if task.num_bytes() as i64 > self.bytes_avail {
-            self.warn_if_needed();
-            false
         } else {
-            true
+            task.num_bytes() as i64 <= self.bytes_avail
         }
     }
 
@@ -205,6 +284,10 @@ impl IoQueue {
         drop(state);
 
         self.notify.notify_one();
+    }
+
+    fn diagnostics(&self) -> SchedulerDiagnostics {
+        self.state.lock().unwrap().diagnostics()
     }
 
     async fn pop(&self) -> Option<IoTask> {
@@ -508,6 +591,50 @@ impl ScanStats {
             requests: stats.requests(),
             bytes_read: stats.bytes_read(),
         }
+    }
+}
+
+fn split_priority(priority: Option<u128>) -> (Option<u64>, Option<u64>) {
+    priority
+        .map(|priority| ((priority >> 64) as u64, priority as u64))
+        .unzip()
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SchedulerQueueKind {
+    Standard,
+    Lite,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SchedulerDiagnostics {
+    pub kind: SchedulerQueueKind,
+    pub stats: ScanStats,
+    pub io_capacity: u64,
+    pub iops_available: u64,
+    pub active_iops: u64,
+    pub pending_iops: u64,
+    pub pending_bytes: u64,
+    pub bytes_available: i64,
+    pub bytes_reserved: i64,
+    pub io_buffer_size_bytes: u64,
+    pub priorities_in_flight: u64,
+    pub no_backpressure: bool,
+    pub head_task_bytes: Option<u64>,
+    pub head_task_priority_high: Option<u64>,
+    pub head_task_priority_low: Option<u64>,
+    pub min_in_flight_priority_high: Option<u64>,
+    pub min_in_flight_priority_low: Option<u64>,
+    pub head_task_can_deliver: Option<bool>,
+    pub head_task_priority_bypass: Option<bool>,
+    pub head_task_blocked_by_iops: Option<bool>,
+    pub head_task_blocked_by_bytes: Option<bool>,
+}
+
+impl SchedulerDiagnostics {
+    fn with_stats(mut self, stats: ScanStats) -> Self {
+        self.stats = stats;
+        self
     }
 }
 
@@ -884,6 +1011,14 @@ impl ScanScheduler {
 
     pub fn stats(&self) -> ScanStats {
         self.stats.snapshot()
+    }
+
+    pub fn diagnostics(&self) -> SchedulerDiagnostics {
+        let diagnostics = match &self.io_queue {
+            IoQueueType::Standard(io_queue) => io_queue.diagnostics(),
+            IoQueueType::Lite(io_queue) => io_queue.diagnostics(),
+        };
+        diagnostics.with_stats(self.stats())
     }
 
     #[cfg(test)]
@@ -1464,6 +1599,98 @@ mod tests {
         // Finally, the low priority request
         semaphore_copy.add_permits(1);
         assert!(second_fut.await.unwrap().unwrap().len() == 20);
+    }
+
+    #[tokio::test]
+    async fn test_standard_scheduler_diagnostics_tracks_queue_state() {
+        let some_path = Path::parse("foo").unwrap();
+        let base_store = Arc::new(InMemory::new());
+        base_store
+            .put(&some_path, vec![0; 1000].into())
+            .await
+            .unwrap();
+
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut obj_store = MockObjectStore::default();
+        let semaphore_copy = semaphore.clone();
+        obj_store
+            .expect_get_opts()
+            .returning(move |location, options| {
+                let semaphore = semaphore.clone();
+                let base_store = base_store.clone();
+                let location = location.clone();
+                async move {
+                    semaphore.acquire().await.unwrap().forget();
+                    base_store.get_opts(&location, options).await
+                }
+                .boxed()
+            });
+        let obj_store = Arc::new(ObjectStore::new(
+            Arc::new(obj_store),
+            Url::parse("mem://").unwrap(),
+            Some(500),
+            None,
+            false,
+            false,
+            1,
+            DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
+        ));
+
+        let scheduler = ScanScheduler::new(
+            obj_store,
+            SchedulerConfig {
+                io_buffer_size_bytes: 1024 * 1024,
+                use_lite_scheduler: Some(false),
+            },
+        );
+        let file_scheduler = scheduler
+            .open_file(&Path::parse("foo").unwrap(), &CachedFileSize::new(1000))
+            .await
+            .unwrap();
+
+        let first_fut = timeout(
+            Duration::from_secs(10),
+            file_scheduler.submit_single(0..10, 0),
+        )
+        .boxed();
+        let second_fut = timeout(
+            Duration::from_secs(10),
+            file_scheduler.submit_single(0..20, 100),
+        )
+        .boxed();
+        let third_fut = timeout(
+            Duration::from_secs(10),
+            file_scheduler.submit_single(0..30, 0),
+        )
+        .boxed();
+
+        let diagnostics = timeout(Duration::from_secs(5), async {
+            loop {
+                let diagnostics = scheduler.diagnostics();
+                if diagnostics.active_iops == 1 && diagnostics.pending_iops == 2 {
+                    break diagnostics;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(diagnostics.kind, SchedulerQueueKind::Standard);
+        assert_eq!(diagnostics.io_capacity, 1);
+        assert_eq!(diagnostics.iops_available, 0);
+        assert_eq!(diagnostics.pending_bytes, 50);
+        assert_eq!(diagnostics.bytes_reserved, 10);
+        assert_eq!(diagnostics.priorities_in_flight, 1);
+        assert_eq!(diagnostics.head_task_bytes, Some(30));
+        assert_eq!(diagnostics.head_task_blocked_by_iops, Some(true));
+        assert_eq!(diagnostics.head_task_blocked_by_bytes, Some(false));
+
+        semaphore_copy.add_permits(3);
+        assert_eq!(first_fut.await.unwrap().unwrap().len(), 10);
+        assert_eq!(third_fut.await.unwrap().unwrap().len(), 30);
+        assert_eq!(second_fut.await.unwrap().unwrap().len(), 20);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -758,7 +758,11 @@ impl SchedulerConfig {
     /// Configuration that should generally maximize bandwidth (not trying to save RAM
     /// at all).  We assume a max page size of 32MiB and then allow 32MiB per I/O thread
     pub fn max_bandwidth(store: &ObjectStore) -> Self {
-        Self::new(32 * 1024 * 1024 * store.io_parallelism() as u64)
+        Self::max_bandwidth_for_io_parallelism(store.io_parallelism())
+    }
+
+    pub fn max_bandwidth_for_io_parallelism(io_parallelism: usize) -> Self {
+        Self::new(32 * 1024 * 1024 * io_parallelism.max(1) as u64)
     }
 
     pub fn with_lite_scheduler(self) -> Self {
@@ -777,7 +781,21 @@ impl ScanScheduler {
     /// * object_store - the store to wrap
     /// * config - configuration settings for the scheduler
     pub fn new(object_store: Arc<ObjectStore>, config: SchedulerConfig) -> Arc<Self> {
-        let io_capacity = object_store.io_parallelism();
+        Self::new_with_io_capacity(object_store, config, None)
+    }
+
+    /// Create a new scheduler with an optional per-scheduler I/O capacity override.
+    ///
+    /// The override only affects this scheduler's internal queue depth.  It does not change the
+    /// shared [`ObjectStore`] default used by other readers.
+    pub fn new_with_io_capacity(
+        object_store: Arc<ObjectStore>,
+        config: SchedulerConfig,
+        io_capacity: Option<usize>,
+    ) -> Arc<Self> {
+        let io_capacity = io_capacity
+            .unwrap_or_else(|| object_store.io_parallelism())
+            .max(1);
         let use_lite = config
             .use_lite_scheduler
             .unwrap_or_else(|| object_store.prefers_lite_scheduler());
@@ -788,10 +806,8 @@ impl ScanScheduler {
             ));
             IoQueueType::Lite(io_queue)
         } else {
-            let io_queue = Arc::new(IoQueue::new(
-                io_capacity as u32,
-                config.io_buffer_size_bytes,
-            ));
+            let io_capacity = u32::try_from(io_capacity).unwrap_or(u32::MAX);
+            let io_queue = Arc::new(IoQueue::new(io_capacity, config.io_buffer_size_bytes));
             let io_queue_clone = io_queue.clone();
             // Best we can do here is fire and forget.  If the I/O loop is still running when the scheduler is
             // dropped we can't wait for it to finish or we'd block a tokio thread.  We could spawn a blocking task
@@ -1943,6 +1959,18 @@ mod tests {
         };
         let scheduler = ScanScheduler::new(memory_store, config);
         assert!(scheduler.uses_lite_scheduler());
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_io_capacity_override() {
+        let obj_store = Arc::new(ObjectStore::memory());
+        let scheduler = ScanScheduler::new_with_io_capacity(
+            obj_store,
+            SchedulerConfig::default_for_testing(),
+            Some(17),
+        );
+
+        assert_eq!(scheduler.diagnostics().io_capacity, 17);
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -33,7 +33,7 @@ use std::{
 use bytes::Bytes;
 use lance_core::{Error, Result};
 
-use super::{BACKPRESSURE_DEBOUNCE, BACKPRESSURE_MIN};
+use super::{BACKPRESSURE_DEBOUNCE, BACKPRESSURE_MIN, SchedulerDiagnostics, SchedulerQueueKind};
 
 type RunFn = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = Result<Bytes>> + Send>> + Send>;
 
@@ -237,6 +237,7 @@ trait BackpressureThrottle: Send {
     /// Unconditionally acquire a zero-cost reservation, tracking only the priority.
     /// Used for bypass tasks that must never be blocked by backpressure.
     fn force_acquire(&mut self, priority: u128) -> BackpressureReservation;
+    fn diagnostics(&self) -> BackpressureDiagnostics;
 }
 
 // We want to allow requests that have a lower priority than any
@@ -275,9 +276,22 @@ impl PrioritiesInFlight {
             self.in_flight.remove(pos);
         }
     }
+
+    fn len(&self) -> usize {
+        self.in_flight.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BackpressureDiagnostics {
+    max_bytes: u64,
+    bytes_available: i64,
+    priorities_in_flight: u64,
+    no_backpressure: bool,
 }
 
 struct SimpleBackpressureThrottle {
+    max_bytes: u64,
     start: Instant,
     last_warn: AtomicU64,
     bytes_available: i64,
@@ -293,6 +307,7 @@ impl SimpleBackpressureThrottle {
             panic!("Max bytes must be less than {}", i64::MAX);
         }
         Self {
+            max_bytes,
             start: Instant::now(),
             last_warn: AtomicU64::new(0),
             bytes_available: max_bytes as i64,
@@ -348,6 +363,15 @@ impl BackpressureThrottle for SimpleBackpressureThrottle {
         BackpressureReservation {
             num_bytes: 0,
             priority,
+        }
+    }
+
+    fn diagnostics(&self) -> BackpressureDiagnostics {
+        BackpressureDiagnostics {
+            max_bytes: self.max_bytes,
+            bytes_available: self.bytes_available,
+            priorities_in_flight: self.priorities_in_flight.len() as u64,
+            no_backpressure: self.no_backpressure,
         }
     }
 }
@@ -417,6 +441,44 @@ impl IoQueueState {
             Err(Error::internal(error.message))
         } else {
             Ok(())
+        }
+    }
+
+    fn diagnostics(&self) -> SchedulerDiagnostics {
+        let backpressure = self.backpressure_throttle.diagnostics();
+        let pending_bytes = self
+            .pending_tasks
+            .iter()
+            .filter_map(|entry| self.tasks.get(&entry.task_id))
+            .map(|task| task.num_bytes)
+            .sum::<u64>();
+        let active_iops = self
+            .tasks
+            .values()
+            .filter(|task| matches!(task.state, TaskState::Running { .. }))
+            .count() as u64;
+        SchedulerDiagnostics {
+            kind: SchedulerQueueKind::Lite,
+            stats: Default::default(),
+            io_capacity: 0,
+            iops_available: 0,
+            active_iops,
+            pending_iops: self.pending_tasks.len() as u64,
+            pending_bytes,
+            bytes_available: backpressure.bytes_available,
+            bytes_reserved: backpressure.max_bytes as i64 - backpressure.bytes_available,
+            io_buffer_size_bytes: backpressure.max_bytes,
+            priorities_in_flight: backpressure.priorities_in_flight,
+            no_backpressure: backpressure.no_backpressure,
+            head_task_bytes: None,
+            head_task_priority_high: None,
+            head_task_priority_low: None,
+            min_in_flight_priority_high: None,
+            min_in_flight_priority_low: None,
+            head_task_can_deliver: None,
+            head_task_priority_bypass: None,
+            head_task_blocked_by_iops: None,
+            head_task_blocked_by_bytes: None,
         }
     }
 }
@@ -569,6 +631,10 @@ impl IoQueue {
         for task in std::mem::take(&mut state.tasks).values_mut() {
             task.cancel();
         }
+    }
+
+    pub(super) fn diagnostics(&self) -> SchedulerDiagnostics {
+        self.state.lock().unwrap().diagnostics()
     }
 }
 

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -196,6 +196,10 @@ name = "scan"
 harness = false
 
 [[bench]]
+name = "s3_file_reader_diagnostics"
+harness = false
+
+[[bench]]
 name = "count_pushdown"
 harness = false
 

--- a/rust/lance/benches/s3_file_reader_diagnostics.rs
+++ b/rust/lance/benches/s3_file_reader_diagnostics.rs
@@ -1,0 +1,2101 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+#![allow(clippy::print_stdout)]
+#![recursion_limit = "256"]
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::hint::black_box;
+use std::ops::Range;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use arrow_array::RecordBatch;
+use futures::future::BoxFuture;
+use futures::stream::{FuturesOrdered, FuturesUnordered};
+use futures::{FutureExt, StreamExt, TryStreamExt};
+use lance::dataset::ProjectionRequest;
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::fragment::{FileFragment, FragReadConfig};
+use lance::dataset::scanner::{
+    ExecutionStatsCallback, ExecutionSummaryCounts, ScanSchedulerDiagnosticsHandle,
+};
+use lance_core::datatypes::Schema;
+use lance_encoding::decoder::PageEncoding;
+use lance_encoding::format::pb21;
+use lance_file::reader::{
+    DEFAULT_READ_CHUNK_SIZE, FileReader as LanceFileReader, FileReaderOptions,
+};
+use lance_io::object_store::ObjectStore as LanceObjectStore;
+use lance_io::scheduler::{
+    FileScheduler, ScanScheduler, ScanStats, SchedulerConfig, SchedulerDiagnostics,
+    SchedulerQueueKind,
+};
+use lance_io::utils::CachedFileSize;
+use serde_json::{Value, json};
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+type Result<T> = std::result::Result<T, Error>;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+struct Config {
+    backend: Backend,
+    uri: String,
+    dataset_version: u64,
+    columns: Option<Vec<String>>,
+    limit_rows: u64,
+    target_bytes: Option<u64>,
+    raw_range_size_bytes: u64,
+    raw_range_mode: RawRangeMode,
+    raw_column_indices: Option<Vec<u32>>,
+    raw_submit_mode: RawSubmitMode,
+    raw_completion_mode: RawCompletionMode,
+    take_repetitions: u64,
+    io_buffer_gib: Vec<Option<u64>>,
+    batch_size: u32,
+    batch_size_bytes: Option<u64>,
+    skip_batch_byte_accounting: bool,
+    read_chunk_size: Option<u64>,
+    fragment_concurrency: usize,
+    batch_concurrency: usize,
+    sample_ms: u64,
+    out_dir: String,
+    case_name: String,
+    describe_layout: bool,
+    detach_fragment_streams: bool,
+    drop_read_tasks: bool,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Backend {
+    FileReader,
+    Scanner,
+    SchedulerRaw,
+    DatasetTake,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RawSubmitMode {
+    Single,
+    SplitNoConcat,
+    SplitConcat,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RawRangeMode {
+    FileSequential,
+    MetadataPages,
+    MetadataPagesRoundRobin,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RawCompletionMode {
+    Unordered,
+    Ordered,
+}
+
+impl RawRangeMode {
+    fn name(self) -> &'static str {
+        match self {
+            Self::FileSequential => "file-sequential",
+            Self::MetadataPages => "metadata-pages",
+            Self::MetadataPagesRoundRobin => "metadata-pages-round-robin",
+        }
+    }
+}
+
+impl RawSubmitMode {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::SplitNoConcat => "split-no-concat",
+            Self::SplitConcat => "split-concat",
+        }
+    }
+}
+
+impl RawCompletionMode {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Unordered => "unordered",
+            Self::Ordered => "ordered",
+        }
+    }
+}
+
+impl Backend {
+    fn name(self) -> &'static str {
+        match self {
+            Self::FileReader => "lance-file-reader",
+            Self::Scanner => "lance-scanner",
+            Self::SchedulerRaw => "lance-scheduler-raw",
+            Self::DatasetTake => "lance-dataset-take",
+        }
+    }
+
+    fn layer(self) -> &'static str {
+        match self {
+            Self::FileReader => "file-reader",
+            Self::Scanner => "scanner",
+            Self::SchedulerRaw => "scheduler",
+            Self::DatasetTake => "dataset-take",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CpuSample {
+    idle: u64,
+    total: u64,
+}
+
+#[derive(Debug, Default)]
+struct SharedCounters {
+    fragments_started: AtomicU64,
+    fragments_completed: AtomicU64,
+    batch_futures_emitted: AtomicU64,
+    batch_futures_received: AtomicU64,
+    batches_completed: AtomicU64,
+    rows_completed: AtomicU64,
+    arrow_bytes: AtomicU64,
+    open_reader_ns: AtomicU64,
+    read_stream_create_ns: AtomicU64,
+    next_batch_poll_ns: AtomicU64,
+    channel_send_wait_ns: AtomicU64,
+    decode_ns: AtomicU64,
+    raw_reassemble_ns: AtomicU64,
+}
+
+#[derive(Debug)]
+struct CaseStats {
+    rows: u64,
+    batches: u64,
+    arrow_bytes: u64,
+    planned_fragments: usize,
+    planned_rows: u64,
+    elapsed: Duration,
+    producer_finished_at: Option<Duration>,
+    peak_decode_in_flight: usize,
+    cpu_avg: Option<f64>,
+    scheduler_diagnostics: SchedulerDiagnostics,
+    counters: Arc<SharedCounters>,
+    samples: Vec<Value>,
+}
+
+#[derive(Debug)]
+struct LastSample {
+    elapsed: Duration,
+    scheduler_stats: ScanStats,
+    rows: u64,
+    batches: u64,
+    arrow_bytes: u64,
+}
+
+fn usage() -> &'static str {
+    "usage: s3_file_reader_diagnostics --uri <s3-dataset-uri> \
+     [--backend <file-reader|scanner|scheduler-raw>] \
+     [--dataset-version <n>] [--columns <all|col[,col...]>] \
+     [--limit-rows <n>] [--target-bytes <n>] [--raw-range-size-bytes <n>] \
+     [--raw-range-mode <file-sequential|metadata-pages|metadata-pages-round-robin>] \
+     [--raw-column-indices <all|n[,n...]>] \
+     [--raw-submit-mode <single|split-no-concat|split-concat>] \
+     [--raw-completion-mode <unordered|ordered>] \
+     [--take-repetitions <n>] \
+     [--io-buffer-gib <auto|n[,n...]>] \
+     [--batch-size <n>] [--batch-size-bytes <n>] [--read-chunk-size <n>] \
+     [--skip-batch-byte-accounting] \
+     [--fragment-concurrency <n>] [--batch-concurrency <n>] \
+     [--sample-ms <n>] [--out-dir <path>] [--case <name>] \
+     [--detach-fragment-streams] [--drop-read-tasks] [--describe-layout]"
+}
+
+fn parse_args() -> Result<Config> {
+    let mut backend = Backend::FileReader;
+    let mut uri = None;
+    let mut dataset_version = 1u64;
+    let mut columns = Some(vec!["vector".to_string()]);
+    let mut limit_rows = 67_108_864u64;
+    let mut target_bytes = None;
+    let mut raw_range_size_bytes = 16 * 1024 * 1024;
+    let mut raw_range_mode = RawRangeMode::FileSequential;
+    let mut raw_column_indices = None;
+    let mut raw_submit_mode = RawSubmitMode::Single;
+    let mut raw_completion_mode = RawCompletionMode::Unordered;
+    let mut take_repetitions = 100u64;
+    let mut io_buffer_gib = vec![Some(8)];
+    let mut batch_size = 8192u32;
+    let mut batch_size_bytes = None;
+    let mut skip_batch_byte_accounting = false;
+    let mut read_chunk_size = None;
+    let mut fragment_concurrency = 256usize;
+    let mut batch_concurrency = 256usize;
+    let mut sample_ms = 1000u64;
+    let mut out_dir = "/tmp/lance-s3-bottleneck-results".to_string();
+    let mut case_name = "lance-file-reader-diagnostics".to_string();
+    let mut describe_layout = false;
+    let mut detach_fragment_streams = false;
+    let mut drop_read_tasks = false;
+
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--backend" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --backend. {}", usage()))?;
+                backend = parse_backend(&value)?;
+            }
+            "--uri" => uri = args.next(),
+            "--dataset-version" => {
+                dataset_version = parse_required_value(&mut args, "--dataset-version")?;
+            }
+            "--columns" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --columns. {}", usage()))?;
+                columns = parse_columns(&value)?;
+            }
+            "--limit-rows" => {
+                limit_rows = parse_required_value(&mut args, "--limit-rows")?;
+            }
+            "--target-bytes" => {
+                target_bytes = Some(parse_required_value(&mut args, "--target-bytes")?);
+            }
+            "--raw-range-size-bytes" => {
+                raw_range_size_bytes = parse_required_value(&mut args, "--raw-range-size-bytes")?;
+            }
+            "--raw-range-mode" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --raw-range-mode. {}", usage()))?;
+                raw_range_mode = parse_raw_range_mode(&value)?;
+            }
+            "--raw-column-indices" => {
+                let value = args.next().ok_or_else(|| {
+                    format!("missing value for --raw-column-indices. {}", usage())
+                })?;
+                raw_column_indices = parse_raw_column_indices(&value)?;
+            }
+            "--raw-submit-mode" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --raw-submit-mode. {}", usage()))?;
+                raw_submit_mode = parse_raw_submit_mode(&value)?;
+            }
+            "--raw-completion-mode" => {
+                let value = args.next().ok_or_else(|| {
+                    format!("missing value for --raw-completion-mode. {}", usage())
+                })?;
+                raw_completion_mode = parse_raw_completion_mode(&value)?;
+            }
+            "--take-repetitions" => {
+                take_repetitions = parse_required_value(&mut args, "--take-repetitions")?;
+            }
+            "--io-buffer-gib" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --io-buffer-gib. {}", usage()))?;
+                io_buffer_gib = parse_io_buffer_gib(&value)?;
+            }
+            "--batch-size" => {
+                batch_size = parse_required_value(&mut args, "--batch-size")?;
+            }
+            "--batch-size-bytes" => {
+                batch_size_bytes = Some(parse_required_value(&mut args, "--batch-size-bytes")?);
+            }
+            "--skip-batch-byte-accounting" => {
+                skip_batch_byte_accounting = true;
+            }
+            "--read-chunk-size" => {
+                read_chunk_size = Some(parse_required_value(&mut args, "--read-chunk-size")?);
+            }
+            "--fragment-concurrency" => {
+                fragment_concurrency = parse_required_value(&mut args, "--fragment-concurrency")?;
+            }
+            "--batch-concurrency" => {
+                batch_concurrency = parse_required_value(&mut args, "--batch-concurrency")?;
+            }
+            "--sample-ms" => {
+                sample_ms = parse_required_value(&mut args, "--sample-ms")?;
+            }
+            "--out-dir" => {
+                out_dir = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --out-dir. {}", usage()))?;
+            }
+            "--case" => {
+                case_name = args
+                    .next()
+                    .ok_or_else(|| format!("missing value for --case. {}", usage()))?;
+            }
+            "--describe-layout" => {
+                describe_layout = true;
+            }
+            "--detach-fragment-streams" => {
+                detach_fragment_streams = true;
+            }
+            "--drop-read-tasks" => {
+                drop_read_tasks = true;
+            }
+            "--help" | "-h" => {
+                println!("{}", usage());
+                std::process::exit(0);
+            }
+            "--bench" => {
+                // Cargo appends this flag when running harness-free benches.
+            }
+            other => {
+                return Err(format!("unknown argument {other}. {}", usage()).into());
+            }
+        }
+    }
+
+    let uri = uri.ok_or_else(|| format!("missing required --uri. {}", usage()))?;
+    if limit_rows == 0 {
+        return Err("--limit-rows must be greater than zero".into());
+    }
+    if matches!(target_bytes, Some(0)) {
+        return Err("--target-bytes must be greater than zero".into());
+    }
+    if raw_range_size_bytes == 0 {
+        return Err("--raw-range-size-bytes must be greater than zero".into());
+    }
+    if take_repetitions == 0 {
+        return Err("--take-repetitions must be greater than zero".into());
+    }
+    if io_buffer_gib.is_empty() {
+        return Err("--io-buffer-gib must not be empty".into());
+    }
+    if batch_size == 0 {
+        return Err("--batch-size must be greater than zero".into());
+    }
+    if matches!(batch_size_bytes, Some(0)) {
+        return Err("--batch-size-bytes must be greater than zero".into());
+    }
+    if matches!(read_chunk_size, Some(0)) {
+        return Err("--read-chunk-size must be greater than zero".into());
+    }
+    if fragment_concurrency == 0 && !matches!(backend, Backend::Scanner) {
+        return Err("--fragment-concurrency must be greater than zero".into());
+    }
+    if batch_concurrency == 0 && !matches!(backend, Backend::Scanner) {
+        return Err("--batch-concurrency must be greater than zero".into());
+    }
+    if sample_ms == 0 {
+        return Err("--sample-ms must be greater than zero".into());
+    }
+
+    Ok(Config {
+        backend,
+        uri,
+        dataset_version,
+        columns,
+        limit_rows,
+        target_bytes,
+        raw_range_size_bytes,
+        raw_range_mode,
+        raw_column_indices,
+        raw_submit_mode,
+        raw_completion_mode,
+        take_repetitions,
+        io_buffer_gib,
+        batch_size,
+        batch_size_bytes,
+        skip_batch_byte_accounting,
+        read_chunk_size,
+        fragment_concurrency,
+        batch_concurrency,
+        sample_ms,
+        out_dir,
+        case_name,
+        describe_layout,
+        detach_fragment_streams,
+        drop_read_tasks,
+    })
+}
+
+fn parse_backend(value: &str) -> Result<Backend> {
+    match value {
+        "file-reader" | "lance-file-reader" => Ok(Backend::FileReader),
+        "scanner" | "lance-scanner" => Ok(Backend::Scanner),
+        "scheduler-raw" | "lance-scheduler-raw" => Ok(Backend::SchedulerRaw),
+        "dataset-take" | "take" | "lance-dataset-take" => Ok(Backend::DatasetTake),
+        other => Err(format!(
+            "invalid --backend value {other}; expected file-reader, scanner, scheduler-raw, or dataset-take"
+        )
+        .into()),
+    }
+}
+
+fn parse_raw_submit_mode(value: &str) -> Result<RawSubmitMode> {
+    match value {
+        "single" => Ok(RawSubmitMode::Single),
+        "split-no-concat" => Ok(RawSubmitMode::SplitNoConcat),
+        "split-concat" => Ok(RawSubmitMode::SplitConcat),
+        other => Err(format!(
+            "invalid --raw-submit-mode value {other}; expected single, split-no-concat, or split-concat"
+        )
+        .into()),
+    }
+}
+
+fn parse_raw_range_mode(value: &str) -> Result<RawRangeMode> {
+    match value {
+        "file-sequential" => Ok(RawRangeMode::FileSequential),
+        "metadata-pages" => Ok(RawRangeMode::MetadataPages),
+        "metadata-pages-round-robin" => Ok(RawRangeMode::MetadataPagesRoundRobin),
+        other => Err(format!(
+            "invalid --raw-range-mode value {other}; expected file-sequential, metadata-pages, or metadata-pages-round-robin"
+        )
+        .into()),
+    }
+}
+
+fn parse_raw_column_indices(value: &str) -> Result<Option<Vec<u32>>> {
+    if value == "all" {
+        return Ok(None);
+    }
+
+    let indices = value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.parse::<u32>()
+                .map_err(|err| format!("invalid raw column index {part}: {err}").into())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if indices.is_empty() {
+        return Err("--raw-column-indices must specify at least one column index or all".into());
+    }
+    Ok(Some(indices))
+}
+
+fn parse_raw_completion_mode(value: &str) -> Result<RawCompletionMode> {
+    match value {
+        "unordered" => Ok(RawCompletionMode::Unordered),
+        "ordered" => Ok(RawCompletionMode::Ordered),
+        other => Err(format!(
+            "invalid --raw-completion-mode value {other}; expected unordered or ordered"
+        )
+        .into()),
+    }
+}
+
+fn parse_required_value<T>(args: &mut impl Iterator<Item = String>, name: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display + Send + Sync + 'static,
+{
+    let value = args
+        .next()
+        .ok_or_else(|| format!("missing value for {name}. {}", usage()))?;
+    value
+        .parse()
+        .map_err(|err| format!("invalid {name} value {value}: {err}").into())
+}
+
+fn parse_columns(value: &str) -> Result<Option<Vec<String>>> {
+    match value {
+        "all" => Ok(None),
+        "empty" => Err("FileReader benchmark requires at least one data column".into()),
+        _ => Ok(Some(
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|column| !column.is_empty())
+                .map(ToString::to_string)
+                .collect(),
+        )),
+    }
+}
+
+fn parse_io_buffer_gib(value: &str) -> Result<Vec<Option<u64>>> {
+    value
+        .split(',')
+        .map(|part| {
+            let part = part.trim();
+            if part == "auto" {
+                Ok(None)
+            } else {
+                part.parse::<u64>()
+                    .map(Some)
+                    .map_err(|err| format!("invalid --io-buffer-gib value {part}: {err}").into())
+            }
+        })
+        .collect()
+}
+
+fn projection_name(columns: &Option<Vec<String>>) -> String {
+    match columns {
+        None => "all".to_string(),
+        Some(columns) => columns.join(","),
+    }
+}
+
+fn page_layout_kind(encoding: &PageEncoding) -> &'static str {
+    match encoding {
+        PageEncoding::Legacy(_) => "legacy",
+        PageEncoding::Structural(layout) => match layout.layout.as_ref() {
+            Some(pb21::page_layout::Layout::MiniBlockLayout(_)) => "miniblock",
+            Some(pb21::page_layout::Layout::ConstantLayout(_)) => "constant",
+            Some(pb21::page_layout::Layout::FullZipLayout(_)) => "fullzip",
+            Some(pb21::page_layout::Layout::BlobLayout(_)) => "blob",
+            None => "missing",
+        },
+    }
+}
+
+fn summarize_u64(values: &[u64]) -> Value {
+    if values.is_empty() {
+        return json!({
+            "count": 0,
+            "min": null,
+            "p50": null,
+            "p90": null,
+            "max": null,
+            "sum": 0,
+        });
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let percentile = |p: f64| {
+        let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+        sorted[idx]
+    };
+    json!({
+        "count": sorted.len(),
+        "min": sorted[0],
+        "p50": percentile(0.5),
+        "p90": percentile(0.9),
+        "max": *sorted.last().unwrap(),
+        "sum": values.iter().sum::<u64>(),
+    })
+}
+
+async fn describe_layout(config: &Config) -> Result<()> {
+    let dataset = Arc::new(
+        DatasetBuilder::from_uri(&config.uri)
+            .with_version(config.dataset_version)
+            .load()
+            .await?,
+    );
+    let fragment = dataset
+        .fragments()
+        .first()
+        .ok_or("dataset has no fragments")?;
+    let data_file = fragment
+        .files
+        .first()
+        .ok_or("first fragment has no data files")?;
+    if data_file.base_id.is_some() {
+        return Err("layout diagnostics do not support external base data files yet".into());
+    }
+
+    let data_path = dataset.data_dir().join(data_file.path.as_str());
+    let (object_store, _) = LanceObjectStore::from_uri(&config.uri).await?;
+    let scheduler = ScanScheduler::new(object_store, SchedulerConfig::new(8 * GIB));
+    let file_scheduler = scheduler
+        .open_file(&data_path, &CachedFileSize::unknown())
+        .await?;
+    let metadata = LanceFileReader::read_all_metadata(&file_scheduler).await?;
+
+    let columns = metadata
+        .column_infos
+        .iter()
+        .map(|column| {
+            let mut layout_counts = BTreeMap::new();
+            let mut page_rows = Vec::with_capacity(column.page_infos.len());
+            let mut page_bytes = Vec::with_capacity(column.page_infos.len());
+            for page in column.page_infos.iter() {
+                *layout_counts
+                    .entry(page_layout_kind(&page.encoding))
+                    .or_insert(0usize) += 1;
+                page_rows.push(page.num_rows);
+                page_bytes.push(
+                    page.buffer_offsets_and_sizes
+                        .iter()
+                        .map(|(_, size)| *size)
+                        .sum::<u64>(),
+                );
+            }
+            json!({
+                "column_index": column.index,
+                "num_pages": column.page_infos.len(),
+                "layout_counts": layout_counts,
+                "page_rows": summarize_u64(&page_rows),
+                "page_bytes": summarize_u64(&page_bytes),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "dataset_uri": config.uri,
+            "dataset_version": config.dataset_version,
+            "fragment_id": fragment.id,
+            "data_file_path": data_file.path,
+            "resolved_data_path": data_path.to_string(),
+            "file_version": metadata.version().to_string(),
+            "num_rows": metadata.num_rows,
+            "num_data_bytes": metadata.num_data_bytes,
+            "columns": columns,
+        }))?
+    );
+    Ok(())
+}
+
+fn projected_schema(dataset_schema: &Schema, columns: &Option<Vec<String>>) -> Result<Schema> {
+    Ok(match columns {
+        None => dataset_schema.clone(),
+        Some(columns) => dataset_schema.project(columns)?,
+    })
+}
+
+fn file_reader_options(config: &Config) -> Option<FileReaderOptions> {
+    if config.batch_size_bytes.is_none() && config.read_chunk_size.is_none() {
+        return None;
+    }
+    Some(FileReaderOptions {
+        batch_size_bytes: config.batch_size_bytes,
+        read_chunk_size: config.read_chunk_size.unwrap_or(DEFAULT_READ_CHUNK_SIZE),
+        ..Default::default()
+    })
+}
+
+fn add_duration(counter: &AtomicU64, duration: Duration) {
+    let nanos = duration.as_nanos().min(u128::from(u64::MAX)) as u64;
+    counter.fetch_add(nanos, Ordering::Relaxed);
+}
+
+fn ns_to_seconds(ns: u64) -> f64 {
+    ns as f64 / 1_000_000_000.0
+}
+
+fn diff_u64(current: u64, previous: u64) -> u64 {
+    current.saturating_sub(previous)
+}
+
+fn scheduler_kind_name(kind: SchedulerQueueKind) -> &'static str {
+    match kind {
+        SchedulerQueueKind::Standard => "standard",
+        SchedulerQueueKind::Lite => "lite",
+    }
+}
+
+fn diagnostics_json(diagnostics: SchedulerDiagnostics) -> Value {
+    json!({
+        "queue_kind": scheduler_kind_name(diagnostics.kind),
+        "scheduler_iops": diagnostics.stats.iops,
+        "scheduler_requests": diagnostics.stats.requests,
+        "scheduler_bytes_read": diagnostics.stats.bytes_read,
+        "io_capacity": diagnostics.io_capacity,
+        "iops_available": diagnostics.iops_available,
+        "active_iops": diagnostics.active_iops,
+        "pending_iops": diagnostics.pending_iops,
+        "pending_bytes": diagnostics.pending_bytes,
+        "bytes_available": diagnostics.bytes_available,
+        "bytes_reserved": diagnostics.bytes_reserved,
+        "io_buffer_size_bytes": diagnostics.io_buffer_size_bytes,
+        "priorities_in_flight": diagnostics.priorities_in_flight,
+        "no_backpressure": diagnostics.no_backpressure,
+        "head_task_bytes": diagnostics.head_task_bytes,
+        "head_task_priority_high": diagnostics.head_task_priority_high,
+        "head_task_priority_low": diagnostics.head_task_priority_low,
+        "min_in_flight_priority_high": diagnostics.min_in_flight_priority_high,
+        "min_in_flight_priority_low": diagnostics.min_in_flight_priority_low,
+        "head_task_can_deliver": diagnostics.head_task_can_deliver,
+        "head_task_priority_bypass": diagnostics.head_task_priority_bypass,
+        "head_task_blocked_by_iops": diagnostics.head_task_blocked_by_iops,
+        "head_task_blocked_by_bytes": diagnostics.head_task_blocked_by_bytes,
+    })
+}
+
+fn empty_scheduler_diagnostics() -> SchedulerDiagnostics {
+    SchedulerDiagnostics {
+        kind: SchedulerQueueKind::Standard,
+        stats: ScanStats::default(),
+        io_capacity: 0,
+        iops_available: 0,
+        active_iops: 0,
+        pending_iops: 0,
+        pending_bytes: 0,
+        bytes_available: 0,
+        bytes_reserved: 0,
+        io_buffer_size_bytes: 0,
+        priorities_in_flight: 0,
+        no_backpressure: false,
+        head_task_bytes: None,
+        head_task_priority_high: None,
+        head_task_priority_low: None,
+        min_in_flight_priority_high: None,
+        min_in_flight_priority_low: None,
+        head_task_can_deliver: None,
+        head_task_priority_bypass: None,
+        head_task_blocked_by_iops: None,
+        head_task_blocked_by_bytes: None,
+    }
+}
+
+#[derive(Debug, Default)]
+struct ExecutionStatsHolder {
+    collected_stats: Arc<Mutex<Option<ExecutionSummaryCounts>>>,
+}
+
+impl ExecutionStatsHolder {
+    fn get_setter(&self) -> ExecutionStatsCallback {
+        let collected_stats = self.collected_stats.clone();
+        Arc::new(move |stats| {
+            *collected_stats.lock().unwrap() = Some(stats.clone());
+        })
+    }
+
+    fn consume(self) -> Option<ExecutionSummaryCounts> {
+        self.collected_stats.lock().unwrap().take()
+    }
+}
+
+#[derive(Debug, Default)]
+struct SchedulerDiagnosticsHandleHolder {
+    handle: Arc<Mutex<Option<ScanSchedulerDiagnosticsHandle>>>,
+}
+
+impl SchedulerDiagnosticsHandleHolder {
+    fn get_setter(&self) -> impl Fn(ScanSchedulerDiagnosticsHandle) + Send + Sync + 'static {
+        let handle = self.handle.clone();
+        move |new_handle| {
+            *handle.lock().unwrap() = Some(new_handle);
+        }
+    }
+
+    fn snapshot(&self, io_buffer_gib: Option<u64>) -> SchedulerDiagnostics {
+        self.handle
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|handle| handle.diagnostics())
+            .unwrap_or_else(|| diagnostics_from_scan_stats(ScanStats::default(), io_buffer_gib))
+    }
+}
+
+fn diagnostics_from_scan_stats(
+    stats: ScanStats,
+    io_buffer_gib: Option<u64>,
+) -> SchedulerDiagnostics {
+    SchedulerDiagnostics {
+        kind: SchedulerQueueKind::Standard,
+        stats,
+        io_capacity: 0,
+        iops_available: 0,
+        active_iops: 0,
+        pending_iops: 0,
+        pending_bytes: 0,
+        bytes_available: 0,
+        bytes_reserved: 0,
+        io_buffer_size_bytes: io_buffer_gib.map(|value| value * GIB).unwrap_or_default(),
+        priorities_in_flight: 0,
+        no_backpressure: false,
+        head_task_bytes: None,
+        head_task_priority_high: None,
+        head_task_priority_low: None,
+        min_in_flight_priority_high: None,
+        min_in_flight_priority_low: None,
+        head_task_can_deliver: None,
+        head_task_priority_bypass: None,
+        head_task_blocked_by_iops: None,
+        head_task_blocked_by_bytes: None,
+    }
+}
+
+fn scan_stats_from_execution_summary(summary: &ExecutionSummaryCounts) -> ScanStats {
+    ScanStats {
+        iops: summary.iops as u64,
+        requests: summary.requests as u64,
+        bytes_read: summary.bytes_read as u64,
+    }
+}
+
+fn sample_json(
+    started: Instant,
+    counters: &SharedCounters,
+    diagnostics: SchedulerDiagnostics,
+    decode_in_flight: usize,
+    channel_buffered: usize,
+    last: &mut LastSample,
+) -> Value {
+    let elapsed = started.elapsed();
+    let interval = elapsed.saturating_sub(last.elapsed);
+    let interval_secs = interval.as_secs_f64();
+    let rows = counters.rows_completed.load(Ordering::Relaxed);
+    let batches = counters.batches_completed.load(Ordering::Relaxed);
+    let arrow_bytes = counters.arrow_bytes.load(Ordering::Relaxed);
+    let scheduler_stats = diagnostics.stats;
+    let delta_scheduler_bytes =
+        diff_u64(scheduler_stats.bytes_read, last.scheduler_stats.bytes_read);
+    let delta_rows = diff_u64(rows, last.rows);
+    let delta_arrow_bytes = diff_u64(arrow_bytes, last.arrow_bytes);
+    let physical_gbps = if interval_secs > 0.0 {
+        delta_scheduler_bytes as f64 * 8.0 / interval_secs / 1_000_000_000.0
+    } else {
+        0.0
+    };
+    let logical_gbps = if interval_secs > 0.0 {
+        delta_arrow_bytes as f64 * 8.0 / interval_secs / 1_000_000_000.0
+    } else {
+        0.0
+    };
+    let rows_per_second = if interval_secs > 0.0 {
+        delta_rows as f64 / interval_secs
+    } else {
+        0.0
+    };
+
+    last.elapsed = elapsed;
+    last.scheduler_stats = scheduler_stats;
+    last.rows = rows;
+    last.batches = batches;
+    last.arrow_bytes = arrow_bytes;
+
+    json!({
+        "elapsed_seconds": elapsed.as_secs_f64(),
+        "interval_seconds": interval_secs,
+        "physical_gbps": physical_gbps,
+        "logical_gbps": logical_gbps,
+        "rows_per_second": rows_per_second,
+        "rows": rows,
+        "batches": batches,
+        "arrow_bytes": arrow_bytes,
+        "delta_rows": delta_rows,
+        "delta_arrow_bytes": delta_arrow_bytes,
+        "delta_scheduler_bytes": delta_scheduler_bytes,
+        "fragments_started": counters.fragments_started.load(Ordering::Relaxed),
+        "fragments_completed": counters.fragments_completed.load(Ordering::Relaxed),
+        "batch_futures_emitted": counters.batch_futures_emitted.load(Ordering::Relaxed),
+        "batch_futures_received": counters.batch_futures_received.load(Ordering::Relaxed),
+        "batches_completed": counters.batches_completed.load(Ordering::Relaxed),
+        "decode_in_flight": decode_in_flight,
+        "channel_buffered": channel_buffered,
+        "open_reader_seconds_total": ns_to_seconds(counters.open_reader_ns.load(Ordering::Relaxed)),
+        "read_stream_create_seconds_total": ns_to_seconds(counters.read_stream_create_ns.load(Ordering::Relaxed)),
+        "next_batch_poll_seconds_total": ns_to_seconds(counters.next_batch_poll_ns.load(Ordering::Relaxed)),
+        "channel_send_wait_seconds_total": ns_to_seconds(counters.channel_send_wait_ns.load(Ordering::Relaxed)),
+        "decode_seconds_total": ns_to_seconds(counters.decode_ns.load(Ordering::Relaxed)),
+        "raw_reassemble_seconds_total": ns_to_seconds(counters.raw_reassemble_ns.load(Ordering::Relaxed)),
+        "scheduler": diagnostics_json(diagnostics),
+    })
+}
+
+async fn run_scanner_case(config: &Config, io_buffer_gib: Option<u64>) -> Result<CaseStats> {
+    let dataset = Arc::new(
+        DatasetBuilder::from_uri(&config.uri)
+            .with_version(config.dataset_version)
+            .load()
+            .await?,
+    );
+
+    let mut remaining_rows = config.limit_rows;
+    let mut planned_fragments = 0usize;
+    let mut planned_rows = 0u64;
+    for fragment in dataset.fragments().iter() {
+        if remaining_rows == 0 {
+            break;
+        }
+        let fragment_rows = fragment
+            .num_rows()
+            .ok_or_else(|| format!("fragment {} is missing num_rows", fragment.id))?
+            as u64;
+        let rows = fragment_rows.min(remaining_rows);
+        planned_fragments += 1;
+        planned_rows += rows;
+        remaining_rows -= rows;
+    }
+    if planned_fragments == 0 {
+        return Err("no fragments selected".into());
+    }
+
+    let counters = Arc::new(SharedCounters::default());
+    let stats_holder = ExecutionStatsHolder::default();
+    let scheduler_diagnostics_holder = SchedulerDiagnosticsHandleHolder::default();
+    let cpu_before = read_cpu_sample();
+    let started = Instant::now();
+
+    let mut scanner = dataset.scan();
+    if let Some(columns) = config.columns.as_ref() {
+        scanner.project(columns)?;
+    }
+    scanner
+        .batch_size(config.batch_size as usize)
+        .scan_in_order(false)
+        .scan_stats_callback(stats_holder.get_setter())
+        .scan_scheduler_diagnostics_callback(scheduler_diagnostics_holder.get_setter());
+    if config.batch_concurrency > 0 {
+        scanner
+            .batch_readahead(config.batch_concurrency)
+            .target_parallelism(config.batch_concurrency);
+    }
+    if config.fragment_concurrency > 0 {
+        scanner.fragment_readahead(config.fragment_concurrency);
+    }
+    if let Some(file_reader_options) = file_reader_options(config) {
+        scanner.with_file_reader_options(file_reader_options);
+    }
+    if let Some(batch_size_bytes) = config.batch_size_bytes {
+        scanner.batch_size_bytes(batch_size_bytes);
+    }
+    if let Some(io_buffer_gib) = io_buffer_gib {
+        scanner.io_buffer_size(io_buffer_gib * GIB);
+    }
+    let limit_rows = i64::try_from(config.limit_rows)
+        .map_err(|_| "--limit-rows is too large for scanner limit")?;
+    scanner.limit(Some(limit_rows), None)?;
+
+    let mut stream = scanner.try_into_stream().await?;
+    let mut rows = 0u64;
+    let mut batches = 0u64;
+    let mut arrow_bytes = 0u64;
+    let mut samples = Vec::new();
+    let mut sample_interval = tokio::time::interval(Duration::from_millis(config.sample_ms));
+    sample_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_sample = LastSample {
+        elapsed: Duration::default(),
+        scheduler_stats: ScanStats::default(),
+        rows: 0,
+        batches: 0,
+        arrow_bytes: 0,
+    };
+    loop {
+        tokio::select! {
+            maybe_batch = stream.next() => {
+                let Some(batch) = maybe_batch else {
+                    break;
+                };
+                let batch = batch?;
+                let batch_bytes = if config.skip_batch_byte_accounting {
+                    0
+                } else {
+                    batch.get_array_memory_size() as u64
+                };
+                rows += batch.num_rows() as u64;
+                batches += 1;
+                arrow_bytes += batch_bytes;
+                counters.batches_completed.fetch_add(1, Ordering::Relaxed);
+                counters
+                    .rows_completed
+                    .fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+                counters.arrow_bytes.fetch_add(batch_bytes, Ordering::Relaxed);
+            }
+            _ = sample_interval.tick() => {
+                samples.push(sample_json(
+                    started,
+                    counters.as_ref(),
+                    scheduler_diagnostics_holder.snapshot(io_buffer_gib),
+                    0,
+                    0,
+                    &mut last_sample,
+                ));
+            }
+        }
+    }
+    drop(stream);
+
+    let elapsed = started.elapsed();
+    let summary = stats_holder
+        .consume()
+        .ok_or("scanner execution stats callback did not run")?;
+    let scheduler_stats = scan_stats_from_execution_summary(&summary);
+    let mut final_diagnostics = scheduler_diagnostics_holder.snapshot(io_buffer_gib);
+    final_diagnostics.stats = scheduler_stats;
+    let cpu_after = read_cpu_sample();
+    samples.push(sample_json(
+        started,
+        counters.as_ref(),
+        final_diagnostics,
+        0,
+        0,
+        &mut last_sample,
+    ));
+
+    Ok(CaseStats {
+        rows,
+        batches,
+        arrow_bytes,
+        planned_fragments,
+        planned_rows,
+        elapsed,
+        producer_finished_at: Some(elapsed),
+        peak_decode_in_flight: 0,
+        cpu_avg: cpu_before.zip(cpu_after).and_then(|(before, after)| {
+            let total = after.total.checked_sub(before.total)?;
+            let idle = after.idle.checked_sub(before.idle)?;
+            if total == 0 {
+                return None;
+            }
+            Some((total - idle) as f64 / total as f64 * 100.0)
+        }),
+        scheduler_diagnostics: final_diagnostics,
+        counters,
+        samples,
+    })
+}
+
+async fn run_dataset_take_case(config: &Config) -> Result<CaseStats> {
+    let dataset = DatasetBuilder::from_uri(&config.uri)
+        .with_version(config.dataset_version)
+        .load()
+        .await?;
+    let projection = Arc::new(projected_schema(dataset.schema(), &config.columns)?);
+    let total_rows = dataset
+        .fragments()
+        .iter()
+        .map(|fragment| {
+            fragment
+                .num_rows()
+                .map(|rows| rows as u64)
+                .ok_or_else(|| format!("fragment {} is missing num_rows", fragment.id))
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .sum::<u64>();
+    if total_rows == 0 {
+        return Err("dataset has no rows".into());
+    }
+
+    let counters = Arc::new(SharedCounters::default());
+    let cpu_before = read_cpu_sample();
+    let started = Instant::now();
+    let mut rows = 0u64;
+    let mut batches = 0u64;
+    let mut arrow_bytes = 0u64;
+    const STRIDE: u64 = 104_729;
+
+    for repetition in 0..config.take_repetitions {
+        let row_ids = (0..config.limit_rows)
+            .map(|offset| {
+                repetition
+                    .wrapping_mul(STRIDE)
+                    .wrapping_add(offset.wrapping_mul(STRIDE))
+                    % total_rows
+            })
+            .collect::<Vec<_>>();
+        let batch = dataset
+            .take(&row_ids, ProjectionRequest::Schema(projection.clone()))
+            .await?;
+        if batch.num_rows() as u64 != config.limit_rows {
+            return Err(format!(
+                "take_rows returned {} rows, expected {}",
+                batch.num_rows(),
+                config.limit_rows
+            )
+            .into());
+        }
+        black_box(&batch);
+        rows += batch.num_rows() as u64;
+        batches += 1;
+        let batch_bytes = if config.skip_batch_byte_accounting {
+            0
+        } else {
+            batch.get_array_memory_size() as u64
+        };
+        arrow_bytes += batch_bytes;
+        counters.batches_completed.fetch_add(1, Ordering::Relaxed);
+        counters
+            .rows_completed
+            .fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+        counters
+            .arrow_bytes
+            .fetch_add(batch_bytes, Ordering::Relaxed);
+    }
+
+    let elapsed = started.elapsed();
+    let cpu_after = read_cpu_sample();
+    Ok(CaseStats {
+        rows,
+        batches,
+        arrow_bytes,
+        planned_fragments: dataset.fragments().len(),
+        planned_rows: total_rows,
+        elapsed,
+        producer_finished_at: Some(elapsed),
+        peak_decode_in_flight: 0,
+        cpu_avg: cpu_before.zip(cpu_after).and_then(|(before, after)| {
+            let total = after.total.checked_sub(before.total)?;
+            let idle = after.idle.checked_sub(before.idle)?;
+            if total == 0 {
+                return None;
+            }
+            Some((total - idle) as f64 / total as f64 * 100.0)
+        }),
+        scheduler_diagnostics: empty_scheduler_diagnostics(),
+        counters,
+        samples: Vec::new(),
+    })
+}
+
+enum RawInFlight {
+    Unordered(FuturesUnordered<BoxFuture<'static, lance_core::Result<usize>>>),
+    Ordered(FuturesOrdered<BoxFuture<'static, lance_core::Result<usize>>>),
+}
+
+impl RawInFlight {
+    fn new(mode: RawCompletionMode) -> Self {
+        match mode {
+            RawCompletionMode::Unordered => Self::Unordered(FuturesUnordered::new()),
+            RawCompletionMode::Ordered => Self::Ordered(FuturesOrdered::new()),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Unordered(in_flight) => in_flight.len(),
+            Self::Ordered(in_flight) => in_flight.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Unordered(in_flight) => in_flight.is_empty(),
+            Self::Ordered(in_flight) => in_flight.is_empty(),
+        }
+    }
+
+    fn push(&mut self, future: BoxFuture<'static, lance_core::Result<usize>>) {
+        match self {
+            Self::Unordered(in_flight) => in_flight.push(future),
+            Self::Ordered(in_flight) => in_flight.push_back(future),
+        }
+    }
+
+    async fn next(&mut self) -> Option<lance_core::Result<usize>> {
+        match self {
+            Self::Unordered(in_flight) => in_flight.next().await,
+            Self::Ordered(in_flight) => in_flight.next().await,
+        }
+    }
+}
+
+fn raw_read_future(
+    file_scheduler: FileScheduler,
+    range: Range<u64>,
+    priority: u64,
+    raw_submit_mode: RawSubmitMode,
+    read_chunk_size: u64,
+    counters: Arc<SharedCounters>,
+) -> BoxFuture<'static, lance_core::Result<usize>> {
+    async move {
+        match raw_submit_mode {
+            RawSubmitMode::Single => {
+                let bytes = file_scheduler.submit_single(range, priority).await?;
+                Ok(bytes.len())
+            }
+            RawSubmitMode::SplitNoConcat => {
+                let ranges = split_range_by_size(range, read_chunk_size);
+                let bytes = file_scheduler.submit_request(ranges, priority).await?;
+                Ok(bytes.iter().map(bytes::Bytes::len).sum())
+            }
+            RawSubmitMode::SplitConcat => {
+                let ranges = split_range_by_size(range, read_chunk_size);
+                let bytes = file_scheduler.submit_request(ranges, priority).await?;
+                let reassemble_started = Instant::now();
+                let total_size = bytes.iter().map(bytes::Bytes::len).sum();
+                let mut combined = Vec::with_capacity(total_size);
+                for chunk in bytes {
+                    combined.extend_from_slice(&chunk);
+                }
+                add_duration(&counters.raw_reassemble_ns, reassemble_started.elapsed());
+                let len = combined.len();
+                black_box(&combined);
+                Ok(len)
+            }
+        }
+    }
+    .boxed()
+}
+
+fn split_range_by_size(range: Range<u64>, chunk_size: u64) -> Vec<Range<u64>> {
+    let range_size = range.end - range.start;
+    if range_size <= chunk_size {
+        return vec![range];
+    }
+
+    let num_chunks = range_size.div_ceil(chunk_size);
+    let per_chunk = range_size / num_chunks;
+    let mut ranges = Vec::with_capacity(num_chunks as usize);
+    for idx in 0..num_chunks {
+        let start = range.start + idx * per_chunk;
+        let end = if idx == num_chunks - 1 {
+            range.end
+        } else {
+            start + per_chunk
+        };
+        ranges.push(start..end);
+    }
+    ranges
+}
+
+fn push_split_planned_ranges(
+    planned: &mut Vec<(usize, Range<u64>)>,
+    file_idx: usize,
+    range: Range<u64>,
+    chunk_size: u64,
+    remaining: &mut u64,
+) {
+    let mut start = range.start;
+    while start < range.end && *remaining > 0 {
+        let bytes_to_read = chunk_size.min(range.end - start).min(*remaining);
+        if bytes_to_read == 0 {
+            break;
+        }
+        let end = start + bytes_to_read;
+        planned.push((file_idx, start..end));
+        *remaining -= bytes_to_read;
+        start = end;
+    }
+}
+
+fn push_split_ranges(ranges: &mut Vec<Range<u64>>, range: Range<u64>, chunk_size: u64) {
+    let mut start = range.start;
+    while start < range.end {
+        let bytes_to_read = chunk_size.min(range.end - start);
+        if bytes_to_read == 0 {
+            break;
+        }
+        let end = start + bytes_to_read;
+        ranges.push(start..end);
+        start = end;
+    }
+}
+
+async fn run_scheduler_raw_case(config: &Config, io_buffer_gib: Option<u64>) -> Result<CaseStats> {
+    let target_bytes = config
+        .target_bytes
+        .ok_or("--target-bytes is required for --backend scheduler-raw")?;
+    let dataset = Arc::new(
+        DatasetBuilder::from_uri(&config.uri)
+            .with_version(config.dataset_version)
+            .load()
+            .await?,
+    );
+    let (object_store, _) = LanceObjectStore::from_uri(&config.uri).await?;
+    let scheduler_config = io_buffer_gib
+        .map(|gib| SchedulerConfig::new(gib * GIB))
+        .unwrap_or_else(|| SchedulerConfig::max_bandwidth(object_store.as_ref()));
+    let scheduler = ScanScheduler::new(object_store, scheduler_config);
+
+    let (selected_files, planned) = match config.raw_range_mode {
+        RawRangeMode::FileSequential => {
+            let mut selected_files = Vec::new();
+            let mut selected_file_bytes = 0u64;
+            for fragment in dataset.fragments().iter() {
+                for data_file in &fragment.files {
+                    if data_file.base_id.is_some() {
+                        continue;
+                    }
+                    let Some(file_size) = data_file.file_size_bytes.get() else {
+                        continue;
+                    };
+                    let path = dataset.data_dir().join(data_file.path.as_str());
+                    let file_scheduler = scheduler
+                        .open_file_with_priority(&path, 0, &data_file.file_size_bytes)
+                        .await?;
+                    selected_file_bytes += file_size.get();
+                    selected_files.push((file_scheduler, file_size.get()));
+                    if selected_file_bytes >= target_bytes {
+                        break;
+                    }
+                }
+                if selected_file_bytes >= target_bytes {
+                    break;
+                }
+            }
+            if selected_files.is_empty() {
+                return Err("scheduler-raw found no data files with known sizes".into());
+            }
+
+            let mut offsets = vec![0u64; selected_files.len()];
+            let mut planned = Vec::new();
+            let mut remaining = target_bytes;
+            let mut file_idx = 0usize;
+            while remaining > 0 {
+                let idx = file_idx % selected_files.len();
+                let file_size = selected_files[idx].1;
+                if offsets[idx] >= file_size {
+                    offsets[idx] = 0;
+                }
+                let available = file_size - offsets[idx];
+                let bytes_to_read = config.raw_range_size_bytes.min(available).min(remaining);
+                let start = offsets[idx];
+                let end = start + bytes_to_read;
+                planned.push((idx, start..end));
+                offsets[idx] = end;
+                remaining -= bytes_to_read;
+                file_idx += 1;
+            }
+            (selected_files, planned)
+        }
+        RawRangeMode::MetadataPages | RawRangeMode::MetadataPagesRoundRobin => {
+            let mut selected_files = Vec::new();
+            let mut per_file_ranges = Vec::<Vec<Range<u64>>>::new();
+            let mut candidate_bytes = 0u64;
+
+            'fragments: for fragment in dataset.fragments().iter() {
+                for data_file in &fragment.files {
+                    if data_file.base_id.is_some() {
+                        continue;
+                    }
+                    if data_file.file_size_bytes.get().is_none() {
+                        continue;
+                    }
+                    let path = dataset.data_dir().join(data_file.path.as_str());
+                    let file_scheduler = scheduler
+                        .open_file_with_priority(&path, 0, &data_file.file_size_bytes)
+                        .await?;
+                    let metadata = LanceFileReader::read_all_metadata(&file_scheduler).await?;
+                    let mut file_ranges = Vec::new();
+
+                    let raw_column_indices = config
+                        .raw_column_indices
+                        .clone()
+                        .unwrap_or_else(|| (0..metadata.column_infos.len() as u32).collect());
+                    for column_index in raw_column_indices {
+                        let column_info = metadata
+                            .column_infos
+                            .get(column_index as usize)
+                            .ok_or_else(|| {
+                                format!(
+                                    "raw metadata-pages requested column index {column_index} but file has {} columns",
+                                    metadata.column_infos.len()
+                                )
+                            })?;
+                        for page in column_info.page_infos.iter() {
+                            for (offset, size) in page.buffer_offsets_and_sizes.iter() {
+                                if *size == 0 {
+                                    continue;
+                                }
+                                push_split_ranges(
+                                    &mut file_ranges,
+                                    *offset..(*offset + *size),
+                                    config.raw_range_size_bytes,
+                                );
+                            }
+                        }
+                    }
+
+                    if !file_ranges.is_empty() {
+                        candidate_bytes += file_ranges
+                            .iter()
+                            .map(|range| range.end - range.start)
+                            .sum::<u64>();
+                        selected_files.push((
+                            file_scheduler,
+                            data_file.file_size_bytes.get().unwrap().get(),
+                        ));
+                        per_file_ranges.push(file_ranges);
+                        if candidate_bytes >= target_bytes {
+                            break 'fragments;
+                        }
+                    }
+                }
+            }
+            if selected_files.is_empty() || per_file_ranges.is_empty() {
+                return Err("scheduler-raw metadata-pages found no readable page buffers".into());
+            }
+
+            let mut planned = Vec::new();
+            let mut remaining = target_bytes;
+            match config.raw_range_mode {
+                RawRangeMode::MetadataPages => {
+                    'ranges: for (file_idx, ranges) in per_file_ranges.iter().enumerate() {
+                        for range in ranges {
+                            push_split_planned_ranges(
+                                &mut planned,
+                                file_idx,
+                                range.clone(),
+                                config.raw_range_size_bytes,
+                                &mut remaining,
+                            );
+                            if remaining == 0 {
+                                break 'ranges;
+                            }
+                        }
+                    }
+                }
+                RawRangeMode::MetadataPagesRoundRobin => {
+                    let mut positions = vec![0usize; per_file_ranges.len()];
+                    while remaining > 0 {
+                        let mut made_progress = false;
+                        for (file_idx, ranges) in per_file_ranges.iter().enumerate() {
+                            if positions[file_idx] >= ranges.len() {
+                                continue;
+                            }
+                            let range = ranges[positions[file_idx]].clone();
+                            positions[file_idx] += 1;
+                            made_progress = true;
+                            push_split_planned_ranges(
+                                &mut planned,
+                                file_idx,
+                                range,
+                                config.raw_range_size_bytes,
+                                &mut remaining,
+                            );
+                            if remaining == 0 {
+                                break;
+                            }
+                        }
+                        if !made_progress {
+                            break;
+                        }
+                    }
+                }
+                RawRangeMode::FileSequential => unreachable!(),
+            }
+
+            if remaining > 0 {
+                return Err(format!(
+                    "scheduler-raw metadata-pages planned {} bytes but target is {target_bytes}",
+                    target_bytes - remaining
+                )
+                .into());
+            }
+            (selected_files, planned)
+        }
+    };
+    let planned_bytes = planned
+        .iter()
+        .map(|(_, range)| range.end - range.start)
+        .sum::<u64>();
+
+    let counters = Arc::new(SharedCounters::default());
+    let cpu_before = read_cpu_sample();
+    let started = Instant::now();
+    let mut samples = Vec::new();
+    let mut sample_interval = tokio::time::interval(Duration::from_millis(config.sample_ms));
+    sample_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_sample = LastSample {
+        elapsed: Duration::default(),
+        scheduler_stats: ScanStats::default(),
+        rows: 0,
+        batches: 0,
+        arrow_bytes: 0,
+    };
+    let mut in_flight = RawInFlight::new(config.raw_completion_mode);
+    let mut next_range = 0usize;
+    let read_chunk_size = config.read_chunk_size.unwrap_or(DEFAULT_READ_CHUNK_SIZE);
+    while next_range < planned.len() && in_flight.len() < config.batch_concurrency {
+        let (idx, range) = planned[next_range].clone();
+        in_flight.push(raw_read_future(
+            selected_files[idx].0.clone(),
+            range,
+            next_range as u64,
+            config.raw_submit_mode,
+            read_chunk_size,
+            counters.clone(),
+        ));
+        next_range += 1;
+    }
+
+    let mut bytes_read = 0u64;
+    let mut requests_completed = 0u64;
+    while !in_flight.is_empty() {
+        tokio::select! {
+            maybe_bytes = in_flight.next() => {
+                let bytes = maybe_bytes.expect("raw read future disappeared")?;
+                let bytes = bytes as u64;
+                bytes_read += bytes;
+                requests_completed += 1;
+                counters.batches_completed.fetch_add(1, Ordering::Relaxed);
+                counters.arrow_bytes.fetch_add(bytes, Ordering::Relaxed);
+                if next_range < planned.len() {
+                    let (idx, range) = planned[next_range].clone();
+                    in_flight.push(raw_read_future(
+                        selected_files[idx].0.clone(),
+                        range,
+                        next_range as u64,
+                        config.raw_submit_mode,
+                        read_chunk_size,
+                        counters.clone(),
+                    ));
+                    next_range += 1;
+                }
+            }
+            _ = sample_interval.tick() => {
+                samples.push(sample_json(
+                    started,
+                    counters.as_ref(),
+                    scheduler.diagnostics(),
+                    in_flight.len(),
+                    planned.len().saturating_sub(next_range),
+                    &mut last_sample,
+                ));
+            }
+        }
+    }
+    counters.arrow_bytes.store(bytes_read, Ordering::Relaxed);
+    samples.push(sample_json(
+        started,
+        counters.as_ref(),
+        scheduler.diagnostics(),
+        in_flight.len(),
+        0,
+        &mut last_sample,
+    ));
+    let elapsed = started.elapsed();
+    let cpu_after = read_cpu_sample();
+
+    Ok(CaseStats {
+        rows: 0,
+        batches: requests_completed,
+        arrow_bytes: bytes_read,
+        planned_fragments: selected_files.len(),
+        planned_rows: planned_bytes,
+        elapsed,
+        producer_finished_at: Some(elapsed),
+        peak_decode_in_flight: config.batch_concurrency,
+        cpu_avg: cpu_before.zip(cpu_after).and_then(|(before, after)| {
+            let total = after.total.checked_sub(before.total)?;
+            let idle = after.idle.checked_sub(before.idle)?;
+            if total == 0 {
+                return None;
+            }
+            Some((total - idle) as f64 / total as f64 * 100.0)
+        }),
+        scheduler_diagnostics: scheduler.diagnostics(),
+        counters,
+        samples,
+    })
+}
+
+async fn run_case(config: &Config, io_buffer_gib: Option<u64>) -> Result<CaseStats> {
+    let dataset = Arc::new(
+        DatasetBuilder::from_uri(&config.uri)
+            .with_version(config.dataset_version)
+            .load()
+            .await?,
+    );
+    let projection = Arc::new(projected_schema(dataset.schema(), &config.columns)?);
+    let (object_store, _) = LanceObjectStore::from_uri(&config.uri).await?;
+    let scheduler_config = io_buffer_gib
+        .map(|gib| SchedulerConfig::new(gib * GIB))
+        .unwrap_or_else(|| SchedulerConfig::max_bandwidth(object_store.as_ref()));
+    let scheduler = ScanScheduler::new(object_store, scheduler_config);
+
+    let mut planned = Vec::new();
+    let mut remaining_rows = config.limit_rows;
+    for fragment in dataset.fragments().iter() {
+        if remaining_rows == 0 {
+            break;
+        }
+        let fragment_rows = fragment
+            .num_rows()
+            .ok_or_else(|| format!("fragment {} is missing num_rows", fragment.id))?
+            as u64;
+        let rows = fragment_rows.min(remaining_rows);
+        planned.push((fragment.clone(), rows));
+        remaining_rows -= rows;
+    }
+    if planned.is_empty() {
+        return Err("no fragments selected".into());
+    }
+    let planned_rows: u64 = planned.iter().map(|(_, rows)| *rows).sum();
+    let planned_fragments = planned.len();
+
+    let counters = Arc::new(SharedCounters::default());
+    let cpu_before = read_cpu_sample();
+    let started = Instant::now();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<
+        BoxFuture<'static, lance_core::Result<RecordBatch>>,
+    >(config.batch_concurrency * 2);
+    let producer = if config.detach_fragment_streams {
+        tokio::spawn({
+            let dataset = dataset.clone();
+            let projection = projection.clone();
+            let scheduler = scheduler.clone();
+            let counters = counters.clone();
+            let batch_size = config.batch_size;
+            let file_reader_options = file_reader_options(config);
+            let fragment_concurrency = config.fragment_concurrency;
+            async move {
+                let drainers = futures::stream::iter(planned.into_iter().enumerate())
+                    .map({
+                        move |(priority, (fragment, rows))| {
+                            let dataset = dataset.clone();
+                            let projection = projection.clone();
+                            let scheduler = scheduler.clone();
+                            let tx = tx.clone();
+                            let counters = counters.clone();
+                            let file_reader_options = file_reader_options.clone();
+                            async move {
+                                counters.fragments_started.fetch_add(1, Ordering::Relaxed);
+                                let file_fragment = FileFragment::new(dataset, fragment);
+                                let read_config = FragReadConfig::default()
+                                    .with_scan_scheduler(scheduler)
+                                    .with_reader_priority(priority as u32);
+                                let read_config = if let Some(file_reader_options) =
+                                    file_reader_options.clone()
+                                {
+                                    read_config.with_file_reader_options(file_reader_options)
+                                } else {
+                                    read_config
+                                };
+
+                                let open_started = Instant::now();
+                                let reader =
+                                    file_fragment.open(projection.as_ref(), read_config).await?;
+                                add_duration(&counters.open_reader_ns, open_started.elapsed());
+
+                                let create_stream_started = Instant::now();
+                                let mut read_stream =
+                                    reader.read_ranges(vec![0..rows].into(), batch_size).await?;
+                                add_duration(
+                                    &counters.read_stream_create_ns,
+                                    create_stream_started.elapsed(),
+                                );
+
+                                let drainer = tokio::spawn(async move {
+                                    loop {
+                                        let next_started = Instant::now();
+                                        let maybe_batch_fut = read_stream.next().await;
+                                        add_duration(
+                                            &counters.next_batch_poll_ns,
+                                            next_started.elapsed(),
+                                        );
+                                        let Some(batch_fut) = maybe_batch_fut else {
+                                            break;
+                                        };
+                                        counters
+                                            .batch_futures_emitted
+                                            .fetch_add(1, Ordering::Relaxed);
+                                        let send_started = Instant::now();
+                                        tx.send(batch_fut)
+                                            .await
+                                            .map_err(|_| "batch consumer dropped")?;
+                                        add_duration(
+                                            &counters.channel_send_wait_ns,
+                                            send_started.elapsed(),
+                                        );
+                                    }
+                                    counters.fragments_completed.fetch_add(1, Ordering::Relaxed);
+                                    Ok::<_, Error>(())
+                                });
+                                Ok::<_, Error>(drainer)
+                            }
+                        }
+                    })
+                    .buffer_unordered(fragment_concurrency)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                for drainer in drainers {
+                    drainer.await.map_err(Error::from)??;
+                }
+                Ok::<_, Error>(())
+            }
+        })
+    } else {
+        tokio::spawn({
+            let dataset = dataset.clone();
+            let projection = projection.clone();
+            let scheduler = scheduler.clone();
+            let counters = counters.clone();
+            let batch_size = config.batch_size;
+            let file_reader_options = file_reader_options(config);
+            let fragment_concurrency = config.fragment_concurrency;
+            async move {
+                futures::stream::iter(planned.into_iter().enumerate())
+                    .map({
+                        move |(priority, (fragment, rows))| {
+                            let dataset = dataset.clone();
+                            let projection = projection.clone();
+                            let scheduler = scheduler.clone();
+                            let tx = tx.clone();
+                            let counters = counters.clone();
+                            let file_reader_options = file_reader_options.clone();
+                            async move {
+                                counters.fragments_started.fetch_add(1, Ordering::Relaxed);
+                                let file_fragment = FileFragment::new(dataset, fragment);
+                                let read_config = FragReadConfig::default()
+                                    .with_scan_scheduler(scheduler)
+                                    .with_reader_priority(priority as u32);
+                                let read_config = if let Some(file_reader_options) =
+                                    file_reader_options.clone()
+                                {
+                                    read_config.with_file_reader_options(file_reader_options)
+                                } else {
+                                    read_config
+                                };
+
+                                let open_started = Instant::now();
+                                let reader =
+                                    file_fragment.open(projection.as_ref(), read_config).await?;
+                                add_duration(&counters.open_reader_ns, open_started.elapsed());
+
+                                let create_stream_started = Instant::now();
+                                let mut read_stream =
+                                    reader.read_ranges(vec![0..rows].into(), batch_size).await?;
+                                add_duration(
+                                    &counters.read_stream_create_ns,
+                                    create_stream_started.elapsed(),
+                                );
+
+                                loop {
+                                    let next_started = Instant::now();
+                                    let maybe_batch_fut = read_stream.next().await;
+                                    add_duration(
+                                        &counters.next_batch_poll_ns,
+                                        next_started.elapsed(),
+                                    );
+                                    let Some(batch_fut) = maybe_batch_fut else {
+                                        break;
+                                    };
+                                    counters
+                                        .batch_futures_emitted
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    let send_started = Instant::now();
+                                    tx.send(batch_fut)
+                                        .await
+                                        .map_err(|_| "batch consumer dropped")?;
+                                    add_duration(
+                                        &counters.channel_send_wait_ns,
+                                        send_started.elapsed(),
+                                    );
+                                }
+                                counters.fragments_completed.fetch_add(1, Ordering::Relaxed);
+                                Ok::<_, Error>(())
+                            }
+                        }
+                    })
+                    .buffer_unordered(fragment_concurrency)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+                Ok::<_, Error>(())
+            }
+        })
+    };
+
+    let mut in_flight = FuturesUnordered::new();
+    let skip_batch_byte_accounting = config.skip_batch_byte_accounting;
+    let drop_read_tasks = config.drop_read_tasks;
+    let mut producer_done = false;
+    let mut producer_finished_at = None;
+    let mut rows = 0u64;
+    let mut batches = 0u64;
+    let mut arrow_bytes = 0u64;
+    let mut peak_decode_in_flight = 0usize;
+    let mut samples = Vec::new();
+    let mut sample_interval = tokio::time::interval(Duration::from_millis(config.sample_ms));
+    sample_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_sample = LastSample {
+        elapsed: Duration::default(),
+        scheduler_stats: ScanStats::default(),
+        rows: 0,
+        batches: 0,
+        arrow_bytes: 0,
+    };
+
+    loop {
+        if producer_done && in_flight.is_empty() {
+            break;
+        }
+        tokio::select! {
+            maybe_batch_fut = rx.recv(), if !producer_done && in_flight.len() < config.batch_concurrency => {
+                if let Some(batch_fut) = maybe_batch_fut {
+                    counters.batch_futures_received.fetch_add(1, Ordering::Relaxed);
+                    if drop_read_tasks {
+                        drop(batch_fut);
+                        counters.batches_completed.fetch_add(1, Ordering::Relaxed);
+                        batches += 1;
+                        continue;
+                    }
+                    let counters_for_task = counters.clone();
+                    in_flight.push(async move {
+                        let decode_started = Instant::now();
+                        let batch = batch_fut.await?;
+                        let batch_bytes = if skip_batch_byte_accounting {
+                            0
+                        } else {
+                            batch.get_array_memory_size() as u64
+                        };
+                        add_duration(&counters_for_task.decode_ns, decode_started.elapsed());
+                        counters_for_task.batches_completed.fetch_add(1, Ordering::Relaxed);
+                        counters_for_task.rows_completed.fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+                        counters_for_task.arrow_bytes.fetch_add(batch_bytes, Ordering::Relaxed);
+                        Ok::<_, lance_core::Error>((batch, batch_bytes))
+                    });
+                    peak_decode_in_flight = peak_decode_in_flight.max(in_flight.len());
+                } else {
+                    producer_done = true;
+                    producer_finished_at = Some(started.elapsed());
+                }
+            }
+            maybe_batch = in_flight.next(), if !in_flight.is_empty() => {
+                let (batch, batch_bytes) = maybe_batch.expect("in-flight batch future disappeared")?;
+                rows += batch.num_rows() as u64;
+                batches += 1;
+                arrow_bytes += batch_bytes;
+            }
+            _ = sample_interval.tick() => {
+                samples.push(sample_json(
+                    started,
+                    counters.as_ref(),
+                    scheduler.diagnostics(),
+                    in_flight.len(),
+                    rx.len(),
+                    &mut last_sample,
+                ));
+            }
+        }
+    }
+    producer.await??;
+
+    samples.push(sample_json(
+        started,
+        counters.as_ref(),
+        scheduler.diagnostics(),
+        in_flight.len(),
+        rx.len(),
+        &mut last_sample,
+    ));
+
+    let elapsed = started.elapsed();
+    let cpu_after = read_cpu_sample();
+
+    Ok(CaseStats {
+        rows,
+        batches,
+        arrow_bytes,
+        planned_fragments,
+        planned_rows,
+        elapsed,
+        producer_finished_at,
+        peak_decode_in_flight,
+        cpu_avg: cpu_before.zip(cpu_after).and_then(|(before, after)| {
+            let total = after.total.checked_sub(before.total)?;
+            let idle = after.idle.checked_sub(before.idle)?;
+            if total == 0 {
+                return None;
+            }
+            Some((total - idle) as f64 / total as f64 * 100.0)
+        }),
+        scheduler_diagnostics: scheduler.diagnostics(),
+        counters,
+        samples,
+    })
+}
+
+fn read_cpu_sample() -> Option<CpuSample> {
+    let contents = fs::read_to_string("/proc/stat").ok()?;
+    let line = contents.lines().next()?;
+    let values = line
+        .split_whitespace()
+        .skip(1)
+        .map(|value| value.parse::<u64>())
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .ok()?;
+    if values.len() < 5 {
+        return None;
+    }
+
+    let idle = values[3] + values[4];
+    let total = values.iter().sum();
+    Some(CpuSample { idle, total })
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+fn current_commit() -> String {
+    option_env!("LANCE_BENCH_COMMIT")
+        .or_else(|| option_env!("GIT_COMMIT"))
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn env_var(name: &str) -> Option<String> {
+    env::var(name).ok()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = parse_args()?;
+    if config.describe_layout {
+        return describe_layout(&config).await;
+    }
+
+    fs::create_dir_all(&config.out_dir)?;
+    let output_path = format!(
+        "{}/s3_file_reader_diagnostics_{}.jsonl",
+        config.out_dir,
+        now_unix_secs()
+    );
+    let mut jsonl = String::new();
+    let commit = current_commit();
+    let instance = env_var("EC2_INSTANCE_TYPE").unwrap_or_else(|| "unknown".to_string());
+    let region = env_var("AWS_REGION")
+        .or_else(|| env_var("AWS_DEFAULT_REGION"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let projection = projection_name(&config.columns);
+
+    for io_buffer_gib in &config.io_buffer_gib {
+        println!(
+            "running case={} backend={} projection={} limit_rows={} io_buffer_gib={} batch_size={} fragment_concurrency={} batch_concurrency={} sample_ms={}",
+            config.case_name,
+            config.backend.name(),
+            projection,
+            config.limit_rows,
+            io_buffer_gib
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "auto".to_string()),
+            config.batch_size,
+            config.fragment_concurrency,
+            config.batch_concurrency,
+            config.sample_ms
+        );
+        let stats = match config.backend {
+            Backend::FileReader => run_case(&config, *io_buffer_gib).await?,
+            Backend::Scanner => run_scanner_case(&config, *io_buffer_gib).await?,
+            Backend::SchedulerRaw => run_scheduler_raw_case(&config, *io_buffer_gib).await?,
+            Backend::DatasetTake => run_dataset_take_case(&config).await?,
+        };
+        let elapsed_secs = stats.elapsed.as_secs_f64();
+        let scheduler_stats = stats.scheduler_diagnostics.stats;
+        let logical_gbps = if elapsed_secs > 0.0 {
+            stats.arrow_bytes as f64 * 8.0 / elapsed_secs / 1_000_000_000.0
+        } else {
+            0.0
+        };
+        let physical_gbps = if elapsed_secs > 0.0 {
+            scheduler_stats.bytes_read as f64 * 8.0 / elapsed_secs / 1_000_000_000.0
+        } else {
+            0.0
+        };
+        let rows_per_second = if elapsed_secs > 0.0 {
+            stats.rows as f64 / elapsed_secs
+        } else {
+            0.0
+        };
+        let bytes_per_row = if stats.rows == 0 {
+            0
+        } else {
+            stats.arrow_bytes / stats.rows
+        };
+        let avg_bytes_per_scheduler_request = if scheduler_stats.requests == 0 {
+            0
+        } else {
+            scheduler_stats.bytes_read / scheduler_stats.requests
+        };
+        let avg_bytes_per_scheduler_iop = if scheduler_stats.iops == 0 {
+            0
+        } else {
+            scheduler_stats.bytes_read / scheduler_stats.iops
+        };
+        let counters = stats.counters.as_ref();
+        let record = json!({
+            "case": config.case_name,
+            "instance": instance,
+            "region": region,
+            "layer": config.backend.layer(),
+            "backend": config.backend.name(),
+            "dataset_uri": config.uri,
+            "dataset_version": config.dataset_version,
+            "lance_commit": commit,
+            "projection": projection,
+            "limit_rows": config.limit_rows,
+            "target_bytes": config.target_bytes,
+            "raw_range_size_bytes": config.raw_range_size_bytes,
+            "raw_range_mode": config.raw_range_mode.name(),
+            "raw_column_indices": config.raw_column_indices.clone(),
+            "raw_submit_mode": config.raw_submit_mode.name(),
+            "raw_completion_mode": config.raw_completion_mode.name(),
+            "take_repetitions": config.take_repetitions,
+            "raw_read_chunk_size_bytes": config.read_chunk_size.unwrap_or(DEFAULT_READ_CHUNK_SIZE),
+            "planned_rows": stats.planned_rows,
+            "planned_fragments": stats.planned_fragments,
+            "rows": stats.rows,
+            "batches": stats.batches,
+            "batch_size": config.batch_size,
+            "batch_size_bytes": config.batch_size_bytes,
+            "skip_batch_byte_accounting": config.skip_batch_byte_accounting,
+            "read_chunk_size": config.read_chunk_size,
+            "fragment_concurrency": config.fragment_concurrency,
+            "batch_concurrency": config.batch_concurrency,
+            "detach_fragment_streams": config.detach_fragment_streams,
+            "drop_read_tasks": config.drop_read_tasks,
+            "sample_ms": config.sample_ms,
+            "io_buffer_bytes": io_buffer_gib.map(|value| value * GIB),
+            "io_buffer_mode": if io_buffer_gib.is_some() { "explicit" } else { "auto" },
+            "lance_io_threads": env_var("LANCE_IO_THREADS").or_else(|| env_var("IO_THREADS")),
+            "lance_default_io_buffer_size": env_var("LANCE_DEFAULT_IO_BUFFER_SIZE"),
+            "lance_max_iop_size": env_var("LANCE_MAX_IOP_SIZE"),
+            "lance_use_lite_scheduler": env_var("LANCE_USE_LITE_SCHEDULER"),
+            "lance_inline_scheduling_threshold": env_var("LANCE_INLINE_SCHEDULING_THRESHOLD"),
+            "elapsed_seconds": elapsed_secs,
+            "producer_finished_seconds": stats.producer_finished_at.map(|duration| duration.as_secs_f64()),
+            "logical_gbps": logical_gbps,
+            "physical_gbps": physical_gbps,
+            "rows_per_second": rows_per_second,
+            "arrow_bytes": stats.arrow_bytes,
+            "bytes_per_row": bytes_per_row,
+            "avg_bytes_per_scheduler_request": avg_bytes_per_scheduler_request,
+            "avg_bytes_per_scheduler_iop": avg_bytes_per_scheduler_iop,
+            "scheduler_iops": scheduler_stats.iops,
+            "scheduler_requests": scheduler_stats.requests,
+            "scheduler_bytes_read": scheduler_stats.bytes_read,
+            "scheduler_diagnostics": diagnostics_json(stats.scheduler_diagnostics),
+            "fragments_started": counters.fragments_started.load(Ordering::Relaxed),
+            "fragments_completed": counters.fragments_completed.load(Ordering::Relaxed),
+            "batch_futures_emitted": counters.batch_futures_emitted.load(Ordering::Relaxed),
+            "batch_futures_received": counters.batch_futures_received.load(Ordering::Relaxed),
+            "batches_completed": counters.batches_completed.load(Ordering::Relaxed),
+            "peak_decode_in_flight": stats.peak_decode_in_flight,
+            "open_reader_seconds_total": ns_to_seconds(counters.open_reader_ns.load(Ordering::Relaxed)),
+            "read_stream_create_seconds_total": ns_to_seconds(counters.read_stream_create_ns.load(Ordering::Relaxed)),
+            "next_batch_poll_seconds_total": ns_to_seconds(counters.next_batch_poll_ns.load(Ordering::Relaxed)),
+            "channel_send_wait_seconds_total": ns_to_seconds(counters.channel_send_wait_ns.load(Ordering::Relaxed)),
+            "decode_seconds_total": ns_to_seconds(counters.decode_ns.load(Ordering::Relaxed)),
+            "raw_reassemble_seconds_total": ns_to_seconds(counters.raw_reassemble_ns.load(Ordering::Relaxed)),
+            "cpu_avg": stats.cpu_avg,
+            "samples": stats.samples,
+        });
+        println!(
+            "case={} backend={} projection={} io_buffer_gib={} elapsed={:.3}s logical_gbps={:.2} physical_gbps={:.2} rows={} batches={} scheduler_bytes_read={} scheduler_iops={} scheduler_requests={} active_iops={} pending_iops={} cpu_avg={}",
+            config.case_name,
+            config.backend.name(),
+            projection,
+            io_buffer_gib
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "auto".to_string()),
+            elapsed_secs,
+            logical_gbps,
+            physical_gbps,
+            stats.rows,
+            stats.batches,
+            scheduler_stats.bytes_read,
+            scheduler_stats.iops,
+            scheduler_stats.requests,
+            stats.scheduler_diagnostics.active_iops,
+            stats.scheduler_diagnostics.pending_iops,
+            stats
+                .cpu_avg
+                .map(|value| format!("{value:.1}%"))
+                .unwrap_or_else(|| "unknown".to_string())
+        );
+        jsonl.push_str(&serde_json::to_string(&record)?);
+        jsonl.push('\n');
+        fs::write(&output_path, &jsonl)?;
+    }
+
+    println!("wrote {output_path}");
+    Ok(())
+}

--- a/rust/lance/benches/s3_file_reader_diagnostics.rs
+++ b/rust/lance/benches/s3_file_reader_diagnostics.rs
@@ -59,6 +59,7 @@ struct Config {
     raw_completion_mode: RawCompletionMode,
     take_repetitions: u64,
     io_buffer_gib: Vec<Option<u64>>,
+    scheduler_io_capacity: Option<usize>,
     batch_size: u32,
     batch_size_bytes: Option<u64>,
     skip_batch_byte_accounting: bool,
@@ -208,7 +209,7 @@ fn usage() -> &'static str {
      [--raw-submit-mode <single|split-no-concat|split-concat>] \
      [--raw-completion-mode <unordered|ordered>] \
      [--take-repetitions <n>] \
-     [--io-buffer-gib <auto|n[,n...]>] \
+     [--io-buffer-gib <auto|n[,n...]>] [--scheduler-io-capacity <n>] \
      [--batch-size <n>] [--batch-size-bytes <n>] [--read-chunk-size <n>] \
      [--skip-batch-byte-accounting] \
      [--fragment-concurrency <n>] [--batch-concurrency <n>] \
@@ -230,6 +231,7 @@ fn parse_args() -> Result<Config> {
     let mut raw_completion_mode = RawCompletionMode::Unordered;
     let mut take_repetitions = 100u64;
     let mut io_buffer_gib = vec![Some(8)];
+    let mut scheduler_io_capacity = None;
     let mut batch_size = 8192u32;
     let mut batch_size_bytes = None;
     let mut skip_batch_byte_accounting = false;
@@ -304,6 +306,10 @@ fn parse_args() -> Result<Config> {
                     .ok_or_else(|| format!("missing value for --io-buffer-gib. {}", usage()))?;
                 io_buffer_gib = parse_io_buffer_gib(&value)?;
             }
+            "--scheduler-io-capacity" => {
+                scheduler_io_capacity =
+                    Some(parse_required_value(&mut args, "--scheduler-io-capacity")?);
+            }
             "--batch-size" => {
                 batch_size = parse_required_value(&mut args, "--batch-size")?;
             }
@@ -373,6 +379,16 @@ fn parse_args() -> Result<Config> {
     if io_buffer_gib.is_empty() {
         return Err("--io-buffer-gib must not be empty".into());
     }
+    if matches!(scheduler_io_capacity, Some(0)) {
+        return Err("--scheduler-io-capacity must be greater than zero".into());
+    }
+    if scheduler_io_capacity.is_some() && matches!(backend, Backend::Scanner | Backend::DatasetTake)
+    {
+        return Err(
+            "--scheduler-io-capacity is only supported by file-reader and scheduler-raw backends"
+                .into(),
+        );
+    }
     if batch_size == 0 {
         return Err("--batch-size must be greater than zero".into());
     }
@@ -406,6 +422,7 @@ fn parse_args() -> Result<Config> {
         raw_completion_mode,
         take_repetitions,
         io_buffer_gib,
+        scheduler_io_capacity,
         batch_size,
         batch_size_bytes,
         skip_batch_byte_accounting,
@@ -1286,8 +1303,17 @@ async fn run_scheduler_raw_case(config: &Config, io_buffer_gib: Option<u64>) -> 
     let (object_store, _) = LanceObjectStore::from_uri(&config.uri).await?;
     let scheduler_config = io_buffer_gib
         .map(|gib| SchedulerConfig::new(gib * GIB))
-        .unwrap_or_else(|| SchedulerConfig::max_bandwidth(object_store.as_ref()));
-    let scheduler = ScanScheduler::new(object_store, scheduler_config);
+        .unwrap_or_else(|| {
+            let io_parallelism = config
+                .scheduler_io_capacity
+                .unwrap_or_else(|| object_store.io_parallelism());
+            SchedulerConfig::max_bandwidth_for_io_parallelism(io_parallelism)
+        });
+    let scheduler = ScanScheduler::new_with_io_capacity(
+        object_store,
+        scheduler_config,
+        config.scheduler_io_capacity,
+    );
 
     let (selected_files, planned) = match config.raw_range_mode {
         RawRangeMode::FileSequential => {
@@ -1583,8 +1609,17 @@ async fn run_case(config: &Config, io_buffer_gib: Option<u64>) -> Result<CaseSta
     let (object_store, _) = LanceObjectStore::from_uri(&config.uri).await?;
     let scheduler_config = io_buffer_gib
         .map(|gib| SchedulerConfig::new(gib * GIB))
-        .unwrap_or_else(|| SchedulerConfig::max_bandwidth(object_store.as_ref()));
-    let scheduler = ScanScheduler::new(object_store, scheduler_config);
+        .unwrap_or_else(|| {
+            let io_parallelism = config
+                .scheduler_io_capacity
+                .unwrap_or_else(|| object_store.io_parallelism());
+            SchedulerConfig::max_bandwidth_for_io_parallelism(io_parallelism)
+        });
+    let scheduler = ScanScheduler::new_with_io_capacity(
+        object_store,
+        scheduler_config,
+        config.scheduler_io_capacity,
+    );
 
     let mut planned = Vec::new();
     let mut remaining_rows = config.limit_rows;
@@ -1949,7 +1984,7 @@ async fn main() -> Result<()> {
 
     for io_buffer_gib in &config.io_buffer_gib {
         println!(
-            "running case={} backend={} projection={} limit_rows={} io_buffer_gib={} batch_size={} fragment_concurrency={} batch_concurrency={} sample_ms={}",
+            "running case={} backend={} projection={} limit_rows={} io_buffer_gib={} scheduler_io_capacity={} batch_size={} fragment_concurrency={} batch_concurrency={} sample_ms={}",
             config.case_name,
             config.backend.name(),
             projection,
@@ -1957,6 +1992,10 @@ async fn main() -> Result<()> {
             io_buffer_gib
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "auto".to_string()),
+            config
+                .scheduler_io_capacity
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "default".to_string()),
             config.batch_size,
             config.fragment_concurrency,
             config.batch_concurrency,
@@ -2019,6 +2058,7 @@ async fn main() -> Result<()> {
             "raw_submit_mode": config.raw_submit_mode.name(),
             "raw_completion_mode": config.raw_completion_mode.name(),
             "take_repetitions": config.take_repetitions,
+            "scheduler_io_capacity": config.scheduler_io_capacity,
             "raw_read_chunk_size_bytes": config.read_chunk_size.unwrap_or(DEFAULT_READ_CHUNK_SIZE),
             "planned_rows": stats.planned_rows,
             "planned_fragments": stats.planned_fragments,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -91,7 +91,9 @@ use crate::index::scalar_logical::scalar_index_fragment_bitmap;
 use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
-use crate::io::exec::filtered_read::{FilteredReadExec, FilteredReadOptions};
+use crate::io::exec::filtered_read::{
+    FilteredReadExec, FilteredReadOptions, ScanSchedulerDiagnosticsCallback,
+};
 use crate::io::exec::fts::{
     BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
 };
@@ -115,6 +117,7 @@ use crate::{
     io::exec::fts::{BoolSlot, BooleanQueryExec, build_boolean_query_children},
 };
 
+pub use crate::io::exec::filtered_read::ScanSchedulerDiagnosticsHandle;
 pub use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
 #[cfg(feature = "substrait")]
 use lance_datafusion::substrait::parse_substrait;
@@ -815,6 +818,8 @@ pub struct Scanner {
     /// If set, this callback will be called after the scan with summary statistics
     scan_stats_callback: Option<ExecutionStatsCallback>,
 
+    scan_scheduler_diagnostics_callback: Option<ScanSchedulerDiagnosticsCallback>,
+
     /// Whether the result returned by the scanner must be of the size of the batch_size.
     /// By default, it is false.
     /// Mainly, if the result is returned strictly according to the batch_size,
@@ -1054,6 +1059,7 @@ impl Scanner {
             use_scalar_index: true,
             include_deleted_rows: false,
             scan_stats_callback: None,
+            scan_scheduler_diagnostics_callback: None,
             strict_batch_size: false,
             file_reader_options,
             aggregate: None,
@@ -1199,6 +1205,16 @@ impl Scanner {
     /// Set the callback to be called after the scan with summary statistics
     pub fn scan_stats_callback(&mut self, callback: ExecutionStatsCallback) -> &mut Self {
         self.scan_stats_callback = Some(callback);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn scan_scheduler_diagnostics_callback(
+        &mut self,
+        callback: impl Fn(ScanSchedulerDiagnosticsHandle) + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.scan_scheduler_diagnostics_callback =
+            Some(ScanSchedulerDiagnosticsCallback::new(callback));
         self
     }
 
@@ -2893,6 +2909,10 @@ impl Scanner {
             read_options = read_options.with_io_buffer_size(io_buffer_size_bytes);
         }
 
+        if let Some(callback) = self.scan_scheduler_diagnostics_callback.clone() {
+            read_options = read_options.with_scan_scheduler_diagnostics_callback(callback);
+        }
+
         if self.fast_search && filter_plan.has_index_query() {
             read_options = read_options.with_only_indexed_fragments();
         }
@@ -2988,6 +3008,11 @@ impl Scanner {
         if let Some(fragment) = self.fragments.as_ref() {
             filtered_read_options =
                 filtered_read_options.with_fragments(Arc::new(fragment.clone()));
+        }
+
+        if let Some(callback) = self.scan_scheduler_diagnostics_callback.clone() {
+            filtered_read_options =
+                filtered_read_options.with_scan_scheduler_diagnostics_callback(callback);
         }
 
         Ok(Arc::new(FilteredReadExec::try_new(

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2877,9 +2877,23 @@ impl Scanner {
         fragments: Option<Arc<Vec<Fragment>>>,
         scan_range: Option<Range<u64>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let ordered_output = if self.ordering.is_some() || self.nearest.is_some() {
+            // If a later plan node sorts the results then the scan does not need
+            // to preserve fragment order.
+            false
+        } else if projection.with_row_last_updated_at_version
+            || projection.with_row_created_at_version
+        {
+            // Version columns require ordered scanning because version metadata
+            // is indexed by position within each fragment.
+            true
+        } else {
+            self.ordered
+        };
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
-            .with_projection(projection);
+            .with_projection(projection)
+            .with_ordered_output(ordered_output);
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -12268,6 +12282,12 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "Schema should include _row_created_at_version"
         );
 
+        scanner.scan_in_order(false);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(filtered.options().ordered_output);
+
         // Actually read the data to ensure version columns are materialized
         let batches = scanner
             .try_into_stream()
@@ -12397,6 +12417,28 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert_eq!(filtered.options().io_buffer_size_bytes, Some(7777));
+    }
+
+    #[tokio::test]
+    async fn test_scan_in_order_propagated_to_filtered_read() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_scan_in_order_propagated", None)
+            .await
+            .unwrap();
+
+        let plan = dataset.scan().create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(filtered.options().ordered_output);
+
+        let mut scanner = dataset.scan();
+        scanner.scan_in_order(false);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert!(!filtered.options().ordered_output);
     }
 
     // The env var key scopes serial_test's lock so this test only blocks others

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -370,6 +370,8 @@ struct FilteredReadStream {
     active_partitions_counter: Arc<AtomicUsize>,
     /// The threading mode for the scan
     threading_mode: FilteredReadThreadingMode,
+    /// If true, output batches preserve fragment/task order.
+    ordered_output: bool,
     /// Range to apply to the result stream if not already pushed down in planning phase
     scan_range_after_filter: Option<Range<u64>>,
 }
@@ -461,20 +463,28 @@ impl FilteredReadStream {
 
         let global_metrics_clone = global_metrics.clone();
 
-        let fragment_streams = futures::stream::iter(scoped_fragments)
-            .map({
-                let scan_range_after_filter = scan_range_after_filter.clone();
-                move |scoped_fragment| {
-                    let metrics = global_metrics_clone.clone();
-                    let limit = scan_range_after_filter.as_ref().map(|r| r.end);
-                    SpawnedTask::spawn(
-                        Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
-                    )
-                    .map(|thread_result| thread_result.unwrap())
-                }
-            })
-            .buffered(fragment_readahead);
-        let task_stream = fragment_streams.try_flatten().boxed();
+        let fragment_tasks = futures::stream::iter(scoped_fragments).map({
+            let scan_range_after_filter = scan_range_after_filter.clone();
+            move |scoped_fragment| {
+                let metrics = global_metrics_clone.clone();
+                let limit = scan_range_after_filter.as_ref().map(|r| r.end);
+                SpawnedTask::spawn(
+                    Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
+                )
+                .map(|thread_result| thread_result.unwrap())
+            }
+        });
+        let task_stream = if options.ordered_output {
+            fragment_tasks
+                .buffered(fragment_readahead)
+                .try_flatten()
+                .boxed()
+        } else {
+            fragment_tasks
+                .buffer_unordered(fragment_readahead)
+                .try_flatten_unordered(Some(fragment_readahead))
+                .boxed()
+        };
 
         Ok(Self {
             output_schema,
@@ -483,6 +493,7 @@ impl FilteredReadStream {
             metrics: global_metrics,
             active_partitions_counter: Arc::new(AtomicUsize::new(0)),
             threading_mode,
+            ordered_output: options.ordered_output,
             scan_range_after_filter,
         })
     }
@@ -1010,10 +1021,10 @@ impl FilteredReadStream {
                 assert_eq!(partition, 0);
                 let output_schema = self.output_schema.clone();
                 let task_stream = self.task_stream.clone();
-                let partition_metrics_clone = partition_metrics.clone();
+                let partition_metrics_for_tasks = partition_metrics.clone();
                 let futures_stream = futures::stream::try_unfold(task_stream, {
                     move |task_stream| {
-                        let partition_metrics = partition_metrics_clone.clone();
+                        let partition_metrics = partition_metrics_for_tasks.clone();
                         async move {
                             // There is no compute we can meaningfully measure here.  The actual work is
                             // done by spawned background threads.
@@ -1025,17 +1036,18 @@ impl FilteredReadStream {
                         }
                     }
                 });
-                let partition_metrics_clone = partition_metrics.clone();
-                let base_batch_stream =
-                    futures_stream
-                        .try_buffered(num_threads)
-                        .try_filter_map(move |batch| {
-                            std::future::ready(Ok(if batch.num_rows() == 0 {
-                                None
-                            } else {
-                                Some(batch)
-                            }))
-                        });
+                let base_batch_stream = if self.ordered_output {
+                    futures_stream.try_buffered(num_threads).boxed()
+                } else {
+                    futures_stream.try_buffer_unordered(num_threads).boxed()
+                }
+                .try_filter_map(move |batch| {
+                    std::future::ready(Ok(if batch.num_rows() == 0 {
+                        None
+                    } else {
+                        Some(batch)
+                    }))
+                });
 
                 let batch_stream = if let Some(ref range) = self.scan_range_after_filter {
                     Self::apply_hard_range(base_batch_stream, range.clone()).boxed()
@@ -1048,9 +1060,10 @@ impl FilteredReadStream {
                 // no output batches were produced (inspect_ok never fires in that case).
                 let global_metrics_final = global_metrics.clone();
                 let scan_scheduler_final = scan_scheduler.clone();
+                let partition_metrics_for_batches = partition_metrics.clone();
                 let batch_stream = batch_stream
                     .inspect_ok(move |batch| {
-                        partition_metrics_clone
+                        partition_metrics_for_batches
                             .baseline_metrics
                             .record_output(batch.num_rows());
                         global_metrics.io_metrics.record(&scan_scheduler);
@@ -1338,6 +1351,8 @@ pub struct FilteredReadOptions {
     pub full_filter: Option<Expr>,
     /// The threading mode to use for the scan
     pub threading_mode: FilteredReadThreadingMode,
+    /// If true, emit fragment tasks in fragment order.
+    pub ordered_output: bool,
     /// The size of the I/O buffer to use for the scan
     pub io_buffer_size_bytes: Option<u64>,
     /// Callback used by diagnostics tools to sample the scan scheduler while a scan is running.
@@ -1374,6 +1389,7 @@ impl FilteredReadOptions {
             io_buffer_size_bytes: None,
             scan_scheduler_diagnostics_callback: None,
             only_indexed_fragments: false,
+            ordered_output: true,
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
                 get_num_compute_intensive_cpus(),
             ),
@@ -1470,6 +1486,12 @@ impl FilteredReadOptions {
     /// scheduler.
     pub fn with_fragment_readahead(mut self, fragment_readahead: usize) -> Self {
         self.fragment_readahead = Some(fragment_readahead);
+        self
+    }
+
+    /// Set whether output batches should preserve fragment order.
+    pub fn with_ordered_output(mut self, ordered_output: bool) -> Self {
+        self.ordered_output = ordered_output;
         self
     }
 
@@ -2599,6 +2621,29 @@ mod tests {
 
         // Some batches will be smaller because we don't coalesce batches across fragments
         assert_eq!(batch_sizes, vec![35, 35, 30, 35, 15, 35, 35, 30]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_unordered_output_preserves_rows() {
+        let fixture = TestFixture::new().await;
+        let options = FilteredReadOptions::basic_full_read(&fixture.dataset)
+            .with_batch_size(35)
+            .with_ordered_output(false);
+
+        let plan = fixture.make_plan(options).await;
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+        let mut values = batch
+            .column(0)
+            .as_primitive::<UInt32Type>()
+            .values()
+            .to_vec();
+        values.sort_unstable();
+
+        let expected = (0..100).chain(250..400).collect::<Vec<u32>>();
+        assert_eq!(values, expected);
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -39,7 +39,7 @@ use lance_datafusion::utils::{
 };
 use lance_file::reader::FileReaderOptions;
 use lance_index::scalar::expression::FilterPlan;
-use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig, SchedulerDiagnostics};
 use lance_select::{
     IndexExprResult, RowAddrSelection, RowAddrTreeMap, bitmap_to_ranges, ranges_to_bitmap,
 };
@@ -299,6 +299,50 @@ pub enum FilteredReadThreadingMode {
     MultiplePartitions(usize),
 }
 
+#[derive(Clone)]
+pub struct ScanSchedulerDiagnosticsHandle {
+    scan_scheduler: Arc<ScanScheduler>,
+}
+
+impl std::fmt::Debug for ScanSchedulerDiagnosticsHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScanSchedulerDiagnosticsHandle").finish()
+    }
+}
+
+impl ScanSchedulerDiagnosticsHandle {
+    fn new(scan_scheduler: Arc<ScanScheduler>) -> Self {
+        Self { scan_scheduler }
+    }
+
+    pub fn diagnostics(&self) -> SchedulerDiagnostics {
+        self.scan_scheduler.diagnostics()
+    }
+}
+
+#[derive(Clone)]
+pub struct ScanSchedulerDiagnosticsCallback {
+    callback: Arc<dyn Fn(ScanSchedulerDiagnosticsHandle) + Send + Sync>,
+}
+
+impl std::fmt::Debug for ScanSchedulerDiagnosticsCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScanSchedulerDiagnosticsCallback").finish()
+    }
+}
+
+impl ScanSchedulerDiagnosticsCallback {
+    pub fn new(callback: impl Fn(ScanSchedulerDiagnosticsHandle) + Send + Sync + 'static) -> Self {
+        Self {
+            callback: Arc::new(callback),
+        }
+    }
+
+    fn notify(&self, handle: ScanSchedulerDiagnosticsHandle) {
+        (self.callback)(handle);
+    }
+}
+
 /// The stream of filtered rows that satisfies the FilteredReadExec node
 ///
 /// This represents a scan of a Lance dataset.  Upon creation of the stream we will
@@ -399,6 +443,9 @@ impl FilteredReadStream {
             SchedulerConfig::max_bandwidth(obj_store.as_ref())
         };
         let scan_scheduler = ScanScheduler::new(obj_store, scheduler_config);
+        if let Some(callback) = options.scan_scheduler_diagnostics_callback.as_ref() {
+            callback.notify(ScanSchedulerDiagnosticsHandle::new(scan_scheduler.clone()));
+        }
 
         // Get scan_range_after_filter from the plan
         let scan_range_after_filter = plan.scan_range_after_filter.clone();
@@ -1293,6 +1340,8 @@ pub struct FilteredReadOptions {
     pub threading_mode: FilteredReadThreadingMode,
     /// The size of the I/O buffer to use for the scan
     pub io_buffer_size_bytes: Option<u64>,
+    /// Callback used by diagnostics tools to sample the scan scheduler while a scan is running.
+    pub scan_scheduler_diagnostics_callback: Option<ScanSchedulerDiagnosticsCallback>,
     /// If true, skip fragments that are not covered by the scalar index result.
     pub only_indexed_fragments: bool,
 }
@@ -1323,6 +1372,7 @@ impl FilteredReadOptions {
             refine_filter: None,
             full_filter: None,
             io_buffer_size_bytes: None,
+            scan_scheduler_diagnostics_callback: None,
             only_indexed_fragments: false,
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
                 get_num_compute_intensive_cpus(),
@@ -1474,6 +1524,15 @@ impl FilteredReadOptions {
     /// See [`crate::dataset::scanner::Scanner::io_buffer_size`] for more details.
     pub fn with_io_buffer_size(mut self, io_buffer_size: u64) -> Self {
         self.io_buffer_size_bytes = Some(io_buffer_size);
+        self
+    }
+
+    /// Install a diagnostics callback for the scan scheduler used by this read.
+    pub fn with_scan_scheduler_diagnostics_callback(
+        mut self,
+        callback: ScanSchedulerDiagnosticsCallback,
+    ) -> Self {
+        self.scan_scheduler_diagnostics_callback = Some(callback);
         self
     }
 
@@ -2131,6 +2190,7 @@ impl ExecutionPlan for FilteredReadExec {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use crate::index::DatasetIndexExt;
     use arrow::{
@@ -2336,6 +2396,27 @@ mod tests {
                 .create_filter_plan(expr, &index_info, use_scalar_index)
                 .unwrap()
         }
+    }
+
+    #[tokio::test]
+    async fn test_scan_scheduler_diagnostics_callback_is_called() {
+        let fixture = TestFixture::new().await;
+        let callback_called = Arc::new(AtomicBool::new(false));
+        let callback_called_copy = callback_called.clone();
+        let options = FilteredReadOptions::basic_full_read(&fixture.dataset)
+            .with_scan_scheduler_diagnostics_callback(ScanSchedulerDiagnosticsCallback::new(
+                move |handle| {
+                    let diagnostics = handle.diagnostics();
+                    assert_eq!(diagnostics.stats.bytes_read, 0);
+                    callback_called_copy.store(true, Ordering::SeqCst);
+                },
+            ));
+
+        let plan = fixture.make_plan(options).await;
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let _ = stream.try_collect::<Vec<_>>().await.unwrap();
+
+        assert!(callback_called.load(Ordering::SeqCst));
     }
 
     async fn dataset_with_bloom_filter_nulls() -> (TempStrDir, Arc<Dataset>) {

--- a/rust/lance/src/io/exec/filtered_read_proto.rs
+++ b/rust/lance/src/io/exec/filtered_read_proto.rs
@@ -145,6 +145,7 @@ fn fr_options_to_proto(
         threading_mode: Some(threading_mode_to_proto(&options.threading_mode)),
         io_buffer_size_bytes: options.io_buffer_size_bytes,
         filter_schema_ipc,
+        ordered_output: Some(options.ordered_output),
     })
 }
 
@@ -196,6 +197,9 @@ async fn fr_options_from_proto(
     }
     if let Some(mode) = proto.threading_mode {
         options.threading_mode = threading_mode_from_proto(&mode)?;
+    }
+    if let Some(ordered_output) = proto.ordered_output {
+        options = options.with_ordered_output(ordered_output);
     }
 
     // Filters — require filter_schema_ipc when filters are present
@@ -615,6 +619,7 @@ mod tests {
         assert_eq!(options.fragment_readahead, back.fragment_readahead);
         assert_eq!(options.io_buffer_size_bytes, back.io_buffer_size_bytes);
         assert_eq!(options.threading_mode, back.threading_mode);
+        assert_eq!(options.ordered_output, back.ordered_output);
         assert_eq!(options.with_deleted_rows, back.with_deleted_rows);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);
         assert_eq!(options.projection.with_row_id, back.projection.with_row_id);
@@ -622,6 +627,24 @@ mod tests {
             options.projection.with_row_addr,
             back.projection.with_row_addr
         );
+    }
+
+    #[tokio::test]
+    async fn test_options_from_old_proto_defaults_to_ordered_output() {
+        let dataset = make_test_dataset().await;
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let filter_schema = Arc::new(prune_schema_for_substrait(&dataset.schema().into()));
+
+        let options = FilteredReadOptions::basic_full_read(&dataset).with_ordered_output(false);
+        let mut proto = fr_options_to_proto(&options, &filter_schema, &state).unwrap();
+        proto.ordered_output = None;
+
+        let back = fr_options_from_proto(proto, &dataset, &state)
+            .await
+            .unwrap();
+
+        assert!(back.ordered_output);
     }
 
     #[tokio::test]
@@ -644,6 +667,7 @@ mod tests {
         options.full_filter = Some(filter_expr);
         options.refine_filter = Some(refine_expr);
         options.threading_mode = FilteredReadThreadingMode::MultiplePartitions(4);
+        options = options.with_ordered_output(false);
 
         let proto = fr_options_to_proto(&options, &filter_schema, &state).unwrap();
 
@@ -660,6 +684,7 @@ mod tests {
         assert!(back.refine_filter.is_some());
         assert!(back.with_deleted_rows);
         assert_eq!(options.threading_mode, back.threading_mode);
+        assert_eq!(options.ordered_output, back.ordered_output);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);
         assert!(back.projection.with_row_id);
     }


### PR DESCRIPTION
## Why

The final goal is to make large S3/cloud scans approach the physical bandwidth limit while keeping small scans and point reads from regressing. This PR provides the scheduler-level control needed to verify whether the default cloud scheduler capacity is an independent bottleneck before any scanner default policy is changed.

## What

- Adds `ScanScheduler::new_with_io_capacity` so a single scheduler can override its internal I/O queue capacity without changing the shared `ObjectStore` default.
- Adds `SchedulerConfig::max_bandwidth_for_io_parallelism` so the buffer budget can scale with an explicit capacity.
- Adds `--scheduler-io-capacity <n>` to `s3_file_reader_diagnostics` for `file-reader` and `scheduler-raw` backends.

## Boundaries

- Does not change `ScanScheduler::new` default behavior.
- Does not change scanner defaults or enable high-bandwidth scan policy.
- Does not change shared `ObjectStore` I/O parallelism.
- Does not change storage format, wire format, Python, Java, or point-read paths.

## Validation

- `cargo test -p lance-io scheduler -- --nocapture`
- `cargo check -p lance --bench s3_file_reader_diagnostics`
- `git diff --check`

Capacity sweep on `lance-over-100gbps`, dataset `s3://lance-over-100gbps/lance-bench/s3-scan-v1/vector1024-4tib/`, backend `scheduler-raw`, target bytes `256GiB`, range size `16MiB`:

| Capacity | Physical throughput | Max sampled active IOPS |
| ---: | ---: | ---: |
| 64 | `45.99Gbps` | 64 |
| 128 | `92.43Gbps` | 128 |
| 256 | `161.68Gbps` | 256 |
| 512 | `160.39Gbps` | 256 |

This confirms the default capacity can independently limit raw scheduler throughput, and that the useful range for this setup plateaus around 256 IOPS.
