### PR TITLE
fix(mem_wal): use slice-aware size estimate for memtable flush threshold

### DIFF
--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -75,11 +75,24 @@ impl StoredBatch {
     }
 
     /// Estimate the memory size of a RecordBatch.
+    ///
+    /// Uses Arrow's slice-aware [`ArrayData::get_slice_memory_size`] so a batch
+    /// that is a zero-copy slice of a larger parent reports only its own window
+    /// instead of the whole shared buffer. `get_array_memory_size` counts every
+    /// buffer's full `capacity()` regardless of the array's offset/length, so N
+    /// slices tiling one parent would each report the parent's size and inflate
+    /// the memtable estimate by ~N× — tripping the flush threshold far below the
+    /// configured size. The fallback keeps the old (over-counting but safe)
+    /// behavior for the rare types where the slice-aware call errors.
     fn estimate_batch_size(batch: &RecordBatch) -> usize {
         batch
             .columns()
             .iter()
-            .map(|col| col.get_array_memory_size())
+            .map(|col| {
+                col.to_data()
+                    .get_slice_memory_size()
+                    .unwrap_or_else(|_| col.get_array_memory_size())
+            })
             .sum::<usize>()
             + std::mem::size_of::<RecordBatch>()
     }
@@ -970,6 +983,58 @@ mod tests {
         // Very small memtable should get minimum capacity
         let cap = BatchStore::recommended_capacity(1024);
         assert_eq!(cap, 16); // minimum
+    }
+
+    #[test]
+    fn test_estimated_size_is_slice_aware() {
+        // A batch that is a zero-copy slice of a larger parent must contribute
+        // only its own window to the estimate, not the whole shared buffer.
+        // `get_array_memory_size` counts every buffer's full capacity regardless
+        // of offset/length, so N slices tiling one parent each report the
+        // parent's size and inflate the memtable estimate ~N×, tripping the
+        // flush threshold far below the configured size.
+        let chunk = 1_000;
+        let num_slices = 100;
+        let parent = create_test_batch(chunk * num_slices);
+
+        // One window vs an equivalently-sized owned batch should track each
+        // other; the buggy per-slice estimate would be ~num_slices× larger.
+        let slice_est = StoredBatch::estimate_batch_size(&parent.slice(0, chunk));
+        let owned_est = StoredBatch::estimate_batch_size(&create_test_batch(chunk));
+        assert!(
+            slice_est <= owned_est * 2,
+            "slice estimate {slice_est} should track its own window (~{owned_est}), not the parent"
+        );
+
+        // End-to-end: tiling the parent with zero-copy slices must not multiply
+        // the store's running estimate. Track what the old full-buffer behavior
+        // would have summed to for contrast.
+        let store = BatchStore::with_capacity(num_slices);
+        let mut over_counting_sum = 0usize;
+        for k in 0..num_slices {
+            let s = parent.slice(k * chunk, chunk);
+            over_counting_sum += s
+                .columns()
+                .iter()
+                .map(|col| col.get_array_memory_size())
+                .sum::<usize>()
+                + std::mem::size_of::<RecordBatch>();
+            store.append(s).unwrap();
+        }
+
+        // Two non-nullable Int32 columns → exactly 4 bytes/row/col of payload.
+        let payload_bytes = num_slices * chunk * 2 * std::mem::size_of::<i32>();
+        let estimated = store.estimated_bytes();
+        assert!(
+            estimated >= payload_bytes,
+            "estimate {estimated} should cover the actual payload {payload_bytes}"
+        );
+        // The old behavior over-counts by ~num_slices×; the fix must be far
+        // below it (generous 10× margin against struct/alignment overhead).
+        assert!(
+            estimated * 10 < over_counting_sum,
+            "estimate {estimated} should be far below the over-counting sum {over_counting_sum}"
+        );
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -95,33 +95,28 @@ impl StoredBatch {
             + std::mem::size_of::<RecordBatch>()
     }
 
-    /// Slice-aware memory estimate for a single array, correcting for view types.
+    /// Slice-aware memory estimate for a single array.
     ///
-    /// [`ArrayData::get_slice_memory_size`] only accounts for the fixed 16-byte
-    /// view entries of `Utf8View`/`BinaryView` and ignores the variadic data
-    /// buffers that hold values longer than 12 bytes. It still returns `Ok` for
-    /// these types, so without this correction a batch of long view values would
-    /// be undercounted as ~`16 * rows` while retaining far more memory. We add
-    /// the variadic buffers back (recursing through nested view children). The
-    /// buffers are shared across zero-copy slices, so counting their full
-    /// capacity over-counts for slices — the safe direction, matching the rest
-    /// of this estimate.
+    /// [`ArrayData::get_slice_memory_size`] ignores the variadic data buffers of
+    /// `Utf8View`/`BinaryView` (values > 12 bytes) yet still returns `Ok`, so
+    /// long view batches would be undercounted as ~`16 * rows`. Add those buffers
+    /// back; they are shared across slices, so counting full capacity over-counts
+    /// for slices — the safe direction, matching the rest of this estimate.
     fn estimate_array_size(data: &ArrayData) -> usize {
         match data.get_slice_memory_size() {
             Ok(size) => size + Self::view_data_buffers_size(data),
-            // The slice-aware call errors only for rare unsupported layouts;
-            // fall back to the over-counting (but complete) buffer sum.
+            // Errors only for rare unsupported layouts; use the over-counting sum.
             Err(_) => data.get_array_memory_size(),
         }
     }
 
-    /// Capacity of the variadic data buffers that [`ArrayData::get_slice_memory_size`]
-    /// omits for `Utf8View`/`BinaryView` arrays, summed recursively over children.
+    /// Capacity of the variadic data buffers `get_slice_memory_size` omits for
+    /// `Utf8View`/`BinaryView`, summed recursively over children.
     fn view_data_buffers_size(data: &ArrayData) -> usize {
         let mut size = 0;
         if matches!(data.data_type(), DataType::Utf8View | DataType::BinaryView) {
-            // buffers()[0] is the 16-byte view array counted by
-            // get_slice_memory_size; buffers()[1..] are the data buffers it skips.
+            // buffers()[0] is the 16-byte view array (already counted); [1..] are
+            // the data buffers get_slice_memory_size skips.
             size += data
                 .buffers()
                 .iter()
@@ -1077,11 +1072,9 @@ mod tests {
 
     #[test]
     fn test_estimated_size_counts_view_data_buffers() {
-        // Utf8View/BinaryView keep values longer than 12 bytes in variadic data
-        // buffers that Arrow's `get_slice_memory_size` ignores (it counts only
-        // the fixed 16-byte view entries and still returns `Ok`). Without the
-        // correction, a batch of long view values would be undercounted as
-        // ~16 * rows while retaining far more memory.
+        // Long Utf8View/BinaryView values live in variadic data buffers that
+        // `get_slice_memory_size` ignores (returning ~16 * rows). The estimate
+        // must include them.
         use arrow_array::StringViewArray;
 
         let num_rows = 1_000;

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -1072,37 +1072,64 @@ mod tests {
     fn test_estimated_size_counts_view_data_buffers() {
         // Long Utf8View/BinaryView values live in variadic data buffers that
         // `get_slice_memory_size` ignores (returning ~16 * rows). The estimate
-        // must include them.
-        use arrow_array::StringViewArray;
+        // must include them, both for a top-level view column and for a view
+        // array nested in a container, which is only reached via child_data
+        // recursion.
+        use arrow_array::{Array, ArrayRef, StringViewArray, StructArray};
 
         let num_rows = 1_000;
         // Each value exceeds the 12-byte inline limit, so it spills to a data buffer.
         let long_value = "x".repeat(64);
         let payload_bytes = num_rows * long_value.len();
-
-        let array = StringViewArray::from(
-            (0..num_rows)
-                .map(|_| Some(long_value.as_str()))
-                .collect::<Vec<_>>(),
-        );
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "s",
-            DataType::Utf8View,
-            false,
-        )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap();
-
-        let estimated = StoredBatch::estimate_batch_size(&batch);
         // What the slice-aware call alone reports: just the 16-byte view entries.
         let view_entries_only = num_rows * 16;
-        assert!(
-            estimated >= payload_bytes,
-            "estimate {estimated} should cover the view data-buffer payload {payload_bytes}"
-        );
-        assert!(
-            estimated > view_entries_only * 2,
-            "estimate {estimated} must exceed the ~{view_entries_only}-byte view-entry-only undercount"
-        );
+
+        let make_views = || {
+            StringViewArray::from(
+                (0..num_rows)
+                    .map(|_| Some(long_value.as_str()))
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let assert_covers = |batch: &RecordBatch| {
+            let estimated = StoredBatch::estimate_batch_size(batch);
+            assert!(
+                estimated >= payload_bytes,
+                "estimate {estimated} should cover the view data-buffer payload {payload_bytes}"
+            );
+            assert!(
+                estimated > view_entries_only * 2,
+                "estimate {estimated} must exceed the ~{view_entries_only}-byte view-entry-only undercount"
+            );
+        };
+
+        // Top-level view column.
+        let flat = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "s",
+                DataType::Utf8View,
+                false,
+            )])),
+            vec![Arc::new(make_views())],
+        )
+        .unwrap();
+        assert_covers(&flat);
+
+        // View nested inside a struct — reachable only through child_data recursion.
+        let nested = StructArray::from(vec![(
+            Arc::new(Field::new("s", DataType::Utf8View, false)),
+            Arc::new(make_views()) as ArrayRef,
+        )]);
+        let nested = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "st",
+                nested.data_type().clone(),
+                false,
+            )])),
+            vec![Arc::new(nested)],
+        )
+        .unwrap();
+        assert_covers(&nested);
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -43,7 +43,9 @@ use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use arrow::array::ArrayData;
 use arrow_array::RecordBatch;
