### PR TITLE
perf(encoding): split fullzip page decode

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -770,17 +770,21 @@ impl CoreFieldDecoderStrategy {
         &self,
         field: &Field,
         column_infos: &mut ColumnInfoIter,
+        split_fullzip_pages: bool,
     ) -> Result<Box<dyn StructuralFieldScheduler>> {
         let data_type = field.data_type();
         validate_fixed_size_list_dimensions(&field.name, &data_type)?;
         if Self::is_structural_primitive(&data_type) {
             let column_info = column_infos.expect_next()?;
-            let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
-                column_info.as_ref(),
-                self.decompressor_strategy.as_ref(),
-                self.cache_repetition_index,
-                field,
-            )?);
+            let scheduler = Box::new(
+                StructuralPrimitiveFieldScheduler::try_new_with_fullzip_page_splitting(
+                    column_info.as_ref(),
+                    self.decompressor_strategy.as_ref(),
+                    self.cache_repetition_index,
+                    field,
+                    split_fullzip_pages,
+                )?,
+            );
 
             // advance to the next top level column
             column_infos.next_top_level();
@@ -792,12 +796,15 @@ impl CoreFieldDecoderStrategy {
                 if field.is_packed_struct() {
                     // Packed struct
                     let column_info = column_infos.expect_next()?;
-                    let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
-                        column_info.as_ref(),
-                        self.decompressor_strategy.as_ref(),
-                        self.cache_repetition_index,
-                        field,
-                    )?);
+                    let scheduler = Box::new(
+                        StructuralPrimitiveFieldScheduler::try_new_with_fullzip_page_splitting(
+                            column_info.as_ref(),
+                            self.decompressor_strategy.as_ref(),
+                            self.cache_repetition_index,
+                            field,
+                            split_fullzip_pages,
+                        )?,
+                    );
 
                     // advance to the next top level column
                     column_infos.next_top_level();
@@ -816,12 +823,15 @@ impl CoreFieldDecoderStrategy {
                         )
                     }) {
                         let column_info = column_infos.expect_next()?;
-                        let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
-                            column_info.as_ref(),
-                            self.decompressor_strategy.as_ref(),
-                            self.cache_repetition_index,
-                            field,
-                        )?);
+                        let scheduler = Box::new(
+                            StructuralPrimitiveFieldScheduler::try_new_with_fullzip_page_splitting(
+                                column_info.as_ref(),
+                                self.decompressor_strategy.as_ref(),
+                                self.cache_repetition_index,
+                                field,
+                                split_fullzip_pages,
+                            )?,
+                        );
                         column_infos.next_top_level();
                         return Ok(scheduler);
                     }
