### PR TITLE
fix(python): avoid CPU bf16 compile flake

### DIFF
--- a/python/python/lance/torch/distance.py
+++ b/python/python/lance/torch/distance.py
@@ -150,8 +150,9 @@ def pairwise_l2(
     if x.dtype != y.dtype or (y2 is not None and x.dtype != y2.dtype):
         raise ValueError("pairwise_l2 data types do not match")
     origin_dtype = x.dtype
-    if x.device == torch.device("cpu") and x.dtype == torch.float16:
-        # Pytorch does not support `x @ y.T` for float16 on CPU
+    if x.device == torch.device("cpu") and x.dtype in (torch.float16, torch.bfloat16):
+        # Pytorch does not support `x @ y.T` for float16 on CPU, and bfloat16
+        # can hit backend-specific compiler paths. Accumulate in float32.
         x = x.type(torch.float32)
         y = y.type(torch.float32)
         if y2 is not None:


### PR DESCRIPTION
## Summary
- Fix the Windows Python CI flake in `test_l2_distance_f16_bf16_cpu`.
- Failure reference: https://github.com/lance-format/lance/actions/runs/28589246239/job/84768429390
- `pairwise_l2` already upcasts CPU `float16` before matmul; extend that same path to CPU `bfloat16`.
- The result is still cast back to the original dtype, while the CPU matmul/accumulation runs in `float32`.

## Tests
- `git diff --check`
- Not run: `env UV_CACHE_DIR=/private/tmp/uv-cache-lance-ddu259 make install PYTHON=3.12` failed during the local `pylance` native build with `Operation not permitted` while writing a cargo `.rlib` under `python/target`.