+use arrow_schema::DataType;
 
 /// A batch stored in the lock-free store.
 #[derive(Clone)]
@@ -88,13 +90,49 @@ impl StoredBatch {
         batch
             .columns()
             .iter()
-            .map(|col| {
-                col.to_data()
-                    .get_slice_memory_size()
-                    .unwrap_or_else(|_| col.get_array_memory_size())
-            })
+            .map(|col| Self::estimate_array_size(&col.to_data()))
             .sum::<usize>()
             + std::mem::size_of::<RecordBatch>()
+    }
+
+    /// Slice-aware memory estimate for a single array, correcting for view types.
+    ///
+    /// [`ArrayData::get_slice_memory_size`] only accounts for the fixed 16-byte
+    /// view entries of `Utf8View`/`BinaryView` and ignores the variadic data
+    /// buffers that hold values longer than 12 bytes. It still returns `Ok` for
+    /// these types, so without this correction a batch of long view values would
+    /// be undercounted as ~`16 * rows` while retaining far more memory. We add
+    /// the variadic buffers back (recursing through nested view children). The
+    /// buffers are shared across zero-copy slices, so counting their full
+    /// capacity over-counts for slices — the safe direction, matching the rest
+    /// of this estimate.
+    fn estimate_array_size(data: &ArrayData) -> usize {
+        match data.get_slice_memory_size() {
+            Ok(size) => size + Self::view_data_buffers_size(data),
+            // The slice-aware call errors only for rare unsupported layouts;
+            // fall back to the over-counting (but complete) buffer sum.
+            Err(_) => data.get_array_memory_size(),
+        }
+    }
+
+    /// Capacity of the variadic data buffers that [`ArrayData::get_slice_memory_size`]
+    /// omits for `Utf8View`/`BinaryView` arrays, summed recursively over children.
+    fn view_data_buffers_size(data: &ArrayData) -> usize {
+        let mut size = 0;
+        if matches!(data.data_type(), DataType::Utf8View | DataType::BinaryView) {
+            // buffers()[0] is the 16-byte view array counted by
+            // get_slice_memory_size; buffers()[1..] are the data buffers it skips.
+            size += data
+                .buffers()
+                .iter()
+                .skip(1)
+                .map(|b| b.capacity())
+                .sum::<usize>();
+        }
+        for child in data.child_data() {
+            size += Self::view_data_buffers_size(child);
+        }
+        size
     }
 }
 
