### PR TITLE
test(bitpacking): actually exercise u64 unchecked round-trip for widths 1..=63

### DIFF
--- a/rust/compression/bitpacking/src/lib.rs
+++ b/rust/compression/bitpacking/src/lib.rs
@@ -2128,6 +2128,10 @@ mod test {
             for value in &mut values {
                 *value = rng.next();
             }
+        } else {
+            for value in &mut values {
+                *value = rng.next() % (1 << bit_width);
+            }
         }
         let mut packed = vec![0; 1024 * bit_width / u64::T];
         unsafe {


### PR DESCRIPTION
## What

Fix `unchecked_pack_unpack_u64` so widths 1..=63 actually round-trip non-zero data.

## Why

`fn unchecked_pack_unpack_u64` in `rust/compression/bitpacking/src/lib.rs` filled random values only when `bit_width == 64`:

```rust
if bit_width == 64 {
    for value in &mut values { *value = rng.next(); }
}
// ← no else branch
let mut packed = vec![0; 1024 * bit_width / u64::T];
unsafe { BitPacking::unchecked_pack(bit_width, &values, &mut packed); }
let mut output = [0; 1024];
unsafe { BitPacking::unchecked_unpack(bit_width, &packed, &mut output) };
assert_eq!(values, output);
```

For every other width called at lines 2209-2271, `values` stayed `[0u64; 1024]`, `packed` started as `vec![0; ...]`, and `output` started as `[0; 1024]`. The `assert_eq!` therefore passed regardless of whether any of the 64 monomorphized `pack_64_N` / `unpack_64_N` fast-path kernels reached from `BitPacking::unchecked_{pack,unpack}` were actually correct.

This is the only test in the crate that covers the fast path for u64 widths 1..=63 — `lance-encoding::bitpacking` and `lance-index::scalar::inverted::{encoding,builder}` both hit that path.

## Fix

Mirror the else branch already present in the sibling slow-path helper `pack_unpack_u64` (`lib.rs:1923-1927`):

```rust
} else {
    for value in &mut values {
        *value = rng.next() % (1 << bit_width);
    }
}
```

Same random seed, same modulo pattern — differs only in that this version drives the `BitPacking` trait dispatch (compile-time-known
width) instead of the runtime-parameterized `pack!`/`unpack!` macros.

## Test plan

- [x] `cargo test -p lance-bitpacking` — 11/11 pass with the fix; the previously-silent widths now actually exercise the fast-path kernels.
- [x] `cargo fmt --all --check` on the touched file — clean.
- [x] `cargo clippy -p lance-bitpacking --tests -- -D warnings` — clean.

## Origin

The pattern was introduced in #2886 (2024-09) when the fastlanes code was migrated from spiraldb/fastlanes to Lance. Upstream fastlanes uses a different test skeleton (`seq!`-generated per-width `#[test] fn`) that does not have this shape, so this is not a vendor-side artifact, just a copy-paste omission when the sibling slow-path helper was adapted to the fast-path helper.