### PR TITLE
fix: avoid scheduler deadlock on same-priority chunks

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6115,17 +6115,13 @@ class ScannerBuilder:
         used by the scanner.  If the buffer is full then the scanner will block until
         the buffer is processed.
 
-        Generally this should scale with the number of concurrent I/O threads.  The
-        default is 2GiB which comfortably provides enough space for somewhere between
-        32 and 256 concurrent I/O threads.
+        Generally this should scale with the number of concurrent I/O threads.  If
+        unset, v2 scans choose a default based on the object store and
+        ``LANCE_DEFAULT_IO_BUFFER_SIZE`` can override that default.
 
         This value is not a hard cap on the amount of RAM the scanner will use.  Some
         space is used for the compute (which can be controlled by the batch size) and
         Lance does not keep track of memory after it is returned to the user.
-
-        Currently, if there is a single batch of data which is larger than the io buffer
-        size then the scanner will deadlock.  This is a known issue and will be fixed in
-        a future release.
 
         This parameter is only used when reading v2 files
         """

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -66,6 +66,10 @@ impl PrioritiesInFlight {
         self.in_flight.first().copied().unwrap_or(u128::MAX)
     }
 
+    fn contains(&self, prio: u128) -> bool {
+        self.in_flight.binary_search(&prio).is_ok()
+    }
+
     fn push(&mut self, prio: u128) {
         let pos = match self.in_flight.binary_search(&prio) {
             Ok(pos) => pos,
@@ -141,6 +145,10 @@ impl IoQueueState {
         } else if self.no_backpressure
             || task.bypass_backpressure
             || task.priority <= self.priorities_in_flight.min_in_flight()
+            // Chunks from an admitted logical request must keep moving.  A
+            // higher-priority request may be scheduled later and remain
+            // unconsumed while the caller awaits this request.
+            || self.priorities_in_flight.contains(task.priority)
         {
             true
         } else if task.num_bytes() as i64 > self.bytes_avail {
@@ -1596,6 +1604,99 @@ mod tests {
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(first_fut.await.unwrap().len(), 10);
         assert_eq!(second_fut.await.unwrap().len(), 10);
+    }
+
+    #[derive(Debug)]
+    struct BlockingReader {
+        semaphore: Arc<tokio::sync::Semaphore>,
+        path: Path,
+    }
+
+    impl lance_core::deepsize::DeepSizeOf for BlockingReader {
+        fn deep_size_of_children(&self, _context: &mut lance_core::deepsize::Context) -> usize {
+            0
+        }
+    }
+
+    impl Reader for BlockingReader {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn block_size(&self) -> usize {
+            4096
+        }
+
+        fn io_parallelism(&self) -> usize {
+            1
+        }
+
+        fn size(&self) -> futures::future::BoxFuture<'_, object_store::Result<usize>> {
+            Box::pin(async { Ok(1_000_000) })
+        }
+
+        fn get_range(
+            &self,
+            range: Range<usize>,
+        ) -> futures::future::BoxFuture<'static, object_store::Result<Bytes>> {
+            let semaphore = self.semaphore.clone();
+            let num_bytes = range.end - range.start;
+            Box::pin(async move {
+                semaphore.acquire().await.unwrap().forget();
+                Ok(Bytes::from(vec![0u8; num_bytes]))
+            })
+        }
+
+        fn get_all(&self) -> futures::future::BoxFuture<'_, object_store::Result<Bytes>> {
+            Box::pin(async { Ok(Bytes::from(vec![0u8; 1_000_000])) })
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_same_priority_chunks_continue_after_higher_priority_request() {
+        let obj_store = Arc::new(ObjectStore::new(
+            Arc::new(InMemory::new()),
+            Url::parse("mem://").unwrap(),
+            Some(4096),
+            None,
+            false,
+            false,
+            1,
+            DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
+        ));
+        let scheduler = ScanScheduler::new(
+            obj_store,
+            SchedulerConfig {
+                io_buffer_size_bytes: 10,
+                use_lite_scheduler: Some(false),
+            },
+        );
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+        let reader: Arc<dyn Reader> = Arc::new(BlockingReader {
+            semaphore: semaphore.clone(),
+            path: Path::parse("test").unwrap(),
+        });
+
+        let low_priority =
+            scheduler.submit_request(reader.clone(), vec![0..6, 100..106], 10, false);
+        let high_priority = scheduler.submit_request(reader, vec![200..204], 0, false);
+
+        semaphore.add_permits(3);
+        let low_priority = timeout(Duration::from_secs(5), low_priority)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            low_priority.iter().map(|bytes| bytes.len()).sum::<usize>(),
+            12
+        );
+
+        let high_priority = timeout(Duration::from_secs(5), high_priority)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(high_priority[0].len(), 4);
     }
 
     /// A Reader that tracks how many times get_range has been called.

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -262,6 +262,10 @@ impl PrioritiesInFlight {
         self.in_flight.first().copied().unwrap_or(u128::MAX)
     }
 
+    fn contains(&self, prio: u128) -> bool {
+        self.in_flight.binary_search(&prio).is_ok()
+    }
+
     fn push(&mut self, prio: u128) {
         let pos = match self.in_flight.binary_search(&prio) {
             Ok(pos) => pos,
@@ -325,6 +329,10 @@ impl BackpressureThrottle for SimpleBackpressureThrottle {
         if self.no_backpressure
             || self.bytes_available >= num_bytes as i64
             || self.priorities_in_flight.min_in_flight() >= priority
+            // Chunks from an admitted logical request must keep moving.  A
+            // higher-priority request may be scheduled later and remain
+            // unconsumed while the caller awaits this request.
+            || self.priorities_in_flight.contains(priority)
         {
             self.bytes_available -= num_bytes as i64;
             self.priorities_in_flight.push(priority);
@@ -801,5 +809,23 @@ mod tests {
         bypass.await.unwrap();
         normal_tx.send(Bytes::from_static(b"done")).unwrap();
         normal.await.unwrap();
+    }
+
+    #[test]
+    fn test_same_priority_reservation_continues_after_higher_priority() {
+        let mut throttle = SimpleBackpressureThrottle::new(10, 128);
+
+        let low_priority_first = throttle.try_acquire(6, 10).unwrap();
+        let high_priority = throttle.try_acquire(4, 0).unwrap();
+        let low_priority_next = throttle.try_acquire(6, 10);
+
+        assert!(
+            low_priority_next.is_some(),
+            "chunks from an already admitted logical request should continue"
+        );
+
+        throttle.release(low_priority_first);
+        throttle.release(high_priority);
+        throttle.release(low_priority_next.unwrap());
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1358,17 +1358,14 @@ impl Scanner {
     /// used by the scanner.  If the buffer is full then the scanner will block until
     /// the buffer is processed.
     ///
-    /// Generally this should scale with the number of concurrent I/O threads.  The
-    /// default is 2GiB which comfortably provides enough space for somewhere between
-    /// 32 and 256 concurrent I/O threads.
+    /// Generally this should scale with the number of concurrent I/O threads.  If
+    /// unset, v2 scans choose a default based on the object store and
+    /// `LANCE_DEFAULT_IO_BUFFER_SIZE` can override that default.
     ///
     /// This value is not a hard cap on the amount of RAM the scanner will use.  Some
     /// space is used for the compute (which can be controlled by the batch size) and
     /// Lance does not keep track of memory after it is returned to the user.
     ///
-    /// Currently, if there is a single batch of data which is larger than the io buffer
-    /// size then the scanner will deadlock.  This is a known issue and will be fixed in
-    /// a future release.
     pub fn io_buffer_size(&mut self, size: u64) -> &mut Self {
         self.io_buffer_size = Some(size);
         self

--- a/rust/lance/src/dataset/tests/dataset_scanner.rs
+++ b/rust/lance/src/dataset/tests/dataset_scanner.rs
@@ -43,6 +43,82 @@ use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
+async fn test_scan_wide_fixed_size_list_at_batch_boundary() {
+    const DIM_A: usize = 140_000;
+    const DIM_B: usize = 4_096;
+    const SHORT_ROWS: usize = 68;
+    const LONG_ROWS: usize = 128;
+
+    fn make_batch(schema: SchemaRef, rows: usize, base: usize) -> RecordBatch {
+        let values_a = Float32Array::from_iter_values(
+            (0..rows * DIM_A).map(|idx| ((idx + base) % 1009) as f32 / 1009.0),
+        );
+        let values_b = Float32Array::from_iter_values(
+            (0..rows * DIM_B).map(|idx| ((idx + base) % 251) as f32 / 251.0),
+        );
+        let arr_a = FixedSizeListArray::try_new_from_values(values_a, DIM_A as i32).unwrap();
+        let arr_b = FixedSizeListArray::try_new_from_values(values_b, DIM_B as i32).unwrap();
+        RecordBatch::try_new(schema, vec![Arc::new(arr_a), Arc::new(arr_b)]).unwrap()
+    }
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new(
+            "a",
+            DataType::FixedSizeList(
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                DIM_A as i32,
+            ),
+            true,
+        ),
+        ArrowField::new(
+            "b",
+            DataType::FixedSizeList(
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                DIM_B as i32,
+            ),
+            true,
+        ),
+    ]));
+
+    let batches = vec![
+        make_batch(schema.clone(), SHORT_ROWS, 0),
+        make_batch(schema.clone(), LONG_ROWS, 17),
+    ];
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+    let write_params = WriteParams {
+        data_storage_version: Some(LanceFileVersion::V2_1),
+        ..WriteParams::default()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let dataset = Dataset::write(reader, dir.path().to_str().unwrap(), Some(write_params))
+        .await
+        .unwrap();
+
+    // The first column splits into 9 read chunks. The second column is a
+    // higher-priority request that can reserve the remaining buffer while the
+    // first column is still awaited.
+    let mut scanner = dataset.scan();
+    scanner.io_buffer_size(70 * 1024 * 1024);
+    scanner
+        .limit(Some(LONG_ROWS as i64), Some(SHORT_ROWS as i64))
+        .unwrap();
+    let mut stream = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        scanner.try_into_stream(),
+    )
+    .await
+    .expect("stream creation timed out")
+    .unwrap();
+    let batch = tokio::time::timeout(std::time::Duration::from_secs(20), stream.try_next())
+        .await
+        .expect("first batch timed out")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(batch.num_rows(), LONG_ROWS);
+}
+
+#[tokio::test]
 async fn test_vector_filter_fts_search() {
     let dataset = prepare_query_filter_dataset().await;
     let schema: ArrowSchema = dataset.schema().into();


### PR DESCRIPTION
This fixes a scanner hang when a ranged read starts at a write-batch boundary and a wide column is split into multiple I/O chunks while another smaller, higher-priority request is scheduled in the same scan line.

The scheduler previously used only the minimum in-flight priority to decide whether a request could bypass byte backpressure. If a higher-priority request remained unconsumed while the decoder awaited a wide-column request, remaining chunks from the already-admitted wide-column request could be blocked behind the byte budget, causing a deadlock.

This changes both the standard and lite schedulers to let chunks with an already in-flight priority keep moving. It also adds scheduler-level and scanner-level regression coverage, and updates the `io_buffer_size` docs now that this deadlock is fixed.

Validated with the relevant `lance-io` scheduler tests and the targeted scanner regression.
