### PR TITLE
test: relax vector delta index assertion

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -1213,7 +1213,14 @@ mod tests {
         assert_eq!(results.num_rows(), 2);
         let mut id_arr = results["id"].as_primitive::<UInt32Type>().values().to_vec();
         id_arr.sort();
-        assert_eq!(id_arr, vec![0, 1000]);
+        assert!(
+            id_arr.iter().any(|id| *id < TOTAL as u32),
+            "expected at least one result from the base segment, got {id_arr:?}"
+        );
+        assert!(
+            id_arr.iter().any(|id| *id >= TOTAL as u32),
+            "expected at least one result from the appended segment, got {id_arr:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Relax `test_query_delta_indices` so it verifies both base and appended vector index segments contribute results.
- Avoid requiring IVF_HNSW_SQ approximate search to return one specific duplicate row ID on every platform.

## Root cause

The Windows CI failure returned `[0, 1474]` instead of `[0, 1000]`. The old assertion required an approximate HNSW/SQ search path to choose a specific duplicate vector row, which is brittle across platforms. The behavior this test needs to cover is that delta index segments remain queryable after `optimize_indices(append())`.

## Validation

- Local build/test validation intentionally not run; Lance GitHub Workflow is the validation gate for this workspace.
