### PR TITLE
perf(dataset): reuse session-cached manifest when opening a dataset

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -731,6 +731,30 @@ impl Dataset {
         Ok(manifest)
     }
 
+    /// Fetch the manifest for `manifest_location` from the session metadata
+    /// cache, loading and caching it on a miss.
+    pub(crate) async fn get_manifest(
+        object_store: &ObjectStore,
+        manifest_location: &ManifestLocation,
+        uri: &str,
+        session: &Session,
+    ) -> Result<Arc<Manifest>> {
+        let metadata_cache = session.metadata_cache.for_dataset(uri);
+        let manifest_key = ManifestKey {
+            version: manifest_location.version,
+            e_tag: manifest_location.e_tag.as_deref(),
+        };
+        if let Some(cached) = metadata_cache.get_with_key(&manifest_key).await {
+            return Ok(cached);
+        }
+        let loaded =
+            Arc::new(Self::load_manifest(object_store, manifest_location, uri, session).await?);
+        metadata_cache
+            .insert_with_key(&manifest_key, loaded.clone())
+            .await;
+        Ok(loaded)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn checkout_manifest(
         object_store: Arc<ObjectStore>,
@@ -2904,30 +2928,13 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
         .map_ok(move |location| {
             let latest_tx = latest_tx.take();
             async move {
-                let manifest_key = ManifestKey {
-                    version: location.version,
-                    e_tag: location.e_tag.as_deref(),
-                };
-                let manifest = if let Some(cached) =
-                    dataset.metadata_cache.get_with_key(&manifest_key).await
-                {
-                    cached
-                } else {
-                    let loaded = Arc::new(
-                        Dataset::load_manifest(
-                            dataset.object_store.as_ref(),
-                            &location,
-                            &dataset.uri,
-                            dataset.session.as_ref(),
-                        )
-                        .await?,
-                    );
-                    dataset
-                        .metadata_cache
-                        .insert_with_key(&manifest_key, loaded.clone())
-                        .await;
-                    loaded
-                };
+                let manifest = Dataset::get_manifest(
+                    dataset.object_store.as_ref(),
+                    &location,
+                    &dataset.uri,
+                    dataset.session.as_ref(),
+                )
+                .await?;
 
                 if let Some(latest_tx) = latest_tx {
                     // We ignore the error, since we don't care if the receiver is dropped.

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -833,7 +833,7 @@ impl DatasetBuilder {
                 let reader = object_store.open(&location.path).await?;
                 populate_schema_dictionary(&mut manifest.schema, reader.as_ref()).await?;
             }
-            (manifest, location)
+            (Arc::new(manifest), location)
         } else {
             let manifest_location = match version_number {
                 Some(version) => {
@@ -866,7 +866,8 @@ impl DatasetBuilder {
                         _ => e,
                     })?,
             };
-            let manifest = Dataset::load_manifest(
+
+            let manifest = Dataset::get_manifest(
                 &object_store,
                 &manifest_location,
                 &table_uri,
@@ -880,7 +881,7 @@ impl DatasetBuilder {
             object_store,
             base_path,
             table_uri,
-            Arc::new(manifest),
+            manifest,
             location,
             session,
             commit_handler,

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -692,12 +692,12 @@ async fn test_load_manifest_iops() {
         .await
         .unwrap();
 
-    // There should be only two IOPS:
-    // 1. List _versions directory to get the latest manifest location
-    // 2. Read the manifest file. (The manifest is small enough to be read in one go.
-    //    Larger manifests would result in more IOPS.)
+    // The write above committed on this same Session, so the manifest is already
+    // in the metadata cache. Opening therefore issues a single IOP:
+    // 1. List _versions directory to resolve the latest manifest location.
+    // The manifest body is served from the cache instead of being read from storage.
     let io_stats = _dataset.object_store.as_ref().io_stats_incremental();
-    assert_io_eq!(io_stats, read_iops, 2);
+    assert_io_eq!(io_stats, read_iops, 1);
 }
 
 #[rstest]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -630,10 +630,9 @@ mod tests {
             .unwrap();
         assert_eq!(new_ds.manifest().version, 7);
         // Session should still be re-used
-        // However, the dataset needs to be loaded and the read version checked out,
-        // so an additional 4 IOPs are needed.
+        // However, the dataset needs to be loaded and the read version checked out.
         let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-        assert_io_eq!(io_stats, read_iops, 5, "load dataset + check version");
+        assert_io_eq!(io_stats, read_iops, 4, "load dataset + check version");
         assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
 
         // Commit transaction with URI and new session. Re-use the store

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -4087,7 +4087,9 @@ mod tests {
         assert_io_eq!(stats, read_bytes, 0);
         assert_eq!(indices.len(), 1);
 
-        session.index_cache.clear().await; // Clear the cache
+        // Clear the cache
+        session.index_cache.clear().await;
+        session.file_metadata_cache().clear().await;
 
         let dataset2 = DatasetBuilder::from_uri(test_uri)
             .with_session(session.clone())


### PR DESCRIPTION
# What changed
Opening a dataset by URI (`DatasetBuilder::load_by_uri`) always read the manifest from storage, even when the same version was already loaded on the session. 

This path now checks the session metadata cache first (keyed by version + e_tag) and only reads + caches on a miss. Manifests are immutable per version, so a cache hit is always safe.

# Why it matters
Take distributed read/write for example

lance-spark shares one Session per executor (`LanceRuntime.CATALOG_SESSIONS`), and every task opens the dataset on its own (`LanceFragmentScanner.create` → `Utils.openDatasetBuilder(...).build()`). Before this change, each task re-read the manifest, so manifest reads scaled with the number of tasks and turned the manifest object into a read hotspot on object storage (large tables, many fragments, wide backfills). After this change the manifest is read once per executor and reused across all tasks on that executor — dropping manifest reads from task-level to executor-level.
