### PR TITLE
feat(index)!: covering ("included") columns for IVF vector indexes

### DIFF
--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -140,10 +140,26 @@ impl IntoJava for &IndexMetadata {
         // Determine index type from index_details type_url
         let index_type = determine_index_type(env, &self.index_details)?;
 
+        // Covered ("included") columns, mirroring `fields`.
+        let included_fields = {
+            let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
+            for field in &self.included_fields {
+                let field_obj =
+                    env.new_object("java/lang/Integer", "(I)V", &[JValue::Int(*field)])?;
+                env.call_method(
+                    &array_list,
+                    "add",
+                    "(Ljava/lang/Object;)Z",
+                    &[JValue::Object(&field_obj)],
+                )?;
+            }
+            array_list
+        };
+
         // Create Index object
         Ok(env.new_object(
             "org/lance/index/Index",
-            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Ljava/lang/Long;Lorg/lance/index/IndexType;)V",
+            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Ljava/lang/Long;Lorg/lance/index/IndexType;Ljava/util/List;)V",
             &[
                 JValue::Object(&uuid),
                 JValue::Object(&fields),
@@ -156,6 +172,7 @@ impl IntoJava for &IndexMetadata {
                 JValue::Object(&base_id),
                 JValue::Object(&size_bytes),
                 JValue::Object(&index_type),
+                JValue::Object(&included_fields),
             ],
         )?)
     }

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -204,6 +204,12 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
             })?;
         let base_id = env.get_optional_u32_from_method(self, "baseId")?;
 
+        // Covered ("included") columns, mirroring `fields` (empty when absent).
+        let included_fields: Vec<i32> =
+            import_vec_from_method(env, self, "includedFields", |env, field_id| {
+                field_id.extract_object(env)
+            })?;
+
         Ok(IndexMetadata {
             uuid,
             fields,
@@ -215,6 +221,7 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
             created_at,
             base_id,
             files: None,
+            included_fields,
         })
     }
 }

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -493,6 +493,7 @@ pub fn get_vector_index_params(
                 version: IndexFileVersion::V3,
                 skip_transpose: false,
                 runtime_hints: Default::default(),
+                include_columns: Vec::new(),
             })
         },
     )?;

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -24,7 +24,7 @@ use lance_linalg::distance::DistanceType;
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
 
-use crate::traits::FromJObjectWithEnv;
+use crate::traits::{FromJObjectWithEnv, import_vec_from_method};
 use lance_index::vector::{ApproxMode, Query};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -487,13 +487,22 @@ pub fn get_vector_index_params(
                 stages.push(StageParams::RQ(rq_params));
             }
 
+            // Covering ("included") columns: names of extra dataset columns stored inline in
+            // the index. Empty when absent. The core validates them when the index is built.
+            let include_columns: Vec<String> = import_vec_from_method(
+                env,
+                &vector_index_params_obj,
+                "getIncludeColumns",
+                |env, elem| Ok(env.get_string(&JString::from(elem))?.into()),
+            )?;
+
             Ok(VectorIndexParams {
                 metric_type: distance_type,
                 stages,
                 version: IndexFileVersion::V3,
                 skip_transpose: false,
                 runtime_hints: Default::default(),
-                include_columns: Vec::new(),
+                include_columns,
             })
         },
     )?;

--- a/java/src/main/java/org/lance/index/Index.java
+++ b/java/src/main/java/org/lance/index/Index.java
@@ -16,7 +16,9 @@ package org.lance.index;
 import com.google.common.base.MoreObjects;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -38,6 +40,7 @@ public class Index {
   private final Integer baseId;
   private final Long sizeBytes;
   private final IndexType indexType;
+  private final List<Integer> includedFields;
 
   private Index(
       UUID uuid,
@@ -50,7 +53,8 @@ public class Index {
       Instant createdAt,
       Integer baseId,
       Long sizeBytes,
-      IndexType indexType) {
+      IndexType indexType,
+      List<Integer> includedFields) {
     this.uuid = uuid;
     this.fields = fields;
     this.name = name;
@@ -62,6 +66,14 @@ public class Index {
     this.baseId = baseId;
     this.sizeBytes = sizeBytes;
     this.indexType = indexType;
+    // Empty (not null) when the index has no covering columns, so the JNI round-trip
+    // never sees a null list. Defensively copied and unmodifiable, matching
+    // VectorIndexParams.includeColumns: later mutation of the caller's list must not
+    // change this value object.
+    this.includedFields =
+        includedFields == null
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(includedFields));
   }
 
   public UUID uuid() {
@@ -145,6 +157,17 @@ public class Index {
     return indexType;
   }
 
+  /**
+   * Get the field ids this index covers ("included" columns) beyond its key column, so a covered
+   * query can be answered from the index without a take from the base table. Empty for indexes
+   * without covering columns.
+   *
+   * @return the covered field IDs
+   */
+  public List<Integer> includedFields() {
+    return includedFields;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -160,7 +183,8 @@ public class Index {
         && Objects.equals(createdAt, index.createdAt)
         && Objects.equals(baseId, index.baseId)
         && Objects.equals(sizeBytes, index.sizeBytes)
-        && indexType == index.indexType;
+        && indexType == index.indexType
+        && Objects.equals(includedFields, index.includedFields);
   }
 
   @Override
@@ -176,7 +200,8 @@ public class Index {
             baseId,
             sizeBytes,
             fragments,
-            indexType);
+            indexType,
+            includedFields);
     result = 31 * result + Arrays.hashCode(indexDetails);
     return result;
   }
@@ -193,6 +218,7 @@ public class Index {
         .add("createdAt", createdAt)
         .add("baseId", baseId)
         .add("sizeBytes", sizeBytes)
+        .add("includedFields", includedFields)
         .toString();
   }
 
@@ -218,6 +244,7 @@ public class Index {
     private Integer baseId;
     private Long sizeBytes;
     private IndexType indexType;
+    private List<Integer> includedFields;
 
     private Builder() {}
 
@@ -276,6 +303,11 @@ public class Index {
       return this;
     }
 
+    public Builder includedFields(List<Integer> includedFields) {
+      this.includedFields = includedFields;
+      return this;
+    }
+
     public Index build() {
       return new Index(
           uuid,
@@ -288,7 +320,8 @@ public class Index {
           createdAt,
           baseId,
           sizeBytes,
-          indexType);
+          indexType,
+          includedFields);
     }
   }
 }

--- a/java/src/main/java/org/lance/index/vector/VectorIndexParams.java
+++ b/java/src/main/java/org/lance/index/vector/VectorIndexParams.java
@@ -17,6 +17,9 @@ import org.lance.index.DistanceType;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /** Parameters for creating a vector index. */
@@ -27,6 +30,7 @@ public class VectorIndexParams {
   private final Optional<HnswBuildParams> hnswParams;
   private final Optional<SQBuildParams> sqParams;
   private final Optional<RQBuildParams> rqParams;
+  private final List<String> includeColumns;
 
   private VectorIndexParams(Builder builder) {
     this.distanceType = builder.distanceType;
@@ -35,6 +39,10 @@ public class VectorIndexParams {
     this.hnswParams = builder.hnswParams;
     this.sqParams = builder.sqParams;
     this.rqParams = builder.rqParams;
+    this.includeColumns =
+        builder.includeColumns == null
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(builder.includeColumns));
     validate();
   }
 
@@ -179,6 +187,7 @@ public class VectorIndexParams {
     private Optional<HnswBuildParams> hnswParams = Optional.empty();
     private Optional<SQBuildParams> sqParams = Optional.empty();
     private Optional<RQBuildParams> rqParams = Optional.empty();
+    private List<String> includeColumns = Collections.emptyList();
 
     /**
      * Create a new builder to create a vector index.
@@ -235,6 +244,20 @@ public class VectorIndexParams {
       return this;
     }
 
+    /**
+     * Set the columns to cover ("include") in the index. Their values are stored inline in the
+     * index so a query projecting only covered columns is answered from the index without a take
+     * from the base table. Each must name a top-level, non-key column of the dataset; the columns
+     * are validated by the core when the index is built. Empty by default (no covering).
+     *
+     * @param includeColumns the covering column names
+     * @return Builder
+     */
+    public Builder setIncludeColumns(List<String> includeColumns) {
+      this.includeColumns = includeColumns;
+      return this;
+    }
+
     public VectorIndexParams build() {
       return new VectorIndexParams(this);
     }
@@ -268,6 +291,16 @@ public class VectorIndexParams {
     return rqParams;
   }
 
+  /**
+   * Get the covering ("included") columns whose values are stored inline in the index. Empty when
+   * the index has no covering columns.
+   *
+   * @return the covering column names
+   */
+  public List<String> getIncludeColumns() {
+    return includeColumns;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -277,6 +310,7 @@ public class VectorIndexParams {
         .add("hnswParams", hnswParams.orElse(null))
         .add("sqParams", sqParams.orElse(null))
         .add("rqParams", rqParams.orElse(null))
+        .add("includeColumns", includeColumns)
         .toString();
   }
 }

--- a/java/src/test/java/org/lance/TransactionTest.java
+++ b/java/src/test/java/org/lance/TransactionTest.java
@@ -73,6 +73,14 @@ public class TransactionTest {
         assertTrue(
             op.getRemovedIndices().isEmpty(), "removedIndices should be empty for CreateIndex");
         assertEquals("btree_id_index", (op.getNewIndices().get(0).name()));
+        // Covering columns round-trip from Rust: a plain btree index covers nothing, so
+        // the list is present (never null) and empty.
+        assertNotNull(
+            op.getNewIndices().get(0).includedFields(),
+            "includedFields should be present (empty), not null");
+        assertTrue(
+            op.getNewIndices().get(0).includedFields().isEmpty(),
+            "a non-covering index should report no included fields");
       }
     }
   }

--- a/java/src/test/java/org/lance/index/VectorIndexTest.java
+++ b/java/src/test/java/org/lance/index/VectorIndexTest.java
@@ -27,12 +27,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VectorIndexTest {
@@ -309,6 +312,106 @@ public class VectorIndexTest {
         assertTrue(
             indexType == IndexType.VECTOR || indexType == IndexType.IVF_RQ,
             "IndexType for IVF_RQ index should be VECTOR or IVF_RQ but was " + indexType);
+      }
+    }
+  }
+
+  /**
+   * {@code includeColumns} must be a defensive, unmodifiable copy: mutating the list the caller
+   * passed to the builder (or the list the getter returns) must not change the params, so the JNI
+   * read at build time sees exactly what was requested.
+   */
+  @Test
+  public void testIncludeColumnsIsDefensivelyCopied() {
+    IvfBuildParams ivf = new IvfBuildParams.Builder().setNumPartitions(2).build();
+    List<String> cols = new ArrayList<>();
+    cols.add("i");
+    VectorIndexParams params = new VectorIndexParams.Builder(ivf).setIncludeColumns(cols).build();
+
+    // Mutating the caller's list after build must not affect the params.
+    cols.add("s");
+    cols.clear();
+    assertEquals(
+        Collections.singletonList("i"),
+        params.getIncludeColumns(),
+        "include columns must be a defensive copy, unaffected by caller mutation");
+
+    // The returned list must be unmodifiable.
+    assertThrows(UnsupportedOperationException.class, () -> params.getIncludeColumns().add("x"));
+  }
+
+  /**
+   * {@code Index.includedFields} must be a defensive, unmodifiable copy, matching {@code
+   * VectorIndexParams.includeColumns}: mutating the caller's list (or the list the getter returns)
+   * must not change the value object -- equals/hashCode would silently drift, and a later JNI
+   * commit would read mutated covering metadata while the index files still carry the payload.
+   */
+  @Test
+  public void testIndexIncludedFieldsIsDefensivelyCopied() {
+    List<Integer> ids = new ArrayList<>();
+    ids.add(3);
+    Index index =
+        Index.builder()
+            .uuid(UUID.randomUUID())
+            .fields(Collections.singletonList(0))
+            .name("covered_idx")
+            .datasetVersion(1L)
+            .indexVersion(0)
+            .includedFields(ids)
+            .build();
+
+    // Mutating the caller's list after build must not affect the index.
+    ids.add(7);
+    ids.clear();
+    assertEquals(
+        Collections.singletonList(3),
+        index.includedFields(),
+        "included fields must be a defensive copy, unaffected by caller mutation");
+
+    // The returned list must be unmodifiable.
+    assertThrows(UnsupportedOperationException.class, () -> index.includedFields().add(9));
+  }
+
+  /**
+   * A covered ("included") column set on {@link VectorIndexParams} must be threaded through the JNI
+   * create path into the built index's metadata, so the committed index reports the covered field
+   * id. Without the wiring the index would build but silently carry no covering columns.
+   */
+  @Test
+  public void testCreateIvfFlatIndexWithCoveringColumns(@TempDir Path tempDir) throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("ivf_flat_covering"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        IvfBuildParams ivf = new IvfBuildParams.Builder().setNumPartitions(2).build();
+
+        // Cover the non-vector "i" column so a projection of it is answered from the index.
+        VectorIndexParams vectorIndexParams =
+            new VectorIndexParams.Builder(ivf)
+                .setDistanceType(DistanceType.L2)
+                .setIncludeColumns(Collections.singletonList("i"))
+                .build();
+        IndexParams indexParams =
+            IndexParams.builder().setVectorIndexParams(vectorIndexParams).build();
+
+        dataset.createIndex(
+            IndexOptions.builder(
+                    Collections.singletonList(TestVectorDataset.vectorColumnName),
+                    IndexType.IVF_FLAT,
+                    indexParams)
+                .withIndexName(TestVectorDataset.indexName)
+                .build());
+
+        Index covered =
+            dataset.getIndexes().stream()
+                .filter(idx -> TestVectorDataset.indexName.equals(idx.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(covered, "Expected covered IVF_FLAT index to be present");
+        assertEquals(
+            1,
+            covered.includedFields().size(),
+            "index should report exactly the one covering column that was requested; was "
+                + covered.includedFields());
       }
     }
   }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -276,7 +276,7 @@ message IndexMetadata {
   // - When Lance APIs refer to indexes they will use the type URL of the index details as the
   //   identifier for the index type.  If a user provides a simple string identifier like
   //   "btree" then it will be converted to "/lance.table.BTreeIndexDetails"
-  // - Type URLs comparisons are case-insensitive.  Thereform an index must have a unique type
+  // - Type URLs comparisons are case-insensitive.  Therefore an index must have a unique type
   //   URL ignoring case.
   google.protobuf.Any index_details = 6;
 
@@ -298,6 +298,12 @@ message IndexMetadata {
   // of index sizes without extra IO.
   // If this is empty, the index files sizes are unknown.
   repeated IndexFile files = 10;
+
+  // Columns co-located ("included") in the index alongside its key columns, so
+  // a query covered by them can be answered from the index without a take from
+  // the base table. These refer to file.Field.id, same as `fields`. Empty for
+  // indexes without covering columns.
+  repeated int32 included_fields = 11;
 }
 
 // Metadata about a single file within an index segment.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5767,6 +5767,8 @@ class Index:
     base_id: Optional[int] = None
     files: Optional[List["IndexFile"]] = None
     index_details: Optional[Tuple[str, bytes]] = None
+    included_fields: Optional[List[int]] = None
+    """Field ids this index covers (stores inline) beyond its indexed key column."""
 
 
 class IndexInformation(TypedDict):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3700,6 +3700,7 @@ class LanceDataset(pa.dataset.Dataset):
         streaming_refine_passes: Optional[int] = None,
         skip_transpose: bool = False,
         rabitq_model: Optional[str] = None,
+        include_columns: Optional[List[str]] = None,
         require_commit: bool = True,
         **kwargs,
     ) -> Index:
@@ -4028,6 +4029,9 @@ class LanceDataset(pa.dataset.Dataset):
         if rabitq_model is not None:
             kwargs["rabitq_model"] = rabitq_model
 
+        if include_columns is not None:
+            kwargs["include_columns"] = include_columns
+
         # Add fragment_ids and index_uuid to kwargs if provided for
         # distributed indexing
         if fragment_ids is not None:
@@ -4088,6 +4092,7 @@ class LanceDataset(pa.dataset.Dataset):
         streaming_coreset_rate: Optional[int] = None,
         streaming_refine_passes: Optional[int] = None,
         skip_transpose: bool = False,
+        include_columns: Optional[List[str]] = None,
         progress_callback: Optional[Callable[[IndexProgress], None]] = None,
         **kwargs,
     ) -> LanceDataset:
@@ -4157,6 +4162,12 @@ class LanceDataset(pa.dataset.Dataset):
             If True, the index will be trained on the data (e.g., compute IVF
             centroids, PQ codebooks). If False, an empty index structure will be
             created without training, which can be populated later.
+        include_columns : List[str], optional
+            Names of extra dataset columns to cover ("include") in a vector index.
+            Their values are stored inline in the index so a query projecting only
+            covered columns is answered from the index without a take from the base
+            table. Each must be a top-level, non-key column; the columns are
+            validated by the core when the index is built. Vector indexes only.
         fragment_ids : List[int], optional
             If provided, the index will be created only on the specified fragments.
             This enables distributed/fragment-level indexing. When provided, the
@@ -4323,6 +4334,7 @@ class LanceDataset(pa.dataset.Dataset):
             streaming_coreset_rate=streaming_coreset_rate,
             streaming_refine_passes=streaming_refine_passes,
             skip_transpose=skip_transpose,
+            include_columns=include_columns,
             require_commit=True,
             **kwargs,
         )
@@ -4361,6 +4373,7 @@ class LanceDataset(pa.dataset.Dataset):
         streaming_refine_passes: Optional[int] = None,
         skip_transpose: bool = False,
         rabitq_model: Optional[str] = None,
+        include_columns: Optional[List[str]] = None,
         **kwargs,
     ) -> Index:
         """
@@ -4469,6 +4482,7 @@ class LanceDataset(pa.dataset.Dataset):
             streaming_refine_passes=streaming_refine_passes,
             skip_transpose=skip_transpose,
             rabitq_model=rabitq_model,
+            include_columns=include_columns,
             require_commit=False,
             **kwargs,
         )

--- a/python/python/lance/lance/indices/__init__.pyi
+++ b/python/python/lance/lance/indices/__init__.pyi
@@ -79,6 +79,7 @@ class IndexSegmentDescription:
     created_at: Optional[datetime]
     size_bytes: Optional[int]
     base_id: Optional[int]
+    included_fields: list[int]
 
     def __repr__(self) -> str: ...
 
@@ -89,6 +90,8 @@ class IndexDescription:
     num_rows_indexed: int
     fields: list[int]
     field_names: list[str]
+    included_fields: list[int]
+    included_field_names: list[str]
     segments: list[IndexSegmentDescription]
     details: dict
     total_size_bytes: Optional[int]

--- a/python/python/tests/test_commit_index.py
+++ b/python/python/tests/test_commit_index.py
@@ -181,6 +181,209 @@ def test_commit_index_with_files(dataset_with_index, test_table, tmp_path):
     assert files_by_path["auxiliary.bin"] == 2048
 
 
+def test_commit_index_with_included_fields(dataset_with_index, test_table, tmp_path):
+    """Test that included_fields (covering columns) round-trip through the Python
+    transaction bindings."""
+    from lance.dataset import Index
+
+    original_desc = dataset_with_index.describe_indices()[0]
+    index_id = original_desc.segments[0].uuid
+
+    dataset_without_index = lance.write_dataset(
+        test_table, tmp_path / "dataset_without_index"
+    )
+    src_index_dir = Path(dataset_with_index.uri) / "_indices" / index_id
+    dest_index_dir = Path(dataset_without_index.uri) / "_indices" / index_id
+    shutil.copytree(src_index_dir, dest_index_dir)
+
+    meta_id = _get_field_id_by_name(dataset_without_index.lance_schema, "meta")
+    price_id = _get_field_id_by_name(dataset_without_index.lance_schema, "price")
+
+    # Declare "price" as a covering (included) column on the index.
+    index = Index(
+        uuid=index_id,
+        name="meta_idx",
+        fields=[meta_id],
+        dataset_version=dataset_without_index.version,
+        fragment_ids=set(
+            [f.fragment_id for f in dataset_without_index.get_fragments()]
+        ),
+        index_version=0,
+        included_fields=[price_id],
+    )
+
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+    dataset_without_index = lance.LanceDataset.commit(
+        dataset_without_index.uri,
+        create_index_op,
+        read_version=dataset_without_index.version,
+    )
+
+    # Read back the transaction to verify the covering columns were stored.
+    transaction = dataset_without_index.get_transactions(1)[0]
+    committed_index = transaction.operation.new_indices[0]
+    assert committed_index.included_fields == [price_id]
+
+
+def test_commit_index_rejects_malformed_included_fields(
+    dataset_with_index, test_table, tmp_path
+):
+    """A malformed included_fields value must propagate an error, not be silently
+    coerced to an empty covering set -- otherwise the covered declaration and its
+    writer fence are dropped while the index files still carry payload columns."""
+    from lance.dataset import Index
+
+    original_desc = dataset_with_index.describe_indices()[0]
+    index_id = original_desc.segments[0].uuid
+
+    dataset_without_index = lance.write_dataset(
+        test_table, tmp_path / "dataset_without_index"
+    )
+    src_index_dir = Path(dataset_with_index.uri) / "_indices" / index_id
+    dest_index_dir = Path(dataset_without_index.uri) / "_indices" / index_id
+    shutil.copytree(src_index_dir, dest_index_dir)
+
+    meta_id = _get_field_id_by_name(dataset_without_index.lance_schema, "meta")
+
+    # 2**40 is a valid Python int but overflows the i32 field-id type.
+    index = Index(
+        uuid=index_id,
+        name="meta_idx",
+        fields=[meta_id],
+        dataset_version=dataset_without_index.version,
+        fragment_ids=set(
+            [f.fragment_id for f in dataset_without_index.get_fragments()]
+        ),
+        index_version=0,
+        included_fields=[2**40],
+    )
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+    with pytest.raises((OverflowError, ValueError, TypeError)):
+        lance.LanceDataset.commit(
+            dataset_without_index.uri,
+            create_index_op,
+            read_version=dataset_without_index.version,
+        )
+
+
+def test_commit_index_propagates_raising_included_fields(
+    dataset_with_index, test_table, tmp_path
+):
+    """An `included_fields` access that raises (e.g. a lazy proxy whose deferred
+    load fails) must propagate the error. Swallowing it would commit an empty
+    covering set while the index files still carry the payload columns."""
+
+    class RaisingIndex:
+        def __init__(self, uuid, name, fields, dataset_version, fragment_ids):
+            self.uuid = uuid
+            self.name = name
+            self.fields = fields
+            self.dataset_version = dataset_version
+            self.fragment_ids = fragment_ids
+            self.index_version = 0
+            self.created_at = None
+            self.base_id = None
+            self.files = None
+
+        @property
+        def included_fields(self):
+            raise RuntimeError("deferred covering-column load failed")
+
+    original_desc = dataset_with_index.describe_indices()[0]
+    index_id = original_desc.segments[0].uuid
+
+    dataset_without_index = lance.write_dataset(
+        test_table, tmp_path / "dataset_without_index"
+    )
+    src_index_dir = Path(dataset_with_index.uri) / "_indices" / index_id
+    dest_index_dir = Path(dataset_without_index.uri) / "_indices" / index_id
+    shutil.copytree(src_index_dir, dest_index_dir)
+
+    meta_id = _get_field_id_by_name(dataset_without_index.lance_schema, "meta")
+    index = RaisingIndex(
+        uuid=index_id,
+        name="meta_idx",
+        fields=[meta_id],
+        dataset_version=dataset_without_index.version,
+        fragment_ids=set(
+            [f.fragment_id for f in dataset_without_index.get_fragments()]
+        ),
+    )
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+    with pytest.raises(RuntimeError, match="deferred covering-column load failed"):
+        lance.LanceDataset.commit(
+            dataset_without_index.uri,
+            create_index_op,
+            read_version=dataset_without_index.version,
+        )
+
+
+def test_commit_index_propagates_getter_attribute_error(
+    dataset_with_index, test_table, tmp_path
+):
+    """An AttributeError raised INSIDE an `included_fields` property getter (e.g. a
+    lazy proxy whose backing attribute is unset) must propagate -- it is not the same
+    as the attribute being absent, and swallowing it would commit an empty covering
+    set while the index files keep the payload columns."""
+
+    class LazyIndex:
+        def __init__(self, uuid, name, fields, dataset_version, fragment_ids):
+            self.uuid = uuid
+            self.name = name
+            self.fields = fields
+            self.dataset_version = dataset_version
+            self.fragment_ids = fragment_ids
+            self.index_version = 0
+            self.created_at = None
+            self.base_id = None
+            self.files = None
+
+        @property
+        def included_fields(self):
+            # `_inner` is never set: the getter itself raises AttributeError.
+            return self._inner.included_fields
+
+    original_desc = dataset_with_index.describe_indices()[0]
+    index_id = original_desc.segments[0].uuid
+
+    dataset_without_index = lance.write_dataset(
+        test_table, tmp_path / "dataset_without_index"
+    )
+    src_index_dir = Path(dataset_with_index.uri) / "_indices" / index_id
+    dest_index_dir = Path(dataset_without_index.uri) / "_indices" / index_id
+    shutil.copytree(src_index_dir, dest_index_dir)
+
+    meta_id = _get_field_id_by_name(dataset_without_index.lance_schema, "meta")
+    index = LazyIndex(
+        uuid=index_id,
+        name="meta_idx",
+        fields=[meta_id],
+        dataset_version=dataset_without_index.version,
+        fragment_ids=set(
+            [f.fragment_id for f in dataset_without_index.get_fragments()]
+        ),
+    )
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+    with pytest.raises(AttributeError, match="_inner"):
+        lance.LanceDataset.commit(
+            dataset_without_index.uri,
+            create_index_op,
+            read_version=dataset_without_index.version,
+        )
+
+
 def test_commit_index_with_index_details(dataset_with_index, test_table, tmp_path):
     """Test that index_details round-trip through Python transaction bindings."""
     from lance.dataset import Index

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -309,6 +309,43 @@ def test_ann(indexed_dataset):
     run(indexed_dataset)
 
 
+def test_create_index_with_included_columns(tmp_path):
+    """A covered ("included") column passed to create_index is threaded through the
+    PyO3 boundary into the built index's metadata, so the committed index reports the
+    covered field id. Without the wiring the index builds but carries no covering
+    columns."""
+    tbl = create_table()
+    dataset = lance.write_dataset(tbl, tmp_path)
+
+    def field_id(name):
+        for field in dataset.lance_schema.fields():
+            if field.name() == name:
+                return field.id()
+        raise KeyError(name)
+
+    price_id = field_id("price")
+
+    dataset = dataset.create_index(
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=16,
+        include_columns=["price"],
+    )
+
+    # The CreateIndex transaction carries the built index's metadata, including the
+    # covered field ids.
+    created_index = dataset.get_transactions(1)[0].operation.new_indices[0]
+    assert created_index.included_fields == [price_id]
+
+    # The covering state is also visible through the index descriptions, so users
+    # can see which columns an index covers without replaying transactions.
+    desc = dataset.describe_indices()[0]
+    assert desc.included_fields == [price_id]
+    assert desc.included_field_names == ["price"]
+    assert desc.segments[0].included_fields == [price_id]
+
+
 def test_create_index_progress_callback_vector(tmp_path):
     ds = _make_sample_dataset_base(tmp_path, "vector_progress", 1500, 128)
     recorder = ProgressRecorder()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4847,6 +4847,7 @@ fn prepare_vector_index_params(
     let mut rq_params = RQBuildParams::default();
     let mut index_file_version = IndexFileVersion::V3;
     let mut skip_transpose = false;
+    let mut include_columns: Vec<String> = Vec::new();
 
     if let Some(kwargs) = kwargs {
         // Parse metric type
@@ -5008,6 +5009,14 @@ fn prepare_vector_index_params(
         if let Some(value) = kwargs.get_item("skip_transpose")? {
             skip_transpose = value.extract()?;
         }
+
+        // Covering ("included") columns: names of extra dataset columns stored inline in the
+        // index. Empty when absent. The core validates them when the index is built.
+        if let Some(cols) = kwargs.get_item("include_columns")?
+            && !cols.is_none()
+        {
+            include_columns = cols.extract()?;
+        }
     }
 
     let mut params = match index_type {
@@ -5053,6 +5062,7 @@ fn prepare_vector_index_params(
     }?;
     params.version(index_file_version);
     params.skip_transpose(skip_transpose);
+    params.include_columns(include_columns);
     if let Some(kwargs) = kwargs
         && let Some(acc) = kwargs.get_item("accelerator")?
     {

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -542,6 +542,7 @@ async fn do_load_shuffled_vectors(
         created_at: Some(Utc::now()),
         base_id: None,
         files: Some(files),
+        included_fields: Vec::new(),
     };
     ds.commit_existing_index_segments(index_name, column, vec![metadata])
         .await

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -542,6 +542,10 @@ async fn do_load_shuffled_vectors(
         created_at: Some(Utc::now()),
         base_id: None,
         files: Some(files),
+        // Correct, not a gap: pre-shuffled vector files never carry covering ("included")
+        // columns, so an empty declaration matches what this segment's storage actually holds.
+        // Making this path build covering segments means threading them through the shuffle,
+        // not populating this field.
         included_fields: Vec::new(),
     };
     ds.commit_existing_index_segments(index_name, column, vec![metadata])
@@ -625,6 +629,9 @@ pub struct PyIndexSegmentDescription {
     /// The id of the dataset base path that stores this segment
     /// (None when the segment is stored in the dataset's default base path)
     pub base_id: Option<i64>,
+    /// The ids of the covering ("included") fields whose values are co-located in
+    /// this segment's storage. Empty for segments without covering columns.
+    pub included_fields: Vec<i32>,
 }
 
 impl PyIndexSegmentDescription {
@@ -644,19 +651,21 @@ impl PyIndexSegmentDescription {
             created_at: segment.created_at,
             size_bytes,
             base_id: segment.base_id.map(|id| id as i64),
+            included_fields: segment.included_fields.clone(),
         }
     }
 
     pub fn __repr__(&self) -> String {
         format!(
-            "IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?}, size_bytes={:?}, base_id={:?})",
+            "IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?}, size_bytes={:?}, base_id={:?}, included_fields={:?})",
             self.uuid,
             self.dataset_version_at_last_update,
             self.fragment_ids,
             self.index_version,
             self.created_at,
             self.size_bytes,
-            self.base_id
+            self.base_id,
+            self.included_fields
         )
     }
 }
@@ -678,6 +687,12 @@ pub struct PyIndexDescription {
     pub num_rows_indexed: u64,
     /// The details of the index
     pub details: PyJson,
+    /// The ids of the covering ("included") fields the index co-locates alongside
+    /// its key fields, so covered queries can skip the base-table take. Empty for
+    /// indexes without covering columns. All segments of one index share the set.
+    pub included_fields: Vec<i32>,
+    /// The resolved names of `included_fields` in the current schema.
+    pub included_field_names: Vec<String>,
     /// The segments of the index
     pub segments: Vec<PyIndexSegmentDescription>,
     /// The total size in bytes of all files across all segments
@@ -698,10 +713,26 @@ impl PyIndexDescription {
             })
             .collect();
 
-        let segments = index
+        let segments: Vec<PyIndexSegmentDescription> = index
             .metadata()
             .iter()
             .map(PyIndexSegmentDescription::from_metadata)
+            .collect();
+
+        // All segments of one logical index declare the same covering columns
+        // (enforced at every commit boundary), so the first segment is authoritative.
+        let included_fields = segments
+            .first()
+            .map(|segment| segment.included_fields.clone())
+            .unwrap_or_default();
+        let included_field_names = included_fields
+            .iter()
+            .map(|field| {
+                dataset
+                    .schema()
+                    .field_path_minimal(*field)
+                    .unwrap_or_else(|_| "<unknown>".to_string())
+            })
             .collect();
 
         let details = index.details().unwrap_or_else(|_| "{}".to_string());
@@ -711,6 +742,8 @@ impl PyIndexDescription {
             fields: index.field_ids().to_vec(),
             field_names,
             index_type: index.index_type().to_string(),
+            included_fields,
+            included_field_names,
             segments,
             type_url: index.type_url().to_string(),
             num_rows_indexed: index.rows_indexed(),

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -22,6 +22,32 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// `getattr` that treats only a missing attribute as absent. Any exception raised
+/// during attribute access -- e.g. a property whose deferred load fails -- must
+/// propagate rather than be coerced to a default. This includes an `AttributeError`
+/// raised INSIDE a property getter (the classic `getattr`/`hasattr` masking pitfall):
+/// when the attribute is defined on the object's type, an `AttributeError` cannot
+/// mean "absent", so it propagates too.
+fn getattr_optional<'py>(
+    ob: &Bound<'py, PyAny>,
+    name: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    match ob.getattr(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(err) if err.is_instance_of::<pyo3::exceptions::PyAttributeError>(ob.py()) => {
+            // Looking the name up on the TYPE returns a descriptor (e.g. the property
+            // object) without invoking the instance getter, so this is side-effect
+            // free even for raising properties.
+            if ob.get_type().hasattr(name)? {
+                Err(err)
+            } else {
+                Ok(None)
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
 // IndexFile bindings
 impl FromPyObject<'_, '_> for PyLance<IndexFile> {
     type Error = PyErr;
@@ -87,11 +113,22 @@ impl FromPyObject<'_, '_> for PyLance<IndexMetadata> {
             .getattr("files")?
             .extract::<Option<Vec<PyLance<IndexFile>>>>()?
             .map(|v| v.into_iter().map(|f| f.0).collect());
-        let index_details = match ob.getattr("index_details") {
-            Ok(details) => details
+        let index_details = match getattr_optional(&ob, "index_details")? {
+            Some(details) => details
                 .extract::<Option<(String, Vec<u8>)>>()?
                 .map(|(type_url, value)| Arc::new(prost_types::Any { type_url, value })),
-            Err(_) => None,
+            None => None,
+        };
+
+        // Covering columns are optional: tolerate objects that predate the field (a missing
+        // attribute), and treat an explicit `None` as empty. But a *malformed* value (a
+        // non-integer or an out-of-range element) or an access that *raises* must
+        // propagate -- silently coercing it to an empty list would drop the covered
+        // declaration and its writer fence while the index files still carry the payload
+        // columns. Mirrors `index_details` above.
+        let included_fields: Vec<i32> = match getattr_optional(&ob, "included_fields")? {
+            Some(value) => value.extract::<Option<Vec<i32>>>()?.unwrap_or_default(),
+            None => Vec::new(),
         };
 
         Ok(Self(IndexMetadata {
@@ -105,6 +142,7 @@ impl FromPyObject<'_, '_> for PyLance<IndexMetadata> {
             created_at,
             base_id,
             files,
+            included_fields,
         }))
     }
 }
@@ -147,6 +185,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&IndexMetadata> {
             .index_details
             .as_ref()
             .map(|details| (details.type_url.clone(), details.value.clone()));
+        let included_fields = self.0.included_fields.clone();
 
         let cls = namespace
             .getattr("Index")
@@ -162,6 +201,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&IndexMetadata> {
             base_id,
             files,
             index_details,
+            included_fields,
         ))
     }
 }

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
 use crate::vector::ApproxMode;
+use crate::vector::PART_ID_COLUMN;
 use crate::vector::bq::dist_table_quant::{
     DistTableDequant, quantize_dist_table_into, quantize_dist_table_u16_into,
 };
@@ -64,6 +65,7 @@ use crate::vector::pq::storage::transpose;
 use crate::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use crate::vector::storage::{
     DistCalculator, DistanceCalculatorOptions, QueryResidual, RabitRawQueryContext, VectorStore,
+    covering_field_indices_excluding,
 };
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
@@ -2048,6 +2050,29 @@ impl VectorStore for RabitQuantizationStorage {
         self.batch.schema_ref()
     }
 
+    /// RQ storage carries the row id plus many internal columns (the binary codes, the
+    /// extended-bit codes, and the per-row factor columns, some present only for higher
+    /// `num_bits`); the covering ("included") columns are everything else.
+    fn covering_field_indices(&self) -> Vec<usize> {
+        // Every RaBitQ-internal column plus the legacy `__ivf_part_id` column
+        // (left in pre-#3606 single-partition builds; unlike PQ, RaBitQ storage
+        // does not drop it at construction, so it is excluded here). Anything
+        // else is a user-declared covering column.
+        const INTERNAL: &[&str] = &[
+            ROW_ID,
+            RABIT_CODE_COLUMN,
+            RABIT_EX_CODE_COLUMN,
+            RABIT_BLOCKED_EX_CODE_COLUMN,
+            ADD_FACTORS_COLUMN,
+            SCALE_FACTORS_COLUMN,
+            ERROR_FACTORS_COLUMN,
+            EX_ADD_FACTORS_COLUMN,
+            EX_SCALE_FACTORS_COLUMN,
+            PART_ID_COLUMN,
+        ];
+        covering_field_indices_excluding(self.schema().as_ref(), INTERNAL)
+    }
+
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch> + Send> {
         Ok(std::iter::once(self.batch.clone()))
     }
@@ -3026,6 +3051,39 @@ mod tests {
             ),
         ])
         .unwrap()
+    }
+
+    #[test]
+    fn test_covering_excludes_legacy_part_id_column() {
+        // Same legacy `__ivf_part_id` guard as the other quantizer storages:
+        // pre-#3606 `num_partitions=1` builds left it in the storage file, and
+        // it must never be classified as a covering column -- otherwise search
+        // emits a column the exec's declared schema (from
+        // `IndexMetadata.included_fields`, empty for those indexes) lacks.
+        use crate::vector::PART_ID_COLUMN;
+        use arrow_array::UInt32Array;
+        use arrow_schema::{DataType, Field, Schema};
+
+        let code_dim = 64;
+        let codes = make_test_codes(10, code_dim);
+        let metadata = make_test_metadata(codes.value_length() as usize * 8);
+        let base = make_test_batch(codes);
+
+        let mut fields: Vec<_> = base.schema().fields().iter().cloned().collect();
+        fields.push(Arc::new(Field::new(PART_ID_COLUMN, DataType::UInt32, true)));
+        let mut columns = base.columns().to_vec();
+        columns.push(Arc::new(UInt32Array::from_iter_values(
+            (0..base.num_rows()).map(|_| 0),
+        )) as ArrayRef);
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap();
+
+        let storage =
+            RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+                .unwrap();
+        assert!(
+            storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as a covering column"
+        );
     }
 
     fn make_test_ex_codes(num_vectors: usize, code_dim: usize, num_bits: u8) -> FixedSizeListArray {

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -65,7 +65,6 @@ use crate::vector::pq::storage::transpose;
 use crate::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use crate::vector::storage::{
     DistCalculator, DistanceCalculatorOptions, QueryResidual, RabitRawQueryContext, VectorStore,
-    covering_field_indices_excluding,
 };
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
@@ -78,6 +77,25 @@ pub const RABIT_EX_CODE_COLUMN: &str = "__ex_codes";
 /// older versions, which fail with a missing-column error instead of
 /// misinterpreting the bytes.
 pub const RABIT_BLOCKED_EX_CODE_COLUMN: &str = "__blocked_ex_codes";
+/// RaBitQ storage's internal (non-covering) column names: the row id, the binary code
+/// and extended-bit code columns, the per-row factor columns (some present only for
+/// higher `num_bits`), and the legacy `__ivf_part_id` column (left in pre-#3606
+/// single-partition builds; unlike PQ, RaBitQ storage does not drop it at
+/// construction). Every other column is a user-declared covering ("included") column.
+/// The single authority for this set -- the distributed shard merger classifies from
+/// it too, so a new factor column added here is excluded everywhere at once.
+pub const RABIT_INTERNAL_COLUMNS: &[&str] = &[
+    ROW_ID,
+    RABIT_CODE_COLUMN,
+    RABIT_EX_CODE_COLUMN,
+    RABIT_BLOCKED_EX_CODE_COLUMN,
+    ADD_FACTORS_COLUMN,
+    SCALE_FACTORS_COLUMN,
+    ERROR_FACTORS_COLUMN,
+    EX_ADD_FACTORS_COLUMN,
+    EX_SCALE_FACTORS_COLUMN,
+    PART_ID_COLUMN,
+];
 pub const SEGMENT_LENGTH: usize = 4;
 pub const SEGMENT_NUM_CODES: usize = 1 << SEGMENT_LENGTH;
 const RABIT_PRUNE_STATS_ENV: &str = "LANCE_RQ_PRUNE_STATS";
@@ -2042,35 +2060,15 @@ fn accumulate_filtered_distances_into_heap(
 impl VectorStore for RabitQuantizationStorage {
     type DistanceCalculator<'a> = RabitDistCalculator<'a>;
 
+    /// RaBitQ storage is `[_rowid, <code/factor cols...>, <included cols...>]`.
+    const INTERNAL_COLUMNS: &'static [&'static str] = RABIT_INTERNAL_COLUMNS;
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
-    }
-
-    /// RQ storage carries the row id plus many internal columns (the binary codes, the
-    /// extended-bit codes, and the per-row factor columns, some present only for higher
-    /// `num_bits`); the covering ("included") columns are everything else.
-    fn covering_field_indices(&self) -> Vec<usize> {
-        // Every RaBitQ-internal column plus the legacy `__ivf_part_id` column
-        // (left in pre-#3606 single-partition builds; unlike PQ, RaBitQ storage
-        // does not drop it at construction, so it is excluded here). Anything
-        // else is a user-declared covering column.
-        const INTERNAL: &[&str] = &[
-            ROW_ID,
-            RABIT_CODE_COLUMN,
-            RABIT_EX_CODE_COLUMN,
-            RABIT_BLOCKED_EX_CODE_COLUMN,
-            ADD_FACTORS_COLUMN,
-            SCALE_FACTORS_COLUMN,
-            ERROR_FACTORS_COLUMN,
-            EX_ADD_FACTORS_COLUMN,
-            EX_SCALE_FACTORS_COLUMN,
-            PART_ID_COLUMN,
-        ];
-        covering_field_indices_excluding(self.schema().as_ref(), INTERNAL)
     }
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch> + Send> {

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use crate::IndexMetadata as IndexMetaSchema;
 use crate::pb;
 use crate::vector::bq::storage::{
-    RABIT_CODE_COLUMN, RABIT_METADATA_KEY, RabitQuantizationMetadata, RabitQueryEstimator,
-    pack_codes, rabit_binary_code_field, rabit_ex_code_field,
+    RABIT_CODE_COLUMN, RABIT_INTERNAL_COLUMNS, RABIT_METADATA_KEY, RabitQuantizationMetadata,
+    RabitQueryEstimator, pack_codes, rabit_binary_code_field, rabit_ex_code_field,
 };
 use crate::vector::bq::transform::{
     ADD_FACTORS_FIELD, ERROR_FACTORS_FIELD, EX_ADD_FACTORS_FIELD, EX_SCALE_FACTORS_FIELD,
@@ -29,14 +29,20 @@ use crate::vector::bq::transform::{
 };
 use crate::vector::bq::validate_rq_num_bits;
 use crate::vector::flat::index::FlatMetadata;
+use crate::vector::flat::storage::{FLAT_COLUMN, FLAT_INTERNAL_COLUMNS};
 use crate::vector::ivf::storage::{IVF_METADATA_KEY, IvfModel as IvfStorageModel};
-use crate::vector::pq::storage::{PQ_METADATA_KEY, ProductQuantizationMetadata, transpose};
+use crate::vector::pq::storage::{
+    PQ_INTERNAL_COLUMNS, PQ_METADATA_KEY, ProductQuantizationMetadata, transpose,
+};
 use crate::vector::quantizer::QuantizerMetadata;
-use crate::vector::sq::storage::{SQ_METADATA_KEY, ScalarQuantizationMetadata};
+use crate::vector::sq::storage::{
+    SQ_INTERNAL_COLUMNS, SQ_METADATA_KEY, ScalarQuantizationMetadata,
+};
 use crate::vector::storage::STORAGE_METADATA_KEY;
+use crate::vector::storage::{COVERING_FIELD_IDS_KEY, covering_field_indices_excluding};
 use crate::vector::{DISTANCE_TYPE_KEY, PQ_CODE_COLUMN, SQ_CODE_COLUMN};
 use crate::{INDEX_AUXILIARY_FILE_NAME, INDEX_METADATA_SCHEMA_KEY};
-use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use bytes::Bytes;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_file::reader::{FileReader as V2Reader, FileReaderOptions as V2ReaderOptions};
@@ -248,6 +254,34 @@ fn init_writer_for_storage(
     Ok(())
 }
 
+/// The covering ("included") columns carried in a shard's auxiliary storage schema: every
+/// field that is not the row id or one of the quantizer's internal code/factor columns (or the
+/// legacy `__ivf_part_id`). The merger rebuilds the unified output schema from quantizer
+/// metadata (it reshapes the code column via the transpose), so these fields must be
+/// re-appended or the covered payload is silently dropped from the merged index. All shards
+/// share the same covering set, so the first shard's schema is authoritative.
+fn covering_fields_from_shard_schema(
+    schema: &ArrowSchema,
+    index_type: SupportedIvfIndexType,
+) -> Vec<FieldRef> {
+    use SupportedIvfIndexType::*;
+    // Each storage's exported internal set already excludes PART_ID_COLUMN, which
+    // matters here: a legacy PQ shard's raw aux schema may still physically carry
+    // `__ivf_part_id` even though PQ storage drops it at load, so classifying from
+    // the raw schema (pre-load) must exclude it or it would be wrongly classified
+    // as a covering column.
+    let internal: &[&str] = match index_type {
+        IvfPq | IvfHnswPq => PQ_INTERNAL_COLUMNS,
+        IvfSq | IvfHnswSq => SQ_INTERNAL_COLUMNS,
+        IvfFlat | IvfHnswFlat => FLAT_INTERNAL_COLUMNS,
+        IvfRq => RABIT_INTERNAL_COLUMNS,
+    };
+    covering_field_indices_excluding(schema, internal)
+        .into_iter()
+        .map(|i| schema.fields()[i].clone())
+        .collect()
+}
+
 /// Create and initialize a unified writer for FLAT storage.
 pub async fn init_writer_for_flat(
     object_store: &lance_io::object_store::ObjectStore,
@@ -256,18 +290,21 @@ pub async fn init_writer_for_flat(
     item_type: &DataType,
     dt: DistanceType,
     format_version: ConcreteFileVersion,
+    covering_fields: &[FieldRef],
 ) -> Result<FileWriter> {
-    let arrow_schema = ArrowSchema::new(vec![
+    let mut fields = vec![
         (*ROW_ID_FIELD).clone(),
         Field::new(
-            crate::vector::flat::storage::FLAT_COLUMN,
+            FLAT_COLUMN,
             DataType::FixedSizeList(
                 Arc::new(Field::new("item", item_type.clone(), true)),
                 d0 as i32,
             ),
             true,
         ),
-    ]);
+    ];
+    fields.extend(covering_fields.iter().map(|f| f.as_ref().clone()));
+    let arrow_schema = ArrowSchema::new(fields);
     let writer = object_store.create(aux_out).await?;
     let mut w = versions::create_writer(
         format_version,
@@ -290,13 +327,14 @@ pub async fn init_writer_for_pq(
     dt: DistanceType,
     pm: &ProductQuantizationMetadata,
     format_version: ConcreteFileVersion,
+    covering_fields: &[FieldRef],
 ) -> Result<FileWriter> {
     let num_bytes = if pm.nbits == 4 {
         pm.num_sub_vectors / 2
     } else {
         pm.num_sub_vectors
     };
-    let arrow_schema = ArrowSchema::new(vec![
+    let mut fields = vec![
         (*ROW_ID_FIELD).clone(),
         Field::new(
             PQ_CODE_COLUMN,
@@ -306,7 +344,9 @@ pub async fn init_writer_for_pq(
             ),
             true,
         ),
-    ]);
+    ];
+    fields.extend(covering_fields.iter().map(|f| f.as_ref().clone()));
+    let arrow_schema = ArrowSchema::new(fields);
     let writer = object_store.create(aux_out).await?;
     let mut w = versions::create_writer(
         format_version,
@@ -335,9 +375,10 @@ pub async fn init_writer_for_sq(
     dt: DistanceType,
     sq_meta: &ScalarQuantizationMetadata,
     format_version: ConcreteFileVersion,
+    covering_fields: &[FieldRef],
 ) -> Result<FileWriter> {
     let d0 = sq_meta.dim;
-    let arrow_schema = ArrowSchema::new(vec![
+    let mut fields = vec![
         (*ROW_ID_FIELD).clone(),
         Field::new(
             SQ_CODE_COLUMN,
@@ -347,7 +388,9 @@ pub async fn init_writer_for_sq(
             ),
             true,
         ),
-    ]);
+    ];
+    fields.extend(covering_fields.iter().map(|f| f.as_ref().clone()));
+    let arrow_schema = ArrowSchema::new(fields);
     let writer = object_store.create(aux_out).await?;
     let mut w = versions::create_writer(
         format_version,
@@ -367,6 +410,7 @@ pub async fn init_writer_for_rq(
     dt: DistanceType,
     rq_meta: &RabitQuantizationMetadata,
     format_version: ConcreteFileVersion,
+    covering_fields: &[FieldRef],
 ) -> Result<FileWriter> {
     let mut fields = vec![
         (*ROW_ID_FIELD).clone(),
@@ -382,6 +426,7 @@ pub async fn init_writer_for_rq(
         fields.push(EX_ADD_FACTORS_FIELD.clone());
         fields.push(EX_SCALE_FACTORS_FIELD.clone());
     }
+    fields.extend(covering_fields.iter().map(|f| f.as_ref().clone()));
     let arrow_schema = ArrowSchema::new(fields);
     let writer = object_store.create(aux_out).await?;
     let mut w = versions::create_writer(
@@ -810,6 +855,11 @@ pub async fn merge_partial_vector_auxiliary_files(
     let mut nlist_opt: Option<usize> = None;
     let mut accumulated_lengths: Vec<u32> = Vec::new();
     let mut first_centroids: Option<FixedSizeListArray> = None;
+    // Covering ("included") columns of the first shard, used as the authoritative set every
+    // later shard must match (see the per-shard check below).
+    // (covering fields, source dataset field ids) of the first shard; every later
+    // shard must match both.
+    let mut first_covering_fields: Option<(Vec<FieldRef>, Option<String>)> = None;
 
     // Track per-shard readers, IVF lengths, and precomputed partition offsets.
     // This avoids reopening each shard file for every partition during merge.
@@ -956,6 +1006,68 @@ pub async fn merge_partial_vector_auxiliary_files(
         // Preserve the historical fallback while keeping the writer boundary exact.
         let fv = format_version.unwrap_or(ConcreteFileVersion::V2_0);
 
+        // Covering ("included") columns carried in this shard's storage. The unified writer
+        // schemas below are rebuilt from quantizer metadata, so these must be re-appended or
+        // the covered payload is dropped from the merged index. The output schema is built
+        // from the *first* shard's covering fields and `concat_batches` combines columns
+        // positionally, so a later shard whose covering columns differ in name, type, or order
+        // would be silently stored under the first shard's names -> wrong covered values.
+        // Reject any such mismatch rather than corrupt the merged index.
+        let shard_arrow: ArrowSchema = reader.schema().as_ref().into();
+        let covering_fields = covering_fields_from_shard_schema(&shard_arrow, idx_type);
+        // Name and type alone cannot establish that two shards cover the *same logical
+        // column*: Arrow fields carry no Lance field id, and the ids in a shard's own
+        // Lance schema are file-local. A column dropped and re-added between two shard
+        // builds yields the same name and type under a different field id, and
+        // `concat_batches` would stack the old values under the new field. The build
+        // stamps the source field ids for exactly this comparison.
+        let covering_source_ids = reader
+            .metadata()
+            .file_schema
+            .metadata
+            .get(COVERING_FIELD_IDS_KEY)
+            .cloned();
+        if !covering_fields.is_empty() && covering_source_ids.is_none() {
+            return Err(Error::index(format!(
+                "Distributed merge: shard {idx} carries covering (included) columns but records \
+                 no source field ids, so it cannot be proven to cover the same fields as the \
+                 other shards. Rebuild the shard."
+            )));
+        }
+        match first_covering_fields.as_ref() {
+            None => {
+                first_covering_fields = Some((covering_fields.clone(), covering_source_ids.clone()))
+            }
+            Some((first, first_source_ids)) => {
+                let matches = first.len() == covering_fields.len()
+                    && first
+                        .iter()
+                        .zip(&covering_fields)
+                        .all(|(a, b)| a.name() == b.name() && a.data_type() == b.data_type())
+                    && *first_source_ids == covering_source_ids;
+                if !matches {
+                    let describe = |fields: &[FieldRef], source_ids: &Option<String>| {
+                        let names = fields
+                            .iter()
+                            .map(|f| format!("{}: {}", f.name(), f.data_type()))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        match source_ids {
+                            Some(ids) => format!("{names} (source field ids {ids})"),
+                            None => names,
+                        }
+                    };
+                    return Err(Error::index(format!(
+                        "Distributed merge: covering (included) columns differ across shards; \
+                         shard 0 has [{}] but shard {idx} has [{}]. All shards must declare the \
+                         same covering columns (same source fields, names, types, and order).",
+                        describe(first, first_source_ids),
+                        describe(&covering_fields, &covering_source_ids),
+                    )));
+                }
+            }
+        }
+
         match idx_type {
             SupportedIvfIndexType::IvfSq => {
                 // Handle Scalar Quantization (SQ) storage for IVF_SQ
@@ -1009,8 +1121,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                     sq_meta = Some(sq_meta_parsed.clone());
                 }
                 if v2w_opt.is_none() {
-                    let w =
-                        init_writer_for_sq(object_store, &aux_out, dt, &sq_meta_parsed, fv).await?;
+                    let w = init_writer_for_sq(
+                        object_store,
+                        &aux_out,
+                        dt,
+                        &sq_meta_parsed,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1117,8 +1236,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                     rq_meta = Some(rq_meta_parsed.clone());
                 }
                 if v2w_opt.is_none() {
-                    let w =
-                        init_writer_for_rq(object_store, &aux_out, dt, &rq_meta_parsed, fv).await?;
+                    let w = init_writer_for_rq(
+                        object_store,
+                        &aux_out,
+                        dt,
+                        &rq_meta_parsed,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1217,8 +1343,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if v2w_opt.is_none() {
                     let mut pm_for_unified = pm.clone();
                     pm_for_unified.transposed = true;
-                    let w =
-                        init_writer_for_pq(object_store, &aux_out, dt, &pm_for_unified, fv).await?;
+                    let w = init_writer_for_pq(
+                        object_store,
+                        &aux_out,
+                        dt,
+                        &pm_for_unified,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1246,8 +1379,16 @@ pub async fn merge_partial_vector_auxiliary_files(
                     return Err(Error::index("Dimension mismatch across shards".to_string()));
                 }
                 if v2w_opt.is_none() {
-                    let w = init_writer_for_flat(object_store, &aux_out, d0, &item_type, dt, fv)
-                        .await?;
+                    let w = init_writer_for_flat(
+                        object_store,
+                        &aux_out,
+                        d0,
+                        &item_type,
+                        dt,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1279,8 +1420,16 @@ pub async fn merge_partial_vector_auxiliary_files(
                     return Err(Error::index("Dimension mismatch across shards".to_string()));
                 }
                 if v2w_opt.is_none() {
-                    let w = init_writer_for_flat(object_store, &aux_out, d0, &item_type, dt, fv)
-                        .await?;
+                    let w = init_writer_for_flat(
+                        object_store,
+                        &aux_out,
+                        d0,
+                        &item_type,
+                        dt,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1375,8 +1524,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if v2w_opt.is_none() {
                     let mut pm_for_unified = pm.clone();
                     pm_for_unified.transposed = true;
-                    let w =
-                        init_writer_for_pq(object_store, &aux_out, dt, &pm_for_unified, fv).await?;
+                    let w = init_writer_for_pq(
+                        object_store,
+                        &aux_out,
+                        dt,
+                        &pm_for_unified,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1427,8 +1583,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                     sq_meta = Some(sq_meta_parsed.clone());
                 }
                 if v2w_opt.is_none() {
-                    let w =
-                        init_writer_for_sq(object_store, &aux_out, dt, &sq_meta_parsed, fv).await?;
+                    let w = init_writer_for_sq(
+                        object_store,
+                        &aux_out,
+                        dt,
+                        &sq_meta_parsed,
+                        fv,
+                        &covering_fields,
+                    )
+                    .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1604,6 +1767,15 @@ pub async fn merge_partial_vector_auxiliary_files(
         };
         for len in accumulated_lengths.iter() {
             ivf_model.add_partition(*len);
+        }
+        // Carry the covering provenance onto the merged output. Every shard has already
+        // been checked to agree on this stamp, so the first shard's value IS the merged
+        // file's value. Without it the merged segment carries covering columns but no
+        // source ids, and feeding it back in as a shard of a later hierarchical merge
+        // would be rejected by the very check that verified its inputs -- with an error
+        // telling the user to rebuild a shard the merger itself produced.
+        if let Some((_, Some(covering_source_ids))) = first_covering_fields.as_ref() {
+            w.add_schema_metadata(COVERING_FIELD_IDS_KEY, covering_source_ids.clone());
         }
         let dt2 = distance_type.ok_or_else(|| Error::index("Distance type missing".to_string()))?;
         write_unified_ivf_and_index_metadata(w, &ivf_model, dt2, idx_type_final).await?;

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -7,7 +7,7 @@ use super::index::FlatMetadata;
 use crate::frag_reuse::FragReuseIndex;
 use crate::vector::PART_ID_COLUMN;
 use crate::vector::quantizer::QuantizerStorage;
-use crate::vector::storage::{DistCalculator, VectorStore, covering_field_indices_excluding};
+use crate::vector::storage::{DistCalculator, VectorStore};
 use crate::vector::utils::do_prefetch;
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
@@ -25,6 +25,14 @@ use lance_linalg::distance::hamming::hamming;
 use lance_linalg::distance::{Cosine, DistanceType, Dot, L2};
 
 pub const FLAT_COLUMN: &str = "flat";
+
+/// Flat storage's internal (non-covering) column names: the row id, the flat vector
+/// column, and the legacy `__ivf_part_id` column (left in pre-#3606 single-partition
+/// builds; unlike PQ, flat storage does not drop it at construction). Every other
+/// column in a flat storage schema is a user-declared covering ("included") column.
+/// The single authority for this set -- the distributed shard merger classifies from
+/// it too, so a new internal column added here is excluded everywhere at once.
+pub const FLAT_INTERNAL_COLUMNS: &[&str] = &[ROW_ID, FLAT_COLUMN, PART_ID_COLUMN];
 
 /// All data are stored in memory
 #[derive(Debug, Clone)]
@@ -129,6 +137,9 @@ impl FlatFloatStorage {
 impl VectorStore for FlatFloatStorage {
     type DistanceCalculator<'a> = FlatFloatDistanceCalc<'a>;
 
+    /// Flat storage is `[_rowid, flat, <included cols...>]`.
+    const INTERNAL_COLUMNS: &'static [&'static str] = FLAT_INTERNAL_COLUMNS;
+
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok([self.batch.clone()].into_iter())
     }
@@ -157,17 +168,6 @@ impl VectorStore for FlatFloatStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
-    }
-
-    /// Flat storage is `[_rowid, flat, <included cols...>]`, so the covering columns
-    /// are every field except the row id, the flat vector column, and the legacy
-    /// `__ivf_part_id` column (left in pre-#3606 single-partition builds; unlike
-    /// PQ, flat storage does not drop it at construction, so it is excluded here).
-    fn covering_field_indices(&self) -> Vec<usize> {
-        covering_field_indices_excluding(
-            self.schema().as_ref(),
-            &[ROW_ID, FLAT_COLUMN, PART_ID_COLUMN],
-        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -302,6 +302,9 @@ impl FlatBinStorage {
 impl VectorStore for FlatBinStorage {
     type DistanceCalculator<'a> = FlatDistanceCal<'a, UInt8Type>;
 
+    /// Flat storage is `[_rowid, flat, <included cols...>]`.
+    const INTERNAL_COLUMNS: &'static [&'static str] = FLAT_INTERNAL_COLUMNS;
+
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok([self.batch.clone()].into_iter())
     }
@@ -330,17 +333,6 @@ impl VectorStore for FlatBinStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
-    }
-
-    /// Flat storage is `[_rowid, flat, <included cols...>]`, so the covering columns
-    /// are every field except the row id, the flat vector column, and the legacy
-    /// `__ivf_part_id` column (left in pre-#3606 single-partition builds; unlike
-    /// PQ, flat storage does not drop it at construction, so it is excluded here).
-    fn covering_field_indices(&self) -> Vec<usize> {
-        covering_field_indices_excluding(
-            self.schema().as_ref(),
-            &[ROW_ID, FLAT_COLUMN, PART_ID_COLUMN],
-        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -584,60 +576,61 @@ mod tests {
     // `IndexMetadata.included_fields`, empty for those indexes) lacks,
     // desyncing the two and failing every query on that legacy index.
     #[test]
-    fn test_flat_float_covering_excludes_legacy_part_id_column() {
-        use crate::vector::PART_ID_COLUMN;
-        const DIM: i32 = 4;
-        const N: usize = 8;
-        let row_ids = UInt64Array::from_iter_values(0..N as u64);
-        let values =
-            arrow_array::Float32Array::from_iter_values((0..N * DIM as usize).map(|v| v as f32));
-        let vectors = FixedSizeListArray::try_new_from_values(values, DIM).unwrap();
-        let part_ids = arrow_array::UInt32Array::from_iter_values((0..N).map(|_| 0));
-        let batch = RecordBatch::try_from_iter_with_nullable(vec![
-            (ROW_ID, Arc::new(row_ids) as ArrayRef, true),
-            (FLAT_COLUMN, Arc::new(vectors) as ArrayRef, true),
-            (PART_ID_COLUMN, Arc::new(part_ids) as ArrayRef, true),
-        ])
-        .unwrap();
-        let storage = FlatFloatStorage::try_from_batch(
-            batch,
-            &FlatMetadata { dim: DIM as usize },
-            DistanceType::L2,
-            None,
-        )
-        .unwrap();
-        assert!(
-            storage.covering_field_indices().is_empty(),
-            "legacy __ivf_part_id must not be classified as a covering column"
-        );
-    }
-
-    #[test]
-    fn test_flat_bin_covering_excludes_legacy_part_id_column() {
+    fn test_flat_covering_excludes_legacy_part_id_column() {
         use crate::vector::PART_ID_COLUMN;
         const DIM: i32 = 8;
         const N: usize = 8;
-        let row_ids = UInt64Array::from_iter_values(0..N as u64);
-        let codes =
-            arrow_array::UInt8Array::from_iter_values((0..N * DIM as usize).map(|v| v as u8));
-        let vectors = FixedSizeListArray::try_new_from_values(codes, DIM).unwrap();
-        let part_ids = arrow_array::UInt32Array::from_iter_values((0..N).map(|_| 0));
-        let batch = RecordBatch::try_from_iter_with_nullable(vec![
-            (ROW_ID, Arc::new(row_ids) as ArrayRef, true),
-            (FLAT_COLUMN, Arc::new(vectors) as ArrayRef, true),
-            (PART_ID_COLUMN, Arc::new(part_ids) as ArrayRef, true),
-        ])
-        .unwrap();
-        let storage = FlatBinStorage::try_from_batch(
-            batch,
-            &FlatMetadata { dim: DIM as usize },
+
+        let part_id_batch = |vectors: ArrayRef| {
+            RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    ROW_ID,
+                    Arc::new(UInt64Array::from_iter_values(0..N as u64)) as ArrayRef,
+                    true,
+                ),
+                (FLAT_COLUMN, vectors, true),
+                (
+                    PART_ID_COLUMN,
+                    Arc::new(arrow_array::UInt32Array::from_iter_values(
+                        (0..N).map(|_| 0),
+                    )) as ArrayRef,
+                    true,
+                ),
+            ])
+            .unwrap()
+        };
+        let meta = FlatMetadata { dim: DIM as usize };
+
+        let floats =
+            arrow_array::Float32Array::from_iter_values((0..N * DIM as usize).map(|v| v as f32));
+        let float_storage = FlatFloatStorage::try_from_batch(
+            part_id_batch(Arc::new(
+                FixedSizeListArray::try_new_from_values(floats, DIM).unwrap(),
+            )),
+            &meta,
             DistanceType::L2,
             None,
         )
         .unwrap();
         assert!(
-            storage.covering_field_indices().is_empty(),
-            "legacy __ivf_part_id must not be classified as a covering column"
+            float_storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as covering (float storage)"
+        );
+
+        let codes =
+            arrow_array::UInt8Array::from_iter_values((0..N * DIM as usize).map(|v| v as u8));
+        let bin_storage = FlatBinStorage::try_from_batch(
+            part_id_batch(Arc::new(
+                FixedSizeListArray::try_new_from_values(codes, DIM).unwrap(),
+            )),
+            &meta,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        assert!(
+            bin_storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as covering (binary storage)"
         );
     }
 

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -5,8 +5,9 @@ use std::{borrow::Cow, sync::Arc};
 
 use super::index::FlatMetadata;
 use crate::frag_reuse::FragReuseIndex;
+use crate::vector::PART_ID_COLUMN;
 use crate::vector::quantizer::QuantizerStorage;
-use crate::vector::storage::{DistCalculator, VectorStore};
+use crate::vector::storage::{DistCalculator, VectorStore, covering_field_indices_excluding};
 use crate::vector::utils::do_prefetch;
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
@@ -156,6 +157,17 @@ impl VectorStore for FlatFloatStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
+    }
+
+    /// Flat storage is `[_rowid, flat, <included cols...>]`, so the covering columns
+    /// are every field except the row id, the flat vector column, and the legacy
+    /// `__ivf_part_id` column (left in pre-#3606 single-partition builds; unlike
+    /// PQ, flat storage does not drop it at construction, so it is excluded here).
+    fn covering_field_indices(&self) -> Vec<usize> {
+        covering_field_indices_excluding(
+            self.schema().as_ref(),
+            &[ROW_ID, FLAT_COLUMN, PART_ID_COLUMN],
+        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -318,6 +330,17 @@ impl VectorStore for FlatBinStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
+    }
+
+    /// Flat storage is `[_rowid, flat, <included cols...>]`, so the covering columns
+    /// are every field except the row id, the flat vector column, and the legacy
+    /// `__ivf_part_id` column (left in pre-#3606 single-partition builds; unlike
+    /// PQ, flat storage does not drop it at construction, so it is excluded here).
+    fn covering_field_indices(&self) -> Vec<usize> {
+        covering_field_indices_excluding(
+            self.schema().as_ref(),
+            &[ROW_ID, FLAT_COLUMN, PART_ID_COLUMN],
+        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -553,6 +576,69 @@ mod tests {
         let values = Float64Array::from(vec![1.0, 2.0, 4.0, 6.0]);
         let vectors = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
         FlatFloatStorage::new(vectors, DistanceType::L2)
+    }
+
+    // Pre-#3606 `num_partitions=1` builds left `__ivf_part_id` in the flat
+    // storage file. It must never be classified as a covering column --
+    // otherwise search emits a column the exec's declared schema (from
+    // `IndexMetadata.included_fields`, empty for those indexes) lacks,
+    // desyncing the two and failing every query on that legacy index.
+    #[test]
+    fn test_flat_float_covering_excludes_legacy_part_id_column() {
+        use crate::vector::PART_ID_COLUMN;
+        const DIM: i32 = 4;
+        const N: usize = 8;
+        let row_ids = UInt64Array::from_iter_values(0..N as u64);
+        let values =
+            arrow_array::Float32Array::from_iter_values((0..N * DIM as usize).map(|v| v as f32));
+        let vectors = FixedSizeListArray::try_new_from_values(values, DIM).unwrap();
+        let part_ids = arrow_array::UInt32Array::from_iter_values((0..N).map(|_| 0));
+        let batch = RecordBatch::try_from_iter_with_nullable(vec![
+            (ROW_ID, Arc::new(row_ids) as ArrayRef, true),
+            (FLAT_COLUMN, Arc::new(vectors) as ArrayRef, true),
+            (PART_ID_COLUMN, Arc::new(part_ids) as ArrayRef, true),
+        ])
+        .unwrap();
+        let storage = FlatFloatStorage::try_from_batch(
+            batch,
+            &FlatMetadata { dim: DIM as usize },
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        assert!(
+            storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as a covering column"
+        );
+    }
+
+    #[test]
+    fn test_flat_bin_covering_excludes_legacy_part_id_column() {
+        use crate::vector::PART_ID_COLUMN;
+        const DIM: i32 = 8;
+        const N: usize = 8;
+        let row_ids = UInt64Array::from_iter_values(0..N as u64);
+        let codes =
+            arrow_array::UInt8Array::from_iter_values((0..N * DIM as usize).map(|v| v as u8));
+        let vectors = FixedSizeListArray::try_new_from_values(codes, DIM).unwrap();
+        let part_ids = arrow_array::UInt32Array::from_iter_values((0..N).map(|_| 0));
+        let batch = RecordBatch::try_from_iter_with_nullable(vec![
+            (ROW_ID, Arc::new(row_ids) as ArrayRef, true),
+            (FLAT_COLUMN, Arc::new(vectors) as ArrayRef, true),
+            (PART_ID_COLUMN, Arc::new(part_ids) as ArrayRef, true),
+        ])
+        .unwrap();
+        let storage = FlatBinStorage::try_from_batch(
+            batch,
+            &FlatMetadata { dim: DIM as usize },
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        assert!(
+            storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as a covering column"
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -45,12 +45,20 @@ use crate::{
         PART_ID_COLUMN, PQ_CODE_COLUMN,
         pq::transform::PQTransformer,
         quantizer::{QuantizerMetadata, QuantizerStorage},
-        storage::{DistCalculator, VectorStore, covering_field_indices_excluding},
+        storage::{DistCalculator, VectorStore},
         transform::Transformer,
     },
 };
 
 pub const PQ_METADATA_KEY: &str = "lance:pq";
+
+/// PQ storage's internal (non-covering) column names: the row id, the PQ code column,
+/// and the legacy `__ivf_part_id` column (written by pre-#3606 single-partition
+/// builds; PQ storage drops it at construction, so post-load it is never present and
+/// excluding it is a no-op -- but pre-load classification, e.g. from a raw shard
+/// schema in the distributed merger, needs it). Every other column is a user-declared
+/// covering ("included") column. The single authority for this set.
+pub const PQ_INTERNAL_COLUMNS: &[&str] = &[ROW_ID, PQ_CODE_COLUMN, PART_ID_COLUMN];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProductQuantizationMetadata {
@@ -714,6 +722,9 @@ impl QuantizerStorage for ProductQuantizationStorage {
 impl VectorStore for ProductQuantizationStorage {
     type DistanceCalculator<'a> = PQDistCalculator;
 
+    /// PQ storage is `[_rowid, __pq_code, <included cols...>]`.
+    const INTERNAL_COLUMNS: &'static [&'static str] = PQ_INTERNAL_COLUMNS;
+
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok(std::iter::once(self.batch.clone()))
     }
@@ -724,12 +735,6 @@ impl VectorStore for ProductQuantizationStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
-    }
-
-    /// PQ storage is `[_rowid, __pq_code, <included cols...>]`, so the covering
-    /// columns are every field except the row id and the PQ code column.
-    fn covering_field_indices(&self) -> Vec<usize> {
-        covering_field_indices_excluding(self.schema().as_ref(), &[ROW_ID, PQ_CODE_COLUMN])
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -14,7 +14,7 @@ use std::{
 use arrow::datatypes::{self, UInt8Type};
 use arrow_array::{ArrayRef, ArrowPrimitiveType, PrimitiveArray};
 use arrow_array::{
-    FixedSizeListArray, RecordBatch, UInt8Array, UInt64Array,
+    FixedSizeListArray, RecordBatch, UInt8Array, UInt32Array, UInt64Array,
     cast::AsArray,
     types::{Float32Type, UInt64Type},
 };
@@ -42,10 +42,10 @@ use crate::vector::graph::{OrderedFloat, OrderedNode};
 use crate::{
     INDEX_METADATA_SCHEMA_KEY, IndexMetadata, pb,
     vector::{
-        PQ_CODE_COLUMN,
+        PART_ID_COLUMN, PQ_CODE_COLUMN,
         pq::transform::PQTransformer,
         quantizer::{QuantizerMetadata, QuantizerStorage},
-        storage::{DistCalculator, VectorStore},
+        storage::{DistCalculator, VectorStore, covering_field_indices_excluding},
         transform::Transformer,
     },
 };
@@ -204,16 +204,23 @@ impl ProductQuantizationStorage {
         transposed: bool,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
-        if batch.num_columns() != 2 {
-            log::warn!(
-                "PQ storage should have 2 columns, but got {} columns: {}",
-                batch.num_columns(),
-                batch.schema(),
-            );
-            batch = batch.project(&[
-                batch.schema().index_of(ROW_ID)?,
-                batch.schema().index_of(PQ_CODE_COLUMN)?,
-            ])?;
+        // Require `_rowid` and the PQ code column, but preserve any additional
+        // ("included"/covering) columns row-aligned.
+        // Normalize the order to `[_rowid, __pq_code, <extras...>]` so the schema
+        // is stable across builds. `__ivf_part_id` is never a covering column:
+        // legacy `num_partitions=1` builds (pre-#3606) wrote it into the index
+        // file, so keep dropping it on load as before.
+        let row_id_idx = batch.schema().index_of(ROW_ID)?;
+        let pq_idx = batch.schema().index_of(PQ_CODE_COLUMN)?;
+        if row_id_idx != 0 || pq_idx != 1 || batch.num_columns() > 2 {
+            let schema = batch.schema();
+            let mut order = Vec::with_capacity(batch.num_columns());
+            order.push(row_id_idx);
+            order.push(pq_idx);
+            order.extend((0..batch.num_columns()).filter(|&i| {
+                i != row_id_idx && i != pq_idx && schema.field(i).name() != PART_ID_COLUMN
+            }));
+            batch = batch.project(&order)?;
         }
 
         let Some(row_ids) = batch.column_by_name(ROW_ID) else {
@@ -259,6 +266,7 @@ impl ProductQuantizationStorage {
             let transposed_codes = pq_code.values();
             let mut new_row_ids = Vec::with_capacity(row_ids.len());
             let mut new_codes = Vec::with_capacity(row_ids.len() * num_sub_vectors);
+            let mut kept_indices: Vec<u32> = Vec::with_capacity(row_ids.len());
 
             let row_ids_values = row_ids.values();
             for (i, row_id) in row_ids_values.iter().enumerate() {
@@ -270,6 +278,7 @@ impl ProductQuantizationStorage {
                         num_sub_vectors,
                         i as u32,
                     ));
+                    kept_indices.push(i as u32);
                 }
             }
 
@@ -285,7 +294,14 @@ impl ProductQuantizationStorage {
                     new_transposed_codes,
                     num_bytes_in_code as i32,
                 )?);
-                RecordBatch::try_new(batch.schema(), vec![new_row_ids, codes_fsl])?
+                // Preserve any included/covering columns row-aligned to the kept rows.
+                rebuild_storage_batch(
+                    batch.schema(),
+                    &batch,
+                    new_row_ids,
+                    codes_fsl,
+                    &UInt32Array::from(kept_indices),
+                )?
             };
             pq_code = batch[PQ_CODE_COLUMN]
                 .as_fixed_size_list()
@@ -503,6 +519,40 @@ where
     transposed_codes.into()
 }
 
+/// Rebuild a PQ-storage batch after a row selection (fragment-reuse remap in
+/// [`ProductQuantizationStorage::new`] or [`ProductQuantizationStorage::remap`]),
+/// preserving any extra ("included"/covering) columns beyond `_rowid` and the PQ
+/// code. The already-remapped `row_ids` and transposed `pq_codes` are supplied
+/// directly; every other column is gathered from `original` at the surviving
+/// positions `kept` so it stays row-aligned. `schema` carries the column order
+/// `[_rowid, __pq_code, <extras...>]`.
+fn rebuild_storage_batch(
+    schema: SchemaRef,
+    original: &RecordBatch,
+    row_ids: ArrayRef,
+    pq_codes: ArrayRef,
+    kept: &UInt32Array,
+) -> Result<RecordBatch> {
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let name = field.name().as_str();
+            if name == ROW_ID {
+                Ok(row_ids.clone())
+            } else if name == PQ_CODE_COLUMN {
+                Ok(pq_codes.clone())
+            } else {
+                let col = original.column_by_name(name).ok_or_else(|| {
+                    Error::index(format!("column '{name}' missing from PQ storage batch"))
+                })?;
+                Ok(arrow::compute::take(col.as_ref(), kept, None)?)
+            }
+        })
+        .collect::<Result<Vec<ArrayRef>>>()?;
+    Ok(RecordBatch::try_new(schema, columns)?)
+}
+
 #[async_trait]
 impl QuantizerStorage for ProductQuantizationStorage {
     type Metadata = ProductQuantizationMetadata;
@@ -554,6 +604,7 @@ impl QuantizerStorage for ProductQuantizationStorage {
         let transposed_codes = self.pq_code.values();
         let mut new_row_ids = Vec::with_capacity(self.len());
         let mut new_codes = Vec::with_capacity(self.len() * self.metadata.num_sub_vectors);
+        let mut kept_indices: Vec<u32> = Vec::with_capacity(self.len());
 
         let row_ids = self.row_ids.values();
         for (i, row_id) in row_ids.iter().enumerate() {
@@ -566,6 +617,7 @@ impl QuantizerStorage for ProductQuantizationStorage {
                         self.metadata.num_sub_vectors,
                         i as u32,
                     ));
+                    kept_indices.push(i as u32);
                 }
                 Some(None) => {}
                 None => {
@@ -576,6 +628,7 @@ impl QuantizerStorage for ProductQuantizationStorage {
                         self.metadata.num_sub_vectors,
                         i as u32,
                     ));
+                    kept_indices.push(i as u32);
                 }
             }
         }
@@ -591,7 +644,14 @@ impl QuantizerStorage for ProductQuantizationStorage {
                 new_transposed_codes,
                 num_bytes_in_code as i32,
             )?);
-            RecordBatch::try_new(self.schema(), vec![new_row_ids.clone(), codes_fsl])?
+            // Preserve any included/covering columns row-aligned to the kept rows.
+            rebuild_storage_batch(
+                self.schema(),
+                &self.batch,
+                new_row_ids.clone(),
+                codes_fsl,
+                &UInt32Array::from(kept_indices),
+            )?
         };
         let transposed_codes = batch[PQ_CODE_COLUMN]
             .as_fixed_size_list()
@@ -664,6 +724,12 @@ impl VectorStore for ProductQuantizationStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.batch.schema_ref()
+    }
+
+    /// PQ storage is `[_rowid, __pq_code, <included cols...>]`, so the covering
+    /// columns are every field except the row id and the PQ code column.
+    fn covering_field_indices(&self) -> Vec<usize> {
+        covering_field_indices_excluding(self.schema().as_ref(), &[ROW_ID, PQ_CODE_COLUMN])
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1235,6 +1301,132 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_build_preserves_extra_column() {
+        // A covering ("included") column beyond _rowid + __pq_code must be kept
+        // in the storage batch, row-aligned to the rows, not dropped.
+        let storage = create_pq_storage_with_extra_column().await;
+        let batch = storage.batch();
+        assert_eq!(batch.num_columns(), 3);
+        assert!(batch.column_by_name(ROW_ID).is_some());
+        assert!(batch.column_by_name(PQ_CODE_COLUMN).is_some());
+        let extra = batch
+            .column_by_name("extra")
+            .expect("extra column should be preserved")
+            .as_primitive::<datatypes::UInt32Type>();
+        // In the fixture extra[i] == row_ids[i] == i, so it must stay aligned.
+        for (i, row_id) in storage.row_ids().enumerate() {
+            assert_eq!(extra.value(i) as u64, *row_id);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_rejects_mismatched_batch_columns() {
+        // Batches merged into one storage must carry the same column set. A
+        // batch with a column the FIRST batch lacks must be rejected: aligning
+        // to the first batch's schema would silently drop it, losing covering
+        // data while the index metadata still advertises it.
+        let codebook = Float32Array::from_iter_values((0..256 * DIM).map(|_| rand::random()));
+        let codebook = FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap();
+        let pq = ProductQuantizer::new(NUM_SUB_VECTORS, 8, DIM, codebook, DistanceType::Dot);
+
+        let vec_field = Field::new(
+            "vec",
+            DataType::FixedSizeList(
+                Field::new_list_field(DataType::Float32, true).into(),
+                DIM as i32,
+            ),
+            true,
+        );
+        let make_fsl = || {
+            let vectors = Float32Array::from_iter_values((0..TOTAL * DIM).map(|_| rand::random()));
+            FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap()
+        };
+        let row_ids = || UInt64Array::from_iter_values((0..TOTAL).map(|v| v as u64));
+
+        let plain_schema = ArrowSchema::new(vec![vec_field.clone(), ROW_ID_FIELD.clone()]);
+        let plain = RecordBatch::try_new(
+            plain_schema.into(),
+            vec![Arc::new(make_fsl()), Arc::new(row_ids())],
+        )
+        .unwrap();
+
+        let covered_schema = ArrowSchema::new(vec![
+            vec_field,
+            ROW_ID_FIELD.clone(),
+            Field::new("extra", DataType::UInt32, true),
+        ]);
+        let covered = RecordBatch::try_new(
+            covered_schema.into(),
+            vec![
+                Arc::new(make_fsl()),
+                Arc::new(row_ids()),
+                Arc::new(UInt32Array::from_iter_values((0..TOTAL).map(|v| v as u32))),
+            ],
+        )
+        .unwrap();
+
+        let err = StorageBuilder::new("vec".to_owned(), pq.distance_type, pq, None)
+            .unwrap()
+            .build(vec![plain, covered])
+            .expect_err("a batch with extra columns must be rejected, not silently projected");
+        assert!(err.to_string().contains("extra"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_new_drops_legacy_part_id_column() {
+        // Pre-#3606 `num_partitions=1` builds wrote `__ivf_part_id` into the
+        // index file. It must still be dropped on load (the legacy read shim),
+        // NOT preserved and misclassified as a covering column -- that would
+        // make search emit an extra column the exec's declared schema (from
+        // `IndexMetadata.included_fields`, empty for those indexes) lacks.
+        use crate::vector::PART_ID_COLUMN;
+        let codebook = Float32Array::from_iter_values((0..256 * DIM).map(|_| rand::random()));
+        let codebook = FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap();
+
+        let schema = ArrowSchema::new(vec![
+            ROW_ID_FIELD.clone(),
+            Field::new(
+                PQ_CODE_COLUMN,
+                DataType::FixedSizeList(
+                    Field::new_list_field(DataType::UInt8, true).into(),
+                    NUM_SUB_VECTORS as i32,
+                ),
+                true,
+            ),
+            Field::new(PART_ID_COLUMN, DataType::UInt32, true),
+        ]);
+        let row_ids = UInt64Array::from_iter_values((0..TOTAL).map(|v| v as u64));
+        let codes = UInt8Array::from_iter_values((0..TOTAL * NUM_SUB_VECTORS).map(|v| v as u8));
+        let codes = FixedSizeListArray::try_new_from_values(codes, NUM_SUB_VECTORS as i32).unwrap();
+        let part_ids = UInt32Array::from_iter_values((0..TOTAL).map(|_| 0));
+        let batch = RecordBatch::try_new(
+            schema.into(),
+            vec![Arc::new(row_ids), Arc::new(codes), Arc::new(part_ids)],
+        )
+        .unwrap();
+
+        let storage = ProductQuantizationStorage::new(
+            codebook,
+            batch,
+            8,
+            NUM_SUB_VECTORS,
+            DIM,
+            DistanceType::L2,
+            true, // codes already transposed
+            None,
+        )
+        .unwrap();
+        assert!(
+            storage.batch().column_by_name(PART_ID_COLUMN).is_none(),
+            "legacy __ivf_part_id must be dropped on load, not kept"
+        );
+        assert!(
+            storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as a covering column"
+        );
+    }
+
+    #[tokio::test]
     async fn test_distance_all() {
         let storage = create_pq_storage().await;
         let query = Arc::new(Float32Array::from_iter_values((0..DIM).map(|v| v as f32)));
@@ -1336,8 +1528,19 @@ mod tests {
             // Rewritten row i lands at offset i of frag 1.
             assert_eq!(*row_id, (1u64 << 32) | i as u64);
         }
-        assert_eq!(new_storage.batch.num_columns(), 2);
+        // The covering ("extra") column must survive remap, row-aligned to the
+        // surviving rows — otherwise PK/covering data is lost on compaction.
+        assert_eq!(new_storage.batch.num_columns(), 3);
         assert!(new_storage.batch.column_by_name(ROW_ID).is_some());
         assert!(new_storage.batch.column_by_name(PQ_CODE_COLUMN).is_some());
+        let extra = new_storage
+            .batch
+            .column_by_name("extra")
+            .expect("extra column should survive remap")
+            .as_primitive::<datatypes::UInt32Type>();
+        // Surviving rows are original indices 0..TOTAL/2, whose extra values are 0..TOTAL/2.
+        for i in 0..TOTAL / 2 {
+            assert_eq!(extra.value(i), i as u32);
+        }
     }
 }

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -29,9 +29,12 @@ use crate::frag_reuse::FragReuseIndex;
 use crate::{
     INDEX_METADATA_SCHEMA_KEY, IndexMetadata,
     vector::{
-        SQ_CODE_COLUMN,
+        PART_ID_COLUMN, SQ_CODE_COLUMN,
         quantizer::{QuantizerMetadata, QuantizerStorage},
-        storage::{DistCalculator, DistanceCalculatorOptions, QueryResidual, VectorStore},
+        storage::{
+            DistCalculator, DistanceCalculatorOptions, QueryResidual, VectorStore,
+            covering_field_indices_excluding,
+        },
         transform::Transformer,
     },
 };
@@ -340,6 +343,17 @@ impl VectorStore for ScalarQuantizationStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.chunks[0].schema()
+    }
+
+    /// SQ storage is `[_rowid, __sq_code, <included cols...>]`, so the covering
+    /// columns are every field except the row id, the SQ code column, and the
+    /// legacy `__ivf_part_id` column (left in pre-#3606 single-partition builds;
+    /// unlike PQ, SQ does not drop it at construction, so it is excluded here).
+    fn covering_field_indices(&self) -> Vec<usize> {
+        covering_field_indices_excluding(
+            self.schema().as_ref(),
+            &[ROW_ID, SQ_CODE_COLUMN, PART_ID_COLUMN],
+        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -755,6 +769,50 @@ mod tests {
             ),
         ]));
         RecordBatch::try_new(schema, vec![Arc::new(row_ids), Arc::new(code_arr)]).unwrap()
+    }
+
+    #[test]
+    fn test_covering_excludes_legacy_part_id_column() {
+        // Pre-#3606 `num_partitions=1` builds left `__ivf_part_id` in the SQ
+        // storage file. It must never be classified as a covering column --
+        // otherwise search emits a column the exec's declared schema (from
+        // `IndexMetadata.included_fields`, empty for those indexes) lacks,
+        // desyncing the two and failing every query on that legacy index.
+        use crate::vector::PART_ID_COLUMN;
+        use arrow_array::UInt32Array;
+        const DIM: usize = 64;
+        const N: usize = 10;
+
+        let row_ids = UInt64Array::from_iter_values(0..N as u64);
+        let sq_code = UInt8Array::from_iter_values((0..N * DIM).map(|v| v as u8));
+        let code_arr = FixedSizeListArray::try_new_from_values(sq_code, DIM as i32).unwrap();
+        let part_ids = UInt32Array::from_iter_values((0..N).map(|_| 0));
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new(
+                SQ_CODE_COLUMN,
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::UInt8, true)),
+                    DIM as i32,
+                ),
+                false,
+            ),
+            Field::new(PART_ID_COLUMN, DataType::UInt32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(row_ids), Arc::new(code_arr), Arc::new(part_ids)],
+        )
+        .unwrap();
+
+        let storage =
+            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -0.7..0.7, [batch], None)
+                .unwrap();
+        assert!(
+            storage.covering_field_indices().is_empty(),
+            "legacy __ivf_part_id must not be classified as a covering column"
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -31,15 +31,19 @@ use crate::{
     vector::{
         PART_ID_COLUMN, SQ_CODE_COLUMN,
         quantizer::{QuantizerMetadata, QuantizerStorage},
-        storage::{
-            DistCalculator, DistanceCalculatorOptions, QueryResidual, VectorStore,
-            covering_field_indices_excluding,
-        },
+        storage::{DistCalculator, DistanceCalculatorOptions, QueryResidual, VectorStore},
         transform::Transformer,
     },
 };
 
 pub const SQ_METADATA_KEY: &str = "lance:sq";
+
+/// SQ storage's internal (non-covering) column names: the row id, the SQ code column,
+/// and the legacy `__ivf_part_id` column (left in pre-#3606 single-partition builds;
+/// unlike PQ, SQ does not drop it at construction). Every other column in an SQ
+/// storage schema is a user-declared covering ("included") column. The single
+/// authority for this set -- the distributed shard merger classifies from it too.
+pub const SQ_INTERNAL_COLUMNS: &[&str] = &[ROW_ID, SQ_CODE_COLUMN, PART_ID_COLUMN];
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalarQuantizationMetadata {
@@ -317,6 +321,9 @@ impl QuantizerStorage for ScalarQuantizationStorage {
 impl VectorStore for ScalarQuantizationStorage {
     type DistanceCalculator<'a> = SQDistCalculator<'a>;
 
+    /// SQ storage is `[_rowid, __sq_code, <included cols...>]`.
+    const INTERNAL_COLUMNS: &'static [&'static str] = SQ_INTERNAL_COLUMNS;
+
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok(self.chunks.iter().map(|c| c.batch.clone()))
     }
@@ -343,17 +350,6 @@ impl VectorStore for ScalarQuantizationStorage {
 
     fn schema(&self) -> &SchemaRef {
         self.chunks[0].schema()
-    }
-
-    /// SQ storage is `[_rowid, __sq_code, <included cols...>]`, so the covering
-    /// columns are every field except the row id, the SQ code column, and the
-    /// legacy `__ivf_part_id` column (left in pre-#3606 single-partition builds;
-    /// unlike PQ, SQ does not drop it at construction, so it is excluded here).
-    fn covering_field_indices(&self) -> Vec<usize> {
-        covering_field_indices_excluding(
-            self.schema().as_ref(),
-            &[ROW_ID, SQ_CODE_COLUMN, PART_ID_COLUMN],
-        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -372,6 +372,25 @@ impl DeepSizeOf for QueryScratchPool {
 ///
 /// It abstracts away the logic to compute the distance between vectors.
 ///
+/// Indices of the covering ("included") columns in a vector-storage schema: every
+/// field whose name is not one of `internal`. Each storage lists its own non-covering
+/// column names (the row id, its quantization code columns, and any legacy bookkeeping
+/// column it carries) and shares this filter, so covering detection stays a per-storage
+/// data decision rather than duplicated iteration logic. See
+/// [`VectorStore::covering_field_indices`] for why the set cannot be inferred generically.
+pub(crate) fn covering_field_indices_excluding(
+    schema: &arrow_schema::Schema,
+    internal: &[&str],
+) -> Vec<usize> {
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| !internal.contains(&f.name().as_str()))
+        .map(|(i, _)| i)
+        .collect()
+}
+
 /// TODO: should we rename this to "VectorDistance"?;
 ///
 /// <section class="warning">
@@ -408,6 +427,45 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     /// Append Raw [RecordBatch] into the Storage.
     /// The storage implement will perform quantization if necessary.
     fn append_batch(&self, batch: RecordBatch, vector_column: &str) -> Result<Self>;
+
+    /// Field indices of the "included"/covering columns: the extra columns
+    /// stored alongside the row id and quantization code so a covered query can
+    /// skip the take from the base table.
+    ///
+    /// The default is empty (no covering). A storage that supports covering must
+    /// override this, since only it knows which of its columns are quantization
+    /// code columns versus included columns — inferring that generically by name
+    /// is unsafe (e.g. it would mistake RaBitQ's code columns for covering ones).
+    fn covering_field_indices(&self) -> Vec<usize> {
+        Vec::new()
+    }
+
+    /// `[_rowid, <included cols...>]` for the whole storage. Captured while a
+    /// partition is loaded during search so covering columns can be emitted with
+    /// the result without a separate take. Returns `None` if there are no
+    /// included columns (ordinary index — nothing to cover).
+    fn covering_batch(&self) -> Result<Option<RecordBatch>> {
+        let included = self.covering_field_indices();
+        if included.is_empty() {
+            return Ok(None);
+        }
+        let schema = self.schema().clone();
+        let row_id_idx = schema.index_of(ROW_ID)?;
+        let mut indices = Vec::with_capacity(included.len() + 1);
+        indices.push(row_id_idx);
+        indices.extend(included);
+        // Project each batch BEFORE concatenating. Concatenating the full partition first
+        // would copy every quantization-code column only to discard it on the next line --
+        // and those columns dominate the partition (HNSW partitions target 1 << 20 rows), so
+        // on a multi-probe query that copy is hundreds of MB of pure waste on the ANN hot
+        // path. Only `[_rowid, <included...>]` is ever read from the result.
+        let projected: Vec<RecordBatch> = self
+            .to_batches()?
+            .map(|batch| batch.project(&indices))
+            .collect::<std::result::Result<_, _>>()?;
+        let projected_schema = Arc::new(schema.project(&indices)?);
+        Ok(Some(concat_batches(&projected_schema, projected.iter())?))
+    }
 
     /// Create a [DistCalculator] to compute the distance between the query.
     ///
@@ -467,7 +525,43 @@ impl<Q: Quantization> StorageBuilder<Q> {
     }
 
     pub fn build(&self, batches: Vec<RecordBatch>) -> Result<Q::Storage> {
-        let mut batch = concat_batches(batches[0].schema_ref(), batches.iter())?;
+        // Batches can come from different sources (existing partitions loaded
+        // from disk vs freshly shuffled/split/reassigned data) that carry the
+        // same columns in a different order -- notably when the index has
+        // included/covering columns. `concat_batches` matches columns by
+        // position, so align every batch to the first batch's column order (by
+        // name). No-op when all batches already share a schema.
+        let schema = batches[0].schema();
+        let aligned: Vec<RecordBatch> = batches
+            .iter()
+            .map(|b| {
+                if b.schema() == schema {
+                    return Ok(b.clone());
+                }
+                // `project_by_schema` reorders by name and errors on a missing
+                // column, but it cannot see extras -- and a batch with MORE
+                // columns must error rather than have them silently dropped
+                // (e.g. covering columns the index metadata still advertises).
+                // Equal count + every expected column present = same set.
+                if b.num_columns() != schema.fields().len() {
+                    let names = |s: &arrow_schema::Schema| {
+                        s.fields()
+                            .iter()
+                            .map(|f| f.name().as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    return Err(Error::index(format!(
+                        "mismatched columns while merging vector storage batches: \
+                         expected [{}], got [{}]",
+                        names(&schema),
+                        names(&b.schema()),
+                    )));
+                }
+                Ok(b.project_by_schema(schema.as_ref())?)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut batch = concat_batches(&schema, aligned.iter())?;
 
         if batch.column_by_name(self.quantizer.column()).is_none() {
             let vectors = batch
@@ -505,6 +599,11 @@ pub struct IvfQuantizationStorage<Q: Quantization> {
 
     ivf: IvfModel,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    /// Lazily-computed covering schema (see [`Self::covering_schema`]). The schema is
+    /// fixed for the storage's lifetime, and computing it constructs an empty
+    /// `Q::Storage` (for PQ this decodes the whole codebook), so it must not be
+    /// recomputed per query.
+    covering_schema: std::sync::OnceLock<Option<SchemaRef>>,
 }
 
 impl<Q: Quantization> DeepSizeOf for IvfQuantizationStorage<Q> {
@@ -566,6 +665,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
             metadata,
             ivf,
             frag_reuse_index,
+            covering_schema: std::sync::OnceLock::new(),
         })
     }
 
@@ -584,6 +684,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
             metadata,
             ivf,
             frag_reuse_index,
+            covering_schema: std::sync::OnceLock::new(),
         }
     }
 
@@ -618,6 +719,28 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
 
     pub fn schema(&self) -> SchemaRef {
         Arc::new(self.reader.schema().as_ref().into())
+    }
+
+    /// The `[_rowid, <included cols...>]` schema for this index's covering
+    /// columns, or `None` if the index has no covering columns. Derived from an
+    /// empty storage instance (no I/O) so callers can emit the correct covered
+    /// output schema even when zero partitions are searched. Computed once and
+    /// cached: it is queried per search, and constructing the empty storage is
+    /// not free (PQ decodes its codebook from metadata).
+    pub fn covering_schema(&self) -> Result<Option<SchemaRef>> {
+        if let Some(cached) = self.covering_schema.get() {
+            return Ok(cached.clone());
+        }
+        let arrow_schema = arrow_schema::Schema::from(self.reader.schema().as_ref());
+        let empty = RecordBatch::new_empty(Arc::new(arrow_schema));
+        let storage = Q::Storage::try_from_batch(
+            empty,
+            self.metadata(),
+            self.distance_type,
+            self.frag_reuse_index.clone(),
+        )?;
+        let computed = storage.covering_batch()?.map(|b| b.schema());
+        Ok(self.covering_schema.get_or_init(|| computed).clone())
     }
 
     /// Get the number of partitions in the storage.

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -154,6 +154,19 @@ pub trait DistCalculator {
 
 pub const STORAGE_METADATA_KEY: &str = "storage_metadata";
 
+/// Schema-metadata key recording the *source dataset* field ids of a storage file's
+/// covering ("included") columns, comma separated in declaration order.
+///
+/// Arrow fields carry no Lance field id, so a storage file's own schema cannot say
+/// which logical column a covering column came from -- and the ids in the file's Lance
+/// schema are file-local, assigned when the writer was built. Without this, a
+/// distributed merge comparing shards by name and type would accept two shards whose
+/// covering columns share a name and type but belong to different fields (a column
+/// dropped and re-added between shard builds) and concatenate them as one.
+///
+/// Absent when the storage has no covering columns.
+pub const COVERING_FIELD_IDS_KEY: &str = "covering_field_ids";
+
 #[derive(Debug)]
 pub struct QueryScratch {
     pub distances: Vec<f32>,
@@ -403,6 +416,17 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     where
         Self: 'a;
 
+    /// This storage's own column names: the row id, its quantization code
+    /// columns, and any legacy bookkeeping column it carries. Everything else in
+    /// the schema is a covering ("included") column.
+    ///
+    /// Required rather than defaulted on purpose: only the storage knows which of
+    /// its columns are code columns, and a wrong answer here silently mislabels
+    /// covering data (e.g. it would mistake RaBitQ's code columns for covering
+    /// ones). Making it a required associated const means a new storage cannot
+    /// forget to answer.
+    const INTERNAL_COLUMNS: &'static [&'static str];
+
     fn as_any(&self) -> &dyn Any;
 
     fn schema(&self) -> &SchemaRef;
@@ -430,14 +454,9 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
 
     /// Field indices of the "included"/covering columns: the extra columns
     /// stored alongside the row id and quantization code so a covered query can
-    /// skip the take from the base table.
-    ///
-    /// The default is empty (no covering). A storage that supports covering must
-    /// override this, since only it knows which of its columns are quantization
-    /// code columns versus included columns — inferring that generically by name
-    /// is unsafe (e.g. it would mistake RaBitQ's code columns for covering ones).
+    /// skip the take from the base table. Derived from [`Self::INTERNAL_COLUMNS`].
     fn covering_field_indices(&self) -> Vec<usize> {
-        Vec::new()
+        covering_field_indices_excluding(self.schema().as_ref(), Self::INTERNAL_COLUMNS)
     }
 
     /// `[_rowid, <included cols...>]` for the whole storage. Captured while a

--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -7,17 +7,17 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use arrow::datatypes::UInt64Type;
-use arrow_array::UInt64Array;
 use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use arrow_array::{Array, ArrowPrimitiveType, RecordBatch, UInt32Array, cast::AsArray};
 use arrow_schema::{DataType, Field, Schema};
 use lance_arrow::RecordBatchExt;
 use num_traits::Float;
 
-use lance_core::{Error, ROW_ID, ROW_ID_FIELD, Result};
+use lance_core::{Error, Result};
 use lance_linalg::kernels::normalize_fsl;
 use tracing::instrument;
+
+use super::{CENTROID_DIST_COLUMN, PART_ID_COLUMN};
 
 /// Transform of a Vector Matrix.
 ///
@@ -194,25 +194,48 @@ impl Transformer for Flatten {
         match arr.data_type() {
             DataType::FixedSizeList(_, _) => Ok(batch.clone()),
             DataType::List(_) => {
-                let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
                 let vectors = arr.as_list::<i32>();
-
-                let row_ids = row_ids.values().iter().zip(vectors.iter()).flat_map(
-                    |(row_id, multivector)| {
-                        std::iter::repeat_n(
-                            *row_id,
-                            multivector.map(|multivec| multivec.len()).unwrap_or(0),
-                        )
-                    },
-                );
-                let row_ids = UInt64Array::from_iter_values(row_ids);
-                let vectors = vectors.values().as_fixed_size_list().clone();
-                let schema = Arc::new(Schema::new(vec![
-                    ROW_ID_FIELD.clone(),
-                    Field::new(self.column.as_str(), vectors.data_type().clone(), true),
-                ]));
-                let batch =
-                    RecordBatch::try_new(schema, vec![Arc::new(row_ids), Arc::new(vectors)])?;
+                // Each source row expands into one output row per vector in its list.
+                // Replicate the row id AND every other column (e.g. covering / "included"
+                // columns) across the expansion via a gather; dropping them here would
+                // silently lose covering data on the multivector build/split path.
+                //
+                // The IVF partition-assignment columns are the exception and must be
+                // DROPPED, not replicated: they describe the source *row*, and after the
+                // expansion each sub-vector needs its own nearest centroid. Carrying them
+                // through makes `PartitionTransformer` see its output column already
+                // present and early-return, silently collapsing every sub-vector of a row
+                // into that row's single partition -- no error, just degraded recall.
+                let take_indices =
+                    UInt32Array::from_iter_values((0..vectors.len()).flat_map(|i| {
+                        let n = if vectors.is_valid(i) {
+                            vectors.value(i).len()
+                        } else {
+                            0
+                        };
+                        std::iter::repeat_n(i as u32, n)
+                    }));
+                let flat_vectors = vectors.values().as_fixed_size_list().clone();
+                let mut fields: Vec<Arc<Field>> = Vec::with_capacity(batch.num_columns());
+                let mut columns: Vec<arrow_array::ArrayRef> =
+                    Vec::with_capacity(batch.num_columns());
+                for (i, field) in batch.schema().fields().iter().enumerate() {
+                    if field.name() == &self.column {
+                        fields.push(Arc::new(Field::new(
+                            self.column.as_str(),
+                            flat_vectors.data_type().clone(),
+                            true,
+                        )));
+                        columns.push(Arc::new(flat_vectors.clone()));
+                    } else if field.name() == PART_ID_COLUMN || field.name() == CENTROID_DIST_COLUMN
+                    {
+                        continue;
+                    } else {
+                        fields.push(field.clone());
+                        columns.push(arrow::compute::take(batch.column(i), &take_indices, None)?);
+                    }
+                }
+                let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)?;
                 Ok(batch)
             }
             _ => Err(Error::index(format!(
@@ -235,6 +258,114 @@ mod tests {
     use half::f16;
     use lance_arrow::*;
     use lance_linalg::distance::L2;
+
+    #[test]
+    fn test_flatten_preserves_extra_columns_for_multivector() {
+        use arrow::buffer::OffsetBuffer;
+        use arrow::datatypes::UInt64Type;
+        use arrow_array::{ListArray, UInt64Array};
+        use lance_core::{ROW_ID, ROW_ID_FIELD};
+
+        // row 10 has 2 vectors, row 20 has 1 vector; a covering column "meta" must be
+        // replicated across each row's expanded vectors, not dropped.
+        let values = Float32Array::from(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0]);
+        let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        let offsets = OffsetBuffer::new(vec![0i32, 2, 3].into());
+        let item = Arc::new(Field::new("item", fsl.data_type().clone(), true));
+        let list = ListArray::new(item, offsets, Arc::new(fsl), None);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                ROW_ID_FIELD.clone(),
+                Field::new("vector", list.data_type().clone(), true),
+                Field::new("meta", DataType::Int32, true),
+            ])),
+            vec![
+                Arc::new(UInt64Array::from(vec![10u64, 20])),
+                Arc::new(list),
+                Arc::new(Int32Array::from(vec![100, 200])),
+            ],
+        )
+        .unwrap();
+
+        let out = Flatten::new("vector").transform(&batch).unwrap();
+
+        assert_eq!(out.num_rows(), 3, "2 + 1 vectors expand to 3 rows");
+        assert_eq!(
+            out[ROW_ID].as_primitive::<UInt64Type>().values(),
+            &[10, 10, 20]
+        );
+        let meta = out
+            .column_by_name("meta")
+            .expect("covering column must survive Flatten")
+            .as_primitive::<arrow_array::types::Int32Type>();
+        assert_eq!(
+            meta.values(),
+            &[100, 100, 200],
+            "covering column replicated per expanded vector"
+        );
+        assert!(matches!(
+            out.column_by_name("vector").unwrap().data_type(),
+            DataType::FixedSizeList(_, 2)
+        ));
+    }
+
+    /// The IVF partition-assignment columns describe the source *row*. Replicating them
+    /// across the multivector expansion makes `PartitionTransformer` see its output column
+    /// already present and early-return, so every sub-vector inherits its row's single
+    /// partition instead of being assigned to its own nearest centroid -- silent recall
+    /// loss with no error. They must be dropped even though covering columns are kept.
+    #[test]
+    fn test_flatten_drops_partition_columns_for_multivector() {
+        use arrow::buffer::OffsetBuffer;
+        use arrow_array::{ListArray, UInt32Array as U32, UInt64Array};
+        use lance_core::ROW_ID_FIELD;
+
+        let values = Float32Array::from(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0]);
+        let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        let offsets = OffsetBuffer::new(vec![0i32, 2, 3].into());
+        let item = Arc::new(Field::new("item", fsl.data_type().clone(), true));
+        let list = ListArray::new(item, offsets, Arc::new(fsl), None);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                ROW_ID_FIELD.clone(),
+                Field::new("vector", list.data_type().clone(), true),
+                Field::new("meta", DataType::Int32, true),
+                Field::new(PART_ID_COLUMN, DataType::UInt32, true),
+                Field::new(CENTROID_DIST_COLUMN, DataType::Float32, true),
+            ])),
+            vec![
+                Arc::new(UInt64Array::from(vec![10u64, 20])),
+                Arc::new(list),
+                Arc::new(Int32Array::from(vec![100, 200])),
+                Arc::new(U32::from(vec![7u32, 9])),
+                Arc::new(Float32Array::from(vec![0.5f32, 0.25])),
+            ],
+        )
+        .unwrap();
+
+        let out = Flatten::new("vector").transform(&batch).unwrap();
+
+        assert_eq!(out.num_rows(), 3);
+        assert!(
+            out.column_by_name(PART_ID_COLUMN).is_none(),
+            "a row's partition assignment must not survive the multivector expansion, or \
+             PartitionTransformer early-returns and every sub-vector shares one partition"
+        );
+        assert!(
+            out.column_by_name(CENTROID_DIST_COLUMN).is_none(),
+            "the row's centroid distance is likewise meaningless per sub-vector"
+        );
+        // ...while genuine covering columns are still replicated.
+        assert_eq!(
+            out.column_by_name("meta")
+                .expect("covering column must survive")
+                .as_primitive::<arrow_array::types::Int32Type>()
+                .values(),
+            &[100, 100, 200]
+        );
+    }
 
     #[tokio::test]
     async fn test_normalize_transformer_f32() {

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -55,7 +55,7 @@ use lance_namespace::models::{
     TableExistsRequest,
 };
 use lance_namespace::schema::arrow_schema_to_json;
-use lance_table::feature_flags::apply_feature_flags;
+use lance_table::feature_flags::{FeatureFlagsConfig, apply_feature_flags};
 use lance_table::format::{Fragment, IndexMetadata, Manifest};
 use lance_table::io::commit::{
     CommitError, CommitHandler, commit_handler_from_url, write_manifest_file_to_path,
@@ -1282,6 +1282,7 @@ impl ManifestNamespace {
             created_at: None,
             base_id: None,
             files: Some(index_files_to_table(trained_index.created_index.files)),
+            included_fields: Vec::new(),
         })
     }
 
@@ -1838,7 +1839,16 @@ impl ManifestNamespace {
         indices: Option<Vec<IndexMetadata>>,
         transaction: Transaction,
     ) -> std::result::Result<(), CommitError> {
-        apply_feature_flags(manifest, false, false).map_err(CommitError::from)?;
+        let has_covered_index =
+            lance_table::feature_flags::manifest_has_covered_index(manifest, indices.as_deref());
+        apply_feature_flags(
+            manifest,
+            &FeatureFlagsConfig {
+                has_covered_index,
+                ..Default::default()
+            },
+        )
+        .map_err(CommitError::from)?;
         let timestamp_nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -3,7 +3,7 @@
 
 //! Feature flags
 
-use crate::format::Manifest;
+use crate::format::{IndexMetadata, Manifest};
 use lance_core::{Error, Result};
 
 /// Fragments may contain deletion files, which record the tombstones of
@@ -39,23 +39,79 @@ pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
 /// invalidating the catch-up position recorded for that index, leaving a stale
 /// position behind. Both must refuse the table.
 pub const FLAG_MEM_WAL_INDEX_CATCHUP: u64 = 128;
+/// An index co-locates ("covers") extra columns beyond its key column
+/// (`IndexMetadata.included_fields`). A writer that does not understand this should not
+/// commit: it would drop the unknown `included_fields` metadata (prost discards the
+/// unknown proto field) while the index files retain those physical columns, leaving
+/// storage that emits columns the manifest no longer declares.
+///
+/// Writer-only, and deliberately so: a reader that ignores `included_fields` simply falls
+/// back to a base-table take, which is correct.
+///
+/// Best-effort, not a guarantee. Released clients enforce writer flags only on the insert
+/// path (`can_write_dataset` has a single call site), so a pre-feature client's delete,
+/// update, or raw `CommitBuilder` commit still lands and re-serializes the index section
+/// through its older prost type -- dropping `included_fields` and clearing this bit. The
+/// result is a covered index silently degraded to an ordinary one, which costs the take
+/// elision but stays correct: undeclared covering columns in storage are dropped on read
+/// rather than surfaced (see `test_undeclared_storage_covering_is_dropped_not_fatal`).
+/// Fencing that hole would require the reader bit, which would lock pre-feature clients
+/// out of covered datasets entirely for what is only a read-side optimization.
+pub const FLAG_COVERED_INDEX_METADATA: u64 = 256;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 256;
+pub const FLAG_UNKNOWN: u64 = 512;
 
 // This build only understands flags below the unknown boundary, so a bit
 // allocated at or above it would be refused by the very readers meant to use it.
 const _: () = assert!(FLAG_MEM_WAL_INDEX_CATCHUP < FLAG_UNKNOWN);
+const _: () = assert!(FLAG_COVERED_INDEX_METADATA < FLAG_UNKNOWN);
+// The two features must not share a bit: mem-wal catch-up is a reader+writer fence
+// while covering is writer-only, so a shared bit would make each feature's datasets
+// unreadable to the other.
+const _: () = assert!(FLAG_MEM_WAL_INDEX_CATCHUP != FLAG_COVERED_INDEX_METADATA);
 
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.
 pub const ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV: &str = "LANCE_ENABLE_UNSTABLE_DATA_OVERLAY_FILES";
 
-/// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
-pub fn apply_feature_flags(
-    manifest: &mut Manifest,
-    enable_stable_row_id: bool,
-    disable_transaction_file: bool,
-) -> Result<()> {
+/// Whether a manifest commit must carry [`FLAG_COVERED_INDEX_METADATA`]: either the
+/// manifest is already fenced (the flag words are reset on every
+/// [`apply_feature_flags`], so an existing fence must be preserved) or one of the
+/// indices being committed declares covering (`included_fields`) columns. `indices` is
+/// the index list accompanying the commit; `None` when the commit does not rewrite the
+/// index section.
+pub fn manifest_has_covered_index(manifest: &Manifest, indices: Option<&[IndexMetadata]>) -> bool {
+    manifest.writer_feature_flags & FLAG_COVERED_INDEX_METADATA != 0
+        || indices.is_some_and(|indices| indices.iter().any(|i| !i.included_fields.is_empty()))
+}
+
+/// Caller-supplied inputs for [`apply_feature_flags`] -- the flag conditions that
+/// cannot be derived from the manifest's contents alone. `Default` (all `false`) matches
+/// the behavior of a plain commit with no special features requested.
+#[derive(Debug, Clone, Default)]
+pub struct FeatureFlagsConfig {
+    /// Require stable row ids: every fragment must carry a row-id index, and both
+    /// reader and writer flags are fenced. Row-id metadata already present on the
+    /// fragments forces the fence regardless of this input.
+    pub enable_stable_row_id: bool,
+    /// The transaction is embedded inline in the manifest instead of a separate
+    /// `_transactions/` file; fences writers that would expect the file.
+    pub disable_transaction_file: bool,
+    /// The commit carries an index with covering (`included_fields`) columns; fences
+    /// writers that would silently drop the unknown metadata. Derive it with
+    /// [`manifest_has_covered_index`] when re-applying flags to an existing manifest.
+    pub has_covered_index: bool,
+}
+
+/// Set the reader and writer feature flags in the manifest based on the contents of the
+/// manifest plus the caller-supplied conditions in `config`. Resets both flag words
+/// first, so every condition must be re-supplied on each call.
+pub fn apply_feature_flags(manifest: &mut Manifest, config: &FeatureFlagsConfig) -> Result<()> {
+    let &FeatureFlagsConfig {
+        enable_stable_row_id,
+        disable_transaction_file,
+        has_covered_index,
+    } = config;
     // Carried across the reset. This bit is not derivable from the manifest --
     // it depends on the `__lance_mem_wal` index details, which a manifest only
     // points at -- and this function runs twice per commit: once in
@@ -137,6 +193,13 @@ pub fn apply_feature_flags(
     manifest.reader_feature_flags |= mem_wal_index_catchup;
     manifest.writer_feature_flags |= mem_wal_index_catchup;
 
+    // Fence writers that predate the feature, so they do not silently drop a covered
+    // index's `included_fields` metadata. Writer-only, and best-effort: released clients
+    // check writer flags on insert alone, so non-insert commit paths still get through --
+    // see FLAG_COVERED_INDEX_METADATA for why that is acceptable.
+    if has_covered_index {
+        manifest.writer_feature_flags |= FLAG_COVERED_INDEX_METADATA;
+    }
     Ok(())
 }
 
@@ -300,7 +363,7 @@ mod tests {
             DataStorageFormat::default(),
             HashMap::new(),
         );
-        apply_feature_flags(&mut manifest, false, false).unwrap();
+        apply_feature_flags(&mut manifest, &FeatureFlagsConfig::default()).unwrap();
         assert_ne!(
             manifest.reader_feature_flags & FLAG_UNSTABLE_DATA_OVERLAY_FILES,
             0
@@ -309,6 +372,115 @@ mod tests {
             manifest.writer_feature_flags & FLAG_UNSTABLE_DATA_OVERLAY_FILES,
             0
         );
+    }
+
+    #[test]
+    fn test_manifest_has_covered_index() {
+        use crate::format::{DataStorageFormat, Fragment, IndexMetadata};
+        use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(vec![Fragment::new(0)]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+        let mut index = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fields: vec![0],
+            name: "idx".to_string(),
+            dataset_version: 1,
+            fragment_bitmap: None,
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: Vec::new(),
+        };
+
+        // No fence yet and no covering declarations.
+        assert!(!manifest_has_covered_index(&manifest, None));
+        assert!(!manifest_has_covered_index(
+            &manifest,
+            Some(std::slice::from_ref(&index))
+        ));
+
+        // An index declaring covering columns requires the fence.
+        index.included_fields = vec![2];
+        assert!(manifest_has_covered_index(
+            &manifest,
+            Some(std::slice::from_ref(&index))
+        ));
+
+        // A manifest already fenced stays fenced even when this commit carries no
+        // index list (the flag words are reset on every apply).
+        manifest.writer_feature_flags |= FLAG_COVERED_INDEX_METADATA;
+        assert!(manifest_has_covered_index(&manifest, None));
+    }
+
+    #[test]
+    fn test_apply_feature_flags_sets_covered_index_flag() {
+        use crate::format::{DataStorageFormat, Fragment};
+        use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(vec![Fragment::new(0)]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+
+        // No covered index: flag not set.
+        apply_feature_flags(&mut manifest, &FeatureFlagsConfig::default()).unwrap();
+        assert_eq!(
+            manifest.writer_feature_flags & FLAG_COVERED_INDEX_METADATA,
+            0
+        );
+
+        // Covered index present: writer flag set, reader flag NOT set (a reader that
+        // ignores `included_fields` falls back to a base-table take, which is correct).
+        apply_feature_flags(
+            &mut manifest,
+            &FeatureFlagsConfig {
+                has_covered_index: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_ne!(
+            manifest.writer_feature_flags & FLAG_COVERED_INDEX_METADATA,
+            0
+        );
+        assert_eq!(
+            manifest.reader_feature_flags & FLAG_COVERED_INDEX_METADATA,
+            0
+        );
+
+        // This build understands the flag, so it can still write the dataset...
+        assert!(can_write_dataset(manifest.writer_feature_flags));
+        // ...but an older writer, whose supported set predates this flag (FLAG_UNKNOWN
+        // was 256), treats it as unknown and refuses -- fencing the metadata-dropping bug.
+        let old_supported = 255u64;
+        assert_ne!(FLAG_COVERED_INDEX_METADATA & !old_supported, 0);
     }
 
     #[test]
@@ -358,7 +530,7 @@ mod tests {
             DataStorageFormat::default(),
             HashMap::new(), // Empty base_paths
         );
-        apply_feature_flags(&mut normal_manifest, false, false).unwrap();
+        apply_feature_flags(&mut normal_manifest, &FeatureFlagsConfig::default()).unwrap();
         assert_eq!(normal_manifest.reader_feature_flags & FLAG_BASE_PATHS, 0);
         assert_eq!(normal_manifest.writer_feature_flags & FLAG_BASE_PATHS, 0);
         // Test 2: Dataset with base_paths (shallow clone or multi-base) should have FLAG_BASE_PATHS
@@ -378,7 +550,7 @@ mod tests {
             DataStorageFormat::default(),
             base_paths,
         );
-        apply_feature_flags(&mut multi_base_manifest, false, false).unwrap();
+        apply_feature_flags(&mut multi_base_manifest, &FeatureFlagsConfig::default()).unwrap();
         assert_ne!(
             multi_base_manifest.reader_feature_flags & FLAG_BASE_PATHS,
             0
@@ -440,7 +612,7 @@ mod tests {
         manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
         manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
 
-        apply_feature_flags(&mut manifest, false, false).unwrap();
+        apply_feature_flags(&mut manifest, &FeatureFlagsConfig::default()).unwrap();
 
         assert_ne!(
             manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
@@ -458,7 +630,7 @@ mod tests {
         let mut manifest = empty_manifest();
         manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
 
-        apply_feature_flags(&mut manifest, false, false).unwrap();
+        apply_feature_flags(&mut manifest, &FeatureFlagsConfig::default()).unwrap();
 
         assert_eq!(
             manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -77,6 +77,12 @@ pub struct IndexMetadata {
     /// This is None if the file sizes are unknown. This happens for indices created
     /// before this field was added.
     pub files: Option<Vec<IndexFile>>,
+
+    /// Columns co-located ("included") in the index alongside its key `fields`,
+    /// so a query covered by them can be answered from the index without a take
+    /// from the base table. These are `Field.id`s, same as `fields`. Empty for
+    /// indexes without covering columns.
+    pub included_fields: Vec<i32>,
 }
 
 impl IndexMetadata {
@@ -179,6 +185,7 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             }),
             base_id: proto.base_id,
             files,
+            included_fields: proto.included_fields,
         })
     }
 }
@@ -223,6 +230,7 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
             created_at: idx.created_at.map(|dt| dt.timestamp_millis() as u64),
             base_id: idx.base_id,
             files,
+            included_fields: idx.included_fields.clone(),
         }
     }
 }
@@ -327,6 +335,7 @@ mod tests {
                     path: "index.idx".to_string(),
                     size_bytes: 1024,
                 }]),
+                included_fields: vec![1],
             },
             IndexMetadata {
                 uuid: Uuid::new_v4(),
@@ -339,6 +348,7 @@ mod tests {
                 created_at: None,
                 base_id: Some(7),
                 files: None,
+                included_fields: Vec::new(),
             },
         ];
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -128,7 +128,7 @@ use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
 use lance_table::feature_flags::{
-    apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
+    FeatureFlagsConfig, apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
 };
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
@@ -3906,10 +3906,18 @@ pub(crate) async fn write_manifest_file(
         // Preserve it here so this second apply_feature_flags call does not clear it
         // when config.use_stable_row_ids is false (the ManifestWriteConfig default).
         let use_stable_row_ids = config.use_stable_row_ids || manifest.uses_stable_row_ids();
+        // Like FLAG_STABLE_ROW_IDS, preserve the covered-index flag build_manifest may
+        // have already set (this second call resets the flag words), and also detect it
+        // from the indices passed here.
+        let has_covered_index =
+            lance_table::feature_flags::manifest_has_covered_index(manifest, indices.as_deref());
         apply_feature_flags(
             manifest,
-            use_stable_row_ids,
-            config.disable_transaction_file,
+            &FeatureFlagsConfig {
+                enable_stable_row_id: use_stable_row_ids,
+                disable_transaction_file: config.disable_transaction_file,
+                has_covered_index,
+            },
         )?;
     }
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -2049,6 +2049,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -233,6 +233,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -1416,6 +1416,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -785,6 +785,7 @@ impl MemTableFlusher {
                 created_at: None,
                 base_id: None,
                 files: None,
+                included_fields: Vec::new(),
             };
             created_indexes.push(index_meta);
 
@@ -1115,6 +1116,14 @@ impl MemTableFlusher {
             created_at: Some(chrono::Utc::now()),
             index_version: 1,
             files: None,
+            // MemWAL flush does not build *covering* ("included") segments: include_columns
+            // is not threaded through the HNSW/SQ flush build, so there is nothing to carry
+            // here. An empty covering set is correct regardless -- covered queries fetch the
+            // projected columns for a non-covering segment's rows via the normal take. This
+            // only needs a real covering set if MemWAL is later extended to build covering
+            // segments (a perf optimization), which also requires threading include_columns
+            // through the flush build, not just populating this field.
+            included_fields: Vec::new(),
         };
 
         Ok(Some(index_meta))

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -6342,6 +6342,7 @@ mod tests {
                     version: crate::index::vector::IndexFileVersion::V3,
                     skip_transpose: false,
                     runtime_hints: Default::default(),
+                    include_columns: Vec::new(),
                 },
                 false,
             )
@@ -6477,6 +6478,7 @@ mod tests {
                     version: crate::index::vector::IndexFileVersion::V3,
                     skip_transpose: false,
                     runtime_hints: Default::default(),
+                    include_columns: Vec::new(),
                 },
                 false,
             )

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -325,16 +325,23 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
     // does not incorporate overlays committed after the source index was built.
     // Exclude those fragments so queries scan their current values instead.
     if let Some(fragment_bitmap) = &mut bitmap_after_remap {
+        // Fields whose value this index materializes: its indexed key fields plus every
+        // covered (included) column expanded to its leaf subtree (an overlay lists leaf
+        // ids, while `included_fields` records a parent struct id).
+        let relevant_field_ids =
+            Transaction::index_dependent_leaf_ids(&curr_index_meta, dataset.schema());
         for fragment in dataset.manifest.fragments.iter() {
-            let has_newer_indexed_overlay = fragment.overlays.iter().any(|overlay| {
+            // An overlay refreshing an indexed or covered field makes the index storage
+            // stale for that fragment: it still holds the pre-overlay copy of the value.
+            let has_newer_relevant_overlay = fragment.overlays.iter().any(|overlay| {
                 overlay.committed_version > curr_index_meta.dataset_version
                     && overlay
                         .data_file
                         .fields
                         .iter()
-                        .any(|field_id| curr_index_meta.fields.contains(field_id))
+                        .any(|field_id| relevant_field_ids.contains(field_id))
             });
-            if has_newer_indexed_overlay {
+            if has_newer_relevant_overlay {
                 fragment_bitmap.remove(fragment.id as u32);
             }
         }
@@ -361,7 +368,8 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
             created_at: curr_index_meta.created_at,
             base_id: None,
             files: curr_index_meta.files.clone(),
-            included_fields: Vec::new(),
+            // Row-id remapping preserves the covering columns.
+            included_fields: curr_index_meta.included_fields.clone(),
         },
         RemapResult::Remapped(remapped_index) => IndexMetadata {
             uuid: remapped_index.new_id,
@@ -374,7 +382,8 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
             created_at: curr_index_meta.created_at,
             base_id: None,
             files: remapped_index.files,
-            included_fields: Vec::new(),
+            // Row-id remapping preserves the covering columns.
+            included_fields: curr_index_meta.included_fields.clone(),
         },
     };
 

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -361,6 +361,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
             created_at: curr_index_meta.created_at,
             base_id: None,
             files: curr_index_meta.files.clone(),
+            included_fields: Vec::new(),
         },
         RemapResult::Remapped(remapped_index) => IndexMetadata {
             uuid: remapped_index.new_id,
@@ -373,6 +374,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
             created_at: curr_index_meta.created_at,
             base_id: None,
             files: remapped_index.files,
+            included_fields: Vec::new(),
         },
     };
 

--- a/rust/lance/src/dataset/overlay.rs
+++ b/rust/lance/src/dataset/overlay.rs
@@ -132,6 +132,18 @@ pub fn overlaid_fragments(fragments: &[Fragment]) -> HashMap<u32, &Fragment> {
         .collect()
 }
 
+/// The field ids whose staleness invalidates an index segment: its key `fields` plus any
+/// covering (`included_fields`) columns materialized in the index storage. An overlay touching
+/// either makes the segment's stored copy stale, so both must gate overlay exclusion.
+fn index_and_covering_field_ids(segment: &IndexMetadata) -> Vec<i32> {
+    segment
+        .fields
+        .iter()
+        .copied()
+        .chain(segment.included_fields.iter().copied())
+        .collect()
+}
+
 /// Insert into `stale` the ids of fragments covered by `segment` whose index entries may be
 /// stale because an overlay committed after the segment was built touches a field the segment
 /// indexes. Field-aware and version-gated via [`overlay_exclusion_offsets`].
@@ -145,11 +157,12 @@ pub fn collect_overlay_stale_frags(
     schema: &Schema,
 ) -> Result<()> {
     let coverage = segment.fragment_bitmap.as_ref();
+    let index_fields = index_and_covering_field_ids(segment);
     for (&frag_id, fragment) in overlaid_frags {
         if stale.contains(frag_id) || !covers_fragment(coverage, frag_id) {
             continue;
         }
-        if !stale_offsets_for_fragment(fragment, &segment.fields, segment.dataset_version, schema)?
+        if !stale_offsets_for_fragment(fragment, &index_fields, segment.dataset_version, schema)?
             .is_empty()
         {
             stale.insert(frag_id);
@@ -171,12 +184,13 @@ pub fn collect_overlay_stale_rows_for_segment(
     schema: &Schema,
 ) -> Result<()> {
     let coverage = segment.fragment_bitmap.as_ref();
+    let index_fields = index_and_covering_field_ids(segment);
     for (&frag_id, fragment) in overlaid_frags {
         if !covers_fragment(coverage, frag_id) {
             continue;
         }
         let excluded =
-            stale_offsets_for_fragment(fragment, &segment.fields, segment.dataset_version, schema)?;
+            stale_offsets_for_fragment(fragment, &index_fields, segment.dataset_version, schema)?;
         if !excluded.is_empty() {
             *stale.entry(frag_id).or_default() |= &excluded;
         }
@@ -1430,5 +1444,47 @@ mod tests {
         )
         .unwrap();
         assert_eq!(stale.get(&3), Some(&bitmap([1, 2])));
+    }
+
+    #[test]
+    fn test_collect_rows_flags_overlay_on_covered_column() {
+        let schema = flat_test_schema();
+        // Segment indexes field 3 (key) and COVERS field 2 (included). An overlay touching
+        // ONLY the covered field must still flag its rows stale -- otherwise a covered query
+        // serves the stale index-stored copy of that column instead of the fresh overlay value.
+        let fragment = fragment_with_overlay(3, dense_overlay(vec![2], [1, 2], 9));
+        let overlaid: HashMap<u32, &Fragment> = HashMap::from([(3u32, &fragment)]);
+        let seg = IndexMetadata {
+            included_fields: vec![2],
+            ..segment(vec![3], 1, Some(bitmap([3])))
+        };
+
+        let mut stale = HashMap::new();
+        collect_overlay_stale_rows_for_segment(&seg, &overlaid, &mut stale, &schema).unwrap();
+        assert_eq!(
+            stale.get(&3),
+            Some(&bitmap([1, 2])),
+            "overlay on a covered (included) column must flag its rows stale"
+        );
+    }
+
+    #[test]
+    fn test_collect_frags_flags_overlay_on_covered_column() {
+        let schema = flat_test_schema();
+        // Same at fragment granularity: an overlay on a covered column marks the fragment stale.
+        let fragment = fragment_with_overlay(3, dense_overlay(vec![2], [1, 2], 9));
+        let overlaid: HashMap<u32, &Fragment> = HashMap::from([(3u32, &fragment)]);
+        let seg = IndexMetadata {
+            included_fields: vec![2],
+            ..segment(vec![3], 1, Some(bitmap([3])))
+        };
+
+        let mut stale = RoaringBitmap::new();
+        collect_overlay_stale_frags(&seg, &overlaid, &mut stale, &schema).unwrap();
+        assert_eq!(
+            stale,
+            bitmap([3]),
+            "overlay on a covered (included) column must flag the fragment stale"
+        );
     }
 }

--- a/rust/lance/src/dataset/overlay.rs
+++ b/rust/lance/src/dataset/overlay.rs
@@ -1340,6 +1340,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -13714,6 +13714,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                     version: crate::index::vector::IndexFileVersion::Legacy,
                     skip_transpose: false,
                     runtime_hints: Default::default(),
+                    include_columns: Vec::new(),
                 },
                 false,
             )

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5017,10 +5017,31 @@ impl Scanner {
             knn_node = self.take(knn_node, vector_projection)?;
         }
 
+        // The index search now emits the index's covering ("included") columns, so every flat
+        // path below must produce the same columns before it is unioned with `knn_node`;
+        // otherwise projecting the flat output to `knn_node.schema()` panics on the missing column.
+        let covering_columns: Vec<String> = indexed_segments
+            .first()
+            .map(|s| s.included_fields.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .filter_map(|id| {
+                self.dataset
+                    .schema()
+                    .field_by_id(*id)
+                    .map(|field| field.name.clone())
+            })
+            .collect();
+
         let mut columns = vec![q.column.clone()];
         if let Some(expr) = filter_plan.full_expr.as_ref() {
             let filter_columns = Planner::column_names_in_expr(expr);
             columns.extend(filter_columns);
+        }
+        for name in &covering_columns {
+            if !columns.contains(name) {
+                columns.push(name.clone());
+            }
         }
 
         // Collect flat-path plans; union order matches original (flat before ANN) so test snapshots
@@ -5069,6 +5090,9 @@ impl Scanner {
             if let Some(expr) = filter_plan.full_expr.as_ref() {
                 let filter_columns = Planner::column_names_in_expr(expr);
                 take_proj = take_proj.union_columns(filter_columns, OnMissing::Error)?;
+            }
+            if !covering_columns.is_empty() {
+                take_proj = take_proj.union_columns(covering_columns.clone(), OnMissing::Error)?;
             }
             let mut stale_node = self.stale_rows_take(stale_rows, take_proj).await?;
             if let Some(expr) = filter_plan.full_expr.as_ref() {

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -791,34 +791,80 @@ pub(super) async fn alter_columns(
 
     new_schema.validate()?;
 
-    // If any column being cast has an attached index, fail fast. Cast operations
-    // rewrite the underlying column data and silently invalidate any index on the
-    // affected column(s). The current behavior is to drop such indices without
-    // warning, which has caused production incidents where vector search silently
-    // regressed to brute-force scan. We require users to explicitly drop the
-    // index before altering the column type, so the action is never silent.
-    if !cast_fields.is_empty() {
+    // Fail fast on alterations that would invalidate an index or desync its
+    // covering data:
+    //   * CAST of an indexed *key* column -- cast rewrites the column data and
+    //     silently invalidates the index. This has caused production incidents
+    //     where vector search regressed to a brute-force scan. (Indices are
+    //     keyed by field id, so a plain rename or nullability change of a key
+    //     column is safe and stays allowed.)
+    //   * ANY alter (rename, cast, or nullability) of a covering ("included")
+    //     column -- the read path resolves the covering column from the live
+    //     schema while the index storage still emits the old name/type, which
+    //     breaks covered queries. The index auto-prune keys on `fields`, so it
+    //     never cleans up a covering-only column for us.
+    // Require the user to drop the index first so the action is never silent.
+    let cast_ids: Vec<i32> = alterations
+        .iter()
+        .filter(|a| a.data_type.is_some())
+        .filter_map(|a| dataset.schema().field(&a.path).map(|f| f.id))
+        .collect();
+    let altered: Vec<(&str, i32)> = alterations
+        .iter()
+        .filter(|a| a.rename.is_some() || a.data_type.is_some() || a.nullable.is_some())
+        .filter_map(|a| {
+            dataset
+                .schema()
+                .field(&a.path)
+                .map(|f| (a.path.as_str(), f.id))
+        })
+        .collect();
+    if !altered.is_empty() {
         let indices = dataset.load_indices().await?;
-        let affected: Vec<&lance_table::format::IndexMetadata> = indices
-            .iter()
-            .filter(|idx| {
-                cast_fields
-                    .iter()
-                    .any(|(old, _)| idx.fields.contains(&old.id))
+        // A covered column is stored as a whole subtree, so altering a *descendant* of a
+        // covered field (e.g. a subfield of a covered struct) invalidates the covering
+        // too; expand each altered field to its ancestors so the covered ancestor's id is
+        // caught. The expansion depends only on the schema, so do it once per altered
+        // field here rather than per (index x altered field) below.
+        let altered: Vec<(&str, i32, Vec<i32>)> = altered
+            .into_iter()
+            .map(|(name, id)| {
+                let ancestors =
+                    field_ids_with_ancestors(dataset.schema(), std::slice::from_ref(&id));
+                (name, id, ancestors)
             })
             .collect();
+        // An index is broken if a covering column of it is altered in any way, or if one
+        // of its indexed key columns is being cast. The cast check stays on the field's
+        // own id (only a cast of the indexed key column rewrites index data).
+        let is_broken = |idx: &lance_table::format::IndexMetadata| {
+            altered.iter().any(|(_, _, ancestors)| {
+                ancestors
+                    .iter()
+                    .any(|ancestor| idx.included_fields.contains(ancestor))
+            }) || cast_ids.iter().any(|id| idx.fields.contains(id))
+        };
+        let affected: Vec<&lance_table::format::IndexMetadata> =
+            indices.iter().filter(|idx| is_broken(idx)).collect();
         if !affected.is_empty() {
-            let affected_cols: Vec<String> = cast_fields
+            let affected_cols: Vec<String> = altered
                 .iter()
-                .filter(|(old, _)| affected.iter().any(|i| i.fields.contains(&old.id)))
-                .map(|(old, _)| old.name.clone())
+                .filter(|(_, id, ancestors)| {
+                    affected.iter().any(|i| {
+                        ancestors
+                            .iter()
+                            .any(|ancestor| i.included_fields.contains(ancestor))
+                            || (cast_ids.contains(id) && i.fields.contains(id))
+                    })
+                })
+                .map(|(name, _, _)| name.to_string())
                 .collect();
             let affected_idx_names: Vec<String> = affected.iter().map(|i| i.name.clone()).collect();
             return Err(Error::invalid_input(format!(
-                "Cannot cast column(s) [{}] to a new type: they have {} index(es) \
-                 attached: [{}]. Cast rewrites column data and invalidates any index \
-                 on the affected column(s). Drop the index(es) with drop_index() \
-                 before altering, then recreate them after the cast completes.",
+                "Cannot alter column(s) [{}]: they are used by {} index(es) [{}] -- as a \
+                 covering (included) column (any change), or as an indexed key column being \
+                 cast (which rewrites the data and invalidates the index). Drop the index(es) \
+                 with drop_index() before altering, then recreate them.",
                 affected_cols.join(", "),
                 affected.len(),
                 affected_idx_names.join(", "),
@@ -936,6 +982,23 @@ pub(super) async fn alter_columns(
     Ok(())
 }
 
+/// Expand `field_ids` to also include every ancestor field id (root -> field).
+/// A covering column is stored as a whole subtree, so touching a *descendant* of a
+/// covered field (e.g. a subfield of a covered struct) still invalidates the covering
+/// even though `included_fields` records only the ancestor's id. Adding each targeted
+/// field's ancestors makes the ancestor's id appear in the set so the exact-membership
+/// checks catch it.
+fn field_ids_with_ancestors(schema: &Schema, field_ids: &[i32]) -> Vec<i32> {
+    let mut expanded = Vec::with_capacity(field_ids.len());
+    for &id in field_ids {
+        match schema.field_ancestry_by_id(id) {
+            Some(ancestry) => expanded.extend(ancestry.iter().map(|field| field.id)),
+            None => expanded.push(id),
+        }
+    }
+    expanded
+}
+
 /// Remove columns from the dataset.
 ///
 /// This is a metadata-only operation and does not remove the data from the
@@ -951,6 +1014,47 @@ pub(super) async fn drop_columns(dataset: &mut Dataset, columns: &[&str]) -> Res
                 col
             )));
         }
+    }
+
+    // Fail fast if any column being dropped is a covering ("included") column of
+    // an index. Dropping the index's *key* column is fine -- the index is
+    // auto-pruned when its indexed field leaves the schema -- but a covering
+    // column is not caught by that prune, so dropping it would silently leave the
+    // index's storage referencing a missing column and break covered queries.
+    // Require the user to drop the index first so the action is never silent.
+    let drop_field_ids: Vec<i32> = columns
+        .iter()
+        .filter_map(|c| dataset.schema().field(c).map(|f| f.id))
+        .collect();
+    let indices = dataset.load_indices().await?;
+    // Treat a descendant of a covered (e.g. struct) column as covered too.
+    let drop_field_ids = field_ids_with_ancestors(dataset.schema(), &drop_field_ids);
+    // An index whose *key* is also being dropped is auto-pruned by
+    // `retain_relevant_indices`, so its covering metadata cannot dangle -- the whole index
+    // goes away. Rejecting here would block the perfectly safe "drop the vector column and
+    // its covered payload together" case. The commit-boundary guard
+    // (`reject_covered_field_subtree_change`) skips these indices for the same reason, and
+    // this preflight must agree with it or it forbids what the commit would accept.
+    let dropped: HashSet<i32> = drop_field_ids.iter().copied().collect();
+    let affected: Vec<&lance_table::format::IndexMetadata> = indices
+        .iter()
+        .filter(|idx| !idx.fields.iter().all(|id| dropped.contains(id)))
+        .filter(|idx| {
+            drop_field_ids
+                .iter()
+                .any(|id| idx.included_fields.contains(id))
+        })
+        .collect();
+    if !affected.is_empty() {
+        let affected_idx_names: Vec<String> = affected.iter().map(|i| i.name.clone()).collect();
+        return Err(Error::invalid_input(format!(
+            "Cannot drop column(s) [{}]: they are a covering (included) column of {} \
+             index(es) [{}]. Drop the index(es) with drop_index() before dropping the \
+             column(s), then recreate them.",
+            columns.join(", "),
+            affected.len(),
+            affected_idx_names.join(", "),
+        )));
     }
 
     let version = dataset.manifest.data_storage_format.lance_file_format();
@@ -3311,6 +3415,345 @@ mod test {
                 Arc::new(ArrowField::new("item", DataType::Float16, true)),
                 64,
             ),
+        );
+
+        Ok(())
+    }
+
+    /// The covered-column schema guards must treat a *descendant* of a covered field as
+    /// covered too: a covered column is stored as a whole subtree, so `included_fields`
+    /// records only the ancestor's id. `field_ids_with_ancestors` expands a targeted
+    /// subfield to include that ancestor so the exact-membership guard catches it.
+    #[test]
+    fn test_field_ids_with_ancestors_expands_struct_subtree() {
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new(
+                "s",
+                DataType::Struct(ArrowFields::from(vec![
+                    ArrowField::new("a", DataType::Int32, true),
+                    ArrowField::new("b", DataType::Int32, true),
+                ])),
+                true,
+            ),
+            ArrowField::new("x", DataType::Int32, true),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let s_id = schema.field("s").unwrap().id;
+        let a_id = schema.field("s.a").unwrap().id;
+
+        let expanded = field_ids_with_ancestors(&schema, &[a_id]);
+        assert!(
+            expanded.contains(&s_id),
+            "expanding a subfield must include its covered struct ancestor's id"
+        );
+        assert!(
+            expanded.contains(&a_id),
+            "the field's own id must be included"
+        );
+    }
+
+    /// Dropping a covered column TOGETHER WITH its index's key column is safe and must be
+    /// allowed: `retain_relevant_indices` drops the whole index once its key leaves the
+    /// schema, so no covering metadata can dangle. The commit-boundary guard
+    /// (`reject_covered_field_subtree_change`) already skips such indices; this preflight
+    /// must agree with it, or it forbids an operation the commit would accept.
+    #[tokio::test]
+    async fn test_drop_covered_column_with_its_index_key_is_allowed() -> Result<()> {
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::IndexType;
+        use lance_linalg::distance::MetricType;
+        use lance_testing::datagen::generate_random_array;
+
+        use crate::index::vector::VectorIndexParams;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    64,
+                ),
+                false,
+            ),
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("keep", DataType::Int32, false),
+        ]));
+        let nrows: i32 = 256;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(
+                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
+                        generate_random_array(64 * nrows as usize),
+                        64,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+            ],
+        )?;
+
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            &test_dir,
+            None,
+        )
+        .await?;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 8, MetricType::L2, 50);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await?;
+
+        // Drop the covered column AND the index key in one call.
+        dataset.drop_columns(&["vec", "id"]).await?;
+
+        assert!(
+            dataset.load_indices().await?.is_empty(),
+            "the index must be pruned once its key column is gone"
+        );
+        let remaining: Vec<&str> = dataset
+            .schema()
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(remaining, vec!["keep"]);
+        Ok(())
+    }
+
+    /// Dropping a column that an index *covers* (an "included"/covering column,
+    /// not the key column) must fail fast rather than leaving the index
+    /// referencing a missing column and breaking covered queries. The user must
+    /// drop the index first.
+    #[tokio::test]
+    async fn test_drop_columns_fails_on_covered_column() -> Result<()> {
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::IndexType;
+        use lance_linalg::distance::MetricType;
+        use lance_testing::datagen::generate_random_array;
+
+        use crate::index::vector::VectorIndexParams;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    64,
+                ),
+                false,
+            ),
+            ArrowField::new("id", DataType::Int32, false),
+        ]));
+        let nrows: i32 = 256;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(
+                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
+                        generate_random_array(64 * nrows as usize),
+                        64,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+            ],
+        )?;
+
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            &test_dir,
+            None,
+        )
+        .await?;
+
+        // IVF_PQ index on `vec` that COVERS `id`.
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 8, MetricType::L2, 50);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await?;
+        let index_name = dataset.load_indices().await?[0].name.clone();
+
+        // Dropping the covered column must fail, naming the column, the index,
+        // and the remediation.
+        let err = dataset
+            .drop_columns(&["id"])
+            .await
+            .expect_err("dropping a covered column should fail");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected Error::InvalidInput, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("id") && msg.contains(&index_name) && msg.contains("drop_index"),
+            "error should mention the column, index, and remediation, got: {msg}"
+        );
+
+        // Unchanged: column still present, index still there.
+        assert!(dataset.schema().field("id").is_some());
+        assert_eq!(dataset.load_indices().await?.len(), 1);
+
+        // After dropping the index, the same drop succeeds.
+        dataset.drop_index(&index_name).await?;
+        dataset.drop_columns(&["id"]).await?;
+        assert!(dataset.schema().field("id").is_none());
+
+        Ok(())
+    }
+
+    /// Dropping a column that is only an INDEXED key column (not a covering
+    /// column) must remain allowed: lance auto-drops the dependent index. Only
+    /// covering ("included") columns are protected by the drop guard -- the
+    /// index auto-prune keys on `fields`, so it already cleans up the indexed
+    /// case, whereas a covered-only column would be silently left dangling.
+    /// Regression guard for the Python `test_drop_columns` behavior.
+    #[tokio::test]
+    async fn test_drop_indexed_noncovered_column_drops_index() -> Result<()> {
+        use crate::index::vector::VectorIndexParams;
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::IndexType;
+        use lance_linalg::distance::MetricType;
+        use lance_testing::datagen::generate_random_array;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    64,
+                ),
+                false,
+            ),
+            ArrowField::new("id", DataType::Int32, false),
+        ]));
+        let nrows: i32 = 256;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(
+                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
+                        generate_random_array(64 * nrows as usize),
+                        64,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+            ],
+        )?;
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            &test_dir,
+            None,
+        )
+        .await?;
+
+        // Plain IVF_PQ index on `vec` -- NO covering columns.
+        let params = VectorIndexParams::ivf_pq(4, 8, 8, MetricType::L2, 50);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await?;
+        assert_eq!(dataset.load_indices().await?.len(), 1);
+
+        // Dropping the indexed key column is allowed and auto-drops the index.
+        dataset.drop_columns(&["vec"]).await?;
+        assert!(dataset.schema().field("vec").is_none());
+        assert_eq!(
+            dataset.load_indices().await?.len(),
+            0,
+            "dropping the indexed column should have dropped its index"
+        );
+
+        Ok(())
+    }
+
+    /// Fix 1: renaming or changing the nullability of a covered ("included")
+    /// column must fail fast (alongside cast) -- it would leave the index storage
+    /// referencing a stale name/schema and break covered queries.
+    #[tokio::test]
+    async fn test_alter_columns_rename_nullable_fail_on_covered_column() -> Result<()> {
+        use crate::index::vector::VectorIndexParams;
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::IndexType;
+        use lance_linalg::distance::MetricType;
+        use lance_testing::datagen::generate_random_array;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    64,
+                ),
+                false,
+            ),
+            ArrowField::new("id", DataType::Int32, false),
+        ]));
+        let nrows: i32 = 256;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(
+                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
+                        generate_random_array(64 * nrows as usize),
+                        64,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+            ],
+        )?;
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            &test_dir,
+            None,
+        )
+        .await?;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 8, MetricType::L2, 50);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await?;
+
+        // Rename of the covered column must fail with the remediation hint.
+        let err = dataset
+            .alter_columns(&[ColumnAlteration::new("id".into()).rename("uid".into())])
+            .await
+            .expect_err("rename of covered column should fail");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected Error::InvalidInput, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("drop_index"),
+            "rename error should suggest drop_index, got: {err}"
+        );
+        assert!(
+            dataset.schema().field("id").is_some(),
+            "rename should not have applied"
+        );
+
+        // Nullability change of the covered column must also fail.
+        let err = dataset
+            .alter_columns(&[ColumnAlteration::new("id".into()).set_nullable(true)])
+            .await
+            .expect_err("nullability change of covered column should fail");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected Error::InvalidInput, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("drop_index"),
+            "nullable error should suggest drop_index, got: {err}"
         );
 
         Ok(())

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2504,6 +2504,7 @@ impl Transaction {
                     &mut final_indices,
                     updated_fragments,
                     fields_modified,
+                    &schema,
                 );
 
                 let mut new_fragments =
@@ -2648,7 +2649,7 @@ impl Transaction {
                 // base data. Any index older than one of those overlays was built on
                 // the pre-overlay values, so drop the rewritten fragment from its
                 // coverage to keep it from serving stale values.
-                Self::prune_overlay_stale_fields_from_indices(&mut final_indices, groups);
+                Self::prune_overlay_stale_fields_from_indices(&mut final_indices, groups, &schema);
 
                 if let Some(frag_reuse_index) = frag_reuse_index {
                     final_indices.retain(|idx| idx.name != frag_reuse_index.name);
@@ -2674,6 +2675,45 @@ impl Transaction {
                         && !new_uuids.contains(&existing_index.uuid)
                 });
                 final_indices.extend(new_indices.clone());
+                // All delta segments of one logical index (same name) must declare
+                // the same covering columns: the covered read path derives its
+                // output schema from one delta but executes all of them, so
+                // committing a mixed set would fail every query on the index.
+                // Scoped to names this operation adds, so a commit untouched by
+                // covering cannot be blocked by pre-existing state.
+                for new_index in new_indices {
+                    // A declared covering field must resolve to a TOP-LEVEL field of
+                    // the schema being committed: the read path resolves the id to its
+                    // bare name, so a nested id (e.g. a struct child) would silently
+                    // bind to a same-named top-level column, and a nonexistent id
+                    // fails every later query at planning time ("index metadata and
+                    // schema are inconsistent"). Reject at the commit boundary.
+                    for id in &new_index.included_fields {
+                        if !schema.fields.iter().any(|field| field.id == *id) {
+                            return Err(Error::invalid_input(format!(
+                                "CreateIndex: index '{}' (segment {}) declares covering \
+                                 field id {}, which is not a top-level field of the \
+                                 schema (covering columns must be top-level)",
+                                new_index.name, new_index.uuid, id
+                            )));
+                        }
+                    }
+                    if let Some(conflict) = final_indices.iter().find(|idx| {
+                        idx.name == new_index.name
+                            && idx.included_fields != new_index.included_fields
+                    }) {
+                        return Err(Error::invalid_input(format!(
+                            "CreateIndex: delta segment {} of index '{}' declares covering \
+                             fields {:?}, but delta segment {} declares {:?}; all segments of \
+                             one index must declare the same covering columns",
+                            new_index.uuid,
+                            new_index.name,
+                            new_index.included_fields,
+                            conflict.uuid,
+                            conflict.included_fields
+                        )));
+                    }
+                }
             }
             Operation::ReserveFragments { .. } | Operation::UpdateConfig { .. } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
@@ -2710,6 +2750,18 @@ impl Transaction {
                 }
                 final_fragments.extend(merged_fragments);
 
+                // `add_columns` commits as a Merge; growing a *covered* field's subtree
+                // (e.g. an AllNulls child under a covered struct, which writes no data file
+                // and so is invisible to the file-path-keyed prune below) would leave the
+                // index emitting the old payload schema while covered queries declare the
+                // new one. Reject at the commit boundary, mirroring the Project guard.
+                Self::reject_covered_field_subtree_change(
+                    &final_indices,
+                    current_manifest.map(|m| &m.schema),
+                    &schema,
+                    "add_columns (Merge)",
+                )?;
+
                 // A Merge can rewrite a column's data file in place; the field stays
                 // in the schema, so the index is retained -- prune its now-stale
                 // entries for the rewritten fragments.
@@ -2717,6 +2769,7 @@ impl Transaction {
                     &mut final_indices,
                     existing_fragments,
                     fragments,
+                    &schema,
                 );
 
                 // Some fields that have indices may have been removed, so we should
@@ -2739,6 +2792,16 @@ impl Transaction {
                             .any(|field_id| remaining_field_ids.contains(field_id))
                     });
                 }
+
+                // A Project that drops or renames a *covered* field would leave dangling
+                // index metadata whose storage still emits the column -- reject it before
+                // dropping/retaining any indices.
+                Self::reject_covered_field_subtree_change(
+                    &final_indices,
+                    current_manifest.map(|m| &m.schema),
+                    &schema,
+                    "Project",
+                )?;
 
                 // Some fields that have indices may have been removed, so we should
                 // remove those indices as well.
@@ -2892,6 +2955,7 @@ impl Transaction {
                     &mut final_indices,
                     &modified_fragments,
                     &replaced_fields,
+                    &schema,
                 );
             }
             Operation::DataOverlay { groups } => {
@@ -3297,9 +3361,21 @@ impl Transaction {
             if index_results_are_row_addrs(index) {
                 continue;
             }
-            let index_covers_modified_field = index.fields.iter().any(|field_id| {
-                value_updated_field_set.contains(&u32::try_from(*field_id).unwrap())
-            });
+            // Covering (`included_fields`) values are materialized in the index
+            // storage just like the indexed `fields`, so a rewrite of either
+            // makes this fragment's entries stale. Reusing them would serve the
+            // pre-update value, so treat both as "modified field" here.
+            //
+            // Expand to the leaf subtree, exactly as every sibling prune does:
+            // `included_fields` can only ever hold TOP-LEVEL ids (index creation
+            // resolves whole columns and rejects dotted names), while the caller
+            // may report the individual leaves it rewrote. Comparing raw ids would
+            // miss a covered struct whose child was rewritten and wrongly extend
+            // this index's bitmap onto the moved fragment, serving the pre-update
+            // subfield value from index storage.
+            let index_covers_modified_field = Self::index_dependent_field_ids(index, schema)
+                .iter()
+                .any(|field_id| value_updated_field_set.contains(field_id));
             if index_covers_modified_field {
                 continue;
             }
@@ -3342,11 +3418,51 @@ impl Transaction {
     }
 
     /// If an operation modifies one or more fields in a fragment then we need to remove
-    /// that fragment from any indices that cover one of the modified fields.
+    /// that fragment from any indices that cover one of the modified fields — whether as
+    /// an indexed key field (`fields`) or as a covering/"included" field
+    /// (`included_fields`, whose values are materialized in the index storage and would
+    /// otherwise be served stale).
+    /// The full set of leaf field ids an index depends on: its indexed key fields plus
+    /// every covered (included) field expanded to its whole subtree. `included_fields`
+    /// records the parent struct id, but a modified/overlaid data file lists leaf ids, so
+    /// a change to a covered struct's subfield must still count as touching the index.
+    /// Leaf field ids an index depends on: its indexed key fields plus every covered
+    /// ("included") field expanded to its whole subtree. Returned as raw `i32` (the field
+    /// id space of `DataFile.fields` / overlay fields), so a change to a leaf subfield of
+    /// a covered *struct* -- whose `included_fields` records only the parent id -- is
+    /// recognized. Shared by the freshness prunes and the conflict-rebase checks.
+    pub(crate) fn index_dependent_leaf_ids(index: &IndexMetadata, schema: &Schema) -> HashSet<i32> {
+        let mut ids: HashSet<i32> = HashSet::new();
+        for &id in index.fields.iter().chain(index.included_fields.iter()) {
+            match schema.field_by_id(id) {
+                Some(field) => crate::index::collect_subtree_field_ids(field, &mut ids),
+                None => {
+                    ids.insert(id);
+                }
+            }
+        }
+        ids
+    }
+
+    fn index_dependent_field_ids(index: &IndexMetadata, schema: &Schema) -> HashSet<u32> {
+        Self::index_dependent_leaf_ids(index, schema)
+            .into_iter()
+            .filter_map(|id| u32::try_from(id).ok())
+            .collect()
+    }
+
+    /// Drop `updated_fragments` from the coverage of any index that depends on a field
+    /// listed in `fields_modified`. Covered struct fields are expanded to their leaf
+    /// subtree: `included_fields` records the parent struct id while a modified data
+    /// file lists leaf ids, so exact-id matching would miss an update to a covered
+    /// struct's subfield and serve its stale value from the index. Every caller must
+    /// therefore supply the schema (the conflict-rebase path captures it at the read
+    /// version).
     pub(crate) fn prune_updated_fields_from_indices(
         indices: &mut [IndexMetadata],
         updated_fragments: &[Fragment],
         fields_modified: &[u32],
+        schema: &Schema,
     ) {
         if fields_modified.is_empty() {
             return;
@@ -3354,14 +3470,12 @@ impl Transaction {
 
         // If we modified any fields in the fragments then we need to remove those fragments
         // from the index if the index covers one of those modified fields.
-        let fields_modified_set = fields_modified.iter().collect::<HashSet<_>>();
+        let fields_modified_set = fields_modified.iter().copied().collect::<HashSet<u32>>();
         for index in indices.iter_mut() {
-            if index
-                .fields
+            let touches_index = Self::index_dependent_field_ids(index, schema)
                 .iter()
-                .any(|field_id| fields_modified_set.contains(&u32::try_from(*field_id).unwrap()))
-                && let Some(fragment_bitmap) = &mut index.fragment_bitmap
-            {
+                .any(|field_id| fields_modified_set.contains(field_id));
+            if touches_index && let Some(fragment_bitmap) = &mut index.fragment_bitmap {
                 for fragment_id in updated_fragments.iter().map(|f| f.id as u32) {
                     fragment_bitmap.remove(fragment_id);
                 }
@@ -3371,7 +3485,7 @@ impl Transaction {
 
     /// Map each (non-tombstoned) field id in a fragment to the path of the data
     /// file that backs it.
-    fn fragment_field_paths(frag: &Fragment) -> HashMap<i32, &str> {
+    pub(crate) fn fragment_field_paths(frag: &Fragment) -> HashMap<i32, &str> {
         let mut map = HashMap::new();
         for file in &frag.files {
             for &field_id in file.fields.iter() {
@@ -3393,6 +3507,7 @@ impl Transaction {
         indices: &mut [IndexMetadata],
         prev_fragments: &[Fragment],
         new_fragments: &[Fragment],
+        schema: &Schema,
     ) {
         let prev_by_id: HashMap<u64, &Fragment> =
             prev_fragments.iter().map(|f| (f.id, f)).collect();
@@ -3419,6 +3534,7 @@ impl Transaction {
                 indices,
                 std::slice::from_ref(new_frag),
                 &changed,
+                schema,
             );
         }
     }
@@ -3433,17 +3549,18 @@ impl Transaction {
     fn prune_overlay_stale_fields_from_indices(
         indices: &mut [IndexMetadata],
         groups: &[RewriteGroup],
+        schema: &Schema,
     ) {
         for group in groups {
             // field id -> newest overlay committed_version supplying that field
-            let mut overlaid_field_versions: HashMap<i32, u64> = HashMap::new();
+            let mut overlaid_field_versions: HashMap<u32, u64> = HashMap::new();
             for old_frag in &group.old_fragments {
                 for overlay in &old_frag.overlays {
                     for &field_id in overlay.data_file.fields.iter() {
-                        if field_id < 0 {
-                            // Tombstoned (obsolete) overlay field: supplies nothing.
+                        // Tombstoned (obsolete) overlay fields (< 0) supply nothing.
+                        let Ok(field_id) = u32::try_from(field_id) else {
                             continue;
-                        }
+                        };
                         let entry = overlaid_field_versions.entry(field_id).or_insert(0);
                         *entry = (*entry).max(overlay.committed_version);
                     }
@@ -3459,11 +3576,20 @@ impl Transaction {
                 .map(|f| f.id as u32)
                 .collect::<Vec<_>>();
             for index in indices.iter_mut() {
-                let is_stale = index.fields.iter().any(|field_id| {
-                    overlaid_field_versions
-                        .get(field_id)
-                        .is_some_and(|&overlay_version| overlay_version > index.dataset_version)
-                });
+                // A covered (included) field an overlay supplied makes the index just as
+                // stale as an indexed field would -- the index storage still holds the
+                // pre-overlay copy of that column. Expand covered structs to their leaf
+                // subtree, since the overlay lists leaf ids.
+                let is_stale =
+                    Self::index_dependent_field_ids(index, schema)
+                        .iter()
+                        .any(|field_id| {
+                            overlaid_field_versions
+                                .get(field_id)
+                                .is_some_and(|&overlay_version| {
+                                    overlay_version > index.dataset_version
+                                })
+                        });
                 if is_stale && let Some(fragment_bitmap) = &mut index.fragment_bitmap {
                     for new_id in &new_fragment_ids {
                         fragment_bitmap.remove(*new_id);
@@ -3481,6 +3607,76 @@ impl Transaction {
                 // Keep file if it has at least one non-tombstoned field
                 file.fields.iter().any(|&field_id| field_id != -2)
             });
+        }
+    }
+
+    /// Reject a commit that would drop, rename, retype, or otherwise change the subtree of
+    /// a field an index *covers* (an "included" column). A covered field's physical payload
+    /// schema is fixed at index build time; `retain_relevant_indices` only drops indices
+    /// whose *key* fields leave the schema, so an index whose key survives but whose covered
+    /// column's subtree changed would keep emitting the old payload schema while covered ANN
+    /// queries declare the new one. This fires for two commit operations:
+    /// - `Project`, which can drop/rename/retype a covered field (public drop/alter APIs
+    ///   preflight this, but a raw `Operation::Project` reaches `build_manifest` directly);
+    /// - `Merge` (how `add_columns` commits), which can grow a covered *struct* by adding a
+    ///   child -- even an AllNulls, metadata-only child that writes no data file, so the
+    ///   file-path-keyed coverage prune never sees it.
+    ///
+    /// `old_schema` is the pre-commit schema (needed to detect renames/retypes/child-adds,
+    /// which keep the covered field's id). `op` names the operation for the error message.
+    fn reject_covered_field_subtree_change(
+        indices: &[IndexMetadata],
+        old_schema: Option<&Schema>,
+        new_schema: &Schema,
+        op: &str,
+    ) -> Result<()> {
+        let new_ids: HashSet<i32> = new_schema.fields_pre_order().map(|f| f.id).collect();
+        for index in indices {
+            // Only indices that survive the commit (their key fields all remain) can be
+            // left with dangling covering metadata; a fully-projected-away index is dropped
+            // by `retain_relevant_indices`.
+            if !index.fields.iter().all(|id| new_ids.contains(id)) {
+                continue;
+            }
+            for &covered_id in &index.included_fields {
+                let changed = match old_schema {
+                    Some(old) => Self::covered_field_subtree_changed(old, new_schema, covered_id),
+                    // Without the pre-commit schema we can only detect a drop.
+                    None => new_schema.field_by_id(covered_id).is_none(),
+                };
+                if changed {
+                    return Err(Error::invalid_input(format!(
+                        "{op} would drop or alter covered (included) field id {covered_id} \
+                         (its subtree changed), still used by index '{}'. Drop the index with \
+                         drop_index() before changing the column.",
+                        index.name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether a covered ("included") field's subtree differs between `old_schema` and
+    /// `new_schema` -- dropped, renamed, retyped, a nullability flip, or any child change.
+    /// Such a change means the index's stored physical payload no longer matches the
+    /// schema a query declares. `data_type()` is recursive for structs, so it also covers
+    /// a child's name/type/nullability change.
+    pub(crate) fn covered_field_subtree_changed(
+        old_schema: &Schema,
+        new_schema: &Schema,
+        covered_id: i32,
+    ) -> bool {
+        let Some(old) = old_schema.field_by_id(covered_id) else {
+            return false;
+        };
+        match new_schema.field_by_id(covered_id) {
+            None => true,
+            Some(new) => {
+                old.name != new.name
+                    || old.nullable != new.nullable
+                    || old.data_type() != new.data_type()
+            }
         }
     }
 
@@ -4888,6 +5084,94 @@ mod tests {
         }
     }
 
+    /// A stable-row-id `RewriteRows` update that modifies ONLY a covering
+    /// (included) column must not re-extend a covered index's fragment
+    /// coverage onto the moved fragment: the index still holds the pre-update
+    /// materialized value, so reusing it would serve a stale covered result.
+    /// The modified field is in `included_fields`, not `fields`.
+    ///
+    /// Both spellings of "the covering column changed" must be caught. `included_fields`
+    /// only ever holds TOP-LEVEL ids (index creation resolves whole columns and rejects
+    /// dotted names), but the caller may report either the covered struct's own id or the
+    /// leaf ids it actually rewrote -- `Operation::Update` is public, so
+    /// `fields_for_preserving_frag_bitmap` is caller-supplied and unvalidated. Comparing raw
+    /// ids catches only the first spelling and silently serves stale subfield values for the
+    /// second.
+    #[test]
+    fn test_pure_rewrite_preserves_covering_index_coverage() {
+        use arrow_schema::Fields as ArrowFields;
+
+        // meta{a} => ids 0 (struct) and 1 (leaf); vector => id 2.
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new(
+                "meta",
+                DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "a",
+                    DataType::Int32,
+                    true,
+                )])),
+                true,
+            ),
+            ArrowField::new("vector", DataType::Int32, true),
+        ]);
+        let schema = LanceSchema::try_from(&arrow).unwrap();
+        let meta_id = schema.field("meta").unwrap().id;
+        let leaf_id = schema.field("meta.a").unwrap().id;
+        let vector_id = schema.field("vector").unwrap().id;
+
+        // Returns (covered index re-extended?, plain index re-extended?).
+        let run = |modified: &[u32]| {
+            let mut covering = sample_index_metadata("covering");
+            covering.fields = vec![vector_id];
+            covering.included_fields = vec![meta_id]; // top-level, as creation guarantees
+            covering.fragment_bitmap = Some([0].into_iter().collect());
+
+            let mut plain = sample_index_metadata("plain");
+            plain.fields = vec![vector_id];
+            plain.included_fields = vec![];
+            plain.fragment_bitmap = Some([0].into_iter().collect());
+
+            let mut indices = vec![covering, plain];
+            let overlaid: HashMap<u32, &Fragment> = HashMap::new();
+            Transaction::register_pure_rewrite_rows_update_frags_in_indices(
+                &mut indices,
+                &[1], // new fragment holding the moved rows
+                &[0], // original fragment (covered by both indices)
+                modified,
+                &overlaid,
+                &schema,
+            )
+            .unwrap();
+            (
+                indices[0].fragment_bitmap.as_ref().unwrap().contains(1),
+                indices[1].fragment_bitmap.as_ref().unwrap().contains(1),
+            )
+        };
+
+        for (label, modified) in [
+            (
+                "covered struct reported by its own id",
+                vec![meta_id as u32],
+            ),
+            (
+                "covered struct reported by its leaf id",
+                vec![leaf_id as u32],
+            ),
+        ] {
+            let (covered_extended, plain_extended) = run(&modified);
+            assert!(
+                !covered_extended,
+                "covered index must not re-extend coverage onto a fragment whose covering \
+                 column was rewritten ({label})"
+            );
+            assert!(
+                plain_extended,
+                "index that neither indexes nor covers the modified field still reuses its \
+                 entries ({label})"
+            );
+        }
+    }
+
     #[test]
     fn test_rewrite_fragments() {
         let existing_fragments: Vec<Fragment> = (0..10).map(Fragment::new).collect();
@@ -5091,6 +5375,192 @@ mod tests {
                 .iter()
                 .any(|idx| idx.uuid == second_index.uuid)
         );
+    }
+
+    /// A raw CreateIndex commit whose new index declares a covering field id missing
+    /// from the schema must be rejected at the commit boundary -- otherwise every later
+    /// query on the index fails at planning time with an inconsistent-metadata error.
+    #[test]
+    fn test_create_index_build_manifest_rejects_unresolvable_covered_field() {
+        let manifest = sample_manifest();
+        let mut covered = sample_index_metadata("vector_idx");
+        covered.included_fields = vec![9999];
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![covered],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        let err = transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("9999"),
+            "an unresolvable covered field id must be rejected at commit: {err}"
+        );
+    }
+
+    /// A covering declaration must reference a TOP-LEVEL field: `included_fields`
+    /// resolution on the read path goes id -> name -> arrow field by bare name, so a
+    /// nested field id (e.g. a struct child) would silently bind to a same-named
+    /// top-level column instead of erroring. The create path rejects dotted names;
+    /// raw commits must reject nested ids for the same reason.
+    #[test]
+    fn test_create_index_build_manifest_rejects_nested_covered_field() {
+        use arrow_schema::Fields as ArrowFields;
+
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new(
+                "s",
+                DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "id",
+                    DataType::Int64,
+                    true,
+                )])),
+                true,
+            ),
+        ]);
+        let schema = LanceSchema::try_from(&arrow).unwrap();
+        let nested_id = schema.field("s.id").unwrap().id;
+        let manifest = Manifest::new(
+            schema,
+            Arc::new(vec![Fragment::new(0)]),
+            DataStorageFormat::new(ConcreteFileVersion::V2_0),
+            HashMap::new(),
+        );
+
+        let mut covered = sample_index_metadata("vector_idx");
+        covered.included_fields = vec![nested_id];
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![covered],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        let err = transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("top-level"),
+            "a nested covered field id must be rejected at commit: {err}"
+        );
+    }
+
+    /// All delta segments of one logical index must declare the same covering columns:
+    /// the covered read path derives its output schema from one delta but executes all
+    /// of them, so a mixed set fails every query on the index at execution time.
+    #[test]
+    fn test_create_index_build_manifest_rejects_mixed_covering_deltas() {
+        let manifest = sample_manifest();
+        let mut covered = sample_index_metadata("vector_idx");
+        covered.included_fields = vec![0];
+        let plain = sample_index_metadata("vector_idx");
+
+        // Adding a non-covered delta to an existing covered index is rejected.
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![plain.clone()],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        let err = transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![covered.clone()],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("covering"),
+            "mixed covering across deltas must be rejected: {err}"
+        );
+
+        // A mixed covering set within one commit's own new segments is rejected too.
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![covered.clone(), plain.clone()],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        let err = transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("covering"),
+            "mixed covering within one commit must be rejected: {err}"
+        );
+
+        // Removing the disagreeing delta in the same commit leaves a homogeneous
+        // final state, which is fine.
+        let mut covered2 = sample_index_metadata("vector_idx");
+        covered2.included_fields = vec![0];
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![covered2],
+                removed_indices: vec![plain.clone()],
+            },
+            None,
+        );
+        let (_, final_indices) = transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![covered.clone(), plain],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
+        assert_eq!(final_indices.len(), 2);
+        assert!(
+            final_indices
+                .iter()
+                .all(|idx| idx.included_fields == vec![0]),
+            "the homogeneous replacement set should commit"
+        );
+
+        // An index with a different name is unaffected.
+        let other = sample_index_metadata("other_idx");
+        let transaction = Transaction::new(
+            manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![other],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        transaction
+            .build_manifest(
+                Some(&manifest),
+                vec![covered],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
     }
 
     #[test]
@@ -7754,6 +8224,11 @@ mod tests {
 
         // Post-remap state: every index already covers the new fragment (7).
         let covering = || Some(RoaringBitmap::from_iter([7u32]));
+        // Indexes an un-overlaid field (3) but *covers* the overlaid field 1 as an
+        // included column; built (v2) before the overlay, so its stored copy of
+        // field 1 is stale and the rewritten fragment must be dropped.
+        let mut covered_stale = create_test_index("covered_stale", 3, 2, covering(), false);
+        covered_stale.included_fields = vec![1];
         let mut indices = vec![
             // Stale: covers the overlaid field 1, built (v2) before the overlay.
             create_test_index("stale", 1, 2, covering(), false),
@@ -7762,9 +8237,16 @@ mod tests {
             create_test_index("fresh", 1, 5, covering(), false),
             // Unrelated: covers field 2, which the overlay never touched.
             create_test_index("unrelated", 2, 2, covering(), false),
+            covered_stale,
         ];
 
-        Transaction::prune_overlay_stale_fields_from_indices(&mut indices, &groups);
+        // Flat field ids with no struct nesting: an empty schema makes subtree
+        // expansion a no-op (each id maps to itself), exercising the id-level logic.
+        Transaction::prune_overlay_stale_fields_from_indices(
+            &mut indices,
+            &groups,
+            &LanceSchema::default(),
+        );
 
         assert!(
             !indices[0].fragment_bitmap.as_ref().unwrap().contains(7),
@@ -7777,6 +8259,201 @@ mod tests {
         assert!(
             indices[2].fragment_bitmap.as_ref().unwrap().contains(7),
             "an index on an un-overlaid field is unaffected"
+        );
+        assert!(
+            !indices[3].fragment_bitmap.as_ref().unwrap().contains(7),
+            "an index whose *covered* field was overlaid is stale too"
+        );
+    }
+
+    /// `included_fields` records a covered struct's parent id, but a modified data file
+    /// lists leaf ids. Schema-aware pruning must expand the covered struct to its subtree
+    /// so an update to a subfield still invalidates the fragment's coverage.
+    #[test]
+    fn test_prune_updated_fields_expands_covered_struct_subtree() {
+        use arrow_schema::Fields as ArrowFields;
+
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new(
+                "s",
+                DataType::Struct(ArrowFields::from(vec![
+                    ArrowField::new("a", DataType::Int32, true),
+                    ArrowField::new("b", DataType::Int32, true),
+                ])),
+                true,
+            ),
+            ArrowField::new("x", DataType::Int32, true),
+        ]);
+        let schema = LanceSchema::try_from(&arrow).unwrap();
+        let s_id = schema.field("s").unwrap().id;
+        let a_id = u32::try_from(schema.field("s.a").unwrap().id).unwrap();
+        let x_id = schema.field("x").unwrap().id;
+
+        // Index keyed on scalar `x`, covering the whole struct `s`, over fragment 0.
+        let mut idx = create_test_index(
+            "cov",
+            x_id,
+            1,
+            Some(RoaringBitmap::from_iter([0u32])),
+            false,
+        );
+        idx.included_fields = vec![s_id];
+
+        // Updating leaf `s.a` prunes the covered struct's fragment: the subtree
+        // expansion bridges the parent-id-vs-leaf-id mismatch that exact-id matching
+        // would miss.
+        let mut indices = vec![idx];
+        Transaction::prune_updated_fields_from_indices(
+            &mut indices,
+            &[Fragment::new(0)],
+            &[a_id],
+            &schema,
+        );
+        assert!(
+            !indices[0].fragment_bitmap.as_ref().unwrap().contains(0),
+            "updating a covered struct's subfield must drop the fragment from coverage"
+        );
+    }
+
+    /// A Project that drops or renames a covered (included) column must be rejected at
+    /// the commit boundary, even when the index's key column survives.
+    #[test]
+    fn test_reject_projected_covered_fields() {
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new("vec", DataType::Int32, false),
+            ArrowField::new("meta", DataType::Utf8, true),
+            ArrowField::new("other", DataType::Int32, true),
+        ]);
+        let old_schema = LanceSchema::try_from(&arrow).unwrap();
+        let vec_id = old_schema.field("vec").unwrap().id;
+        let meta_id = old_schema.field("meta").unwrap().id;
+
+        // Index keyed on `vec`, covering `meta`.
+        let mut idx = create_test_index(
+            "cov",
+            vec_id,
+            1,
+            Some(RoaringBitmap::from_iter([0u32])),
+            true,
+        );
+        idx.included_fields = vec![meta_id];
+        let indices = vec![idx];
+
+        // Keeping every field -> Ok.
+        assert!(
+            Transaction::reject_covered_field_subtree_change(
+                &indices,
+                Some(&old_schema),
+                &old_schema,
+                "Project"
+            )
+            .is_ok()
+        );
+
+        // Dropping the covered `meta` while keeping the key -> rejected.
+        let dropped = old_schema.project(&["vec", "other"]).unwrap();
+        let err = Transaction::reject_covered_field_subtree_change(
+            &indices,
+            Some(&old_schema),
+            &dropped,
+            "Project",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("drop or alter covered"),
+            "expected a covered-subtree rejection, got: {err}"
+        );
+
+        // Dropping the key too (the index would be dropped) -> not our concern.
+        let drop_all = old_schema.project(&["other"]).unwrap();
+        assert!(
+            Transaction::reject_covered_field_subtree_change(
+                &indices,
+                Some(&old_schema),
+                &drop_all,
+                "Project"
+            )
+            .is_ok()
+        );
+
+        // Renaming the covered field (id stays, name changes) -> rejected.
+        let mut renamed = old_schema.clone();
+        renamed.field_by_id_mut(meta_id).unwrap().name = "meta_renamed".to_string();
+        assert!(
+            Transaction::reject_covered_field_subtree_change(
+                &indices,
+                Some(&old_schema),
+                &renamed,
+                "Project"
+            )
+            .is_err(),
+            "renaming a covered field must be rejected"
+        );
+
+        // Flipping the covered field's nullability (id + name stay) -> rejected.
+        let mut retyped_null = old_schema.clone();
+        retyped_null.field_by_id_mut(meta_id).unwrap().nullable = false;
+        assert!(
+            Transaction::reject_covered_field_subtree_change(
+                &indices,
+                Some(&old_schema),
+                &retyped_null,
+                "Project"
+            )
+            .is_err(),
+            "a covered field nullability change must be rejected"
+        );
+    }
+
+    /// Growing a covered *struct*'s subtree (adding a child) is what `add_columns`/Merge
+    /// does; the covered field id is unchanged but its `data_type()` differs, so the commit
+    /// boundary must reject it just like the Project drop/alter cases above.
+    #[test]
+    fn test_reject_covered_struct_child_add() {
+        let child = ArrowField::new("a", DataType::Int32, false);
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new("vec", DataType::Int32, false),
+            ArrowField::new("meta", DataType::Struct(vec![child.clone()].into()), true),
+        ]);
+        let old_schema = LanceSchema::try_from(&arrow).unwrap();
+        let vec_id = old_schema.field("vec").unwrap().id;
+        let meta_id = old_schema.field("meta").unwrap().id;
+
+        let mut idx = create_test_index(
+            "cov",
+            vec_id,
+            1,
+            Some(RoaringBitmap::from_iter([0u32])),
+            true,
+        );
+        idx.included_fields = vec![meta_id]; // covers the struct's parent id
+        let indices = vec![idx];
+
+        // New schema grows `meta` with a second child -> the struct's data_type changes.
+        let grown_arrow = ArrowSchema::new(vec![
+            ArrowField::new("vec", DataType::Int32, false),
+            ArrowField::new(
+                "meta",
+                DataType::Struct(vec![child, ArrowField::new("b", DataType::Int32, true)].into()),
+                true,
+            ),
+        ]);
+        // Preorder id assignment gives `meta` the same id (1) in both schemas, so the
+        // covered id resolves to the struct on each side and only its data_type differs.
+        let grown = LanceSchema::try_from(&grown_arrow).unwrap();
+        assert_eq!(grown.field("meta").unwrap().id, meta_id);
+
+        let err = Transaction::reject_covered_field_subtree_change(
+            &indices,
+            Some(&old_schema),
+            &grown,
+            "add_columns (Merge)",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("drop or alter covered")
+                && err.to_string().contains("add_columns"),
+            "expected a covered-struct-growth rejection, got: {err}"
         );
     }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -32,7 +32,7 @@ use lance_index::mem_wal::{CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX
 use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{
-    FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, apply_feature_flags,
+    FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, FeatureFlagsConfig, apply_feature_flags,
     inherit_mem_wal_index_catchup, validate_mem_wal_index_catchup_flags,
 };
 use lance_table::rowids::read_row_ids;
@@ -3032,10 +3032,16 @@ impl Transaction {
                 .map(|m| m.uses_stable_row_ids())
                 .unwrap_or(false);
             let use_stable_row_ids = config.use_stable_row_ids || inherited;
+            let has_covered_index = final_indices
+                .iter()
+                .any(|index| !index.included_fields.is_empty());
             apply_feature_flags(
                 &mut manifest,
-                use_stable_row_ids,
-                config.disable_transaction_file,
+                &FeatureFlagsConfig {
+                    enable_stable_row_id: use_stable_row_ids,
+                    disable_transaction_file: config.disable_transaction_file,
+                    has_covered_index,
+                },
             )?;
         }
         // Carried from the manifest this one is derived from. `new_from_previous`
@@ -4878,6 +4884,7 @@ mod tests {
             created_at: Some(Utc::now()),
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 
@@ -5474,6 +5481,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 
@@ -5496,6 +5504,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 
@@ -8048,6 +8057,7 @@ mod tests {
                 created_at: None,
                 base_id: None,
                 files: None,
+                included_fields: Vec::new(),
             }
         }
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -50,6 +50,7 @@ use super::{
 use crate::dataset::rowids::get_row_id_index;
 use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
 use crate::dataset::utils::CapturedRowIds;
+use crate::dataset::{ProjectionRequest, TakeBuilder};
 use crate::index::DatasetIndexExt;
 use crate::{
     Dataset,
@@ -1340,6 +1341,209 @@ impl MergeInsertJob {
         self.create_full_table_joined_stream(source).await
     }
 
+    /// Names of `source_schema` columns this merge would update that are covered
+    /// ("included") by some index. Updating such a column in place would leave a
+    /// stale copy in the index storage (only an optimize refreshes it), so on the
+    /// partial-schema path we rewrite those updates as row-moves -- identical to
+    /// how `dataset.update()` and full-schema merges already behave -- letting the
+    /// deletion mask hide the stale copy. Join keys are matched, not updated, so
+    /// they are excluded.
+    async fn covered_columns_updated(&self, source_schema: &Schema) -> Result<Vec<String>> {
+        // Only the update-matched modes actually patch matched rows into fragments;
+        // DoNothing / Fail leave matched rows untouched (Delete is handled separately
+        // and never reaches this path). Without this gate, a partial source carrying a
+        // covered payload under the default DoNothing + InsertAll would be wrongly
+        // flagged and rejected even though no covered column is ever patched in place.
+        if !matches!(
+            self.params.when_matched,
+            WhenMatched::UpdateAll | WhenMatched::UpdateIf(_) | WhenMatched::UpdateIfExpr(_)
+        ) {
+            return Ok(Vec::new());
+        }
+        let indices = self.dataset.load_indices().await?;
+        let covered: HashSet<i32> = indices
+            .iter()
+            .flat_map(|idx| idx.included_fields.iter().copied())
+            .collect();
+        if covered.is_empty() {
+            return Ok(Vec::new());
+        }
+        let target = self.dataset.schema();
+        let keys: HashSet<&str> = self.params.on.iter().map(|s| s.as_str()).collect();
+        let mut updated = Vec::new();
+        for field in source_schema.fields() {
+            let name = field.name();
+            if keys.contains(name.as_str()) {
+                continue;
+            }
+            if let Some(tf) = target.field(name)
+                && covered.contains(&tf.id)
+            {
+                updated.push(name.clone());
+            }
+        }
+        Ok(updated)
+    }
+
+    /// Rewrite a partial-schema covered-column update as a row-move: read the full
+    /// existing rows for the touched addresses, overlay the updated columns, write
+    /// them as new fragments, and tombstone the originals. The stale index copy at
+    /// the old address is then hidden by the deletion mask -- so no duplicate can
+    /// survive to a later append-optimize.
+    ///
+    /// `source` is the merger's partial output stream (`_rowaddr` + updated cols); it is consumed
+    /// in bounded batches so peak memory is one batch of full rows rather than the whole update.
+    /// Mirrors `dataset.update()`'s streamed `RewriteRows` move (`update.rs::execute_impl`).
+    /// Returns the resulting `RewriteRows` operation together with the moved rows' addresses, so
+    /// the caller can publish them as `affected_rows` and let a concurrent delete/update rebase
+    /// instead of hard-conflicting. Non-stable-row-id datasets only; the caller rejects
+    /// stable-row-id and insert-carrying combinations up front.
+    async fn rewrite_covered_update_as_move(
+        &self,
+        source: SendableRecordBatchStream,
+        target_bases_info: Option<Vec<TargetBaseInfo>>,
+    ) -> Result<(Operation, RoaringTreemap)> {
+        let full_schema = self.dataset.schema().clone();
+        let preserving: Vec<u32> = full_schema.fields.iter().map(|f| f.id as u32).collect();
+        let empty_op = |fields_bitmap: Vec<u32>| Operation::Update {
+            removed_fragment_ids: Vec::new(),
+            updated_fragments: Vec::new(),
+            new_fragments: Vec::new(),
+            fields_modified: Vec::new(),
+            compacted_sstables: self.params.compacted_sstables.clone(),
+            fields_for_preserving_frag_bitmap: fields_bitmap,
+            update_mode: Some(RewriteRows),
+            inserted_rows_filter: None,
+            updated_fragment_offsets: None,
+        };
+
+        // Per merger batch: take the full existing rows for its addresses and overlay the updated
+        // columns, streaming the result so peak memory is one batch of full rows rather than the
+        // whole update. Each batch carries `_rowid` (== `_rowaddr` on a non-stable-row-id dataset
+        // -- the only kind this path handles) so the capture stream below can record which
+        // originals to tombstone, then strips it before the fragments are written.
+        let dataset = self.dataset.clone();
+        let plan = Arc::new(
+            ProjectionRequest::from_schema(full_schema.clone())
+                .into_projection_plan(dataset.clone())?,
+        );
+        let out_arrow = Arc::new(Schema::from(&full_schema));
+
+        // Record which originals to tombstone as the overlay runs. `make_rowid_capture_stream` is
+        // deliberately not reused here: its `AddressStyle` capture bulk-loads a `RoaringTreemap`
+        // with `append`, which rejects any value <= the running maximum. The merger's output is
+        // join-ordered (it follows the source rows the user supplied), not address-ordered, so
+        // `append` would fail the whole merge on ordinary input. `update.rs` can rely on it only
+        // because its stream comes straight off a scan, which is already address-ordered.
+        let moved_addrs = Arc::new(Mutex::new(RoaringTreemap::new()));
+        let moved_addrs_for_stream = moved_addrs.clone();
+        let out_arrow_for_stream = out_arrow.clone();
+        // `.then` processes one batch at a time (fully bounded); a small `.buffered(k)` could later
+        // pipeline the take of the next batch with the write of the current one.
+        let overlaid = source.then(move |batch| {
+            let dataset = dataset.clone();
+            let plan = plan.clone();
+            let moved_addrs = moved_addrs_for_stream.clone();
+            async move {
+                let batch = batch?;
+                let addresses: Vec<u64> = batch[ROW_ADDR]
+                    .as_primitive::<arrow::datatypes::UInt64Type>()
+                    .values()
+                    .to_vec();
+                let full_rows =
+                    TakeBuilder::try_new_from_addresses(dataset, addresses.clone(), plan)?
+                        .execute()
+                        .await?;
+                let mut overlaid = full_rows;
+                for field in batch.schema().fields() {
+                    let name = field.name();
+                    if name == ROW_ADDR || name == ROW_ID {
+                        continue;
+                    }
+                    let new_col = batch
+                        .column_by_name(name)
+                        .expect("updated column present in merger output")
+                        .clone();
+                    overlaid = overlaid.replace_column_by_name(name, new_col)?;
+                }
+                // Only after the take succeeded: a batch that never reaches the writer must not
+                // tombstone its originals.
+                moved_addrs
+                    .lock()
+                    .expect("covered move address set poisoned")
+                    .extend(addresses);
+                Ok::<_, DataFusionError>(overlaid)
+            }
+        });
+        let write_stream = Box::pin(RecordBatchStreamAdapter::new(
+            out_arrow_for_stream,
+            overlaid,
+        ));
+
+        // Write the moved rows as new fragments.
+        // Retain the target-base info: `write_fragments_internal` consumes it, but a later cleanup
+        // must still resolve fragments routed to external bases (otherwise `cleanup_data_fragments`
+        // skips every file with a `base_id`, orphaning it).
+        let bases_for_cleanup = target_bases_info.clone();
+        let (new_fragments, _) = write_fragments_internal(
+            self.dataset
+                .manifest()
+                .data_storage_format
+                .lance_file_format(),
+            Some(&self.dataset),
+            self.dataset.object_store.clone(),
+            &self.dataset.base,
+            full_schema.clone(),
+            write_stream,
+            WriteParams::default(),
+            target_bases_info,
+        )
+        .await?;
+
+        // The overlay recorded every address it handed to the writer; the write above has now
+        // drained the stream, so the set is complete.
+        let removed_row_addrs = std::mem::take(
+            &mut *moved_addrs
+                .lock()
+                .expect("covered move address set poisoned"),
+        );
+        if removed_row_addrs.is_empty() {
+            // Nothing matched -> nothing written; return a no-op update.
+            return Ok((empty_op(preserving), RoaringTreemap::new()));
+        }
+
+        // Tombstone the originals.
+        let deletions = Self::apply_deletions(&self.dataset, &removed_row_addrs).await;
+        let (updated_fragments, removed_fragment_ids) = match deletions {
+            Ok(v) => v,
+            Err(e) => {
+                cleanup_data_fragments(
+                    &self.dataset.object_store,
+                    &self.dataset.base,
+                    bases_for_cleanup.as_deref(),
+                    &new_fragments,
+                )
+                .await;
+                return Err(e);
+            }
+        };
+
+        Ok((
+            Operation::Update {
+                removed_fragment_ids,
+                updated_fragments,
+                new_fragments,
+                fields_modified: Vec::new(),
+                compacted_sstables: self.params.compacted_sstables.clone(),
+                fields_for_preserving_frag_bitmap: preserving,
+                update_mode: Some(RewriteRows),
+                inserted_rows_filter: None,
+                updated_fragment_offsets: None,
+            },
+            removed_row_addrs,
+        ))
+    }
+
     async fn update_fragments(
         dataset: Arc<Dataset>,
         source: SendableRecordBatchStream,
@@ -2365,7 +2569,7 @@ impl MergeInsertJob {
         let joined = self.create_joined_stream(source).await?;
         let merger = Merger::try_new(
             self.params.clone(),
-            source_schema,
+            source_schema.clone(),
             !is_full_schema,
             self.dataset.manifest.uses_stable_row_ids(),
         )?;
@@ -2445,30 +2649,90 @@ impl MergeInsertJob {
                 return Err(Error::not_supported_source("Deleting rows from the target table when there is no match in the source table is not supported when the source data has a different schema than the target data".into()));
             }
 
-            // We will have a different commit path here too, as we are modifying
-            // fragments rather than writing new ones
-            let (updated_fragments, new_fragments, fields_modified) = Self::update_fragments(
-                self.dataset.clone(),
-                Box::pin(stream),
-                self.dataset.manifest.version + 1,
-                target_bases_info,
-            )
-            .await?;
+            // Updating a column an index *covers* would patch a stale copy into the
+            // index storage (only an optimize refreshes it), so a later append-optimize
+            // could surface both the stale and fresh values. Rewrite those updates as
+            // row-moves so the deletion mask hides the stale copy -- matching how an
+            // indexed-column update already behaves.
+            let covered = self.covered_columns_updated(source_schema.as_ref()).await?;
+            if !covered.is_empty() {
+                if self.dataset.manifest.uses_stable_row_ids() {
+                    return Err(Error::not_supported_source(
+                        format!(
+                            "merge_insert updating covered column(s) {covered:?} on a stable-row-id \
+                             dataset is not yet supported; use dataset.update() (which already moves \
+                             rows) or provide the full target schema",
+                        )
+                        .into(),
+                    ));
+                }
+                if self.params.insert_not_matched {
+                    return Err(Error::not_supported_source(
+                        format!(
+                            "merge_insert updating covered column(s) {covered:?} while also inserting \
+                             unmatched rows is not yet supported; provide the full target schema",
+                        )
+                        .into(),
+                    ));
+                }
+                // The move re-reads full rows via a take, which materializes legacy (v1)
+                // blob columns as description structs, not binary -- writing those back
+                // would corrupt the blob. The full-schema path reads them as binary via
+                // the scan provider (`SomeBlobsBinary`); the take path has no equivalent.
+                // Reject rather than silently corrupt.
+                if self
+                    .dataset
+                    .schema()
+                    .fields_pre_order()
+                    .any(|f| f.is_blob() && !f.is_blob_v2())
+                {
+                    return Err(Error::not_supported_source(
+                        format!(
+                            "merge_insert updating covered column(s) {covered:?} on a dataset with \
+                             legacy (v1) blob columns is not yet supported; provide the full target \
+                             schema",
+                        )
+                        .into(),
+                    ));
+                }
+                let (operation, removed_row_addrs) = self
+                    .rewrite_covered_update_as_move(
+                        Box::pin(stream) as SendableRecordBatchStream,
+                        target_bases_info,
+                    )
+                    .await?;
+                // Same shape as the full-schema `RewriteRows` paths below -- deletions on the
+                // originals plus new fragments -- so publish the moved addresses. Without them
+                // `check_update_txn` turns any concurrent delete/update touching these fragments
+                // into a hard conflict, costing covered datasets concurrency that non-covered
+                // ones keep.
+                (operation, Some(RowAddrTreeMap::from(removed_row_addrs)))
+            } else {
+                // We will have a different commit path here too, as we are modifying
+                // fragments rather than writing new ones
+                let (updated_fragments, new_fragments, fields_modified) = Self::update_fragments(
+                    self.dataset.clone(),
+                    Box::pin(stream),
+                    self.dataset.manifest.version + 1,
+                    target_bases_info,
+                )
+                .await?;
 
-            let operation = Operation::Update {
-                removed_fragment_ids: Vec::new(),
-                updated_fragments,
-                new_fragments,
-                fields_modified,
-                compacted_sstables: self.params.compacted_sstables.clone(),
-                fields_for_preserving_frag_bitmap: vec![], // in-place update do not affect preserving frag bitmap
-                update_mode: Some(RewriteColumns),
-                inserted_rows_filter: None, // not implemented for v1
-                updated_fragment_offsets: None,
-            };
-            // We have rewritten the fragments, not just the deletion files, so
-            // we can't use affected rows here.
-            (operation, None)
+                let operation = Operation::Update {
+                    removed_fragment_ids: Vec::new(),
+                    updated_fragments,
+                    new_fragments,
+                    fields_modified,
+                    compacted_sstables: self.params.compacted_sstables.clone(),
+                    fields_for_preserving_frag_bitmap: vec![], // in-place update do not affect preserving frag bitmap
+                    update_mode: Some(RewriteColumns),
+                    inserted_rows_filter: None, // not implemented for v1
+                    updated_fragment_offsets: None,
+                };
+                // We have rewritten the fragments, not just the deletion files, so
+                // we can't use affected rows here.
+                (operation, None)
+            }
         } else {
             let cleanup_bases = target_bases_info.clone();
             let (mut new_fragments, _) = write_fragments_internal(
@@ -10848,7 +11112,7 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
 
     mod external_error {
         use super::*;
-        use arrow_schema::{ArrowError, Field as ArrowField, Schema as ArrowSchema};
+        use arrow_schema::{ArrowError, Field as ArrowField, Schema};
         use std::fmt;
 
         #[derive(Debug)]
@@ -10867,7 +11131,7 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
 
         #[tokio::test]
         async fn test_merge_insert_execute_reader_preserves_error_message() {
-            let schema = Arc::new(ArrowSchema::new(vec![
+            let schema = Arc::new(Schema::new(vec![
                 ArrowField::new("key", DataType::Int32, false),
                 ArrowField::new("value", DataType::Int32, false),
             ]));
@@ -11299,16 +11563,14 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
         assert_eq!(combined.num_rows(), 300);
     }
 
-    // Regression test: after a partial-schema merge_insert drops a fragment from the vector
-    // index bitmap, a vector search should not return duplicate rows. The stale vector index
-    // data still references the dropped fragment, and the scanner also flat-scans unindexed
-    // fragments, causing the same rows to appear from both paths.
-    #[tokio::test]
-    async fn test_partial_merge_insert_stale_vector_index_duplicates() {
+    /// Build a dataset with a plain (non-covered) IVF_FLAT vector index whose fragment 1
+    /// has been pruned from the index bitmap by a partial-schema merge_insert that patched
+    /// the indexed vector column in place -- the pruned fragment's stale rows still live in
+    /// the old index segment's storage. Returns `(dataset, total_rows, rows_per_frag, dim)`.
+    async fn build_pruned_plain_vector_dataset(uri: &str) -> (Arc<Dataset>, usize, usize, i32) {
         let dim = 4i32;
         let rows_per_frag = 10usize;
         let num_frags = 3usize;
-        let total_rows = rows_per_frag * num_frags;
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Utf8, false),
@@ -11345,9 +11607,7 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
         // Write 3 fragments
         let batch0 = make_batch(0, 0.0);
         let reader = Box::new(RecordBatchIterator::new([Ok(batch0)], schema.clone()));
-        let mut ds = Dataset::write(reader, "memory://vector_stale_test", None)
-            .await
-            .unwrap();
+        let mut ds = Dataset::write(reader, uri, None).await.unwrap();
         for frag_idx in 1..num_frags {
             let batch = make_batch(frag_idx, 0.0);
             let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
@@ -11397,7 +11657,18 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .await
             .unwrap();
 
-        // KNN search with k = total_rows to retrieve all rows
+        (ds, rows_per_frag * num_frags, rows_per_frag, dim)
+    }
+
+    /// A KNN query over every row must return each id exactly once -- no stale duplicate
+    /// served from old index storage alongside the fresh copy.
+    async fn assert_knn_no_duplicate_ids(
+        ds: &Dataset,
+        total_rows: usize,
+        rows_per_frag: usize,
+        dim: i32,
+    ) {
+        let frag1_start = rows_per_frag;
         let query: Float32Array = (0..dim)
             .map(|i| (frag1_start * dim as usize + i as usize) as f32 + 0.5)
             .collect();
@@ -11409,7 +11680,6 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .await
             .unwrap();
 
-        // Check no duplicate ids
         let ids = results
             .column_by_name("id")
             .unwrap()
@@ -11424,6 +11694,945 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             "Found duplicate ids in KNN results: {} unique out of {} total",
             unique_ids.len(),
             ids.len()
+        );
+    }
+
+    // Regression test: after a partial-schema merge_insert drops a fragment from the vector
+    // index bitmap, a vector search should not return duplicate rows. The stale vector index
+    // data still references the dropped fragment, and the scanner also flat-scans unindexed
+    // fragments, causing the same rows to appear from both paths.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_vector_index_duplicates() {
+        let (ds, total_rows, rows_per_frag, dim) =
+            build_pruned_plain_vector_dataset("memory://vector_stale_test").await;
+        assert_knn_no_duplicate_ids(&ds, total_rows, rows_per_frag, dim).await;
+    }
+
+    /// Same pruned-fragment state, but merged back into the index:
+    /// `optimize_indices(merge)` re-scans the pruned fragment as unindexed data AND
+    /// carries the fragment's stale rows from the old segment's storage -- the merge
+    /// must drop the stale copies for plain (non-covered) indexes just as it does for
+    /// covered ones, or ANN queries return duplicate row ids from the merged index.
+    #[tokio::test]
+    async fn test_optimize_merge_after_partial_update_no_duplicates_non_covered() {
+        use lance_index::optimize::OptimizeOptions;
+        let (ds, total_rows, rows_per_frag, dim) =
+            build_pruned_plain_vector_dataset("memory://vector_stale_opt_merge").await;
+        let mut ds = Arc::try_unwrap(ds).unwrap_or_else(|arc| (*arc).clone());
+        ds.optimize_indices(&OptimizeOptions::merge(1))
+            .await
+            .unwrap();
+        assert_knn_no_duplicate_ids(&ds, total_rows, rows_per_frag, dim).await;
+    }
+
+    /// A partial merge_insert that rewrites only a covered column is a row-MOVE: the
+    /// touched rows are tombstoned at their old addresses and reinserted into a new
+    /// fragment, so the index's stale copy is hidden by the deletion mask rather than
+    /// patched in place. Fragment 1 is updated in full, so it disappears entirely, and a
+    /// covered query must observe the fresh values for every row.
+    #[tokio::test]
+    async fn test_partial_merge_insert_moves_covered_column_rows() {
+        let (ds, total_rows, rows_per_frag, dim) =
+            build_moved_covering_dataset("memory://covering_move_test").await;
+        assert!(
+            !ds.get_fragments().iter().any(|f| f.id() == 1),
+            "fragment 1's rows should have been moved out (tombstoned + reinserted), \
+             but fragment 1 is still present"
+        );
+
+        assert_covered_query_no_duplicates_fresh(&ds, total_rows, rows_per_frag, dim).await;
+    }
+
+    /// Bounded-streaming regression for the covered row-move: a covered-column update spanning
+    /// MORE than one scan batch (> `BATCH_SIZE_FALLBACK` = 8192 rows) must move every row exactly
+    /// once with its fresh value. `rewrite_covered_update_as_move` streams the take/overlay/write
+    /// per batch and accumulates the tombstoned addresses across batches, so this exercises the
+    /// multi-batch accumulation path the small covered tests never reach.
+    #[tokio::test]
+    async fn test_covered_update_move_streams_multiple_batches() {
+        use arrow_array::cast::AsArray;
+        use std::collections::HashSet;
+
+        let dim = 2i32;
+        let rows_per_frag = 5000usize; // 2 frags => 10_000 rows > BATCH_SIZE_FALLBACK (8192)
+        let num_frags = 2usize;
+        let total_rows = rows_per_frag * num_frags;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let make_batch = |frag_idx: usize| {
+            let start = frag_idx * rows_per_frag;
+            let ids: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("id-{j:05}"))
+                .collect();
+            let cats: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("cat-{j:05}"))
+                .collect();
+            let values: Vec<f32> = (0..rows_per_frag * dim as usize)
+                .map(|i| (start * dim as usize + i) as f32)
+                .collect();
+            let vectors =
+                FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(cats)),
+                    Arc::new(vectors),
+                ],
+            )
+            .unwrap()
+        };
+
+        let reader = Box::new(RecordBatchIterator::new(
+            [Ok(make_batch(0))],
+            schema.clone(),
+        ));
+        let mut ds = Dataset::write(reader, "memory://covered_move_multibatch", None)
+            .await
+            .unwrap();
+        for frag_idx in 1..num_frags {
+            let reader = Box::new(RecordBatchIterator::new(
+                [Ok(make_batch(frag_idx))],
+                schema.clone(),
+            ));
+            ds.append(reader, None).await.unwrap();
+        }
+
+        // BTree on the join key + a vector index covering `category`.
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+        let ds = Arc::new(ds);
+
+        // Partial merge_insert rewriting `category` for EVERY row -> a >1-batch covered move.
+        let ids: Vec<String> = (0..total_rows).map(|j| format!("id-{j:05}")).collect();
+        let new_cats: Vec<String> = (0..total_rows).map(|j| format!("updated-{j:05}")).collect();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(new_cats)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let (ds, _) = MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+
+        // Every row must survive exactly once with its fresh category -- nothing lost or
+        // duplicated across the batch boundary the streaming move crosses.
+        let batch = ds
+            .scan()
+            .project(&["id", "category"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            total_rows,
+            "row count changed after a multi-batch covered move"
+        );
+        let ids_col = batch["id"].as_string::<i32>();
+        let cats_col = batch["category"].as_string::<i32>();
+        let mut seen = HashSet::new();
+        for i in 0..batch.num_rows() {
+            let id = ids_col.value(i);
+            assert!(
+                seen.insert(id.to_string()),
+                "duplicate id {id} after covered move"
+            );
+            let n: usize = id[3..].parse().unwrap();
+            assert_eq!(
+                cats_col.value(i),
+                format!("updated-{n:05}"),
+                "stale or missing covered value for {id}"
+            );
+        }
+        assert_eq!(seen.len(), total_rows);
+    }
+
+    /// The covered row-move must not depend on the order its source arrives in. Today both join
+    /// paths happen to emit target-scan order (ascending addresses), which is why accumulating
+    /// the tombstoned addresses with a bulk `RoaringTreemap::append` -- which rejects any value
+    /// <= the running maximum -- worked at all. That is an accident of query planning, not a
+    /// guarantee: were it to change, the merge would abort with "invalid Roaring array: sorted
+    /// integers expected" *after* writing fragments, orphaning them. This pins the
+    /// order-independent accumulation by feeding the source in reverse key order.
+    #[tokio::test]
+    async fn test_covered_update_move_accepts_unsorted_source_order() {
+        use arrow_array::cast::AsArray;
+        use std::collections::HashSet;
+
+        let dim = 2i32;
+        let total_rows = 128usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let ids: Vec<String> = (0..total_rows).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..total_rows).map(|j| format!("cat-{j:04}")).collect();
+        let values: Vec<f32> = (0..total_rows * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids.clone())),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://covered_move_unsorted", None)
+            .await
+            .unwrap();
+        // Deliberately NO scalar index on the join key: that routes the merge through the
+        // full-table hash join, whose output follows the source (probe) order. The indexed-scan
+        // path reads in fragment order and would hide the bug.
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+        let ds = Arc::new(ds);
+
+        // Reverse order: every address after the first is below the running maximum, so a bulk
+        // `append` fails on the very second row.
+        let mut update_ids: Vec<String> = ids.clone();
+        update_ids.reverse();
+        let new_cats: Vec<String> = update_ids
+            .iter()
+            .map(|id| format!("updated-{}", &id[3..]))
+            .collect();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(update_ids)),
+                Arc::new(StringArray::from(new_cats)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let (ds, _) = MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+
+        let batch = ds
+            .scan()
+            .project(&["id", "category"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            total_rows,
+            "row count changed after an out-of-order covered move"
+        );
+        let ids_col = batch["id"].as_string::<i32>();
+        let cats_col = batch["category"].as_string::<i32>();
+        let mut seen = HashSet::new();
+        for i in 0..batch.num_rows() {
+            let id = ids_col.value(i);
+            assert!(
+                seen.insert(id.to_string()),
+                "duplicate id {id} after covered move"
+            );
+            assert_eq!(
+                cats_col.value(i),
+                format!("updated-{}", &id[3..]),
+                "stale or missing covered value for {id}"
+            );
+        }
+        assert_eq!(seen.len(), total_rows);
+    }
+
+    /// The covered row-move must publish the moved rows as `affected_rows`, exactly as the
+    /// full-schema `RewriteRows` paths do. Without them `check_update_txn` short-circuits on
+    /// `affected_rows.is_none()` and turns any concurrent delete/update touching the same
+    /// fragments into a retryable conflict, so covered datasets would silently lose the
+    /// merge_insert/delete concurrency that non-covered ones keep.
+    #[tokio::test]
+    async fn test_covered_update_move_publishes_affected_rows() {
+        let dim = 2i32;
+        let total_rows = 64usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let ids: Vec<String> = (0..total_rows).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..total_rows).map(|j| format!("cat-{j:04}")).collect();
+        let values: Vec<f32> = (0..total_rows * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://covered_move_affected_rows", None)
+            .await
+            .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+        let ds = Arc::new(ds);
+
+        // Single fragment written in id order, so row N sits at address N.
+        let targets = [2usize, 5, 7];
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(
+                    targets
+                        .iter()
+                        .map(|n| format!("id-{n:04}"))
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    targets
+                        .iter()
+                        .map(|n| format!("updated-{n:04}"))
+                        .collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let UncommittedMergeInsert { affected_rows, .. } =
+            MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+                .unwrap()
+                .when_matched(WhenMatched::UpdateAll)
+                .when_not_matched(WhenNotMatched::DoNothing)
+                .try_build()
+                .unwrap()
+                .execute_uncommitted(reader)
+                .await
+                .unwrap();
+
+        let expected =
+            RowAddrTreeMap::from(RoaringTreemap::from_iter(targets.iter().map(|n| *n as u64)));
+        assert_eq!(
+            affected_rows,
+            Some(expected),
+            "covered row-move must publish the moved addresses so a concurrent delete can rebase"
+        );
+    }
+
+    /// Builds a 3-fragment dataset with an IVF_PQ index covering `category`, then does a
+    /// partial merge_insert that rewrites only `category` for fragment 1. That update is a
+    /// row-MOVE: fragment 1's rows are tombstoned and rewritten into a new fragment, while
+    /// the old segment's storage still physically holds their pre-update covering values.
+    /// Returns `(post-move dataset, total_rows, rows_per_frag, dim)`.
+    async fn build_moved_covering_dataset(uri: &str) -> (Arc<Dataset>, usize, usize, i32) {
+        let dim = 4i32;
+        let rows_per_frag = 256usize;
+        let num_frags = 3usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+
+        let make_batch = |frag_idx: usize| {
+            let start = frag_idx * rows_per_frag;
+            let ids: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("id-{j:04}"))
+                .collect();
+            let cats: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("cat-{j:04}"))
+                .collect();
+            let values: Vec<f32> = (0..rows_per_frag * dim as usize)
+                .map(|i| (start * dim as usize + i) as f32)
+                .collect();
+            let vectors =
+                FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(cats)),
+                    Arc::new(vectors),
+                ],
+            )
+            .unwrap()
+        };
+
+        let reader = Box::new(RecordBatchIterator::new(
+            [Ok(make_batch(0))],
+            schema.clone(),
+        ));
+        let mut ds = Dataset::write(reader, uri, None).await.unwrap();
+        for frag_idx in 1..num_frags {
+            let reader = Box::new(RecordBatchIterator::new(
+                [Ok(make_batch(frag_idx))],
+                schema.clone(),
+            ));
+            ds.append(reader, None).await.unwrap();
+        }
+
+        // Scalar index on the join key so the merge joins via the indexed scan. The write
+        // strategy is unaffected: a covered-column update is always a row-move.
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_pq(1, 8, 2, MetricType::L2, 2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+        let ds = Arc::new(ds);
+
+        // Partial merge_insert rewriting ONLY `category` for fragment 1 -> prunes
+        // fragment 1 from the vector index's coverage bitmap.
+        let frag1_start = rows_per_frag;
+        let ids: Vec<String> = (frag1_start..frag1_start + rows_per_frag)
+            .map(|j| format!("id-{j:04}"))
+            .collect();
+        let new_cats: Vec<String> = (frag1_start..frag1_start + rows_per_frag)
+            .map(|j| format!("updated-{j:04}"))
+            .collect();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(new_cats)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let (ds, _) = MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+
+        // Precondition every caller relies on: the covering column really is recorded on
+        // the index metadata, since the move/prune logic keys on it.
+        let category_field_id = ds.schema().field("category").unwrap().id;
+        let indices = ds.load_indices().await.unwrap();
+        let vec_idx = indices.iter().find(|i| i.name == "vec_idx").unwrap();
+        assert_eq!(vec_idx.included_fields, vec![category_field_id]);
+
+        (ds, num_frags * rows_per_frag, rows_per_frag, dim)
+    }
+
+    /// A covered query over every row must return each row exactly once (no stale duplicate
+    /// from the old storage) with the fresh `category` value.
+    async fn assert_covered_query_no_duplicates_fresh(
+        ds: &Dataset,
+        total_rows: usize,
+        rows_per_frag: usize,
+        dim: i32,
+    ) {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::UInt64Type;
+        use lance_core::ROW_ID;
+        use std::collections::HashSet;
+
+        let frag1_start = rows_per_frag;
+        let query: Float32Array = (0..dim)
+            .map(|i| (frag1_start * dim as usize + i as usize) as f32)
+            .collect();
+        let results = ds
+            .scan()
+            .nearest("vec", &query, total_rows)
+            .unwrap()
+            .with_row_id()
+            .project(&["id", "category"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        let rowids = results[ROW_ID].as_primitive::<UInt64Type>();
+        let unique: HashSet<u64> = rowids.values().iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            rowids.len(),
+            "optimize double-counted the pruned fragment: duplicate row ids in covered results"
+        );
+        assert_eq!(
+            results.num_rows(),
+            total_rows,
+            "covered query returned {} rows, expected {total_rows} (dropped/duplicated rows)",
+            results.num_rows()
+        );
+
+        let ids_col = results["id"].as_string::<i32>();
+        let cats = results["category"].as_string::<i32>();
+        for i in 0..ids_col.len() {
+            let id = ids_col.value(i);
+            let n: usize = id[3..].parse().unwrap();
+            let expected = if (frag1_start..frag1_start + rows_per_frag).contains(&n) {
+                format!("updated-{n:04}")
+            } else {
+                format!("cat-{n:04}")
+            };
+            assert_eq!(cats.value(i), expected, "stale covering value for row {id}");
+        }
+    }
+
+    /// After a covered-column update moves rows out of a fragment, an optimize must not
+    /// resurrect the stale copies still sitting in the old segment's storage. `merge`
+    /// re-scans the moved rows as unindexed data *and* folds in the old segment, so it must
+    /// not double-count them; the default (append) optimize leaves the old segment in place,
+    /// so the deletion mask must keep hiding them.
+    #[rstest::rstest]
+    #[case::merge(lance_index::optimize::OptimizeOptions::merge(1))]
+    #[case::append_default(lance_index::optimize::OptimizeOptions::default())]
+    #[tokio::test]
+    async fn test_optimize_after_covering_move_no_duplicate_rows(
+        #[case] options: lance_index::optimize::OptimizeOptions,
+    ) {
+        let (ds, total_rows, rows_per_frag, dim) =
+            build_moved_covering_dataset("memory://covered_opt").await;
+        let mut ds = Arc::try_unwrap(ds).unwrap_or_else(|arc| (*arc).clone());
+        ds.optimize_indices(&options).await.unwrap();
+        assert_covered_query_no_duplicates_fresh(&ds, total_rows, rows_per_frag, dim).await;
+    }
+
+    /// The covered-column move relies on non-stable row-ids (moved rows get new addresses).
+    /// On a stable-row-id dataset preserving ids through the move is not yet implemented, so a
+    /// partial-schema merge_insert on a covered column must reject cleanly (fail loud) rather
+    /// than silently patch in place and leave a stale index copy.
+    #[tokio::test]
+    async fn test_merge_insert_covered_update_rejected_on_stable_row_ids() {
+        let dim = 4i32;
+        let n = 256usize; // enough rows to train PQ
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let ids: Vec<String> = (0..n).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..n).map(|j| format!("cat-{j:04}")).collect();
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids.clone())),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(
+            reader,
+            "memory://covered_stable_reject",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_pq(1, 8, 2, MetricType::L2, 2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // Partial merge_insert updating only the covered `category`.
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(
+                    (0..n).map(|j| format!("new-{j:04}")).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update)], sub_schema));
+        let result = MergeInsertBuilder::try_new(Arc::new(ds), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await;
+        assert!(result.is_err(), "expected rejection, got Ok");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("covered") && msg.contains("stable-row-id"),
+            "error should explain the covered + stable-row-id limitation; got: {msg}"
+        );
+    }
+
+    /// A partial-schema merge that does NOT update matched rows (DoNothing + InsertAll)
+    /// must not be treated as a covered-column update, even when the source carries a
+    /// covered column -- matched rows are untouched and unmatched rows enter unindexed
+    /// fragments, so nothing is patched into the index.
+    #[tokio::test]
+    async fn test_merge_insert_covered_donothing_insert_not_rejected() {
+        let dim = 4i32;
+        let n = 20usize;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                // nullable so InsertAll with a partial source is permitted
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+        let ids: Vec<String> = (0..n).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..n).map(|j| format!("cat-{j:04}")).collect();
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://covered_donothing", None)
+            .await
+            .unwrap();
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // DoNothing on matched + InsertAll unmatched, partial source (id + category)
+        // including new rows to insert.
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let new_ids: Vec<String> = (n..n + 5).map(|j| format!("id-{j:04}")).collect();
+        let new_cats: Vec<String> = (n..n + 5).map(|j| format!("cat-{j:04}")).collect();
+        let update = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(new_ids)),
+                Arc::new(StringArray::from(new_cats)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update)], sub_schema));
+        let result = MergeInsertBuilder::try_new(Arc::new(ds), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::DoNothing)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await;
+        assert!(
+            result.is_ok(),
+            "DoNothing + InsertAll with a covered column in a partial source must not be \
+             rejected as a covered update; got {:?}",
+            result.err()
+        );
+    }
+
+    /// An upsert that touches a covered column -- `UpdateAll` matched plus `InsertAll`
+    /// unmatched -- is rejected up front. The covered update is rewritten as a row-move,
+    /// which writes the moved rows as new fragments; folding freshly inserted rows into
+    /// that same write is not supported yet, so the combination must fail loudly rather
+    /// than silently drop the inserts. Distinct from its `DoNothing` sibling, which never
+    /// reaches this guard because `covered_columns_updated` short-circuits first.
+    #[tokio::test]
+    async fn test_merge_insert_covered_update_with_insert_rejected() {
+        let dim = 4i32;
+        let n = 20usize;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                // nullable so InsertAll with a partial source is permitted
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+        let ids: Vec<String> = (0..n).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..n).map(|j| format!("cat-{j:04}")).collect();
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://covered_update_insert", None)
+            .await
+            .unwrap();
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // Partial source mixing an update to an existing row with a brand-new row.
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let update = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "id-0001".to_string(),
+                    format!("id-{:04}", n),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    "updated-0001".to_string(),
+                    "brand-new".to_string(),
+                ])),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update)], sub_schema));
+        let err = MergeInsertBuilder::try_new(Arc::new(ds), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .expect_err("covered update combined with inserts must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("category") && message.contains("inserting unmatched rows"),
+            "rejection must name the covered column and the unsupported combination, got: {message}"
+        );
+    }
+
+    /// The covered-column row-move re-reads full rows via a take, which cannot round-trip
+    /// legacy (v1) blob columns as binary. A partial covered update on a dataset carrying
+    /// a v1 blob column must be rejected up front rather than silently corrupting the blob.
+    #[tokio::test]
+    async fn test_merge_insert_covered_update_rejected_with_v1_blob() {
+        use arrow_array::LargeBinaryArray;
+        use lance_arrow::BLOB_META_KEY;
+
+        let dim = 4i32;
+        let n = 20usize;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+            Field::new("blobs", DataType::LargeBinary, true).with_metadata(HashMap::from([(
+                BLOB_META_KEY.to_string(),
+                "true".to_string(),
+            )])),
+        ]));
+        let ids: Vec<String> = (0..n).map(|j| format!("id-{j:04}")).collect();
+        let cats: Vec<String> = (0..n).map(|j| format!("cat-{j:04}")).collect();
+        let blobs: Vec<Option<&[u8]>> = (0..n).map(|_| Some(b"payload".as_slice())).collect();
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32).collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vectors),
+                Arc::new(LargeBinaryArray::from(blobs)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+        let mut ds = Dataset::write(
+            reader,
+            "memory://covered_v1_blob",
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        params.include_columns(vec!["category".to_string()]);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // Partial source updating the covered `category` on matched rows only.
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let upd_ids: Vec<String> = (0..3).map(|j| format!("id-{j:04}")).collect();
+        let upd_cats: Vec<String> = (0..3).map(|j| format!("new-{j:04}")).collect();
+        let update = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(upd_ids)),
+                Arc::new(StringArray::from(upd_cats)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update)], sub_schema));
+        let result = MergeInsertBuilder::try_new(Arc::new(ds), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await;
+        let err = result.expect_err("covered update with a v1 blob column must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("legacy (v1) blob"),
+            "expected a legacy-blob rejection, got: {msg}"
         );
     }
 
@@ -12521,11 +13730,11 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
     #[tokio::test]
     async fn test_merge_insert_with_blob_v1_source_provides_blob() {
         use arrow_array::LargeBinaryArray;
-        use arrow_schema::Schema as ArrowSchema;
+        use arrow_schema::Schema;
         use lance_arrow::BLOB_META_KEY;
 
         let test_dir = TempStrDir::default();
-        let schema = Arc::new(ArrowSchema::new(vec![
+        let schema = Arc::new(Schema::new(vec![
             Field::new("blobs", DataType::LargeBinary, true).with_metadata(HashMap::from([(
                 BLOB_META_KEY.to_string(),
                 "true".to_string(),
@@ -12600,10 +13809,10 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
     #[tokio::test]
     async fn test_merge_insert_with_blob_v2_source_provides_blob() {
         use crate::{BlobArrayBuilder, blob_field};
-        use arrow_schema::Schema as ArrowSchema;
+        use arrow_schema::Schema;
 
         let test_dir = TempStrDir::default();
-        let schema = Arc::new(ArrowSchema::new(vec![
+        let schema = Arc::new(Schema::new(vec![
             blob_field("blobs", true),
             Field::new("id", DataType::Int64, true),
             Field::new("other", DataType::Int64, true),

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -136,7 +136,7 @@ fn validate_segment_metadata(index_name: &str, segments: &[IndexMetadata]) -> Re
     Ok(())
 }
 
-fn collect_subtree_field_ids(field: &Field, field_ids: &mut HashSet<i32>) {
+pub(crate) fn collect_subtree_field_ids(field: &Field, field_ids: &mut HashSet<i32>) {
     field_ids.insert(field.id);
     for child in &field.children {
         collect_subtree_field_ids(child, field_ids);
@@ -201,6 +201,37 @@ async fn prune_stale_segment_coverage(
             .iter_mut()
             .filter(|segment| segment.dataset_version() == version)
         {
+            // Fields whose value this segment materializes: the indexed subtree plus
+            // every covered (included) column's subtree. A change to any of them -- a
+            // rewritten data file or a newer overlay -- makes the segment's stored copy
+            // stale for that fragment, whether the change touched the indexed column or
+            // only a covered one.
+            let mut relevant_field_ids = indexed_field_ids.clone();
+            for included_id in segment.included_fields() {
+                // A covered field whose subtree changed between the segment's build version
+                // and now -- e.g. a struct that gained a child via `add_columns` (which
+                // commits while this segment is still uncommitted, so the Merge-commit guard
+                // never saw it) -- makes the segment's stored covering payload type-
+                // incompatible with the current schema for *every* row it covers. No
+                // per-fragment file-path prune below can repair a global type change, so
+                // reject the commit; the segment must be rebuilt against the current schema.
+                if Transaction::covered_field_subtree_changed(
+                    historical.schema(),
+                    dataset.schema(),
+                    *included_id,
+                ) {
+                    return Err(Error::invalid_input(format!(
+                        "CreateIndex: covered (included) field id {included_id} changed its \
+                         subtree between the segment's build version {version} and the current \
+                         dataset version {}; the segment's stored covering payload no longer \
+                         matches the schema. Rebuild the segment against the current schema.",
+                        dataset.manifest.version
+                    )));
+                }
+                if let Some(included_field) = dataset.schema().field_by_id(*included_id) {
+                    collect_subtree_field_ids(included_field, &mut relevant_field_ids);
+                }
+            }
             let stale_fragments = segment
                 .fragment_bitmap()
                 .iter()
@@ -212,8 +243,8 @@ async fn prune_stale_segment_coverage(
                         return true;
                     };
                     let changed_files =
-                        fragment_field_paths(historical_fragment, &indexed_field_ids)
-                            != fragment_field_paths(current_fragment, &indexed_field_ids);
+                        fragment_field_paths(historical_fragment, &relevant_field_ids)
+                            != fragment_field_paths(current_fragment, &relevant_field_ids);
                     let changed_overlays = prune_newer_overlays
                         && current_fragment.overlays.iter().any(|overlay| {
                             overlay.committed_version > version
@@ -221,7 +252,7 @@ async fn prune_stale_segment_coverage(
                                     .data_file
                                     .fields
                                     .iter()
-                                    .any(|field_id| indexed_field_ids.contains(field_id))
+                                    .any(|field_id| relevant_field_ids.contains(field_id))
                         });
                     changed_files || changed_overlays
                 })
@@ -248,6 +279,10 @@ pub(crate) async fn build_index_metadata_from_segments(
 
     let mut seen_segment_ids = HashSet::with_capacity(segments.len());
     let mut covered_fragments = RoaringBitmap::new();
+    // All segments of one logical index must advertise the same covering columns;
+    // otherwise the committed metadata's `included_fields` would misdescribe some
+    // segment's storage.
+    let expected_included_fields = segments[0].included_fields().to_vec();
     for segment in &segments {
         if segment.dataset_version() > dataset.manifest.version {
             return Err(Error::invalid_input(format!(
@@ -255,6 +290,14 @@ pub(crate) async fn build_index_metadata_from_segments(
                 segment.uuid(),
                 segment.dataset_version(),
                 dataset.manifest.version
+            )));
+        }
+        if segment.included_fields() != expected_included_fields.as_slice() {
+            return Err(Error::invalid_input(format!(
+                "CreateIndex: segment {} has covering fields {:?}, but the segment set expects {:?}",
+                segment.uuid(),
+                segment.included_fields(),
+                expected_included_fields
             )));
         }
         if segment.fields() != [field_id] {
@@ -284,6 +327,7 @@ pub(crate) async fn build_index_metadata_from_segments(
     prune_stale_segment_coverage(dataset, field_id, &mut segments, false, false).await?;
 
     let new_indices = futures::stream::iter(segments.into_iter().map(|segment| async move {
+        let included_fields = segment.included_fields().to_vec();
         let (uuid, fragment_bitmap, fields, index_details, index_version, dataset_version) =
             segment.into_parts();
         let is_inverted_index = index_details.type_url.ends_with("InvertedIndexDetails");
@@ -299,7 +343,7 @@ pub(crate) async fn build_index_metadata_from_segments(
                 created_at: Some(chrono::Utc::now()),
                 base_id: None,
                 files: None,
-                included_fields: Vec::new(),
+                included_fields: included_fields.clone(),
             };
             crate::index::scalar::inverted::finalize_segment_files_if_needed(dataset, &metadata)
                 .await?;
@@ -320,7 +364,7 @@ pub(crate) async fn build_index_metadata_from_segments(
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(files),
-            included_fields: Vec::new(),
+            included_fields,
         })
     }))
     .buffered(dataset.object_store.io_parallelism())
@@ -1938,6 +1982,11 @@ impl DatasetIndexExt for Dataset {
             .index_details
             .as_ref()
             .map(|details| details.type_url.clone());
+        // All incoming segments share one covering set (enforced by
+        // `build_index_metadata_from_segments`); any existing segment we *retain*
+        // alongside them must advertise the same covering, or the committed index would
+        // hold segments that disagree on which columns they materialize.
+        let incoming_included_fields = new_indices[0].included_fields.clone();
         let mut incoming_fragments = RoaringBitmap::new();
         for segment in &new_indices {
             if segment.fields != [field.id] {
@@ -2013,6 +2062,15 @@ impl DatasetIndexExt for Dataset {
                 }
 
                 if existing_fragments.is_disjoint(&incoming_fragments) {
+                    // Retained (not removed) -- it must share the incoming covering.
+                    if idx.included_fields != incoming_included_fields {
+                        return Err(Error::invalid_input(format!(
+                            "CreateIndex: retained segment {} for '{}' covers fields {:?}, but the \
+                             incoming segments cover {:?}; all segments of one index must share the \
+                             same covering columns",
+                            idx.uuid, index_name, idx.included_fields, incoming_included_fields
+                        )));
+                    }
                     return Ok(None);
                 }
 
@@ -2166,7 +2224,9 @@ impl DatasetIndexExt for Dataset {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None, // New merged index file locates in the cloned dataset.
                 files: Some(res.files),
-                included_fields: Vec::new(),
+                // Covering columns are unchanged by a merge; the merged storage
+                // still carries them, so keep declaring them.
+                included_fields: last_idx.included_fields.clone(),
             };
             removed_indices.extend(res.removed_indices.iter().map(|&idx| idx.clone()));
             new_indices.push(new_idx);
@@ -7643,6 +7703,375 @@ mod tests {
                 .iter()
                 .all(|idx| idx.files.as_ref().is_some_and(|files| !files.is_empty())),
             "committed segment metadata should capture on-disk file info"
+        );
+    }
+
+    /// A covering segment's `included_fields` must survive `commit_existing_index_segments`.
+    /// The segment files still hold the payload, so dropping the declaration would silently
+    /// fall covered queries back to a base-table take.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_preserves_included_fields() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+        // A real covered segment: its auxiliary storage physically holds the "id"
+        // payload, which the commit-boundary cross-check verifies.
+        let mut params = crate::index::vector::VectorIndexParams::ivf_flat(
+            1,
+            lance_linalg::distance::MetricType::L2,
+        );
+        params.include_columns(vec!["id".to_string()]);
+        let seg = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert_eq!(seg.included_fields, vec![id_field_id]);
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg)],
+            )
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(
+            committed[0].included_fields,
+            vec![id_field_id],
+            "committed segment must preserve its covering `included_fields`"
+        );
+    }
+
+    /// A second commit whose incoming segment covers a different column set than an
+    /// existing, disjoint segment we would *retain* must be rejected: all segments of one
+    /// logical index must agree on their covering, or the committed `included_fields`
+    /// would misdescribe some segment's storage.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_inconsistent_retained_covering() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+
+        // First commit: a real segment covering `id`, over fragment 0 only.
+        let mut covered_params = crate::index::vector::VectorIndexParams::ivf_flat(
+            1,
+            lance_linalg::distance::MetricType::L2,
+        );
+        covered_params.include_columns(vec!["id".to_string()]);
+        let seg0 = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &covered_params)
+            .name("vector_idx".to_string())
+            .fragments(vec![0])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert_eq!(seg0.included_fields, vec![id_field_id]);
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg0)],
+            )
+            .await
+            .unwrap();
+
+        // Second commit: a disjoint segment (fragment 1) that covers *nothing*. It would
+        // be retained alongside seg0, whose covering is `[id]` -- an inconsistency.
+        let plain_params = crate::index::vector::VectorIndexParams::ivf_flat(
+            1,
+            lance_linalg::distance::MetricType::L2,
+        );
+        let seg1 = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &plain_params)
+            .name("vector_idx".to_string())
+            // The name already exists (seg0 was committed); replace(true) only skips
+            // the duplicate-name check for this uncommitted build.
+            .replace(true)
+            .fragments(vec![1])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert!(seg1.included_fields.is_empty());
+        let result = dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg1)],
+            )
+            .await;
+        let err =
+            result.expect_err("mismatched covering across retained segments must be rejected");
+        assert!(
+            err.to_string().contains("same covering columns"),
+            "expected a covering-consistency rejection, got: {err}"
+        );
+    }
+
+    /// When a segment covers a column whose data file was rewritten in place after the
+    /// segment was built, `prune_stale_segment_coverage` must drop the affected fragment
+    /// from the segment's coverage -- even though the *indexed* column's file is untouched.
+    /// Otherwise a covered query reads the segment's stale copy of that column.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_prunes_stale_covered_fragment() {
+        use crate::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let dim = 8i32;
+        let n = 20i32;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("tag", DataType::Int32, true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let vectors = FixedSizeListArray::try_new_from_values(
+            Float32Array::from((0..n * dim).map(|v| v as f32).collect::<Vec<_>>()),
+            dim,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from((0..n).collect::<Vec<_>>())),
+                Arc::new(Int32Array::from((0..n).collect::<Vec<_>>())),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+        // Two fragments (ids 0..10 -> frag 0, 10..20 -> frag 1).
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // A scalar index on the merge key routes the partial-schema update through the
+        // in-place column-rewrite path (RewriteColumns) instead of a row-move, so the
+        // covered column's file changes while the fragment id is preserved.
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::BTree,
+                None,
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let tag_field_id = dataset.schema().field("tag").unwrap().id;
+
+        // Build a real covering segment BEFORE the update, so it is stamped at the
+        // pre-update version and covers `tag`, whose files still hold the old values.
+        let mut params = crate::index::vector::VectorIndexParams::ivf_flat(
+            1,
+            lance_linalg::distance::MetricType::L2,
+        );
+        params.include_columns(vec!["tag".to_string()]);
+        let seg = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert_eq!(seg.included_fields, vec![tag_field_id]);
+
+        // In-place rewrite of the covered `tag` column for fragment 0 only (no covering
+        // index committed yet, so this patches the column file in place and keeps the
+        // fragment id). The indexed `vector` column's file is untouched.
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("tag", DataType::Int32, true),
+        ]));
+        let update = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from((0..5).collect::<Vec<_>>())),
+                Arc::new(Int32Array::from((100..105).collect::<Vec<_>>())),
+            ],
+        )
+        .unwrap();
+        let (updated, _) = MergeInsertBuilder::try_new(Arc::new(dataset), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(Box::new(RecordBatchIterator::new([Ok(update)], sub_schema)))
+            .await
+            .unwrap();
+        let mut dataset = Arc::try_unwrap(updated).unwrap_or_else(|arc| (*arc).clone());
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg)],
+            )
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(committed.len(), 1);
+        let bitmap = committed[0].fragment_bitmap.as_ref().unwrap();
+        assert!(
+            !bitmap.contains(0),
+            "fragment 0's covered column was rewritten; its stale coverage must be pruned"
+        );
+        assert!(
+            bitmap.contains(1),
+            "fragment 1's covered column was untouched; it stays covered"
+        );
+    }
+
+    /// A covered *struct* that grows a child (via `add_columns`) after a segment was built
+    /// makes the segment's stored covering payload type-incompatible for every covered row --
+    /// a global change no per-fragment prune can repair. Since the covering index is not
+    /// committed while the segment is staged, the Merge-commit guard never sees the add;
+    /// `prune_stale_segment_coverage` must reject the segment commit instead.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_grown_covered_struct() {
+        use arrow_array::StructArray;
+        use arrow_schema::Fields;
+        use lance_file::version::LanceFileVersion;
+
+        use crate::dataset::NewColumnTransform;
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let dim = 8i32;
+        let n = 10i32;
+        let meta_fields = Fields::from(vec![Field::new("a", DataType::Int32, false)]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("meta", DataType::Struct(meta_fields.clone()), true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let a = Arc::new(Int32Array::from((0..n).collect::<Vec<_>>()));
+        let meta = Arc::new(StructArray::new(meta_fields, vec![a], None));
+        let vectors = FixedSizeListArray::try_new_from_values(
+            Float32Array::from((0..n * dim).map(|v| v as f32).collect::<Vec<_>>()),
+            dim,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![meta, Arc::new(vectors)]).unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let meta_field_id = dataset.schema().field("meta").unwrap().id;
+
+        // Build a real covering segment stamped at the current (pre-add) version,
+        // covering the struct column `meta`.
+        let mut params = crate::index::vector::VectorIndexParams::ivf_flat(
+            1,
+            lance_linalg::distance::MetricType::L2,
+        );
+        params.include_columns(vec!["meta".to_string()]);
+        let seg = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert_eq!(seg.included_fields, vec![meta_field_id]);
+
+        // Grow the covered struct AFTER the segment was built. No covering index is
+        // committed yet, so the Merge-commit guard does not fire and the add succeeds.
+        let add =
+            NewColumnTransform::AllNulls(Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                "meta",
+                DataType::Struct(Fields::from(vec![Field::new("b", DataType::Int32, true)])),
+                true,
+            )])));
+        dataset.add_columns(add, None, None).await.unwrap();
+
+        // Committing the now-stale segment must be rejected: its stored covering payload
+        // still holds the pre-child struct type.
+        let err = dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg)],
+            )
+            .await
+            .expect_err("committing a segment covering a since-grown struct must be rejected");
+        assert!(
+            err.to_string().contains("changed its subtree"),
+            "expected a covered-subtree-change rejection, got: {err}"
         );
     }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -299,6 +299,7 @@ pub(crate) async fn build_index_metadata_from_segments(
                 created_at: Some(chrono::Utc::now()),
                 base_id: None,
                 files: None,
+                included_fields: Vec::new(),
             };
             crate::index::scalar::inverted::finalize_segment_files_if_needed(dataset, &metadata)
                 .await?;
@@ -319,6 +320,7 @@ pub(crate) async fn build_index_metadata_from_segments(
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(files),
+            included_fields: Vec::new(),
         })
     }))
     .buffered(dataset.object_store.io_parallelism())
@@ -2164,6 +2166,7 @@ impl DatasetIndexExt for Dataset {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None, // New merged index file locates in the cloned dataset.
                 files: Some(res.files),
+                included_fields: Vec::new(),
             };
             removed_indices.extend(res.removed_indices.iter().map(|&idx| idx.clone()));
             new_indices.push(new_idx);
@@ -3451,6 +3454,7 @@ mod tests {
                 path: INDEX_FILE_NAME.to_string(),
                 size_bytes: payload.len() as u64,
             }]),
+            included_fields: Vec::new(),
         }
     }
 
@@ -5420,6 +5424,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let desc = IndexDescriptionImpl::try_new(vec![metadata], &dataset)
@@ -5460,6 +5465,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let desc = IndexDescriptionImpl::try_new(vec![metadata], &dataset)
@@ -7874,6 +7880,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: seg0.files.clone(),
+            included_fields: Vec::new(),
         };
 
         let err = dataset

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -44,7 +44,8 @@ use lance_index::vector::sq::ScalarQuantizer;
 use lance_index::vector::v3::subindex::IvfSubIndex;
 use lance_index::{
     FtsPrewarmDiagnostics, FtsPrewarmOptions, FtsPrewarmResult, FtsPrewarmSegmentStatus,
-    INDEX_FILE_NAME, Index, IndexType, PrewarmOptions, pb, vector::VectorIndex,
+    INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME, Index, IndexType, PrewarmOptions, pb,
+    vector::VectorIndex,
 };
 use lance_index::{
     IndexCriteria, is_system_index,
@@ -133,6 +134,121 @@ fn validate_segment_metadata(index_name: &str, segments: &[IndexMetadata]) -> Re
         covered_fragments |= fragment_bitmap.clone();
     }
 
+    Ok(())
+}
+
+/// Cross-check a segment's declared covering columns (`included_fields`) against the
+/// covering columns physically present in its V3 auxiliary storage file. The read path
+/// trusts the two to agree: `ANNIvfSubIndexExec` declares its output schema from the
+/// manifest's `included_fields` while the per-partition search emits whatever extra
+/// columns the storage carries, so committing a mismatch fails every subsequent query
+/// on the index.
+///
+/// A segment that declares covering columns MUST have a readable V3 auxiliary file at
+/// the standard location -- covering only exists in the V3 format, so an unreadable
+/// aux file means the declaration cannot be true, and committing it would fail every
+/// covered query at read time. Segments declaring no covering tolerate an unreadable
+/// aux file (legacy formats and non-standard layouts fail loudly at index-open time
+/// regardless, and never carry covering columns).
+async fn validate_segment_covering_against_storage(
+    dataset: &Dataset,
+    scheduler: &Arc<ScanScheduler>,
+    segment: &IndexSegment,
+) -> Result<()> {
+    let declared_ids = segment.included_fields();
+    let is_vector = segment
+        .index_details()
+        .type_url
+        .ends_with("VectorIndexDetails");
+    if !is_vector {
+        if !declared_ids.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "CreateIndex: segment {} declares covering columns (field ids {:?}) but is not \
+                 a vector index segment; covering columns are only supported on vector indexes",
+                segment.uuid(),
+                declared_ids
+            )));
+        }
+        return Ok(());
+    }
+
+    let aux_path = dataset
+        .indices_dir()
+        .join(segment.uuid().to_string())
+        .join(INDEX_AUXILIARY_FILE_NAME);
+    let reader = match scheduler
+        .open_file(&aux_path, &CachedFileSize::unknown())
+        .await
+    {
+        Ok(file_scheduler) => {
+            lance_file::reader::FileReader::try_open(
+                file_scheduler,
+                None,
+                Default::default(),
+                &dataset.metadata_cache.file_metadata_cache(&aux_path),
+                FileReaderOptions::default(),
+            )
+            .await
+        }
+        Err(e) => Err(e),
+    };
+    let reader = match reader {
+        Ok(reader) => reader,
+        Err(e) => {
+            if !declared_ids.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "CreateIndex: segment {} declares covering columns (field ids {:?}) but its \
+                     auxiliary storage could not be opened to cross-check them: {}",
+                    segment.uuid(),
+                    declared_ids,
+                    e
+                )));
+            }
+            return Ok(());
+        }
+    };
+
+    // Compare names *and* Arrow types: the ANN plan declares the covered schema from the
+    // dataset fields while storage emits its own physical fields, so a segment carrying the
+    // right column name at a different type would only fail once a covered query ran.
+    let storage_covering: Vec<(String, DataType)> = reader
+        .schema()
+        .fields
+        .iter()
+        .filter(|field| !vector::RESERVED_STORAGE_COLUMNS.contains(field.name.as_str()))
+        .map(|field| (field.name.clone(), field.data_type()))
+        .collect();
+    let declared_covering = declared_ids
+        .iter()
+        .map(|id| {
+            dataset
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.id == *id)
+                .map(|field| (field.name.clone(), field.data_type()))
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "CreateIndex: segment {} declares covering field id {}, which is not a \
+                         top-level field of the dataset schema (covering columns must be \
+                         top-level)",
+                        segment.uuid(),
+                        id
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if storage_covering != declared_covering {
+        return Err(Error::invalid_input(format!(
+            "CreateIndex: segment {} declares covering columns {:?} (field ids {:?}) but its \
+             auxiliary storage carries covering columns {:?}; the declaration and the storage \
+             must match exactly, in both name and type",
+            segment.uuid(),
+            declared_covering,
+            declared_ids,
+            storage_covering
+        )));
+    }
     Ok(())
 }
 
@@ -324,7 +440,29 @@ pub(crate) async fn build_index_metadata_from_segments(
         covered_fragments |= segment.fragment_bitmap().clone();
     }
 
+    // Segments agree with each other (above); now each must also agree with the dataset
+    // schema and then with its own storage. Schema staleness is checked first: it reads
+    // only the manifest and explains *why* a segment is unacceptable (a covered subtree
+    // changed since the build), which is a better diagnostic than the storage cross-check's
+    // raw type comparison for the same segment.
     prune_stale_segment_coverage(dataset, field_id, &mut segments, false, false).await?;
+
+    // Now each segment must agree with its own storage, or the committed `included_fields`
+    // misdescribes the index files. One shared scheduler, validations fanned out, so a
+    // many-segment distributed commit pays a handful of parallel round trips instead of N
+    // serial ones.
+    let scheduler = ScanScheduler::new(
+        dataset.object_store.clone(),
+        SchedulerConfig::max_bandwidth(&dataset.object_store),
+    );
+    let validations = segments
+        .iter()
+        .map(|segment| validate_segment_covering_against_storage(dataset, &scheduler, segment))
+        .collect::<Vec<_>>();
+    futures::stream::iter(validations)
+        .buffered(dataset.object_store.io_parallelism())
+        .try_collect::<Vec<_>>()
+        .await?;
 
     let new_indices = futures::stream::iter(segments.into_iter().map(|segment| async move {
         let included_fields = segment.included_fields().to_vec();
@@ -7706,11 +7844,14 @@ mod tests {
         );
     }
 
-    /// A covering segment's `included_fields` must survive `commit_existing_index_segments`.
-    /// The segment files still hold the payload, so dropping the declaration would silently
-    /// fall covered queries back to a base-table take.
+    /// A segment whose declared `included_fields` disagree with the covering columns
+    /// physically present in its auxiliary storage must be rejected at commit, in both
+    /// directions: a declaration without payload makes every covered query fail at read
+    /// time (the exec declares a column the storage never emits), and payload without a
+    /// declaration is storage the manifest misdescribes.
     #[tokio::test]
-    async fn test_commit_existing_index_segments_preserves_included_fields() {
+    async fn test_commit_existing_index_segments_rejects_covering_storage_desync() {
+        use crate::index::vector::VectorIndexParams;
         use lance_datagen::{BatchCount, RowCount, array};
 
         let test_dir = tempfile::tempdir().unwrap();
@@ -7722,23 +7863,155 @@ mod tests {
                 "vector",
                 array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
             )
-            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
-
-        let mut dataset = Dataset::write(
-            reader,
-            test_uri,
-            Some(WriteParams {
-                max_rows_per_file: 10,
-                max_rows_per_group: 10,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
+            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
         let id_field_id = dataset.schema().field("id").unwrap().id;
-        // A real covered segment: its auxiliary storage physically holds the "id"
-        // payload, which the commit-boundary cross-check verifies.
+
+        // Direction 1: storage built WITHOUT covering, declaration fabricated.
+        let params = VectorIndexParams::ivf_pq(2, 8, 4, lance_linalg::distance::MetricType::L2, 2);
+        let mut plain_segment = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert!(plain_segment.included_fields.is_empty());
+        plain_segment.included_fields = vec![id_field_id];
+        let err = dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&plain_segment)],
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("covering"),
+            "declaring covering absent from storage must fail loudly: {err}"
+        );
+
+        // Direction 2: storage built WITH covering, declaration dropped.
+        let mut covered_params =
+            VectorIndexParams::ivf_pq(2, 8, 4, lance_linalg::distance::MetricType::L2, 2);
+        covered_params.include_columns(vec!["id".to_string()]);
+        let mut covered_segment = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &covered_params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        assert_eq!(covered_segment.included_fields, vec![id_field_id]);
+        covered_segment.included_fields = Vec::new();
+        let err = dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&covered_segment)],
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("covering"),
+            "storage carrying undeclared covering columns must fail loudly: {err}"
+        );
+
+        // Sanity: the honest covered segment commits fine, and the declaration survives the
+        // round trip. That matters beyond bookkeeping -- the segment files still hold the
+        // payload, so losing the declaration would silently drop covered queries back to a
+        // base-table take.
+        covered_segment.included_fields = vec![id_field_id];
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&covered_segment)],
+            )
+            .await
+            .unwrap();
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].included_fields, vec![id_field_id]);
+    }
+
+    /// A segment that declares covering columns but has no readable V3 auxiliary
+    /// storage must be rejected at commit: covering only exists in the V3 format, so
+    /// the declaration cannot be true, and committing it would fail every covered
+    /// query at read time.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_covered_segment_without_storage() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+        // A fabricated segment with no auxiliary file at all.
+        let mut seg = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"seg",
+        )
+        .await;
+        seg.included_fields = vec![id_field_id];
+
+        let err = dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg)],
+            )
+            .await
+            .expect_err("covering declared without readable auxiliary storage must be rejected");
+        assert!(
+            err.to_string().contains("could not be opened"),
+            "expected an unreadable-storage rejection, got: {err}"
+        );
+    }
+
+    /// A segment whose storage carries the declared covering column under the right *name*
+    /// but the wrong Arrow *type* must be rejected at commit. The plan declares the covered
+    /// schema from the dataset field while storage emits its own physical field, so a type
+    /// disagreement would surface later as a query-time schema mismatch.
+    ///
+    /// This state is unreachable through the dataset APIs -- an `alter_columns` cast assigns
+    /// the field a new id, which the top-level-id check already rejects -- so it is reproduced
+    /// the only way it can occur in practice: an externally authored segment, which is exactly
+    /// what `commit_existing_index_segments` accepts.
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_covered_type_mismatch() {
+        use arrow_array::Int64Array;
+        use lance_datagen::{BatchCount, RowCount, array};
+        use lance_file::writer::FileWriterOptions;
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        assert_eq!(
+            dataset.schema().field("id").unwrap().data_type(),
+            DataType::Int32
+        );
+
         let mut params = crate::index::vector::VectorIndexParams::ivf_flat(
             1,
             lance_linalg::distance::MetricType::L2,
@@ -7750,23 +8023,47 @@ mod tests {
             .execute_uncommitted()
             .await
             .unwrap();
-        assert_eq!(seg.included_fields, vec![id_field_id]);
+        assert!(!seg.included_fields.is_empty());
 
-        dataset
+        // Replace the segment's auxiliary storage with one carrying `id` as Int64 -- the
+        // covering column under the declared name, but not the dataset's type.
+        let aux_path = dataset
+            .indices_dir()
+            .join(seg.uuid.to_string())
+            .join(INDEX_AUXILIARY_FILE_NAME);
+        let arrow_schema = arrow_schema::Schema::new(vec![Field::new("id", DataType::Int64, true)]);
+        let lance_schema = lance_core::datatypes::Schema::try_from(&arrow_schema).unwrap();
+        let mut writer = lance_file::versions::create_writer(
+            lance_file::version::ConcreteFileVersion::V2_1,
+            dataset.object_store.create(&aux_path).await.unwrap(),
+            (&lance_schema).try_into().unwrap(),
+            FileWriterOptions::default(),
+        )
+        .unwrap();
+        writer
+            .write_batch(
+                &RecordBatch::try_new(
+                    Arc::new(arrow_schema),
+                    vec![Arc::new(Int64Array::from(vec![0_i64; 10]))],
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+
+        let err = dataset
             .commit_existing_index_segments(
                 "vector_idx",
                 "vector",
                 vec![segment_from_metadata(&seg)],
             )
             .await
-            .unwrap();
-
-        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
-        assert_eq!(committed.len(), 1);
-        assert_eq!(
-            committed[0].included_fields,
-            vec![id_field_id],
-            "committed segment must preserve its covering `included_fields`"
+            .expect_err("covering storage whose column type diverged must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("Int32") && message.contains("Int64"),
+            "rejection must name both the dataset and storage types, got: {message}"
         );
     }
 

--- a/rust/lance/src/index/api.rs
+++ b/rust/lance/src/index/api.rs
@@ -27,6 +27,9 @@ pub struct IndexSegment {
     fragment_bitmap: RoaringBitmap,
     /// Field IDs whose physical values are encoded in this segment.
     fields: Vec<i32>,
+    /// Covering ("included") field IDs whose values are materialized in this
+    /// segment's storage (empty for a non-covering index).
+    included_fields: Vec<i32>,
     /// Metadata specific to the index type.
     index_details: Arc<prost_types::Any>,
     /// The on-disk index version for this segment.
@@ -53,10 +56,24 @@ impl IndexSegment {
             uuid,
             fragment_bitmap: fragment_bitmap.into_iter().collect(),
             fields: fields.into_iter().collect(),
+            included_fields: Vec::new(),
             index_details,
             index_version,
             dataset_version,
         }
+    }
+
+    /// Declare the covering ("included") field IDs materialized in this segment's
+    /// storage. Must be carried through commit so the manifest keeps advertising the
+    /// covered columns the segment's files physically contain.
+    pub fn with_included_fields<G: IntoIterator<Item = i32>>(mut self, included_fields: G) -> Self {
+        self.included_fields = included_fields.into_iter().collect();
+        self
+    }
+
+    /// Return the covering ("included") field IDs materialized in this segment.
+    pub fn included_fields(&self) -> &[i32] {
+        &self.included_fields
     }
 
     /// Return the UUID of this segment.
@@ -93,7 +110,8 @@ impl IndexSegment {
         self.dataset_version
     }
 
-    /// Consume the segment and return its component parts.
+    /// Consume the segment and return its component parts. Covering columns are read
+    /// separately via [`IndexSegment::included_fields`] to keep this tuple narrow.
     pub fn into_parts(
         self,
     ) -> (
@@ -149,7 +167,8 @@ impl IntoIndexSegment for IndexMetadata {
             index_details,
             self.index_version,
             self.dataset_version,
-        ))
+        )
+        .with_included_fields(self.included_fields))
     }
 }
 
@@ -354,6 +373,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let segment = metadata.into_index_segment().unwrap();

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -663,6 +663,7 @@ async fn build_fresh_vector_segment(
     logical_index: &LogicalVectorIndex,
     field_path: &str,
     fragment_bitmap: &RoaringBitmap,
+    covering_columns: &[String],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<IndexMetadata> {
     let (reference_metadata, reference_index) = logical_index.iter().last().ok_or_else(|| {
@@ -671,7 +672,12 @@ async fn build_fresh_vector_segment(
             logical_index.name()
         ))
     })?;
-    let params = fresh_vector_segment_params(reference_metadata, reference_index.as_ref())?;
+    let mut params = fresh_vector_segment_params(reference_metadata, reference_index.as_ref())?;
+    // A retrain rebuilds the storage from scratch, so re-declare the covering
+    // ("included") columns -- otherwise the fresh files omit the payload while the
+    // committed metadata still advertises `included_fields`, and covered queries
+    // then expect columns the storage cannot emit.
+    params.include_columns(covering_columns.to_vec());
     let mut build_dataset = dataset.clone();
     CreateIndexBuilder::new(
         &mut build_dataset,
@@ -692,12 +698,17 @@ async fn scan_vector_fragments(
     field_path: &str,
     column_nullable: bool,
     fragments: &[Fragment],
+    covering_columns: &[String],
 ) -> Result<crate::dataset::scanner::DatasetRecordBatchStream> {
     let mut scanner = dataset.scan();
+    // Project the vector column plus any covering ("included") columns so rows from the
+    // newly-indexed fragments carry the same columns as the existing partitions.
+    let mut projection: Vec<&str> = vec![field_path];
+    projection.extend(covering_columns.iter().map(String::as_str));
     scanner
         .with_fragments(fragments.to_vec())
         .with_row_id()
-        .project(&[field_path])?;
+        .project(&projection)?;
     if column_nullable {
         let column_expr = lance_datafusion::logical_expr::field_path_to_expr(field_path)?;
         scanner.filter_expr(column_expr.is_not_null());
@@ -788,6 +799,29 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
         .as_ref()
         .map(|resolved| resolved.canonical_path.clone())
         .unwrap_or(raw_field_path);
+    // Covering ("included") columns recorded on the index, resolved to names.
+    // Threaded into the merge builder and projected into the new-data scan so
+    // they survive optimize/merge and partition split/join. An unresolvable id
+    // must fail loudly: the merged delta is committed with the original
+    // `included_fields`, so silently rebuilding without the column would leave
+    // metadata advertising a column the storage cannot emit.
+    let covering_columns: Vec<String> = old_indices[0]
+        .included_fields
+        .iter()
+        .map(|id| {
+            dataset
+                .schema()
+                .field_by_id(*id)
+                .map(|f| f.name.clone())
+                .ok_or_else(|| {
+                    Error::index(format!(
+                        "Append index: covering field id {} recorded on index '{}' does not \
+                         exist in the dataset schema; index metadata and schema are inconsistent",
+                        id, old_indices[0].name
+                    ))
+                })
+        })
+        .collect::<Result<_>>()?;
     let first_is_vector_index = metadata_is_vector_index(dataset.as_ref(), old_indices[0]).await?;
     for idx in old_indices.iter().skip(1) {
         let is_vector_index = metadata_is_vector_index(dataset.as_ref(), idx).await?;
@@ -878,6 +912,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     &logical_index,
                     &field_path,
                     &fragment_bitmap,
+                    &covering_columns,
                     options.progress.clone(),
                 )
                 .await?;
@@ -920,6 +955,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     &field_path,
                     column.nullable,
                     unindexed,
+                    &covering_columns,
                 )
                 .await?;
                 let mut append_options = options.clone();
@@ -931,6 +967,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     &field_path,
                     &reference_ivf_view,
                     &append_options,
+                    &covering_columns,
                 )
                 .boxed()
                 .await?;
@@ -1012,6 +1049,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     &field_path,
                     &selected_ivf_view,
                     options,
+                    &covering_columns,
                 ))
                 .await?;
                 if indices_merged == 0 {
@@ -1067,6 +1105,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                             &field_path,
                             column.nullable,
                             unindexed,
+                            &covering_columns,
                         )
                         .await?,
                     )
@@ -1078,6 +1117,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     &field_path,
                     &merge_ivf_view,
                     options,
+                    &covering_columns,
                 )
                 .boxed()
                 .await?;
@@ -2810,6 +2850,69 @@ mod tests {
         assert!(
             merge_result.is_some(),
             "subset merges should respect the caller-provided indices"
+        );
+    }
+
+    /// An index whose `included_fields` records a field id missing from the current
+    /// schema is metadata/schema-inconsistent. Optimize must fail loudly rather than
+    /// silently rebuild without the covered column: the merged delta would be committed
+    /// still advertising the column, and every covered query would then fail at read
+    /// time.
+    #[tokio::test]
+    async fn test_merge_indices_errors_on_unresolvable_covered_field() {
+        const DIM: usize = 16;
+        const TOTAL: usize = 256;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let vectors = generate_random_array(TOTAL * DIM);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIM as i32,
+                ),
+                true,
+            ),
+            Field::new("id", DataType::UInt32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap()),
+                Arc::new(UInt32Array::from_iter_values(0..TOTAL as u32)),
+            ],
+        )
+        .unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let index_params = VectorIndexParams::ivf_pq(2, 8, 4, MetricType::L2, 2);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &index_params, true)
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let mut stale_index = indices[0].clone();
+        stale_index.included_fields = vec![9999];
+        let old_indices = vec![&stale_index];
+        let result = merge_indices_with_unindexed_frags(
+            Arc::new(dataset),
+            &old_indices,
+            &[],
+            &OptimizeOptions::merge(1),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::Index { .. }),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("9999"),
+            "error should name the unresolvable covered field id: {err}"
         );
     }
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -1416,6 +1416,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let frag_reuse_index = FragReuseIndex {
             uuid: Uuid::new_v4(),

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -611,6 +611,7 @@ impl<'a> CreateIndexBuilder<'a> {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(index_files_to_table(created_index.files)),
+included_fields: Vec::new(),
         })
         }
         .boxed()
@@ -765,6 +766,7 @@ impl<'a> CreateIndexBuilder<'a> {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None,
                 files: Some(index_files_to_table(created_index.files)),
+                included_fields: Vec::new(),
             };
             let segments = vec![metadata.into_index_segment()?];
             let new_indices =
@@ -834,6 +836,7 @@ impl<'a> CreateIndexBuilder<'a> {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None,
                 files: Some(index_files_to_table(created_index.files)),
+                included_fields: Vec::new(),
             });
         }
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -592,6 +592,20 @@ impl<'a> CreateIndexBuilder<'a> {
             }
         };
 
+        // Resolve any covering ("included") columns to field ids for the generic
+        // IndexMetadata. The build path has already validated these names exist in the schema.
+        let included_fields = self
+            .params
+            .as_any()
+            .downcast_ref::<VectorIndexParams>()
+            .map(|vp| {
+                vp.include_columns
+                    .iter()
+                    .filter_map(|name| self.dataset.schema().field(name).map(|f| f.id))
+                    .collect::<Vec<i32>>()
+            })
+            .unwrap_or_default();
+
         Ok(IndexMetadata {
             uuid: output_index_uuid,
             name: index_name,
@@ -611,7 +625,7 @@ impl<'a> CreateIndexBuilder<'a> {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(index_files_to_table(created_index.files)),
-included_fields: Vec::new(),
+            included_fields,
         })
         }
         .boxed()

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -174,5 +174,6 @@ pub(crate) async fn build_frag_reuse_index_metadata(
         base_id: None,
         // Fragment reuse index is inline (no files)
         files: None,
+        included_fields: Vec::new(),
     })
 }

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -144,6 +144,7 @@ pub(crate) fn new_mem_wal_index_meta(
         base_id: None,
         // Memory WAL index is inline (no files)
         files: None,
+        included_fields: Vec::new(),
     })
 }
 
@@ -655,6 +656,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -569,6 +569,7 @@ mod test {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let prefilter = DatasetPreFilter::new(Arc::new(dataset), &[index], None);
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -882,6 +882,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 

--- a/rust/lance/src/index/scalar/btree.rs
+++ b/rust/lance/src/index/scalar/btree.rs
@@ -162,5 +162,6 @@ pub(crate) async fn merge_segments(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(index_files_to_table(created_index.files)),
+        included_fields: Vec::new(),
     })
 }

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -1050,6 +1050,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let details =
             normalize_inverted_details(&metadata, InvertedIndexDetails::default()).unwrap();
@@ -1073,6 +1074,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let details = InvertedIndexDetails::try_from(&InvertedIndexParams::default()).unwrap();
 

--- a/rust/lance/src/index/scalar/ngram.rs
+++ b/rust/lance/src/index/scalar/ngram.rs
@@ -144,6 +144,7 @@ pub(in crate::index) async fn merge_segments(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(index_files_to_table(created_index.files)),
+        included_fields: Vec::new(),
     })
 }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -287,14 +287,14 @@ impl VectorIndexParams {
         self
     }
 
-    /// Set the columns to co-locate ("include") in the index storage.
-    pub fn include_columns(&mut self, columns: Vec<String>) -> &mut Self {
-        self.include_columns = columns;
+    pub fn skip_transpose(&mut self, skip_transpose: bool) -> &mut Self {
+        self.skip_transpose = skip_transpose;
         self
     }
 
-    pub fn skip_transpose(&mut self, skip_transpose: bool) -> &mut Self {
-        self.skip_transpose = skip_transpose;
+    /// Set the columns to co-locate ("include") in the index storage.
+    pub fn include_columns(&mut self, columns: Vec<String>) -> &mut Self {
+        self.include_columns = columns;
         self
     }
 
@@ -631,6 +631,18 @@ pub(crate) async fn build_distributed_vector_index(
     fragment_ids: &[u32],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<(Uuid, Vec<IndexFile>)> {
+    // The distributed shard builders and the distributed merger have no covering-column
+    // plumbing: each shard would write storage without the payload while the committed
+    // metadata still advertises `included_fields`, desyncing the two. Reject covering on
+    // this path up front rather than publishing an inconsistent index.
+    if !params.include_columns.is_empty() {
+        return Err(Error::invalid_input(
+            "include_columns (covering columns) are not supported for distributed vector index \
+             builds (precomputed IVF centroids with a fragment subset). Build the covered index \
+             without a fragment restriction / precomputed IVF."
+                .to_string(),
+        ));
+    }
     let (element_type, index_type, ivf_params, shuffler) = prepare_vector_segment_build(
         dataset,
         column,
@@ -1044,6 +1056,97 @@ async fn build_vector_index_impl(
     .await?;
     let stages = &params.stages;
 
+    // Covering ("included") columns require the V3 index file format: only the V3
+    // covering-aware storages preserve the extra columns row-aligned and report them via
+    // `covering_field_indices`. Every vector index type supports covering at V3, so reject
+    // only legacy/non-V3 builds up front -- otherwise the build silently ignores the option
+    // while `included_fields` still lands in the index metadata, and the search exec then
+    // declares a covered schema the storage cannot emit.
+    if !params.include_columns.is_empty() && !matches!(params.version, IndexFileVersion::V3) {
+        return Err(Error::invalid_input(format!(
+            "include_columns (covering columns) requires index file version V3, but got {:?}",
+            params.version
+        )));
+    }
+
+    // A covering column is stored inline in the index, row-aligned with the code, and
+    // projected by name from the source batch. Reject columns that cannot satisfy that
+    // contract up front (otherwise the build fails deep in projection, or -- worse --
+    // stores unusable data): nested/dotted paths (the covering gather projects only
+    // top-level names) and blob columns (which store out-of-line descriptors, not inline
+    // data).
+    // Names that collide with a build pipeline's own internal columns. Covering one would
+    // advertise a column in `included_fields` that the storage's `covering_field_indices`
+    // excludes (so a covered query declares a column storage never emits), or fail deep in
+    // the quantizer transform. This check runs before the `match index_type` below, so it
+    // must list the *union* of every pipeline's internal names -- the row id, distance,
+    // partition id, each quantizer's code column, RaBitQ's extended-code and per-row factor
+    // columns, and the IVF partition transform's transient `__centroid_dist`.
+    const RESERVED_STORAGE_COLUMNS: &[&str] = &[
+        lance_core::ROW_ID,
+        lance_index::vector::DIST_COL,
+        lance_index::vector::PART_ID_COLUMN,
+        lance_index::vector::CENTROID_DIST_COLUMN,
+        lance_index::vector::PQ_CODE_COLUMN,
+        lance_index::vector::SQ_CODE_COLUMN,
+        lance_index::vector::flat::storage::FLAT_COLUMN,
+        lance_index::vector::bq::storage::RABIT_CODE_COLUMN,
+        lance_index::vector::bq::storage::RABIT_EX_CODE_COLUMN,
+        lance_index::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN,
+        lance_index::vector::bq::transform::ADD_FACTORS_COLUMN,
+        lance_index::vector::bq::transform::SCALE_FACTORS_COLUMN,
+        lance_index::vector::bq::transform::ERROR_FACTORS_COLUMN,
+        lance_index::vector::bq::transform::EX_ADD_FACTORS_COLUMN,
+        lance_index::vector::bq::transform::EX_SCALE_FACTORS_COLUMN,
+    ];
+    let mut seen_include = std::collections::HashSet::with_capacity(params.include_columns.len());
+    for name in &params.include_columns {
+        if name.contains('.') {
+            return Err(Error::invalid_input(format!(
+                "include_columns: nested/dotted covering column '{name}' is not supported; only \
+                 top-level columns can be covered"
+            )));
+        }
+        if name == column {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' is the indexed vector column itself; it \
+                 is stored as the quantization code, not a covered payload"
+            )));
+        }
+        if RESERVED_STORAGE_COLUMNS.contains(&name.as_str()) {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' collides with a reserved index storage \
+                 column name"
+            )));
+        }
+        if !seen_include.insert(name.as_str()) {
+            return Err(Error::invalid_input(format!(
+                "include_columns: duplicate covering column '{name}'"
+            )));
+        }
+        let field = dataset.schema().field(name).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "include_columns: covering column '{name}' does not exist in the dataset schema"
+            ))
+        })?;
+        if field.is_blob() {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' is a blob column; blob columns cannot be \
+                 covered by a vector index"
+            )));
+        }
+    }
+
+    // Covering is implemented for IVF_PQ in this change; the other IVF vector types land in a
+    // follow-up. Reject covering on a non-PQ index up front rather than recording
+    // `included_fields` the storage cannot serve.
+    if !params.include_columns.is_empty() && !matches!(index_type, IndexType::IvfPq) {
+        return Err(Error::invalid_input(
+            "include_columns (covering columns) are currently only supported for IVF_PQ indexes"
+                .to_string(),
+        ));
+    }
+
     match index_type {
         IndexType::IvfFlat => match element_type {
             DataType::Float16 | DataType::Float32 | DataType::Float64 => {
@@ -1058,6 +1161,7 @@ async fn build_vector_index_impl(
                     (),
                     frag_reuse_index,
                 )?
+                .with_include_columns(params.include_columns.clone())
                 .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
                 .build()
@@ -1076,6 +1180,7 @@ async fn build_vector_index_impl(
                     (),
                     frag_reuse_index,
                 )?
+                .with_include_columns(params.include_columns.clone())
                 .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
                 .build()
@@ -1131,6 +1236,7 @@ async fn build_vector_index_impl(
                     )?;
 
                     let summary = builder
+                        .with_include_columns(params.include_columns.clone())
                         .with_transpose(!params.skip_transpose)
                         .with_optional_fragment_filter(fragment_ids)
                         .with_progress(progress.clone())
@@ -1159,6 +1265,7 @@ async fn build_vector_index_impl(
                 (),
                 frag_reuse_index,
             )?
+            .with_include_columns(params.include_columns.clone())
             .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
@@ -1186,6 +1293,7 @@ async fn build_vector_index_impl(
             )?;
 
             let summary = builder
+                .with_include_columns(params.include_columns.clone())
                 .with_transpose(!params.skip_transpose)
                 .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
@@ -1213,6 +1321,7 @@ async fn build_vector_index_impl(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_include_columns(params.include_columns.clone())
                     .with_optional_fragment_filter(fragment_ids)
                     .with_progress(progress.clone())
                     .build()
@@ -1231,6 +1340,7 @@ async fn build_vector_index_impl(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_include_columns(params.include_columns.clone())
                     .with_optional_fragment_filter(fragment_ids)
                     .with_progress(progress.clone())
                     .build()
@@ -1263,6 +1373,7 @@ async fn build_vector_index_impl(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_include_columns(params.include_columns.clone())
             .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
@@ -1293,6 +1404,7 @@ async fn build_vector_index_impl(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_include_columns(params.include_columns.clone())
             .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
@@ -1374,6 +1486,11 @@ pub(crate) async fn build_vector_index_incremental(
     // Determine the index type and build incrementally
     let (sub_index_type, quantization_type) = existing_index.sub_index_type();
 
+    // Every vector index type supports covering ("included") columns, so the
+    // incremental/copy path needs no per-type gate here -- each branch below threads
+    // `include_columns` into its builder, and the source index was already built with a
+    // covering-aware storage.
+
     match (sub_index_type, quantization_type) {
         // IVF_FLAT
         (SubIndexType::Flat, QuantizationType::Flat) => {
@@ -1389,6 +1506,7 @@ pub(crate) async fn build_vector_index_incremental(
             )?
             .with_ivf(ivf_model)
             .with_quantizer(quantizer.try_into()?)
+            .with_include_columns(params.include_columns.clone())
             .with_progress(progress.clone())
             .build()
             .await?;
@@ -1407,6 +1525,7 @@ pub(crate) async fn build_vector_index_incremental(
             )?
             .with_ivf(ivf_model)
             .with_quantizer(quantizer.try_into()?)
+            .with_include_columns(params.include_columns.clone())
             .with_progress(progress.clone())
             .build()
             .await?;
@@ -1428,6 +1547,7 @@ pub(crate) async fn build_vector_index_incremental(
                 .with_ivf(ivf_model)
                 .with_quantizer(quantizer.try_into()?)
                 .with_transpose(!params.skip_transpose)
+                .with_include_columns(params.include_columns.clone())
                 .with_progress(progress.clone())
                 .build()
                 .await?;
@@ -1447,6 +1567,7 @@ pub(crate) async fn build_vector_index_incremental(
             )?
             .with_ivf(ivf_model)
             .with_quantizer(quantizer.try_into()?)
+            .with_include_columns(params.include_columns.clone())
             .with_progress(progress.clone())
             .build()
             .await?;
@@ -1467,6 +1588,7 @@ pub(crate) async fn build_vector_index_incremental(
             let summary = builder
                 .with_ivf(ivf_model)
                 .with_quantizer(quantizer.try_into()?)
+                .with_include_columns(params.include_columns.clone())
                 .with_transpose(!params.skip_transpose)
                 .with_progress(progress.clone())
                 .build()
@@ -1496,6 +1618,7 @@ pub(crate) async fn build_vector_index_incremental(
                     )?
                     .with_ivf(ivf_model)
                     .with_quantizer(quantizer.try_into()?)
+                    .with_include_columns(params.include_columns.clone())
                     .with_progress(progress.clone())
                     .build()
                     .await?;
@@ -1514,6 +1637,7 @@ pub(crate) async fn build_vector_index_incremental(
                     )?
                     .with_ivf(ivf_model)
                     .with_quantizer(quantizer.try_into()?)
+                    .with_include_columns(params.include_columns.clone())
                     .with_progress(progress.clone())
                     .build()
                     .await?;
@@ -1532,6 +1656,7 @@ pub(crate) async fn build_vector_index_incremental(
                     )?
                     .with_ivf(ivf_model)
                     .with_quantizer(quantizer.try_into()?)
+                    .with_include_columns(params.include_columns.clone())
                     .with_progress(progress.clone())
                     .build()
                     .await?;
@@ -1550,6 +1675,7 @@ pub(crate) async fn build_vector_index_incremental(
                     )?
                     .with_ivf(ivf_model)
                     .with_quantizer(quantizer.try_into()?)
+                    .with_include_columns(params.include_columns.clone())
                     .with_progress(progress.clone())
                     .build()
                     .await?;
@@ -1883,7 +2009,7 @@ pub async fn initialize_vector_index(
     let (sub_index_type, quantization_type) = source_vector_index.sub_index_type();
     let ivf_params = derive_ivf_params(ivf_model);
 
-    let params = match (sub_index_type, quantization_type) {
+    let mut params = match (sub_index_type, quantization_type) {
         (SubIndexType::Flat, QuantizationType::Flat)
         | (SubIndexType::Flat, QuantizationType::FlatBin) => {
             VectorIndexParams::with_ivf_flat_params(metric_type, ivf_params)
@@ -1938,6 +2064,27 @@ pub async fn initialize_vector_index(
         }
     };
 
+    // Carry the source index's covering ("included") columns so the rebuilt
+    // target storage keeps them. included_fields are field ids in the source;
+    // resolve to names (the same columns must exist in the target dataset).
+    let included_columns: Vec<String> = source_index
+        .included_fields
+        .iter()
+        .map(|id| {
+            source_dataset
+                .schema()
+                .field_by_id(*id)
+                .map(|f| f.name.clone())
+                .ok_or_else(|| {
+                    Error::index(format!(
+                        "covering field id {id} (from index '{}') not found in source dataset schema",
+                        source_index.name
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    params.include_columns(included_columns);
+
     let new_uuid = Uuid::new_v4();
     let frag_reuse_index = target_dataset
         .open_frag_reuse_index(&NoOpMetricsCollector)
@@ -1963,6 +2110,25 @@ pub async fn initialize_vector_index(
 
     let fragment_bitmap = Some(target_dataset.fragment_bitmap.as_ref().clone());
 
+    // Field ids are per-dataset: re-resolve the covering column names against
+    // the TARGET schema (like `fields` below), never copy the source's ids.
+    let included_fields = params
+        .include_columns
+        .iter()
+        .map(|name| {
+            target_dataset
+                .schema()
+                .field(name)
+                .map(|f| f.id)
+                .ok_or_else(|| {
+                    Error::index(format!(
+                        "covering column '{}' not found in target dataset schema",
+                        name
+                    ))
+                })
+        })
+        .collect::<Result<Vec<i32>>>()?;
+
     let new_idx = IndexMetadata {
         uuid: new_uuid,
         name: source_index.name.clone(),
@@ -1974,7 +2140,7 @@ pub async fn initialize_vector_index(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(summary.files),
-        included_fields: Vec::new(),
+        included_fields,
     };
 
     let transaction = Transaction::new(
@@ -2542,6 +2708,170 @@ mod tests {
         assert_eq!(results.num_rows(), 10, "Should return 10 nearest neighbors");
     }
 
+    /// `include_columns` requires the V3 index file format. A legacy/non-V3 build must be
+    /// rejected at create time: the build would silently ignore the option while
+    /// `create_index` still records `included_fields` in the manifest, so the exec would
+    /// declare a covered schema the storage cannot emit and every query on the index would
+    /// fail.
+    #[tokio::test]
+    async fn test_include_columns_rejected_for_unsupported_index_types() {
+        let test_dir = TempStrDir::default();
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(32.into()))
+            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, test_dir.as_str(), None)
+            .await
+            .unwrap();
+
+        for (label, mut params) in [(
+            "IVF_PQ legacy",
+            VectorIndexParams::with_ivf_pq_params(
+                MetricType::L2,
+                IvfBuildParams::new(4),
+                PQBuildParams::new(8, 8),
+            )
+            .version(IndexFileVersion::Legacy)
+            .clone(),
+        )] {
+            params.include_columns(vec!["id".to_string()]);
+            let err = dataset
+                .create_index(&["vector"], IndexType::Vector, None, &params, true)
+                .await
+                .expect_err(&format!("include_columns on {label} must be rejected"));
+            assert!(
+                err.to_string().contains("include_columns"),
+                "{label}: error should name include_columns, got: {err}"
+            );
+            // Fail fast: no index metadata must have been committed.
+            assert!(
+                dataset.load_indices().await.unwrap().is_empty(),
+                "{label}: no index should have been created"
+            );
+        }
+    }
+
+    /// Copying/importing a covered index into another dataset (initialize) must
+    /// rebuild the target storage WITH the covering columns, not just copy the
+    /// `included_fields` metadata -- otherwise the target advertises covering
+    /// columns its storage can't emit and covered queries fail.
+    #[rstest::rstest]
+    #[case::pq(VectorIndexParams::ivf_pq(10, 8, 16, MetricType::L2, 50))]
+    #[case::sq(VectorIndexParams::with_ivf_sq_params(
+        MetricType::L2,
+        IvfBuildParams::new(10),
+        SQBuildParams::default()
+    ))]
+    #[case::hnsw_pq(VectorIndexParams::with_ivf_hnsw_pq_params(
+        MetricType::L2,
+        IvfBuildParams::new(10),
+        HnswBuildParams::default(),
+        PQBuildParams::new(16, 8)
+    ))]
+    #[case::hnsw_sq(VectorIndexParams::with_ivf_hnsw_sq_params(
+        MetricType::L2,
+        IvfBuildParams::new(10),
+        HnswBuildParams::default(),
+        SQBuildParams::default()
+    ))]
+    #[case::rq(VectorIndexParams::with_ivf_rq_params(
+        MetricType::L2,
+        IvfBuildParams::new(10),
+        RQBuildParams::with_rotation_type(1, RQRotationType::Fast)
+    ))]
+    #[case::flat(VectorIndexParams::ivf_flat(10, MetricType::L2))]
+    #[case::hnsw_flat(VectorIndexParams::ivf_hnsw(
+        MetricType::L2,
+        IvfBuildParams::new(10),
+        HnswBuildParams::default()
+    ))]
+    #[tokio::test]
+    async fn test_initialize_vector_index_preserves_covering(
+        #[case] mut params: VectorIndexParams,
+    ) {
+        let test_dir = TempStrDir::default();
+        let source_uri = format!("{}/source", test_dir.as_str());
+        let target_uri = format!("{}/target", test_dir.as_str());
+
+        let source_reader = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(32.into()))
+            .into_reader_rows(RowCount::from(300), BatchCount::from(1));
+        let mut source_dataset = Dataset::write(source_reader, &source_uri, None)
+            .await
+            .unwrap();
+
+        // Covered index on source (covers `id`).
+        params.include_columns(vec!["id".to_string()]);
+        source_dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vidx".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let source_dataset = Dataset::open(&source_uri).await.unwrap();
+        let source_index = source_dataset
+            .load_indices()
+            .await
+            .unwrap()
+            .iter()
+            .find(|i| i.name == "vidx")
+            .unwrap()
+            .clone();
+
+        // The target has an extra leading column, so its field ids are shifted
+        // relative to the source's: `included_fields` must be re-resolved
+        // against the TARGET schema (by name), not copied from the source.
+        let target_reader = lance_datagen::gen_batch()
+            .col("pad", array::step::<Int32Type>())
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(32.into()))
+            .into_reader_rows(RowCount::from(300), BatchCount::from(1));
+        let mut target_dataset = Dataset::write(target_reader, &target_uri, None)
+            .await
+            .unwrap();
+
+        initialize_vector_index(
+            &mut target_dataset,
+            &source_dataset,
+            &source_index,
+            &["vector"],
+        )
+        .await
+        .unwrap();
+
+        // Metadata carried over, resolved to the target's field ids.
+        let target_index = target_dataset.load_indices().await.unwrap()[0].clone();
+        let id_field = target_dataset.schema().field("id").unwrap().id;
+        assert_ne!(
+            id_field, source_index.included_fields[0],
+            "test setup must give 'id' different field ids in source and target"
+        );
+        assert_eq!(target_index.included_fields, vec![id_field]);
+
+        // End-to-end: a covered projection on the copied index skips the take and
+        // returns `id` -- which only works if the rebuilt storage carries it.
+        let query = arrow_array::Float32Array::from(vec![0.5f32; 32]);
+        let mut scan = target_dataset.scan();
+        scan.nearest("vector", &query, 10).unwrap();
+        scan.project(&["id"]).unwrap();
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection should skip the take on the copied index; plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(
+            batch.column_by_name("id").is_some(),
+            "copied index should emit the covering column 'id'"
+        );
+    }
+
     #[tokio::test]
     async fn test_initialize_vector_index_ivf_flat() {
         let test_dir = TempStrDir::default();
@@ -2790,6 +3120,47 @@ mod tests {
             result.is_ok(),
             "Expected Ok for invalid fragment ids, got {:?}",
             result
+        );
+    }
+
+    /// The distributed build + merge path has no covering-column plumbing, so it must
+    /// reject `include_columns` up front rather than publish an index whose metadata
+    /// advertises columns the shard files do not contain.
+    #[tokio::test]
+    async fn test_build_distributed_rejects_include_columns() {
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/ds", test_dir.as_str());
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(32.into()))
+            .into_reader_rows(RowCount::from(128), BatchCount::from(1));
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(4, MetricType::L2);
+        params.include_columns(vec!["id".to_string()]);
+
+        let result = build_distributed_vector_index(
+            &dataset,
+            "vector",
+            "vector_dist",
+            Uuid::new_v4(),
+            &params,
+            None,
+            &[0],
+            noop_progress(),
+        )
+        .await;
+
+        assert!(
+            matches!(&result, Err(Error::InvalidInput { .. })),
+            "distributed build must reject include_columns, got {:?}",
+            result
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("include_columns") && msg.contains("distributed"),
+            "error should mention include_columns and the distributed path; got: {msg}"
         );
     }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1137,16 +1137,6 @@ async fn build_vector_index_impl(
         }
     }
 
-    // Covering is implemented for IVF_PQ in this change; the other IVF vector types land in a
-    // follow-up. Reject covering on a non-PQ index up front rather than recording
-    // `included_fields` the storage cannot serve.
-    if !params.include_columns.is_empty() && !matches!(index_type, IndexType::IvfPq) {
-        return Err(Error::invalid_input(
-            "include_columns (covering columns) are currently only supported for IVF_PQ indexes"
-                .to_string(),
-        ));
-    }
-
     match index_type {
         IndexType::IvfFlat => match element_type {
             DataType::Float16 | DataType::Float32 | DataType::Float64 => {

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -71,6 +71,29 @@ use crate::{Error, Result, dataset::Dataset, index::pb::vector_index_stage::Stag
 
 pub const LANCE_VECTOR_INDEX: &str = "__lance_vector_index";
 
+/// Names a user column can never take inside vector index storage: the union of every
+/// storage's exported internal set (row id, partition id, each quantizer's code/factor
+/// columns -- extending any `*_INTERNAL_COLUMNS` const extends this set automatically)
+/// plus the pipeline-transient names that never reach storage (the distance column and
+/// the IVF partition transform's `__centroid_dist`). Used both to reject reserved names
+/// in `include_columns` at create time and to classify which columns of an index
+/// storage schema are covering ("included") payload.
+pub(crate) static RESERVED_STORAGE_COLUMNS: std::sync::LazyLock<
+    std::collections::HashSet<&'static str>,
+> = std::sync::LazyLock::new(|| {
+    lance_index::vector::pq::storage::PQ_INTERNAL_COLUMNS
+        .iter()
+        .chain(lance_index::vector::sq::storage::SQ_INTERNAL_COLUMNS)
+        .chain(lance_index::vector::flat::storage::FLAT_INTERNAL_COLUMNS)
+        .chain(lance_index::vector::bq::storage::RABIT_INTERNAL_COLUMNS)
+        .chain(&[
+            lance_index::vector::DIST_COL,
+            lance_index::vector::CENTROID_DIST_COLUMN,
+        ])
+        .copied()
+        .collect()
+});
+
 /// A materialized snapshot of one logical vector index and all of its segments.
 #[derive(Debug)]
 pub struct LogicalVectorIndex {
@@ -618,6 +641,79 @@ async fn prepare_vector_segment_build(
     Ok((element_type, index_type, ivf_params, shuffler))
 }
 
+/// Validate `include_columns` (covering columns) at the API boundary, before any build.
+/// Rejects non-V3 format, nested/dotted names, the indexed vector column itself, names that
+/// collide with a build pipeline's internal storage/transform columns, duplicates, missing
+/// columns, and blob columns. Shared by the single-node and distributed vector build paths so
+/// the reserved-name list lives in one place. No-op when no covering columns are configured.
+fn validate_include_columns(
+    params: &VectorIndexParams,
+    dataset: &Dataset,
+    column: &str,
+) -> Result<()> {
+    if params.include_columns.is_empty() {
+        return Ok(());
+    }
+
+    // Covering ("included") columns require the V3 index file format: only the V3
+    // covering-aware storages preserve the extra columns row-aligned and report them via
+    // `covering_field_indices`. Every vector index type supports covering at V3, so reject
+    // only legacy/non-V3 builds up front -- otherwise the build silently ignores the option
+    // while `included_fields` still lands in the index metadata, and the search exec then
+    // declares a covered schema the storage cannot emit.
+    if !matches!(params.version, IndexFileVersion::V3) {
+        return Err(Error::invalid_input(format!(
+            "include_columns (covering columns) requires index file version V3, but got {:?}",
+            params.version
+        )));
+    }
+
+    // A covering column is stored inline in the index, row-aligned with the code, and
+    // projected by name from the source batch. Reject columns that cannot satisfy that
+    // contract up front (otherwise the build fails deep in projection, or -- worse --
+    // stores unusable data): nested/dotted paths (the covering gather projects only
+    // top-level names) and blob columns (which store out-of-line descriptors, not inline
+    // data).
+    let mut seen_include = std::collections::HashSet::with_capacity(params.include_columns.len());
+    for name in &params.include_columns {
+        if name.contains('.') {
+            return Err(Error::invalid_input(format!(
+                "include_columns: nested/dotted covering column '{name}' is not supported; only \
+                 top-level columns can be covered"
+            )));
+        }
+        if name == column {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' is the indexed vector column itself; it \
+                 is stored as the quantization code, not a covered payload"
+            )));
+        }
+        if RESERVED_STORAGE_COLUMNS.contains(&name.as_str()) {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' collides with a reserved index storage \
+                 column name"
+            )));
+        }
+        if !seen_include.insert(name.as_str()) {
+            return Err(Error::invalid_input(format!(
+                "include_columns: duplicate covering column '{name}'"
+            )));
+        }
+        let field = dataset.schema().field(name).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "include_columns: covering column '{name}' does not exist in the dataset schema"
+            ))
+        })?;
+        if field.is_blob() {
+            return Err(Error::invalid_input(format!(
+                "include_columns: covering column '{name}' is a blob column; blob columns cannot be \
+                 covered by a vector index"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Build a Distributed Vector Index for specific fragments
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "debug", skip(dataset))]
@@ -631,18 +727,15 @@ pub(crate) async fn build_distributed_vector_index(
     fragment_ids: &[u32],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<(Uuid, Vec<IndexFile>)> {
-    // The distributed shard builders and the distributed merger have no covering-column
-    // plumbing: each shard would write storage without the payload while the committed
-    // metadata still advertises `included_fields`, desyncing the two. Reject covering on
-    // this path up front rather than publishing an inconsistent index.
-    if !params.include_columns.is_empty() {
-        return Err(Error::invalid_input(
-            "include_columns (covering columns) are not supported for distributed vector index \
-             builds (precomputed IVF centroids with a fragment subset). Build the covered index \
-             without a fragment restriction / precomputed IVF."
-                .to_string(),
-        ));
-    }
+    // Each shard reuses `IvfIndexBuilder`, which threads `include_columns` through its
+    // projection and per-partition storage exactly like the single-node build (the shard is
+    // just a precomputed-IVF, fragment-filtered build). Validate the covering columns up
+    // front, same as the single-node path, then thread them into each shard builder below so
+    // the segment storage carries the payload the committed `included_fields` advertises.
+    // The cross-shard segment merger carries covering too (`merge_partial_vector_auxiliary_files`
+    // appends the covering fields to each writer's schema and rejects shards whose covering sets
+    // disagree), so both per-segment commit and merged builds are covered.
+    validate_include_columns(params, dataset, column)?;
     let (element_type, index_type, ivf_params, shuffler) = prepare_vector_segment_build(
         dataset,
         column,
@@ -720,6 +813,7 @@ pub(crate) async fn build_distributed_vector_index(
                     frag_reuse_index,
                 )?
                 .with_ivf(ivf_model)
+                .with_include_columns(params.include_columns.clone())
                 .with_fragment_filter(fragment_filter)
                 .with_progress(progress.clone())
                 .build()
@@ -741,6 +835,7 @@ pub(crate) async fn build_distributed_vector_index(
                     frag_reuse_index,
                 )?
                 .with_ivf(ivf_model)
+                .with_include_columns(params.include_columns.clone())
                 .with_fragment_filter(fragment_filter)
                 .with_progress(progress.clone())
                 .build()
@@ -790,6 +885,7 @@ pub(crate) async fn build_distributed_vector_index(
                     // For distributed shards, keep PQ codes in row-major layout.
                     // A single transpose is performed in the distributed merge stage.
                     .with_transpose(false)
+                    .with_include_columns(params.include_columns.clone())
                     .with_fragment_filter(fragment_filter)
                     .with_progress(progress.clone())
                     .build()
@@ -817,6 +913,7 @@ pub(crate) async fn build_distributed_vector_index(
                 (),
                 frag_reuse_index,
             )?
+            .with_include_columns(params.include_columns.clone())
             .with_fragment_filter(fragment_filter)
             .with_progress(progress.clone())
             .build()
@@ -845,6 +942,7 @@ pub(crate) async fn build_distributed_vector_index(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_include_columns(params.include_columns.clone())
                     .with_fragment_filter(fragment_filter)
                     .with_progress(progress.clone())
                     .build()
@@ -863,6 +961,7 @@ pub(crate) async fn build_distributed_vector_index(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_include_columns(params.include_columns.clone())
                     .with_fragment_filter(fragment_filter)
                     .with_progress(progress.clone())
                     .build()
@@ -905,6 +1004,7 @@ pub(crate) async fn build_distributed_vector_index(
             // For distributed shards, keep PQ codes in row-major layout.
             // A single transpose is performed in the distributed merge stage.
             .with_transpose(false)
+            .with_include_columns(params.include_columns.clone())
             .with_fragment_filter(fragment_filter)
             .with_progress(progress.clone())
             .build()
@@ -936,6 +1036,7 @@ pub(crate) async fn build_distributed_vector_index(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_include_columns(params.include_columns.clone())
             .with_fragment_filter(fragment_filter)
             .with_progress(progress.clone())
             .build()
@@ -968,6 +1069,7 @@ pub(crate) async fn build_distributed_vector_index(
             // For distributed shards, keep RQ codes in row-major layout.
             // A single packing pass is performed in the distributed merge stage.
             .with_transpose(false)
+            .with_include_columns(params.include_columns.clone())
             .with_fragment_filter(fragment_filter)
             .with_progress(progress.clone())
             .build()
@@ -1056,86 +1158,7 @@ async fn build_vector_index_impl(
     .await?;
     let stages = &params.stages;
 
-    // Covering ("included") columns require the V3 index file format: only the V3
-    // covering-aware storages preserve the extra columns row-aligned and report them via
-    // `covering_field_indices`. Every vector index type supports covering at V3, so reject
-    // only legacy/non-V3 builds up front -- otherwise the build silently ignores the option
-    // while `included_fields` still lands in the index metadata, and the search exec then
-    // declares a covered schema the storage cannot emit.
-    if !params.include_columns.is_empty() && !matches!(params.version, IndexFileVersion::V3) {
-        return Err(Error::invalid_input(format!(
-            "include_columns (covering columns) requires index file version V3, but got {:?}",
-            params.version
-        )));
-    }
-
-    // A covering column is stored inline in the index, row-aligned with the code, and
-    // projected by name from the source batch. Reject columns that cannot satisfy that
-    // contract up front (otherwise the build fails deep in projection, or -- worse --
-    // stores unusable data): nested/dotted paths (the covering gather projects only
-    // top-level names) and blob columns (which store out-of-line descriptors, not inline
-    // data).
-    // Names that collide with a build pipeline's own internal columns. Covering one would
-    // advertise a column in `included_fields` that the storage's `covering_field_indices`
-    // excludes (so a covered query declares a column storage never emits), or fail deep in
-    // the quantizer transform. This check runs before the `match index_type` below, so it
-    // must list the *union* of every pipeline's internal names -- the row id, distance,
-    // partition id, each quantizer's code column, RaBitQ's extended-code and per-row factor
-    // columns, and the IVF partition transform's transient `__centroid_dist`.
-    const RESERVED_STORAGE_COLUMNS: &[&str] = &[
-        lance_core::ROW_ID,
-        lance_index::vector::DIST_COL,
-        lance_index::vector::PART_ID_COLUMN,
-        lance_index::vector::CENTROID_DIST_COLUMN,
-        lance_index::vector::PQ_CODE_COLUMN,
-        lance_index::vector::SQ_CODE_COLUMN,
-        lance_index::vector::flat::storage::FLAT_COLUMN,
-        lance_index::vector::bq::storage::RABIT_CODE_COLUMN,
-        lance_index::vector::bq::storage::RABIT_EX_CODE_COLUMN,
-        lance_index::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN,
-        lance_index::vector::bq::transform::ADD_FACTORS_COLUMN,
-        lance_index::vector::bq::transform::SCALE_FACTORS_COLUMN,
-        lance_index::vector::bq::transform::ERROR_FACTORS_COLUMN,
-        lance_index::vector::bq::transform::EX_ADD_FACTORS_COLUMN,
-        lance_index::vector::bq::transform::EX_SCALE_FACTORS_COLUMN,
-    ];
-    let mut seen_include = std::collections::HashSet::with_capacity(params.include_columns.len());
-    for name in &params.include_columns {
-        if name.contains('.') {
-            return Err(Error::invalid_input(format!(
-                "include_columns: nested/dotted covering column '{name}' is not supported; only \
-                 top-level columns can be covered"
-            )));
-        }
-        if name == column {
-            return Err(Error::invalid_input(format!(
-                "include_columns: covering column '{name}' is the indexed vector column itself; it \
-                 is stored as the quantization code, not a covered payload"
-            )));
-        }
-        if RESERVED_STORAGE_COLUMNS.contains(&name.as_str()) {
-            return Err(Error::invalid_input(format!(
-                "include_columns: covering column '{name}' collides with a reserved index storage \
-                 column name"
-            )));
-        }
-        if !seen_include.insert(name.as_str()) {
-            return Err(Error::invalid_input(format!(
-                "include_columns: duplicate covering column '{name}'"
-            )));
-        }
-        let field = dataset.schema().field(name).ok_or_else(|| {
-            Error::invalid_input(format!(
-                "include_columns: covering column '{name}' does not exist in the dataset schema"
-            ))
-        })?;
-        if field.is_blob() {
-            return Err(Error::invalid_input(format!(
-                "include_columns: covering column '{name}' is a blob column; blob columns cannot be \
-                 covered by a vector index"
-            )));
-        }
-    }
+    validate_include_columns(params, dataset, column)?;
 
     match index_type {
         IndexType::IvfFlat => match element_type {
@@ -2074,6 +2097,11 @@ pub async fn initialize_vector_index(
         })
         .collect::<Result<Vec<_>>>()?;
     params.include_columns(included_columns);
+    // Validate against the TARGET dataset, not the source: the names resolve there, but
+    // the column they resolve to may be a different kind (a blob, a reserved storage name,
+    // a non-V3 build). Without this, the two ordinary build entry points would reject a
+    // covering set that this cross-dataset path silently accepts.
+    validate_include_columns(&params, target_dataset, column_name)?;
 
     let new_uuid = Uuid::new_v4();
     let frag_reuse_index = target_dataset
@@ -2741,6 +2769,97 @@ mod tests {
         }
     }
 
+    /// `initialize_vector_index` re-resolves the source index's covering columns
+    /// against the TARGET schema, so a name that was valid to cover in the source can
+    /// resolve to something that is not coverable in the target. It must run the same
+    /// validation the two ordinary build entry points do, or it silently materializes
+    /// (here) blob descriptor structs as the covered payload.
+    #[tokio::test]
+    async fn test_initialize_vector_index_validates_covering_against_target() {
+        let test_dir = TempStrDir::default();
+        let source_uri = format!("{}/source", test_dir.as_str());
+        let target_uri = format!("{}/target", test_dir.as_str());
+
+        // Source: `payload` is an ordinary binary column, perfectly coverable.
+        let source_reader = lance_datagen::gen_batch()
+            .col("payload", array::rand_type(&ArrowDataType::LargeBinary))
+            .col("vector", array::rand_vec::<Float32Type>(32.into()))
+            .into_reader_rows(RowCount::from(300), BatchCount::from(1));
+        let mut source_dataset = Dataset::write(source_reader, &source_uri, None)
+            .await
+            .unwrap();
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 2, MetricType::L2, 20);
+        params.include_columns(vec!["payload".to_string()]);
+        source_dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vidx".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        let source_dataset = Dataset::open(&source_uri).await.unwrap();
+        let source_index = source_dataset
+            .load_indices()
+            .await
+            .unwrap()
+            .iter()
+            .find(|i| i.name == "vidx")
+            .unwrap()
+            .clone();
+
+        // Target: same column name, same arrow type -- but declared a blob, so it
+        // stores out-of-line descriptors rather than inline data.
+        let rows = 300usize;
+        let payload: arrow_array::ArrayRef =
+            Arc::new(arrow_array::LargeBinaryArray::from_iter_values(
+                (0..rows).map(|i| format!("v{i}").into_bytes()),
+            ));
+        let vectors: arrow_array::ArrayRef = Arc::new(
+            arrow_array::FixedSizeListArray::try_new_from_values(
+                arrow_array::Float32Array::from(vec![0.5f32; rows * 32]),
+                32,
+            )
+            .unwrap(),
+        );
+        let blob_field = Field::new("payload", ArrowDataType::LargeBinary, true).with_metadata(
+            [(lance_arrow::BLOB_META_KEY.to_string(), "true".to_string())]
+                .into_iter()
+                .collect(),
+        );
+        let target_schema = Arc::new(ArrowSchema::new(vec![
+            blob_field,
+            Field::new("vector", vectors.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(target_schema.clone(), vec![payload, vectors]).unwrap();
+        let target_reader =
+            arrow_array::RecordBatchIterator::new(vec![Ok(batch)], target_schema.clone());
+        let mut target_dataset = Dataset::write(target_reader, &target_uri, None)
+            .await
+            .unwrap();
+        assert!(
+            target_dataset.schema().field("payload").unwrap().is_blob(),
+            "test setup must give the target a blob 'payload', or this test proves nothing"
+        );
+
+        let err = initialize_vector_index(
+            &mut target_dataset,
+            &source_dataset,
+            &source_index,
+            &["vector"],
+        )
+        .await
+        .expect_err("covering a blob column in the target must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("blob") && msg.contains("payload"),
+            "error should name the offending blob covering column; was: {msg}"
+        );
+    }
+
     /// Copying/importing a covered index into another dataset (initialize) must
     /// rebuild the target storage WITH the covering columns, not just copy the
     /// `included_fields` metadata -- otherwise the target advertises covering
@@ -3110,47 +3229,6 @@ mod tests {
             result.is_ok(),
             "Expected Ok for invalid fragment ids, got {:?}",
             result
-        );
-    }
-
-    /// The distributed build + merge path has no covering-column plumbing, so it must
-    /// reject `include_columns` up front rather than publish an index whose metadata
-    /// advertises columns the shard files do not contain.
-    #[tokio::test]
-    async fn test_build_distributed_rejects_include_columns() {
-        let test_dir = TempStrDir::default();
-        let uri = format!("{}/ds", test_dir.as_str());
-
-        let reader = lance_datagen::gen_batch()
-            .col("id", array::step::<Int32Type>())
-            .col("vector", array::rand_vec::<Float32Type>(32.into()))
-            .into_reader_rows(RowCount::from(128), BatchCount::from(1));
-        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
-
-        let mut params = VectorIndexParams::ivf_flat(4, MetricType::L2);
-        params.include_columns(vec!["id".to_string()]);
-
-        let result = build_distributed_vector_index(
-            &dataset,
-            "vector",
-            "vector_dist",
-            Uuid::new_v4(),
-            &params,
-            None,
-            &[0],
-            noop_progress(),
-        )
-        .await;
-
-        assert!(
-            matches!(&result, Err(Error::InvalidInput { .. })),
-            "distributed build must reject include_columns, got {:?}",
-            result
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("include_columns") && msg.contains("distributed"),
-            "error should mention include_columns and the distributed path; got: {msg}"
         );
     }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -275,11 +275,21 @@ pub struct VectorIndexParams {
     /// Keys use reverse-DNS namespacing (e.g., "lance.ivf.max_iters").
     /// Populated by the build path and merged into VectorIndexDetails at creation time.
     pub runtime_hints: HashMap<String, String>,
+
+    /// Columns to co-locate ("include") in the index storage alongside the row id
+    /// and the quantization code. Empty by default.
+    pub include_columns: Vec<String>,
 }
 
 impl VectorIndexParams {
     pub fn version(&mut self, version: IndexFileVersion) -> &mut Self {
         self.version = version;
+        self
+    }
+
+    /// Set the columns to co-locate ("include") in the index storage.
+    pub fn include_columns(&mut self, columns: Vec<String>) -> &mut Self {
+        self.include_columns = columns;
         self
     }
 
@@ -297,6 +307,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -308,6 +319,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -343,6 +355,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -370,6 +383,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -386,6 +400,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -401,6 +416,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -416,6 +432,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -431,6 +448,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -453,6 +471,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -475,6 +494,7 @@ impl VectorIndexParams {
             version: IndexFileVersion::V3,
             skip_transpose: false,
             runtime_hints: HashMap::new(),
+            include_columns: Vec::new(),
         }
     }
 
@@ -1954,6 +1974,7 @@ pub async fn initialize_vector_index(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(summary.files),
+        included_fields: Vec::new(),
     };
 
     let transaction = Transaction::new(

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -75,7 +75,7 @@ use lance_table::format::IndexFile;
 use log::info;
 use object_store::path::Path;
 use prost::Message;
-use roaring::RoaringBitmap;
+use roaring::{RoaringBitmap, RoaringTreemap};
 use tokio::sync::OnceCell;
 use tracing::{Level, instrument, span};
 
@@ -89,13 +89,29 @@ use crate::index::vector::utils::infer_vector_dim;
 use super::v2::IVFIndex;
 use super::{
     ivf::load_precomputed_partitions_if_available,
-    utils::{self, get_vector_type},
+    utils::{self, gather_covering_columns_by_row_id, get_vector_type},
 };
 
 // the number of partitions to evaluate for reassigning
 const REASSIGN_RANGE: usize = 64;
 // sample size for kmeans training when splitting a partition (sample_rate * k = 256 * 2)
 const SPLIT_SAMPLE_SIZE: usize = 512;
+
+/// Append the covering columns from `covering` (`[_rowid, <included cols...>]`)
+/// onto `batch` (which must contain a `_rowid` column), gathered by row id.
+/// Used to re-attach covering columns to rows that were reordered/regrouped by
+/// the partition-join reassignment.
+fn append_covering_by_row_id(
+    mut batch: RecordBatch,
+    covering: &RecordBatch,
+) -> Result<RecordBatch> {
+    let target_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+    let included = gather_covering_columns_by_row_id(covering, target_ids)?;
+    for (field, col) in included {
+        batch = batch.try_with_column(field.as_ref().clone(), col)?;
+    }
+    Ok(batch)
+}
 
 /// Build a new centroid array that incorporates the results of partition splits.
 ///
@@ -222,6 +238,9 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     ivf_params: Option<IvfBuildParams>,
     quantizer_params: Option<Q::BuildParams>,
     sub_index_params: Option<S::BuildParams>,
+    /// Columns to co-locate ("include") in the index storage alongside the row
+    /// id and quantization code, so covered queries can avoid a take.
+    include_columns: Vec<String>,
     _temp_dir: TempStdDir, // store this for keeping the temp dir alive and clean up after build
     temp_dir: Path,
 
@@ -304,6 +323,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             optimize_options: None,
             merged_num: 0,
             transpose_codes: true,
+            include_columns: Vec::new(),
             format_version,
             progress: Arc::new(NoopIndexBuildProgress),
         })
@@ -346,6 +366,24 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .downcast_ref::<IVFIndex<S, Q>>()
             .ok_or(Error::invalid_input("existing index is not IVF index"))?;
 
+        // Carry the covering ("included") columns so the remapped storage keeps
+        // them -- otherwise merge_partitions would write a schema without them
+        // while the metadata still advertises them.
+        //
+        // Restricted to columns the dataset still has: this set comes from *storage*,
+        // which can outlive the schema. In the degraded state the writer fence tolerates
+        // by design (metadata cleared while the payload survives -- see
+        // `FLAG_COVERED_INDEX_METADATA` and `drop_undeclared_covering`), `drop_columns`
+        // guards only *declared* `included_fields`, so a storage-only covering column can
+        // legitimately be dropped. Carrying it on would make `covering_arrow_fields` fail
+        // to resolve it and break `compact_files` permanently; dropping it here instead
+        // lets the remap converge the index to an ordinary one.
+        let include_columns = ivf_index
+            .covering_column_names()?
+            .into_iter()
+            .filter(|name| dataset.schema().field(name).is_some())
+            .collect();
+
         let temp_dir = TempStdDir::default();
         let temp_dir_path = Path::from_filesystem_path(&temp_dir)?;
         let format_version = dataset_format_version(&dataset);
@@ -371,6 +409,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             optimize_options: None,
             merged_num: 0,
             transpose_codes: true,
+            include_columns,
             format_version,
             progress: Arc::new(NoopIndexBuildProgress),
         })
@@ -505,6 +544,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// This mainly affects intermediate PQ/RQ storage when building distributed indices.
     pub fn with_transpose(&mut self, transpose: bool) -> &mut Self {
         self.transpose_codes = transpose;
+        self
+    }
+
+    /// Set columns to co-locate ("include") in the index storage so covered
+    /// queries can avoid a take from the base table.
+    pub fn with_include_columns(&mut self, columns: Vec<String>) -> &mut Self {
+        self.include_columns = columns;
         self
     }
 
@@ -675,6 +721,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .and_then(|p| p.precomputed_shuffle_buffers.as_ref())
         {
             Some((uri, _)) => {
+                // Precomputed shuffle buffers were materialized without the covering
+                // columns, so a covered build reading from them would silently omit those
+                // columns from partition storage. Reject the combination up front.
+                if !self.include_columns.is_empty() {
+                    return Err(Error::invalid_input(
+                        "include_columns (covering columns) are not supported with precomputed \
+                         shuffle buffers: the precomputed buffers do not carry the covering columns"
+                            .to_string(),
+                    ));
+                }
                 let uri = to_local_path(uri);
                 // the uri points to data directory,
                 // so need to trim the "data" suffix for reading the dataset
@@ -685,10 +741,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             _ => {
                 log::info!("shuffle column {} over dataset", self.column);
+                // Read the vector column plus any included ("covering") columns
+                // so they flow through the shuffle into the partition storage.
+                let mut projection: Vec<&str> = Vec::with_capacity(1 + self.include_columns.len());
+                projection.push(self.column.as_str());
+                projection.extend(self.include_columns.iter().map(String::as_str));
                 let mut builder = dataset.scan();
                 builder
                     .batch_readahead(get_num_compute_intensive_cpus())
-                    .project(&[self.column.as_str()])?
+                    .project(&projection)?
                     .with_row_id();
 
                 // Apply fragment filter for distributed indexing
@@ -985,6 +1046,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let distance_type = self.distance_type;
         let column = self.column.clone();
         let frag_reuse_index = self.frag_reuse_index.clone();
+        // Covering builds may re-scan a pruned fragment that still lives in old
+        // storage; drop the stale duplicate row ids during the partition read.
+        let dedup_existing = !self.include_columns.is_empty();
         let partition_adjustment = Arc::new(partition_adjustment);
         let build_iter =
             assign_batches
@@ -998,6 +1062,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let sub_index_params = sub_index_params.clone();
                     let column = column.clone();
                     let frag_reuse_index = frag_reuse_index.clone();
+                    let dedup_existing = dedup_existing;
                     let partition_adjustment = partition_adjustment.clone();
                     async move {
                         let (is_affected, split_reader) = match partition_adjustment.as_ref() {
@@ -1028,6 +1093,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 partition,
                                 &[],
                                 Some(split_reader.as_ref().unwrap().as_ref()),
+                                dedup_existing,
                             )
                             .await?
                         } else {
@@ -1035,6 +1101,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 partition,
                                 indices.as_ref(),
                                 Some(reader.as_ref()),
+                                dedup_existing,
                             )
                             .await?
                         };
@@ -1042,9 +1109,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         // For unaffected partitions during a split, vectors from
                         // affected partitions may have been reassigned here.
                         if !is_affected && let Some(sr) = split_reader.as_ref() {
-                            let (extra, extra_loss) =
-                                Self::take_partition_batches(partition, &[], Some(sr.as_ref()))
-                                    .await?;
+                            let (extra, extra_loss) = Self::take_partition_batches(
+                                partition,
+                                &[],
+                                Some(sr.as_ref()),
+                                dedup_existing,
+                            )
+                            .await?;
                             batches.extend(extra);
                             loss += extra_loss;
                         }
@@ -1121,6 +1192,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         part_id: usize,
         existing_indices: &[ExistingIndex],
         reader: Option<&dyn ShuffleReader>,
+        dedup_by_row_id: bool,
     ) -> Result<(Vec<RecordBatch>, f64)> {
         let mut batches = Vec::new();
         for source in existing_indices.iter() {
@@ -1197,6 +1269,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             batches.extend(part_batches);
         }
 
+        // Everything pushed so far came from existing-segment storage; anything
+        // pushed below comes from the fresh shuffle reader. The dedup at the end
+        // only removes stale existing rows whose row id reappears in the fresh data.
+        let existing_end = batches.len();
+
         let mut loss = 0.0;
         // Skip if this partition doesn't exist in the reader
         // This can happen after a split creates a new partition
@@ -1221,7 +1298,71 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         }
 
+        // When rebuilding a covering index, a fragment pruned from a segment's
+        // coverage (e.g. an in-place rewrite of a covering column) is re-scanned as
+        // fresh unindexed data *and* is still present, stale, in an old segment's
+        // storage -- the same row id then appears in both. Drop the stale existing
+        // copy in favour of the fresh one.
+        //
+        // The dedup is scoped to the existing-storage <-> fresh-reader boundary: it
+        // removes only an *existing-storage* row whose row id reappears in the fresh
+        // reader data, and never dedups within a single source. That preserves
+        // legitimate repeated row ids -- a multivector column stores one entry per
+        // sub-vector, all sharing the source row's id -- which a global per-row-id
+        // dedup would otherwise silently collapse.
+        if dedup_by_row_id && existing_end > 0 {
+            // A roaring treemap rather than a `HashSet<u64>`: this holds every fresh row
+            // id in the partition, HNSW partitions target `1 << 20` rows, and
+            // `build_partitions` runs several partitions concurrently.
+            let mut fresh = RoaringTreemap::new();
+            for batch in &batches[existing_end..] {
+                for rid in batch[ROW_ID].as_primitive::<UInt64Type>().iter().flatten() {
+                    fresh.insert(rid);
+                }
+            }
+            if !fresh.is_empty() {
+                for batch in batches[..existing_end].iter_mut() {
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+                    let keep: Vec<bool> = row_ids
+                        .iter()
+                        .map(|row_id| match row_id {
+                            Some(rid) => !fresh.contains(rid),
+                            None => true,
+                        })
+                        .collect();
+                    *batch = arrow::compute::filter_record_batch(batch, &BooleanArray::from(keep))?;
+                }
+            }
+        }
+
         Ok((batches, loss))
+    }
+
+    /// Resolve the covering ("included") columns to their arrow fields from the dataset
+    /// schema, in declaration order. Empty when no covering columns are configured. Both
+    /// the code-storage schema and the empty-flat fallback schema append these so covered
+    /// storage is written consistently regardless of whether any partition held data.
+    fn covering_arrow_fields(&self) -> Result<Vec<arrow_schema::Field>> {
+        if self.include_columns.is_empty() {
+            return Ok(Vec::new());
+        }
+        let Some(ds) = self.dataset.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let ds_schema = arrow_schema::Schema::from(ds.schema());
+        self.include_columns
+            .iter()
+            .map(|name| {
+                ds_schema.field_with_name(name).cloned().map_err(|e| {
+                    Error::invalid_input(format!(
+                        "include column '{name}' not found in dataset schema: {e}"
+                    ))
+                })
+            })
+            .collect()
     }
 
     #[instrument(name = "merge_partitions", level = "debug", skip_all)]
@@ -1248,11 +1389,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let index_path = self.index_dir.clone().join(INDEX_FILE_NAME);
 
         let writer_options = FileWriterOptions::default();
+        // Covering columns are appended to whichever storage schema this build writes
+        // (code storage below, or the empty-flat fallback further down).
+        let covering_fields = self.covering_arrow_fields()?;
         let mut storage_writer = if is_flat {
             None
         } else {
             let mut fields = vec![ROW_ID_FIELD.clone(), quantizer.field()];
             fields.extend(quantizer.extra_fields());
+            // Append any included ("covering") columns so they are persisted in
+            // the auxiliary storage file alongside the row id and code.
+            fields.extend(covering_fields.iter().cloned());
             let storage_schema: Schema = (&arrow_schema::Schema::new(fields)).try_into()?;
             Some(file_versions::create_writer(
                 self.format_version,
@@ -1383,7 +1530,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     "flat storage writer could not infer schema from empty partitions without IVF centroids",
                 ));
             };
-            let flat_schema = arrow_schema::Schema::new(vec![
+            let mut flat_fields = vec![
                 ROW_ID_FIELD.as_ref().clone(),
                 arrow_schema::Field::new(
                     lance_index::vector::flat::storage::FLAT_COLUMN,
@@ -1397,7 +1544,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ),
                     true,
                 ),
-            ]);
+            ];
+            // An all-empty covered flat index must still declare its covering columns,
+            // or the written storage schema disagrees with `included_fields`.
+            flat_fields.extend(covering_fields.iter().cloned());
+            let flat_schema = arrow_schema::Schema::new(flat_fields);
             let storage_schema: Schema = (&flat_schema).try_into()?;
             storage_writer = Some(file_versions::create_writer(
                 self.format_version,
@@ -1487,14 +1638,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
     // take raw vectors from the dataset
     //
-    // returns batches of schema | row_id | vector |
+    // returns batches of schema | row_id | vector | <covering cols...> |
     async fn take_vectors(
         dataset: &Dataset,
         column: &str,
         store: &ObjectStore,
         row_ids: &[u64],
+        include_columns: &[String],
     ) -> Result<Vec<RecordBatch>> {
-        let projection = Arc::new(dataset.schema().project(&[column])?);
+        let mut proj_columns: Vec<&str> = vec![column];
+        proj_columns.extend(include_columns.iter().map(String::as_str));
+        let projection = Arc::new(dataset.schema().project(&proj_columns)?);
         // arrow uses i32 for index, so we chunk the row ids to avoid large batch causing overflow
         let mut batches = Vec::new();
         let row_ids = dataset.filter_deleted_ids(row_ids).await?;
@@ -1518,11 +1672,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(batches)
     }
 
-    // helper to load row ids and vectors for a partition
+    // helper to load row ids and vectors for a partition, plus a covering batch
+    // `[_rowid, <included cols...>]` (None when the index has no covering columns)
+    // so the columns can be re-attached to reassigned rows after quantization.
     async fn load_partition_raw_vectors(
         &self,
         part_idx: usize,
-    ) -> Result<Option<(UInt64Array, FixedSizeListArray)>> {
+    ) -> Result<Option<(UInt64Array, FixedSizeListArray, Option<RecordBatch>)>> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before split partition",
@@ -1536,11 +1692,42 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         // dedup is needed if it's multivector
         row_ids.dedup();
 
-        let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
+        let batches = Self::take_vectors(
+            dataset,
+            &self.column,
+            &self.store,
+            &row_ids,
+            &self.include_columns,
+        )
+        .await?;
         if batches.is_empty() {
             return Ok(None);
         }
         let batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter())?;
+        // Extract the covering columns BEFORE flattening. For multivector (List)
+        // vectors, `Flatten` rebuilds the batch as just `[_rowid, vector]` and
+        // drops the included columns; the pre-flatten batch has one row per row
+        // id, which is what the later gather-by-row-id expects.
+        let covering = if self.include_columns.is_empty() {
+            None
+        } else {
+            let mut indices = vec![batch.schema().index_of(ROW_ID)?];
+            for name in &self.include_columns {
+                indices.push(batch.schema().index_of(name)?);
+            }
+            Some(batch.project(&indices)?)
+        };
+        // Narrow to `[_rowid, vector]` first: `Flatten` replicates every remaining column
+        // across the multivector expansion, so leaving the covering columns in would
+        // materialize a second copy of the payload that nothing reads -- the gather below
+        // uses the pre-flatten `covering` batch. Skipped when the vector column is not a
+        // plain top-level column (precomputed buffers), where `Flatten` is a no-op anyway.
+        let batch = match (&covering, batch.schema().index_of(&self.column)) {
+            (Some(_), Ok(vector_idx)) => {
+                batch.project(&[batch.schema().index_of(ROW_ID)?, vector_idx])?
+            }
+            _ => batch,
+        };
         // for multivector, we need to flatten the vectors
         let batch = Flatten::new(&self.column).transform(&batch)?;
         // need to retrieve the row ids from the batch because some rows may have been deleted
@@ -1554,7 +1741,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )))?
             .as_fixed_size_list()
             .clone();
-        Ok(Some((row_ids, vectors)))
+        Ok(Some((row_ids, vectors, covering)))
     }
 
     // check whether need to split or join partition
@@ -1746,8 +1933,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         all_row_ids.sort();
         all_row_ids.dedup();
 
-        // Stream raw vectors in chunks
-        let projection = Arc::new(dataset.schema().project(&[self.column.as_str()])?);
+        // Stream raw vectors plus any covering ("included") columns so a
+        // partition split preserves them in the re-quantized storage.
+        let mut split_projection: Vec<&str> = vec![self.column.as_str()];
+        split_projection.extend(self.include_columns.iter().map(String::as_str));
+        let projection = Arc::new(dataset.schema().project(&split_projection)?);
         let row_ids = dataset.filter_deleted_ids(&all_row_ids).await?;
         let block_size = self.store.block_size();
         let column = self.column.clone();
@@ -1856,7 +2046,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             row_ids = (0..sample_size).map(|i| row_ids[i * stride]).collect();
         }
 
-        let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
+        // Centroid sampling only needs the vectors, not covering columns.
+        let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids, &[]).await?;
         if batches.is_empty() {
             return Ok(None);
         }
@@ -1933,8 +2124,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let new_centroids =
             FixedSizeListArray::try_new_from_values(new_centroids, centroids.value_length())?;
 
-        // take the raw vectors from dataset
-        let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
+        // take the raw vectors from dataset (plus any covering columns)
+        let Some((row_ids, vectors, covering)) = self.load_partition_raw_vectors(part_idx).await?
+        else {
             return Ok(AssignResult {
                 assign_batches: vec![None; ivf.num_partitions() - 1],
                 new_centroids,
@@ -1948,6 +2140,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &row_ids,
                     &vectors,
+                    covering.as_ref(),
                     new_centroids,
                 )
                 .await
@@ -1958,6 +2151,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &row_ids,
                     &vectors,
+                    covering.as_ref(),
                     new_centroids,
                 )
                 .await
@@ -1968,6 +2162,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &row_ids,
                     &vectors,
+                    covering.as_ref(),
                     new_centroids,
                 )
                 .await
@@ -1978,6 +2173,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &row_ids,
                     &vectors,
+                    covering.as_ref(),
                     new_centroids,
                 )
                 .await
@@ -1995,6 +2191,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         ivf: &IvfModel,
         row_ids: &UInt64Array,
         vectors: &FixedSizeListArray,
+        // `[_rowid, <included cols...>]` for the reassigned rows, or None when the
+        // index has no covering columns. Re-attached to each assign batch by row id.
+        covering: Option<&RecordBatch>,
         new_centroids: FixedSizeListArray,
     ) -> Result<AssignResult>
     where
@@ -2037,6 +2236,21 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             assign_ops[new_part_id(idx as usize)].push(AssignOp::Add((row_id, vectors.value(i))));
         }
         let assign_batches = self.build_assign_batch::<T>(&new_centroids, &assign_ops)?;
+
+        // Re-attach the covering columns to each reassigned batch, gathered by
+        // row id (in-memory; the rows were reordered across target partitions).
+        let assign_batches = match covering {
+            None => assign_batches,
+            Some(covering) => assign_batches
+                .into_iter()
+                .map(|entry| match entry {
+                    Some((batch, deleted)) => {
+                        Ok(Some((append_covering_by_row_id(batch, covering)?, deleted)))
+                    }
+                    None => Ok(None),
+                })
+                .collect::<Result<Vec<_>>>()?,
+        };
 
         Ok(AssignResult {
             assign_batches,
@@ -2588,6 +2802,7 @@ mod tests {
             0,
             &[],
             Some(&reader),
+            false,
         )
         .await
         .unwrap();

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -42,7 +42,7 @@ use lance_index::vector::quantizer::{
 };
 use lance_index::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use lance_index::vector::shared::{SupportedIvfIndexType, write_unified_ivf_and_index_metadata};
-use lance_index::vector::storage::STORAGE_METADATA_KEY;
+use lance_index::vector::storage::{COVERING_FIELD_IDS_KEY, STORAGE_METADATA_KEY};
 use lance_index::vector::transform::Flatten;
 use lance_index::vector::v3::shuffler::{EmptyReader, IvfShufflerReader, create_ivf_shuffler};
 use lance_index::vector::v3::subindex::SubIndexType;
@@ -83,6 +83,7 @@ use crate::Dataset;
 use crate::dataset::ProjectionRequest;
 use crate::dataset::index::dataset_format_version;
 use crate::index::append::build_old_data_filter;
+use crate::index::vector::RESERVED_STORAGE_COLUMNS;
 use crate::index::vector::ivf::v2::PartitionEntry;
 use crate::index::vector::utils::infer_vector_dim;
 
@@ -111,6 +112,36 @@ fn append_covering_by_row_id(
         batch = batch.try_with_column(field.as_ref().clone(), col)?;
     }
     Ok(batch)
+}
+
+/// Drop covering ("included") columns that the index metadata does not declare.
+///
+/// A writer predating `FLAG_COVERED_INDEX_METADATA` can clear `included_fields` while the
+/// auxiliary storage keeps the payload -- the degraded state that flag documents. Existing
+/// partition storage then still carries those columns while freshly scanned rows do not
+/// (the scan projects only what the metadata declares), and `StorageBuilder::build` rejects
+/// the width mismatch, leaving a readable index that can never be merge-optimized again.
+/// The manifest declaration is the source of truth here, exactly as it is on the read path,
+/// so narrow storage down to it rather than widening the fresh side -- widening would
+/// re-materialize a payload the metadata does not advertise.
+///
+/// A no-op in the healthy case: storage and `declared` agree, so nothing is projected away.
+fn drop_undeclared_covering(batch: RecordBatch, declared: &[String]) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    let keep: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| {
+            RESERVED_STORAGE_COLUMNS.contains(field.name().as_str())
+                || declared.iter().any(|name| name == field.name())
+        })
+        .map(|(idx, _)| idx)
+        .collect();
+    if keep.len() == batch.num_columns() {
+        return Ok(batch);
+    }
+    Ok(batch.project(&keep)?)
 }
 
 /// Build a new centroid array that incorporates the results of partition splits.
@@ -715,6 +746,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             return Err(Error::invalid_input("dataset not set before shuffling"));
         };
 
+        let mut from_precomputed_buffers = false;
         let stream = match self
             .ivf_params
             .as_ref()
@@ -731,6 +763,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             .to_string(),
                     ));
                 }
+                from_precomputed_buffers = true;
                 let uri = to_local_path(uri);
                 // the uri points to data directory,
                 // so need to trim the "data" suffix for reading the dataset
@@ -772,10 +805,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         };
 
-        if let Some((row_id_idx, _)) = stream.schema().column_with_name("row_id") {
-            // When using precomputed shuffle buffers we can't use the column name _rowid
-            // since it is reserved.  So we tolerate `row_id` as well here (and rename it
-            // to _rowid to match the non-precomputed path)
+        // Scoped to the precomputed-buffer path on purpose. Those buffers cannot name a
+        // column `_rowid` (reserved), so they materialize it as `row_id` and it is renamed
+        // back here to match the non-precomputed path. The ordinary scan above already
+        // produces a real `_rowid` via `with_row_id()`, and it now also projects the
+        // covering columns -- so renaming there would rewrite a *user* column named
+        // `row_id` on top of the real one and fail index creation with
+        // `Duplicate field name "_rowid" in schema`.
+        if from_precomputed_buffers
+            && let Some((row_id_idx, _)) = stream.schema().column_with_name("row_id")
+        {
             self.shuffle_data(Some(Self::rename_row_id(stream, row_id_idx)))
                 .await?;
         } else {
@@ -1049,6 +1088,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         // Covering builds may re-scan a pruned fragment that still lives in old
         // storage; drop the stale duplicate row ids during the partition read.
         let dedup_existing = !self.include_columns.is_empty();
+        // The covering set this build declares. Existing storage may be WIDER (see
+        // `drop_undeclared_covering`); narrow it so every batch handed to
+        // `StorageBuilder::build` agrees on width.
+        let declared_covering = Arc::new(self.include_columns.clone());
         let partition_adjustment = Arc::new(partition_adjustment);
         let build_iter =
             assign_batches
@@ -1063,6 +1106,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let column = column.clone();
                     let frag_reuse_index = frag_reuse_index.clone();
                     let dedup_existing = dedup_existing;
+                    let declared_covering = declared_covering.clone();
                     let partition_adjustment = partition_adjustment.clone();
                     async move {
                         let (is_affected, split_reader) = match partition_adjustment.as_ref() {
@@ -1119,6 +1163,14 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             batches.extend(extra);
                             loss += extra_loss;
                         }
+
+                        // Existing storage can carry covering columns this build does not
+                        // declare; narrow before the fresh rows join them below.
+
+                        batches = batches
+                            .into_iter()
+                            .map(|batch| drop_undeclared_covering(batch, &declared_covering))
+                            .collect::<Result<Vec<_>>>()?;
 
                         spawn_cpu(move || {
                             // Apply assign_batch for join operations (splits no
@@ -1365,6 +1417,20 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .collect()
     }
 
+    /// The *source dataset* field ids of the covering columns, in declaration order.
+    /// Stamped into the storage file (see [`COVERING_FIELD_IDS_KEY`]) so a distributed
+    /// merge can tell shards that cover the same logical fields from shards whose
+    /// covering columns merely share a name and type.
+    fn covering_field_ids(&self) -> Vec<i32> {
+        let Some(ds) = self.dataset.as_ref() else {
+            return Vec::new();
+        };
+        self.include_columns
+            .iter()
+            .filter_map(|name| ds.schema().field(name).map(|field| field.id))
+            .collect()
+    }
+
     #[instrument(name = "merge_partitions", level = "debug", skip_all)]
     async fn merge_partitions(
         &mut self,
@@ -1588,6 +1654,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             STORAGE_METADATA_KEY,
             serde_json::to_string(&storage_partition_metadata)?,
         );
+        let covering_field_ids = self.covering_field_ids();
+        if !covering_field_ids.is_empty() {
+            storage_writer.add_schema_metadata(
+                COVERING_FIELD_IDS_KEY,
+                covering_field_ids
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
 
         let index_type_str = index_type_string(S::name().try_into()?, Q::quantization_type());
         if let Some(idx_type) = SupportedIvfIndexType::from_index_type_str(&index_type_str) {

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -934,6 +934,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -956,6 +957,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -976,6 +978,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -1013,6 +1016,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         }
     }
 
@@ -1099,6 +1103,7 @@ mod tests {
                 created_at: None,
                 base_id: None,
                 files: None,
+                included_fields: Vec::new(),
             };
 
             let metric = metric_type_from_index_metadata(&index);

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2431,6 +2431,7 @@ pub(crate) async fn merge_segments_with_progress(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(files),
+        included_fields: Vec::new(),
         ..merged_segment
     };
     Ok(merged_segment)
@@ -5418,6 +5419,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         // We need to commit this index to the dataset so that it can be found
@@ -5457,6 +5459,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         let prefilter = Arc::new(DatasetPreFilter::new(dataset.clone(), &[index_meta], None));
@@ -5516,6 +5519,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
 
         // We need to commit this new index to the dataset so it can be found

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -602,6 +602,9 @@ pub(crate) async fn optimize_vector_indices(
     vector_column: &str,
     logical_index: &LogicalIvfView<'_>,
     options: &OptimizeOptions,
+    // Covering ("included") column names to preserve through the merge. Empty
+    // for ordinary indexes. Only the v2 path supports covering columns.
+    included_columns: &[String],
 ) -> Result<(Uuid, usize, Vec<IndexFile>)> {
     let existing_indices = logical_index.indices().cloned().collect::<Vec<_>>();
     // Sanity check the indices
@@ -616,8 +619,15 @@ pub(crate) async fn optimize_vector_indices(
     // fallback to v2 IVFIndex if it's not v1 IVFIndex
     if !existing_indices[0].as_any().is::<IVFIndex>() {
         let sources = existing_index_sources(&dataset, logical_index);
-        return optimize_vector_indices_v2(&dataset, unindexed, vector_column, &sources, options)
-            .await;
+        return optimize_vector_indices_v2(
+            &dataset,
+            unindexed,
+            vector_column,
+            &sources,
+            options,
+            included_columns,
+        )
+        .await;
     }
 
     let new_uuid = Uuid::new_v4();
@@ -688,6 +698,9 @@ pub(crate) async fn optimize_vector_indices_v2(
     vector_column: &str,
     existing_indices: &[ExistingIndex],
     options: &OptimizeOptions,
+    // Covering ("included") column names to preserve through the merge/split/join.
+    // Empty for ordinary indexes.
+    included_columns: &[String],
 ) -> Result<(Uuid, usize, Vec<IndexFile>)> {
     // Sanity check the indices
     if existing_indices.is_empty() {
@@ -714,6 +727,8 @@ pub(crate) async fn optimize_vector_indices_v2(
     let shuffler = create_ivf_shuffler(temp_dir_path, num_partitions, format_version, None);
 
     let (_, element_type) = get_vector_type(dataset.schema(), vector_column)?;
+    // Every vector index type supports covering ("included") columns, so each branch below
+    // threads `included_columns` into its builder regardless of quantizer.
     let summary = match index_type {
         // IVF_FLAT
         (SubIndexType::Flat, QuantizationType::Flat) => {
@@ -730,6 +745,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
+                .with_include_columns(included_columns.to_vec())
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
@@ -748,6 +764,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
+                .with_include_columns(included_columns.to_vec())
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
@@ -771,6 +788,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -791,6 +809,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -811,6 +830,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -830,6 +850,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -849,6 +870,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
+                .with_include_columns(included_columns.to_vec())
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
@@ -867,6 +889,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
+                .with_include_columns(included_columns.to_vec())
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
@@ -890,6 +913,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -910,6 +934,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_include_columns(included_columns.to_vec())
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -2431,7 +2456,6 @@ pub(crate) async fn merge_segments_with_progress(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(files),
-        included_fields: Vec::new(),
         ..merged_segment
     };
     Ok(merged_segment)
@@ -4860,6 +4884,7 @@ mod tests {
             "vector",
             &sources,
             &OptimizeOptions::new(),
+            &[],
         )
         .await
         .unwrap();
@@ -4875,6 +4900,7 @@ mod tests {
             "vector",
             &sources,
             &OptimizeOptions::merge(1),
+            &[],
         )
         .await
         .unwrap();

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1054,9 +1054,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
     /// Append the index's included/covering columns to a per-partition search
     /// result (`[_distance, _rowid]`), gathered from the live partition storage.
     /// No-op when the index has no covering columns.
-    /// Append the index's included/covering columns to a per-partition search
-    /// result (`[_distance, _rowid]`), gathered from the live partition storage.
-    /// No-op when the index has no covering columns.
     /// The schema search results carry: `[_distance, _rowid]` plus any covering
     /// ("included") columns the storage holds, in storage order. Used to declare
     /// stream schemas that stay consistent with the (possibly widened) batches.
@@ -3095,16 +3092,564 @@ mod tests {
         );
     }
 
-    /// Read-side payoff : a vector query projecting only a covered column
-    /// is satisfied from the index — no `TakeExec` against the base table.
+    /// Covering must never change QUERY RESULTS: for any query, a covered index
+    /// returns exactly the rows and distances a non-covered index returns (covering
+    /// only changes how projected columns are fetched). Exercises both the late-search
+    /// shortcut config (min < max nprobes: prefilter-matched rows without index
+    /// entries come back with INFINITY distance) and the all-partitions-searched
+    /// corner (min == max: such rows are NOT returned at all).
     #[tokio::test]
-    async fn test_ivf_pq_covered_projection_skips_take() {
+    async fn test_covered_prefilter_results_match_non_covered() {
+        use arrow_array::types::UInt64Type;
+        use arrow_array::{Int32Array, RecordBatchIterator, StringArray};
+        use arrow_buffer::NullBuffer;
+
+        const INDEX: &str = "vec_idx";
+        let dim = 4i32;
+        let n = 4096usize;
+        let n_null = 3usize; // ids 0..3 have NULL vectors (no index entry)
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+        let ids: Vec<i32> = (0..n as i32).collect();
+        // The prefilter matches ids 0..5: three null-vector rows plus two real ones.
+        let cats: Vec<&str> = (0..n)
+            .map(|i| if i < 5 { "picked" } else { "rest" })
+            .collect();
+        // Two well-separated clusters (around 0.0 and 100.0). The real picked rows
+        // (ids 3, 4) live in cluster B; the query below probes cluster A first, so the
+        // late search / shortcut path is genuinely exercised at min < max nprobes.
+        let values: Vec<f32> = (0..n)
+            .flat_map(|r| {
+                let center = if r % 2 == 0 { 0.0f32 } else { 100.0 };
+                (0..dim as usize)
+                    .map(move |d| center + ((r * dim as usize + d) % 400) as f32 * 1e-3)
+            })
+            .collect();
+        let validity: Vec<bool> = (0..n).map(|i| i >= n_null).collect();
+        let vector = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim,
+            Arc::new(Float32Array::from(values)),
+            Some(NullBuffer::from(validity)),
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vector),
+            ],
+        )
+        .unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covered_noncovered_parity",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // (rowid -> distance) results for the prefiltered query under the given probe
+        // configuration and index variant.
+        async fn run(dataset: &Dataset, min_nprobes: usize, max_nprobes: usize) -> Vec<(u64, f32)> {
+            let q = Float32Array::from(vec![0.0f32; 4]);
+            let mut scan = dataset.scan();
+            scan.nearest("vector", &q, 10).unwrap();
+            scan.minimum_nprobes(min_nprobes);
+            scan.maximum_nprobes(max_nprobes);
+            scan.filter("category = 'picked'").unwrap();
+            scan.prefilter(true);
+            scan.with_row_id();
+            scan.project(&["id"]).unwrap();
+            let plan = scan.explain_plan(false).await.unwrap();
+            assert!(
+                plan.contains("ANNSubIndex"),
+                "the parity comparison requires the index path; plan:\n{plan}"
+            );
+            let batch = scan.try_into_batch().await.unwrap();
+            let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+            let dists = batch["_distance"].as_primitive::<Float32Type>();
+            let mut out: Vec<(u64, f32)> = row_ids
+                .values()
+                .iter()
+                .zip(dists.values().iter())
+                .map(|(r, d)| (*r, *d))
+                .collect();
+            out.sort_by_key(|(r, _)| *r);
+            out
+        }
+
+        for (min_nprobes, max_nprobes) in [(1usize, 2usize), (2, 2)] {
+            let centroids = || {
+                let vals: Vec<f32> = [0.0f32, 100.0]
+                    .iter()
+                    .flat_map(|c| std::iter::repeat_n(*c, dim as usize))
+                    .collect();
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(Float32Array::from(vals), dim).unwrap(),
+                )
+            };
+            let plain_params = VectorIndexParams::with_ivf_flat_params(
+                DistanceType::L2,
+                IvfBuildParams::try_with_centroids(2, centroids()).unwrap(),
+            );
+            dataset
+                .create_index(
+                    &["vector"],
+                    IndexType::Vector,
+                    Some(INDEX.to_string()),
+                    &plain_params,
+                    true,
+                )
+                .await
+                .unwrap();
+            let plain = run(&dataset, min_nprobes, max_nprobes).await;
+
+            let mut covered_params = VectorIndexParams::with_ivf_flat_params(
+                DistanceType::L2,
+                IvfBuildParams::try_with_centroids(2, centroids()).unwrap(),
+            );
+            covered_params.include_columns(vec!["id".to_string()]);
+            dataset
+                .create_index(
+                    &["vector"],
+                    IndexType::Vector,
+                    Some(INDEX.to_string()),
+                    &covered_params,
+                    true,
+                )
+                .await
+                .unwrap();
+            let covered = run(&dataset, min_nprobes, max_nprobes).await;
+
+            assert_eq!(
+                covered, plain,
+                "covered results must be identical to non-covered \
+                 (min_nprobes={min_nprobes}, max_nprobes={max_nprobes})"
+            );
+        }
+    }
+
+    /// A row whose vector is null has no index entry, so the covered search never returns
+    /// it -- but a bounded, selective prefilter that admits it still expects it in the
+    /// results (parity with a non-covered scan). The covered path must recover it, with
+    /// its covering column fetched from the base table.
+    #[tokio::test]
+    async fn test_ivf_covered_recovers_null_vector_prefilter_rows() {
+        use arrow_array::types::{Int32Type, UInt64Type};
+        use arrow_array::{Int32Array, RecordBatchIterator, StringArray};
+        use arrow_buffer::NullBuffer;
+
+        const INDEX: &str = "vec_idx";
+        let dim = 4i32;
+        let n = 40usize;
+        let n_rare = 3usize; // category "rare" rows, all with NULL vectors (no index entry)
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+
+        let ids: Vec<i32> = (0..n as i32).collect();
+        let cats: Vec<&str> = (0..n)
+            .map(|i| if i < n_rare { "rare" } else { "common" })
+            .collect();
+        // Two well-separated clusters so early pruning keeps minimum_nprobes at 1:
+        // the recovery path only fires where the non-covered shortcut would (an
+        // all-partitions-searched query returns only found rows on both).
+        let values: Vec<f32> = (0..n)
+            .flat_map(|r| {
+                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
+                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
+            })
+            .collect();
+        let validity: Vec<bool> = (0..n).map(|i| i >= n_rare).collect();
+        let vector = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim,
+            Arc::new(Float32Array::from(values)),
+            Some(NullBuffer::from(validity)),
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vector),
+            ],
+        )
+        .unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covered_null_vec_recover",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        let scalar = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(&["category"], IndexType::BTree, None, &scalar, false)
+            .await
+            .unwrap();
+
+        // The prefilter admits only the "rare" rows -- all null-vector, so the search
+        // returns nothing; every result row must come from the recovery path.
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 10).unwrap();
+        // Recovery matches the non-covered shortcut, which needs unsearched
+        // partitions to exist (min < max nprobes); all-partitions-searched queries
+        // return only found rows on both covered and non-covered indexes.
+        scan.minimum_nprobes(1);
+        scan.filter("category = 'rare'").unwrap();
+        scan.prefilter(true);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            n_rare,
+            "all null-vector prefilter rows must be recovered (covered parity with non-covered)"
+        );
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' must be emitted")
+            .as_primitive::<Int32Type>();
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        for i in 0..ids.len() {
+            // Row-aligned covered value fetched from the base table for the recovered row.
+            assert_eq!(ids.value(i) as u64, row_ids.value(i));
+            assert!(
+                (ids.value(i) as usize) < n_rare,
+                "only the rare rows are admitted"
+            );
+        }
+    }
+
+    /// The covered exec emits from two paths in one stream: the search path (rows with an
+    /// index entry, covering columns read back from index storage) and the recovery path
+    /// (null-vector rows, covering columns taken from the base table with the exec's declared
+    /// dataset-typed schema). A prefilter admitting BOTH kinds forces both paths into a single
+    /// result, so this guards that their batch schemas stay compatible -- if the index
+    /// round-trip ever changed a covered field's type or nullability, the concatenation here
+    /// would fail. Covered column is non-nullable to make a nullability drift observable.
+    #[tokio::test]
+    async fn test_ivf_covered_mixed_search_and_recovery_share_schema() {
+        use arrow_array::types::{Int32Type, UInt64Type};
+        use arrow_array::{Int32Array, RecordBatchIterator, StringArray};
+        use arrow_buffer::NullBuffer;
+
+        const INDEX: &str = "vec_idx";
+        let dim = 4i32;
+        let n = 40usize;
+        let n_null = 3usize; // rows 0..3 have NULL vectors (no index entry -> recovery path)
+        let admit_below = 5i32; // prefilter admits ids 0..5: null rows 0,1,2 + indexed rows 3,4
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+
+        let ids: Vec<i32> = (0..n as i32).collect();
+        let cats: Vec<&str> = (0..n).map(|_| "x").collect();
+        // Two well-separated clusters so early pruning keeps minimum_nprobes at 1
+        // (see test_ivf_covered_recovers_null_vector_prefilter_rows).
+        let values: Vec<f32> = (0..n)
+            .flat_map(|r| {
+                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
+                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
+            })
+            .collect();
+        let validity: Vec<bool> = (0..n).map(|i| i >= n_null).collect();
+        let vector = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim,
+            Arc::new(Float32Array::from(values)),
+            Some(NullBuffer::from(validity)),
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(cats)),
+                Arc::new(vector),
+            ],
+        )
+        .unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covered_mixed_recover",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        // A btree on id makes `id < admit_below` a bounded, selective prefilter.
+        let scalar = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(&["id"], IndexType::BTree, None, &scalar, false)
+            .await
+            .unwrap();
+
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 10).unwrap();
+        // Recovery matches the non-covered shortcut, which needs unsearched
+        // partitions to exist (min < max nprobes); all-partitions-searched queries
+        // return only found rows on both covered and non-covered indexes.
+        scan.minimum_nprobes(1);
+        scan.filter(&format!("id < {admit_below}")).unwrap();
+        scan.prefilter(true);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        // Concatenating the search-path batches (ids 3,4) with the recovery batch (ids 0,1,2)
+        // succeeds only if both paths carry a compatible schema for the covered `id` column.
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            admit_below as usize,
+            "both indexed and null-vector admitted rows must be returned"
+        );
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' must be emitted")
+            .as_primitive::<Int32Type>();
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        let mut got: Vec<i32> = Vec::with_capacity(ids.len());
+        for i in 0..ids.len() {
+            // id == row offset == _rowid, so a row-aligned covered value equals its row id.
+            assert_eq!(ids.value(i) as u64, row_ids.value(i));
+            got.push(ids.value(i));
+        }
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            (0..admit_below).collect::<Vec<_>>(),
+            "search-path and recovery-path rows must together cover every admitted id"
+        );
+    }
+
+    /// On a STABLE-ROW-ID dataset the covered null-vector recovery must resolve stable row
+    /// ids through the row-id index before taking covering payload -- feeding them to an
+    /// address-space take (`frag = id >> 32`, `offset = id`) reads the wrong physical row or
+    /// errors once stable id != physical address. A second fragment makes the two diverge:
+    /// its rows have addresses `(1 << 32) | offset` but small monotonic stable ids.
+    #[tokio::test]
+    async fn test_ivf_covered_recovers_null_vector_stable_row_ids() {
+        use arrow_array::types::{Int32Type, UInt64Type};
+        use arrow_array::{Int32Array, RecordBatchIterator};
+        use arrow_buffer::NullBuffer;
+
+        const INDEX: &str = "vec_idx";
+        let dim = 4i32;
+        let frag0 = 10usize; // fragment 0: ids 0..10, all indexed
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+
+        let make_batch = |ids: Vec<i32>, null_rows: &[i32]| {
+            let n = ids.len();
+            let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32 + 1.0).collect();
+            let validity: Vec<bool> = ids.iter().map(|id| !null_rows.contains(id)).collect();
+            let vector = FixedSizeListArray::new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dim,
+                Arc::new(Float32Array::from(values)),
+                Some(NullBuffer::from(validity)),
+            );
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(vector)],
+            )
+            .unwrap()
+        };
+
+        // Fragment 0: ids 0..10, all with vectors.
+        let batch0 = make_batch((0..frag0 as i32).collect(), &[]);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch0)], schema.clone()),
+            "memory://covered_stable_null_recover",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                max_rows_per_file: frag0,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Fragment 1 (append): ids 10..14; 10 and 11 have NULL vectors (no index entry).
+        // Their stable ids (10, 11) are far smaller than their physical addresses
+        // ((1 << 32) | 0/1), so an address-space take of id 10 lands at fragment 0 offset 10,
+        // which is out of range (fragment 0 has offsets 0..9) -- the bug.
+        let batch1 = make_batch((frag0 as i32..frag0 as i32 + 4).collect(), &[10, 11]);
+        dataset
+            .append(RecordBatchIterator::new([Ok(batch1)], schema.clone()), None)
+            .await
+            .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        // A btree on id makes `id >= 10` a bounded, selective prefilter.
+        let scalar = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(&["id"], IndexType::BTree, None, &scalar, false)
+            .await
+            .unwrap();
+
+        // Admit ids 10..14: 12,13 come from the search path, 10,11 from the recovery path.
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 10).unwrap();
+        // Recovery matches the non-covered shortcut, which needs unsearched
+        // partitions to exist (min < max nprobes); all-partitions-searched queries
+        // return only found rows on both covered and non-covered indexes.
+        scan.minimum_nprobes(1);
+        scan.filter("id >= 10").unwrap();
+        scan.prefilter(true);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(batch.num_rows(), 4, "all admitted rows must be returned");
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' must be emitted")
+            .as_primitive::<Int32Type>();
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        for i in 0..ids.len() {
+            // id == stable row id == _rowid, so a correctly-resolved covered value matches.
+            assert_eq!(
+                ids.value(i) as u64,
+                row_ids.value(i),
+                "covered id must be the row's true value, not an address-space misread"
+            );
+        }
+        let mut got: Vec<i32> = ids.values().to_vec();
+        got.sort_unstable();
+        assert_eq!(got, vec![10, 11, 12, 13]);
+    }
+
+    /// Read-side payoff for every vector index type: a query projecting only a covered
+    /// column is satisfied from the index -- no `TakeExec` against the base table --
+    /// with row-aligned values and sane recall.
+    #[rstest]
+    #[case::pq(VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2))]
+    #[case::sq(VectorIndexParams::with_ivf_sq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        SQBuildParams::default()
+    ))]
+    #[case::hnsw_pq(VectorIndexParams::with_ivf_hnsw_pq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default(),
+        PQBuildParams::new(4, 8)
+    ))]
+    #[case::hnsw_sq(VectorIndexParams::with_ivf_hnsw_sq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default(),
+        SQBuildParams::default()
+    ))]
+    // RQ uses 5 bits: 1-bit RaBitQ quantization is too coarse to clear the recall
+    // gate on this random data without a refine (which would re-add the take).
+    #[case::rq(VectorIndexParams::with_ivf_rq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        RQBuildParams::with_rotation_type(5, RQRotationType::Fast)
+    ))]
+    #[case::flat(VectorIndexParams::ivf_flat(4, DistanceType::L2))]
+    #[case::hnsw_flat(VectorIndexParams::ivf_hnsw(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default()
+    ))]
+    #[tokio::test]
+    async fn test_covered_projection_skips_take(#[case] mut params: VectorIndexParams) {
         const INDEX_NAME: &str = "vector_idx";
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
         let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
 
-        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
         params.include_columns(vec!["id".to_string()]);
         dataset
             .create_index(
@@ -3132,23 +3677,34 @@ mod tests {
         );
 
         let batch = scan.try_into_batch().await.unwrap();
-        assert!(batch.column_by_name("id").is_some());
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' column must be emitted")
+            .as_primitive::<UInt64Type>();
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        assert_eq!(ids.len(), 10, "should return k=10 rows");
+        // Single-fragment, step-id dataset => id == row offset == _rowid, so a correctly
+        // covered id equals the row id for every returned row (row-aligned, not stale).
+        for i in 0..ids.len() {
+            assert_eq!(
+                ids.value(i),
+                row_ids.value(i),
+                "covered id must match the row's true id (row {i})"
+            );
+        }
 
-        // Take elision is worthless if the covered search returns the wrong
-        // neighbors, so also gate on recall: compare the covered result's row ids
-        // against brute-force ground truth (use_index(false)). All 4 partitions
-        // are probed, so 0.5 sits far below IVF_PQ's real recall on this data.
-        let returned: HashSet<u64> = batch[ROW_ID]
-            .as_primitive::<UInt64Type>()
-            .values()
-            .iter()
-            .copied()
-            .collect();
+        // Take elision is worthless if the covered search returns the wrong neighbors,
+        // so also gate on recall against brute-force ground truth. All 4 partitions are
+        // probed, so 0.5 sits far below any quantizer's real recall on this data.
+        let returned: HashSet<u64> = row_ids.values().iter().copied().collect();
         let truth = ground_truth(&dataset, "vector", q, 10, DistanceType::L2).await;
         let recall = truth.intersection(&returned).count() as f32 / truth.len() as f32;
         assert!(
             recall >= 0.5,
-            "covered IVF_PQ recall {recall} < 0.5 (returned {returned:?}, truth {truth:?})"
+            "covered recall {recall} < 0.5 (returned {returned:?}, truth {truth:?})"
         );
     }
 
@@ -3266,14 +3822,43 @@ mod tests {
     /// through the incremental optimize pipeline -- the unindexed-fragment
     /// shuffle, the partition-split reshuffle, and the partition-join
     /// reassignment -- as passenger columns (re-gathered by row id).
+    #[rstest]
+    #[case::pq(VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2))]
+    #[case::sq(VectorIndexParams::with_ivf_sq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        SQBuildParams::default()
+    ))]
+    #[case::hnsw_pq(VectorIndexParams::with_ivf_hnsw_pq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default(),
+        PQBuildParams::new(4, 8)
+    ))]
+    #[case::hnsw_sq(VectorIndexParams::with_ivf_hnsw_sq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default(),
+        SQBuildParams::default()
+    ))]
+    #[case::rq(VectorIndexParams::with_ivf_rq_params(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        RQBuildParams::with_rotation_type(1, RQRotationType::Fast)
+    ))]
+    #[case::flat(VectorIndexParams::ivf_flat(4, DistanceType::L2))]
+    #[case::hnsw_flat(VectorIndexParams::ivf_hnsw(
+        DistanceType::L2,
+        IvfBuildParams::new(4),
+        HnswBuildParams::default()
+    ))]
     #[tokio::test]
-    async fn test_ivf_pq_covered_survives_optimize() {
+    async fn test_covered_survives_optimize(#[case] mut params: VectorIndexParams) {
         const INDEX_NAME: &str = "vector_idx";
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
         let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
 
-        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
         params.include_columns(vec!["id".to_string()]);
         dataset
             .create_index(
@@ -3293,15 +3878,11 @@ mod tests {
             .await
             .unwrap();
 
-        // The merged partition storage must still carry the covering column.
-        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
-        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
-        assert!(
-            storage.batch().column_by_name("id").is_some(),
-            "merged storage should still carry covering column 'id'"
-        );
-
-        // And a covered projection is still answered from the index (no take).
+        // A covered projection must still be answered from the index with no take after
+        // the merge. This is the real proof that the appended rows kept their covering
+        // column: if the merge had dropped it, `try_into_batch` would error on the
+        // schema mismatch (the exec declares `id` from `included_fields`, but the
+        // storage could not emit it).
         let q = vectors.value(0);
         let q = q.as_primitive::<Float32Type>();
         let mut scan = dataset.scan();
@@ -3313,6 +3894,7 @@ mod tests {
             "covered projection ['id'] should skip the take after optimize; plan:\n{plan}"
         );
         let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(batch.num_rows(), 10);
         assert!(batch.column_by_name("id").is_some());
     }
 
@@ -3367,6 +3949,91 @@ mod tests {
         );
         let batch = scan.try_into_batch().await.unwrap();
         assert!(batch.column_by_name("id").is_some());
+    }
+
+    /// The streaming partition-search branch (used by HNSW sub-indexes and controlled
+    /// late searches) must declare the covered schema on the stream it returns, matching
+    /// the widened batches it emits -- the global-heap branch already does. A stream
+    /// whose declared schema disagrees with its batches is a latent hazard for any
+    /// consumer that trusts the declaration.
+    #[tokio::test]
+    async fn test_covered_search_partitions_stream_declares_covering_schema() {
+        use arrow_array::UInt32Array;
+        use futures::TryStreamExt;
+        use lance_index::prefilter::NoFilter;
+        use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
+
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_hnsw(
+            DistanceType::L2,
+            IvfBuildParams::new(4),
+            HnswBuildParams::default(),
+        );
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let query = Query {
+            column: "vector".to_string(),
+            key: vectors.value(0),
+            k: 5,
+            lower_bound: None,
+            upper_bound: None,
+            minimum_nprobes: 4,
+            maximum_nprobes: None,
+            ef: None,
+            refine_factor: None,
+            metric_type: Some(DistanceType::L2),
+            use_index: true,
+            query_parallelism: DEFAULT_QUERY_PARALLELISM,
+            dist_q_c: 0.0,
+            approx_mode: Default::default(),
+        };
+        let partitions = Arc::new(UInt32Array::from(vec![0u32, 1, 2, 3]));
+        let dists = Arc::new(Float32Array::from(vec![0.0f32; 4]));
+        let stream = ctx
+            .index
+            .clone()
+            .search_partitions(
+                query,
+                partitions,
+                dists,
+                0,
+                4,
+                Arc::new(NoFilter),
+                None,
+                Arc::new(NoOpMetricsCollector),
+            )
+            .await
+            .unwrap();
+
+        let declared = stream.schema();
+        assert!(
+            declared.column_with_name("id").is_some(),
+            "the covered stream must declare the covering column; declared: {declared:?}"
+        );
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        assert!(!batches.is_empty());
+        for batch in &batches {
+            assert_eq!(
+                batch.schema(),
+                declared,
+                "emitted batches must match the declared stream schema"
+            );
+        }
     }
 
     /// Index storage that physically carries covering columns while the manifest
@@ -4075,6 +4742,44 @@ mod tests {
             Field::new("vector", vectors.data_type().clone(), false),
         ]));
         let batch = RecordBatch::try_new(schema.clone(), vec![ids, vectors]).unwrap();
+
+        (schema, vec![batch])
+    }
+
+    /// Like `make_two_fragment_batches`, but with two covering columns: a non-null `id` and a
+    /// **nullable** `payload` (every 3rd value null). Covered tests use this so null covering
+    /// values are exercised through the per-segment build and the cross-shard merge.
+    fn make_covered_test_batches() -> (Arc<Schema>, Vec<RecordBatch>) {
+        let ids = Arc::new(UInt64Array::from_iter_values(0..TWO_FRAG_NUM_ROWS as u64));
+        let payload = Arc::new(UInt64Array::from_iter(
+            (0..TWO_FRAG_NUM_ROWS as u64).map(|v| if v % 3 == 0 { None } else { Some(v + 1000) }),
+        ));
+
+        // Clustered vectors: uniform-random 128-dim data is pathological for IVF_PQ recall (the
+        // curse of dimensionality), which would make a recall gate flaky. Instead pack points into
+        // well-separated clusters of <= k points each (centers 4.0 apart per dim -> ~45 in L2, tiny
+        // within-cluster jitter), so a query drawn from a cluster has its whole cluster as the
+        // unambiguous nearest neighbors and IVF_PQ recall is reliably high.
+        const CLUSTER_SIZE: usize = 8;
+        let mut flat = Vec::with_capacity(TWO_FRAG_NUM_ROWS * TWO_FRAG_DIM);
+        for row in 0..TWO_FRAG_NUM_ROWS {
+            let center = (row / CLUSTER_SIZE) as f32 * 4.0;
+            let within = (row % CLUSTER_SIZE) as f32;
+            for d in 0..TWO_FRAG_DIM {
+                flat.push(center + within * 0.002 + d as f32 * 0.00001);
+            }
+        }
+        let vectors = Arc::new(
+            FixedSizeListArray::try_new_from_values(Float32Array::from(flat), TWO_FRAG_DIM as i32)
+                .unwrap(),
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("payload", DataType::UInt64, true),
+            Field::new("vector", vectors.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, payload, vectors]).unwrap();
 
         (schema, vec![batch])
     }
@@ -4875,6 +5580,339 @@ mod tests {
             .await
             .unwrap();
         assert!(result.num_rows() > 0);
+    }
+
+    /// A distributed (sharded, precomputed-IVF) build must support covering ("included")
+    /// columns: each shard writes the covered column into its own segment's storage, the
+    /// segment metadata advertises `included_fields`, and a covered projection over the
+    /// committed index skips the base-table TakeExec while returning correct, row-aligned
+    /// covered values.
+    #[tokio::test]
+    async fn test_distributed_vector_build_supports_covering_columns() {
+        use crate::dataset::{ProjectionRequest, TakeBuilder};
+
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+        let (schema, batches) = make_covered_test_batches();
+        let dataset_uri = format!("{}/distributed_covered", base_uri);
+        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, batches).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+        let payload_field_id = dataset.schema().field("payload").unwrap().id;
+
+        let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+        let mut params =
+            VectorIndexParams::with_ivf_pq_params(DistanceType::L2, ivf_params, pq_params);
+        params.include_columns(vec!["id".to_string(), "payload".to_string()]);
+
+        // One covered segment per fragment, over ALL fragments, so the committed index gives
+        // full coverage -- no uncovered flat delta-scan can mask a covering defect. Each shard
+        // reads the covering columns from its own fragment subset and writes them into its
+        // segment's storage.
+        let mut segments = Vec::new();
+        for fragment in fragments.iter() {
+            let segment = dataset
+                .create_index_builder(&["vector"], IndexType::Vector, &params)
+                .name("vec_idx".to_string())
+                .fragments(vec![fragment.id() as u32])
+                .execute_uncommitted()
+                .await
+                .unwrap();
+            assert_eq!(
+                segment.included_fields,
+                vec![id_field_id, payload_field_id],
+                "distributed covered segment must record both covered columns' field ids"
+            );
+            segments.push(segment);
+        }
+
+        dataset
+            .commit_existing_index_segments("vec_idx", "vector", segments)
+            .await
+            .unwrap();
+
+        // Covered projection ['id','payload'] must skip the base-table TakeExec.
+        let query_batch = dataset
+            .scan()
+            .project(&["vector"] as &[&str])
+            .unwrap()
+            .limit(Some(1), None)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let q = query_batch["vector"].as_fixed_size_list().value(0);
+        let q = q.as_primitive::<Float32Type>();
+
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.nprobes(4);
+        scan.with_row_id();
+        scan.project(&["id", "payload"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id','payload'] should skip TakeExec; plan was:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+        assert!(!row_ids.is_empty());
+
+        // Every covered column -- including the nullable `payload` with its nulls -- must be
+        // row-aligned with the base-table take. Full array equality checks values AND validity,
+        // so a dropped/shifted null slot would fail here.
+        let gt = TakeBuilder::try_new_from_ids(
+            Arc::new(dataset.clone()),
+            row_ids.values().to_vec(),
+            ProjectionRequest::from_columns(
+                vec!["id".to_string(), "payload".to_string()],
+                dataset.schema(),
+            ),
+        )
+        .unwrap()
+        .execute()
+        .await
+        .unwrap();
+        for col in ["id", "payload"] {
+            assert_eq!(
+                &batch[col], &gt[col],
+                "covered '{col}' must match the base-table value (incl. nulls) for each row"
+            );
+        }
+
+        // Take elision is worthless if the covered search returns the wrong neighbors, so also
+        // gate on recall against brute-force ground truth (all 4 partitions probed).
+        let returned: HashSet<u64> = row_ids.values().iter().copied().collect();
+        let truth = ground_truth(&dataset, "vector", q, 10, DistanceType::L2).await;
+        let recall = truth.intersection(&returned).count() as f32 / truth.len() as f32;
+        assert!(
+            recall >= 0.5,
+            "covered distributed build recall {recall} < 0.5 (returned {returned:?}, truth {truth:?})"
+        );
+    }
+
+    /// The cross-shard segment *merger* must also carry covering columns: merging covered
+    /// shards into one unified auxiliary index must retain the covered payload (not drop it at
+    /// the merger's rebuilt output schema), so a covered projection over the merged index still
+    /// skips the take and returns correct values. Parametrized over quantizer family so each
+    /// type's internal-name list (which the merger uses to detect the covering columns) is
+    /// exercised on the covered-merge path -- RQ especially, whose internal list is longest, and
+    /// IVF_HNSW_PQ so the HNSW-variant covering-detection lists are exercised too.
+    // Note: IVF_RQ is intentionally excluded -- distributed RQ *merge* fails independently of
+    // covering (shards train different `fast_rotation_signs`, so the merger's structural-equality
+    // check rejects them); covered RQ works on the per-segment-commit path instead.
+    #[rstest]
+    #[case::pq("IVF_PQ")]
+    #[case::sq("IVF_SQ")]
+    #[case::flat("IVF_FLAT")]
+    #[case::hnsw_pq("IVF_HNSW_PQ")]
+    #[tokio::test]
+    async fn test_distributed_vector_merge_supports_covering_columns(#[case] index_type: &str) {
+        use crate::dataset::{ProjectionRequest, TakeBuilder};
+
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+        let (schema, batches) = make_covered_test_batches();
+        let dataset_uri = format!("{}/distributed_covered_merge_{index_type}", base_uri);
+        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, batches).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+        let payload_field_id = dataset.schema().field("payload").unwrap().id;
+
+        let mut params = match index_type {
+            "IVF_PQ" => {
+                let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+                VectorIndexParams::with_ivf_pq_params(DistanceType::L2, ivf_params, pq_params)
+            }
+            "IVF_SQ" => VectorIndexParams::with_ivf_sq_params(
+                DistanceType::L2,
+                prepare_global_ivf(&dataset, "vector").await,
+                SQBuildParams::default(),
+            ),
+            "IVF_FLAT" => VectorIndexParams::with_ivf_flat_params(
+                DistanceType::L2,
+                prepare_global_ivf(&dataset, "vector").await,
+            ),
+            "IVF_HNSW_PQ" => {
+                let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+                VectorIndexParams::with_ivf_hnsw_pq_params(
+                    DistanceType::L2,
+                    ivf_params,
+                    HnswBuildParams::default(),
+                    pq_params,
+                )
+            }
+            other => panic!("unexpected index type {other}"),
+        };
+        params.include_columns(vec!["id".to_string(), "payload".to_string()]);
+
+        // All fragments, so the merged index gives full coverage (no uncovered delta scan).
+        let mut segments = Vec::new();
+        for fragment in fragments.iter() {
+            let segment = dataset
+                .create_index_builder(&["vector"], IndexType::Vector, &params)
+                .name("vec_idx".to_string())
+                .fragments(vec![fragment.id() as u32])
+                .execute_uncommitted()
+                .await
+                .unwrap();
+            segments.push(segment);
+        }
+
+        // Merge the covered shards into one unified segment, then commit it.
+        let merged = dataset
+            .merge_existing_index_segments(segments)
+            .await
+            .unwrap();
+        assert_eq!(
+            merged.included_fields,
+            vec![id_field_id, payload_field_id],
+            "merged covered segment must retain both covered columns' field ids"
+        );
+        dataset
+            .commit_existing_index_segments("vec_idx", "vector", vec![merged])
+            .await
+            .unwrap();
+
+        let query_batch = dataset
+            .scan()
+            .project(&["vector"] as &[&str])
+            .unwrap()
+            .limit(Some(1), None)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let q = query_batch["vector"].as_fixed_size_list().value(0);
+        let q = q.as_primitive::<Float32Type>();
+
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.nprobes(4);
+        scan.with_row_id();
+        scan.project(&["id", "payload"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection over the merged index should skip TakeExec; plan was:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+        assert!(!row_ids.is_empty());
+
+        // Both covered columns (incl. the nullable `payload` with its nulls) must be row-aligned
+        // with the base-table take over the merged index. Full array equality checks validity too.
+        let gt = TakeBuilder::try_new_from_ids(
+            Arc::new(dataset.clone()),
+            row_ids.values().to_vec(),
+            ProjectionRequest::from_columns(
+                vec!["id".to_string(), "payload".to_string()],
+                dataset.schema(),
+            ),
+        )
+        .unwrap()
+        .execute()
+        .await
+        .unwrap();
+        for col in ["id", "payload"] {
+            assert_eq!(
+                &batch[col], &gt[col],
+                "covered '{col}' over the merged index must match the base-table value for each row"
+            );
+        }
+
+        // Gate on recall too, so a merge that returns the wrong neighbors is caught.
+        let returned: HashSet<u64> = row_ids.values().iter().copied().collect();
+        let truth = ground_truth(&dataset, "vector", q, 10, DistanceType::L2).await;
+        let recall = truth.intersection(&returned).count() as f32 / truth.len() as f32;
+        assert!(
+            recall >= 0.5,
+            "covered merged {index_type} recall {recall} < 0.5 (returned {returned:?}, truth {truth:?})"
+        );
+    }
+
+    /// Two individually-valid covered shards that declare DIFFERENT covering columns must be
+    /// rejected by the cross-shard merge, not silently concatenated by position. The merger
+    /// rebuilds the unified output schema from the FIRST shard's covering set and
+    /// `concat_batches` combines columns positionally, so without a guard shard B's `id2`
+    /// values would be stored under shard A's `id` name -> wrong covered results. Reject with a
+    /// descriptive error instead (AGENTS.md:81).
+    #[tokio::test]
+    async fn test_distributed_vector_merge_rejects_mismatched_covering_columns() {
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+
+        // Two same-typed columns so the shards' covering sets differ only by name (the
+        // silent-corruption case): shard A covers `id`, shard B covers `id2`.
+        let ids = Arc::new(UInt64Array::from_iter_values(0..TWO_FRAG_NUM_ROWS as u64));
+        let ids2 = Arc::new(UInt64Array::from_iter_values(
+            (0..TWO_FRAG_NUM_ROWS as u64).map(|v| v + 1000),
+        ));
+        let values = generate_random_array_with_range(TWO_FRAG_NUM_ROWS * TWO_FRAG_DIM, 0.0..1.0);
+        let vectors = Arc::new(
+            FixedSizeListArray::try_new_from_values(
+                Float32Array::from(values),
+                TWO_FRAG_DIM as i32,
+            )
+            .unwrap(),
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("id2", DataType::UInt64, false),
+            Field::new("vector", vectors.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, ids2, vectors]).unwrap();
+        let dataset_uri = format!("{}/distributed_covered_merge_mismatch", base_uri);
+        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, vec![batch]).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+
+        let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+        let mut params =
+            VectorIndexParams::with_ivf_pq_params(DistanceType::L2, ivf_params, pq_params);
+
+        // Shard A over fragment 0 covers `id`.
+        params.include_columns(vec!["id".to_string()]);
+        let segment_a = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vec_idx".to_string())
+            .fragments(vec![fragments[0].id() as u32])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+
+        // Shard B over fragment 1 covers `id2` -- individually valid, but a different set.
+        params.include_columns(vec!["id2".to_string()]);
+        let segment_b = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vec_idx".to_string())
+            .fragments(vec![fragments[1].id() as u32])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+
+        let err = dataset
+            .merge_existing_index_segments(vec![segment_a, segment_b])
+            .await
+            .expect_err("merging shards with mismatched covering columns must fail");
+        assert!(
+            matches!(err, lance_core::Error::Index { .. }),
+            "covering-mismatch rejection must be an Index error; was: {err:?}"
+        );
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("covering") || msg.contains("included"),
+            "error should describe the covering-column mismatch; was: {msg}"
+        );
     }
 
     #[rstest]

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2373,6 +2373,36 @@ mod tests {
         assert_eq!(capacity.u32, 0);
     }
 
+    /// Vector values laid out as `num_clusters` well-separated clusters: row `r` lands in
+    /// cluster `r % num_clusters`, centred at `cluster * 1000.0` with a tiny per-row offset
+    /// so no two rows coincide.
+    ///
+    /// **The separation is load-bearing, not cosmetic.** `early_pruning` RAISES
+    /// `minimum_nprobes` to the number of centroids within `dists[0] * factor` (7.0 for
+    /// `k` in 2..=10, 81.0 for `k >= 11`). With evenly-spread vectors every centroid
+    /// survives pruning, so `minimum_nprobes` reaches `maximum_nprobes`, `late_search`
+    /// returns at its first guard, and the no-rows shortcut -- and therefore the covered
+    /// recovery path -- is never reached. A test targeting either then passes vacuously
+    /// against a live bug, which has happened repeatedly on this feature. With these
+    /// clusters a query at the origin is ~10^6 times closer to cluster 0 than to any
+    /// other, so pruning yields 1 and unsearched partitions remain.
+    ///
+    /// See also `generate_clustered_batch`, the pre-existing generator used by the
+    /// non-covering partition-split tests; it emits a different schema and is not a
+    /// drop-in substitute here.
+    fn clustered_vector_values(
+        rows: impl IntoIterator<Item = usize>,
+        dim: i32,
+        num_clusters: usize,
+    ) -> Vec<f32> {
+        rows.into_iter()
+            .flat_map(|r| {
+                let center = (r % num_clusters) as f32 * 1000.0;
+                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
+            })
+            .collect()
+    }
+
     async fn generate_test_dataset<T: ArrowPrimitiveType>(
         test_uri: &str,
         range: Range<T::Native>,
@@ -3271,12 +3301,7 @@ mod tests {
         // Two well-separated clusters so early pruning keeps minimum_nprobes at 1:
         // the recovery path only fires where the non-covered shortcut would (an
         // all-partitions-searched query returns only found rows on both).
-        let values: Vec<f32> = (0..n)
-            .flat_map(|r| {
-                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
-                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
-            })
-            .collect();
+        let values: Vec<f32> = clustered_vector_values(0..n, dim, 2);
         let validity: Vec<bool> = (0..n).map(|i| i >= n_rare).collect();
         let vector = FixedSizeListArray::new(
             Arc::new(Field::new("item", DataType::Float32, true)),
@@ -3393,12 +3418,7 @@ mod tests {
         let cats: Vec<&str> = (0..n).map(|_| "x").collect();
         // Two well-separated clusters so early pruning keeps minimum_nprobes at 1
         // (see test_ivf_covered_recovers_null_vector_prefilter_rows).
-        let values: Vec<f32> = (0..n)
-            .flat_map(|r| {
-                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
-                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
-            })
-            .collect();
+        let values: Vec<f32> = clustered_vector_values(0..n, dim, 2);
         let validity: Vec<bool> = (0..n).map(|i| i >= n_null).collect();
         let vector = FixedSizeListArray::new(
             Arc::new(Field::new("item", DataType::Float32, true)),
@@ -3511,8 +3531,13 @@ mod tests {
         ]));
 
         let make_batch = |ids: Vec<i32>, null_rows: &[i32]| {
-            let n = ids.len();
-            let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32 + 1.0).collect();
+            // Two well-separated clusters. Recovery is only reachable while
+            // `minimum_nprobes < maximum_nprobes`, and `early_pruning` raises the minimum to
+            // the number of centroids within `dists[0] * 7.0` (k = 10). Points strung along
+            // a line leave those centroids only ~7.5x apart -- a margin thin enough that a
+            // different kmeans outcome silently disables the path this test exists to cover.
+            let values: Vec<f32> =
+                clustered_vector_values(ids.iter().map(|id| *id as usize), dim, 2);
             let validity: Vec<bool> = ids.iter().map(|id| !null_rows.contains(id)).collect();
             let vector = FixedSizeListArray::new(
                 Arc::new(Field::new("item", DataType::Float32, true)),
@@ -3634,13 +3659,8 @@ mod tests {
         // Two separated clusters so `early_pruning` leaves an unsearched partition and the
         // late-search shortcut (which arms the covered recovery) is reachable.
         let make_batch = |ids: Vec<i32>| {
-            let values: Vec<f32> = ids
-                .iter()
-                .flat_map(|id| {
-                    let center = if id % 2 == 0 { 0.0f32 } else { 1000.0 };
-                    (0..dim as usize).map(move |d| center + (*id as usize * 4 + d) as f32 * 1e-3)
-                })
-                .collect();
+            let values: Vec<f32> =
+                clustered_vector_values(ids.iter().map(|id| *id as usize), dim, 2);
             RecordBatch::try_new(
                 schema.clone(),
                 vec![
@@ -3750,12 +3770,7 @@ mod tests {
         // hence the covered recovery) reachable -- with evenly spread vectors early pruning
         // raises minimum_nprobes to cover every partition and the shortcut never fires.
         let ids: Vec<i32> = (0..n as i32).collect();
-        let values: Vec<f32> = (0..n)
-            .flat_map(|r| {
-                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
-                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
-            })
-            .collect();
+        let values: Vec<f32> = clustered_vector_values(0..n, dim, 2);
         let vector = FixedSizeListArray::new(
             Arc::new(Field::new("item", DataType::Float32, true)),
             dim,
@@ -3843,6 +3858,193 @@ mod tests {
             got,
             (0..n as i32).filter(|id| *id != 1).collect::<Vec<_>>(),
             "every live row must appear exactly once"
+        );
+    }
+
+    /// A covered index whose `included_fields` a pre-feature writer cleared -- the degraded
+    /// state `FLAG_COVERED_INDEX_METADATA` documents -- must stay MAINTAINABLE, not just
+    /// readable. Its auxiliary storage still physically carries the payload while freshly
+    /// scanned rows do not, so combining the two used to fail `StorageBuilder::build`'s width
+    /// check ("mismatched columns while merging vector storage batches: expected
+    /// [_rowid, __pq_code, id], got [_rowid, __pq_code]"), leaving an index that could never
+    /// be merge-optimized again -- recoverable only by dropping and rebuilding it.
+    /// `OptimizeOptions::append()` never hit this because it does not load existing storage.
+    #[tokio::test]
+    async fn test_degraded_covered_index_can_still_be_optimized() {
+        use crate::dataset::WriteDestination;
+        use crate::dataset::transaction::Operation;
+        use arrow_array::{Int32Array, RecordBatchIterator};
+
+        const DIMS: usize = 16;
+        const TOTAL: usize = 256;
+        const NPART: usize = 4;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let make = |lo: i32, hi: i32| {
+            let ids: Vec<i32> = (lo..hi).collect();
+            let values: Vec<f32> =
+                clustered_vector_values(ids.iter().map(|r| *r as usize), DIMS as i32, NPART);
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new(
+                    "vector",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        DIMS as i32,
+                    ),
+                    true,
+                ),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids)),
+                    Arc::new(
+                        FixedSizeListArray::try_new_from_values(
+                            Float32Array::from(values),
+                            DIMS as i32,
+                        )
+                        .unwrap(),
+                    ),
+                ],
+            )
+            .unwrap();
+            (schema, batch)
+        };
+
+        let (schema, batch) = make(0, TOTAL as i32);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            test_uri,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_pq(NPART, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // Degrade: clear the declaration, leave the payload in the auxiliary file.
+        let mut cleared = dataset.load_indices_by_name("vector_idx").await.unwrap()[0].clone();
+        assert!(!cleared.included_fields.is_empty());
+        cleared.included_fields = Vec::new();
+        let read_version = dataset.manifest.version;
+        let mut dataset = Dataset::commit(
+            WriteDestination::Dataset(Arc::new(dataset)),
+            Operation::CreateIndex {
+                new_indices: vec![cleared],
+                removed_indices: vec![],
+            },
+            Some(read_version),
+            None,
+            None,
+            Arc::new(Default::default()),
+            false,
+        )
+        .await
+        .unwrap();
+
+        // Fresh rows land in an unindexed fragment; the merge below must combine them with
+        // the wider existing storage.
+        let (schema2, batch2) = make(TOTAL as i32, TOTAL as i32 + 128);
+        dataset
+            .append(RecordBatchIterator::new([Ok(batch2)], schema2), None)
+            .await
+            .unwrap();
+
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(1))
+            .await
+            .expect("a metadata-degraded covered index must still merge-optimize");
+
+        // The rebuilt storage is narrowed to the declaration, so it no longer carries the
+        // undeclared payload -- and the index still answers queries.
+        let ctx = load_vector_index_context(&dataset, "vector", "vector_idx").await;
+        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
+        assert!(
+            storage.batch().column_by_name("id").is_none(),
+            "merged storage must drop payload the metadata no longer declares"
+        );
+
+        let q = Float32Array::from(vec![0.0f32; DIMS]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 5).unwrap();
+        scan.project(&["id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(batch.num_rows(), 5);
+        assert!(batch.column_by_name("id").is_some());
+    }
+
+    /// `row_id` is an ordinary user column name -- `_rowid` is the reserved one -- so it is
+    /// coverable. The `row_id` -> `_rowid` rename exists only for precomputed shuffle buffers
+    /// (which cannot name a column `_rowid`), but it used to run on the ordinary scan path
+    /// too. Once covering started projecting user columns into that scan, covering a column
+    /// named `row_id` renamed it on top of the real `_rowid` from `with_row_id()` and index
+    /// creation died with `Duplicate field name "_rowid" in schema`.
+    #[tokio::test]
+    async fn test_covering_column_named_row_id_is_supported() {
+        use arrow_array::types::Int32Type;
+        use arrow_array::{Int32Array, RecordBatchIterator};
+
+        let dim = 4i32;
+        let n = 128usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("row_id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from((0..n as i32).collect::<Vec<_>>())),
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim)
+                        .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covering_named_row_id",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["row_id".to_string()]);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .expect("a covering column named `row_id` must not collide with the virtual _rowid");
+
+        // And the covered payload is served correctly, not confused with the virtual column.
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 5).unwrap();
+        scan.project(&["row_id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(batch.num_rows(), 5);
+        let ids = batch["row_id"].as_primitive::<Int32Type>();
+        let mut got: Vec<i32> = ids.values().to_vec();
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            vec![0, 1, 2, 3, 4],
+            "covered `row_id` payload must be the user's values"
         );
     }
 
@@ -4022,17 +4224,54 @@ mod tests {
         );
     }
 
-    /// Same payoff but forcing the BATCH/late-search path: `k` larger than one
-    /// partition makes the initial `minimum_nprobes` sweep under-fill, so
-    /// `late_search` (the run_prepared batch path) fires. Covering must hold there too.
+    /// Same payoff but forcing the BATCH/late-search path: the initial `minimum_nprobes`
+    /// sweep under-fills, so `late_search` (the run_prepared batch path) fires. Covering
+    /// must hold there too.
+    ///
+    /// Uses well-separated clusters, and that is load-bearing: `early_pruning` RAISES
+    /// `minimum_nprobes` to the number of centroids within `dists[0] * factor` (81.0 once
+    /// `k >= 11`). With the evenly-spread unit-sphere data of `generate_test_dataset`
+    /// every centroid survives pruning, so `minimum_nprobes` reaches `maximum_nprobes`,
+    /// `late_search` returns at its first guard, and this test passes without ever
+    /// exercising the path it names.
     #[tokio::test]
     async fn test_ivf_pq_covered_projection_batch_path() {
-        const INDEX_NAME: &str = "vector_idx";
-        let test_dir = TempStrDir::default();
-        let test_uri = test_dir.as_str();
-        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+        use arrow_array::{Int32Array, RecordBatchIterator};
 
-        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        const INDEX_NAME: &str = "vector_idx";
+        const NPART: usize = 4;
+        let dim = 8i32;
+        let n = 512usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+        let values: Vec<f32> = clustered_vector_values(0..n, dim, NPART);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from((0..n as i32).collect::<Vec<_>>())),
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim)
+                        .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covered_batch_path",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_pq(NPART, 8, 4, DistanceType::L2, 2);
         params.include_columns(vec!["id".to_string()]);
         dataset
             .create_index(
@@ -4045,13 +4284,14 @@ mod tests {
             .await
             .unwrap();
 
-        let q = vectors.value(0);
-        let q = q.as_primitive::<Float32Type>();
+        // Query sits on cluster 0, so pruning keeps `minimum_nprobes` at 1 and the other
+        // three partitions are reached only by the late search.
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
         let mut scan = dataset.scan();
-        // k >> one partition's rows (NUM_ROWS=512 / 4 parts) forces late expansion.
-        scan.nearest("vector", q, 500).unwrap();
+        scan.nearest("vector", &q, 500).unwrap();
         scan.minimum_nprobes(1);
-        scan.maximum_nprobes(4);
+        scan.maximum_nprobes(NPART);
+        scan.with_row_id();
         scan.project(&["id"]).unwrap();
 
         let plan = scan.explain_plan(true).await.unwrap();
@@ -4060,8 +4300,22 @@ mod tests {
             "covered projection ['id'] should not require a TakeExec (batch path); plan:\n{plan}"
         );
         let batch = scan.try_into_batch().await.unwrap();
-        assert!(batch.column_by_name("id").is_some());
-        assert!(batch.num_rows() > 100, "late search should have expanded");
+        // Only the late search can supply rows beyond cluster 0's 128; reaching all 500
+        // proves it ran and that covering survived it.
+        assert_eq!(
+            batch.num_rows(),
+            500,
+            "late search must expand past the single probed partition"
+        );
+        let ids = batch["id"].as_primitive::<arrow_array::types::Int32Type>();
+        let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+        for i in 0..ids.len() {
+            assert_eq!(
+                ids.value(i) as u64,
+                row_ids.value(i),
+                "covered payload must stay row-aligned through the batch path"
+            );
+        }
     }
 
     /// A covered query combined with a selective prefilter (scalar index +
@@ -4379,12 +4633,7 @@ mod tests {
         // `max_nprobes <= min_nprobes` holds and `late_search` returns before it can emit the
         // shortcut batch this test needs.
         let ids: Vec<i32> = (0..TOTAL as i32).collect();
-        let values: Vec<f32> = (0..TOTAL)
-            .flat_map(|r| {
-                let center = (r % NPART) as f32 * 1000.0;
-                (0..DIMS).map(move |d| center + (r * DIMS + d) as f32 * 1e-3)
-            })
-            .collect();
+        let values: Vec<f32> = clustered_vector_values(0..TOTAL, DIMS as i32, NPART);
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new(
@@ -4620,40 +4869,6 @@ mod tests {
         for v in ids.values() {
             assert!(*v >= 100, "deleted rows (id < 100) must not be returned");
         }
-    }
-
-    /// Fix 2: under query parallelism > 1 the parallel search branch (which uses
-    /// `search_in_partition`, not the heap merge) must also emit covering
-    /// columns. On a multi-core runner this exercises the parallel path; if the
-    /// session resolves parallelism to 1 it still passes via the sequential path.
-    #[tokio::test]
-    async fn test_ivf_pq_covered_projection_parallel() {
-        const INDEX_NAME: &str = "vector_idx";
-        let test_dir = TempStrDir::default();
-        let test_uri = test_dir.as_str();
-        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
-        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
-        params.include_columns(vec!["id".to_string()]);
-        dataset
-            .create_index(
-                &["vector"],
-                IndexType::Vector,
-                Some(INDEX_NAME.to_string()),
-                &params,
-                true,
-            )
-            .await
-            .unwrap();
-
-        let q = vectors.value(0);
-        let q = q.as_primitive::<Float32Type>();
-        let mut scan = dataset.scan();
-        scan.nearest("vector", q, 10).unwrap();
-        scan.minimum_nprobes(4); // search several partitions...
-        scan.query_parallelism(4); // ...in parallel, forcing the parallel branch
-        scan.project(&["id"]).unwrap();
-        let batch = scan.try_into_batch().await.unwrap();
-        assert!(batch.column_by_name("id").is_some());
     }
 
     /// Fix 3: a covered index with unindexed fragments (rows appended but not
@@ -6217,7 +6432,7 @@ mod tests {
     /// rebuilds the unified output schema from the FIRST shard's covering set and
     /// `concat_batches` combines columns positionally, so without a guard shard B's `id2`
     /// values would be stored under shard A's `id` name -> wrong covered results. Reject with a
-    /// descriptive error instead (AGENTS.md:81).
+    /// descriptive error instead.
     #[tokio::test]
     async fn test_distributed_vector_merge_rejects_mismatched_covering_columns() {
         let test_dir = TempStrDir::default();
@@ -6285,6 +6500,157 @@ mod tests {
         assert!(
             msg.contains("covering") || msg.contains("included"),
             "error should describe the covering-column mismatch; was: {msg}"
+        );
+    }
+
+    /// A merged covered segment must itself be usable as an input to a later merge --
+    /// the hierarchical/incremental distributed workflow. The merger requires every
+    /// covered shard to carry its source field ids, so the merged output has to carry
+    /// them too; otherwise the merger rejects its own product and tells the user to
+    /// rebuild a shard that only the merger can produce.
+    #[tokio::test]
+    async fn test_distributed_covered_merge_output_can_be_merged_again() {
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+        let (schema, batches) = make_covered_test_batches();
+        let dataset_uri = format!("{}/distributed_covered_remerge", base_uri);
+        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, batches).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(
+            fragments.len() >= 3,
+            "need >= 3 fragments so the second-stage merge has more than one input"
+        );
+        // IVF_FLAT: a merged *PQ* segment stores transposed codes and the merger requires
+        // row-major shards, so PQ cannot be re-merged for reasons unrelated to covering.
+        // FLAT and SQ can, which is where the missing stamp actually bit.
+        let mut params = VectorIndexParams::with_ivf_flat_params(
+            DistanceType::L2,
+            prepare_global_ivf(&dataset, "vector").await,
+        );
+        params.include_columns(vec!["payload".to_string()]);
+
+        let mut segments = Vec::new();
+        for fragment in fragments.iter() {
+            segments.push(
+                dataset
+                    .create_index_builder(&["vector"], IndexType::Vector, &params)
+                    .name("vec_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        // Stage 1: merge the first two shards.
+        let rest = segments.split_off(2);
+        let merged = dataset
+            .merge_existing_index_segments(segments)
+            .await
+            .unwrap();
+        // Stage 2: feed that merged segment back in alongside the remaining shards. This
+        // is the hierarchical workflow the missing stamp used to make impossible.
+        let mut stage_two = vec![merged];
+        stage_two.extend(rest);
+        let remerged = dataset
+            .merge_existing_index_segments(stage_two)
+            .await
+            .expect("a merged covered segment must be mergeable again");
+        assert_eq!(
+            remerged.included_fields,
+            vec![dataset.schema().field("payload").unwrap().id],
+            "the re-merged segment must still declare the covered field"
+        );
+        dataset
+            .commit_existing_index_segments("vec_idx", "vector", vec![remerged])
+            .await
+            .unwrap();
+    }
+
+    /// Same covering column *name and type* across shards, but two different logical
+    /// fields: `payload` is dropped and re-added between the two shard builds, so it
+    /// comes back with a fresh field id. Name+type comparison accepts this and
+    /// `concat_batches` would then stack shard A's values for the dropped field under
+    /// the re-added one -- covered queries over shard A's rows serving the old column.
+    #[tokio::test]
+    async fn test_distributed_vector_merge_rejects_covering_of_different_field_ids() {
+        use crate::dataset::NewColumnTransform;
+
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+
+        let payload = Arc::new(UInt64Array::from_iter_values(0..TWO_FRAG_NUM_ROWS as u64));
+        let values = generate_random_array_with_range(TWO_FRAG_NUM_ROWS * TWO_FRAG_DIM, 0.0..1.0);
+        let vectors = Arc::new(
+            FixedSizeListArray::try_new_from_values(
+                Float32Array::from(values),
+                TWO_FRAG_DIM as i32,
+            )
+            .unwrap(),
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("payload", DataType::UInt64, true),
+            Field::new("vector", vectors.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![payload, vectors]).unwrap();
+        let dataset_uri = format!("{}/distributed_covered_merge_field_id", base_uri);
+        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, vec![batch]).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+
+        let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+        let mut params =
+            VectorIndexParams::with_ivf_pq_params(DistanceType::L2, ivf_params, pq_params);
+        params.include_columns(vec!["payload".to_string()]);
+
+        // Shard A covers `payload` as it exists now.
+        let segment_a = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vec_idx".to_string())
+            .fragments(vec![fragments[0].id() as u32])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        let original_field_id = dataset.schema().field("payload").unwrap().id;
+
+        // Drop and re-add `payload`: same name, same type, new field id. The re-add is
+        // metadata-only (AllNulls), so no data file changes and nothing else notices.
+        dataset.drop_columns(&["payload"]).await.unwrap();
+        dataset
+            .add_columns(
+                NewColumnTransform::AllNulls(Arc::new(arrow_schema::Schema::new(vec![
+                    Field::new("payload", DataType::UInt64, true),
+                ]))),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let new_field_id = dataset.schema().field("payload").unwrap().id;
+        assert_ne!(
+            original_field_id, new_field_id,
+            "re-adding the column must produce a new field id, or this test proves nothing"
+        );
+
+        let fragments = dataset.get_fragments();
+        let segment_b = dataset
+            .create_index_builder(&["vector"], IndexType::Vector, &params)
+            .name("vec_idx".to_string())
+            .fragments(vec![fragments[1].id() as u32])
+            .execute_uncommitted()
+            .await
+            .unwrap();
+
+        let err = dataset
+            .merge_existing_index_segments(vec![segment_a, segment_b])
+            .await
+            .expect_err("merging shards covering different field ids must fail");
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("covering") || msg.contains("included"),
+            "error should describe the covering mismatch; was: {msg}"
         );
     }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -8,15 +8,17 @@ use std::marker::PhantomData;
 use std::{
     any::Any,
     borrow::Cow,
-    collections::{BinaryHeap, HashMap},
+    collections::{BinaryHeap, HashMap, HashSet},
     sync::{Arc, LazyLock, Mutex},
 };
 
-use crate::index::vector::{IndexFileVersion, builder::index_type_string};
+use crate::index::vector::{
+    IndexFileVersion, builder::index_type_string, utils::gather_covering_columns_by_row_id,
+};
 use crate::index::{PreFilter, vector::VectorIndex};
 use arrow::compute::concat_batches;
 use arrow_arith::numeric::sub;
-use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt32Array, UInt64Array};
+use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt32Array, UInt64Array, cast::AsArray};
 use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
@@ -834,7 +836,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             residual,
             scratch,
         )?;
-        Ok(batch)
+        // Emit covering columns with the per-partition result (batch path; no re-fetch).
+        Self::append_covering(batch, &part.storage)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -843,6 +846,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         use_residual_scratch: bool,
         prepared: PreparedPartitionSearch<S, Q>,
         heap: &mut BinaryHeap<OrderedNode<u64>>,
+        covering_map: &mut HashMap<u64, RecordBatch>,
         scratch: &mut QueryScratch,
         metrics: &dyn MetricsCollector,
     ) -> Result<()> {
@@ -882,6 +886,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .ok_or(Error::internal(
                 "failed to downcast partition entry".to_string(),
             ))?;
+        // Accumulate this partition's contribution to the top-k heap first, so the heap
+        // membership consulted below already reflects it.
         part.index.accumulate_topk_with_scratch(
             query.key,
             k,
@@ -892,7 +898,70 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             residual,
             scratch,
             metrics,
-        )
+        )?;
+        // Keep covering O(k): rather than buffering every probed partition's covering
+        // (O(nprobe * partition_size)) though only the k heap winners are emitted, extract
+        // only the covering rows for the current heap survivors -- deep-copied via
+        // `take_row` so this partition's storage can be released -- then prune the map to
+        // the heap's membership so rows evicted by this partition drop their covering.
+        // Every heap survivor's covering is present: a row is a survivor only if it was in
+        // the top-k when its own partition was processed (the heap never re-admits an
+        // evicted row), so it was extracted then -- or it is new from this partition.
+        // The lookup scans the partition's row ids against the (<= k)-sized needed set
+        // with an early exit, instead of building a partition-sized side map per probe.
+        if let Some(covering) = part.storage.covering_batch()? {
+            let src_rowids = covering
+                .column_by_name(ROW_ID)
+                .ok_or_else(|| Error::internal("covering batch missing row id".to_string()))?
+                .as_primitive::<arrow_array::types::UInt64Type>();
+            let heap_ids: HashSet<u64> = heap.iter().map(|node| node.id).collect();
+            let mut needed: HashSet<u64> = heap_ids
+                .iter()
+                .filter(|id| !covering_map.contains_key(id))
+                .copied()
+                .collect();
+            if !needed.is_empty() {
+                let mut positions: Vec<u32> = Vec::with_capacity(needed.len());
+                let mut ids: Vec<u64> = Vec::with_capacity(needed.len());
+                for (i, rid) in src_rowids.values().iter().enumerate() {
+                    if needed.remove(rid) {
+                        positions.push(i as u32);
+                        ids.push(*rid);
+                        if needed.is_empty() {
+                            break;
+                        }
+                    }
+                }
+                if !positions.is_empty() {
+                    // One take for this partition's whole contribution, not one per row:
+                    // a per-row take ran an arrow take plus a `RecordBatch` schema
+                    // validation to move a single cell, up to nprobe * k times per query.
+                    let taken = arrow::compute::take_record_batch(
+                        &covering,
+                        &arrow_array::UInt32Array::from(positions),
+                    )?;
+                    // Each entry must OWN its row. A bare `taken.slice(offset, 1)` shares
+                    // `taken`'s buffers, so one surviving winner would pin that whole
+                    // partition's take batch -- with effective k = k * refine_factor,
+                    // retained covering data becomes O(k^2) rows, not the O(k) this map
+                    // exists to guarantee. `shrink_to_fit` deep-copies the single row, so
+                    // both `taken` and the partition storage are released on drop.
+                    for (offset, rid) in ids.into_iter().enumerate() {
+                        covering_map.insert(rid, taken.slice(offset, 1).shrink_to_fit()?);
+                    }
+                }
+            }
+            covering_map.retain(|id, _| heap_ids.contains(id));
+            // Invariant: the map holds covering for exactly the heap's distinct row ids --
+            // never more (that would break the O(k) bound) and never fewer (a survivor
+            // would be missing its covering at emit time).
+            debug_assert_eq!(
+                covering_map.len(),
+                heap_ids.len(),
+                "covering map must track exactly the heap's survivors (O(k))"
+            );
+        }
+        Ok(())
     }
 
     fn query_context_for_scratch<'a>(
@@ -920,14 +989,114 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         }
     }
 
-    fn global_heap_to_batch(heap: BinaryHeap<OrderedNode<u64>>) -> Result<RecordBatch> {
+    fn global_heap_to_batch(
+        heap: BinaryHeap<OrderedNode<u64>>,
+        // `row_id -> 1-row [_rowid, <included cols...>]` for exactly the heap survivors,
+        // kept O(k) by `accumulate_prepared_partition_search`.
+        covering_map: &HashMap<u64, RecordBatch>,
+        // `[_rowid, <included cols...>]` schema for the index's covering columns,
+        // or None for an ordinary index. This is a stable per-index property, so
+        // it -- not `covering_map.is_empty()` -- decides whether to emit the wider
+        // covered schema. That keeps the emitted schema equal to the schema the
+        // exec declares even when zero partitions were searched (heap empty).
+        covering_schema: Option<&arrow_schema::Schema>,
+    ) -> Result<RecordBatch> {
         let (row_ids, dists): (Vec<_>, Vec<_>) = heap.into_iter().map(|r| (r.id, r.dist.0)).unzip();
+        let dist_arr: ArrayRef = Arc::new(Float32Array::from(dists));
+        let row_id_arr: ArrayRef = Arc::new(UInt64Array::from(row_ids));
+        let Some(covering_schema) = covering_schema else {
+            // Ordinary index: `[_distance, _rowid]`.
+            return Ok(RecordBatch::try_new(
+                VECTOR_RESULT_SCHEMA.clone(),
+                vec![dist_arr, row_id_arr],
+            )?);
+        };
+        // Covered index: emit `[_distance, _rowid, <included cols...>]`.
+        let mut fields: Vec<arrow_schema::FieldRef> = VECTOR_RESULT_SCHEMA.fields().to_vec();
+        let mut columns: Vec<ArrayRef> = vec![dist_arr, row_id_arr.clone()];
+        if covering_map.is_empty() {
+            // No survivors (heap empty / zero partitions searched). Emit the covering
+            // columns as null arrays of the (zero) row count so the schema still matches
+            // the declared covered schema.
+            for field in covering_schema.fields() {
+                if field.name() == ROW_ID {
+                    continue;
+                }
+                fields.push(field.clone());
+                columns.push(arrow_array::new_null_array(
+                    field.data_type(),
+                    row_id_arr.len(),
+                ));
+            }
+        } else {
+            // Append the included columns for the final row ids, gathered from the O(k)
+            // side map of survivor covering rows captured in-flight during accumulate (no
+            // re-fetch from the base table).
+            let buf_schema = covering_map
+                .values()
+                .next()
+                .expect("covering_map is non-empty in this branch")
+                .schema();
+            let combined = concat_batches(&buf_schema, covering_map.values())?;
+            let row_id_u64 = row_id_arr.as_primitive::<arrow_array::types::UInt64Type>();
+            let included = gather_covering_columns_by_row_id(&combined, row_id_u64)?;
+            for (field, array) in included {
+                fields.push(field);
+                columns.push(array);
+            }
+        }
         Ok(RecordBatch::try_new(
-            VECTOR_RESULT_SCHEMA.clone(),
-            vec![
-                Arc::new(Float32Array::from(dists)),
-                Arc::new(UInt64Array::from(row_ids)),
-            ],
+            Arc::new(arrow_schema::Schema::new(fields)),
+            columns,
+        )?)
+    }
+
+    /// Append the index's included/covering columns to a per-partition search
+    /// result (`[_distance, _rowid]`), gathered from the live partition storage.
+    /// No-op when the index has no covering columns.
+    /// Append the index's included/covering columns to a per-partition search
+    /// result (`[_distance, _rowid]`), gathered from the live partition storage.
+    /// No-op when the index has no covering columns.
+    /// The schema search results carry: `[_distance, _rowid]` plus any covering
+    /// ("included") columns the storage holds, in storage order. Used to declare
+    /// stream schemas that stay consistent with the (possibly widened) batches.
+    fn covered_result_schema(
+        covering_schema: Option<&arrow_schema::Schema>,
+    ) -> arrow_schema::SchemaRef {
+        let Some(covering_schema) = covering_schema else {
+            return VECTOR_RESULT_SCHEMA.clone();
+        };
+        let mut fields: Vec<arrow_schema::FieldRef> = VECTOR_RESULT_SCHEMA.fields().to_vec();
+        for field in covering_schema.fields() {
+            if field.name() == ROW_ID {
+                continue;
+            }
+            fields.push(field.clone());
+        }
+        Arc::new(arrow_schema::Schema::new(fields))
+    }
+
+    fn append_covering(batch: RecordBatch, storage: &Q::Storage) -> Result<RecordBatch> {
+        let Some(covering) = storage.covering_batch()? else {
+            return Ok(batch);
+        };
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .ok_or_else(|| Error::internal("search result missing row id".to_string()))?
+            .as_primitive::<arrow_array::types::UInt64Type>();
+        let included = gather_covering_columns_by_row_id(&covering, row_ids)?;
+        if included.is_empty() {
+            return Ok(batch);
+        }
+        let mut fields: Vec<arrow_schema::FieldRef> = batch.schema().fields().to_vec();
+        let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
+        for (field, array) in included {
+            fields.push(field);
+            columns.push(array);
+        }
+        Ok(RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(fields)),
+            columns,
         )?)
     }
 
@@ -1296,6 +1465,24 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         self.storage.load_partition(partition_id, io_stats).await
     }
 
+    /// Names of this index's covering ("included") columns, in storage order, or
+    /// empty if the index has none. Used by remap/rebuild paths to re-project the
+    /// covering columns so they survive into the rewritten storage.
+    pub(crate) fn covering_column_names(&self) -> Result<Vec<String>> {
+        Ok(self
+            .storage
+            .covering_schema()?
+            .map(|schema| {
+                schema
+                    .fields()
+                    .iter()
+                    .filter(|f| f.name() != ROW_ID)
+                    .map(|f| f.name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
     /// preprocess the query vector given the partition id.
     ///
     /// Internal API with no stability guarantees.
@@ -1529,6 +1716,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                     scratch,
                 )
             })?;
+            // Emit any covering columns (parallel branch analog of the batch
+            // path's append_covering; no-op for ordinary indexes).
+            let batch = Self::append_covering(batch, &part.storage)?;
             Result::Ok((batch, local_metrics))
         })
         .await?;
@@ -1647,8 +1837,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             let use_residual_scratch = self.use_residual_scratch;
             let search_metrics = metrics.clone();
             let scratch_pool = self.scratch_pool.clone();
+            // Stable per-index covering schema, so the emitted schema matches the
+            // covered schema even if zero partitions are searched (heap empty).
+            let covering_schema = self.storage.covering_schema()?;
             let batch = spawn_cpu(move || -> DataFusionResult<RecordBatch> {
                 let mut heap = BinaryHeap::with_capacity(heap_capacity);
+                // O(k) side map of survivor covering rows (`row_id -> 1-row [_rowid,
+                // included...]`) captured in-flight; used to emit covering columns with the
+                // merged result (empty for ordinary indexes).
+                let mut covering_map: HashMap<u64, RecordBatch> = HashMap::new();
                 scratch_pool.with_scratch(|scratch| -> DataFusionResult<()> {
                     for prepared in prepared {
                         Self::accumulate_prepared_partition_search(
@@ -1656,6 +1853,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                             use_residual_scratch,
                             prepared,
                             &mut heap,
+                            &mut covering_map,
                             scratch,
                             search_metrics.as_ref(),
                         )
@@ -1663,12 +1861,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                     }
                     Ok(())
                 })?;
-                Self::global_heap_to_batch(heap).map_err(DataFusionError::from)
+                Self::global_heap_to_batch(heap, &covering_map, covering_schema.as_deref())
+                    .map_err(DataFusionError::from)
             })
             .await?;
 
+            // Schema may be wider than VECTOR_RESULT_SCHEMA when covering columns
+            // are emitted; take it from the produced batch so they stay consistent.
+            let result_schema = batch.schema();
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                VECTOR_RESULT_SCHEMA.clone(),
+                result_schema,
                 stream::once(async move { Ok(batch) }),
             )));
         }
@@ -1855,8 +2057,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             }
         });
 
+        // The per-partition batches are widened with the storage's covering columns
+        // (`append_covering`), so declare the matching schema -- the global-heap
+        // branch above already emits its batch's own (covered) schema.
+        let result_schema = Self::covered_result_schema(self.storage.covering_schema()?.as_deref());
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            VECTOR_RESULT_SCHEMA.clone(),
+            result_schema,
             ReceiverStream::new(batch_rx),
         )))
     }
@@ -2063,6 +2269,7 @@ mod tests {
     use crate::index::vector::ivf::v2::{
         IVFPartitionKey, IvfFlatIndex, IvfHnswSqIndex, IvfPq, IvfStateEntryBox, PartitionEntry,
     };
+    use crate::index::vector::utils::gather_covering_columns_by_row_id;
     use crate::utils::test::copy_test_data_to_tmp;
     use crate::{
         Dataset,
@@ -2567,6 +2774,882 @@ mod tests {
             stats,
             index,
         }
+    }
+
+    /// End-to-end test for index-included ("covering") columns : an
+    /// `include_columns` request on the build params must survive the full
+    /// build -> shuffle -> persist -> reopen path and land in the IVF_PQ
+    /// partition storage, so covered queries can avoid a take.
+    #[tokio::test]
+    async fn test_ivf_pq_include_columns_roundtrip() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        // `generate_test_dataset` produces an `id` (UInt64) column besides `vector`.
+        let (mut dataset, _) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
+        assert!(
+            storage.batch().column_by_name("id").is_some(),
+            "included column 'id' should be co-located in IVF_PQ partition storage"
+        );
+
+        // The covering columns are also declared generically on IndexMetadata
+        // (by field id), so the read path can discover them for any index type.
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+        let indices = dataset.load_indices().await.unwrap();
+        let idx = indices
+            .iter()
+            .find(|i| i.name == INDEX_NAME)
+            .expect("index should exist");
+        assert_eq!(
+            idx.included_fields,
+            vec![id_field_id],
+            "IndexMetadata.included_fields should record the covered column's field id"
+        );
+
+        // The commit must fence older writers that would drop `included_fields`.
+        assert_ne!(
+            dataset.manifest.writer_feature_flags
+                & lance_table::feature_flags::FLAG_COVERED_INDEX_METADATA,
+            0,
+            "a covering index must set the covered-index writer feature flag"
+        );
+    }
+
+    /// A multivector column stores one entry per sub-vector (all sharing the source
+    /// row id). The covering build must preserve every sub-vector -- the stale-row
+    /// dedup must not collapse legitimate repeated row ids, or recall silently drops.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_multivector_preserves_all_subvectors() {
+        const INDEX_NAME: &str = "vector_idx";
+        const SUBVECS_PER_ROW: usize = 3;
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, _) =
+            generate_multivec_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        // Multivector requires cosine. Cover the `id` column.
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::Cosine, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let mut total_stored = 0usize;
+        let mut has_id = false;
+        for p in 0..ctx.num_partitions() {
+            let storage = ctx.ivf().load_partition_storage(p, None).await.unwrap();
+            total_stored += storage.batch().num_rows();
+            has_id |= storage.batch().column_by_name("id").is_some();
+        }
+        assert!(
+            has_id,
+            "multivector covered storage should carry covering column 'id'"
+        );
+        assert_eq!(
+            total_stored,
+            NUM_ROWS * SUBVECS_PER_ROW,
+            "covering multivector build must keep every sub-vector, not collapse per row id"
+        );
+    }
+
+    /// Read-side payoff for multivector: a covered projection is carried through
+    /// `MultivectorScoringExec` (which re-groups sub-vectors back to rows), so no
+    /// `TakeExec` against the base table is needed.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_multivector_projection_skips_take() {
+        use arrow_array::types::UInt64Type;
+
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let (mut dataset, vectors) =
+            generate_multivec_test_dataset::<Float32Type>(test_dir.as_str(), 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::Cosine, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let query = vectors.value(0);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &query, 10).unwrap();
+        scan.minimum_nprobes(4);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered multivector projection ['id'] should skip TakeExec; plan was:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' must be emitted through multivector scoring")
+            .as_primitive::<UInt64Type>();
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        assert!(batch.num_rows() > 0, "query should return rows");
+        // Single-fragment, step-id dataset => id == row offset == _rowid, so a correctly
+        // carried covered value equals the row id for every returned row (payload
+        // re-attached to the right row through scoring, not misaligned or stale).
+        for i in 0..ids.len() {
+            assert_eq!(
+                ids.value(i),
+                row_ids.value(i),
+                "covered 'id' must stay row-aligned through multivector scoring"
+            );
+        }
+    }
+
+    /// A dotted/nested include path cannot be covered (the covering gather projects only
+    /// top-level names); reject it at build time.
+    #[tokio::test]
+    async fn test_ivf_pq_rejects_dotted_include_column() {
+        let test_dir = TempStrDir::default();
+        let (mut dataset, _) =
+            generate_test_dataset::<Float32Type>(test_dir.as_str(), 0.0..1.0).await;
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id.sub".to_string()]);
+        let err = dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .expect_err("a dotted include column must be rejected");
+        assert!(
+            err.to_string().contains("nested/dotted"),
+            "expected a nested/dotted rejection, got: {err}"
+        );
+    }
+
+    /// Covering names that collide with index storage (the indexed vector column itself,
+    /// a reserved storage column, or a duplicate) must be rejected at build time.
+    #[tokio::test]
+    async fn test_ivf_rejects_reserved_and_duplicate_include_columns() {
+        let test_dir = TempStrDir::default();
+        let (mut dataset, _) =
+            generate_test_dataset::<Float32Type>(test_dir.as_str(), 0.0..1.0).await;
+        let build = |cols: Vec<String>| {
+            let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+            params.include_columns(cols);
+            params
+        };
+
+        // The indexed vector column itself.
+        let err = dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                None,
+                &build(vec!["vector".to_string()]),
+                true,
+            )
+            .await
+            .expect_err("covering the indexed vector column must be rejected");
+        assert!(
+            err.to_string().contains("indexed vector column itself"),
+            "got: {err}"
+        );
+
+        // Reserved storage/transform column names. The reserved check runs before the
+        // schema-existence check, so these are rejected even though the dataset lacks them.
+        // The RaBitQ code/factor columns and the IVF partition transform's `__centroid_dist`
+        // are internal to the build pipeline: covering one would advertise it in
+        // `included_fields` while the storage's `covering_field_indices` drops it, so a
+        // covered query would declare a column storage never emits.
+        for internal in [
+            "__pq_code",
+            "__sq_code",
+            "__ivf_part_id",
+            "__centroid_dist",
+            "__ex_codes",
+            "__blocked_ex_codes",
+            "__add_factors",
+            "__scale_factors",
+            "__error_factors",
+            "__add_factors_ex",
+            "__scale_factors_ex",
+        ] {
+            let err = dataset
+                .create_index(
+                    &["vector"],
+                    IndexType::Vector,
+                    None,
+                    &build(vec![internal.to_string()]),
+                    true,
+                )
+                .await
+                .expect_err("covering a reserved storage/transform name must be rejected");
+            assert!(
+                err.to_string().contains("reserved index storage"),
+                "internal name '{internal}' must be reserved, got: {err}"
+            );
+        }
+
+        // Duplicate covering columns.
+        let err = dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                None,
+                &build(vec!["id".to_string(), "id".to_string()]),
+                true,
+            )
+            .await
+            .expect_err("duplicate covering columns must be rejected");
+        assert!(err.to_string().contains("duplicate"), "got: {err}");
+    }
+
+    /// A blob column stores out-of-line descriptors, not inline data, so it cannot be
+    /// covered by a vector index; reject it at build time.
+    #[tokio::test]
+    async fn test_ivf_flat_rejects_blob_include_column() {
+        use arrow_array::{
+            Float32Array, Int32Array, LargeBinaryArray, RecordBatch, RecordBatchIterator,
+        };
+        use lance_arrow::BLOB_META_KEY;
+        use lance_file::version::LanceFileVersion;
+        use std::collections::HashMap;
+
+        let dim = 4i32;
+        let n = 32usize;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+            Field::new("blobs", DataType::LargeBinary, true).with_metadata(HashMap::from([(
+                BLOB_META_KEY.to_string(),
+                "true".to_string(),
+            )])),
+        ]));
+        let vectors = FixedSizeListArray::try_new_from_values(
+            Float32Array::from((0..n as i32 * dim).map(|v| v as f32).collect::<Vec<_>>()),
+            dim,
+        )
+        .unwrap();
+        let blobs: Vec<Option<&[u8]>> = (0..n).map(|_| Some(b"x".as_slice())).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from((0..n as i32).collect::<Vec<_>>())),
+                Arc::new(vectors),
+                Arc::new(LargeBinaryArray::from(blobs)),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://c1-blob-include",
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["blobs".to_string()]);
+        let err = dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .expect_err("a blob include column must be rejected");
+        assert!(
+            err.to_string().contains("blob column"),
+            "expected a blob rejection, got: {err}"
+        );
+    }
+
+    /// Read-side payoff : a vector query projecting only a covered column
+    /// is satisfied from the index — no `TakeExec` against the base table.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_projection_skips_take() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.nprobes(4);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should not require a TakeExec; plan was:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+
+        // Take elision is worthless if the covered search returns the wrong
+        // neighbors, so also gate on recall: compare the covered result's row ids
+        // against brute-force ground truth (use_index(false)). All 4 partitions
+        // are probed, so 0.5 sits far below IVF_PQ's real recall on this data.
+        let returned: HashSet<u64> = batch[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect();
+        let truth = ground_truth(&dataset, "vector", q, 10, DistanceType::L2).await;
+        let recall = truth.intersection(&returned).count() as f32 / truth.len() as f32;
+        assert!(
+            recall >= 0.5,
+            "covered IVF_PQ recall {recall} < 0.5 (returned {returned:?}, truth {truth:?})"
+        );
+    }
+
+    /// Same payoff but forcing the BATCH/late-search path: `k` larger than one
+    /// partition makes the initial `minimum_nprobes` sweep under-fill, so
+    /// `late_search` (the run_prepared batch path) fires. Covering must hold there too.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_projection_batch_path() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        // k >> one partition's rows (NUM_ROWS=512 / 4 parts) forces late expansion.
+        scan.nearest("vector", q, 500).unwrap();
+        scan.minimum_nprobes(1);
+        scan.maximum_nprobes(4);
+        scan.project(&["id"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should not require a TakeExec (batch path); plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+        assert!(batch.num_rows() > 100, "late search should have expanded");
+    }
+
+    /// A covered query combined with a selective prefilter (scalar index +
+    /// `prefilter`) must still skip the TakeExec and return correct, filtered
+    /// rows. Exercises the covering read path under a scalar-index prefilter.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_with_scalar_prefilter() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // A scalar index on `id` turns the prefilter into a bounded AllowList.
+        let scalar_params = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::BTree,
+                Some("id_btree".to_string()),
+                &scalar_params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.filter("id < 5").unwrap();
+        scan.prefilter(true);
+        scan.project(&["id"]).unwrap();
+
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should not require a TakeExec even with a prefilter; plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<arrow_array::types::UInt64Type>();
+        for v in ids.values() {
+            assert!(
+                *v < 5,
+                "all returned rows must satisfy the prefilter id < 5"
+            );
+        }
+    }
+
+    /// A covered index must keep its covering columns through optimize/merge.
+    /// After appending rows and merging them into the index, the merged
+    /// auxiliary storage must still carry the included column, and a covered
+    /// projection must still skip the take. The covering columns are threaded
+    /// through the incremental optimize pipeline -- the unindexed-fragment
+    /// shuffle, the partition-split reshuffle, and the partition-join
+    /// reassignment -- as passenger columns (re-gathered by row id).
+    #[tokio::test]
+    async fn test_ivf_pq_covered_survives_optimize() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Append rows (unindexed fragments) and merge them into the index.
+        append_dataset::<Float32Type>(&mut dataset, NUM_ROWS, 0.0..1.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::new())
+            .await
+            .unwrap();
+
+        // The merged partition storage must still carry the covering column.
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
+        assert!(
+            storage.batch().column_by_name("id").is_some(),
+            "merged storage should still carry covering column 'id'"
+        );
+
+        // And a covered projection is still answered from the index (no take).
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.project(&["id"]).unwrap();
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should skip the take after optimize; plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+    }
+
+    /// Covering must survive a *retrain* optimize. Retrain rebuilds the storage from
+    /// scratch, so the covering column must be re-materialized -- otherwise the fresh
+    /// files omit it while the committed metadata still advertises `included_fields`,
+    /// and a covered projection expects a column the storage cannot emit.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_survives_retrain() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        append_dataset::<Float32Type>(&mut dataset, NUM_ROWS, 0.0..1.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::retrain())
+            .await
+            .unwrap();
+
+        // The retrained storage must re-materialize the covering column.
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
+        assert!(
+            storage.batch().column_by_name("id").is_some(),
+            "retrained storage should re-materialize covering column 'id'"
+        );
+
+        // And a covered projection is still answered from the index (no take).
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.project(&["id"]).unwrap();
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should skip the take after retrain; plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+    }
+
+    /// Index storage that physically carries covering columns while the manifest
+    /// declares none (`included_fields` empty) must still be queryable: the extra
+    /// columns are dropped from search batches (with a warning) instead of emitting
+    /// batches wider than the plan's declared `[_distance, _rowid]` schema. This is
+    /// the legacy-tolerance contract: a stable-format index file with an unexpected
+    /// extra column used to be projected down with a warning, never a query failure.
+    #[tokio::test]
+    async fn test_undeclared_storage_covering_is_dropped_not_fatal() {
+        use crate::dataset::WriteDestination;
+        use crate::dataset::transaction::Operation;
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        const DIMS: usize = 16;
+        const TOTAL: usize = 256;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<Float32Type>((DIMS as u32).into()),
+            )
+            .into_reader_rows(RowCount::from(TOTAL as u64), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        let mut params = VectorIndexParams::ivf_pq(1, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        // Re-commit the index metadata with the covering declaration cleared while the
+        // storage keeps the payload column -- the state a pre-covering writer (which
+        // drops the unknown `included_fields` proto field) or a legacy index file with
+        // a stray extra column would produce.
+        let mut cleared = dataset.load_indices_by_name("vector_idx").await.unwrap()[0].clone();
+        assert!(!cleared.included_fields.is_empty());
+        cleared.included_fields = Vec::new();
+        let read_version = dataset.manifest.version;
+        let dataset = Dataset::commit(
+            WriteDestination::Dataset(Arc::new(dataset)),
+            Operation::CreateIndex {
+                new_indices: vec![cleared],
+                removed_indices: vec![],
+            },
+            Some(read_version),
+            None,
+            None,
+            Arc::new(Default::default()),
+            false,
+        )
+        .await
+        .unwrap();
+
+        // The index is no longer covering, so the query takes `id` from the base
+        // table; the storage's undeclared payload column must be silently dropped
+        // from the search batches, not fail the query.
+        let q = Float32Array::from(vec![0.5f32; DIMS]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 5).unwrap();
+        scan.project(&["id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(batch.num_rows(), 5);
+        assert!(batch.column_by_name("id").is_some());
+
+        // The hard case: a bounded selective prefilter mixes the plan's 2-column
+        // not-found shortcut batch with search batches -- if the search batches still
+        // carried the undeclared payload column, the widths would disagree where the
+        // stream is concatenated and the query would fail.
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 5).unwrap();
+        scan.filter("id < 3").unwrap();
+        scan.prefilter(true);
+        scan.project(&["id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            3,
+            "all prefilter-matched rows must come back"
+        );
+    }
+
+    /// A covered index that searches zero partitions (empty heap)
+    /// must still emit the covered schema `[_distance, _rowid, <included>]`, not
+    /// the bare `[_distance, _rowid]` -- otherwise the produced batch mismatches
+    /// the wider schema the exec declares from `included_fields`. The decision is
+    /// driven by the stable per-index covering schema, not `covered_buf`.
+    #[test]
+    fn test_global_heap_to_batch_covered_empty_emits_covered_schema() {
+        use arrow_schema::{DataType, Field, Schema};
+        let covering = Schema::new(vec![
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("id", DataType::UInt64, true),
+        ]);
+        // Empty heap + empty covered_buf, but the index IS covered.
+        let batch = IvfPq::global_heap_to_batch(
+            std::collections::BinaryHeap::new(),
+            &HashMap::new(),
+            Some(&covering),
+        )
+        .unwrap();
+        assert_eq!(batch.num_rows(), 0);
+        assert_eq!(
+            batch.num_columns(),
+            3,
+            "covered empty result must keep the covering column"
+        );
+        assert!(batch.column_by_name("id").is_some());
+
+        // Ordinary (non-covered) index: bare `[_distance, _rowid]`.
+        let plain =
+            IvfPq::global_heap_to_batch(std::collections::BinaryHeap::new(), &HashMap::new(), None)
+                .unwrap();
+        assert_eq!(plain.num_columns(), 2);
+    }
+
+    /// A result row id that is absent from the covering buffer is an invariant
+    /// break (every heap winner comes from a searched partition whose covering
+    /// batch was captured). It must surface as an error -- never as row 0's
+    /// covering values silently attached to an unrelated row.
+    #[test]
+    fn test_gather_included_by_rowid_errors_on_missing_rowid() {
+        use arrow_schema::{DataType, Field, Schema};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("id", DataType::UInt64, true),
+        ]));
+        let source = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt64Array::from(vec![1, 2, 3])),
+                Arc::new(UInt64Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+
+        // Present row ids gather fine.
+        let ok =
+            gather_covering_columns_by_row_id(&source, &UInt64Array::from(vec![3, 1])).unwrap();
+        assert_eq!(ok.len(), 1);
+        let (_, values) = &ok[0];
+        let values = values.as_primitive::<arrow_array::types::UInt64Type>();
+        assert_eq!(values.values(), &[30, 10]);
+
+        // Row id 99 is absent from the covering source: must be an error.
+        let err = gather_covering_columns_by_row_id(&source, &UInt64Array::from(vec![2, 99]))
+            .expect_err("missing row id must error, not return unrelated values");
+        assert!(err.to_string().contains("99"), "got: {err}");
+    }
+
+    /// A covered index must keep its covering columns through compaction, which
+    /// rewrites fragments and REMAPS the index's row ids. Delete rows to force a
+    /// compaction+remap; the remapped storage must still carry the covering
+    /// column and covered projections must still skip the take.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_survives_compaction() {
+        use crate::dataset::optimize::{CompactionOptions, compact_files};
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Delete rows so compaction rewrites fragments and remaps the index.
+        dataset.delete("id < 100").await.unwrap();
+        compact_files(&mut dataset, CompactionOptions::default(), None)
+            .await
+            .unwrap();
+
+        // The remapped partition storage must still carry the covering column.
+        let ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let storage = ctx.ivf().load_partition_storage(0, None).await.unwrap();
+        assert!(
+            storage.batch().column_by_name("id").is_some(),
+            "remapped storage should keep covering column 'id'"
+        );
+
+        // Covered projection still skips the take, and deleted rows are gone.
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.project(&["id"]).unwrap();
+        let plan = scan.explain_plan(true).await.unwrap();
+        assert!(
+            !plan.contains("Take"),
+            "covered projection ['id'] should skip the take after compaction; plan:\n{plan}"
+        );
+        let batch = scan.try_into_batch().await.unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered projection should return id")
+            .as_primitive::<arrow_array::types::UInt64Type>();
+        for v in ids.values() {
+            assert!(*v >= 100, "deleted rows (id < 100) must not be returned");
+        }
+    }
+
+    /// Fix 2: under query parallelism > 1 the parallel search branch (which uses
+    /// `search_in_partition`, not the heap merge) must also emit covering
+    /// columns. On a multi-core runner this exercises the parallel path; if the
+    /// session resolves parallelism to 1 it still passes via the sequential path.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_projection_parallel() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.minimum_nprobes(4); // search several partitions...
+        scan.query_parallelism(4); // ...in parallel, forcing the parallel branch
+        scan.project(&["id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
+    }
+
+    /// Fix 3: a covered index with unindexed fragments (rows appended but not
+    /// optimized) must not panic on a non-fast-search query. The flat search
+    /// over the unindexed rows now projects the covering columns so the union
+    /// with the index result succeeds.
+    #[tokio::test]
+    async fn test_ivf_pq_covered_with_unindexed_fragments() {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+        let mut params = VectorIndexParams::ivf_pq(4, 8, 4, DistanceType::L2, 2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Append rows WITHOUT optimizing -> unindexed fragments; a (non-fast)
+        // query then goes through the index + flat-search combine path.
+        append_dataset::<Float32Type>(&mut dataset, 100, 0.0..1.0).await;
+
+        let q = vectors.value(0);
+        let q = q.as_primitive::<Float32Type>();
+        let mut scan = dataset.scan();
+        scan.nearest("vector", q, 10).unwrap();
+        scan.project(&["id"]).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        assert!(batch.column_by_name("id").is_some());
     }
 
     async fn verify_partition_split_after_append(

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -3608,6 +3608,320 @@ mod tests {
         assert_eq!(got, vec![10, 11, 12, 13]);
     }
 
+    /// The covered recovery takes its payload with `MissingRowPolicy::Ignore`, which silently
+    /// returns fewer rows than requested when an id no longer resolves. A stale prefilter can
+    /// list such ids: a scalar index built over a fragment that a later delete removed keeps
+    /// emitting that fragment's rows, and `create_deletion_mask_impl` produces no mask at all
+    /// when every fragment in the VECTOR index's bitmap is intact. Pairing the requested ids
+    /// with the returned payload then fails with "all columns in a record batch must have the
+    /// same length" -- a query the same dataset answers fine without covering.
+    #[tokio::test]
+    async fn test_covered_recovery_tolerates_unresolvable_prefilter_ids() {
+        use arrow_array::{Int32Array, RecordBatchIterator};
+
+        let dim = 4i32;
+        let frag0 = 16usize;
+        let extra = 3usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+        // Two separated clusters so `early_pruning` leaves an unsearched partition and the
+        // late-search shortcut (which arms the covered recovery) is reachable.
+        let make_batch = |ids: Vec<i32>| {
+            let values: Vec<f32> = ids
+                .iter()
+                .flat_map(|id| {
+                    let center = if id % 2 == 0 { 0.0f32 } else { 1000.0 };
+                    (0..dim as usize).map(move |d| center + (*id as usize * 4 + d) as f32 * 1e-3)
+                })
+                .collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids)),
+                    Arc::new(
+                        FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim)
+                            .unwrap(),
+                    ),
+                ],
+            )
+            .unwrap()
+        };
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(
+                [Ok(make_batch((0..frag0 as i32).collect()))],
+                schema.clone(),
+            ),
+            "memory://covered_recovery_stale_prefilter",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                max_rows_per_file: frag0,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Covered index over fragment 0 only.
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
+
+        // Fragment 1, then a scalar index spanning BOTH fragments.
+        let ids: Vec<i32> = (frag0 as i32..(frag0 + extra) as i32).collect();
+        dataset
+            .append(
+                RecordBatchIterator::new([Ok(make_batch(ids))], schema.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+        let scalar = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(&["id"], IndexType::BTree, None, &scalar, false)
+            .await
+            .unwrap();
+
+        // Drop fragment 1 entirely. The BTree still lists its ids, so the prefilter admits
+        // rows the row-id index can no longer resolve.
+        dataset.delete("id >= 16").await.unwrap();
+
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        scan.nearest("vector", &q, 10).unwrap();
+        scan.minimum_nprobes(1);
+        scan.filter("id >= 15").unwrap();
+        scan.prefilter(true);
+        scan.project(&["id"]).unwrap();
+
+        let batch = scan
+            .try_into_batch()
+            .await
+            .expect("covered query must tolerate prefilter ids that no longer resolve");
+        let ids = batch["id"].as_primitive::<arrow_array::types::Int32Type>();
+        let got: Vec<i32> = ids.values().to_vec();
+        assert_eq!(
+            got,
+            vec![15],
+            "only the surviving admitted row may come back; ids from the deleted fragment \
+             must be dropped, not paired with mismatched payload"
+        );
+    }
+
+    /// The covered end-of-stream recovery re-emits every prefilter row the search did not
+    /// emit. `DatasetPreFilter` produces a bounded ALLOW LIST from deletions alone on a
+    /// stable-row-id dataset, so that recovery fires on queries carrying NO filter at all
+    /// (`PreFilterSource::None`). Tracking the emitted row ids must therefore not be gated
+    /// on a prefilter source being present -- otherwise the "already emitted" set is empty
+    /// and every live row is emitted a second time with INFINITY distance.
+    #[tokio::test]
+    async fn test_covered_unfiltered_query_does_not_duplicate_rows() {
+        use arrow_array::types::{Int32Type, UInt64Type};
+        use arrow_array::{Int32Array, RecordBatchIterator};
+
+        const INDEX: &str = "vec_idx";
+        let dim = 4i32;
+        let n = 12usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+
+        // Two well-separated clusters with the query sitting on top of the first: the second
+        // centroid is orders of magnitude farther, so `early_pruning` leaves minimum_nprobes
+        // at 1. An unsearched partition is what makes the late-search no-rows shortcut (and
+        // hence the covered recovery) reachable -- with evenly spread vectors early pruning
+        // raises minimum_nprobes to cover every partition and the shortcut never fires.
+        let ids: Vec<i32> = (0..n as i32).collect();
+        let values: Vec<f32> = (0..n)
+            .flat_map(|r| {
+                let center = if r % 2 == 0 { 0.0f32 } else { 1000.0 };
+                (0..dim as usize).map(move |d| center + (r * dim as usize + d) as f32 * 1e-3)
+            })
+            .collect();
+        let vector = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim,
+            Arc::new(Float32Array::from(values)),
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(ids)), Arc::new(vector)],
+        )
+        .unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://covered_unfiltered_no_dupes",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["id".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // A deletion makes the stable-row-id deletion mask a bounded ALLOW LIST, so
+        // `max_len()` is Some(live) even though the query below carries no filter.
+        dataset.delete("id = 1").await.unwrap();
+        let live = n - 1;
+
+        let q = Float32Array::from(vec![0.0f32; dim as usize]);
+        let mut scan = dataset.scan();
+        // k > live so the "fewer than k prefilter matches" shortcut condition holds.
+        scan.nearest("vector", &q, live + 9).unwrap();
+        scan.minimum_nprobes(1);
+        scan.with_row_id();
+        scan.project(&["id"]).unwrap();
+
+        let batch = scan.try_into_batch().await.unwrap();
+
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .expect("row id column")
+            .as_primitive::<UInt64Type>();
+        let mut seen: Vec<u64> = row_ids.values().to_vec();
+        seen.sort_unstable();
+        let mut distinct = seen.clone();
+        distinct.dedup();
+        assert_eq!(
+            seen.len(),
+            distinct.len(),
+            "covered unfiltered query returned DUPLICATE row ids: {seen:?}"
+        );
+        assert_eq!(
+            batch.num_rows(),
+            live,
+            "covered unfiltered query must return each live row exactly once"
+        );
+
+        let ids = batch
+            .column_by_name("id")
+            .expect("covered 'id' must be emitted")
+            .as_primitive::<Int32Type>();
+        for i in 0..ids.len() {
+            assert_eq!(
+                ids.value(i) as u64,
+                row_ids.value(i),
+                "covered id must stay row-aligned"
+            );
+        }
+        let mut got: Vec<i32> = ids.values().to_vec();
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            (0..n as i32).filter(|id| *id != 1).collect::<Vec<_>>(),
+            "every live row must appear exactly once"
+        );
+    }
+
+    /// A covered ("included") struct's payload schema is fixed at index build time. Growing
+    /// that struct via `add_columns` (which commits as `Operation::Merge`) -- even an
+    /// AllNulls, metadata-only child that writes no data file -- would leave the index
+    /// emitting the old struct type while covered queries declare the new one, an Arrow type
+    /// mismatch. The commit boundary must reject it (drop the index first), mirroring the
+    /// `Project` drop/alter guard.
+    #[tokio::test]
+    async fn test_add_columns_child_to_covered_struct_is_rejected() {
+        use arrow_array::{Int32Array, RecordBatchIterator, StructArray};
+        use arrow_schema::Fields;
+        use lance_file::version::LanceFileVersion;
+
+        use crate::dataset::NewColumnTransform;
+
+        let n = 64usize;
+        let dim = 4i32;
+        let meta_fields = Fields::from(vec![Field::new("a", DataType::Int32, false)]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("meta", DataType::Struct(meta_fields.clone()), true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]));
+
+        let a = Arc::new(Int32Array::from((0..n as i32).collect::<Vec<_>>()));
+        let meta = Arc::new(StructArray::new(meta_fields, vec![a], None));
+        let values: Vec<f32> = (0..n * dim as usize).map(|i| i as f32 + 1.0).collect();
+        let vector = Arc::new(
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap(),
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![meta, vector]).unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema.clone()),
+            "memory://covered_struct_add_child",
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let mut params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        params.include_columns(vec!["meta".to_string()]);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vec_idx".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Add child `meta.b` -- merges into the covered struct, changing its type.
+        let add =
+            NewColumnTransform::AllNulls(Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                "meta",
+                DataType::Struct(Fields::from(vec![Field::new("b", DataType::Int32, true)])),
+                true,
+            )])));
+        let err = dataset
+            .add_columns(add, None, None)
+            .await
+            .expect_err("growing a covered struct's subtree must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("included") && msg.contains("vec_idx"),
+            "expected a covered-field rejection naming the index, got: {err}"
+        );
+    }
+
     /// Read-side payoff for every vector index type: a query projecting only a covered
     /// column is satisfied from the index -- no `TakeExec` against the base table --
     /// with row-aligned values and sane recall.
@@ -4036,34 +4350,75 @@ mod tests {
         }
     }
 
-    /// Index storage that physically carries covering columns while the manifest
-    /// declares none (`included_fields` empty) must still be queryable: the extra
-    /// columns are dropped from search batches (with a warning) instead of emitting
-    /// batches wider than the plan's declared `[_distance, _rowid]` schema. This is
-    /// the legacy-tolerance contract: a stable-format index file with an unexpected
-    /// extra column used to be projected down with a warning, never a query failure.
+    /// Index storage that physically carries covering columns while the manifest declares
+    /// none (`included_fields` empty) must still be queryable: the ANN node narrows every
+    /// emitted batch to its declared schema, so the query degrades to a base-table take
+    /// rather than emitting batches wider than the plan declares.
+    ///
+    /// Uses a MULTI-partition index on purpose. With one partition
+    /// `max_nprobes <= min_nprobes` and `late_search` returns immediately, so the
+    /// non-covered 2-column shortcut batch is never produced and the mixed-width case
+    /// below cannot arise -- an earlier single-partition version of this test asserted
+    /// that case in a comment while never reaching it.
     #[tokio::test]
     async fn test_undeclared_storage_covering_is_dropped_not_fatal() {
         use crate::dataset::WriteDestination;
         use crate::dataset::transaction::Operation;
-        use lance_datagen::{BatchCount, RowCount, array};
+        use arrow_array::{Int32Array, RecordBatchIterator};
 
         const DIMS: usize = 16;
         const TOTAL: usize = 256;
+        const NPART: usize = 8;
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
 
-        let reader = lance_datagen::gen_batch()
-            .col("id", array::step::<arrow_array::types::Int32Type>())
-            .col(
+        // Eight well-separated clusters, row r in cluster r % NPART. Randomly spread vectors
+        // would not do: `early_pruning` raises `minimum_nprobes` to the number of centroids
+        // that survive pruning, so with no clear nearest centroid every partition is probed,
+        // `max_nprobes <= min_nprobes` holds and `late_search` returns before it can emit the
+        // shortcut batch this test needs.
+        let ids: Vec<i32> = (0..TOTAL as i32).collect();
+        let values: Vec<f32> = (0..TOTAL)
+            .flat_map(|r| {
+                let center = (r % NPART) as f32 * 1000.0;
+                (0..DIMS).map(move |d| center + (r * DIMS + d) as f32 * 1e-3)
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
                 "vector",
-                array::rand_vec::<Float32Type>((DIMS as u32).into()),
-            )
-            .into_reader_rows(RowCount::from(TOTAL as u64), BatchCount::from(1));
-        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIMS as i32,
+                ),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(
+                        Float32Array::from(values),
+                        DIMS as i32,
+                    )
+                    .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            test_uri,
+            None,
+        )
+        .await
+        .unwrap();
 
-        let mut params = VectorIndexParams::ivf_pq(1, 8, 4, DistanceType::L2, 2);
+        let mut params = VectorIndexParams::ivf_pq(NPART, 8, 4, DistanceType::L2, 2);
         params.include_columns(vec!["id".to_string()]);
         dataset
             .create_index(&["vector"], IndexType::Vector, None, &params, false)
@@ -4104,21 +4459,39 @@ mod tests {
         assert_eq!(batch.num_rows(), 5);
         assert!(batch.column_by_name("id").is_some());
 
-        // The hard case: a bounded selective prefilter mixes the plan's 2-column
-        // not-found shortcut batch with search batches -- if the search batches still
-        // carried the undeclared payload column, the widths would disagree where the
-        // stream is concatenated and the query would fail.
-        let mut scan = dataset.scan();
-        scan.nearest("vector", &q, 5).unwrap();
-        scan.filter("id < 3").unwrap();
-        scan.prefilter(true);
-        scan.project(&["id"]).unwrap();
-        let batch = scan.try_into_batch().await.unwrap();
-        assert_eq!(
-            batch.num_rows(),
-            3,
-            "all prefilter-matched rows must come back"
-        );
+        // The hard case: a bounded selective prefilter over unsearched partitions makes
+        // `late_search` emit its 2-column not-found shortcut batch into the same stream as
+        // the search batches. Unnarrowed, those search batches still carry the undeclared
+        // payload column, so the widths disagree where DataFusion's TopK concatenates them
+        // -- `interleave_record_batch` reads every batch through the FIRST batch's schema
+        // and panics with an out-of-bounds column index.
+        // Repeated because the unnarrowed failure is order-dependent: it only panics when
+        // TopK happens to store a wide batch first, which is roughly 4 runs in 5. One
+        // iteration would make this test pass intermittently against a real regression.
+        for attempt in 0..5 {
+            let mut scan = dataset.scan();
+            scan.nearest("vector", &q, 5).unwrap();
+            scan.minimum_nprobes(1);
+            scan.maximum_nprobes(NPART);
+            scan.filter("id < 3").unwrap();
+            scan.prefilter(true);
+            scan.project(&["id"]).unwrap();
+            let batch = scan.try_into_batch().await.unwrap();
+            assert_eq!(
+                batch.num_rows(),
+                3,
+                "all prefilter-matched rows must come back (attempt {attempt})"
+            );
+            let ids = batch["id"].as_primitive::<arrow_array::types::Int32Type>();
+            let mut got: Vec<i32> = ids.values().to_vec();
+            got.sort_unstable();
+            assert_eq!(
+                got,
+                vec![0, 1, 2],
+                "covered payload must be taken from the base table once the declaration is \
+                 gone (attempt {attempt})"
+            );
+        }
     }
 
     /// A covered index that searches zero partitions (empty heap)

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -23,6 +23,52 @@ use tokio::sync::Mutex;
 
 use crate::dataset::{Dataset, ProjectionRequest, TakeBuilder, row_offsets_to_row_addresses};
 use crate::{Error, Result};
+use lance_core::ROW_ID;
+
+/// Row-align the non-`_rowid` columns of `source` (a `[_rowid, <cols...>]` batch)
+/// to `target_rowids`, gathered by row id. Every target row id must be present in
+/// `source`; a miss returns an error, because silently gathering an unrelated
+/// row's values would corrupt the covered result. Returns the taken columns paired
+/// with their fields, in `source` column order, with `_rowid` excluded.
+///
+/// Shared by the covered-search read path (regrouping heap winners into
+/// `[_distance, _rowid, <included...>]`) and the reassignment build path
+/// (re-attaching covering columns to rows regrouped by the partition join).
+pub(super) fn gather_covering_columns_by_row_id(
+    source: &RecordBatch,
+    target_rowids: &arrow_array::UInt64Array,
+) -> Result<Vec<(arrow_schema::FieldRef, ArrayRef)>> {
+    let src_rowids = source
+        .column_by_name(ROW_ID)
+        .ok_or_else(|| Error::internal("covering source missing row id".to_string()))?
+        .as_primitive::<arrow_array::types::UInt64Type>();
+    let mut pos: std::collections::HashMap<u64, u32> =
+        std::collections::HashMap::with_capacity(src_rowids.len());
+    for (i, rid) in src_rowids.values().iter().enumerate() {
+        pos.insert(*rid, i as u32);
+    }
+    let take_idx: arrow_array::UInt32Array = target_rowids
+        .values()
+        .iter()
+        .map(|rid| {
+            pos.get(rid).copied().ok_or_else(|| {
+                Error::internal(format!(
+                    "row id {rid} missing from covering source during row-id gather"
+                ))
+            })
+        })
+        .collect::<Result<Vec<u32>>>()?
+        .into();
+    let mut out = Vec::with_capacity(source.num_columns().saturating_sub(1));
+    for (i, field) in source.schema().fields().iter().enumerate() {
+        if field.name() == ROW_ID {
+            continue;
+        }
+        let taken = arrow::compute::take(source.column(i), &take_idx, None)?;
+        out.push((field.clone(), taken));
+    }
+    Ok(out)
+}
 
 /// Helper function to extract a column from a RecordBatch, supporting nested field paths.
 ///

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -10,7 +10,7 @@ use crate::{
     dataset::transaction::{DataOverlayGroup, Operation, Transaction, UpdateMode},
 };
 use futures::{StreamExt, TryStreamExt};
-use lance_core::{Error, Result, utils::deletion::DeletionVector};
+use lance_core::{Error, Result, datatypes::Schema, utils::deletion::DeletionVector};
 use lance_index::frag_reuse::FRAG_REUSE_INDEX_NAME;
 use lance_index::mem_wal::{CompactedSsTable, MEM_WAL_INDEX_NAME};
 use lance_select::{RowAddrTreeMap, RowSetOps};
@@ -37,6 +37,57 @@ pub struct TransactionRebase<'a> {
     /// Compacted SSTables from conflicting UpdateMemWalState transactions.
     /// Used when rebasing CreateIndex of MemWalIndex.
     conflicting_mem_wal_compacted_sstables: Vec<CompactedSsTable>,
+    /// The dataset schema at the read version, used to expand a covering index's
+    /// covered (included) struct fields to their leaf subtrees when checking whether a
+    /// concurrent transaction touches covered data.
+    schema: Arc<Schema>,
+    /// Read-version snapshot of which data file backs each covered (included) leaf
+    /// field, per fragment: `fragment id -> field id -> path`. Empty unless this
+    /// transaction creates an index that declares covering columns.
+    ///
+    /// This is what lets `check_create_index_txn` tell a concurrent `Merge` that
+    /// rewrote covered data *in place* from one that merely added a column. The
+    /// post-merge fragments alone cannot answer that: a rewrite tombstones the
+    /// superseded field with a single sentinel that does not name it.
+    covered_field_paths: Arc<HashMap<u64, HashMap<i32, String>>>,
+}
+
+/// Snapshot the data file backing each covered leaf field of `new_indices`, as of
+/// `dataset`'s version. Covered struct fields are expanded to their whole subtree
+/// because a rewritten data file lists leaf ids while `included_fields` records only
+/// the parent id. Fragments with no covered field are omitted.
+fn covered_field_paths_at(
+    dataset: &Dataset,
+    new_indices: &[IndexMetadata],
+    schema: &Schema,
+) -> HashMap<u64, HashMap<i32, String>> {
+    let mut covered: HashSet<i32> = HashSet::new();
+    for index in new_indices {
+        for &id in index.included_fields.iter() {
+            match schema.field_by_id(id) {
+                Some(field) => crate::index::collect_subtree_field_ids(field, &mut covered),
+                None => {
+                    covered.insert(id);
+                }
+            }
+        }
+    }
+    if covered.is_empty() {
+        return HashMap::new();
+    }
+    dataset
+        .manifest
+        .fragments
+        .iter()
+        .filter_map(|fragment| {
+            let paths: HashMap<i32, String> = Transaction::fragment_field_paths(fragment)
+                .into_iter()
+                .filter(|(field_id, _)| covered.contains(field_id))
+                .map(|(field_id, path)| (field_id, path.to_string()))
+                .collect();
+            (!paths.is_empty()).then_some((fragment.id, paths))
+        })
+        .collect()
 }
 
 /// Whether `operation` may make a nullability-affecting schema change: a
@@ -78,6 +129,55 @@ impl<'a> TransactionRebase<'a> {
         transaction: Transaction,
         affected_rows: Option<&'a RowAddrTreeMap>,
     ) -> Result<Self> {
+        // Capture the schema AS OF THE TRANSACTION'S READ VERSION, matching what
+        // `initial_fragments_for_rebase` does for fragments. The dataset handed to us is not
+        // necessarily at that version: the URI commit path deliberately loads the *latest*
+        // version ("we are writing to the main history, and need to check out the latest
+        // version") for any non-detached read version. The covering checks below use this as
+        // the *pre-commit* side when asking whether a concurrent operation changed a covered
+        // field's subtree, so capturing the latest schema would compare a post-change schema
+        // against itself -- silently missing a covered-field rename or retype and committing
+        // index storage under a schema it was never built against.
+        //
+        // Only `check_create_index_txn` and `check_data_replacement_txn` consult this, so
+        // only they pay for the extra checkout; every other operation gets the in-hand schema
+        // and never reads it. If a new check starts using `self.schema`, add its operation
+        // here or it will silently see the wrong version.
+        //
+        // CreateIndex is narrowed further to indices that actually declare covering columns:
+        // comparing a covered subtree across versions is the only thing that can observe the
+        // difference, so an ordinary index build keeps the pre-covering behaviour (in-hand
+        // schema, no extra round trip) instead of paying for a manifest load on every commit
+        // retry. DataReplacement cannot be narrowed the same way -- the covering it has to
+        // respect belongs to a *concurrent* transaction's indices, which are not known until
+        // the check runs.
+        //
+        // `read_version == 0` is the "no prior version" sentinel (overwrite/create): there is
+        // nothing to check out, and attempting it fails with DatasetNotFound.
+        let needs_read_version_schema = match &transaction.operation {
+            Operation::CreateIndex { new_indices, .. } => new_indices
+                .iter()
+                .any(|idx| !idx.included_fields.is_empty()),
+            Operation::DataReplacement { .. } => true,
+            _ => false,
+        };
+        let checked_out;
+        let at_read_version = if !needs_read_version_schema
+            || transaction.read_version == 0
+            || dataset.manifest.version == transaction.read_version
+        {
+            dataset
+        } else {
+            checked_out = dataset.checkout_version(transaction.read_version).await?;
+            &checked_out
+        };
+        let schema = Arc::new(at_read_version.schema().clone());
+        let covered_field_paths = Arc::new(match &transaction.operation {
+            Operation::CreateIndex { new_indices, .. } if needs_read_version_schema => {
+                covered_field_paths_at(at_read_version, new_indices, &schema)
+            }
+            _ => HashMap::new(),
+        });
         match &transaction.operation {
             // These operations add new fragments or don't modify any.
             Operation::Append { .. }
@@ -96,6 +196,8 @@ impl<'a> TransactionRebase<'a> {
                 modified_fragment_ids: HashSet::new(),
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                schema: schema.clone(),
+                covered_field_paths: covered_field_paths.clone(),
             }),
             Operation::Delete {
                 updated_fragments,
@@ -124,6 +226,8 @@ impl<'a> TransactionRebase<'a> {
                         affected_rows: None,
                         conflicting_frag_reuse_indices: Vec::new(),
                         conflicting_mem_wal_compacted_sstables: Vec::new(),
+                        schema: schema.clone(),
+                        covered_field_paths: covered_field_paths.clone(),
                     });
                 }
 
@@ -137,6 +241,8 @@ impl<'a> TransactionRebase<'a> {
                     modified_fragment_ids,
                     conflicting_frag_reuse_indices: Vec::new(),
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
+                    schema: schema.clone(),
+                    covered_field_paths: covered_field_paths.clone(),
                 })
             }
             Operation::Rewrite { groups, .. } => {
@@ -155,6 +261,8 @@ impl<'a> TransactionRebase<'a> {
                     modified_fragment_ids,
                     conflicting_frag_reuse_indices: Vec::new(),
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
+                    schema: schema.clone(),
+                    covered_field_paths: covered_field_paths.clone(),
                 })
             }
             Operation::DataReplacement { replacements } => {
@@ -170,6 +278,8 @@ impl<'a> TransactionRebase<'a> {
                     modified_fragment_ids,
                     conflicting_frag_reuse_indices: Vec::new(),
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
+                    schema: schema.clone(),
+                    covered_field_paths: covered_field_paths.clone(),
                 })
             }
             Operation::DataOverlay { groups } => {
@@ -185,6 +295,8 @@ impl<'a> TransactionRebase<'a> {
                     modified_fragment_ids,
                     conflicting_frag_reuse_indices: Vec::new(),
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
+                    schema: schema.clone(),
+                    covered_field_paths: covered_field_paths.clone(),
                 })
             }
             Operation::Merge { fragments, .. } => {
@@ -199,6 +311,8 @@ impl<'a> TransactionRebase<'a> {
                     modified_fragment_ids,
                     conflicting_frag_reuse_indices: Vec::new(),
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
+                    schema: schema.clone(),
+                    covered_field_paths: covered_field_paths.clone(),
                 })
             }
         }
@@ -617,6 +731,10 @@ impl<'a> TransactionRebase<'a> {
         other_transaction: &Transaction,
         other_version: u64,
     ) -> Result<()> {
+        // Captured before the mutable borrow below so the covered-field checks can expand
+        // covered struct fields to their leaf subtree (an Arc clone is cheap).
+        let schema = self.schema.clone();
+        let covered_field_paths = self.covered_field_paths.clone();
         if let Operation::CreateIndex {
             new_indices,
             removed_indices,
@@ -674,17 +792,106 @@ impl<'a> TransactionRebase<'a> {
                     fields_modified,
                     ..
                 } => {
+                    // Expand covered struct fields to their leaf subtree so a concurrent
+                    // update of a covered struct's child still invalidates the fragment's
+                    // coverage (the schema is captured at the read version above).
                     Transaction::prune_updated_fields_from_indices(
                         new_indices,
                         updated_fragments,
                         fields_modified,
+                        schema.as_ref(),
                     );
                     Ok(())
                 }
-                // Merge, reserve, and project don't change row ids, so this should be fine.
-                Operation::Merge { .. } => Ok(()),
+                // Reserve and project don't change row ids, so this is fine.
+                // Merge is usually fine too, but it can rewrite a column's data file
+                // *in place* (see `prune_merge_rewritten_fields_from_indices`). If that
+                // column is one a racing index *covers* -- i.e. materializes its values
+                // into index storage -- the rebased index would serve stale covered
+                // values, so force a retry and let it rebuild against the merged data.
+                //
+                // Merely *adding* a column (the common `add_columns` case, including a
+                // metadata-only AllNulls add) leaves every covered field's backing file
+                // untouched and cannot make covered data stale, so it keeps the
+                // optimistic path -- otherwise an unrelated `add_columns` would discard
+                // a covered index build that may have been running for hours.
+                //
+                // A Merge can make covered data stale in TWO independent ways, and neither
+                // check subsumes the other -- both must run:
+                //
+                //  (a) it rewrites a covered column's data file in place. The field keeps
+                //      its id and type, so the schema is identical; only the backing file
+                //      changes. Detected with `covered_field_paths`, the read-version
+                //      snapshot captured in `try_new` -- the post-merge fragments alone
+                //      cannot answer it, because a rewrite tombstones the superseded field
+                //      with a sentinel that does not name it. A fragment absent from the
+                //      snapshot did not exist at our read version, so it holds no covered
+                //      data of ours.
+                //
+                //  (b) it changes a covered field's *subtree* -- notably `add_columns`
+                //      growing a covered struct with an AllNulls child, which is
+                //      metadata-only and writes NO data file, so (a) is blind to it. The
+                //      index would then publish storage built for the old struct type
+                //      under the new schema. Detected the same way the `Project` arm below
+                //      does, against the schema the Merge carries.
+                //
+                // Merely *adding an unrelated column* trips neither, and keeps the
+                // optimistic path -- otherwise a routine `add_columns` would discard a
+                // covered index build that may have been running for hours.
+                Operation::Merge {
+                    fragments,
+                    schema: merged_schema,
+                    ..
+                } => {
+                    let rewrote_covered_data = fragments.iter().any(|fragment| {
+                        let Some(previous) = covered_field_paths.get(&fragment.id) else {
+                            return false;
+                        };
+                        let current = Transaction::fragment_field_paths(fragment);
+                        previous.iter().any(|(field_id, previous_path)| {
+                            current
+                                .get(field_id)
+                                .is_some_and(|current_path| *current_path != previous_path.as_str())
+                        })
+                    });
+                    let changed_covered_subtree = new_indices.iter().any(|idx| {
+                        idx.included_fields.iter().any(|id| {
+                            Transaction::covered_field_subtree_changed(&schema, merged_schema, *id)
+                        })
+                    });
+                    if rewrote_covered_data || changed_covered_subtree {
+                        Err(self.retryable_conflict_err(other_transaction, other_version))
+                    } else {
+                        Ok(())
+                    }
+                }
                 Operation::ReserveFragments { .. } => Ok(()),
-                Operation::Project { .. } => Ok(()),
+                Operation::Project {
+                    schema: projected_schema,
+                    ..
+                } => {
+                    // A concurrent Project that changes a covered field's subtree in *any*
+                    // way -- drop, rename, retype, nullability, child change -- leaves the
+                    // rebased index emitting a schema the dataset no longer declares, so
+                    // force a retry and let the index rebuild against the projected schema.
+                    // A rename counts: `covered_field_subtree_changed` compares names, and
+                    // the index's covering payload carries the old one.
+                    // Non-covering indexes, and covered subtrees the Project left alone,
+                    // keep the optimistic path (row ids are unchanged either way).
+                    if new_indices.iter().any(|idx| {
+                        idx.included_fields.iter().any(|id| {
+                            Transaction::covered_field_subtree_changed(
+                                &schema,
+                                projected_schema,
+                                *id,
+                            )
+                        })
+                    }) {
+                        Err(self.retryable_conflict_err(other_transaction, other_version))
+                    } else {
+                        Ok(())
+                    }
+                }
                 // Should be compatible with rewrite if it didn't move the rows
                 // we indexed. If it did, we could retry.
                 // TODO: this will change with stable row ids.
@@ -762,15 +969,19 @@ impl<'a> TransactionRebase<'a> {
                 }
                 Operation::UpdateConfig { .. } => Ok(()),
                 Operation::DataReplacement { replacements } => {
-                    // A data replacement only conflicts if it is updating the field that
-                    // is being indexed.
-                    let newly_indexed_fields = new_indices
-                        .iter()
-                        .flat_map(|idx| idx.fields.iter())
-                        .collect::<HashSet<_>>();
+                    // A data replacement conflicts if it updates a field the index
+                    // either *indexes* or *covers*: a covered field's values are
+                    // materialized in the index storage, so replacing them would
+                    // leave the rebased index serving stale values. Expand each field to
+                    // its leaf subtree, since `included_fields` records a covered struct's
+                    // parent id while a replacement lists leaf ids.
+                    let mut relevant_fields: HashSet<i32> = HashSet::new();
+                    for idx in new_indices.iter() {
+                        relevant_fields.extend(Transaction::index_dependent_leaf_ids(idx, &schema));
+                    }
                     for replacement in replacements {
                         for field in replacement.1.fields.iter() {
-                            if newly_indexed_fields.contains(&field) {
+                            if relevant_fields.contains(field) {
                                 return Err(
                                     self.retryable_conflict_err(other_transaction, other_version)
                                 );
@@ -1082,6 +1293,7 @@ impl<'a> TransactionRebase<'a> {
         other_transaction: &Transaction,
         other_version: u64,
     ) -> Result<()> {
+        let schema = self.schema.clone();
         if let Operation::DataReplacement { replacements } = &self.transaction.operation {
             match &other_transaction.operation {
                 Operation::Append { .. }
@@ -1156,20 +1368,26 @@ impl<'a> TransactionRebase<'a> {
                     Ok(())
                 }
                 Operation::CreateIndex { new_indices, .. } => {
-                    // A data replacement only conflicts if it is updating the field that
-                    // is being indexed.
+                    // A data replacement conflicts if it updates a field the index
+                    // either indexes or *covers* (a covered field's values are
+                    // materialized in the index storage, so replacing them would
+                    // leave the index serving stale values).
                     //
                     // TODO: We could potentially just drop the fragments being replaced from
                     // the index's fragment bitmap, which would lead to fewer conflicts.  However
                     // this would introduce fragment bitmaps with holes which may not be well tested
                     // yet.  For now, we don't allow this case.
-                    let newly_indexed_fields = new_indices
-                        .iter()
-                        .flat_map(|idx| idx.fields.iter())
-                        .collect::<HashSet<_>>();
+                    // Expand covered fields to their leaf subtree so replacing a covered
+                    // struct's subfield (a leaf id, while `included_fields` records the
+                    // parent) is still recognized as touching the index -- matching the
+                    // reverse rebase direction in check_create_index_txn.
+                    let mut relevant_fields: HashSet<i32> = HashSet::new();
+                    for idx in new_indices.iter() {
+                        relevant_fields.extend(Transaction::index_dependent_leaf_ids(idx, &schema));
+                    }
                     for replacement in replacements {
                         for field in replacement.1.fields.iter() {
-                            if newly_indexed_fields.contains(&field) {
+                            if relevant_fields.contains(field) {
                                 return Err(
                                     self.retryable_conflict_err(other_transaction, other_version)
                                 );
@@ -2218,6 +2436,14 @@ mod tests {
     };
     use lance_table::format::DataFile;
 
+    /// An empty schema for manually-constructed rebases in tests: covered-field subtree
+    /// expansion is a no-op against it (each id maps to itself), preserving the exact-id
+    /// behavior these tests assert. Tests that exercise covered structs build the rebase
+    /// via `try_new`, which captures the real dataset schema.
+    fn empty_lance_schema() -> Arc<lance_core::datatypes::Schema> {
+        Arc::new(lance_core::datatypes::Schema::default())
+    }
+
     async fn test_dataset(num_rows: usize, num_fragments: usize) -> Dataset {
         let write_params = WriteParams {
             max_rows_per_file: num_rows / num_fragments,
@@ -2362,6 +2588,276 @@ mod tests {
         let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
         assert_io_eq!(io_stats, write_iops, 0);
+    }
+
+    /// A concurrent Project that drops a column an in-flight index *covers* must force
+    /// the index build to rebase (retryable conflict); a Project that preserves the
+    /// covered column stays on the optimistic path.
+    #[tokio::test]
+    async fn test_create_index_conflicts_with_project_dropping_covered_field() {
+        use roaring::RoaringBitmap;
+
+        let dataset = test_dataset(10, 2).await;
+        let a_id = dataset.schema().field("a").unwrap().id;
+        let b_id = dataset.schema().field("b").unwrap().id;
+
+        // A covering index over key "a" that also covers "b".
+        let covering_index = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "cov_idx".to_string(),
+            fields: vec![a_id],
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([0u32, 1])),
+            index_details: Some(Arc::new(prost_types::Any {
+                type_url: "type.googleapis.com/lance.index.VectorIndexDetails".to_string(),
+                value: vec![],
+            })),
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: vec![b_id],
+        };
+        let self_txn = Transaction::new_from_version(
+            1,
+            Operation::CreateIndex {
+                new_indices: vec![covering_index],
+                removed_indices: vec![],
+            },
+        );
+
+        // Concurrent Project that drops "b" (the covered column) -> conflict.
+        let dropped_schema = dataset.schema().project(&["a"]).unwrap();
+        let drop_txn = Transaction::new_from_version(
+            2,
+            Operation::Project {
+                schema: dropped_schema,
+                preserves_nullability: true,
+            },
+        );
+        let mut rebase = TransactionRebase::try_new(&dataset, self_txn.clone(), None)
+            .await
+            .unwrap();
+        assert!(
+            rebase.check_txn(&drop_txn, 2).is_err(),
+            "dropping a covered column must conflict with an in-flight covering index build"
+        );
+
+        // A Project that preserves "b" -> no conflict.
+        let keep_txn = Transaction::new_from_version(
+            2,
+            Operation::Project {
+                schema: dataset.schema().clone(),
+                preserves_nullability: true,
+            },
+        );
+        let mut rebase = TransactionRebase::try_new(&dataset, self_txn.clone(), None)
+            .await
+            .unwrap();
+        assert!(
+            rebase.check_txn(&keep_txn, 2).is_ok(),
+            "a project that preserves the covered column must not conflict"
+        );
+
+        // A Project that renames the covered column (id stays, name changes) -> conflict:
+        // the built index still emits the old name.
+        let mut renamed_schema = dataset.schema().clone();
+        renamed_schema.field_by_id_mut(b_id).unwrap().name = "b_renamed".to_string();
+        let rename_txn = Transaction::new_from_version(
+            2,
+            Operation::Project {
+                schema: renamed_schema,
+                preserves_nullability: true,
+            },
+        );
+        let mut rebase = TransactionRebase::try_new(&dataset, self_txn, None)
+            .await
+            .unwrap();
+        assert!(
+            rebase.check_txn(&rename_txn, 2).is_err(),
+            "renaming a covered column must conflict with an in-flight covering index build"
+        );
+    }
+
+    /// A concurrent DataReplacement of a *child* of a covered struct must conflict with
+    /// an in-flight covering index build: `included_fields` records the struct's parent
+    /// id, but the replacement lists the leaf id, so the check must expand the subtree.
+    #[tokio::test]
+    async fn test_create_index_conflicts_with_replacement_of_covered_struct_child() {
+        use arrow_schema::{
+            DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
+        };
+        use roaring::RoaringBitmap;
+
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new("vec", DataType::Int32, false),
+            ArrowField::new(
+                "s",
+                DataType::Struct(ArrowFields::from(vec![
+                    ArrowField::new("a", DataType::Int32, true),
+                    ArrowField::new("b", DataType::Int32, true),
+                ])),
+                true,
+            ),
+        ]);
+        let schema = lance_core::datatypes::Schema::try_from(&arrow).unwrap();
+        let vec_id = schema.field("vec").unwrap().id;
+        let s_id = schema.field("s").unwrap().id;
+        let a_id = schema.field("s.a").unwrap().id;
+
+        // Index keyed on `vec`, covering the whole struct `s`.
+        let covering_index = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "cov_idx".to_string(),
+            fields: vec![vec_id],
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([0u32])),
+            index_details: Some(Arc::new(prost_types::Any {
+                type_url: "type.googleapis.com/lance.index.VectorIndexDetails".to_string(),
+                value: vec![],
+            })),
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: vec![s_id],
+        };
+        let self_txn = Transaction::new_from_version(
+            1,
+            Operation::CreateIndex {
+                new_indices: vec![covering_index],
+                removed_indices: vec![],
+            },
+        );
+
+        // try_new needs a real dataset, so build the rebase directly with the struct schema.
+        let mut rebase = TransactionRebase {
+            transaction: self_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: HashSet::new(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: Arc::new(schema),
+        };
+
+        // A concurrent DataReplacement rewriting the covered struct's child `s.a`.
+        let replace_child = Transaction::new_from_version(
+            2,
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(
+                    0,
+                    DataFile::new_legacy_from_fields("child.lance", vec![a_id], None),
+                )],
+            },
+        );
+        assert!(
+            rebase.check_txn(&replace_child, 2).is_err(),
+            "replacing a child of a covered struct must conflict (subtree expansion)"
+        );
+    }
+
+    /// A concurrent `add_columns` (which commits as `Operation::Merge`) that grows a
+    /// covered struct with an AllNulls child writes **no data file**, so the covered-file
+    /// path comparison cannot see it. The index would otherwise commit storage built for
+    /// the old struct type under the new schema, and every covered query on it would fail.
+    /// The Merge arm must therefore also compare the covered subtree, as the Project arm
+    /// does -- the two checks are complementary and neither subsumes the other.
+    #[tokio::test]
+    async fn test_create_index_conflicts_with_merge_growing_covered_struct() {
+        use arrow_schema::{
+            DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
+        };
+        use roaring::RoaringBitmap;
+
+        let struct_of = |children: Vec<ArrowField>| {
+            ArrowSchema::new(vec![
+                ArrowField::new("vec", DataType::Int32, false),
+                ArrowField::new("s", DataType::Struct(ArrowFields::from(children)), true),
+            ])
+        };
+        let before = lance_core::datatypes::Schema::try_from(&struct_of(vec![ArrowField::new(
+            "a",
+            DataType::Int32,
+            true,
+        )]))
+        .unwrap();
+        // The AllNulls child add keeps every existing id and gives the new leaf a fresh one.
+        let after = lance_core::datatypes::Schema::try_from(&struct_of(vec![
+            ArrowField::new("a", DataType::Int32, true),
+            ArrowField::new("b", DataType::Int32, true),
+        ]))
+        .unwrap();
+        let vec_id = before.field("vec").unwrap().id;
+        let s_id = before.field("s").unwrap().id;
+        assert_eq!(
+            s_id,
+            after.field("s").unwrap().id,
+            "the struct keeps its id"
+        );
+
+        let covering_index = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "cov_idx".to_string(),
+            fields: vec![vec_id],
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([0u32])),
+            index_details: Some(Arc::new(prost_types::Any {
+                type_url: "type.googleapis.com/lance.index.VectorIndexDetails".to_string(),
+                value: vec![],
+            })),
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: vec![s_id],
+        };
+        let create = |index: IndexMetadata| {
+            Transaction::new_from_version(
+                1,
+                Operation::CreateIndex {
+                    new_indices: vec![index],
+                    removed_indices: vec![],
+                },
+            )
+        };
+        let rebase_over = |index: IndexMetadata| TransactionRebase {
+            transaction: create(index),
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: HashSet::new(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_compacted_sstables: Vec::new(),
+            // Empty: the conflict must come from the schema comparison alone, not from
+            // any data-file path change.
+            covered_field_paths: Default::default(),
+            schema: Arc::new(before.clone()),
+        };
+        let merge_with = |schema: lance_core::datatypes::Schema| {
+            Transaction::new_from_version(
+                1,
+                Operation::Merge {
+                    fragments: vec![],
+                    schema,
+                    preserves_nullability: true,
+                },
+            )
+        };
+
+        let mut rebase = rebase_over(covering_index.clone());
+        assert!(
+            rebase.check_txn(&merge_with(after), 2).is_err(),
+            "a Merge that grows a covered struct's subtree must conflict"
+        );
+
+        // Control: a Merge that leaves the covered subtree alone keeps the optimistic
+        // path, so an ordinary add_columns still does not discard a covered build.
+        let mut rebase = rebase_over(covering_index);
+        assert!(
+            rebase.check_txn(&merge_with(before), 2).is_ok(),
+            "a Merge that does not touch the covered subtree must not conflict"
+        );
     }
 
     async fn apply_deletion(
@@ -3157,6 +3653,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
 
             for (other, expected_conflict) in other_transactions.iter().zip(expected_conflicts) {
@@ -3362,6 +3860,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
             let other_txn = Transaction::new(0, other.clone(), None);
             let result = rebase.check_txn(&other_txn, 1);
@@ -3421,6 +3921,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
             let other_txn = Transaction::new(0, other.clone(), None);
             let result = rebase.check_txn(&other_txn, 1);
@@ -3533,6 +4035,8 @@ mod tests {
                 affected_rows: affected_rows.as_ref(),
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
             let other_txn = Transaction::new(0, other.clone(), None);
             let result = rebase.check_txn(&other_txn, 1);
@@ -3575,6 +4079,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: Arc::new(lance_core::datatypes::Schema::default()),
             };
             let result = append_rebase.check_txn(&Transaction::new(0, merge.clone(), None), 1);
             assert_eq!(
@@ -3590,6 +4096,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: Arc::new(lance_core::datatypes::Schema::default()),
             };
             let result = merge_rebase.check_txn(&Transaction::new(0, append, None), 1);
             assert!(
@@ -3666,6 +4174,8 @@ mod tests {
                         affected_rows: None,
                         conflicting_frag_reuse_indices: Vec::new(),
                         conflicting_mem_wal_compacted_sstables: Vec::new(),
+                        covered_field_paths: Default::default(),
+                        schema: Arc::new(lance_core::datatypes::Schema::default()),
                     };
                     let result = rebase.check_txn(&Transaction::new(0, theirs, None), 1);
                     assert_eq!(
@@ -3800,6 +4310,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
         let update = Transaction::new(
             1,
@@ -3864,6 +4376,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let same_name = Transaction::new(
@@ -3919,6 +4433,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
         let different_name_result = rebase.check_txn(&different_name, 1);
         assert!(
@@ -3987,6 +4503,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
             let result = rebase.check_txn(&rewrite, 2);
             if expect_conflict {
@@ -4334,6 +4852,119 @@ mod tests {
         assert!(rebase.check_txn(&txn2, 2).is_ok());
     }
 
+    /// A covering-index build must treat its *covered* fields as dependencies during
+    /// conflict resolution: a concurrent write to a covered field would leave the
+    /// rebased index serving stale materialized values.
+    #[tokio::test]
+    async fn test_create_covering_index_conflicts_with_writes_to_covered_field() {
+        let dataset = test_dataset(10, 2).await; // fields: 0 = "a", 1 = "b"
+
+        let make_index = |name: &str, included_fields: Vec<i32>| IndexMetadata {
+            uuid: Uuid::new_v4(),
+            fields: vec![0],
+            name: name.to_string(),
+            dataset_version: 1,
+            fragment_bitmap: Some([0, 1].into_iter().collect()),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields,
+        };
+        let create = |idx: IndexMetadata| {
+            Transaction::new_from_version(
+                1,
+                Operation::CreateIndex {
+                    new_indices: vec![idx],
+                    removed_indices: vec![],
+                },
+            )
+        };
+        let replace_field1 = || {
+            Transaction::new_from_version(
+                1,
+                Operation::DataReplacement {
+                    replacements: vec![DataReplacementGroup(
+                        0,
+                        DataFile::new_legacy_from_fields("replace.lance", vec![1], None),
+                    )],
+                },
+            )
+        };
+        // `fragment_field_paths` reads the last live file listing a field, which is how an
+        // in-place rewrite presents itself (the rewrite adds a file for the field and
+        // tombstones the old entry, and tombstones are skipped). So appending a file that
+        // carries `field` models a rewrite of it, and one carrying a brand-new id models
+        // `add_columns`.
+        let merge_appending_file_for = |field: i32, path: &str| {
+            let mut fragments = dataset.fragments().as_ref().clone();
+            for fragment in fragments.iter_mut() {
+                fragment
+                    .files
+                    .push(DataFile::new_legacy_from_fields(path, vec![field], None));
+            }
+            Transaction::new_from_version(
+                1,
+                Operation::Merge {
+                    fragments,
+                    schema: dataset.schema().clone(),
+                    preserves_nullability: true,
+                },
+            )
+        };
+        let merge_rewriting_covered = || merge_appending_file_for(1, "rewritten.lance");
+        let merge_adding_column = || merge_appending_file_for(2, "added.lance");
+
+        // Covering index (covers field 1): a replacement of field 1 conflicts...
+        let mut rebase =
+            TransactionRebase::try_new(&dataset, create(make_index("covering", vec![1])), None)
+                .await
+                .unwrap();
+        assert!(
+            rebase.check_txn(&replace_field1(), 2).is_err(),
+            "covering-index build must conflict with a data replacement of its covered field"
+        );
+        // ...and so does a merge that rewrites the covered column's data file in place.
+        let mut rebase =
+            TransactionRebase::try_new(&dataset, create(make_index("covering", vec![1])), None)
+                .await
+                .unwrap();
+        assert!(
+            rebase.check_txn(&merge_rewriting_covered(), 2).is_err(),
+            "covering-index build must conflict with a merge that rewrites its covered field"
+        );
+        // But a merge that only ADDS a column leaves the covered field's data untouched,
+        // so it must NOT discard the (potentially hours-long) covered index build.
+        let mut rebase =
+            TransactionRebase::try_new(&dataset, create(make_index("covering", vec![1])), None)
+                .await
+                .unwrap();
+        assert!(
+            rebase.check_txn(&merge_adding_column(), 2).is_ok(),
+            "covering-index build must not conflict with an add_columns that leaves covered data alone"
+        );
+
+        // Control: a plain index (no covered fields) keeps the optimistic path for
+        // both a merge and a replacement of the un-indexed field 1.
+        let mut rebase =
+            TransactionRebase::try_new(&dataset, create(make_index("plain", vec![])), None)
+                .await
+                .unwrap();
+        assert!(
+            rebase.check_txn(&merge_rewriting_covered(), 2).is_ok(),
+            "non-covering index build should keep the optimistic merge path"
+        );
+        let mut rebase =
+            TransactionRebase::try_new(&dataset, create(make_index("plain", vec![])), None)
+                .await
+                .unwrap();
+        assert!(
+            rebase.check_txn(&replace_field1(), 2).is_ok(),
+            "non-covering index build should not conflict with a replacement of an un-indexed field"
+        );
+    }
+
     /// Returns the IDs of fragments that have been modified by this operation.
     ///
     /// This does not include new fragments.
@@ -4633,6 +5264,8 @@ mod tests {
                 affected_rows: None,
                 conflicting_frag_reuse_indices: Vec::new(),
                 conflicting_mem_wal_compacted_sstables: Vec::new(),
+                covered_field_paths: Default::default(),
+                schema: empty_lance_schema(),
             };
 
             let result = rebase.check_txn(&txn2, 1);
@@ -4698,6 +5331,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result = rebase.check_txn(&committed_txn, 1);
@@ -4738,6 +5373,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result = rebase.check_txn(&committed_txn, 1);
@@ -4779,6 +5416,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result = rebase.check_txn(&committed_txn, 1);
@@ -4820,6 +5459,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result = rebase.check_txn(&committed_txn, 1);
@@ -4871,6 +5512,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result = rebase.check_txn(&committed_txn, 1);
@@ -4897,6 +5540,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         let result_higher = rebase_higher.check_txn(&committed_txn, 1);
@@ -4944,6 +5589,8 @@ mod tests {
             affected_rows: None,
             conflicting_frag_reuse_indices: Vec::new(),
             conflicting_mem_wal_compacted_sstables: Vec::new(),
+            covered_field_paths: Default::default(),
+            schema: empty_lance_schema(),
         };
 
         // CreateIndex of MemWalIndex should be compatible with UpdateMemWalState

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -2707,6 +2707,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let fragment0 = Fragment::new(0);
         let fragment1 = Fragment::new(1);
@@ -3783,6 +3784,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let mut rebase = TransactionRebase {
             transaction: Transaction::new(
@@ -3839,6 +3841,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let index1 = IndexMetadata {
             uuid: uuid::Uuid::new_v4(),
@@ -3905,6 +3908,7 @@ mod tests {
                         created_at: None,
                         base_id: None,
                         files: None,
+                        included_fields: Vec::new(),
                     }],
                     removed_indices: vec![],
                 },
@@ -3940,6 +3944,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let frag_reuse_index = IndexMetadata {
             uuid: Uuid::new_v4(),
@@ -3952,6 +3957,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let rewrite = Transaction::new(
             1,

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -62,7 +62,7 @@ use uuid::Uuid;
 
 use lance_select::RowAddrMask;
 
-use crate::dataset::Dataset;
+use crate::dataset::{Dataset, ProjectionRequest, TakeBuilder};
 use crate::index::DatasetIndexInternalExt;
 use crate::index::prefilter::{DatasetPreFilter, FilterLoader};
 use crate::index::vector::utils::{get_vector_type, validate_distance_type_for};
@@ -1389,6 +1389,10 @@ pub struct ANNIvfSubIndexExec {
     /// index results at execution time via [`DatasetPreFilter::with_overlay_block`].
     overlay_block: Option<RowAddrMask>,
 
+    /// Output schema: `[_distance, _rowid]` plus any included/covering columns
+    /// the index emits.
+    output_schema: SchemaRef,
+
     /// Datafusion Plan Properties
     properties: Arc<PlanProperties>,
 
@@ -1409,8 +1413,45 @@ impl ANNIvfSubIndexExec {
                 PART_ID_COLUMN
             )));
         }
+        // Declare any included/covering columns recorded in the index manifest
+        // (`IndexMetadata.included_fields`, by field id); the per-partition search
+        // emits them so a covered projection lets TakeExec skip the base-table
+        // fetch. Empty for ordinary indexes. Resolve id -> name -> arrow field so
+        // the declared schema matches the columns stored at build time exactly.
+        let mut fields = KNN_INDEX_SCHEMA.fields().to_vec();
+        let included_ids = indices
+            .first()
+            .map(|idx| idx.included_fields.clone())
+            .unwrap_or_default();
+        if !included_ids.is_empty() {
+            let lance_schema = dataset.schema();
+            for id in &included_ids {
+                // The manifest is authoritative: a declared covering field that cannot
+                // be resolved means the index metadata and schema disagree. Silently
+                // dropping it would leave the declared output schema missing a column a
+                // covered projection expects -- TakeExec would then wrongly elide the
+                // base-table fetch for a column that is never emitted. Fail loudly
+                // instead (a covered column cannot be dropped while its index exists).
+                let lance_field = lance_schema
+                    .fields
+                    .iter()
+                    .find(|field| field.id == *id)
+                    .ok_or_else(|| {
+                        Error::index(format!(
+                            "ANNIvfSubIndexExec: index declares covering field id {id}, which is \
+                             not present as a top-level field in the current dataset schema; \
+                             index metadata and schema are inconsistent"
+                        ))
+                    })?;
+                // Convert just this field. `ArrowSchema::from(&lance_schema)` would give the
+                // same result -- it is exactly this conversion mapped over every field -- but
+                // it walks the whole table (including nested structs) on every covered plan.
+                fields.push(Arc::new(arrow_schema::Field::from(lance_field)));
+            }
+        }
+        let output_schema = Arc::new(arrow_schema::Schema::new(fields));
         let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
+            EquivalenceProperties::new(output_schema.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -1422,6 +1463,7 @@ impl ANNIvfSubIndexExec {
             query,
             prefilter_source,
             overlay_block: None,
+            output_schema,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
         })
@@ -1493,6 +1535,12 @@ struct ANNIvfEarlySearchResults {
     deltas_remaining: AtomicUsize,
     all_deltas_done: Notify,
     took_no_rows_shortcut: AtomicBool,
+    /// Set when a covered delta's late search reaches the no-rows shortcut. The
+    /// exec-level covered recovery emits ONLY when this is armed, so covered result
+    /// sets stay identical to non-covered ones: when every partition was already
+    /// searched (`maximum_nprobes <= minimum_nprobes`) the non-covered path returns
+    /// nothing for prefilter rows without index entries, and covered must match.
+    covered_recovery_armed: AtomicBool,
 }
 
 impl ANNIvfEarlySearchResults {
@@ -1504,6 +1552,7 @@ impl ANNIvfEarlySearchResults {
             deltas_remaining: AtomicUsize::new(deltas_remaining),
             all_deltas_done: Notify::new(),
             took_no_rows_shortcut: AtomicBool::new(false),
+            covered_recovery_armed: AtomicBool::new(false),
         }
     }
 
@@ -1634,6 +1683,7 @@ impl ANNIvfSubIndexExec {
         metrics: Arc<AnnIndexMetrics>,
         state: Arc<ANNIvfEarlySearchResults>,
         target_partitions: usize,
+        has_covered: bool,
     ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
         let stream = futures::stream::once(async move {
             let max_nprobes = query
@@ -1667,6 +1717,21 @@ impl ANNIvfSubIndexExec {
             {
                 // In this case there are fewer than k results matching the prefilter so
                 // just return the prefilter ids and don't bother searching any further
+
+                // The shortcut batch emits only [_distance, _rowid]; a covering
+                // index's declared schema carries more columns, and their values
+                // cannot be fabricated here. Emit nothing instead: the
+                // end-of-stream covered recovery (`covered_not_found_batch`)
+                // returns every unemitted prefilter row with INFINITY distance
+                // and its covering columns via a take bounded by the prefilter
+                // size -- mirroring the non-covered shortcut's semantics without
+                // searching (a prefilter row with no index entry, e.g. a null
+                // vector, could otherwise never be found and would drive the
+                // search through every partition).
+                if has_covered {
+                    state.covered_recovery_armed.store(true, Ordering::Relaxed);
+                    return futures::stream::empty().boxed();
+                }
 
                 // This next if check should be true, because we wouldn't get max_results otherwise
                 if let Some(iter_addrs) = prefilter_mask.iter_addrs() {
@@ -1849,6 +1914,81 @@ impl ANNIvfSubIndexExec {
             .buffered(query_parallelism)
             .boxed()
     }
+
+    /// Recover rows that match a bounded, selective prefilter but have no index entry
+    /// (their vector is null or an empty multivector), which the covered search never
+    /// returns. The non-covered path recovers them via its not-found shortcut with
+    /// `INFINITY` distance; a covered index must do the same but also supply the covering
+    /// columns, which it fetches from the base table for these few missing rows. Returns
+    /// `None` when there is nothing to recover (non-covered, unbounded/non-selective
+    /// prefilter, or every prefilter row was already emitted).
+    async fn covered_not_found_batch(
+        has_covered: bool,
+        prefilter: Arc<DatasetPreFilter>,
+        dataset: Arc<Dataset>,
+        output_schema: SchemaRef,
+        k: usize,
+        emitted: Arc<std::sync::Mutex<roaring::RoaringTreemap>>,
+    ) -> DataFusionResult<Option<RecordBatch>> {
+        if !has_covered {
+            return Ok(None);
+        }
+        prefilter
+            .wait_for_ready()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("prefilter not ready: {e}")))?;
+        let mask = prefilter.mask();
+        // Only a bounded, selective prefilter (at most k allowed rows) guarantees every
+        // matching row belongs in the result; an unbounded prefilter has no not-found set.
+        let Some(max_len) = mask.max_len() else {
+            return Ok(None);
+        };
+        if max_len as usize > k {
+            return Ok(None);
+        }
+        let Some(addrs) = mask.iter_addrs() else {
+            return Ok(None);
+        };
+        let not_found: Vec<u64> = {
+            let emitted = emitted.lock().unwrap();
+            addrs
+                .map(u64::from)
+                .filter(|addr| !emitted.contains(*addr))
+                .collect()
+        };
+        if not_found.is_empty() {
+            return Ok(None);
+        }
+
+        // Fetch the covering columns (the fields after `[_distance, _rowid]`) from the
+        // base table for the missing rows; the take is bounded by `not_found.len()`.
+        let covered_names: Vec<String> = output_schema
+            .fields()
+            .iter()
+            .skip(2)
+            .map(|field| field.name().clone())
+            .collect();
+        let projection = ProjectionRequest::from_columns(covered_names, dataset.schema());
+        // `not_found` holds row ids (the `_rowid` space): stable logical ids on a
+        // stable-row-id dataset, physical addresses otherwise. `try_new_from_ids`
+        // resolves them through the row-id index when one exists and falls back to
+        // identity (id == address) when it does not, so it is correct in both cases --
+        // unlike `try_new_from_addresses`, which would misread a stable id as
+        // `frag = id >> 32, offset = id` and take the wrong physical row (or error).
+        let covered = TakeBuilder::try_new_from_ids(dataset, not_found.clone(), projection)?
+            .execute()
+            .await?;
+
+        let n = not_found.len();
+        let mut columns: Vec<ArrayRef> = vec![
+            Arc::new(Float32Array::from_value(f32::INFINITY, n)),
+            Arc::new(UInt64Array::from(not_found)),
+        ];
+        columns.extend(covered.columns().iter().cloned());
+        let batch = RecordBatch::try_new(output_schema, columns)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        Ok(Some(batch))
+    }
 }
 
 impl ExecutionPlan for ANNIvfSubIndexExec {
@@ -1857,7 +1997,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
     }
 
     fn schema(&self) -> arrow_schema::SchemaRef {
-        KNN_INDEX_SCHEMA.clone()
+        self.output_schema.clone()
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -1903,6 +2043,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 query: self.query.clone(),
                 prefilter_source,
                 overlay_block: self.overlay_block.clone(),
+                output_schema: self.output_schema.clone(),
                 properties: self.properties.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
             }
@@ -1921,6 +2062,10 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
     ) -> DataFusionResult<datafusion::physical_plan::SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context.clone())?;
         let schema = self.schema();
+        // When the index emits covering columns, the output schema is wider than
+        // [_distance, _rowid]; the late-search no-rows shortcut emits only those
+        // two columns, so disable it here and let the full search emit covering.
+        let has_covered = schema.fields().len() > KNN_INDEX_SCHEMA.fields().len();
         let target_partitions = context.session_config().target_partitions();
         let query = self.query.clone();
         let ds = self.dataset.clone();
@@ -1993,6 +2138,22 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
 
         let state = Arc::new(ANNIvfEarlySearchResults::new(indices.len(), query.k));
 
+        // Covered null-vector recovery: track which row ids the search emits, then after
+        // it finishes emit any prefilter-matched rows that had no index entry, with their
+        // covering columns taken from the base table (see `covered_not_found_batch`).
+        // Tracking is skipped when recovery provably cannot emit anything: without a
+        // prefilter source there is no allow-list, so `covered_not_found_batch` always
+        // returns `None` -- the per-batch lock and inserts would be pure overhead on
+        // the covered hot path.
+        let track_emitted = has_covered && !matches!(self.prefilter_source, PreFilterSource::None);
+        let emitted_row_ids = Arc::new(std::sync::Mutex::new(roaring::RoaringTreemap::new()));
+        let emitted_for_inspect = emitted_row_ids.clone();
+        let recon_prefilter = pre_filter.clone();
+        let recon_state = state.clone();
+        let recon_ds = ds.clone();
+        let recon_schema = schema.clone();
+        let recon_k = query.k;
+
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
             per_index_stream
@@ -2030,6 +2191,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                             metrics,
                             state,
                             target_partitions,
+                            has_covered,
                         );
                         DataFusionResult::Ok(early_search.chain(late_search).boxed())
                     }
@@ -2038,6 +2200,36 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 // Each delta stream is split into an early and late search.  The late search
                 // will not start until the early search is complete across all deltas.
                 .try_flatten_unordered(None)
+                .inspect_ok(move |batch| {
+                    // Record emitted row ids so the reconciliation below can find the
+                    // prefilter rows the search never returned (no index entry).
+                    if track_emitted && let Some(col) = batch.column_by_name(ROW_ID) {
+                        emitted_for_inspect
+                            .lock()
+                            .unwrap()
+                            .extend(col.as_primitive::<UInt64Type>().values().iter().copied());
+                    }
+                })
+                .chain(
+                    stream::once(async move {
+                        // Only recover when a covered late search actually took the
+                        // no-rows shortcut; otherwise the non-covered path would not
+                        // have emitted these rows either, and covered must match.
+                        if !recon_state.covered_recovery_armed.load(Ordering::Relaxed) {
+                            return Ok(None);
+                        }
+                        Self::covered_not_found_batch(
+                            has_covered,
+                            recon_prefilter,
+                            recon_ds,
+                            recon_schema,
+                            recon_k,
+                            emitted_row_ids,
+                        )
+                        .await
+                    })
+                    .try_filter_map(|opt| future::ready(Ok(opt))),
+                )
                 .finally(move || {
                     // Publish the exact index-file I/O measured for this query
                     // (cache misses only) to the iops/requests/bytes_read gauges.
@@ -2113,13 +2305,24 @@ pub struct MultivectorScoringExec {
     // the inputs are sorted ANN search results
     inputs: Vec<Arc<dyn ExecutionPlan>>,
     query: Query,
+    /// Output schema: `[_distance, _rowid]` plus any covering columns the ANN children
+    /// emit. The covered payload is per source row (replicated across its sub-vectors),
+    /// so it is carried through the per-row-id reduction below.
+    output_schema: SchemaRef,
     properties: Arc<PlanProperties>,
 }
 
 impl MultivectorScoringExec {
     pub fn try_new(inputs: Vec<Arc<dyn ExecutionPlan>>, query: Query) -> Result<Self> {
+        // Inherit the children's schema so covering columns flow through scoring instead
+        // of being dropped (a covered multivector query would otherwise still take from
+        // the base table).
+        let output_schema = inputs
+            .first()
+            .map(|input| input.schema())
+            .unwrap_or_else(|| KNN_INDEX_SCHEMA.clone());
         let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
+            EquivalenceProperties::new(output_schema.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -2128,6 +2331,7 @@ impl MultivectorScoringExec {
         Ok(Self {
             inputs,
             query,
+            output_schema,
             properties,
         })
     }
@@ -2152,7 +2356,7 @@ impl ExecutionPlan for MultivectorScoringExec {
     }
 
     fn schema(&self) -> arrow_schema::SchemaRef {
-        KNN_INDEX_SCHEMA.clone()
+        self.output_schema.clone()
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -2187,11 +2391,18 @@ impl ExecutionPlan for MultivectorScoringExec {
             .map(|input| input.execute(partition, context.clone()))
             .collect::<DataFusionResult<Vec<_>>>()?;
 
+        // Covering columns (if any) follow `[_distance, _rowid]` in the child schema.
+        // They are per source row -- identical across a row's sub-vectors -- so we carry
+        // them through the per-row-id reduction and re-attach one copy per output row.
+        let output_schema = self.output_schema.clone();
+        let n_covered = output_schema.fields().len().saturating_sub(2);
+
         // collect the top k results from each stream,
         // and max-reduce for each query,
         // records the minimum distance for each query as estimation.
         let mut reduced_inputs = stream::select_all(inputs.into_iter().map(|stream| {
-            stream.map(|batch| {
+            let output_schema = output_schema.clone();
+            stream.map(move |batch| {
                 let batch = batch?;
                 let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
                 let dists = batch[DIST_COL].as_primitive::<Float32Type>();
@@ -2205,9 +2416,15 @@ impl ExecutionPlan for MultivectorScoringExec {
                     .unwrap_or_default();
                 let mut new_row_ids = Vec::with_capacity(row_ids.len());
                 let mut new_sims = Vec::with_capacity(row_ids.len());
+                let mut keep_indices: Vec<u32> = Vec::with_capacity(row_ids.len());
                 let mut visited_row_ids = HashSet::with_capacity(row_ids.len());
 
-                for (row_id, dist) in row_ids.values().iter().zip(dists.values().iter()) {
+                for (i, (row_id, dist)) in row_ids
+                    .values()
+                    .iter()
+                    .zip(dists.values().iter())
+                    .enumerate()
+                {
                     // the results are sorted by distance, so we can skip if we have seen this row id before
                     if visited_row_ids.contains(row_id) {
                         continue;
@@ -2216,14 +2433,20 @@ impl ExecutionPlan for MultivectorScoringExec {
                     new_row_ids.push(*row_id);
                     // it's cosine distance, so we need to convert it to similarity
                     new_sims.push(1.0 - *dist);
+                    keep_indices.push(i as u32);
                 }
-                let new_row_ids = UInt64Array::from(new_row_ids);
-                let new_dists = Float32Array::from(new_sims);
 
-                let batch = RecordBatch::try_new(
-                    KNN_INDEX_SCHEMA.clone(),
-                    vec![Arc::new(new_dists), Arc::new(new_row_ids)],
-                )?;
+                let mut columns: Vec<ArrayRef> = vec![
+                    Arc::new(Float32Array::from(new_sims)),
+                    Arc::new(UInt64Array::from(new_row_ids)),
+                ];
+                if n_covered > 0 {
+                    let keep = arrow_array::UInt32Array::from(keep_indices);
+                    for covered_col in batch.columns().iter().skip(2) {
+                        columns.push(arrow::compute::take(covered_col, &keep, None)?);
+                    }
+                }
+                let batch = RecordBatch::try_new(output_schema.clone(), columns)?;
 
                 Ok::<_, DataFusionError>((min_sim, batch))
             })
@@ -2235,10 +2458,27 @@ impl ExecutionPlan for MultivectorScoringExec {
         let stream = stream::once(async move {
             // at most, we will have k * refine_factor results for each query
             let mut results = HashMap::with_capacity(k * refactor);
+            // row id -> its covering-column cells (recorded once, first seen).
+            let mut payloads: HashMap<u64, Vec<datafusion::scalar::ScalarValue>> = HashMap::new();
             let mut missed_sim_sum = 0.0;
             while let Some((min_sim, batch)) = reduced_inputs.try_next().await? {
                 let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
                 let sims = batch[DIST_COL].as_primitive::<Float32Type>();
+
+                if n_covered > 0 {
+                    for (i, row_id) in row_ids.values().iter().enumerate() {
+                        if !payloads.contains_key(row_id) {
+                            let mut cells = Vec::with_capacity(n_covered);
+                            for covered_col in batch.columns().iter().skip(2) {
+                                cells.push(datafusion::scalar::ScalarValue::try_from_array(
+                                    covered_col,
+                                    i,
+                                )?);
+                            }
+                            payloads.insert(*row_id, cells);
+                        }
+                    }
+                }
 
                 let query_results = row_ids
                     .values()
@@ -2265,18 +2505,32 @@ impl ExecutionPlan for MultivectorScoringExec {
                 missed_sim_sum += min_sim;
             }
 
-            let (row_ids, sims): (Vec<_>, Vec<_>) = results.into_iter().unzip();
+            let (row_ids, sims): (Vec<u64>, Vec<f32>) = results.into_iter().unzip();
             let dists = sims
-                .into_iter()
+                .iter()
                 // it's similarity, so we need to convert it back to distance
                 .map(|sim| num_queries - sim)
                 .collect::<Vec<_>>();
-            let row_ids = UInt64Array::from(row_ids);
-            let dists = Float32Array::from(dists);
-            let batch = RecordBatch::try_new(
-                KNN_INDEX_SCHEMA.clone(),
-                vec![Arc::new(dists), Arc::new(row_ids)],
-            )?;
+            let mut columns: Vec<ArrayRef> = vec![
+                Arc::new(Float32Array::from(dists)),
+                Arc::new(UInt64Array::from(row_ids.clone())),
+            ];
+            for covered_pos in 0..n_covered {
+                let field = output_schema.field(2 + covered_pos);
+                let array = if row_ids.is_empty() {
+                    arrow::array::new_empty_array(field.data_type())
+                } else {
+                    let cells = row_ids.iter().map(|row_id| {
+                        payloads
+                            .get(row_id)
+                            .map(|cells| cells[covered_pos].clone())
+                            .unwrap_or(datafusion::scalar::ScalarValue::Null)
+                    });
+                    datafusion::scalar::ScalarValue::iter_to_array(cells)?
+                };
+                columns.push(array);
+            }
+            let batch = RecordBatch::try_new(output_schema.clone(), columns)?;
             Ok::<_, DataFusionError>(batch)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -2351,6 +2605,68 @@ mod tests {
             dist_q_c: 0.0,
             approx_mode: Default::default(),
         }
+    }
+
+    /// The read path is manifest-authoritative: if an index declares a covering field id
+    /// the current schema cannot resolve, `ANNIvfSubIndexExec::try_new` must fail loudly
+    /// rather than silently produce an output schema missing that column -- which would
+    /// let `TakeExec` wrongly elide the base-table fetch for a column never emitted.
+    #[tokio::test]
+    async fn test_ann_sub_index_rejects_unresolvable_covering_field() {
+        use lance_datafusion::exec::OneShotExec;
+
+        // Minimal input plan carrying the required PART_ID_COLUMN schema.
+        let input = Arc::new(OneShotExec::from_batch(RecordBatch::new_empty(
+            KNN_PARTITION_SCHEMA.clone(),
+        )));
+
+        // A dataset whose schema has no field with id 9999.
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(batch)], schema),
+                "memory://d2-unresolvable-covering",
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        let index = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fields: vec![],
+            name: "vector_idx".to_string(),
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::new()),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: vec![9999],
+        };
+
+        let result = ANNIvfSubIndexExec::try_new(
+            input,
+            dataset,
+            vec![index],
+            base_query(),
+            PreFilterSource::None,
+        );
+        let err = result.expect_err("unresolvable covering field id must be rejected");
+        assert!(
+            err.to_string().contains("covering field id 9999"),
+            "expected a manifest/schema inconsistency error, got: {err}"
+        );
     }
 
     #[test]
@@ -2578,7 +2894,12 @@ mod tests {
         }
 
         fn find_partitions(&self, _query: &Query) -> Result<(UInt32Array, Float32Array)> {
-            unimplemented!()
+            // No additional partitions to reveal; the covered re-rank in
+            // late_search treats an empty result as "nothing more to search".
+            Ok((
+                UInt32Array::from(Vec::<u32>::new()),
+                Float32Array::from(Vec::<f32>::new()),
+            ))
         }
 
         fn total_partitions(&self) -> usize {
@@ -2835,6 +3156,69 @@ mod tests {
         prefilter
     }
 
+    /// A `FilterLoader` that yields a fixed allow-list of row addresses, so the
+    /// resulting prefilter mask is a bounded `AllowList` (`max_len()` is `Some`).
+    struct StaticAllowList(Vec<u64>);
+
+    #[async_trait]
+    impl FilterLoader for StaticAllowList {
+        async fn load(self: Box<Self>) -> lance_core::Result<lance_select::RowAddrMask> {
+            Ok(lance_select::RowAddrMask::from_allowed(
+                lance_select::RowAddrTreeMap::from_iter(self.0.iter().copied()),
+            ))
+        }
+    }
+
+    /// Like `empty_prefilter`, but the prefilter mask is a bounded allow-list of
+    /// the given row addresses, which drives the late-search no-rows shortcut.
+    async fn bounded_prefilter(allow: Vec<u64>) -> Arc<DatasetPreFilter> {
+        static NEXT_PREFILTER_DATASET_ID: AtomicUsize = AtomicUsize::new(100_000);
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let uri = format!(
+            "memory://bounded-prefilter-{}",
+            NEXT_PREFILTER_DATASET_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema),
+                &uri,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let mut indexed_fragments = RoaringBitmap::new();
+        for fragment in dataset.manifest.fragments.iter() {
+            indexed_fragments.insert(fragment.id as u32);
+        }
+        let index = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fields: vec![],
+            name: "test".to_string(),
+            dataset_version: 1,
+            fragment_bitmap: Some(indexed_fragments),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: Vec::new(),
+        };
+        let loader: Box<dyn FilterLoader> = Box::new(StaticAllowList(allow));
+        let prefilter = Arc::new(DatasetPreFilter::new(dataset, &[index], Some(loader)));
+        prefilter.wait_for_ready().await.unwrap();
+        prefilter
+    }
+
     fn prepared_metrics() -> Arc<AnnIndexMetrics> {
         Arc::new(AnnIndexMetrics::new(&ExecutionPlanMetricsSet::new(), 0))
     }
@@ -3037,6 +3421,7 @@ mod tests {
             prepared_metrics(),
             state.clone(),
             usize::MAX,
+            false,
         )
         .try_collect::<Vec<_>>()
         .await
@@ -3046,6 +3431,70 @@ mod tests {
         assert_eq!(*prepared_partitions.lock().unwrap(), vec![0, 1, 2]);
         assert_eq!(*searched_partitions.lock().unwrap(), vec![0]);
         assert_eq!(state.num_results_found.load(Ordering::Relaxed), 2);
+    }
+
+    /// With a bounded selective prefilter, the late-search no-rows shortcut must fire
+    /// for covered indexes too -- but emit nothing: the shortcut's `[_distance, _rowid]`
+    /// batch would drop the covering columns, so the end-of-stream covered recovery
+    /// (`covered_not_found_batch`) emits the missing rows instead, with a take bounded
+    /// by the prefilter size. Searching instead of shortcutting is the failure mode this
+    /// pins down: a prefilter-matched row with no index entry (null vector) can never be
+    /// found, so the search degenerates to scoring every partition on every query.
+    #[tokio::test]
+    async fn test_late_search_covered_skips_search_on_selective_prefilter() {
+        // Bounded prefilter (one allowed row) + k=2 => max_results=1 <= k, and an
+        // empty initial state => found_so_far=0 < max_results: shortcut criteria.
+        async fn run_late_search(has_covered: bool) -> (Vec<RecordBatch>, Vec<usize>) {
+            let (index, _prepared, searched_partitions, _threads) =
+                prepared_index(vec![21, 22, 23]);
+            let mut query = base_query();
+            query.k = 2;
+            query.minimum_nprobes = 0;
+            query.maximum_nprobes = Some(3);
+            let state = Arc::new(ANNIvfEarlySearchResults::new(1, query.k));
+
+            let batches = ANNIvfSubIndexExec::late_search(
+                index,
+                query,
+                Arc::new(UInt32Array::from(vec![0, 1, 2])),
+                Arc::new(Float32Array::from(vec![0.1, 0.2, 0.3])),
+                bounded_prefilter(vec![0]).await,
+                prepared_metrics(),
+                state,
+                usize::MAX,
+                has_covered,
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+            let searched = searched_partitions.lock().unwrap().clone();
+            (batches, searched)
+        }
+
+        // Control: a non-covered index takes the shortcut, so no partition is
+        // searched and the only batch is the [_distance, _rowid] not-found batch.
+        let (batches, searched) = run_late_search(false).await;
+        assert!(
+            searched.is_empty(),
+            "non-covered query should take the shortcut and skip the search, searched={searched:?}"
+        );
+        assert!(
+            batches.iter().all(|b| b.num_columns() == 2),
+            "the shortcut emits only [_distance, _rowid]"
+        );
+
+        // Covered: the shortcut fires too (no partition searched), but emits nothing --
+        // the end-of-stream covered recovery supplies the not-found rows with their
+        // covering columns.
+        let (batches, searched) = run_late_search(true).await;
+        assert!(
+            searched.is_empty(),
+            "covered query must take the shortcut and skip the search, searched={searched:?}"
+        );
+        assert!(
+            batches.is_empty(),
+            "the covered shortcut emits nothing; recovery happens at end of stream"
+        );
     }
 
     #[tokio::test]
@@ -3066,6 +3515,7 @@ mod tests {
             prepared_metrics(),
             state.clone(),
             usize::MAX,
+            false,
         )
         .try_collect::<Vec<_>>();
 
@@ -3083,6 +3533,7 @@ mod tests {
             prepared_metrics(),
             state,
             usize::MAX,
+            false,
         )
         .try_collect::<Vec<_>>();
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -1423,6 +1423,21 @@ impl ANNIvfSubIndexExec {
             .first()
             .map(|idx| idx.included_fields.clone())
             .unwrap_or_default();
+        // This exec declares one output schema but executes every delta segment,
+        // each emitting covering columns from its own storage -- so all deltas
+        // must agree on the covering set. The commit boundary enforces this; the
+        // check here defends against already-committed inconsistent metadata,
+        // failing with a clear error instead of a downstream schema mismatch.
+        if let Some(mismatch) = indices
+            .iter()
+            .find(|idx| idx.included_fields != included_ids)
+        {
+            return Err(Error::index(format!(
+                "ANNIvfSubIndexExec: delta segments of index '{}' disagree on covering fields \
+                 ({:?} vs {:?}); the index metadata is inconsistent -- rebuild the index",
+                mismatch.name, included_ids, mismatch.included_fields
+            )));
+        }
         if !included_ids.is_empty() {
             let lance_schema = dataset.schema();
             for id in &included_ids {
@@ -1962,11 +1977,22 @@ impl ANNIvfSubIndexExec {
 
         // Fetch the covering columns (the fields after `[_distance, _rowid]`) from the
         // base table for the missing rows; the take is bounded by `not_found.len()`.
-        let covered_names: Vec<String> = output_schema
-            .fields()
-            .iter()
-            .skip(2)
-            .map(|field| field.name().clone())
+        // Ask for `_rowid` alongside them: the take resolves ids with
+        // `MissingRowPolicy::Ignore` and silently returns FEWER rows than requested when an
+        // id no longer maps (a row deleted since the prefilter was built, or a prefilter that
+        // still lists a tombstoned row). Rebuilding the batch from `not_found` would then pair
+        // N distance/rowid values with < N covering values and fail with "all columns in a
+        // record batch must have the same length". Carrying `_rowid` through lets the batch be
+        // rebuilt from the rows the take actually returned, which is what the non-covered path
+        // does when its `TakeExec` drops the same ids.
+        let covered_names: Vec<String> = std::iter::once(ROW_ID.to_string())
+            .chain(
+                output_schema
+                    .fields()
+                    .iter()
+                    .skip(2)
+                    .map(|field| field.name().clone()),
+            )
             .collect();
         let projection = ProjectionRequest::from_columns(covered_names, dataset.schema());
         // `not_found` holds row ids (the `_rowid` space): stable logical ids on a
@@ -1975,16 +2001,28 @@ impl ANNIvfSubIndexExec {
         // identity (id == address) when it does not, so it is correct in both cases --
         // unlike `try_new_from_addresses`, which would misread a stable id as
         // `frag = id >> 32, offset = id` and take the wrong physical row (or error).
-        let covered = TakeBuilder::try_new_from_ids(dataset, not_found.clone(), projection)?
+        let covered = TakeBuilder::try_new_from_ids(dataset, not_found, projection)?
             .execute()
             .await?;
 
-        let n = not_found.len();
+        // Realign on what came back, not on what was asked for.
+        let returned_ids = covered
+            .column_by_name(ROW_ID)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "covered recovery take did not return the requested {ROW_ID} column"
+                ))
+            })?
+            .clone();
+        let n = covered.num_rows();
+        if n == 0 {
+            return Ok(None);
+        }
         let mut columns: Vec<ArrayRef> = vec![
             Arc::new(Float32Array::from_value(f32::INFINITY, n)),
-            Arc::new(UInt64Array::from(not_found)),
+            returned_ids,
         ];
-        columns.extend(covered.columns().iter().cloned());
+        columns.extend(covered.columns().iter().skip(1).cloned());
         let batch = RecordBatch::try_new(output_schema, columns)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
         Ok(Some(batch))
@@ -2141,11 +2179,13 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         // Covered null-vector recovery: track which row ids the search emits, then after
         // it finishes emit any prefilter-matched rows that had no index entry, with their
         // covering columns taken from the base table (see `covered_not_found_batch`).
-        // Tracking is skipped when recovery provably cannot emit anything: without a
-        // prefilter source there is no allow-list, so `covered_not_found_batch` always
-        // returns `None` -- the per-batch lock and inserts would be pure overhead on
-        // the covered hot path.
-        let track_emitted = has_covered && !matches!(self.prefilter_source, PreFilterSource::None);
+        // This must NOT be gated on `prefilter_source`: `DatasetPreFilter` builds a bounded
+        // allow-list from the deletion mask alone, so an unfiltered query over a dataset with
+        // deletions (or a fragment outside the index bitmap) still arms recovery. Skipping the
+        // bookkeeping there left `emitted` empty, and recovery re-emitted every live row on top
+        // of the ones the search had already returned. The cost is already confined to covered
+        // plans, and recovery itself stays gated behind `covered_recovery_armed`.
+        let track_emitted = has_covered;
         let emitted_row_ids = Arc::new(std::sync::Mutex::new(roaring::RoaringTreemap::new()));
         let emitted_for_inspect = emitted_row_ids.clone();
         let recon_prefilter = pre_filter.clone();
@@ -2153,6 +2193,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         let recon_ds = ds.clone();
         let recon_schema = schema.clone();
         let recon_k = query.k;
+        let declared_schema = schema.clone();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
@@ -2200,6 +2241,25 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 // Each delta stream is split into an early and late search.  The late search
                 // will not start until the early search is complete across all deltas.
                 .try_flatten_unordered(None)
+                // The search emits covering columns read from index STORAGE, while this node
+                // declares them from the manifest (`IndexMetadata.included_fields`). The two can
+                // disagree: `FLAG_COVERED_INDEX_METADATA` is a best-effort writer fence, so a
+                // client predating it can drop the declaration while the index files keep the
+                // payload. Without narrowing, this stream mixes batch widths -- a wider search
+                // batch next to the narrower non-covered shortcut batch -- which panics inside
+                // DataFusion's TopK (`interleave_record_batch` reads every batch through the
+                // first batch's schema). Narrow to the declaration so the query degrades to a
+                // base-table take instead. Only ever narrows: the opposite desync (declared but
+                // absent from storage) fails loudly at plan time, which is the right outcome.
+                .map(move |batch| {
+                    let batch = batch?;
+                    if batch.num_columns() > declared_schema.fields().len() {
+                        return batch
+                            .project_by_schema(declared_schema.as_ref())
+                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+                    }
+                    Ok(batch)
+                })
                 .inspect_ok(move |batch| {
                     // Record emitted row ids so the reconciliation below can find the
                     // prefilter rows the search never returned (no index entry).
@@ -2666,6 +2726,72 @@ mod tests {
         assert!(
             err.to_string().contains("covering field id 9999"),
             "expected a manifest/schema inconsistency error, got: {err}"
+        );
+    }
+
+    /// The exec declares one output schema but executes every delta segment, so delta
+    /// segments that disagree on covering fields must be rejected up front with a clear
+    /// error, not fail later with a stream/plan schema mismatch. (The commit boundary
+    /// rejects new mixed sets; this defends against already-committed metadata.)
+    #[tokio::test]
+    async fn test_ann_sub_index_rejects_mixed_covering_deltas() {
+        use lance_datafusion::exec::OneShotExec;
+
+        let input = Arc::new(OneShotExec::from_batch(RecordBatch::new_empty(
+            KNN_PARTITION_SCHEMA.clone(),
+        )));
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(batch)], schema),
+                "memory://d2-mixed-covering-deltas",
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let id_field_id = dataset.schema().field("id").unwrap().id;
+
+        let covered_delta = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fields: vec![],
+            name: "vector_idx".to_string(),
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::new()),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            included_fields: vec![id_field_id],
+        };
+        let plain_delta = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            included_fields: Vec::new(),
+            ..covered_delta.clone()
+        };
+
+        let result = ANNIvfSubIndexExec::try_new(
+            input,
+            dataset,
+            vec![covered_delta, plain_delta],
+            base_query(),
+            PreFilterSource::None,
+        );
+        let err = result.expect_err("delta segments with mixed covering must be rejected");
+        assert!(
+            err.to_string().contains("disagree on covering fields"),
+            "expected a delta covering mismatch error, got: {err}"
         );
     }
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -2828,6 +2828,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            included_fields: Vec::new(),
         };
         let prefilter = Arc::new(DatasetPreFilter::new(dataset, &[index], None));
         prefilter.wait_for_ready().await.unwrap();


### PR DESCRIPTION

# Description

Lets a vector index materialize extra columns alongside its quantization codes, so a query whose projection is fully covered is answered from the index with **no take against the base table**.

```python
ds.create_index("vec", "IVF_PQ", include_columns=["price"])
ds.to_table(nearest={"column": "vec", "q": q, "k": 10}, columns=["price"])  # no TakeExec
```

The index metadata gains `included_fields` (`table.proto` field 11), and a covered query drops the base-table take from the plan.

## Scope

Covering works on all seven IVF variants — `IVF_PQ`, `IVF_SQ`, `IVF_RQ`, `IVF_FLAT`, `IVF_HNSW_PQ`, `IVF_HNSW_SQ`, `IVF_HNSW_FLAT`. Each quantizer storage carries its own `covering_field_indices()` override so its internal code/factor columns are never mistaken for payload.

Creation is available from **Rust, Python, and Java**; validation stays centralized in the Rust core.

Supported across the index lifecycle: append/optimize (merge, append, retrain), compaction and row-id remap, partition split/join, distributed sharded builds (per-shard commit *and* cross-shard merge), schema evolution, and concurrent-commit conflict resolution.

### Rejected up front, with a clear error

- covering the indexed vector column itself (it is stored as the quantization code)
- nested/dotted columns — cover the whole top-level struct instead
- reserved storage names (`_rowid`, `_distance`, `__ivf_part_id`, quantizer code/factor columns), duplicates, blob columns
- `merge_insert` of a covered column on a stable-row-id dataset, combined with inserts, or on legacy v1 blob columns — provide the full target schema
- `include_columns` together with precomputed shuffle buffers (those buffers do not carry the payload)

## Format change

New optional proto field `IndexMetadata.included_fields` (field 11) plus a **writer** feature flag, `FLAG_COVERED_INDEX_METADATA` (bit 128).

The flag exists because `prost` silently drops unknown fields: a writer predating this change would re-serialize the index section without `included_fields` while the index files still physically hold the payload columns, leaving storage the manifest no longer describes. The flag is writer-only on purpose — a reader that ignores `included_fields` simply falls back to a base-table take, which is correct, so fencing readers would turn a read-side optimization into a fleet-wide break.


## Breaking changes

- `IndexMetadata` gains a required `included_fields` field
- `VectorIndexParams` gains a required `include_columns` field
- `apply_feature_flags` keeps its name but takes `(&mut Manifest, &FeatureFlagsConfig)` instead of `(&mut Manifest, bool, bool)`
- `init_writer_for_{flat,pq,sq,rq}` in `lance-index` gain a trailing `covering_fields: &[FieldRef]` parameter (pass `&[]` for the previous behavior)

