### PR TITLE
fix(lance-io): include goosefs feature in DEFAULT_CLOUD_BLOCK_SIZE cfg gate

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -69,6 +69,7 @@ const DEFAULT_LOCAL_BLOCK_SIZE: usize = 4 * 1024; // 4KB block size
     feature = "tencent",
     feature = "huggingface",
     feature = "tos",
+    feature = "goosefs",
 ))]
 const DEFAULT_CLOUD_BLOCK_SIZE: usize = 64 * 1024; // 64KB block size
 


### PR DESCRIPTION
## Summary

The `DEFAULT_CLOUD_BLOCK_SIZE` constant in `rust/lance-io/src/object_store.rs`
is gated behind a `cfg(any(...))` attribute that lists all cloud-backend
features, but `goosefs` was missing from that list. As a result, building
`lance-io` / `lance` with only the `goosefs` feature enabled fails with:

```
error[E0425]: cannot find value `DEFAULT_CLOUD_BLOCK_SIZE` in this scope
```

because the goosefs provider imports and uses this constant.

## Fix

Add `goosefs` to the `cfg(any(...))` list, mirroring the treatment of the
other cloud backends (`aws` / `gcp` / `azure` / `oss` / `tencent` /
`huggingface` / `tos`).

## Verification

Verified locally with feature-gated builds:

```bash
cargo check -p lance-io --no-default-features --features goosefs
cargo check -p lance    --no-default-features --features goosefs
cargo fmt --all -- --check
```

All checks pass. No behavior change for any other feature combination —
this only fixes a compile break for the `goosefs`-only build.