### PR TITLE
fix(cache): count key footprint in MokaCacheBackend eviction weight

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use futures::Future;
 
 use crate::Result;
+use crate::deepsize::{Context, DeepSizeOf};
 
 use super::CacheCodec;
 
@@ -64,6 +65,13 @@ impl InternalCacheKey {
     /// Returns true if this key's prefix starts with the given string.
     pub fn starts_with(&self, prefix: &str) -> bool {
         self.prefix.starts_with(prefix)
+    }
+}
+
+impl DeepSizeOf for InternalCacheKey {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        // `type_name` is a `&'static str` borrow, so it owns no heap memory.
+        self.prefix.deep_size_of_children(context) + self.key.deep_size_of_children(context)
     }
 }
 

--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use futures::Future;
 
 use crate::Result;
-use crate::deepsize::{Context, DeepSizeOf};
 
 use super::CacheCodec;
 
@@ -65,13 +64,6 @@ impl InternalCacheKey {
     /// Returns true if this key's prefix starts with the given string.
     pub fn starts_with(&self, prefix: &str) -> bool {
         self.prefix.starts_with(prefix)
-    }
-}
-
-impl DeepSizeOf for InternalCacheKey {
-    fn deep_size_of_children(&self, context: &mut Context) -> usize {
-        // `type_name` is a `&'static str` borrow, so it owns no heap memory.
-        self.prefix.deep_size_of_children(context) + self.key.deep_size_of_children(context)
     }
 }
 

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -689,6 +689,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_cache_weighs_key_footprint() {
+        // A long key must count toward the weighted size; otherwise many small
+        // values stored under long keys (e.g. dataset URIs) would blow past the
+        // configured capacity because only the value size was charged.
+        let cache = LanceCache::with_capacity(usize::MAX);
+        let long_key = "k".repeat(10_000);
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new(&long_key), Arc::new(vec![1]))
+            .await;
+
+        let size_bytes = cache.size_bytes().await;
+        assert!(
+            size_bytes >= long_key.len(),
+            "weighted size {size_bytes} should include the {}-byte key",
+            long_key.len()
+        );
+    }
+
+    #[test]
+    fn test_internal_cache_key_counts_string_bytes() {
+        // Both owned strings are charged; the `&'static str` type name is a
+        // borrow and contributes nothing.
+        let key = InternalCacheKey::new(Arc::from("a-prefix"), Arc::from("a-key"), "SomeType");
+        let size = key.deep_size_of();
+        assert!(
+            size >= std::mem::size_of::<InternalCacheKey>() + "a-prefix".len() + "a-key".len(),
+            "deep_size_of {size} should cover the struct and both strings"
+        );
+    }
+
+    #[tokio::test]
     async fn test_cache_trait_objects() {
         #[derive(Debug, DeepSizeOf)]
         struct MyType(i32);

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -690,43 +690,35 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_weighs_key_footprint() {
-        // A long key must count toward the weighted size; otherwise many small
-        // values under long, high-cardinality keys would blow past the
-        // configured capacity because only the value size was charged.
+        // Weighted size charges the key's unique bytes, not just the value.
         let cache = LanceCache::with_capacity(usize::MAX);
-        let long_key = "k".repeat(10_000);
+        let key = "k".repeat(10_000);
+        let value = Arc::new(vec![1_i32]);
+        let expected =
+            std::mem::size_of::<InternalCacheKey>() + key.len() + cache_entry_size(&*value);
         cache
-            .insert_with_key(&TestKey::<Vec<i32>>::new(&long_key), Arc::new(vec![1]))
+            .insert_with_key(&TestKey::<Vec<i32>>::new(&key), value)
             .await;
-
-        let size_bytes = cache.size_bytes().await;
-        assert!(
-            size_bytes >= long_key.len(),
-            "weighted size {size_bytes} should include the {}-byte key",
-            long_key.len()
-        );
+        assert_eq!(cache.size_bytes().await, expected);
     }
 
     #[tokio::test]
     async fn test_cache_shared_prefix_not_charged_per_entry() {
-        // The prefix `Arc<str>` is shared by every entry under a cache handle and
-        // is not freed when a single entry is evicted, so it must not be weighed
-        // per entry. Many entries under a 10 KB prefix should stay far below what
-        // a per-entry prefix charge (~entries * prefix_len) would produce.
+        // The shared prefix contributes nothing per entry (it isn't freed on a
+        // single eviction); only struct + unique key + value are charged.
         let cache = LanceCache::with_capacity(usize::MAX).with_key_prefix(&"p".repeat(10_000));
         for i in 0..100 {
             cache
-                .insert_with_key(&TestKey::<Vec<i32>>::new(&i.to_string()), Arc::new(vec![1]))
+                .insert_with_key(
+                    &TestKey::<Vec<i32>>::new(&i.to_string()),
+                    Arc::new(vec![1_i32]),
+                )
                 .await;
         }
-
-        let size_bytes = cache.size_bytes().await;
-        // Charging the prefix per entry would be ~100 * 10 KB ≈ 1 MB; the
-        // marginal cost is ~100 * (struct + tiny key + value) ≈ a few KB.
-        assert!(
-            size_bytes < 100 * 1024,
-            "shared prefix must not be charged per entry, got {size_bytes}"
-        );
+        let value_cost = cache_entry_size(&vec![1_i32]);
+        let key_bytes: usize = (0..100).map(|i| i.to_string().len()).sum();
+        let expected = 100 * (std::mem::size_of::<InternalCacheKey>() + value_cost) + key_bytes;
+        assert_eq!(cache.size_bytes().await, expected);
     }
 
     #[tokio::test]

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -691,7 +691,7 @@ mod tests {
     #[tokio::test]
     async fn test_cache_weighs_key_footprint() {
         // A long key must count toward the weighted size; otherwise many small
-        // values stored under long keys (e.g. dataset URIs) would blow past the
+        // values under long, high-cardinality keys would blow past the
         // configured capacity because only the value size was charged.
         let cache = LanceCache::with_capacity(usize::MAX);
         let long_key = "k".repeat(10_000);
@@ -707,15 +707,25 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_internal_cache_key_counts_string_bytes() {
-        // Both owned strings are charged; the `&'static str` type name is a
-        // borrow and contributes nothing.
-        let key = InternalCacheKey::new(Arc::from("a-prefix"), Arc::from("a-key"), "SomeType");
-        let size = key.deep_size_of();
+    #[tokio::test]
+    async fn test_cache_shared_prefix_not_charged_per_entry() {
+        // The prefix `Arc<str>` is shared by every entry under a cache handle and
+        // is not freed when a single entry is evicted, so it must not be weighed
+        // per entry. Many entries under a 10 KB prefix should stay far below what
+        // a per-entry prefix charge (~entries * prefix_len) would produce.
+        let cache = LanceCache::with_capacity(usize::MAX).with_key_prefix(&"p".repeat(10_000));
+        for i in 0..100 {
+            cache
+                .insert_with_key(&TestKey::<Vec<i32>>::new(&i.to_string()), Arc::new(vec![1]))
+                .await;
+        }
+
+        let size_bytes = cache.size_bytes().await;
+        // Charging the prefix per entry would be ~100 * 10 KB ≈ 1 MB; the
+        // marginal cost is ~100 * (struct + tiny key + value) ≈ a few KB.
         assert!(
-            size >= std::mem::size_of::<InternalCacheKey>() + "a-prefix".len() + "a-key".len(),
-            "deep_size_of {size} should cover the struct and both strings"
+            size_bytes < 100 * 1024,
+            "shared prefix must not be charged per entry, got {size_bytes}"
         );
     }
 

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use futures::Future;
 
 use crate::Result;
-use crate::deepsize::DeepSizeOf;
 
 use super::CacheCodec;
 use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
@@ -21,13 +20,16 @@ struct MokaCacheEntry {
     size_bytes: usize,
 }
 
-/// Footprint moka pays to store a key: the [`InternalCacheKey`] struct, its
-/// owned string bytes, and the `Arc` moka wraps it in. Counted per entry so
-/// eviction reflects key-heavy workloads (e.g. long dataset URIs as prefixes),
+/// Marginal, reclaimable cost of one entry's key: the [`InternalCacheKey`]
+/// struct plus the unique `key` string's heap bytes. Counted per entry so
+/// eviction reflects key-heavy workloads (e.g. long, high-cardinality keys),
 /// which the value size alone ignores.
+///
+/// The `prefix` `Arc<str>` is deliberately excluded: it is shared by every
+/// entry under a cache handle and is not freed when a single entry is evicted,
+/// so charging it per entry would systematically over-count.
 fn key_footprint(key: &InternalCacheKey) -> usize {
-    // Mirror `cache_entry_size`'s Arc accounting: two atomic counters.
-    key.deep_size_of() + 2 * std::mem::size_of::<std::sync::atomic::AtomicUsize>()
+    std::mem::size_of::<InternalCacheKey>() + key.key().len()
 }
 
 /// Default [`CacheBackend`] backed by a [moka](https://crates.io/crates/moka) cache.

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -20,14 +20,8 @@ struct MokaCacheEntry {
     size_bytes: usize,
 }
 
-/// Marginal, reclaimable cost of one entry's key: the [`InternalCacheKey`]
-/// struct plus the unique `key` string's heap bytes. Counted per entry so
-/// eviction reflects key-heavy workloads (e.g. long, high-cardinality keys),
-/// which the value size alone ignores.
-///
-/// The `prefix` `Arc<str>` is deliberately excluded: it is shared by every
-/// entry under a cache handle and is not freed when a single entry is evicted,
-/// so charging it per entry would systematically over-count.
+/// Per-entry key cost for eviction: the struct plus the unique `key` bytes.
+/// Excludes the shared `prefix` `Arc<str>`, which isn't freed per eviction.
 fn key_footprint(key: &InternalCacheKey) -> usize {
     std::mem::size_of::<InternalCacheKey>() + key.key().len()
 }

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use futures::Future;
 
 use crate::Result;
+use crate::deepsize::DeepSizeOf;
 
 use super::CacheCodec;
 use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
@@ -18,6 +19,15 @@ use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKe
 struct MokaCacheEntry {
     entry: CacheEntry,
     size_bytes: usize,
+}
+
+/// Footprint moka pays to store a key: the [`InternalCacheKey`] struct, its
+/// owned string bytes, and the `Arc` moka wraps it in. Counted per entry so
+/// eviction reflects key-heavy workloads (e.g. long dataset URIs as prefixes),
+/// which the value size alone ignores.
+fn key_footprint(key: &InternalCacheKey) -> usize {
+    // Mirror `cache_entry_size`'s Arc accounting: two atomic counters.
+    key.deep_size_of() + 2 * std::mem::size_of::<std::sync::atomic::AtomicUsize>()
 }
 
 /// Default [`CacheBackend`] backed by a [moka](https://crates.io/crates/moka) cache.
@@ -40,7 +50,12 @@ impl MokaCacheBackend {
     pub fn with_capacity(capacity: usize) -> Self {
         let cache = moka::future::Cache::builder()
             .max_capacity(capacity as u64)
-            .weigher(|_, v: &MokaCacheEntry| v.size_bytes.try_into().unwrap_or(u32::MAX))
+            .weigher(|key: &InternalCacheKey, entry: &MokaCacheEntry| {
+                key_footprint(key)
+                    .saturating_add(entry.size_bytes)
+                    .try_into()
+                    .unwrap_or(u32::MAX)
+            })
             .support_invalidation_closures()
             .build();
         Self { cache }
@@ -148,6 +163,9 @@ impl CacheBackend for MokaCacheBackend {
         // Iterate rather than using `weighted_size()` because moka's
         // weighted_size can be stale without `run_pending_tasks()`, which
         // is async and can't be called from this synchronous context.
-        self.cache.iter().map(|(_, v)| v.size_bytes).sum()
+        self.cache
+            .iter()
+            .map(|(key, entry)| key_footprint(key.as_ref()) + entry.size_bytes)
+            .sum()
     }
 }


### PR DESCRIPTION
## Summary

`MokaCacheBackend`'s weigher charged only the value's `size_bytes` and ignored the key entirely:

```rust
.weigher(|_, v: &MokaCacheEntry| v.size_bytes.try_into().unwrap_or(u32::MAX))
```

Since moka evicts by weighted size, workloads that store **many small values under long, high-cardinality keys** under-count their memory and can grow past the configured `max_capacity`. The key (`InternalCacheKey`: two `Arc<str>` + a `&'static str`) was effectively free.

## Change

A per-entry weigher should approximate the **marginal, reclaimable** cost of an entry — what is freed when that one entry is evicted:

- `key_footprint(key) = size_of::<InternalCacheKey>() + key.key().len()` — the struct plus the entry's unique `key` string.
- Used in both the weigher (eviction) and the synchronous `approx_size_bytes` (`DeepSizeOf` reporting) so the two stay consistent.

The **`prefix` is deliberately excluded**. `build_key` clones the prefix `Arc<str>` (shared) and allocates a fresh `key` per entry (unique). The prefix is one shared allocation per cache handle and is *not* reclaimed when a single entry is evicted, so charging `prefix.len()` per entry would over-count in proportion to entry count (e.g. a 60-byte S3 prefix × 10k entries = 600 KB of phantom weight) and make the cache evict too early.

Accounting stays in the backend that actually stores the key, so other `CacheBackend` impls are unaffected.

## Test plan

- [x] `test_cache_weighs_key_footprint` — a 10 KB key contributes to `size_bytes()`; fails before this change.
- [x] `test_cache_shared_prefix_not_charged_per_entry` — 100 entries under a 10 KB shared prefix stay well under the ~1 MB a per-entry prefix charge would produce.
- [x] Existing cache tests still pass (`cargo test -p lance-core cache::`), incl. `test_cache_bytes`.
- [x] `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` clean.