### PR TITLE
perf(index): skip FM-Index rebuild when merging a single fully-live segment

### DIFF
--- a/rust/lance/src/index/scalar/fmindex.rs
+++ b/rust/lance/src/index/scalar/fmindex.rs
@@ -14,6 +14,12 @@ use crate::{Dataset, Error, Result};
 /// to combine two BWT structures. This function re-reads text data from the
 /// dataset for all fragments covered by the source segments and builds a fresh
 /// FM-Index over the combined data.
+///
+/// As an exception, a single source segment whose fragment coverage is still
+/// fully live is returned as-is: rebuilding it would produce equivalent content
+/// over the same fragments, which makes distributed builds (one uncommitted
+/// segment per worker, merged 1:1 into final segments) pay for every segment
+/// twice.
 pub(in crate::index) async fn merge_segments(
     dataset: &Dataset,
     segments: Vec<IndexMetadata>,
@@ -73,6 +79,10 @@ pub(in crate::index) async fn merge_segments(
             files: Some(created_index.files),
             ..segments[0].clone()
         });
+    }
+
+    if segments.len() == 1 && segments[0].fragment_bitmap.as_ref() == Some(&fragment_bitmap) {
+        return Ok(segments.into_iter().next().unwrap());
     }
 
     let fragment_ids: Vec<u32> = fragment_bitmap.iter().collect();

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -1460,4 +1460,188 @@ mod tests {
             "rows from live fragment should still be searchable"
         );
     }
+
+    #[tokio::test]
+    async fn test_fmindex_merge_single_segment_passthrough() {
+        let test_dir = TempStrDir::default();
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "text",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let write_params = crate::dataset::write::WriteParams {
+            max_rows_per_file: 4,
+            ..Default::default()
+        };
+        let batches = vec![
+            arrow_array::RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(arrow_array::StringArray::from(vec![
+                    "alpha beta gamma delta",
+                    "beta gamma delta epsilon",
+                    "gamma delta epsilon zeta",
+                    "delta epsilon zeta eta",
+                    "epsilon zeta eta theta",
+                    "zeta eta theta iota",
+                    "eta theta iota kappa",
+                    "theta iota kappa lambda",
+                ]))],
+            )
+            .unwrap(),
+        ];
+        let reader =
+            arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(reader, test_dir.as_str(), Some(write_params))
+            .await
+            .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 2);
+        let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
+
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Fm);
+        let segment = CreateIndexBuilder::new(&mut dataset, &["text"], IndexType::Fm, &params)
+            .name("text_fmindex_single".to_string())
+            .fragments(fragment_ids.clone())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        let source_uuid = segment.uuid;
+
+        // A single segment whose coverage is fully live is reused, not rebuilt.
+        let merged = dataset
+            .merge_existing_index_segments(vec![segment])
+            .await
+            .unwrap();
+        assert_eq!(
+            merged.uuid, source_uuid,
+            "single-segment merge with unchanged coverage should reuse the segment"
+        );
+        assert_eq!(
+            merged
+                .fragment_bitmap
+                .as_ref()
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>(),
+            fragment_ids
+        );
+
+        dataset
+            .commit_existing_index_segments("text_fmindex_single", "text", vec![merged])
+            .await
+            .unwrap();
+
+        let logical = open_named_scalar_index(
+            &dataset,
+            "text",
+            "text_fmindex_single",
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+        assert_eq!(logical.index_type(), IndexType::Fm);
+
+        let query = lance_index::scalar::TextQuery::StringContains("delta".to_string());
+        let result = logical.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let row_addrs = match result {
+            SearchResult::Exact(row_addrs) => row_addrs,
+            other => panic!("expected exact result from fmindex, got {:?}", other),
+        };
+        assert_eq!(row_addrs.true_rows().row_addrs().unwrap().count(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_fmindex_merge_single_segment_rebuilds_when_coverage_shrinks() {
+        let test_dir = TempStrDir::default();
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "text",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let write_params = crate::dataset::write::WriteParams {
+            max_rows_per_file: 4,
+            enable_stable_row_ids: true,
+            ..Default::default()
+        };
+        let batches = vec![
+            arrow_array::RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(arrow_array::StringArray::from(vec![
+                    "alpha beta gamma",
+                    "beta gamma delta",
+                    "gamma delta epsilon",
+                    "delta epsilon zeta",
+                    "epsilon zeta eta",
+                    "zeta eta theta",
+                    "eta theta iota",
+                    "theta iota kappa",
+                ]))],
+            )
+            .unwrap(),
+        ];
+        let reader =
+            arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(reader, test_dir.as_str(), Some(write_params))
+            .await
+            .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 2);
+
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Fm);
+        let segment = CreateIndexBuilder::new(&mut dataset, &["text"], IndexType::Fm, &params)
+            .name("text_fmindex_shrink".to_string())
+            .fragments(fragments.iter().map(|f| f.id() as u32).collect())
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        let source_uuid = segment.uuid;
+
+        // Retire fragment 0: delete its rows and compact it away.
+        dataset.delete("text = 'alpha beta gamma'").await.unwrap();
+        dataset.delete("text = 'beta gamma delta'").await.unwrap();
+        crate::dataset::optimize::compact_files(
+            &mut dataset,
+            crate::dataset::optimize::CompactionOptions {
+                target_rows_per_fragment: 4,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        let live_frags: RoaringBitmap = dataset
+            .get_fragments()
+            .iter()
+            .map(|f| f.id() as u32)
+            .collect();
+        assert!(
+            !live_frags.contains(0),
+            "compaction should retire fragment 0"
+        );
+        assert!(live_frags.contains(1), "fragment 1 should stay live");
+
+        // Coverage shrank, so even a single segment must be rebuilt.
+        let merged = dataset
+            .merge_existing_index_segments(vec![segment])
+            .await
+            .unwrap();
+        assert_ne!(
+            merged.uuid, source_uuid,
+            "shrunk coverage must trigger a rebuild"
+        );
+        assert_eq!(
+            merged
+                .fragment_bitmap
+                .as_ref()
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`merge_existing_index_segments` for FM-Index always rebuilds the segment from source text — correct for multi-source merges (there is no cheap way to combine two BWT structures), but wasted work when merging a *single* segment whose fragment coverage is unchanged.

This makes distributed FM-Index builds pay for everything twice: workers build per-fragment-subset segments via `execute_uncommitted`, and when intermediates fold 1:1 into final segments, the merge step discards each one and rebuilds identical content over the same fragments.

## Fix

After computing the merged coverage (union of source bitmaps ∩ live fragments), if there is exactly one source segment and its coverage is still fully live, return it as-is. The caller already re-stamps `dataset_version`/`fields`, and the segment (from `execute_uncommitted`) carries its `index_details` and `files`, so commit-side validation is unaffected.

Multi-source merges, empty coverage, and single segments with retired fragments (concurrent compaction) keep the existing rebuild behavior — the new `test_fmindex_merge_single_segment_rebuilds_when_coverage_shrinks` test guards that boundary.