@@ -1034,6 +1072,45 @@ mod tests {
         assert!(
             estimated * 10 < over_counting_sum,
             "estimate {estimated} should be far below the over-counting sum {over_counting_sum}"
+        );
+    }
+
+    #[test]
+    fn test_estimated_size_counts_view_data_buffers() {
+        // Utf8View/BinaryView keep values longer than 12 bytes in variadic data
+        // buffers that Arrow's `get_slice_memory_size` ignores (it counts only
+        // the fixed 16-byte view entries and still returns `Ok`). Without the
+        // correction, a batch of long view values would be undercounted as
+        // ~16 * rows while retaining far more memory.
+        use arrow_array::StringViewArray;
+
+        let num_rows = 1_000;
+        // Each value exceeds the 12-byte inline limit, so it spills to a data buffer.
+        let long_value = "x".repeat(64);
+        let payload_bytes = num_rows * long_value.len();
+
+        let array = StringViewArray::from(
+            (0..num_rows)
+                .map(|_| Some(long_value.as_str()))
+                .collect::<Vec<_>>(),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "s",
+            DataType::Utf8View,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap();
+
+        let estimated = StoredBatch::estimate_batch_size(&batch);
+        // What the slice-aware call alone reports: just the 16-byte view entries.
+        let view_entries_only = num_rows * 16;
+        assert!(
+            estimated >= payload_bytes,
+            "estimate {estimated} should cover the view data-buffer payload {payload_bytes}"
+        );
+        assert!(
+            estimated > view_entries_only * 2,
+            "estimate {estimated} must exceed the ~{view_entries_only}-byte view-entry-only undercount"
         );
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -78,14 +78,10 @@ impl StoredBatch {
 
     /// Estimate the memory size of a RecordBatch.
     ///
-    /// Uses Arrow's slice-aware [`ArrayData::get_slice_memory_size`] so a batch
-    /// that is a zero-copy slice of a larger parent reports only its own window
-    /// instead of the whole shared buffer. `get_array_memory_size` counts every
-    /// buffer's full `capacity()` regardless of the array's offset/length, so N
-    /// slices tiling one parent would each report the parent's size and inflate
-    /// the memtable estimate by ~N× — tripping the flush threshold far below the
-    /// configured size. The fallback keeps the old (over-counting but safe)
-    /// behavior for the rare types where the slice-aware call errors.
+    /// Sums each column's slice-aware buffer size (see
+    /// [`Self::estimate_array_size`]) plus the struct overhead, so a column that
+    /// is a zero-copy slice of a larger parent contributes only its own window
+    /// rather than the whole shared buffer.
     fn estimate_batch_size(batch: &RecordBatch) -> usize {
         batch
             .columns()
@@ -95,28 +91,30 @@ impl StoredBatch {
             + std::mem::size_of::<RecordBatch>()
     }
 
-    /// Slice-aware memory estimate for a single array.
+    /// Slice-aware buffer size of a single array.
     ///
-    /// [`ArrayData::get_slice_memory_size`] ignores the variadic data buffers of
-    /// `Utf8View`/`BinaryView` (values > 12 bytes) yet still returns `Ok`, so
-    /// long view batches would be undercounted as ~`16 * rows`. Add those buffers
-    /// back; they are shared across slices, so counting full capacity over-counts
-    /// for slices — the safe direction, matching the rest of this estimate.
+    /// [`ArrayData::get_slice_memory_size`] reports each buffer's own window
+    /// (not the whole shared buffer), but omits the variadic data buffers of
+    /// `Utf8View`/`BinaryView` (values > 12 bytes) while still returning `Ok`, so
+    /// [`Self::view_data_buffers_size`] adds them. Those buffers are shared across
+    /// zero-copy slices and are counted at full capacity for each slice — an
+    /// over-count in the safe direction.
     fn estimate_array_size(data: &ArrayData) -> usize {
         match data.get_slice_memory_size() {
             Ok(size) => size + Self::view_data_buffers_size(data),
-            // Errors only for rare unsupported layouts; use the over-counting sum.
+            // Fall back to the full-buffer sum for layouts the slice-aware call
+            // cannot handle.
             Err(_) => data.get_array_memory_size(),
         }
     }
 
-    /// Capacity of the variadic data buffers `get_slice_memory_size` omits for
-    /// `Utf8View`/`BinaryView`, summed recursively over children.
+    /// Capacity of the variadic `Utf8View`/`BinaryView` data buffers that
+    /// [`ArrayData::get_slice_memory_size`] omits, summed recursively over children.
     fn view_data_buffers_size(data: &ArrayData) -> usize {
         let mut size = 0;
         if matches!(data.data_type(), DataType::Utf8View | DataType::BinaryView) {
-            // buffers()[0] is the 16-byte view array (already counted); [1..] are
-            // the data buffers get_slice_memory_size skips.
+            // buffers()[0] is the 16-byte view array that get_slice_memory_size
+            // already counts; [1..] are the data buffers it skips.
             size += data
                 .buffers()
                 .iter()


### PR DESCRIPTION
## Problem

`StoredBatch::estimate_batch_size` (mem_wal `batch_store.rs`) summed `Array::get_array_memory_size`, which counts every buffer's full `capacity()` **regardless of the array's offset/length**. Arrow's own docs are explicit: a sliced `ArrayData` "may only refer to a subset of the data ... but the size returned includes the entire size of the buffers," and slices sharing a buffer "will both report the same size."

When ingest slices one incoming batch into N zero-copy WAL chunks, each slice therefore reports the **whole shared parent buffer**. This estimate feeds `maybe_trigger_memtable_flush` (`estimated_size() >= max_memtable_size`), so the active memtable flushed far below the configured size — e.g. a 250 MB target tripping at a few MB of real data.

## Fix

Use Arrow's slice-aware `ArrayData::get_slice_memory_size`, which reports only the slice's own window, with a fallback to the old call for the rare types where it errors (conservative — over-counts, never under).

## Evidence

A standalone repro (100 zero-copy slices of a 20 MB parent, the common ingest pattern):

| | estimate |
|---|---|
| actual retained heap | ~20 MB |
| old (`get_array_memory_size`) | **~2744 MB** (131× over-count) |
| new (`get_slice_memory_size`) | ~20 MB |

Even a single owned (non-sliced) batch over-counts ~1.26× under the old path, so the new estimate is strictly more accurate.

## Test

Adds `test_estimated_size_is_slice_aware`: tiles a parent into 100 zero-copy slices, appends them, and asserts the store's running estimate covers the real payload without the ~N× blow-up (guarded against the old over-counting sum).

`cargo test -p lance --lib batch_store`, `cargo fmt --all`, and `cargo clippy -p lance --tests -- -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)