### PR TITLE
perf(lance): enable high bandwidth cloud scans

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2893,7 +2893,10 @@ impl Scanner {
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
             .with_projection(projection)
-            .with_ordered_output(ordered_output);
+            .with_ordered_output(ordered_output)
+            .with_high_bandwidth_scan(
+                !ordered_output && self.ordering.is_none() && self.nearest.is_none(),
+            );
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -12287,6 +12290,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert!(filtered.options().ordered_output);
+        assert!(!filtered.options().high_bandwidth_scan_enabled());
 
         // Actually read the data to ensure version columns are materialized
         let batches = scanner
@@ -12432,6 +12436,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert!(filtered.options().ordered_output);
+        assert!(!filtered.options().high_bandwidth_scan_enabled());
 
         let mut scanner = dataset.scan();
         scanner.scan_in_order(false);
@@ -12439,6 +12444,48 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert!(!filtered.options().ordered_output);
+        assert!(filtered.options().high_bandwidth_scan_enabled());
+    }
+
+    #[tokio::test]
+    async fn test_high_bandwidth_scan_not_enabled_for_order_by_or_nearest() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .col(
+                "vec",
+                lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(4)),
+            )
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(
+            data,
+            "memory://test_high_bandwidth_scan_not_enabled_for_order_by_or_nearest",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut ordered_scan = dataset.scan();
+        ordered_scan
+            .order_by(Some(vec![ColumnOrdering {
+                column_name: "x".to_string(),
+                ascending: true,
+                nulls_first: true,
+            }]))
+            .unwrap();
+        let plan = ordered_scan.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the order_by scan plan");
+        assert!(!filtered.options().ordered_output);
+        assert!(!filtered.options().high_bandwidth_scan_enabled());
+
+        let query = Float32Array::from(vec![0.0, 0.0, 0.0, 0.0]);
+        let mut nearest_scan = dataset.scan();
+        nearest_scan.nearest("vec", &query, 1).unwrap();
+        let plan = nearest_scan.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the nearest scan plan");
+        assert!(!filtered.options().ordered_output);
+        assert!(!filtered.options().high_bandwidth_scan_enabled());
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -92,8 +92,7 @@ use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
 use crate::io::exec::filtered_read::{
-    FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
-    ScanSchedulerDiagnosticsCallback,
+    FilteredReadExec, FilteredReadOptions, ScanSchedulerDiagnosticsCallback,
 };
 use crate::io::exec::fts::{
     BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
@@ -2894,10 +2893,7 @@ impl Scanner {
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
             .with_projection(projection)
-            .with_ordered_output(ordered_output)
-            .with_threading_mode(FilteredReadThreadingMode::OnePartitionMultipleThreads(
-                self.batch_readahead.max(1),
-            ));
+            .with_ordered_output(ordered_output);
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -12446,23 +12442,16 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     }
 
     #[tokio::test]
-    async fn test_batch_readahead_propagated_to_filtered_read_threading() {
+    async fn test_batch_readahead_does_not_set_execution_target_partition() {
         let data = lance_datagen::gen_batch()
             .col("x", lance_datagen::array::step::<Int32Type>())
             .into_reader_rows(RowCount::from(8), BatchCount::from(1));
-        let dataset = Dataset::write(data, "memory://test_batch_readahead_threading", None)
+        let dataset = Dataset::write(data, "memory://test_batch_readahead_target_partition", None)
             .await
             .unwrap();
 
         let mut scanner = dataset.scan();
         scanner.batch_readahead(17);
-        let plan = scanner.create_plan().await.unwrap();
-        let filtered = find_filtered_read(plan.as_ref())
-            .expect("expected a FilteredReadExec in the scan plan");
-        assert_eq!(
-            filtered.options().threading_mode,
-            FilteredReadThreadingMode::OnePartitionMultipleThreads(17)
-        );
         assert_eq!(scanner.execution_options().target_partition, None);
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2897,7 +2897,7 @@ impl Scanner {
             .with_projection(projection)
             .with_ordered_output(ordered_output)
             .with_threading_mode(FilteredReadThreadingMode::OnePartitionMultipleThreads(
-                self.batch_readahead.max(1),
+                self.filtered_read_threading_parallelism(),
             ));
 
         if let Some(fragments) = fragments {
@@ -4270,6 +4270,18 @@ impl Scanner {
             return target_parallelism.max(1);
         }
 
+        self.default_scan_parallelism()
+    }
+
+    fn filtered_read_threading_parallelism(&self) -> usize {
+        if self.target_parallelism.is_some() {
+            self.batch_readahead.max(1)
+        } else {
+            self.default_scan_parallelism()
+        }
+    }
+
+    fn default_scan_parallelism(&self) -> usize {
         let base_parallelism = self.batch_readahead.max(1);
         if self.dataset.object_store.is_cloud()
             && !self.ordered

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2079,7 +2079,6 @@ impl Scanner {
                 plan,
                 LanceExecutionOptions {
                     batch_size: self.batch_size,
-                    target_partition: Some(self.execution_target_parallelism()),
                     execution_stats_callback: self.scan_stats_callback.clone(),
                     ..Default::default()
                 },
@@ -2098,9 +2097,6 @@ impl Scanner {
         if options.execution_stats_callback.is_none() {
             options.execution_stats_callback = self.scan_stats_callback.clone();
         }
-        if options.target_partition.is_none() {
-            options.target_partition = Some(self.execution_target_parallelism());
-        }
 
         execute_plan(plan, options)
     }
@@ -2108,7 +2104,6 @@ impl Scanner {
     pub(crate) fn execution_options(&self) -> LanceExecutionOptions {
         LanceExecutionOptions {
             batch_size: self.batch_size,
-            target_partition: Some(self.execution_target_parallelism()),
             execution_stats_callback: self.scan_stats_callback.clone(),
             ..Default::default()
         }
@@ -2674,7 +2669,9 @@ impl Scanner {
 
             let optimizer = get_physical_optimizer();
             let mut options = ConfigOptions::default();
-            options.execution.target_partitions = self.execution_target_parallelism();
+            options.execution.target_partitions = self
+                .target_parallelism
+                .unwrap_or_else(get_num_compute_intensive_cpus);
             for rule in optimizer.rules {
                 plan = rule.optimize(plan, &options)?;
             }
@@ -2739,7 +2736,9 @@ impl Scanner {
 
         let optimizer = get_physical_optimizer();
         let mut options = ConfigOptions::default();
-        options.execution.target_partitions = self.execution_target_parallelism();
+        options.execution.target_partitions = self
+            .target_parallelism
+            .unwrap_or_else(get_num_compute_intensive_cpus);
         for rule in optimizer.rules {
             plan = rule.optimize(plan, &options)?;
         }
@@ -4263,14 +4262,6 @@ impl Scanner {
 
     fn get_io_buffer_size(&self) -> u64 {
         self.io_buffer_size.unwrap_or(*DEFAULT_IO_BUFFER_SIZE)
-    }
-
-    fn execution_target_parallelism(&self) -> usize {
-        if let Some(target_parallelism) = self.target_parallelism {
-            return target_parallelism.max(1);
-        }
-
-        self.batch_readahead.max(1)
     }
 
     /// Create an Execution plan with a scan node
@@ -12472,7 +12463,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             filtered.options().threading_mode,
             FilteredReadThreadingMode::OnePartitionMultipleThreads(17)
         );
-        assert_eq!(scanner.execution_options().target_partition, Some(17));
+        assert_eq!(scanner.execution_options().target_partition, None);
     }
 
     // The env var key scopes serial_test's lock so this test only blocks others

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -92,7 +92,8 @@ use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
 use crate::io::exec::filtered_read::{
-    FilteredReadExec, FilteredReadOptions, ScanSchedulerDiagnosticsCallback,
+    FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
+    ScanSchedulerDiagnosticsCallback, high_bandwidth_scan_parallelism_target,
 };
 use crate::io::exec::fts::{
     BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
@@ -2078,6 +2079,7 @@ impl Scanner {
                 plan,
                 LanceExecutionOptions {
                     batch_size: self.batch_size,
+                    target_partition: Some(self.execution_target_parallelism()),
                     execution_stats_callback: self.scan_stats_callback.clone(),
                     ..Default::default()
                 },
@@ -2096,6 +2098,9 @@ impl Scanner {
         if options.execution_stats_callback.is_none() {
             options.execution_stats_callback = self.scan_stats_callback.clone();
         }
+        if options.target_partition.is_none() {
+            options.target_partition = Some(self.execution_target_parallelism());
+        }
 
         execute_plan(plan, options)
     }
@@ -2103,6 +2108,7 @@ impl Scanner {
     pub(crate) fn execution_options(&self) -> LanceExecutionOptions {
         LanceExecutionOptions {
             batch_size: self.batch_size,
+            target_partition: Some(self.execution_target_parallelism()),
             execution_stats_callback: self.scan_stats_callback.clone(),
             ..Default::default()
         }
@@ -2668,9 +2674,7 @@ impl Scanner {
 
             let optimizer = get_physical_optimizer();
             let mut options = ConfigOptions::default();
-            options.execution.target_partitions = self
-                .target_parallelism
-                .unwrap_or_else(get_num_compute_intensive_cpus);
+            options.execution.target_partitions = self.execution_target_parallelism();
             for rule in optimizer.rules {
                 plan = rule.optimize(plan, &options)?;
             }
@@ -2735,9 +2739,7 @@ impl Scanner {
 
         let optimizer = get_physical_optimizer();
         let mut options = ConfigOptions::default();
-        options.execution.target_partitions = self
-            .target_parallelism
-            .unwrap_or_else(get_num_compute_intensive_cpus);
+        options.execution.target_partitions = self.execution_target_parallelism();
         for rule in optimizer.rules {
             plan = rule.optimize(plan, &options)?;
         }
@@ -2893,7 +2895,10 @@ impl Scanner {
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
             .with_projection(projection)
-            .with_ordered_output(ordered_output);
+            .with_ordered_output(ordered_output)
+            .with_threading_mode(FilteredReadThreadingMode::OnePartitionMultipleThreads(
+                self.batch_readahead.max(1),
+            ));
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -4258,6 +4263,23 @@ impl Scanner {
 
     fn get_io_buffer_size(&self) -> u64 {
         self.io_buffer_size.unwrap_or(*DEFAULT_IO_BUFFER_SIZE)
+    }
+
+    fn execution_target_parallelism(&self) -> usize {
+        if let Some(target_parallelism) = self.target_parallelism {
+            return target_parallelism.max(1);
+        }
+
+        let base_parallelism = self.batch_readahead.max(1);
+        if self.dataset.object_store.is_cloud()
+            && !self.ordered
+            && self.ordering.is_none()
+            && self.nearest.is_none()
+        {
+            high_bandwidth_scan_parallelism_target(base_parallelism)
+        } else {
+            base_parallelism
+        }
     }
 
     /// Create an Execution plan with a scan node
@@ -12439,6 +12461,27 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert!(!filtered.options().ordered_output);
+    }
+
+    #[tokio::test]
+    async fn test_batch_readahead_propagated_to_filtered_read_threading() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_batch_readahead_threading", None)
+            .await
+            .unwrap();
+
+        let mut scanner = dataset.scan();
+        scanner.batch_readahead(17);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert_eq!(
+            filtered.options().threading_mode,
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(17)
+        );
+        assert_eq!(scanner.execution_options().target_partition, Some(17));
     }
 
     // The env var key scopes serial_test's lock so this test only blocks others

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -93,7 +93,7 @@ use crate::index::vector::utils::{
 };
 use crate::io::exec::filtered_read::{
     FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
-    ScanSchedulerDiagnosticsCallback, high_bandwidth_scan_parallelism_target,
+    ScanSchedulerDiagnosticsCallback,
 };
 use crate::io::exec::fts::{
     BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
@@ -2897,7 +2897,7 @@ impl Scanner {
             .with_projection(projection)
             .with_ordered_output(ordered_output)
             .with_threading_mode(FilteredReadThreadingMode::OnePartitionMultipleThreads(
-                self.filtered_read_threading_parallelism(),
+                self.batch_readahead.max(1),
             ));
 
         if let Some(fragments) = fragments {
@@ -4270,28 +4270,7 @@ impl Scanner {
             return target_parallelism.max(1);
         }
 
-        self.default_scan_parallelism()
-    }
-
-    fn filtered_read_threading_parallelism(&self) -> usize {
-        if self.target_parallelism.is_some() {
-            self.batch_readahead.max(1)
-        } else {
-            self.default_scan_parallelism()
-        }
-    }
-
-    fn default_scan_parallelism(&self) -> usize {
-        let base_parallelism = self.batch_readahead.max(1);
-        if self.dataset.object_store.is_cloud()
-            && !self.ordered
-            && self.ordering.is_none()
-            && self.nearest.is_none()
-        {
-            high_bandwidth_scan_parallelism_target(base_parallelism)
-        } else {
-            base_parallelism
-        }
+        self.batch_readahead.max(1)
     }
 
     /// Create an Execution plan with a scan node

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -79,6 +79,15 @@ fn is_high_bandwidth_scan_candidate(
         && planned_row_count >= HIGH_BANDWIDTH_SCAN_MIN_ROWS
 }
 
+fn effective_high_bandwidth_scan_row_count(
+    planned_row_count: u64,
+    scan_range_after_filter: Option<&Range<u64>>,
+) -> u64 {
+    scan_range_after_filter
+        .map(|range| range.end.saturating_sub(range.start).min(planned_row_count))
+        .unwrap_or(planned_row_count)
+}
+
 pub(crate) fn high_bandwidth_scan_parallelism_target(base_parallelism: usize) -> usize {
     let base_parallelism = base_parallelism.max(1);
     let total_runtime_threads =
@@ -499,7 +508,10 @@ impl FilteredReadStream {
 
         let io_parallelism = dataset.object_store.io_parallelism();
         let planned_fragment_count = plan.planned_fragment_count();
-        let planned_row_count = plan.planned_row_count();
+        let planned_row_count = effective_high_bandwidth_scan_row_count(
+            plan.planned_row_count(),
+            plan.scan_range_after_filter.as_ref(),
+        );
         let is_high_bandwidth_candidate = is_high_bandwidth_scan_candidate(
             dataset.object_store.is_cloud(),
             options.ordered_output,
@@ -2453,6 +2465,19 @@ mod tests {
                 base
             ),
             base
+        );
+    }
+
+    #[test]
+    fn test_high_bandwidth_scan_row_count_uses_post_filter_range() {
+        assert_eq!(effective_high_bandwidth_scan_row_count(100, None), 100);
+        assert_eq!(
+            effective_high_bandwidth_scan_row_count(100, Some(&(10..30))),
+            20
+        );
+        assert_eq!(
+            effective_high_bandwidth_scan_row_count(100, Some(&(10..1_000))),
+            100
         );
     }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -62,7 +62,7 @@ use super::utils::IoMetrics;
 
 const ENV_LANCE_DEFAULT_FRAGMENT_READAHEAD: &str = "LANCE_DEFAULT_FRAGMENT_READAHEAD";
 const HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS: usize = 16;
-const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 1_048_576;
+const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 16_777_216;
 const HIGH_BANDWIDTH_SCAN_IO_PER_CPU: usize = 4;
 const HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM: usize = 512;
 const HIGH_BANDWIDTH_SCAN_TARGET_BATCH_BYTES: u64 = 16 * 1024 * 1024;
@@ -2377,22 +2377,52 @@ mod tests {
     #[test]
     fn test_high_bandwidth_scan_io_parallelism_requires_cloud_unordered_large_scan() {
         let base = 8;
-        let boosted = high_bandwidth_scan_io_parallelism(true, false, 16, 1_048_576, base);
+        let boosted = high_bandwidth_scan_io_parallelism(
+            true,
+            false,
+            HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+            HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+            base,
+        );
         assert!(boosted >= base);
         assert_eq!(
-            high_bandwidth_scan_io_parallelism(false, false, 16, 1_048_576, base),
+            high_bandwidth_scan_io_parallelism(
+                false,
+                false,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+                base
+            ),
             base
         );
         assert_eq!(
-            high_bandwidth_scan_io_parallelism(true, true, 16, 1_048_576, base),
+            high_bandwidth_scan_io_parallelism(
+                true,
+                true,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+                base
+            ),
             base
         );
         assert_eq!(
-            high_bandwidth_scan_io_parallelism(true, false, 15, 1_048_576, base),
+            high_bandwidth_scan_io_parallelism(
+                true,
+                false,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS - 1,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+                base
+            ),
             base
         );
         assert_eq!(
-            high_bandwidth_scan_io_parallelism(true, false, 16, 1_048_575, base),
+            high_bandwidth_scan_io_parallelism(
+                true,
+                false,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS - 1,
+                base
+            ),
             base
         );
     }

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -54,8 +54,7 @@ use crate::Dataset;
 use crate::dataset::fragment::{FileFragment, FragReadConfig};
 use crate::dataset::rowids::load_row_id_sequence;
 use crate::dataset::scanner::{
-    BATCH_SIZE_FALLBACK, LEGACY_DEFAULT_FRAGMENT_READAHEAD, get_default_batch_size,
-    get_default_io_buffer_size_override,
+    BATCH_SIZE_FALLBACK, get_default_batch_size, get_default_io_buffer_size_override,
 };
 
 use super::utils::IoMetrics;
@@ -124,7 +123,7 @@ fn default_fragment_readahead_for_scan(
     if is_high_bandwidth_candidate {
         scan_io_parallelism.max(1)
     } else {
-        LEGACY_DEFAULT_FRAGMENT_READAHEAD
+        scan_io_parallelism.saturating_mul(2).max(1)
     }
 }
 
@@ -2479,6 +2478,12 @@ mod tests {
             effective_high_bandwidth_scan_row_count(100, Some(&(10..1_000))),
             100
         );
+    }
+
+    #[test]
+    fn test_default_fragment_readahead_preserves_non_high_bandwidth_fallback() {
+        assert_eq!(default_fragment_readahead_for_scan(false, 128), 256);
+        assert_eq!(default_fragment_readahead_for_scan(true, 128), 128);
     }
 
     #[test]

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -30,7 +30,7 @@ use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::OnMissing;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::futures::FinallyStreamExt;
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::tokio::{IO_CORE_RESERVATION, get_num_compute_intensive_cpus};
 use lance_core::{Error, Result, datatypes::Projection};
 use lance_datafusion::planner::Planner;
 use lance_datafusion::utils::{
@@ -54,11 +54,91 @@ use crate::Dataset;
 use crate::dataset::fragment::{FileFragment, FragReadConfig};
 use crate::dataset::rowids::load_row_id_sequence;
 use crate::dataset::scanner::{
-    BATCH_SIZE_FALLBACK, DEFAULT_FRAGMENT_READAHEAD, get_default_batch_size,
+    BATCH_SIZE_FALLBACK, LEGACY_DEFAULT_FRAGMENT_READAHEAD, get_default_batch_size,
     get_default_io_buffer_size_override,
 };
 
 use super::utils::IoMetrics;
+
+const ENV_LANCE_DEFAULT_FRAGMENT_READAHEAD: &str = "LANCE_DEFAULT_FRAGMENT_READAHEAD";
+const HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS: usize = 16;
+const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 1_048_576;
+const HIGH_BANDWIDTH_SCAN_IO_PER_CPU: usize = 4;
+const HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM: usize = 512;
+const HIGH_BANDWIDTH_SCAN_TARGET_BATCH_BYTES: u64 = 16 * 1024 * 1024;
+
+fn is_high_bandwidth_scan_candidate(
+    is_cloud_store: bool,
+    ordered_output: bool,
+    planned_fragment_count: usize,
+    planned_row_count: u64,
+) -> bool {
+    is_cloud_store
+        && !ordered_output
+        && planned_fragment_count >= HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS
+        && planned_row_count >= HIGH_BANDWIDTH_SCAN_MIN_ROWS
+}
+
+pub(crate) fn high_bandwidth_scan_parallelism_target(base_parallelism: usize) -> usize {
+    let base_parallelism = base_parallelism.max(1);
+    let total_runtime_threads =
+        get_num_compute_intensive_cpus().saturating_add(*IO_CORE_RESERVATION);
+    let cpu_scaled_target = total_runtime_threads
+        .saturating_mul(HIGH_BANDWIDTH_SCAN_IO_PER_CPU)
+        .min(HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM);
+    base_parallelism.max(cpu_scaled_target)
+}
+
+fn high_bandwidth_scan_io_parallelism(
+    is_cloud_store: bool,
+    ordered_output: bool,
+    planned_fragment_count: usize,
+    planned_row_count: u64,
+    base_io_parallelism: usize,
+) -> usize {
+    let base_io_parallelism = base_io_parallelism.max(1);
+    if !is_high_bandwidth_scan_candidate(
+        is_cloud_store,
+        ordered_output,
+        planned_fragment_count,
+        planned_row_count,
+    ) {
+        return base_io_parallelism;
+    }
+    high_bandwidth_scan_parallelism_target(base_io_parallelism)
+}
+
+fn default_fragment_readahead_for_scan(
+    is_high_bandwidth_candidate: bool,
+    scan_io_parallelism: usize,
+) -> usize {
+    if is_high_bandwidth_candidate {
+        scan_io_parallelism.max(1)
+    } else {
+        LEGACY_DEFAULT_FRAGMENT_READAHEAD
+    }
+}
+
+fn default_fragment_readahead_override() -> Option<usize> {
+    std::env::var(ENV_LANCE_DEFAULT_FRAGMENT_READAHEAD)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
+fn apply_high_bandwidth_batch_size_bytes(
+    file_reader_options: &mut Option<FileReaderOptions>,
+    is_high_bandwidth_candidate: bool,
+) {
+    if !is_high_bandwidth_candidate {
+        return;
+    }
+
+    let options = file_reader_options.get_or_insert_with(Default::default);
+    if options.batch_size_bytes.is_none() {
+        options.batch_size_bytes = Some(HIGH_BANDWIDTH_SCAN_TARGET_BATCH_BYTES);
+    }
+}
 
 #[derive(Debug)]
 pub struct EvaluatedIndex {
@@ -394,23 +474,45 @@ impl FilteredReadStream {
         let global_metrics = Arc::new(FilteredReadGlobalMetrics::new(metrics));
 
         let threading_mode = options.threading_mode;
-
-        let io_parallelism = dataset.object_store.io_parallelism();
-        let fragment_readahead = options
-            .fragment_readahead
-            .unwrap_or_else(|| (*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
-            .max(1);
-
         let fragments = options
             .fragments
             .clone()
             .unwrap_or_else(|| dataset.fragments().clone());
 
+        let io_parallelism = dataset.object_store.io_parallelism();
+        let planned_fragment_count = plan.planned_fragment_count();
+        let planned_row_count = plan.planned_row_count();
+        let is_high_bandwidth_candidate = is_high_bandwidth_scan_candidate(
+            dataset.object_store.is_cloud(),
+            options.ordered_output,
+            planned_fragment_count,
+            planned_row_count,
+        );
+        let scan_io_parallelism = high_bandwidth_scan_io_parallelism(
+            dataset.object_store.is_cloud(),
+            options.ordered_output,
+            planned_fragment_count,
+            planned_row_count,
+            io_parallelism,
+        );
+        let fragment_readahead = options
+            .fragment_readahead
+            .unwrap_or_else(|| {
+                default_fragment_readahead_override().unwrap_or_else(|| {
+                    default_fragment_readahead_for_scan(
+                        is_high_bandwidth_candidate,
+                        scan_io_parallelism,
+                    )
+                })
+            })
+            .max(1);
+
         log::debug!(
-            "Filtered read on {} fragments with frag_readahead={} and io_parallelism={}",
+            "Filtered read on {} fragments with frag_readahead={}, io_parallelism={}, scan_io_parallelism={}",
             fragments.len(),
             fragment_readahead,
-            io_parallelism
+            io_parallelism,
+            scan_io_parallelism
         );
 
         // Ideally we don't need to collect here but if we don't we get "implementation of FnOnce is
@@ -427,7 +529,7 @@ impl FilteredReadStream {
             .collect::<Vec<_>>();
         let loaded_fragments = futures::stream::iter(frag_futs)
             // Cannot use unordered because we need to populate logical_offset based on user-provided order
-            .try_buffered(io_parallelism)
+            .try_buffered(scan_io_parallelism)
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -442,9 +544,13 @@ impl FilteredReadStream {
         {
             SchedulerConfig::new(io_buffer_size_bytes)
         } else {
-            SchedulerConfig::max_bandwidth(obj_store.as_ref())
+            SchedulerConfig::max_bandwidth_for_io_parallelism(scan_io_parallelism)
         };
-        let scan_scheduler = ScanScheduler::new(obj_store, scheduler_config);
+        let scan_scheduler = ScanScheduler::new_with_io_capacity(
+            obj_store,
+            scheduler_config,
+            Some(scan_io_parallelism),
+        );
         if let Some(callback) = options.scan_scheduler_diagnostics_callback.as_ref() {
             callback.notify(ScanSchedulerDiagnosticsHandle::new(scan_scheduler.clone()));
         }
@@ -453,6 +559,11 @@ impl FilteredReadStream {
         let scan_range_after_filter = plan.scan_range_after_filter.clone();
 
         // Convert plan to scoped fragments for I/O
+        let mut options = options;
+        apply_high_bandwidth_batch_size_bytes(
+            &mut options.file_reader_options,
+            is_high_bandwidth_candidate,
+        );
         let scoped_fragments = Self::plan_to_scoped_fragments(
             &plan,
             &loaded_fragments,
@@ -1495,6 +1606,12 @@ impl FilteredReadOptions {
         self
     }
 
+    /// Set the threading mode to use for the scan.
+    pub fn with_threading_mode(mut self, threading_mode: FilteredReadThreadingMode) -> Self {
+        self.threading_mode = threading_mode;
+        self
+    }
+
     /// Specify the filter plan to use for the scan.
     ///
     /// This consists of up to two filters.  The full filter is the filter that needs to be satisfied
@@ -1622,6 +1739,21 @@ struct FilteredReadInternalPlan {
 }
 
 impl FilteredReadInternalPlan {
+    fn planned_fragment_count(&self) -> usize {
+        self.rows
+            .values()
+            .filter(|ranges| !ranges.is_empty())
+            .count()
+    }
+
+    fn planned_row_count(&self) -> u64 {
+        self.rows
+            .values()
+            .flat_map(|ranges| ranges.iter())
+            .map(|range| range.end - range.start)
+            .sum()
+    }
+
     /// Convert internal plan (ranges) to external plan (bitmap) for distributed execution
     fn to_external_plan(&self) -> FilteredReadPlan {
         let mut rows = RowAddrTreeMap::new();
@@ -2241,6 +2373,29 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_high_bandwidth_scan_io_parallelism_requires_cloud_unordered_large_scan() {
+        let base = 8;
+        let boosted = high_bandwidth_scan_io_parallelism(true, false, 16, 1_048_576, base);
+        assert!(boosted >= base);
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(false, false, 16, 1_048_576, base),
+            base
+        );
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(true, true, 16, 1_048_576, base),
+            base
+        );
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(true, false, 15, 1_048_576, base),
+            base
+        );
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(true, false, 16, 1_048_575, base),
+            base
+        );
+    }
 
     struct TestFixture {
         _tmp_path: TempStrDir,

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -30,6 +30,7 @@ use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::OnMissing;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::futures::FinallyStreamExt;
+use lance_core::utils::parse::str_is_truthy;
 use lance_core::utils::tokio::{IO_CORE_RESERVATION, get_num_compute_intensive_cpus};
 use lance_core::{Error, Result, datatypes::Projection};
 use lance_datafusion::planner::Planner;
@@ -60,6 +61,8 @@ use crate::dataset::scanner::{
 use super::utils::IoMetrics;
 
 const ENV_LANCE_DEFAULT_FRAGMENT_READAHEAD: &str = "LANCE_DEFAULT_FRAGMENT_READAHEAD";
+const ENV_LANCE_HIGH_BANDWIDTH_SCAN: &str = "LANCE_HIGH_BANDWIDTH_SCAN";
+const ENV_LANCE_IO_THREADS: &str = "LANCE_IO_THREADS";
 const HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS: usize = 16;
 const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 64 * 1024 * 1024;
 const HIGH_BANDWIDTH_SCAN_IO_PER_CPU: usize = 4;
@@ -67,12 +70,15 @@ const HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM: usize = 512;
 const HIGH_BANDWIDTH_SCAN_TARGET_BATCH_BYTES: u64 = 16 * 1024 * 1024;
 
 fn is_high_bandwidth_scan_candidate(
+    enable_high_bandwidth_scan: bool,
     is_cloud_store: bool,
     ordered_output: bool,
     planned_fragment_count: usize,
     planned_row_count: u64,
 ) -> bool {
-    is_cloud_store
+    enable_high_bandwidth_scan
+        && high_bandwidth_scan_policy_enabled()
+        && is_cloud_store
         && !ordered_output
         && planned_fragment_count >= HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS
         && planned_row_count >= HIGH_BANDWIDTH_SCAN_MIN_ROWS
@@ -87,25 +93,61 @@ fn effective_high_bandwidth_scan_row_count(
         .unwrap_or(planned_row_count)
 }
 
-pub(crate) fn high_bandwidth_scan_parallelism_target(base_parallelism: usize) -> usize {
+fn high_bandwidth_scan_policy_enabled() -> bool {
+    std::env::var(ENV_LANCE_HIGH_BANDWIDTH_SCAN)
+        .ok()
+        .map(|value| str_is_truthy(value.trim()))
+        .unwrap_or(true)
+}
+
+fn explicit_io_parallelism_override() -> Option<usize> {
+    std::env::var(ENV_LANCE_IO_THREADS)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|value| value.max(1))
+}
+
+fn high_bandwidth_scan_parallelism_cap(
+    target_partitions_cap: Option<usize>,
+    io_parallelism_cap: Option<usize>,
+) -> Option<usize> {
+    match (target_partitions_cap, io_parallelism_cap) {
+        (Some(target), Some(io)) => Some(target.min(io).max(1)),
+        (Some(target), None) => Some(target.max(1)),
+        (None, Some(io)) => Some(io.max(1)),
+        (None, None) => None,
+    }
+}
+
+pub(crate) fn high_bandwidth_scan_parallelism_target(
+    base_parallelism: usize,
+    parallelism_cap: Option<usize>,
+) -> usize {
     let base_parallelism = base_parallelism.max(1);
     let total_runtime_threads =
         get_num_compute_intensive_cpus().saturating_add(*IO_CORE_RESERVATION);
     let cpu_scaled_target = total_runtime_threads
         .saturating_mul(HIGH_BANDWIDTH_SCAN_IO_PER_CPU)
         .min(HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM);
-    base_parallelism.max(cpu_scaled_target)
+    let target = base_parallelism.max(cpu_scaled_target);
+    parallelism_cap
+        .map(|cap| target.min(cap.max(1)))
+        .unwrap_or(target)
+        .max(1)
 }
 
 fn high_bandwidth_scan_io_parallelism(
+    enable_high_bandwidth_scan: bool,
     is_cloud_store: bool,
     ordered_output: bool,
     planned_fragment_count: usize,
     planned_row_count: u64,
     base_io_parallelism: usize,
+    parallelism_cap: Option<usize>,
 ) -> usize {
     let base_io_parallelism = base_io_parallelism.max(1);
     if !is_high_bandwidth_scan_candidate(
+        enable_high_bandwidth_scan,
         is_cloud_store,
         ordered_output,
         planned_fragment_count,
@@ -113,7 +155,7 @@ fn high_bandwidth_scan_io_parallelism(
     ) {
         return base_io_parallelism;
     }
-    high_bandwidth_scan_parallelism_target(base_io_parallelism)
+    high_bandwidth_scan_parallelism_target(base_io_parallelism, parallelism_cap)
 }
 
 fn default_fragment_readahead_for_scan(
@@ -511,18 +553,25 @@ impl FilteredReadStream {
             plan.planned_row_count(),
             plan.scan_range_after_filter.as_ref(),
         );
+        let high_bandwidth_parallelism_cap = high_bandwidth_scan_parallelism_cap(
+            options.high_bandwidth_scan_parallelism_cap,
+            explicit_io_parallelism_override(),
+        );
         let is_high_bandwidth_candidate = is_high_bandwidth_scan_candidate(
+            options.enable_high_bandwidth_scan,
             dataset.object_store.is_cloud(),
             options.ordered_output,
             planned_fragment_count,
             planned_row_count,
         );
         let scan_io_parallelism = high_bandwidth_scan_io_parallelism(
+            options.enable_high_bandwidth_scan,
             dataset.object_store.is_cloud(),
             options.ordered_output,
             planned_fragment_count,
             planned_row_count,
             io_parallelism,
+            high_bandwidth_parallelism_cap,
         );
         let threading_mode = high_bandwidth_scan_threading_mode(
             options.threading_mode,
@@ -1510,6 +1559,17 @@ pub struct FilteredReadOptions {
     pub scan_scheduler_diagnostics_callback: Option<ScanSchedulerDiagnosticsCallback>,
     /// If true, skip fragments that are not covered by the scalar index result.
     pub only_indexed_fragments: bool,
+    /// If true, large cloud unordered scans may opt into the high-bandwidth policy.
+    ///
+    /// This is intentionally separate from `ordered_output`: `order_by` and `nearest`
+    /// also make the physical scan unordered, but they are not plain throughput scans.
+    enable_high_bandwidth_scan: bool,
+    /// Upper bound for automatic high-bandwidth parallelism.
+    ///
+    /// `target_partitions` sets this when callers explicitly constrain DataFusion
+    /// execution parallelism. `LANCE_IO_THREADS` is checked separately at execution
+    /// time and has the same opt-out effect for I/O parallelism.
+    high_bandwidth_scan_parallelism_cap: Option<usize>,
 }
 
 impl FilteredReadOptions {
@@ -1540,6 +1600,8 @@ impl FilteredReadOptions {
             io_buffer_size_bytes: None,
             scan_scheduler_diagnostics_callback: None,
             only_indexed_fragments: false,
+            enable_high_bandwidth_scan: false,
+            high_bandwidth_scan_parallelism_cap: None,
             ordered_output: true,
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
                 get_num_compute_intensive_cpus(),
@@ -1650,6 +1712,26 @@ impl FilteredReadOptions {
     pub fn with_threading_mode(mut self, threading_mode: FilteredReadThreadingMode) -> Self {
         self.threading_mode = threading_mode;
         self
+    }
+
+    /// Allow automatic high-bandwidth behavior for large cloud unordered scans.
+    pub(crate) fn with_high_bandwidth_scan(mut self, enable_high_bandwidth_scan: bool) -> Self {
+        self.enable_high_bandwidth_scan = enable_high_bandwidth_scan;
+        self
+    }
+
+    /// Cap automatic high-bandwidth parallelism.
+    pub(crate) fn with_high_bandwidth_scan_parallelism_cap(
+        mut self,
+        parallelism_cap: Option<usize>,
+    ) -> Self {
+        self.high_bandwidth_scan_parallelism_cap = parallelism_cap.map(|cap| cap.max(1));
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn high_bandwidth_scan_enabled(&self) -> bool {
+        self.enable_high_bandwidth_scan
     }
 
     /// Specify the filter plan to use for the scan.
@@ -1999,6 +2081,7 @@ impl FilteredReadExec {
                 n.min(target_partitions).max(1),
             );
         }
+        options = options.with_high_bandwidth_scan_parallelism_cap(Some(target_partitions.max(1)));
         let batch_size_bytes = options
             .file_reader_options
             .as_ref()
@@ -2419,51 +2502,104 @@ mod tests {
         let base = 8;
         let boosted = high_bandwidth_scan_io_parallelism(
             true,
+            true,
             false,
             HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
             HIGH_BANDWIDTH_SCAN_MIN_ROWS,
             base,
+            None,
         );
         assert!(boosted >= base);
         assert_eq!(
             high_bandwidth_scan_io_parallelism(
                 false,
+                true,
                 false,
                 HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
                 HIGH_BANDWIDTH_SCAN_MIN_ROWS,
-                base
+                base,
+                None,
             ),
             base
         );
         assert_eq!(
             high_bandwidth_scan_io_parallelism(
+                true,
+                false,
+                false,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+                base,
+                None,
+            ),
+            base
+        );
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(
+                true,
                 true,
                 true,
                 HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
                 HIGH_BANDWIDTH_SCAN_MIN_ROWS,
-                base
+                base,
+                None,
             ),
             base
         );
         assert_eq!(
             high_bandwidth_scan_io_parallelism(
+                true,
                 true,
                 false,
                 HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS - 1,
                 HIGH_BANDWIDTH_SCAN_MIN_ROWS,
-                base
+                base,
+                None,
             ),
             base
         );
         assert_eq!(
             high_bandwidth_scan_io_parallelism(
                 true,
+                true,
                 false,
                 HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
                 HIGH_BANDWIDTH_SCAN_MIN_ROWS - 1,
-                base
+                base,
+                None,
             ),
             base
+        );
+    }
+
+    #[test]
+    fn test_high_bandwidth_scan_parallelism_respects_explicit_caps() {
+        assert_eq!(
+            high_bandwidth_scan_parallelism_cap(Some(16), None),
+            Some(16)
+        );
+        assert_eq!(
+            high_bandwidth_scan_parallelism_cap(None, Some(12)),
+            Some(12)
+        );
+        assert_eq!(
+            high_bandwidth_scan_parallelism_cap(Some(16), Some(12)),
+            Some(12)
+        );
+        assert_eq!(high_bandwidth_scan_parallelism_cap(None, None), None);
+
+        let base = 64;
+        assert_eq!(
+            high_bandwidth_scan_io_parallelism(
+                true,
+                true,
+                false,
+                HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS,
+                HIGH_BANDWIDTH_SCAN_MIN_ROWS,
+                base,
+                Some(16),
+            ),
+            16
         );
     }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -62,7 +62,7 @@ use super::utils::IoMetrics;
 
 const ENV_LANCE_DEFAULT_FRAGMENT_READAHEAD: &str = "LANCE_DEFAULT_FRAGMENT_READAHEAD";
 const HIGH_BANDWIDTH_SCAN_MIN_FRAGMENTS: usize = 16;
-const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 16_777_216;
+const HIGH_BANDWIDTH_SCAN_MIN_ROWS: u64 = 64 * 1024 * 1024;
 const HIGH_BANDWIDTH_SCAN_IO_PER_CPU: usize = 4;
 const HIGH_BANDWIDTH_SCAN_MAX_IO_PARALLELISM: usize = 512;
 const HIGH_BANDWIDTH_SCAN_TARGET_BATCH_BYTES: u64 = 16 * 1024 * 1024;
@@ -566,14 +566,20 @@ impl FilteredReadStream {
             .or_else(get_default_io_buffer_size_override)
         {
             SchedulerConfig::new(io_buffer_size_bytes)
-        } else {
+        } else if is_high_bandwidth_candidate {
             SchedulerConfig::max_bandwidth_for_io_parallelism(scan_io_parallelism)
+        } else {
+            SchedulerConfig::max_bandwidth(obj_store.as_ref())
         };
-        let scan_scheduler = ScanScheduler::new_with_io_capacity(
-            obj_store,
-            scheduler_config,
-            Some(scan_io_parallelism),
-        );
+        let scan_scheduler = if is_high_bandwidth_candidate {
+            ScanScheduler::new_with_io_capacity(
+                obj_store,
+                scheduler_config,
+                Some(scan_io_parallelism),
+            )
+        } else {
+            ScanScheduler::new(obj_store, scheduler_config)
+        };
         if let Some(callback) = options.scan_scheduler_diagnostics_callback.as_ref() {
             callback.notify(ScanSchedulerDiagnosticsHandle::new(scan_scheduler.clone()));
         }

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -140,6 +140,25 @@ fn apply_high_bandwidth_batch_size_bytes(
     }
 }
 
+fn high_bandwidth_scan_threading_mode(
+    threading_mode: FilteredReadThreadingMode,
+    is_high_bandwidth_candidate: bool,
+    scan_io_parallelism: usize,
+) -> FilteredReadThreadingMode {
+    if !is_high_bandwidth_candidate {
+        return threading_mode;
+    }
+
+    match threading_mode {
+        FilteredReadThreadingMode::OnePartitionMultipleThreads(num_threads) => {
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(
+                num_threads.max(scan_io_parallelism).max(1),
+            )
+        }
+        FilteredReadThreadingMode::MultiplePartitions(_) => threading_mode,
+    }
+}
+
 #[derive(Debug)]
 pub struct EvaluatedIndex {
     index_result: IndexExprResult,
@@ -473,7 +492,6 @@ impl FilteredReadStream {
     ) -> DataFusionResult<Self> {
         let global_metrics = Arc::new(FilteredReadGlobalMetrics::new(metrics));
 
-        let threading_mode = options.threading_mode;
         let fragments = options
             .fragments
             .clone()
@@ -494,6 +512,11 @@ impl FilteredReadStream {
             planned_fragment_count,
             planned_row_count,
             io_parallelism,
+        );
+        let threading_mode = high_bandwidth_scan_threading_mode(
+            options.threading_mode,
+            is_high_bandwidth_candidate,
+            scan_io_parallelism,
         );
         let fragment_readahead = options
             .fragment_readahead
@@ -2424,6 +2447,25 @@ mod tests {
                 base
             ),
             base
+        );
+    }
+
+    #[test]
+    fn test_high_bandwidth_scan_threading_only_scales_single_partition_large_scans() {
+        let base_mode = FilteredReadThreadingMode::OnePartitionMultipleThreads(8);
+        assert_eq!(
+            high_bandwidth_scan_threading_mode(base_mode, false, 256),
+            base_mode
+        );
+        assert_eq!(
+            high_bandwidth_scan_threading_mode(base_mode, true, 256),
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(256)
+        );
+
+        let partitioned_mode = FilteredReadThreadingMode::MultiplePartitions(8);
+        assert_eq!(
+            high_bandwidth_scan_threading_mode(partitioned_mode, true, 256),
+            partitioned_mode
         );
     }
 


### PR DESCRIPTION
## Why

This PR is part of the S3/cloud scan performance stack. The final goal is to make large cloud scans capable of approaching the physical bandwidth limit of high-bandwidth hosts while avoiding noticeable regressions for point lookup and non-throughput-oriented scan paths.

The previous layers improve page decode and read scheduling. This layer adds an automatic high-bandwidth scan policy so sufficiently large unordered cloud scans can use more I/O parallelism and larger scan batches without requiring every caller to hand-tune low-level read options.

## What

This PR enables high-bandwidth behavior only for large plain unordered cloud scans:

- Scales automatic I/O parallelism for large cloud scans.
- Uses larger batch sizing for high-bandwidth scan candidates.
- Preserves existing default behavior for ordered and latency-sensitive paths.
- Treats explicit resource controls as limits:
  - `target_partitions` caps high-bandwidth automatic expansion.
  - `LANCE_IO_THREADS` caps high-bandwidth automatic expansion.
- Adds an explicit rollback switch:
  - `LANCE_HIGH_BANDWIDTH_SCAN=0` disables the automatic high-bandwidth policy.

The default policy excludes paths that are not plain throughput scans:

- `nearest`
- `order_by`
- ordered scans
- version-column scans

## Boundaries

This PR does not change the persistent format or public API.

It does not attempt to optimize nearest-neighbor search, ordered output, small-limit point lookup, or version-column materialization paths. Those paths remain outside the high-bandwidth policy by default to avoid trading latency or ordering correctness for bulk throughput.

It also does not remove existing user controls. Explicit `target_partitions`, `LANCE_IO_THREADS`, and `LANCE_HIGH_BANDWIDTH_SCAN=0` remain the intended rollback and resource-control mechanisms.

## Validation

Validated with targeted Rust checks covering the policy and scan-plan invariants:

- `cargo test -p lance --lib high_bandwidth_scan -- --nocapture`
- `cargo test -p lance --lib test_scan_in_order_propagated_to_filtered_read -- --nocapture`
- `cargo test -p lance --lib test_scan_with_version_columns -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p lance --bench s3_file_reader_diagnostics`

No `lance-over-100gbps` benchmark was run for this update.
