### PR TITLE
fix(commit): verify finalized external manifests

### DIFF
--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -347,6 +347,69 @@ pub struct ExternalManifestCommitHandler {
 }
 
 impl ExternalManifestCommitHandler {
+    async fn verify_finalized_manifest_location(
+        &self,
+        base_path: &Path,
+        location: ManifestLocation,
+        object_store: &dyn OSObjectStore,
+    ) -> std::result::Result<ManifestLocation, Error> {
+        match object_store.head(&location.path).await {
+            Ok(ObjectMeta { size, e_tag, .. }) => {
+                let ManifestLocation {
+                    version,
+                    path,
+                    size: expected_size,
+                    naming_scheme,
+                    e_tag: expected_e_tag,
+                } = location;
+
+                let size = match expected_size {
+                    Some(expected_size) if expected_size != size => {
+                        return Err(Error::corrupt_file(
+                            path,
+                            format!(
+                                "Manifest size mismatch for version {}: external store expected {}, object store returned {}",
+                                version, expected_size, size
+                            ),
+                        ));
+                    }
+                    Some(expected_size) => Some(expected_size),
+                    None => Some(size),
+                };
+
+                let e_tag = match expected_e_tag {
+                    Some(expected_e_tag) => {
+                        if e_tag.as_ref() != Some(&expected_e_tag) {
+                            return Err(Error::corrupt_file(
+                                path,
+                                format!(
+                                    "Manifest e_tag mismatch for version {}: external store expected {:?}, object store returned {:?}",
+                                    version, expected_e_tag, e_tag
+                                ),
+                            ));
+                        }
+                        Some(expected_e_tag)
+                    }
+                    None => e_tag,
+                };
+
+                Ok(ManifestLocation {
+                    version,
+                    path,
+                    size,
+                    naming_scheme,
+                    e_tag,
+                })
+            }
+            Err(ObjectStoreError::NotFound { .. }) => {
+                // The external store may hold a stale finalized V2 path while
+                // the object store still has the manifest at the V1 location.
+                default_resolve_version(base_path, location.version, object_store).await
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// The manifest is considered committed once the staging manifest is written
     /// to object store and that path is committed to the external store.
     ///
@@ -441,23 +504,24 @@ impl CommitHandler for ExternalManifestCommitHandler {
             .await?;
 
         match location {
-            Some(ManifestLocation {
-                version,
-                path,
-                size,
-                naming_scheme,
-                e_tag,
-            }) => {
-                // The path is finalized, no need to check object store
-                if path.extension() == Some(MANIFEST_EXTENSION) {
-                    return Ok(ManifestLocation {
-                        version,
-                        path,
-                        size,
-                        naming_scheme,
-                        e_tag,
-                    });
+            Some(location) => {
+                if location.path.extension() == Some(MANIFEST_EXTENSION) {
+                    return self
+                        .verify_finalized_manifest_location(
+                            base_path,
+                            location,
+                            object_store.inner.as_ref(),
+                        )
+                        .await;
                 }
+
+                let ManifestLocation {
+                    version,
+                    path,
+                    size,
+                    naming_scheme,
+                    e_tag,
+                } = location;
 
                 let (size, e_tag) = if let Some(size) = size {
                     (size, e_tag)
@@ -552,9 +616,10 @@ impl CommitHandler for ExternalManifestCommitHandler {
             Err(e) => return Err(e),
         };
 
-        // finalized path, just return
         if location.path.extension() == Some(MANIFEST_EXTENSION) {
-            return Ok(location);
+            return self
+                .verify_finalized_manifest_location(base_path, location, object_store)
+                .await;
         }
 
         let naming_scheme =

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -14,10 +14,11 @@ mod test {
     use futures::stream::BoxStream;
     use futures::{StreamExt, TryStreamExt, future::join_all};
     use lance_core::{Error, Result};
+    use lance_io::object_store::ObjectStore;
     use lance_table::io::commit::external_manifest::{
         ExternalManifestCommitHandler, ExternalManifestStore,
     };
-    use lance_table::io::commit::{CommitHandler, ManifestNamingScheme};
+    use lance_table::io::commit::{CommitHandler, ManifestLocation, ManifestNamingScheme};
     use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
     use object_store::memory::InMemory;
     use object_store::{
@@ -125,6 +126,70 @@ mod test {
         }
     }
 
+    #[derive(Debug)]
+    struct StaticExternalManifestStore {
+        location: ManifestLocation,
+    }
+
+    #[async_trait]
+    impl ExternalManifestStore for StaticExternalManifestStore {
+        async fn get(&self, _uri: &str, version: u64) -> Result<String> {
+            if version == self.location.version {
+                Ok(self.location.path.to_string())
+            } else {
+                Err(Error::not_found(format!("version {}", version)))
+            }
+        }
+
+        async fn get_manifest_location(
+            &self,
+            _base_uri: &str,
+            version: u64,
+        ) -> Result<ManifestLocation> {
+            if version == self.location.version {
+                Ok(self.location.clone())
+            } else {
+                Err(Error::not_found(format!("version {}", version)))
+            }
+        }
+
+        async fn get_latest_version(&self, _uri: &str) -> Result<Option<(u64, String)>> {
+            Ok(Some((
+                self.location.version,
+                self.location.path.to_string(),
+            )))
+        }
+
+        async fn get_latest_manifest_location(
+            &self,
+            _base_uri: &str,
+        ) -> Result<Option<ManifestLocation>> {
+            Ok(Some(self.location.clone()))
+        }
+
+        async fn put_if_not_exists(
+            &self,
+            _uri: &str,
+            _version: u64,
+            _path: &str,
+            _size: u64,
+            _e_tag: Option<String>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn put_if_exists(
+            &self,
+            _uri: &str,
+            _version: u64,
+            _path: &str,
+            _size: u64,
+            _e_tag: Option<String>,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
     fn read_params(handler: Arc<dyn CommitHandler>) -> ReadParams {
         ReadParams {
             commit_handler: Some(handler),
@@ -137,6 +202,143 @@ mod test {
             commit_handler: Some(handler),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn finalized_external_manifest_location_is_head_checked() {
+        let sleepy_store = SleepyExternalManifestStore::new();
+        let inner_store = sleepy_store.store.clone();
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(sleepy_store),
+        };
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("repro");
+        let version = 7;
+        let final_path = ManifestNamingScheme::V2.manifest_path(&base_path, version);
+        let body = b"manifest body";
+
+        object_store
+            .inner
+            .put(&final_path, PutPayload::from_static(body))
+            .await
+            .expect("seed finalized manifest");
+        inner_store
+            .lock()
+            .await
+            .insert((base_path.to_string(), version), final_path.to_string());
+
+        let location = handler
+            .resolve_latest_location(&base_path, &object_store)
+            .await
+            .expect("resolve latest finalized manifest");
+
+        assert_eq!(location.path, final_path);
+        assert_eq!(location.size, Some(body.len() as u64));
+        assert_eq!(location.naming_scheme, ManifestNamingScheme::V2);
+    }
+
+    #[tokio::test]
+    async fn finalized_external_manifest_location_falls_back_to_v1() {
+        let sleepy_store = SleepyExternalManifestStore::new();
+        let inner_store = sleepy_store.store.clone();
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(sleepy_store),
+        };
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("repro");
+        let version = 7;
+        let missing_v2_path = ManifestNamingScheme::V2.manifest_path(&base_path, version);
+        let v1_path = ManifestNamingScheme::V1.manifest_path(&base_path, version);
+
+        object_store
+            .inner
+            .put(&v1_path, PutPayload::from_static(b"v1 manifest body"))
+            .await
+            .expect("seed V1 manifest");
+        inner_store.lock().await.insert(
+            (base_path.to_string(), version),
+            missing_v2_path.to_string(),
+        );
+
+        let latest_location = handler
+            .resolve_latest_location(&base_path, &object_store)
+            .await
+            .expect("resolve latest should fall back to V1");
+        assert_eq!(latest_location.path, v1_path);
+        assert_eq!(latest_location.naming_scheme, ManifestNamingScheme::V1);
+
+        let version_location = handler
+            .resolve_version_location(&base_path, version, object_store.inner.as_ref())
+            .await
+            .expect("resolve version should fall back to V1");
+        assert_eq!(version_location.path, v1_path);
+        assert_eq!(version_location.naming_scheme, ManifestNamingScheme::V1);
+    }
+
+    #[tokio::test]
+    async fn finalized_external_manifest_location_rejects_size_mismatch() {
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("repro");
+        let version = 7;
+        let final_path = ManifestNamingScheme::V2.manifest_path(&base_path, version);
+        let body = b"manifest body";
+
+        object_store
+            .inner
+            .put(&final_path, PutPayload::from_static(body))
+            .await
+            .expect("seed finalized manifest");
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(StaticExternalManifestStore {
+                location: ManifestLocation {
+                    version,
+                    path: final_path,
+                    size: Some(body.len() as u64 + 1),
+                    naming_scheme: ManifestNamingScheme::V2,
+                    e_tag: None,
+                },
+            }),
+        };
+
+        let err = handler
+            .resolve_latest_location(&base_path, &object_store)
+            .await
+            .expect_err("stale external manifest size should be rejected");
+        assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
+        assert!(err.to_string().contains("Manifest size mismatch"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn finalized_external_manifest_location_rejects_etag_mismatch() {
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("repro");
+        let version = 7;
+        let final_path = ManifestNamingScheme::V2.manifest_path(&base_path, version);
+        let body = b"manifest body";
+
+        object_store
+            .inner
+            .put(&final_path, PutPayload::from_static(body))
+            .await
+            .expect("seed finalized manifest");
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(StaticExternalManifestStore {
+                location: ManifestLocation {
+                    version,
+                    path: final_path,
+                    size: Some(body.len() as u64),
+                    naming_scheme: ManifestNamingScheme::V2,
+                    e_tag: Some("stale-etag".to_string()),
+                },
+            }),
+        };
+
+        let err = handler
+            .resolve_latest_location(&base_path, &object_store)
+            .await
+            .expect_err("stale external manifest e_tag should be rejected");
+        assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
+        assert!(err.to_string().contains("Manifest e_tag mismatch"), "{err}");
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -317,9 +317,10 @@ async fn test_ddb_open_iops() {
         .await
         .unwrap();
     let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-    // Open dataset can be read with 1 IOP, just to read the manifest.
-    // Looking up latest manifest is handled in dynamodb.
-    assert_io_eq!(io_stats, read_iops, 1);
+    // Open dataset can be read with 2 IOPs: HEAD verifies that the
+    // finalized path returned by DynamoDB still exists, then the manifest
+    // itself is read. Looking up the latest manifest is handled in DynamoDB.
+    assert_io_eq!(io_stats, read_iops, 2);
     assert_io_eq!(io_stats, write_iops, 0);
 
     // Append
@@ -341,10 +342,8 @@ async fn test_ddb_open_iops() {
     // Checkout original version
     dataset.checkout_version(1).await.unwrap();
     let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-    // Checkout: 0 read IOPS. Version 1's manifest was already loaded and cached
-    // on this Session when the dataset was opened above, so the checkout serves
-    // the manifest body from the metadata cache. Version resolution is handled
-    // in DynamoDB and issues no S3 read.
-    assert_io_eq!(io_stats, read_iops, 0);
+    // Checkout: 1 read IOP. Version resolution HEAD-checks the finalized path,
+    // while the manifest body is served from the Session metadata cache.
+    assert_io_eq!(io_stats, read_iops, 1);
     assert_io_eq!(io_stats, write_iops, 0);
 }


### PR DESCRIPTION
## Bug Fix

- What is the bug?
  ExternalManifestCommitHandler trusted finalized `.manifest` paths returned by the external manifest store without checking that the object existed.

- What issues or incorrect behavior does the bug cause?
  A stale finalized V2 path could bypass object-store verification and skip the default V2-to-V1 manifest fallback.

- How does this PR fix the problem?
  Finalized external manifest locations are now HEAD-checked before use. If the finalized path is missing, resolution falls back through the default version resolver, preserving the V2-first then V1 fallback behavior. The same verification path is used for latest and explicit version resolution.

## Validation

- `cargo fmt --all`
- `git diff --check -- rust/lance-table/src/io/commit/external_manifest.rs rust/lance/src/io/commit/external_manifest.rs`
- `PROTOC=/private/tmp/protoc-35.1-osx-aarch_64/bin/protoc PROTOC_INCLUDE=/private/tmp/protoc-35.1-osx-aarch_64/include cargo test -p lance finalized_external_manifest_location --lib`
- `PROTOC=/private/tmp/protoc-35.1-osx-aarch_64/bin/protoc PROTOC_INCLUDE=/private/tmp/protoc-35.1-osx-aarch_64/include cargo clippy --all --tests --benches -- -D warnings`