### PR TITLE
fix(fsst): correct decoder output-buffer size contract to 8x

### DIFF
--- a/rust/compression/fsst/examples/benchmark.rs
+++ b/rust/compression/fsst/examples/benchmark.rs
@@ -56,7 +56,10 @@ fn benchmark(file_path: &str) {
     let mut decompression_out_bufs = vec![];
     let mut decompression_out_offsets_bufs = vec![];
     for _ in 0..TEST_NUM {
-        let this_decom_out_buf = vec![0u8; BUFFER_SIZE * 3];
+        // `decompress` requires the output buffer to be at least 8x the compressed input (a 1-byte
+        // code can expand to an 8-byte symbol). The compressed buffer is at most `BUFFER_SIZE`, so
+        // `BUFFER_SIZE * 8` is a safe upper bound.
+        let this_decom_out_buf = vec![0u8; BUFFER_SIZE * 8];
         let this_decom_out_offsets_buf = vec![0i32; BUFFER_SIZE * 3];
         decompression_out_bufs.push(this_decom_out_buf);
         decompression_out_offsets_bufs.push(this_decom_out_offsets_buf);

--- a/rust/compression/fsst/src/fsst.rs
+++ b/rust/compression/fsst/src/fsst.rs
@@ -819,23 +819,30 @@ fn decompress_bulk<T: OffsetSizeTrait>(
     let symbols = decoder.symbols;
     let lens = decoder.lens;
     // SAFETY invariant shared by every `unsafe` block in this closure:
-    // - `out` was sized by the caller to be at least 8x `compressed_strs` (enforced in
-    //   `FsstDecoder::init`, which only lets the decoder run this path once that holds). Each code
-    //   advances `out_curr` by at most 8 and each consumed input byte yields at most 8 output
-    //   bytes, so `out_curr + 8 <= out.len()` holds for every write, including the final one. This
-    //   is why we can `write_unaligned` a full 8-byte word per code and advance by only the symbol
-    //   length.
+    // - `out` is sized to at least 8x `compressed_strs` (checked in `FsstDecoder::init`, which the
+    //   sole public entry point always runs before reaching this function). Each code advances
+    //   `out_curr` by `lens[code]`, which is 1..=8 for a well-formed symbol table, and each
+    //   consumed input byte yields at most 8 output bytes, so `out_curr + 8 <= out.len()` at every
+    //   8-byte write, including the final one. This is why we can `write_unaligned` a full 8-byte
+    //   word per code and advance by only the length.
+    //   NOTE: `lens` is loaded verbatim from the (untrusted) symbol table and is NOT re-validated
+    //   to be <= 8 on decode, and offsets (below) are likewise trusted. A corrupted table or
+    //   offset buffer can violate these bounds; callers must supply structures produced by
+    //   `compress` (or otherwise trusted). Hardening the decoder against corrupt input is a
+    //   separate concern, not addressed here.
     // - The only unchecked read is `read_unaligned::<u32>`, gated by `in_curr + 4 <= in_end`; the
     //   scalar paths use bounds-checked indexing. `in_end` is a caller-provided offset into
-    //   `compressed_strs`, so soundness of the u32 read relies on the offsets being well-formed
-    //   (`in_end <= compressed_strs.len()`), which holds for offsets produced by the encoder.
+    //   `compressed_strs`; the read is sound only if `in_end <= compressed_strs.len()`, which is a
+    //   trusted precondition (holds for encoder-produced offsets; not validated here).
     let mut decompress = |mut in_curr: usize, in_end: usize, out_curr: &mut usize| {
         // Do SIMD operation here by 4 bytes
         while in_curr + 4 <= in_end {
             let next_block;
             let mut code;
             let mut len;
-            // SAFETY: `in_curr + 4 <= in_end <= compressed_strs.len()`, so 4 bytes are readable.
+            // SAFETY: the loop guard proves `in_curr + 4 <= in_end`. Per the closure-level
+            // invariant, `in_end <= compressed_strs.len()` is a trusted precondition (not checked
+            // here), so the 4-byte read is in bounds for well-formed input.
             unsafe {
                 next_block =
                     ptr::read_unaligned(compressed_strs.as_ptr().add(in_curr) as *const u32);
@@ -1214,8 +1221,15 @@ impl<T: OffsetSizeTrait> FsstDecoder<T> {
         // decoded output can be up to 8x the input. `decompress_bulk` also relies on this bound: it
         // writes a full 8-byte word per code (advancing only by the symbol length), so the output
         // buffer must be large enough that even the final write stays in bounds. Require out_buf to
-        // be at least 8x in_buf.
-        if self.decoder_switch_on && in_buf.len() * 8 > out_buf.len() {
+        // be at least 8x in_buf. `checked_mul` guards against `in_buf.len() * 8` wrapping on 32-bit
+        // targets (an input >= 512 MiB would otherwise bypass the check); treat overflow as too
+        // small.
+        if self.decoder_switch_on
+            && in_buf
+                .len()
+                .checked_mul(8)
+                .is_none_or(|needed| needed > out_buf.len())
+        {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "output buffer too small for FSST decoder",

--- a/rust/compression/fsst/src/fsst.rs
+++ b/rust/compression/fsst/src/fsst.rs
@@ -57,6 +57,12 @@ use std::ptr;
 
 #[inline]
 fn fsst_unaligned_load_unchecked(v: *const u8) -> u64 {
+    // SAFETY: the caller must guarantee that `v` points to at least 8 readable bytes. All callers
+    // uphold this: `compress_bulk` reads from a `[u8; 520]` buffer padded with a sentinel byte,
+    // `build_symbol_table` guards the load with `word.len() > 7 && curr < word.len() - 7`,
+    // `find_longest_symbol_from_char_slice` copies into a stack `[u8; 8]` before loading, and
+    // `FsstDecoder::init` reads symbols from a `symbol_table` buffer already validated to be
+    // exactly `FSST_SYMBOL_TABLE_SIZE` bytes.
     unsafe { ptr::read_unaligned(v as *const u64) }
 }
 
@@ -812,12 +818,21 @@ fn decompress_bulk<T: OffsetSizeTrait>(
 ) -> io::Result<()> {
     let symbols = decoder.symbols;
     let lens = decoder.lens;
+    // SAFETY invariant shared by every `unsafe` block in this closure:
+    // - `out` was sized by the caller to be at least 8x `compressed_strs` (enforced in
+    //   `FsstDecoder::init`). Each code advances `out_curr` by at most 8 and each consumed input
+    //   byte yields at most 8 output bytes, so `out_curr + 8 <= out.len()` holds for every write,
+    //   including the final one. This is why we can `write_unaligned` a full 8-byte word per code
+    //   and advance by only the symbol length.
+    // - Every `read_unaligned::<u32>` reads 4 bytes gated by `in_curr + 4 <= in_end`; the trailing
+    //   scalar paths read within `in_end`, which is bounded by `compressed_strs.len()`.
     let mut decompress = |mut in_curr: usize, in_end: usize, out_curr: &mut usize| {
         // Do SIMD operation here by 4 bytes
         while in_curr + 4 <= in_end {
             let next_block;
             let mut code;
             let mut len;
+            // SAFETY: `in_curr + 4 <= in_end <= compressed_strs.len()`, so 4 bytes are readable.
             unsafe {
                 next_block =
                     ptr::read_unaligned(compressed_strs.as_ptr().add(in_curr) as *const u32);
@@ -983,6 +998,10 @@ fn decompress_bulk<T: OffsetSizeTrait>(
         if in_curr < in_end {
             // last code cannot be an escape code
             let code = compressed_strs[in_curr] as usize;
+            // SAFETY: see the closure-level invariant. This is the final write and has no
+            // subsequent write to cover its slack, so it is the tightest case: `out_curr` is at
+            // most 8*(consumed_input_bytes - 1), and the 8-byte store lands within `out.len()`
+            // precisely because the caller sized `out` to 8x the input.
             unsafe {
                 let src = symbols[code];
                 ptr::write_unaligned(out.as_mut_ptr().add(*out_curr) as *mut u64, src);
@@ -1188,8 +1207,12 @@ impl<T: OffsetSizeTrait> FsstDecoder<T> {
         }
 
         self.decoder_switch_on = (st_info & (1 << 24)) != 0;
-        // when decoder_switch_on is true, we make sure the out_buf is at least 3 times the size of the in_buf,
-        if self.decoder_switch_on && in_buf.len() * 3 > out_buf.len() {
+        // A single 1-byte code can decode to a symbol of up to MAX_SYMBOL_LENGTH (8) bytes, so the
+        // decoded output can be up to 8x the input. `decompress_bulk` also relies on this bound: it
+        // writes a full 8-byte word per code (advancing only by the symbol length), so the output
+        // buffer must be large enough that even the final write stays in bounds. Require out_buf to
+        // be at least 8x in_buf.
+        if self.decoder_switch_on && in_buf.len() * 8 > out_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "output buffer too small for FSST decoder",
@@ -1288,8 +1311,10 @@ pub fn compress<T: OffsetSizeTrait>(
 // the following 32 bits after FSST_MAGIC contains information about FSST encoding, such as decoder_switch_on, suffix_lim, terminator, n_symbols
 // when the decoder_switch_on is off in the in_buf header, `decompress` first make sure the out_buf is at least the same size as the in_buf, then simply copy the
 // input data to the output
-// when the decoder_switch_on is on, `decompress` first make sure the out_buf is at least 3 times the size of the in_buf, then start decoding the
-// data using the symbol table
+// when the decoder_switch_on is on, `decompress` first make sure the out_buf is at least 8 times the size of the in_buf, then start decoding the
+// data using the symbol table. The 8x bound is required for correctness: a 1-byte code can expand to
+// an 8-byte symbol, and the decode loop writes a full 8-byte word per code, so a smaller buffer can
+// be written out of bounds.
 // the out_offsets_buf should be at least the same size as the in_offsets_buf, otherwise an error is returned
 // the symbol_table is the same symbol table created by `compression`
 pub fn decompress<T: OffsetSizeTrait>(
@@ -1643,5 +1668,60 @@ But exactly how the acquaintance and friendship came about, we cannot say.";
                 std::str::from_utf8(original)
             );
         }
+    }
+
+    // Build a genuinely FSST-compressed (decoder_switch_on) buffer to exercise the decode-side
+    // output-buffer size contract. Returns (symbol_table, compressed_bytes, compressed_offsets).
+    fn compress_paragraph() -> ([u8; FSST_SYMBOL_TABLE_SIZE], Vec<u8>, Vec<i32>) {
+        let test_input = TEST_PARAGRAPH.repeat((1024 * 1024) / TEST_PARAGRAPH.len());
+        let lines_vec = test_input.lines().collect::<Vec<&str>>();
+        let string_array = StringArray::from(lines_vec);
+        let mut compress_output_buf: Vec<u8> = vec![0; string_array.value_data().len()];
+        let mut compress_offset_buf: Vec<i32> = vec![0; string_array.value_offsets().len()];
+        let mut symbol_table = [0; FSST_SYMBOL_TABLE_SIZE];
+        compress(
+            symbol_table.as_mut(),
+            string_array.value_data(),
+            string_array.value_offsets(),
+            &mut compress_output_buf,
+            &mut compress_offset_buf,
+        )
+        .unwrap();
+        (symbol_table, compress_output_buf, compress_offset_buf)
+    }
+
+    // The decoder writes a full 8-byte word per code, so the output buffer must be at least 8x the
+    // compressed input. A buffer sized below 8x must be rejected rather than written out of bounds.
+    #[test_log::test(tokio::test)]
+    async fn test_decompress_rejects_undersized_output_buffer() {
+        let (symbol_table, compressed, compressed_offsets) = compress_paragraph();
+        // Sanity check: this input actually engaged FSST compression (decoder_switch_on).
+        let st_info = u64::from_ne_bytes(symbol_table[..8].try_into().unwrap());
+        assert!(st_info & (1 << 24) != 0, "expected decoder_switch_on input");
+
+        // One byte short of the 8x requirement must be rejected.
+        let mut too_small = vec![0u8; compressed.len() * 8 - 1];
+        let mut out_offsets = vec![0i32; compressed_offsets.len()];
+        let err = decompress(
+            &symbol_table,
+            &compressed,
+            &compressed_offsets,
+            &mut too_small,
+            &mut out_offsets,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+        // Exactly 8x is the tight bound and must succeed.
+        let mut exact = vec![0u8; compressed.len() * 8];
+        let mut out_offsets = vec![0i32; compressed_offsets.len()];
+        decompress(
+            &symbol_table,
+            &compressed,
+            &compressed_offsets,
+            &mut exact,
+            &mut out_offsets,
+        )
+        .unwrap();
     }
 }

--- a/rust/compression/fsst/src/fsst.rs
+++ b/rust/compression/fsst/src/fsst.rs
@@ -58,8 +58,8 @@ use std::ptr;
 #[inline]
 fn fsst_unaligned_load_unchecked(v: *const u8) -> u64 {
     // SAFETY: the caller must guarantee that `v` points to at least 8 readable bytes. All callers
-    // uphold this: `compress_bulk` reads from a `[u8; 520]` buffer padded with a sentinel byte,
-    // `build_symbol_table` guards the load with `word.len() > 7 && curr < word.len() - 7`,
+    // uphold this: `compress_bulk` loads from a 520-byte stack buffer at an offset < 511 (leaving
+    // >= 8 bytes), `build_symbol_table` guards the load with `word.len() > 7 && curr < word.len() - 7`,
     // `find_longest_symbol_from_char_slice` copies into a stack `[u8; 8]` before loading, and
     // `FsstDecoder::init` reads symbols from a `symbol_table` buffer already validated to be
     // exactly `FSST_SYMBOL_TABLE_SIZE` bytes.
@@ -820,12 +820,15 @@ fn decompress_bulk<T: OffsetSizeTrait>(
     let lens = decoder.lens;
     // SAFETY invariant shared by every `unsafe` block in this closure:
     // - `out` was sized by the caller to be at least 8x `compressed_strs` (enforced in
-    //   `FsstDecoder::init`). Each code advances `out_curr` by at most 8 and each consumed input
-    //   byte yields at most 8 output bytes, so `out_curr + 8 <= out.len()` holds for every write,
-    //   including the final one. This is why we can `write_unaligned` a full 8-byte word per code
-    //   and advance by only the symbol length.
-    // - Every `read_unaligned::<u32>` reads 4 bytes gated by `in_curr + 4 <= in_end`; the trailing
-    //   scalar paths read within `in_end`, which is bounded by `compressed_strs.len()`.
+    //   `FsstDecoder::init`, which only lets the decoder run this path once that holds). Each code
+    //   advances `out_curr` by at most 8 and each consumed input byte yields at most 8 output
+    //   bytes, so `out_curr + 8 <= out.len()` holds for every write, including the final one. This
+    //   is why we can `write_unaligned` a full 8-byte word per code and advance by only the symbol
+    //   length.
+    // - The only unchecked read is `read_unaligned::<u32>`, gated by `in_curr + 4 <= in_end`; the
+    //   scalar paths use bounds-checked indexing. `in_end` is a caller-provided offset into
+    //   `compressed_strs`, so soundness of the u32 read relies on the offsets being well-formed
+    //   (`in_end <= compressed_strs.len()`), which holds for offsets produced by the encoder.
     let mut decompress = |mut in_curr: usize, in_end: usize, out_curr: &mut usize| {
         // Do SIMD operation here by 4 bytes
         while in_curr + 4 <= in_end {


### PR DESCRIPTION
## What

The FSST decoder needs its output buffer to be at least `8x` the compressed input, but the size guard only required `3x` and the public `decompress` doc claimed "at least 3 times". This raises the guard to `8x` (with 32-bit overflow safety), fixes the docs, documents the `unsafe` invariants, and aligns the in-tree example.

## Why

`decompress_bulk` writes a full 8-byte word per code but advances the output cursor by only the symbol length, relying on a later write (or spare capacity) to overwrite the slack — the standard FSST decode trick:

```rust
// fsst.rs, final symbol of a run — no following write to cover the slack
let code = compressed_strs[in_curr] as usize;
unsafe {
    ptr::write_unaligned(out.as_mut_ptr().add(*out_curr) as *mut u64, src); // writes 8 bytes
}
*out_curr += lens[code] as usize; // advances by len (1..=8)
```

`MAX_SYMBOL_LENGTH` is 8, so a 1-byte code expands to at most 8 bytes and the whole decoded output is at most `8x` the input. The last code of a run is the tightest case: it has no following write, so its 8-byte store must still land inside the buffer. Both facts require the buffer to be at least `8x`.

The guard in `FsstDecoder::init` was:

```rust
// when decoder_switch_on is true, we make sure the out_buf is at least 3 times the size of the in_buf,
if self.decoder_switch_on && in_buf.len() * 3 > out_buf.len() {
    return Err(...);
}
```

`3x` is too weak: it accepts a buffer between `3x` and `8x` that the decode loop then writes out of bounds. This is **not reachable from the in-tree decompressors** (`FsstPerValueDecompressor`, `FsstMiniBlockDecompressor`, and the v2.0 `FsstPageDecoder`) — they already allocate `in_buf.len() * 8`, so the `3x` check never fires for them. But the crate's own `benchmark` example allocated `3x` and would now be rejected, and the guard was unsound for any future caller that trusted the "3 times" wording.

## Changes

- Raise the guard from `* 3` to `* 8`, using `checked_mul(8)` so a `>= 512 MiB` input can't wrap `len * 8` on a 32-bit target and bypass the check (overflow is treated as "too small"). This is a threshold comparison, not an allocation — no extra memory: existing `8x` callers still pass, and a `<8x` buffer is now rejected instead of silently overflowing.
- Fix the misleading "3 times" wording in the guard comment and the `decompress` pub-doc to `8x`, with the 8-byte-write reason.
- Add `// SAFETY:` comments to the unaligned load/store blocks in `fsst_unaligned_load_unchecked` and `decompress_bulk`, per the repo convention of documenting every `unsafe` block. The comments honestly disclose which conditions are *proven* (loop guards, the `8x` output-buffer check, the symbol-table size check) versus which are *trusted preconditions* for well-formed input (`lens[code] <= 8` and offset values are loaded verbatim from the symbol table / offsets and are not re-validated on decode). Hardening the decoder against corrupt on-disk structures is a separate concern, out of scope here.
- Update the `benchmark` example's decode buffer from `3x` to `8x` so it satisfies the corrected guard.
- Add a regression test `test_decompress_rejects_undersized_output_buffer` asserting a 1-byte-short buffer is rejected and an exact-`8x` buffer succeeds (fails against the old `3x` guard).

## Test plan

- [x] `cargo test -p fsst` — 4/4 pass (incl. new test).
- [x] `cargo test -p lance-encoding fsst` — 12/12 pass (all consumers).
- [x] `cargo fmt -p fsst --check` — clean.
- [x] `cargo clippy -p fsst --tests --examples -- -D warnings` — clean.