@@ -829,8 +839,11 @@ impl CoreFieldDecoderStrategy {
 
                 let mut child_schedulers = Vec::with_capacity(field.children.len());
                 for field in field.children.iter() {
-                    let field_scheduler =
-                        self.create_structural_field_scheduler(field, column_infos)?;
+                    let field_scheduler = self.create_structural_field_scheduler(
+                        field,
+                        column_infos,
+                        split_fullzip_pages,
+                    )?;
                     child_schedulers.push(field_scheduler);
                 }
 
@@ -842,8 +855,11 @@ impl CoreFieldDecoderStrategy {
             }
             DataType::List(_) | DataType::LargeList(_) => {
                 let child = field.children.first().expect_ok()?;
-                let child_scheduler =
-                    self.create_structural_field_scheduler(child, column_infos)?;
+                let child_scheduler = self.create_structural_field_scheduler(
+                    child,
+                    column_infos,
+                    split_fullzip_pages,
+                )?;
                 Ok(Box::new(StructuralListScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
             }
@@ -851,8 +867,11 @@ impl CoreFieldDecoderStrategy {
                 if matches!(inner.data_type(), DataType::Struct(_)) =>
             {
                 let child = field.children.first().expect_ok()?;
-                let child_scheduler =
-                    self.create_structural_field_scheduler(child, column_infos)?;
+                let child_scheduler = self.create_structural_field_scheduler(
+                    child,
+                    column_infos,
+                    split_fullzip_pages,
+                )?;
                 Ok(Box::new(StructuralFixedSizeListScheduler::new(
                     child_scheduler,
                     *dimension,
@@ -866,8 +885,11 @@ impl CoreFieldDecoderStrategy {
                     return Err(Error::not_supported_source(format!("Map data type is not supported with keys_sorted=true now, current value is {}", *keys_sorted).into()));
                 }
                 let entries_child = field.children.first().expect_ok()?;
-                let child_scheduler =
-                    self.create_structural_field_scheduler(entries_child, column_infos)?;
+                let child_scheduler = self.create_structural_field_scheduler(
+                    entries_child,
+                    column_infos,
+                    split_fullzip_pages,
+                )?;
                 Ok(Box::new(StructuralMapScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
             }
@@ -1081,6 +1103,36 @@ impl DecodeBatchScheduler {
         filter: &FilterExpression,
         decoder_config: &DecoderConfig,
     ) -> Result<Self> {
+        Self::try_new_with_fullzip_page_splitting(
+            schema,
+            column_indices,
+            column_infos,
+            file_buffer_positions_and_sizes,
+            num_rows,
+            _decoder_plugins,
+            io,
+            cache,
+            filter,
+            decoder_config,
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn try_new_with_fullzip_page_splitting<'a>(
+        schema: &'a Schema,
+        column_indices: &[u32],
+        column_infos: &[Arc<ColumnInfo>],
+        file_buffer_positions_and_sizes: &'a Vec<(u64, u64)>,
+        num_rows: u64,
+        _decoder_plugins: Arc<DecoderPlugins>,
+        io: Arc<dyn EncodingsIo>,
+        cache: Arc<LanceCache>,
+        filter: &FilterExpression,
+        decoder_config: &DecoderConfig,
+        split_fullzip_pages: bool,
+    ) -> Result<Self> {
         assert!(num_rows > 0);
         let buffers = FileBuffers {
             positions_and_sizes: file_buffer_positions_and_sizes,
@@ -1101,8 +1153,11 @@ impl DecodeBatchScheduler {
             let mut column_iter = ColumnInfoIter::new(column_infos.to_vec(), column_indices);
 
             let strategy = CoreFieldDecoderStrategy::from_decoder_config(decoder_config);
-            let mut root_scheduler =
-                strategy.create_structural_field_scheduler(&root_field, &mut column_iter)?;
+            let mut root_scheduler = strategy.create_structural_field_scheduler(
+                &root_field,
+                &mut column_iter,
+                split_fullzip_pages,
+            )?;
 
             let context = SchedulerContext::new(io, cache.clone());
             root_scheduler.initialize(filter, &context).await?;
@@ -2296,6 +2351,7 @@ async fn create_scheduler_decoder(
     config: SchedulerDecoderConfig,
 ) -> Result<BoxStream<'static, ReadBatchTask>> {
     let num_rows = requested_rows.num_rows();
+    let is_range_scan = matches!(requested_rows, RequestedRows::Ranges(_));
 
     let is_structural = column_infos[0].is_structural();
     let mode = std::env::var(ENV_LANCE_STRUCTURAL_BATCH_DECODE_SPAWN_MODE);
@@ -2322,7 +2378,7 @@ async fn create_scheduler_decoder(
     // unless that metadata is already in the cache.  This metadata loading
     // happens as part of this call and should be parallelized if reading
     // multiple files.
-    let mut decode_scheduler = DecodeBatchScheduler::try_new(
+    let mut decode_scheduler = DecodeBatchScheduler::try_new_with_fullzip_page_splitting(
         target_schema.as_ref(),
         &column_indices,
         &column_infos,
@@ -2333,6 +2389,7 @@ async fn create_scheduler_decoder(
         config.cache,
         &filter,
         &config.decoder_config,
+        is_range_scan,
     )
     .await?;
 
@@ -3132,7 +3189,7 @@ mod tests {
 
         let mut structural_columns = ColumnInfoIter::new(vec![], &[]);
         let err = strategy
-            .create_structural_field_scheduler(&field, &mut structural_columns)
+            .create_structural_field_scheduler(&field, &mut structural_columns, false)
             .unwrap_err();
         assert!(
             err.to_string()

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -771,6 +771,7 @@ impl CoreFieldDecoderStrategy {
         field: &Field,
         column_infos: &mut ColumnInfoIter,
         split_fullzip_pages: bool,
+        fullzip_split_row_alignment: u64,
     ) -> Result<Box<dyn StructuralFieldScheduler>> {
         let data_type = field.data_type();
         validate_fixed_size_list_dimensions(&field.name, &data_type)?;
@@ -783,6 +784,7 @@ impl CoreFieldDecoderStrategy {
                     self.cache_repetition_index,
                     field,
                     split_fullzip_pages,
+                    fullzip_split_row_alignment,
                 )?,
             );
 
@@ -803,6 +805,7 @@ impl CoreFieldDecoderStrategy {
                             self.cache_repetition_index,
                             field,
                             split_fullzip_pages,
+                            fullzip_split_row_alignment,
                         )?,
                     );
 
@@ -830,6 +833,7 @@ impl CoreFieldDecoderStrategy {
                                 self.cache_repetition_index,
                                 field,
                                 split_fullzip_pages,
+                                fullzip_split_row_alignment,
                             )?,
                         );
                         column_infos.next_top_level();
@@ -843,6 +847,7 @@ impl CoreFieldDecoderStrategy {
                         field,
                         column_infos,
                         split_fullzip_pages,
+                        fullzip_split_row_alignment,
                     )?;
                     child_schedulers.push(field_scheduler);
                 }
@@ -859,6 +864,7 @@ impl CoreFieldDecoderStrategy {
                     child,
                     column_infos,
                     split_fullzip_pages,
+                    fullzip_split_row_alignment,
                 )?;
                 Ok(Box::new(StructuralListScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
@@ -866,11 +872,23 @@ impl CoreFieldDecoderStrategy {
             DataType::FixedSizeList(inner, dimension)
                 if matches!(inner.data_type(), DataType::Struct(_)) =>
             {
+                let child_split_row_alignment = fullzip_split_row_alignment
+                    .checked_mul(*dimension as u64)
+                    .ok_or_else(|| {
+                        Error::invalid_input_source(
+                            format!(
+                                "FixedSizeList dimension {} overflows fullzip split row alignment {}",
+                                dimension, fullzip_split_row_alignment
+                            )
+                            .into(),
+                        )
+                    })?;
                 let child = field.children.first().expect_ok()?;
                 let child_scheduler = self.create_structural_field_scheduler(
                     child,
                     column_infos,
                     split_fullzip_pages,
+                    child_split_row_alignment,
                 )?;
                 Ok(Box::new(StructuralFixedSizeListScheduler::new(
                     child_scheduler,
@@ -889,6 +907,7 @@ impl CoreFieldDecoderStrategy {
                     entries_child,
                     column_infos,
                     split_fullzip_pages,
+                    fullzip_split_row_alignment,
                 )?;
                 Ok(Box::new(StructuralMapScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
@@ -1157,6 +1176,7 @@ impl DecodeBatchScheduler {
                 &root_field,
                 &mut column_iter,
                 split_fullzip_pages,
+                1,
             )?;
 
             let context = SchedulerContext::new(io, cache.clone());
@@ -3215,7 +3235,7 @@ mod tests {
 
         let mut structural_columns = ColumnInfoIter::new(vec![], &[]);
         let err = strategy
-            .create_structural_field_scheduler(&field, &mut structural_columns, false)
+            .create_structural_field_scheduler(&field, &mut structural_columns, false, 1)
             .unwrap_err();
         assert!(
             err.to_string()
@@ -3239,6 +3259,86 @@ mod tests {
                 .contains("dimension must be a positive integer"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fullzip_split_preserves_fsl_struct_row_contract() {
+        let dimension = 3_i32;
+        // The default fullzip split target is 8MiB. For Int32 this is
+        // 2,097,152 child rows, which is not divisible by dimension 3.
+        let aligned_child_rows_per_chunk = 2_097_150_u64;
+        let child_rows = aligned_child_rows_per_chunk * 2;
+        let parent_rows = child_rows / dimension as u64;
+
+        let item_struct = DataType::Struct(Fields::from(vec![Arc::new(ArrowField::new(
+            "x",
+            DataType::Int32,
+            false,
+        ))]));
+        let fsl_type = DataType::FixedSizeList(
+            Arc::new(ArrowField::new("item", item_struct, false)),
+            dimension,
+        );
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("values", fsl_type, false)]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let page_layout = crate::format::ProtobufUtils21::fixed_full_zip_layout(
+            0,
+            0,
+            32,
+            crate::format::ProtobufUtils21::flat(32, None),
+            &[crate::repdef::DefinitionInterpretation::AllValidItem],
+            child_rows as u32,
+            child_rows as u32,
+        );
+        let page_info = PageInfo {
+            num_rows: child_rows,
+            priority: 0,
+            encoding: PageEncoding::Structural(page_layout),
+            buffer_offsets_and_sizes: Arc::from([(0, child_rows * 4)]),
+        };
+        let column_info = Arc::new(ColumnInfo::new(
+            0,
+            Arc::from([page_info]),
+            vec![],
+            pb::ColumnEncoding {
+                column_encoding: Some(column_encoding::ColumnEncoding::Values(())),
+            },
+        ));
+        let io = Arc::new(BufferScheduler::new(Bytes::new())) as Arc<dyn EncodingsIo>;
+        let cache = Arc::new(LanceCache::no_cache());
+        let mut scheduler = DecodeBatchScheduler::try_new_with_fullzip_page_splitting(
+            &schema,
+            &[0],
+            &[column_info],
+            &vec![],
+            parent_rows,
+            Arc::new(DecoderPlugins::default()),
+            io.clone(),
+            cache,
+            &FilterExpression::no_filter(),
+            &DecoderConfig::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        let messages = scheduler
+            .schedule_ranges_to_vec(&[0..parent_rows], &FilterExpression::no_filter(), io, None)
+            .unwrap();
+
+        assert!(
+            messages.len() > 1,
+            "test must exercise the split fullzip path"
+        );
+        assert_eq!(messages.last().unwrap().scheduled_so_far, parent_rows);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.scheduled_so_far)
+                .collect::<Vec<_>>(),
+            vec![aligned_child_rows_per_chunk / dimension as u64, parent_rows]
         );
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -106,16 +106,16 @@ const DEFAULT_FULLZIP_PAGE_LOAD_TARGET_BYTES: u64 = 8 * 1024 * 1024;
 static FULLZIP_ALIGNMENT_COPY_COUNT: AtomicU64 = AtomicU64::new(0);
 static FULLZIP_ALIGNMENT_COPY_BYTES: AtomicU64 = AtomicU64::new(0);
 
-#[doc(hidden)]
-pub fn fullzip_alignment_copy_stats() -> (u64, u64) {
+#[cfg(test)]
+fn fullzip_alignment_copy_stats() -> (u64, u64) {
     (
         FULLZIP_ALIGNMENT_COPY_COUNT.load(Ordering::Relaxed),
         FULLZIP_ALIGNMENT_COPY_BYTES.load(Ordering::Relaxed),
     )
 }
 
-#[doc(hidden)]
-pub fn reset_fullzip_alignment_copy_stats() {
+#[cfg(test)]
+fn reset_fullzip_alignment_copy_stats() {
     FULLZIP_ALIGNMENT_COPY_COUNT.store(0, Ordering::Relaxed);
     FULLZIP_ALIGNMENT_COPY_BYTES.store(0, Ordering::Relaxed);
 }
@@ -2166,6 +2166,8 @@ pub struct FullZipScheduler {
     enable_cache: bool,
     /// Whether full-page fixed-width reads may be split into smaller load tasks.
     split_large_pages: bool,
+    /// Required row multiple for split chunks, used by row-multiplying wrappers.
+    split_row_alignment: u64,
 }
 
 impl FullZipScheduler {
@@ -2253,6 +2255,7 @@ impl FullZipScheduler {
             cached_state: None,
             enable_cache: false,
             split_large_pages: false,
+            split_row_alignment: 1,
         })
     }
 
@@ -2446,6 +2449,21 @@ impl FullZipScheduler {
         chunks
     }
 
+    fn aligned_split_target_rows(
+        target_bytes: u64,
+        total_bytes_per_value: u64,
+        alignment: u64,
+    ) -> u64 {
+        debug_assert!(total_bytes_per_value > 0);
+        let target_rows = (target_bytes / total_bytes_per_value).max(1);
+        let alignment = alignment.max(1);
+        if target_rows < alignment {
+            alignment
+        } else {
+            (target_rows / alignment) * alignment
+        }
+    }
+
     fn schedule_simple_chunks(
         chunks: Vec<(Vec<Range<u64>>, u64, u64)>,
         io: &Arc<dyn EncodingsIo>,
@@ -2594,10 +2612,20 @@ impl FullZipScheduler {
         let bytes_per_value = bits_per_value / 8;
         let bytes_per_cw = self.details.ctrl_word_parser.bytes_per_word();
         let total_bytes_per_value = bytes_per_value + bytes_per_cw as u64;
+        if total_bytes_per_value == 0 {
+            return Err(Error::internal(
+                "Invalid encoding: per-row byte width must be greater than 0",
+            ));
+        }
         let target_rows =
             if self.split_large_pages && Self::covers_entire_page(ranges, self.rows_in_page) {
-                fullzip_page_load_target_bytes()
-                    .map(|target_bytes| (target_bytes / total_bytes_per_value).max(1))
+                fullzip_page_load_target_bytes().map(|target_bytes| {
+                    Self::aligned_split_target_rows(
+                        target_bytes,
+                        total_bytes_per_value,
+                        self.split_row_alignment,
+                    )
+                })
             } else {
                 None
             };
@@ -3501,6 +3529,7 @@ impl StructuralPrimitiveFieldScheduler {
             cache_repetition_index,
             target_field,
             false,
+            1,
         )
     }
 
@@ -3510,6 +3539,7 @@ impl StructuralPrimitiveFieldScheduler {
         cache_repetition_index: bool,
         target_field: &Field,
         split_fullzip_pages: bool,
+        fullzip_split_row_alignment: u64,
     ) -> Result<Self> {
         let page_schedulers = column_info
             .page_infos
@@ -3523,6 +3553,7 @@ impl StructuralPrimitiveFieldScheduler {
                     cache_repetition_index,
                     target_field,
                     split_fullzip_pages,
+                    fullzip_split_row_alignment,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -3540,6 +3571,7 @@ impl StructuralPrimitiveFieldScheduler {
         cache_repetition_index: bool,
         target_field: &Field,
         split_fullzip_pages: bool,
+        fullzip_split_row_alignment: u64,
     ) -> Result<Box<dyn StructuralPageScheduler>> {
         use pb21::page_layout::Layout;
         Ok(match page_layout.layout.as_ref().expect_ok()? {
@@ -3560,6 +3592,7 @@ impl StructuralPrimitiveFieldScheduler {
                 )?;
                 scheduler.enable_cache = cache_repetition_index;
                 scheduler.split_large_pages = split_fullzip_pages;
+                scheduler.split_row_alignment = fullzip_split_row_alignment.max(1);
                 Box::new(scheduler)
             }
             Layout::ConstantLayout(constant_layout) => {
@@ -3615,6 +3648,7 @@ impl StructuralPrimitiveFieldScheduler {
                     cache_repetition_index,
                     target_field,
                     split_fullzip_pages,
+                    fullzip_split_row_alignment,
                 )?;
                 let def_meaning = blob
                     .layers
@@ -3647,6 +3681,7 @@ impl StructuralPrimitiveFieldScheduler {
         cache_repetition_index: bool,
         target_field: &Field,
         split_fullzip_pages: bool,
+        fullzip_split_row_alignment: u64,
     ) -> Result<PageInfoAndScheduler> {
         let page_layout = page_info.encoding.as_structural();
         let scheduler = Self::page_layout_to_scheduler(
@@ -3656,6 +3691,7 @@ impl StructuralPrimitiveFieldScheduler {
             cache_repetition_index,
             target_field,
             split_fullzip_pages,
+            fullzip_split_row_alignment,
         )?;
         Ok(PageInfoAndScheduler {
             page_index,
@@ -6844,6 +6880,7 @@ mod tests {
             cached_state: None,
             enable_cache: false,
             split_large_pages: false,
+            split_row_alignment: 1,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();
@@ -6987,6 +7024,72 @@ mod tests {
         assert_eq!(
             sparse,
             vec![(vec![1024..1028, 1064..1068, 1104..1108], 3, 0)]
+        );
+    }
+
+    #[test]
+    fn test_fullzip_split_target_rows_aligns_to_row_multiple() {
+        assert_eq!(FullZipScheduler::aligned_split_target_rows(10, 1, 3), 9);
+        assert_eq!(FullZipScheduler::aligned_split_target_rows(2, 1, 3), 3);
+
+        let target_rows = FullZipScheduler::aligned_split_target_rows(10, 1, 3);
+        let chunks =
+            FullZipScheduler::chunk_simple_ranges(&[0..27], 27, 1024, 1, Some(target_rows));
+        assert_eq!(
+            chunks.iter().map(|(_, rows, _)| *rows).collect::<Vec<_>>(),
+            vec![9, 9, 9]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fullzip_simple_rejects_zero_width_rows() {
+        #[derive(Debug)]
+        struct ZeroWidthDecompressor;
+
+        impl FixedPerValueDecompressor for ZeroWidthDecompressor {
+            fn decompress(
+                &self,
+                _data: FixedWidthDataBlock,
+                _num_rows: u64,
+            ) -> crate::Result<DataBlock> {
+                unimplemented!("zero-width test should fail before decoding")
+            }
+
+            fn bits_per_value(&self) -> u64 {
+                0
+            }
+        }
+
+        let scheduler = FullZipScheduler {
+            data_buf_position: 0,
+            data_buf_size: 0,
+            rep_index: None,
+            priority: 0,
+            rows_in_page: 8,
+            bits_per_offset: 32,
+            details: Arc::new(FullZipDecodeDetails {
+                value_decompressor: PerValueDecompressor::Fixed(Arc::new(ZeroWidthDecompressor)),
+                def_meaning: Arc::new([crate::repdef::DefinitionInterpretation::AllValidItem]),
+                ctrl_word_parser: crate::repdef::ControlWordParser::new(0, 0),
+                max_rep: 0,
+                max_visible_def: 0,
+            }),
+            cached_state: None,
+            enable_cache: false,
+            split_large_pages: true,
+            split_row_alignment: 1,
+        };
+        let io = Arc::new(crate::BufferScheduler::new(bytes::Bytes::new()))
+            as Arc<dyn crate::EncodingsIo>;
+
+        let err = match scheduler.schedule_ranges_simple(&[0..8], &io) {
+            Ok(_) => panic!("expected zero-width fullzip scheduling to fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("per-row byte width must be greater than 0"),
+            "unexpected error: {err}"
         );
     }
 
@@ -7159,6 +7262,7 @@ mod tests {
             cached_state: None,
             enable_cache: true,
             split_large_pages: false,
+            split_row_alignment: 1,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();
@@ -7269,6 +7373,7 @@ mod tests {
             cached_state: None,
             enable_cache: false,
             split_large_pages: false,
+            split_row_alignment: 1,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -8,7 +8,10 @@ use std::{
     fmt::Debug,
     iter,
     ops::Range,
-    sync::Arc,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     vec,
 };
 
@@ -98,6 +101,35 @@ const DEFAULT_DICT_DIVISOR: u64 = 2;
 const DEFAULT_DICT_MAX_CARDINALITY: u64 = 100_000;
 const DEFAULT_DICT_SIZE_RATIO: f64 = 0.8;
 const DEFAULT_DICT_VALUES_COMPRESSION: &str = "lz4";
+const ENV_LANCE_FULLZIP_PAGE_LOAD_TARGET_BYTES: &str = "LANCE_FULLZIP_PAGE_LOAD_TARGET_BYTES";
+const DEFAULT_FULLZIP_PAGE_LOAD_TARGET_BYTES: u64 = 8 * 1024 * 1024;
+static FULLZIP_ALIGNMENT_COPY_COUNT: AtomicU64 = AtomicU64::new(0);
+static FULLZIP_ALIGNMENT_COPY_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[doc(hidden)]
+pub fn fullzip_alignment_copy_stats() -> (u64, u64) {
+    (
+        FULLZIP_ALIGNMENT_COPY_COUNT.load(Ordering::Relaxed),
+        FULLZIP_ALIGNMENT_COPY_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+#[doc(hidden)]
+pub fn reset_fullzip_alignment_copy_stats() {
+    FULLZIP_ALIGNMENT_COPY_COUNT.store(0, Ordering::Relaxed);
+    FULLZIP_ALIGNMENT_COPY_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn fullzip_page_load_target_bytes() -> Option<u64> {
+    static TARGET_BYTES: OnceLock<Option<u64>> = OnceLock::new();
+    *TARGET_BYTES.get_or_init(|| {
+        env::var(ENV_LANCE_FULLZIP_PAGE_LOAD_TARGET_BYTES)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .map(|value| if value == 0 { None } else { Some(value) })
+            .unwrap_or(Some(DEFAULT_FULLZIP_PAGE_LOAD_TARGET_BYTES))
+    })
+}
 
 struct PageLoadTask {
     decoder_fut: BoxFuture<'static, Result<Box<dyn StructuralPageDecoder>>>,
@@ -2132,6 +2164,8 @@ pub struct FullZipScheduler {
     cached_state: Option<Arc<FullZipCacheableState>>,
     /// Whether repetition index metadata should be cached during initialize.
     enable_cache: bool,
+    /// Whether full-page fixed-width reads may be split into smaller load tasks.
+    split_large_pages: bool,
 }
 
 impl FullZipScheduler {
@@ -2218,6 +2252,7 @@ impl FullZipScheduler {
             bits_per_offset,
             cached_state: None,
             enable_cache: false,
+            split_large_pages: false,
         })
     }
 
@@ -2348,6 +2383,95 @@ impl FullZipScheduler {
             .collect()
     }
 
+    fn chunk_simple_ranges(
+        ranges: &[Range<u64>],
+        rows_in_page: u64,
+        data_buf_position: u64,
+        total_bytes_per_value: u64,
+        target_rows: Option<u64>,
+    ) -> Vec<(Vec<Range<u64>>, u64, u64)> {
+        let mut chunks = Vec::new();
+        let mut current_ranges = Vec::new();
+        let mut current_rows = 0;
+        let mut current_priority_offset = 0;
+        let flush_current = |chunks: &mut Vec<(Vec<Range<u64>>, u64, u64)>,
+                             current_ranges: &mut Vec<Range<u64>>,
+                             current_rows: &mut u64,
+                             current_priority_offset: &mut u64| {
+            if *current_rows > 0 {
+                chunks.push((
+                    std::mem::take(current_ranges),
+                    *current_rows,
+                    *current_priority_offset,
+                ));
+                *current_rows = 0;
+                *current_priority_offset = 0;
+            }
+        };
+        for range in ranges {
+            debug_assert!(range.end <= rows_in_page);
+            let mut start_row = range.start;
+            while start_row < range.end {
+                if current_rows == 0 {
+                    current_priority_offset = start_row;
+                }
+                let available_rows = target_rows
+                    .map(|target_rows| target_rows.saturating_sub(current_rows).max(1))
+                    .unwrap_or(range.end - start_row);
+                let end_row = (start_row + available_rows).min(range.end);
+                let start = data_buf_position + start_row * total_bytes_per_value;
+                let end = data_buf_position + end_row * total_bytes_per_value;
+                current_ranges.push(start..end);
+                current_rows += end_row - start_row;
+                start_row = end_row;
+                if target_rows
+                    .map(|target_rows| current_rows >= target_rows)
+                    .unwrap_or(false)
+                {
+                    flush_current(
+                        &mut chunks,
+                        &mut current_ranges,
+                        &mut current_rows,
+                        &mut current_priority_offset,
+                    );
+                }
+            }
+        }
+        flush_current(
+            &mut chunks,
+            &mut current_ranges,
+            &mut current_rows,
+            &mut current_priority_offset,
+        );
+        chunks
+    }
+
+    fn schedule_simple_chunks(
+        chunks: Vec<(Vec<Range<u64>>, u64, u64)>,
+        io: &Arc<dyn EncodingsIo>,
+        priority: u64,
+        details: Arc<FullZipDecodeDetails>,
+        bits_per_offset: u8,
+        lazy_rows: Option<u64>,
+    ) -> Vec<PageLoadTask> {
+        chunks
+            .into_iter()
+            .map(|(byte_ranges, chunk_rows, priority_offset)| {
+                let io = io.clone();
+                let priority = priority + priority_offset;
+                let io_future = if lazy_rows
+                    .map(|lazy_rows| chunk_rows >= lazy_rows)
+                    .unwrap_or(false)
+                {
+                    async move { io.submit_request(byte_ranges, priority).await }.boxed()
+                } else {
+                    io.submit_request(byte_ranges, priority).boxed()
+                };
+                Self::create_page_load_task(io_future, chunk_rows, details.clone(), bits_per_offset)
+            })
+            .collect::<Vec<_>>()
+    }
+
     /// Computes the ranges in the repetition index that need to be loaded
     fn compute_rep_index_ranges(
         ranges: &[Range<u64>],
@@ -2450,7 +2574,7 @@ impl FullZipScheduler {
         io: &Arc<dyn EncodingsIo>,
     ) -> Result<Vec<PageLoadTask>> {
         // Convert row ranges to item ranges (i.e. multiply by items per row)
-        let num_rows = ranges.iter().map(|r| r.end - r.start).sum();
+        let num_rows: u64 = ranges.iter().map(|r| r.end - r.start).sum();
 
         let PerValueDecompressor::Fixed(decompressor) = &self.details.value_decompressor else {
             unreachable!()
@@ -2470,24 +2594,37 @@ impl FullZipScheduler {
         let bytes_per_value = bits_per_value / 8;
         let bytes_per_cw = self.details.ctrl_word_parser.bytes_per_word();
         let total_bytes_per_value = bytes_per_value + bytes_per_cw as u64;
-        let byte_ranges = ranges
-            .iter()
-            .map(|r| {
-                debug_assert!(r.end <= self.rows_in_page);
-                let start = self.data_buf_position + r.start * total_bytes_per_value;
-                let end = self.data_buf_position + r.end * total_bytes_per_value;
-                start..end
-            })
-            .collect::<Vec<_>>();
-
-        let io_future = io.submit_request(byte_ranges, self.priority);
-        let page_load_task = Self::create_page_load_task(
-            io_future,
-            num_rows,
+        let target_rows =
+            if self.split_large_pages && Self::covers_entire_page(ranges, self.rows_in_page) {
+                fullzip_page_load_target_bytes()
+                    .map(|target_bytes| (target_bytes / total_bytes_per_value).max(1))
+            } else {
+                None
+            };
+        let chunks = Self::chunk_simple_ranges(
+            ranges,
+            self.rows_in_page,
+            self.data_buf_position,
+            total_bytes_per_value,
+            target_rows,
+        );
+        let page_load_tasks = Self::schedule_simple_chunks(
+            chunks,
+            io,
+            self.priority,
             self.details.clone(),
             self.bits_per_offset,
+            target_rows,
         );
-        Ok(vec![page_load_task])
+
+        debug_assert_eq!(
+            page_load_tasks
+                .iter()
+                .map(|task| task.num_rows)
+                .sum::<u64>(),
+            num_rows
+        );
+        Ok(page_load_tasks)
     }
 }
 
@@ -3064,32 +3201,68 @@ struct FixedFullZipDecodeTask {
     bytes_per_value: usize,
 }
 
+fn align_fixed_width_data_if_needed(mut fixed_data: FixedWidthDataBlock) -> FixedWidthDataBlock {
+    if fixed_data.bits_per_value.is_multiple_of(8) {
+        let bytes_per_value = (fixed_data.bits_per_value / 8) as usize;
+        let alignment = bytes_per_value.next_power_of_two().min(8);
+        if alignment > 1 && fixed_data.data.as_ptr().align_offset(alignment) != 0 {
+            FULLZIP_ALIGNMENT_COPY_COUNT.fetch_add(1, Ordering::Relaxed);
+            FULLZIP_ALIGNMENT_COPY_BYTES.fetch_add(fixed_data.data.len() as u64, Ordering::Relaxed);
+            fixed_data.data = LanceBuffer::copy_slice(&fixed_data.data);
+        }
+    }
+    fixed_data
+}
+
 impl DecodePageTask for FixedFullZipDecodeTask {
     fn decode(self: Box<Self>) -> Result<DecodedPage> {
-        // Multiply by 2 to make a stab at the size of the output buffer (which will be decompressed and thus bigger)
-        let estimated_size_bytes = self
-            .data
-            .iter()
-            .map(|task_item| task_item.data.data_size() as usize)
-            .sum::<usize>()
-            * 2;
-        let mut data_builder =
-            DataBlockBuilder::with_capacity_estimate(estimated_size_bytes as u64);
-
         if self.details.ctrl_word_parser.bytes_per_word() == 0 {
             // Fast path, no need to unzip because there is no rep/def
-            //
-            // We decompress each buffer and add it to our output buffer
+            let PerValueDecompressor::Fixed(decompressor) = &self.details.value_decompressor else {
+                unreachable!()
+            };
+            if self.data.len() == 1 {
+                let task_item = self.data.into_iter().next().unwrap();
+                let PerValueDataBlock::Fixed(fixed_data) = task_item.data else {
+                    unreachable!()
+                };
+                debug_assert_eq!(fixed_data.num_values, task_item.rows_in_buf);
+                let decompressed = decompressor.decompress(
+                    align_fixed_width_data_if_needed(fixed_data),
+                    task_item.rows_in_buf,
+                )?;
+                let unraveler = RepDefUnraveler::new(
+                    None,
+                    None,
+                    self.details.def_meaning.clone(),
+                    self.num_rows as u64,
+                );
+
+                return Ok(DecodedPage {
+                    data: decompressed,
+                    repdef: unraveler,
+                });
+            }
+
+            // Multiply by 2 to make a stab at the size of the output buffer
+            // (which will be decompressed and thus bigger).
+            let estimated_size_bytes = self
+                .data
+                .iter()
+                .map(|task_item| task_item.data.data_size() as usize)
+                .sum::<usize>()
+                * 2;
+            let mut data_builder =
+                DataBlockBuilder::with_capacity_estimate(estimated_size_bytes as u64);
             for task_item in self.data.into_iter() {
                 let PerValueDataBlock::Fixed(fixed_data) = task_item.data else {
                     unreachable!()
                 };
-                let PerValueDecompressor::Fixed(decompressor) = &self.details.value_decompressor
-                else {
-                    unreachable!()
-                };
                 debug_assert_eq!(fixed_data.num_values, task_item.rows_in_buf);
-                let decompressed = decompressor.decompress(fixed_data, task_item.rows_in_buf)?;
+                let decompressed = decompressor.decompress(
+                    align_fixed_width_data_if_needed(fixed_data),
+                    task_item.rows_in_buf,
+                )?;
                 data_builder.append(&decompressed, 0..task_item.rows_in_buf);
             }
 
@@ -3106,6 +3279,16 @@ impl DecodePageTask for FixedFullZipDecodeTask {
             })
         } else {
             // Slow path, unzipping needed
+            // Multiply by 2 to make a stab at the size of the output buffer
+            // (which will be decompressed and thus bigger).
+            let estimated_size_bytes = self
+                .data
+                .iter()
+                .map(|task_item| task_item.data.data_size() as usize)
+                .sum::<usize>()
+                * 2;
+            let mut data_builder =
+                DataBlockBuilder::with_capacity_estimate(estimated_size_bytes as u64);
             let mut rep = Vec::with_capacity(self.num_rows);
             let mut def = Vec::with_capacity(self.num_rows);
 
@@ -3313,6 +3496,22 @@ impl StructuralPrimitiveFieldScheduler {
         cache_repetition_index: bool,
         target_field: &Field,
     ) -> Result<Self> {
+        Self::try_new_with_fullzip_page_splitting(
+            column_info,
+            decompressors,
+            cache_repetition_index,
+            target_field,
+            false,
+        )
+    }
+
+    pub(crate) fn try_new_with_fullzip_page_splitting(
+        column_info: &ColumnInfo,
+        decompressors: &dyn DecompressionStrategy,
+        cache_repetition_index: bool,
+        target_field: &Field,
+        split_fullzip_pages: bool,
+    ) -> Result<Self> {
         let page_schedulers = column_info
             .page_infos
             .iter()
@@ -3324,6 +3523,7 @@ impl StructuralPrimitiveFieldScheduler {
                     decompressors,
                     cache_repetition_index,
                     target_field,
+                    split_fullzip_pages,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -3340,6 +3540,7 @@ impl StructuralPrimitiveFieldScheduler {
         decompressors: &dyn DecompressionStrategy,
         cache_repetition_index: bool,
         target_field: &Field,
+        split_fullzip_pages: bool,
     ) -> Result<Box<dyn StructuralPageScheduler>> {
         use pb21::page_layout::Layout;
         Ok(match page_layout.layout.as_ref().expect_ok()? {
@@ -3359,6 +3560,7 @@ impl StructuralPrimitiveFieldScheduler {
                     decompressors,
                 )?;
                 scheduler.enable_cache = cache_repetition_index;
+                scheduler.split_large_pages = split_fullzip_pages;
                 Box::new(scheduler)
             }
             Layout::ConstantLayout(constant_layout) => {
@@ -3413,6 +3615,7 @@ impl StructuralPrimitiveFieldScheduler {
                     decompressors,
                     cache_repetition_index,
                     target_field,
+                    split_fullzip_pages,
                 )?;
                 let def_meaning = blob
                     .layers
@@ -3444,6 +3647,7 @@ impl StructuralPrimitiveFieldScheduler {
         decompressors: &dyn DecompressionStrategy,
         cache_repetition_index: bool,
         target_field: &Field,
+        split_fullzip_pages: bool,
     ) -> Result<PageInfoAndScheduler> {
         let page_layout = page_info.encoding.as_structural();
         let scheduler = Self::page_layout_to_scheduler(
@@ -3452,6 +3656,7 @@ impl StructuralPrimitiveFieldScheduler {
             decompressors,
             cache_repetition_index,
             target_field,
+            split_fullzip_pages,
         )?;
         Ok(PageInfoAndScheduler {
             page_index,
@@ -5781,10 +5986,11 @@ impl FieldEncoder for PrimitiveStructuralEncoder {
 #[allow(clippy::single_range_in_vec_init)]
 mod tests {
     use super::{
-        ChunkInstructions, DataBlock, DecodeMiniBlockTask, FixedPerValueDecompressor,
-        FixedWidthDataBlock, FullZipCacheableState, FullZipDecodeDetails, FullZipReadSource,
-        FullZipRepIndexDetails, FullZipScheduler, MiniBlockChunk, MiniBlockCompressed,
-        MiniBlockRepIndex, PerValueDecompressor, PreambleAction, StructuralPageScheduler,
+        ChunkInstructions, DataBlock, DecodeMiniBlockTask, FixedFullZipDecodeTask,
+        FixedPerValueDecompressor, FixedWidthDataBlock, FullZipCacheableState,
+        FullZipDecodeDetails, FullZipDecodeTaskItem, FullZipReadSource, FullZipRepIndexDetails,
+        FullZipScheduler, MiniBlockChunk, MiniBlockCompressed, MiniBlockRepIndex,
+        PerValueDataBlock, PerValueDecompressor, PreambleAction, StructuralPageScheduler,
         VariableFullZipDecoder,
     };
     use crate::buffer::LanceBuffer;
@@ -5795,10 +6001,11 @@ mod tests {
         STRUCTURAL_ENCODING_MINIBLOCK,
     };
     use crate::data::BlockInfo;
-    use crate::decoder::PageEncoding;
+    use crate::decoder::{DecodePageTask, PageEncoding};
     use crate::encodings::logical::primitive::{
         ChunkDrainInstructions, PrimitiveStructuralEncoder,
     };
+    use crate::encodings::physical::value::ValueDecompressor;
     use crate::format::ProtobufUtils21;
     use crate::format::pb21;
     use crate::format::pb21::compressive_encoding::Compression;
@@ -6637,6 +6844,7 @@ mod tests {
             }),
             cached_state: None,
             enable_cache: false,
+            split_large_pages: false,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();
@@ -6671,6 +6879,200 @@ mod tests {
         let mut data = source.fetch(&ranges, 0).await.unwrap();
         assert_eq!(data.pop_front().unwrap().as_ref(), &[0, 1, 2]);
         assert_eq!(data.pop_front().unwrap().as_ref(), &[4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_fixed_fullzip_single_task_decode_is_zero_copy() {
+        let data = LanceBuffer::copy_slice(&[0_u8, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
+        let data_ptr = data.as_ptr();
+        let task = FixedFullZipDecodeTask {
+            details: Arc::new(FullZipDecodeDetails {
+                value_decompressor: PerValueDecompressor::Fixed(Arc::new(
+                    ValueDecompressor::from_flat(&pb21::Flat {
+                        bits_per_value: 32,
+                        data: None,
+                    }),
+                )),
+                def_meaning: Arc::new([crate::repdef::DefinitionInterpretation::AllValidItem]),
+                ctrl_word_parser: crate::repdef::ControlWordParser::new(0, 0),
+                max_rep: 0,
+                max_visible_def: 0,
+            }),
+            data: vec![FullZipDecodeTaskItem {
+                data: PerValueDataBlock::Fixed(FixedWidthDataBlock {
+                    data,
+                    bits_per_value: 32,
+                    num_values: 4,
+                    block_info: BlockInfo::new(),
+                }),
+                rows_in_buf: 4,
+            }],
+            num_rows: 4,
+            bytes_per_value: 4,
+        };
+
+        let decoded = Box::new(task).decode().unwrap();
+        let DataBlock::FixedWidth(block) = decoded.data else {
+            panic!("expected fixed-width block");
+        };
+        assert_eq!(block.data.as_ptr(), data_ptr);
+        assert_eq!(
+            block.data.as_ref(),
+            &[0_u8, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn test_fixed_fullzip_single_task_decode_copies_unaligned_data() {
+        super::reset_fullzip_alignment_copy_stats();
+        let source =
+            LanceBuffer::copy_slice(&[255_u8, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
+        let data = source.slice_with_length(1, 16);
+        let data_ptr = data.as_ptr();
+        let task = FixedFullZipDecodeTask {
+            details: Arc::new(FullZipDecodeDetails {
+                value_decompressor: PerValueDecompressor::Fixed(Arc::new(
+                    ValueDecompressor::from_flat(&pb21::Flat {
+                        bits_per_value: 32,
+                        data: None,
+                    }),
+                )),
+                def_meaning: Arc::new([crate::repdef::DefinitionInterpretation::AllValidItem]),
+                ctrl_word_parser: crate::repdef::ControlWordParser::new(0, 0),
+                max_rep: 0,
+                max_visible_def: 0,
+            }),
+            data: vec![FullZipDecodeTaskItem {
+                data: PerValueDataBlock::Fixed(FixedWidthDataBlock {
+                    data,
+                    bits_per_value: 32,
+                    num_values: 4,
+                    block_info: BlockInfo::new(),
+                }),
+                rows_in_buf: 4,
+            }],
+            num_rows: 4,
+            bytes_per_value: 4,
+        };
+
+        let decoded = Box::new(task).decode().unwrap();
+        let DataBlock::FixedWidth(block) = decoded.data else {
+            panic!("expected fixed-width block");
+        };
+        assert_ne!(block.data.as_ptr(), data_ptr);
+        assert_eq!(super::fullzip_alignment_copy_stats(), (1, 16));
+        assert_eq!(
+            block.data.as_ref(),
+            &[0_u8, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn test_fullzip_simple_ranges_chunk_by_target_rows() {
+        let chunks = FullZipScheduler::chunk_simple_ranges(&[0..10], 100, 1024, 4, Some(3));
+        assert_eq!(
+            chunks,
+            vec![
+                (vec![1024..1036], 3, 0),
+                (vec![1036..1048], 3, 3),
+                (vec![1048..1060], 3, 6),
+                (vec![1060..1064], 1, 9),
+            ]
+        );
+
+        let unsplit = FullZipScheduler::chunk_simple_ranges(&[2..5], 100, 1024, 4, None);
+        assert_eq!(unsplit, vec![(vec![1032..1044], 3, 2)]);
+
+        let sparse =
+            FullZipScheduler::chunk_simple_ranges(&[0..1, 10..11, 20..21], 100, 1024, 4, Some(4));
+        assert_eq!(
+            sparse,
+            vec![(vec![1024..1028, 1064..1068, 1104..1108], 3, 0)]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fullzip_simple_chunk_schedule_is_lazy() {
+        use futures::{FutureExt, future::BoxFuture};
+        use std::ops::Range;
+        use std::sync::Mutex;
+
+        #[derive(Debug, Clone)]
+        struct RecordingScheduler {
+            data: bytes::Bytes,
+            requests: Arc<Mutex<Vec<Vec<Range<u64>>>>>,
+        }
+
+        impl RecordingScheduler {
+            fn new(data: bytes::Bytes) -> Self {
+                Self {
+                    data,
+                    requests: Arc::new(Mutex::new(Vec::new())),
+                }
+            }
+
+            fn requests(&self) -> Vec<Vec<Range<u64>>> {
+                self.requests.lock().unwrap().clone()
+            }
+        }
+
+        impl crate::EncodingsIo for RecordingScheduler {
+            fn submit_request(
+                &self,
+                ranges: Vec<Range<u64>>,
+                _priority: u64,
+            ) -> BoxFuture<'static, crate::Result<Vec<bytes::Bytes>>> {
+                self.requests.lock().unwrap().push(ranges.clone());
+                let data = ranges
+                    .into_iter()
+                    .map(|range| self.data.slice(range.start as usize..range.end as usize))
+                    .collect::<Vec<_>>();
+                std::future::ready(Ok(data)).boxed()
+            }
+        }
+
+        #[derive(Debug)]
+        struct TestFixedDecompressor;
+
+        impl FixedPerValueDecompressor for TestFixedDecompressor {
+            fn decompress(
+                &self,
+                _data: FixedWidthDataBlock,
+                _num_rows: u64,
+            ) -> crate::Result<DataBlock> {
+                unimplemented!("Test decompressor")
+            }
+
+            fn bits_per_value(&self) -> u64 {
+                32
+            }
+        }
+
+        let data_start = 128_u64;
+        let io = Arc::new(RecordingScheduler::new(bytes::Bytes::from(vec![0; 1024])));
+        let details = Arc::new(FullZipDecodeDetails {
+            value_decompressor: PerValueDecompressor::Fixed(Arc::new(TestFixedDecompressor)),
+            def_meaning: Arc::new([crate::repdef::DefinitionInterpretation::AllValidItem]),
+            ctrl_word_parser: crate::repdef::ControlWordParser::new(0, 0),
+            max_rep: 0,
+            max_visible_def: 0,
+        });
+        let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();
+        let tasks = FullZipScheduler::schedule_simple_chunks(
+            vec![(vec![data_start..(data_start + 16)], 4, 0)],
+            &io_dyn,
+            7,
+            details,
+            32,
+            Some(4),
+        );
+        assert!(
+            io.requests().is_empty(),
+            "full simple chunks should defer data I/O until the page future is polled"
+        );
+
+        let _ = tasks.into_iter().next().unwrap().decoder_fut.await.unwrap();
+        assert_eq!(io.requests(), vec![vec![data_start..(data_start + 16)]]);
     }
 
     #[tokio::test]
@@ -6757,6 +7159,7 @@ mod tests {
             }),
             cached_state: None,
             enable_cache: true,
+            split_large_pages: false,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();
@@ -6866,6 +7269,7 @@ mod tests {
             }),
             cached_state: None,
             enable_cache: false,
+            split_large_pages: false,
         };
 
         let io_dyn: Arc<dyn crate::EncodingsIo> = io.clone();


### PR DESCRIPTION
## Why

This is one step toward making large S3/cloud scans approach physical bandwidth limits without noticeably regressing point lookups.

After structural page loading is pipelined, large fixed-width `fullzip` pages can still become a bottleneck because a full-page scan is loaded and decoded as one large task. This PR splits those scan-time fullzip page loads into smaller tasks so I/O and decode can overlap more effectively.

## What

- Split full-page fixed-width `fullzip` range scans into smaller page-load tasks.
- Keep the split limited to scan-style range reads; point lookup / take paths keep the existing behavior.
- Add a zero-copy single-task fast path for fixed-width fullzip decode when alignment allows it.
- Keep split rows aligned with `FixedSizeList<Struct<...>>` child/parent row contracts.
- Return an error for malformed zero-width fullzip metadata instead of panicking.
- Keep new fullzip copy counters private to tests, avoiding new public API surface.

## Validation

Performance validation from the S3 scan stack showed:

- Vector scan throughput improved from `19.29Gbps` to `58.68Gbps`.
- Mixed scan throughput improved from `25.15Gbps` to `32.92Gbps`.
- Take smoke validation did not show a regression (`1.283s` to `0.806s`).

Local validation:

- `cargo test -p lance-encoding fullzip -- --nocapture`
- `cargo test -p lance-encoding fixed_size_list -- --nocapture`
- `cargo test -p lance-encoding decoder -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p lance --bench s3_file_reader_diagnostics`

## Boundaries

This PR does not change the Lance file format, protobuf layout, writer behavior, or public API. It does not change #7557 behavior. It also does not attempt to tune the final split size globally; the current goal is to unblock overlap for large scan-time fullzip pages while preserving decoder contracts and point-lookup behavior.
