### PR TITLE
feat: support Lance namespace context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4990,9 +4990,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "c282440580af5cee0bed45ad58e6d74288a3855dcf88800f625b892d3106931f"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ lance-linalg = { version = "=9.0.0-beta.11", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=9.0.0-beta.11", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=9.0.0-beta.11", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=7.0.0-beta.9", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.8.6"
+lance-namespace-reqwest-client = "0.9.0"
 lance-select = { version = "=9.0.0-beta.11", path = "./rust/lance-select" }
 lance-tokenizer = { version = "=9.0.0-beta.11", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=9.0.0-beta.11", path = "./rust/lance-table" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "datafusion",
@@ -4155,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "c282440580af5cee0bed45ad58e6d74288a3855dcf88800f625b892d3106931f"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1.23", features = [
     "sync",
 ] }
 async-trait = "0.1"
+base64 = "0.22"
 jni = "0.21.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }

--- a/java/lance-jni/src/namespace.rs
+++ b/java/lance-jni/src/namespace.rs
@@ -5,10 +5,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use bytes::Bytes;
 use jni::JNIEnv;
 use jni::objects::{GlobalRef, JByteArray, JMap, JObject, JString, JValue};
-use jni::sys::{jbyteArray, jlong, jobject, jstring};
+use jni::sys::{jlong, jobject, jstring};
 use lance_namespace::LanceNamespace as LanceNamespaceTrait;
 use lance_namespace::models::*;
 use lance_namespace_impls::{
@@ -337,6 +338,48 @@ impl JavaLanceNamespace {
         Ok(response_str)
     }
 
+    fn deserialize_response<Resp>(response_str: &str) -> lance_core::Result<Resp>
+    where
+        Resp: serde::de::DeserializeOwned,
+    {
+        serde_json::from_str(response_str).map_err(|e| {
+            lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
+                "Failed to deserialize response: {}",
+                e
+            ))))
+        })
+    }
+
+    fn deserialize_query_table_response(
+        response_str: &str,
+    ) -> lance_core::Result<QueryTableResponse> {
+        let mut value: serde_json::Value = serde_json::from_str(response_str).map_err(|e| {
+            lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
+                "Failed to deserialize queryTable response JSON: {}",
+                e
+            ))))
+        })?;
+
+        if let Some(data) = value.get_mut("data")
+            && let Some(data_base64) = data.as_str()
+        {
+            let bytes = BASE64_STANDARD.decode(data_base64).map_err(|e| {
+                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
+                    "Failed to decode queryTable response data: {}",
+                    e
+                ))))
+            })?;
+            *data = serde_json::Value::Array(
+                bytes
+                    .into_iter()
+                    .map(|byte| serde_json::Value::Number(byte.into()))
+                    .collect(),
+            );
+        }
+
+        Self::deserialize_response(&value.to_string())
+    }
+
     /// Helper to call a Java method that takes a request object and returns a response object.
     /// JSON conversion is done via Jackson ObjectMapper.
     async fn call_json_method<Req, Resp>(
@@ -406,71 +449,23 @@ impl JavaLanceNamespace {
             // Serialize Java response to JSON via ObjectMapper
             let response_str = Self::serialize_response(&mut env, &response_obj)?;
 
-            serde_json::from_str(&response_str).map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to deserialize response: {}",
-                    e
-                ))))
-            })
-        })
-        .await
-        .map_err(|e| {
-            lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                "Failed to spawn blocking task: {}",
-                e
-            ))))
-        })?
-    }
-
-    /// Helper for void methods (return ()).
-    async fn call_void_method<Req>(
-        &self,
-        method_name: &'static str,
-        request_class: &str,
-        request: Req,
-    ) -> lance_core::Result<()>
-    where
-        Req: serde::Serialize + Send + 'static,
-    {
-        let java_namespace = self.java_namespace.clone();
-        let jvm = self.jvm.clone();
-        let request_class = request_class.to_string();
-
-        tokio::task::spawn_blocking(move || {
-            let mut env = jvm.attach_current_thread().map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to attach to JVM: {}",
-                    e
-                ))))
-            })?;
-
-            // Serialize request to JSON
-            let request_json = serde_json::to_string(&request).map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to serialize request: {}",
-                    e
-                ))))
-            })?;
-
-            // Deserialize JSON to Java request object via ObjectMapper
-            let request_obj = Self::deserialize_request(&mut env, &request_json, &request_class)?;
-
-            // Call the interface method with request object
-            let method_sig = format!("(L{};)V", request_class);
-            env.call_method(
-                &java_namespace,
-                method_name,
-                &method_sig,
-                &[JValue::Object(&request_obj)],
-            )
-            .map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to call {}: {}",
-                    method_name, e
-                ))))
-            })?;
-
-            Ok(())
+            if response_class.ends_with("/QueryTableResponse") {
+                let response = Self::deserialize_query_table_response(&response_str)?;
+                let response = serde_json::to_value(response).map_err(|e| {
+                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
+                        "Failed to normalize queryTable response: {}",
+                        e
+                    ))))
+                })?;
+                serde_json::from_value(response).map_err(|e| {
+                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
+                        "Failed to deserialize queryTable response: {}",
+                        e
+                    ))))
+                })
+            } else {
+                Self::deserialize_response(&response_str)
+            }
         })
         .await
         .map_err(|e| {
@@ -564,96 +559,6 @@ impl JavaLanceNamespace {
         })?
     }
 
-    /// Helper for methods returning Long (boxed).
-    async fn call_long_method<Req>(
-        &self,
-        method_name: &'static str,
-        request_class: &str,
-        request: Req,
-    ) -> lance_core::Result<i64>
-    where
-        Req: serde::Serialize + Send + 'static,
-    {
-        let java_namespace = self.java_namespace.clone();
-        let jvm = self.jvm.clone();
-        let request_class = request_class.to_string();
-
-        tokio::task::spawn_blocking(move || {
-            let mut env = jvm.attach_current_thread().map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to attach to JVM: {}",
-                    e
-                ))))
-            })?;
-
-            // Serialize request to JSON
-            let request_json = serde_json::to_string(&request).map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to serialize request: {}",
-                    e
-                ))))
-            })?;
-
-            // Deserialize JSON to Java request object via ObjectMapper
-            let request_obj = Self::deserialize_request(&mut env, &request_json, &request_class)?;
-
-            // Call the interface method with request object - returns Long (boxed)
-            let method_sig = format!("(L{};)Ljava/lang/Long;", request_class);
-            let result = env
-                .call_method(
-                    &java_namespace,
-                    method_name,
-                    &method_sig,
-                    &[JValue::Object(&request_obj)],
-                )
-                .map_err(|e| {
-                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                        "Failed to call {}: {}",
-                        method_name, e
-                    ))))
-                })?;
-
-            let long_obj = result.l().map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "{} did not return an object: {}",
-                    method_name, e
-                ))))
-            })?;
-
-            if long_obj.is_null() {
-                return Err(lance_core::Error::io_source(Box::new(
-                    std::io::Error::other(format!("{} returned null", method_name)),
-                )));
-            }
-
-            // Unbox Long to long
-            let long_value = env
-                .call_method(&long_obj, "longValue", "()J", &[])
-                .map_err(|e| {
-                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                        "Failed to call longValue: {}",
-                        e
-                    ))))
-                })?
-                .j()
-                .map_err(|e| {
-                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                        "longValue did not return a long: {}",
-                        e
-                    ))))
-                })?;
-
-            Ok(long_value)
-        })
-        .await
-        .map_err(|e| {
-            lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                "Failed to spawn blocking task: {}",
-                e
-            ))))
-        })?
-    }
-
     /// Helper for methods with Bytes parameter (request + byte[] data).
     async fn call_with_bytes_method<Req, Resp>(
         &self,
@@ -736,87 +641,6 @@ impl JavaLanceNamespace {
                     e
                 ))))
             })
-        })
-        .await
-        .map_err(|e| {
-            lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                "Failed to spawn blocking task: {}",
-                e
-            ))))
-        })?
-    }
-
-    /// Helper for methods returning Bytes (byte[]).
-    async fn call_bytes_method<Req>(
-        &self,
-        method_name: &'static str,
-        request_class: &str,
-        request: Req,
-    ) -> lance_core::Result<Bytes>
-    where
-        Req: serde::Serialize + Send + 'static,
-    {
-        let java_namespace = self.java_namespace.clone();
-        let jvm = self.jvm.clone();
-        let request_class = request_class.to_string();
-
-        tokio::task::spawn_blocking(move || {
-            let mut env = jvm.attach_current_thread().map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to attach to JVM: {}",
-                    e
-                ))))
-            })?;
-
-            // Serialize request to JSON
-            let request_json = serde_json::to_string(&request).map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to serialize request: {}",
-                    e
-                ))))
-            })?;
-
-            // Deserialize JSON to Java request object via ObjectMapper
-            let request_obj = Self::deserialize_request(&mut env, &request_json, &request_class)?;
-
-            // Call the interface method with request object - returns byte[]
-            let method_sig = format!("(L{};)[B", request_class);
-            let result = env
-                .call_method(
-                    &java_namespace,
-                    method_name,
-                    &method_sig,
-                    &[JValue::Object(&request_obj)],
-                )
-                .map_err(|e| {
-                    lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                        "Failed to call {}: {}",
-                        method_name, e
-                    ))))
-                })?;
-
-            let response_obj = result.l().map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "{} did not return an object: {}",
-                    method_name, e
-                ))))
-            })?;
-
-            if response_obj.is_null() {
-                return Err(lance_core::Error::io_source(Box::new(
-                    std::io::Error::other(format!("{} returned null", method_name)),
-                )));
-            }
-
-            let byte_array = JByteArray::from(response_obj);
-            let bytes = env.convert_byte_array(byte_array).map_err(|e| {
-                lance_core::Error::io_source(Box::new(std::io::Error::other(format!(
-                    "Failed to convert byte array: {}",
-                    e
-                ))))
-            })?;
-
-            Ok(Bytes::from(bytes))
         })
         .await
         .map_err(|e| {
@@ -997,10 +821,14 @@ impl LanceNamespaceTrait for JavaLanceNamespace {
         .await
     }
 
-    async fn namespace_exists(&self, request: NamespaceExistsRequest) -> lance_core::Result<()> {
-        self.call_void_method(
+    async fn namespace_exists(
+        &self,
+        request: NamespaceExistsRequest,
+    ) -> lance_core::Result<NamespaceExistsResponse> {
+        self.call_json_method(
             "namespaceExists",
             &format!("{}/NamespaceExistsRequest", MODEL_PKG),
+            &format!("{}/NamespaceExistsResponse", MODEL_PKG),
             request,
         )
         .await
@@ -1045,10 +873,14 @@ impl LanceNamespaceTrait for JavaLanceNamespace {
         .await
     }
 
-    async fn table_exists(&self, request: TableExistsRequest) -> lance_core::Result<()> {
-        self.call_void_method(
+    async fn table_exists(
+        &self,
+        request: TableExistsRequest,
+    ) -> lance_core::Result<TableExistsResponse> {
+        self.call_json_method(
             "tableExists",
             &format!("{}/TableExistsRequest", MODEL_PKG),
+            &format!("{}/TableExistsResponse", MODEL_PKG),
             request,
         )
         .await
@@ -1077,10 +909,14 @@ impl LanceNamespaceTrait for JavaLanceNamespace {
         .await
     }
 
-    async fn count_table_rows(&self, request: CountTableRowsRequest) -> lance_core::Result<i64> {
-        self.call_long_method(
+    async fn count_table_rows(
+        &self,
+        request: CountTableRowsRequest,
+    ) -> lance_core::Result<CountTableRowsResponse> {
+        self.call_json_method(
             "countTableRows",
             &format!("{}/CountTableRowsRequest", MODEL_PKG),
+            &format!("{}/CountTableRowsResponse", MODEL_PKG),
             request,
         )
         .await
@@ -1170,10 +1006,14 @@ impl LanceNamespaceTrait for JavaLanceNamespace {
         .await
     }
 
-    async fn query_table(&self, request: QueryTableRequest) -> lance_core::Result<Bytes> {
-        self.call_bytes_method(
+    async fn query_table(
+        &self,
+        request: QueryTableRequest,
+    ) -> lance_core::Result<QueryTableResponse> {
+        self.call_json_method(
             "queryTable",
             &format!("{}/QueryTableRequest", MODEL_PKG),
+            &format!("{}/QueryTableResponse", MODEL_PKG),
             request,
         )
         .await
@@ -1695,13 +1535,15 @@ pub extern "system" fn Java_org_lance_namespace_DirectoryNamespace_namespaceExis
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) {
-    ok_or_throw_without_return!(
+) -> jstring {
+    ok_or_throw_with_return!(
         env,
-        call_namespace_void_method(&mut env, handle, request_json, |namespace_client, req| {
+        call_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
             RT.block_on(namespace_client.inner.namespace_exists(req))
-        })
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -1761,13 +1603,15 @@ pub extern "system" fn Java_org_lance_namespace_DirectoryNamespace_tableExistsNa
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) {
-    ok_or_throw_without_return!(
+) -> jstring {
+    ok_or_throw_with_return!(
         env,
-        call_namespace_void_method(&mut env, handle, request_json, |namespace_client, req| {
+        call_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
             RT.block_on(namespace_client.inner.table_exists(req))
-        })
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -1810,12 +1654,15 @@ pub extern "system" fn Java_org_lance_namespace_DirectoryNamespace_countTableRow
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) -> jlong {
+) -> jstring {
     ok_or_throw_with_return!(
         env,
-        call_namespace_count_method(&mut env, handle, request_json),
-        0
+        call_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
+            RT.block_on(namespace_client.inner.count_table_rows(req))
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -1964,10 +1811,15 @@ pub extern "system" fn Java_org_lance_namespace_DirectoryNamespace_queryTableNat
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) -> jbyteArray {
+) -> jstring {
     ok_or_throw_with_return!(
         env,
-        call_namespace_query_method(&mut env, handle, request_json),
+        call_namespace_query_table_method(
+            &mut env,
+            handle,
+            request_json,
+            |namespace_client, req| { RT.block_on(namespace_client.inner.query_table(req)) }
+        ),
         std::ptr::null_mut()
     )
     .into_raw()
@@ -2645,13 +2497,15 @@ pub extern "system" fn Java_org_lance_namespace_RestNamespace_namespaceExistsNat
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) {
-    ok_or_throw_without_return!(
+) -> jstring {
+    ok_or_throw_with_return!(
         env,
-        call_rest_namespace_void_method(&mut env, handle, request_json, |namespace_client, req| {
+        call_rest_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
             RT.block_on(namespace_client.inner.namespace_exists(req))
-        })
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -2711,13 +2565,15 @@ pub extern "system" fn Java_org_lance_namespace_RestNamespace_tableExistsNative(
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) {
-    ok_or_throw_without_return!(
+) -> jstring {
+    ok_or_throw_with_return!(
         env,
-        call_rest_namespace_void_method(&mut env, handle, request_json, |namespace_client, req| {
+        call_rest_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
             RT.block_on(namespace_client.inner.table_exists(req))
-        })
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -2760,12 +2616,15 @@ pub extern "system" fn Java_org_lance_namespace_RestNamespace_countTableRowsNati
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) -> jlong {
+) -> jstring {
     ok_or_throw_with_return!(
         env,
-        call_rest_namespace_count_method(&mut env, handle, request_json),
-        0
+        call_rest_namespace_method(&mut env, handle, request_json, |namespace_client, req| {
+            RT.block_on(namespace_client.inner.count_table_rows(req))
+        }),
+        std::ptr::null_mut()
     )
+    .into_raw()
 }
 
 #[unsafe(no_mangle)]
@@ -2914,10 +2773,15 @@ pub extern "system" fn Java_org_lance_namespace_RestNamespace_queryTableNative(
     _obj: JObject,
     handle: jlong,
     request_json: JString,
-) -> jbyteArray {
+) -> jstring {
     ok_or_throw_with_return!(
         env,
-        call_rest_namespace_query_method(&mut env, handle, request_json),
+        call_rest_namespace_query_table_method(
+            &mut env,
+            handle,
+            request_json,
+            |namespace_client, req| { RT.block_on(namespace_client.inner.query_table(req)) }
+        ),
         std::ptr::null_mut()
     )
     .into_raw()
@@ -3469,27 +3333,6 @@ where
     env.new_string(response_json).map_err(Into::into)
 }
 
-/// Helper function for void methods (DirectoryNamespace)
-fn call_namespace_void_method<Req, F>(
-    env: &mut JNIEnv,
-    handle: jlong,
-    request_json: JString,
-    f: F,
-) -> Result<()>
-where
-    Req: for<'de> Deserialize<'de>,
-    F: FnOnce(&BlockingDirectoryNamespace, Req) -> lance_core::Result<()>,
-{
-    let namespace = unsafe { &*(handle as *const BlockingDirectoryNamespace) };
-    let request_str: String = env.get_string(&request_json)?.into();
-    let request: Req = serde_json::from_str(&request_str)
-        .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
-
-    f(namespace, request).map_err(Error::from)?;
-
-    Ok(())
-}
-
 /// Helper function for methods that return String directly (not JSON-serialized) (DirectoryNamespace)
 fn call_namespace_string_method<'local, Req, F>(
     env: &mut JNIEnv<'local>,
@@ -3509,24 +3352,6 @@ where
     let response = f(namespace, request).map_err(Error::from)?;
 
     env.new_string(response).map_err(Into::into)
-}
-
-/// Helper function for count methods (DirectoryNamespace)
-fn call_namespace_count_method(
-    env: &mut JNIEnv,
-    handle: jlong,
-    request_json: JString,
-) -> Result<jlong> {
-    let namespace = unsafe { &*(handle as *const BlockingDirectoryNamespace) };
-    let request_str: String = env.get_string(&request_json)?.into();
-    let request: CountTableRowsRequest = serde_json::from_str(&request_str)
-        .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
-
-    let count = RT
-        .block_on(namespace.inner.count_table_rows(request))
-        .map_err(Error::from)?;
-
-    Ok(count)
 }
 
 /// Helper function for methods with data parameter (DirectoryNamespace)
@@ -3558,23 +3383,47 @@ where
     env.new_string(response_json).map_err(Into::into)
 }
 
-/// Helper function for query methods that return byte arrays (DirectoryNamespace)
-fn call_namespace_query_method<'local>(
+fn query_table_response_to_java_json(response: &QueryTableResponse) -> Result<String> {
+    let mut object = serde_json::Map::new();
+    if let Some(context) = &response.context {
+        object.insert(
+            "context".to_string(),
+            serde_json::to_value(context)
+                .map_err(|e| Error::runtime_error(format!("Failed to serialize context: {}", e)))?,
+        );
+    }
+    if let Some(data) = &response.data {
+        object.insert(
+            "data".to_string(),
+            serde_json::Value::String(BASE64_STANDARD.encode(data)),
+        );
+    }
+
+    serde_json::to_string(&object)
+        .map_err(|e| Error::runtime_error(format!("Failed to serialize response: {}", e)))
+}
+
+fn call_namespace_query_table_method<'local, F>(
     env: &mut JNIEnv<'local>,
     handle: jlong,
     request_json: JString,
-) -> Result<JByteArray<'local>> {
+    f: F,
+) -> Result<JString<'local>>
+where
+    F: FnOnce(
+        &BlockingDirectoryNamespace,
+        QueryTableRequest,
+    ) -> lance_core::Result<QueryTableResponse>,
+{
     let namespace = unsafe { &*(handle as *const BlockingDirectoryNamespace) };
     let request_str: String = env.get_string(&request_json)?.into();
     let request: QueryTableRequest = serde_json::from_str(&request_str)
         .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
 
-    let result_bytes = RT
-        .block_on(namespace.inner.query_table(request))
-        .map_err(Error::from)?;
+    let response = f(namespace, request).map_err(Error::from)?;
+    let response_json = query_table_response_to_java_json(&response)?;
 
-    let byte_array = env.byte_array_from_slice(&result_bytes)?;
-    Ok(byte_array)
+    env.new_string(response_json).map_err(Into::into)
 }
 
 /// Helper function to call namespace methods that return a response object (RestNamespace)
@@ -3602,27 +3451,6 @@ where
     env.new_string(response_json).map_err(Into::into)
 }
 
-/// Helper function for void methods (RestNamespace)
-fn call_rest_namespace_void_method<Req, F>(
-    env: &mut JNIEnv,
-    handle: jlong,
-    request_json: JString,
-    f: F,
-) -> Result<()>
-where
-    Req: for<'de> Deserialize<'de>,
-    F: FnOnce(&BlockingRestNamespace, Req) -> lance_core::Result<()>,
-{
-    let namespace = unsafe { &*(handle as *const BlockingRestNamespace) };
-    let request_str: String = env.get_string(&request_json)?.into();
-    let request: Req = serde_json::from_str(&request_str)
-        .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
-
-    f(namespace, request).map_err(Error::from)?;
-
-    Ok(())
-}
-
 /// Helper function for methods that return String directly (not JSON-serialized) (RestNamespace)
 fn call_rest_namespace_string_method<'local, Req, F>(
     env: &mut JNIEnv<'local>,
@@ -3644,22 +3472,24 @@ where
     env.new_string(response).map_err(Into::into)
 }
 
-/// Helper function for count methods (RestNamespace)
-fn call_rest_namespace_count_method(
-    env: &mut JNIEnv,
+fn call_rest_namespace_query_table_method<'local, F>(
+    env: &mut JNIEnv<'local>,
     handle: jlong,
     request_json: JString,
-) -> Result<jlong> {
+    f: F,
+) -> Result<JString<'local>>
+where
+    F: FnOnce(&BlockingRestNamespace, QueryTableRequest) -> lance_core::Result<QueryTableResponse>,
+{
     let namespace = unsafe { &*(handle as *const BlockingRestNamespace) };
     let request_str: String = env.get_string(&request_json)?.into();
-    let request: CountTableRowsRequest = serde_json::from_str(&request_str)
+    let request: QueryTableRequest = serde_json::from_str(&request_str)
         .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
 
-    let count = RT
-        .block_on(namespace.inner.count_table_rows(request))
-        .map_err(Error::from)?;
+    let response = f(namespace, request).map_err(Error::from)?;
+    let response_json = query_table_response_to_java_json(&response)?;
 
-    Ok(count)
+    env.new_string(response_json).map_err(Into::into)
 }
 
 /// Helper function for methods with data parameter (RestNamespace)
@@ -3691,24 +3521,6 @@ where
     env.new_string(response_json).map_err(Into::into)
 }
 
-/// Helper function for query methods that return byte arrays (RestNamespace)
-fn call_rest_namespace_query_method<'local>(
-    env: &mut JNIEnv<'local>,
-    handle: jlong,
-    request_json: JString,
-) -> Result<JByteArray<'local>> {
-    let namespace = unsafe { &*(handle as *const BlockingRestNamespace) };
-    let request_str: String = env.get_string(&request_json)?.into();
-    let request: QueryTableRequest = serde_json::from_str(&request_str)
-        .map_err(|e| Error::input_error(format!("Failed to parse request JSON: {}", e)))?;
-
-    let result_bytes = RT
-        .block_on(namespace.inner.query_table(request))
-        .map_err(Error::from)?;
-
-    let byte_array = env.byte_array_from_slice(&result_bytes)?;
-    Ok(byte_array)
-}
 // ============================================================================
 // RestAdapter - Server for testing
 // ============================================================================
@@ -3844,5 +3656,29 @@ pub extern "system" fn Java_org_lance_namespace_RestAdapter_releaseNative(
                 server_handle.shutdown();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_table_response_decodes_java_base64_data() {
+        let response =
+            JavaLanceNamespace::deserialize_query_table_response(r#"{"data":"AQIDBA=="}"#).unwrap();
+        assert_eq!(response.data, Some(vec![1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn query_table_response_serializes_data_for_java_model() {
+        let response = QueryTableResponse {
+            context: None,
+            data: Some(vec![1, 2, 3, 4]),
+        };
+
+        let response_json = query_table_response_to_java_json(&response).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&response_json).unwrap();
+        assert_eq!(value["data"], "AQIDBA==");
     }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,16 +109,21 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.7</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.7</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.15.2</version>
         </dependency>
         <!-- AWS SDK for S3 integration testing -->

--- a/java/src/main/java/org/lance/namespace/DirectoryNamespace.java
+++ b/java/src/main/java/org/lance/namespace/DirectoryNamespace.java
@@ -26,6 +26,7 @@ import org.lance.namespace.model.AnalyzeTableQueryPlanRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateMaterializedViewRequest;
 import org.lance.namespace.model.CreateMaterializedViewResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
@@ -83,7 +84,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -91,6 +94,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -101,6 +105,7 @@ import org.lance.namespace.model.UpdateTableTagResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.arrow.memory.BufferAllocator;
 
 import java.io.Closeable;
@@ -239,6 +244,7 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
 
   private static ObjectMapper createObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper;
   }
@@ -329,10 +335,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    namespaceExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    String responseJson = namespaceExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return fromJson(responseJson, NamespaceExistsResponse.class);
   }
 
   @Override
@@ -360,10 +367,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
+  public TableExistsResponse tableExists(TableExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    tableExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    String responseJson = tableExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return fromJson(responseJson, TableExistsResponse.class);
   }
 
   @Override
@@ -383,10 +391,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return countTableRowsNative(nativeDirectoryNamespaceHandle, requestJson);
+    String responseJson = countTableRowsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return fromJson(responseJson, CountTableRowsResponse.class);
   }
 
   @Override
@@ -451,10 +460,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return queryTableNative(nativeDirectoryNamespaceHandle, requestJson);
+    String responseJson = queryTableNative(nativeDirectoryNamespaceHandle, requestJson);
+    return fromJson(responseJson, QueryTableResponse.class);
   }
 
   @Override
@@ -758,7 +768,7 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
 
   private native String dropNamespaceNative(long handle, String requestJson);
 
-  private native void namespaceExistsNative(long handle, String requestJson);
+  private native String namespaceExistsNative(long handle, String requestJson);
 
   private native String listTablesNative(long handle, String requestJson);
 
@@ -766,13 +776,13 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
 
   private native String registerTableNative(long handle, String requestJson);
 
-  private native void tableExistsNative(long handle, String requestJson);
+  private native String tableExistsNative(long handle, String requestJson);
 
   private native String dropTableNative(long handle, String requestJson);
 
   private native String deregisterTableNative(long handle, String requestJson);
 
-  private native long countTableRowsNative(long handle, String requestJson);
+  private native String countTableRowsNative(long handle, String requestJson);
 
   private native String createTableNative(long handle, String requestJson, byte[] requestData);
 
@@ -789,7 +799,7 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
 
   private native String deleteFromTableNative(long handle, String requestJson);
 
-  private native byte[] queryTableNative(long handle, String requestJson);
+  private native String queryTableNative(long handle, String requestJson);
 
   private native String createTableIndexNative(long handle, String requestJson);
 

--- a/java/src/main/java/org/lance/namespace/DynamicContextProvider.java
+++ b/java/src/main/java/org/lance/namespace/DynamicContextProvider.java
@@ -21,9 +21,9 @@ import java.util.Map;
  * <p>Implementations can generate per-request context (e.g., authentication headers) based on the
  * operation being performed. The provider is called synchronously before each namespace operation.
  *
- * <p>For RestNamespace, context keys that start with {@code headers.} are converted to HTTP headers
- * by stripping the prefix. For example, {@code {"headers.Authorization": "Bearer abc123"}} becomes
- * the {@code Authorization: Bearer abc123} header. Keys without the {@code headers.} prefix are
+ * <p>For RestNamespace, context keys that start with {@code header.} are converted to HTTP headers
+ * by stripping the prefix. For example, {@code {"header.Authorization": "Bearer abc123"}} becomes
+ * the {@code Authorization: Bearer abc123} header. Keys without the {@code header.} prefix are
  * ignored for HTTP headers but may be used for other purposes.
  *
  * <p>Example implementation:
@@ -33,8 +33,8 @@ import java.util.Map;
  *   &#64;Override
  *   public Map&lt;String, String&gt; provideContext(String operation, String objectId) {
  *     Map&lt;String, String&gt; context = new HashMap&lt;&gt;();
- *     context.put("headers.Authorization", "Bearer " + getAuthToken());
- *     context.put("headers.X-Request-Id", UUID.randomUUID().toString());
+ *     context.put("header.Authorization", "Bearer " + getAuthToken());
+ *     context.put("header.X-Request-Id", UUID.randomUUID().toString());
  *     return context;
  *   }
  * }
@@ -69,8 +69,8 @@ public interface DynamicContextProvider {
    * @param operation The operation name (e.g., "list_tables", "describe_table", "create_namespace")
    * @param objectId The object identifier (namespace or table ID in delimited form, e.g.,
    *     "workspace$table_name")
-   * @return Map of context key-value pairs. For HTTP headers, use keys with the "headers." prefix
-   *     (e.g., "headers.Authorization"). Return an empty map if no additional context is needed.
+   * @return Map of context key-value pairs. For HTTP headers, use keys with the "header." prefix
+   *     (e.g., "header.Authorization"). Return an empty map if no additional context is needed.
    *     Must not return null.
    */
   Map<String, String> provideContext(String operation, String objectId);

--- a/java/src/main/java/org/lance/namespace/RestNamespace.java
+++ b/java/src/main/java/org/lance/namespace/RestNamespace.java
@@ -26,6 +26,7 @@ import org.lance.namespace.model.AnalyzeTableQueryPlanRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateMaterializedViewRequest;
 import org.lance.namespace.model.CreateMaterializedViewResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
@@ -83,7 +84,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -91,6 +94,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -99,7 +103,9 @@ import org.lance.namespace.model.UpdateTableTagRequest;
 import org.lance.namespace.model.UpdateTableTagResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.arrow.memory.BufferAllocator;
 
 import java.io.Closeable;
@@ -149,7 +155,14 @@ public class RestNamespace implements LanceNamespace, Closeable {
     JniLoader.ensureLoaded();
   }
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return mapper;
+  }
 
   private long nativeRestNamespaceHandle;
   private BufferAllocator allocator;
@@ -166,7 +179,7 @@ public class RestNamespace implements LanceNamespace, Closeable {
    * Initialize with a dynamic context provider.
    *
    * <p>The context provider is called before each namespace operation and can return per-request
-   * context (e.g., authentication headers). Context keys that start with {@code headers.} are
+   * context (e.g., authentication headers). Context keys that start with {@code header.} are
    * converted to HTTP headers by stripping the prefix.
    *
    * <p>If contextProvider is null and the properties contain {@code dynamic_context_provider.impl},
@@ -241,10 +254,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    namespaceExistsNative(nativeRestNamespaceHandle, requestJson);
+    String responseJson = namespaceExistsNative(nativeRestNamespaceHandle, requestJson);
+    return fromJson(responseJson, NamespaceExistsResponse.class);
   }
 
   @Override
@@ -272,10 +286,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
+  public TableExistsResponse tableExists(TableExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    tableExistsNative(nativeRestNamespaceHandle, requestJson);
+    String responseJson = tableExistsNative(nativeRestNamespaceHandle, requestJson);
+    return fromJson(responseJson, TableExistsResponse.class);
   }
 
   @Override
@@ -295,10 +310,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return countTableRowsNative(nativeRestNamespaceHandle, requestJson);
+    String responseJson = countTableRowsNative(nativeRestNamespaceHandle, requestJson);
+    return fromJson(responseJson, CountTableRowsResponse.class);
   }
 
   @Override
@@ -362,10 +378,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return queryTableNative(nativeRestNamespaceHandle, requestJson);
+    String responseJson = queryTableNative(nativeRestNamespaceHandle, requestJson);
+    return fromJson(responseJson, QueryTableResponse.class);
   }
 
   @Override
@@ -663,7 +680,7 @@ public class RestNamespace implements LanceNamespace, Closeable {
 
   private native String dropNamespaceNative(long handle, String requestJson);
 
-  private native void namespaceExistsNative(long handle, String requestJson);
+  private native String namespaceExistsNative(long handle, String requestJson);
 
   private native String listTablesNative(long handle, String requestJson);
 
@@ -671,13 +688,13 @@ public class RestNamespace implements LanceNamespace, Closeable {
 
   private native String registerTableNative(long handle, String requestJson);
 
-  private native void tableExistsNative(long handle, String requestJson);
+  private native String tableExistsNative(long handle, String requestJson);
 
   private native String dropTableNative(long handle, String requestJson);
 
   private native String deregisterTableNative(long handle, String requestJson);
 
-  private native long countTableRowsNative(long handle, String requestJson);
+  private native String countTableRowsNative(long handle, String requestJson);
 
   private native String createTableNative(long handle, String requestJson, byte[] requestData);
 
@@ -694,7 +711,7 @@ public class RestNamespace implements LanceNamespace, Closeable {
 
   private native String deleteFromTableNative(long handle, String requestJson);
 
-  private native byte[] queryTableNative(long handle, String requestJson);
+  private native String queryTableNative(long handle, String requestJson);
 
   private native String createTableIndexNative(long handle, String requestJson);
 

--- a/java/src/test/java/org/lance/namespace/CustomNamespace.java
+++ b/java/src/test/java/org/lance/namespace/CustomNamespace.java
@@ -29,6 +29,7 @@ import org.lance.namespace.model.BatchCreateTableVersionsResponse;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
 import org.lance.namespace.model.CreateNamespaceResponse;
 import org.lance.namespace.model.CreateTableIndexRequest;
@@ -84,7 +85,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -92,6 +95,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -174,8 +178,8 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
-    inner.namespaceExists(request);
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
+    return inner.namespaceExists(request);
   }
 
   // Table operations
@@ -196,8 +200,8 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
-    inner.tableExists(request);
+  public TableExistsResponse tableExists(TableExistsRequest request) {
+    return inner.tableExists(request);
   }
 
   @Override
@@ -211,7 +215,7 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     return inner.countTableRows(request);
   }
 
@@ -250,7 +254,7 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     return inner.queryTable(request);
   }
 

--- a/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
+++ b/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
@@ -23,6 +23,7 @@ import org.lance.WriteParams;
 import org.lance.namespace.errors.ErrorCode;
 import org.lance.namespace.errors.LanceNamespaceException;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
 import org.lance.namespace.model.CreateNamespaceResponse;
 import org.lance.namespace.model.CreateTableIndexRequest;
@@ -56,6 +57,7 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.namespace.model.QueryTableRequest;
 import org.lance.namespace.model.QueryTableRequestVector;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
@@ -1161,7 +1163,8 @@ public class DirectoryNamespaceTest {
     // Count rows
     CountTableRowsRequest countReq =
         new CountTableRowsRequest().id(Arrays.asList("workspace", "test_table"));
-    long count = namespaceClient.countTableRows(countReq);
+    CountTableRowsResponse response = namespaceClient.countTableRows(countReq);
+    long count = response.getCount();
     assertEquals(3, count);
   }
 
@@ -1183,7 +1186,8 @@ public class DirectoryNamespaceTest {
         new CountTableRowsRequest()
             .id(Arrays.asList("workspace", "test_table"))
             .predicate("age > 28");
-    long count = namespaceClient.countTableRows(countReq);
+    CountTableRowsResponse response = namespaceClient.countTableRows(countReq);
+    long count = response.getCount();
     assertEquals(2, count); // Alice (30) and Charlie (35)
   }
 
@@ -1210,7 +1214,8 @@ public class DirectoryNamespaceTest {
     // Verify row count increased
     CountTableRowsRequest countReq =
         new CountTableRowsRequest().id(Arrays.asList("workspace", "test_table"));
-    long count = namespaceClient.countTableRows(countReq);
+    CountTableRowsResponse response = namespaceClient.countTableRows(countReq);
+    long count = response.getCount();
     assertEquals(6, count);
   }
 
@@ -1233,7 +1238,8 @@ public class DirectoryNamespaceTest {
             .id(Arrays.asList("workspace", "test_table"))
             .k(10)
             .vector(new QueryTableRequestVector());
-    byte[] resultBytes = namespaceClient.queryTable(queryReq);
+    QueryTableResponse response = namespaceClient.queryTable(queryReq);
+    byte[] resultBytes = response.getData();
     assertNotNull(resultBytes);
     assertTrue(resultBytes.length > 0);
   }

--- a/java/src/test/java/org/lance/namespace/DynamicContextProviderTest.java
+++ b/java/src/test/java/org/lance/namespace/DynamicContextProviderTest.java
@@ -59,8 +59,8 @@ public class DynamicContextProviderTest {
         (operation, objectId) -> {
           callCount.incrementAndGet();
           Map<String, String> context = new HashMap<>();
-          context.put("headers.Authorization", "Bearer test-token-123");
-          context.put("headers.X-Request-Id", "req-" + operation);
+          context.put("header.Authorization", "Bearer test-token-123");
+          context.put("header.X-Request-Id", "req-" + operation);
           return context;
         };
 
@@ -130,8 +130,8 @@ public class DynamicContextProviderTest {
         (operation, objectId) -> {
           callCount.incrementAndGet();
           Map<String, String> context = new HashMap<>();
-          context.put("headers.Authorization", "Bearer xyz-token");
-          context.put("headers.X-Trace-Id", "trace-" + System.currentTimeMillis());
+          context.put("header.Authorization", "Bearer xyz-token");
+          context.put("header.X-Trace-Id", "trace-" + System.currentTimeMillis());
           return context;
         };
 
@@ -284,7 +284,7 @@ public class DynamicContextProviderTest {
         (operation, objectId) -> {
           explicitCallCount.incrementAndGet();
           Map<String, String> ctx = new HashMap<>();
-          ctx.put("headers.Authorization", "Bearer explicit");
+          ctx.put("header.Authorization", "Bearer explicit");
           return ctx;
         };
 

--- a/java/src/test/java/org/lance/namespace/TestContextProvider.java
+++ b/java/src/test/java/org/lance/namespace/TestContextProvider.java
@@ -29,8 +29,8 @@ public class TestContextProvider implements DynamicContextProvider {
   @Override
   public Map<String, String> provideContext(String operation, String objectId) {
     Map<String, String> context = new HashMap<>();
-    context.put("headers.Authorization", prefix + " " + token);
-    context.put("headers.X-Operation", operation);
+    context.put("header.Authorization", prefix + " " + token);
+    context.put("header.X-Operation", operation);
     return context;
   }
 }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4523,9 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "c282440580af5cee0bed45ad58e6d74288a3855dcf88800f625b892d3106931f"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.8.5,<0.9"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.9,<0.10"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/python/lance/namespace.py
+++ b/python/python/lance/namespace.py
@@ -28,6 +28,7 @@ from lance_namespace import (
     AlterTransactionResponse,
     AnalyzeTableQueryPlanRequest,
     CountTableRowsRequest,
+    CountTableRowsResponse,
     CreateMaterializedViewRequest,
     CreateMaterializedViewResponse,
     CreateNamespaceRequest,
@@ -87,6 +88,9 @@ from lance_namespace import (
     MergeInsertIntoTableRequest,
     MergeInsertIntoTableResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
+    QueryTableRequest,
+    QueryTableResponse,
     RefreshMaterializedViewRequest,
     RefreshMaterializedViewResponse,
     RegisterTableRequest,
@@ -96,6 +100,7 @@ from lance_namespace import (
     RestoreTableRequest,
     RestoreTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
     UpdateTableRequest,
     UpdateTableResponse,
     UpdateTableSchemaMetadataRequest,
@@ -136,8 +141,8 @@ class DynamicContextProvider(ABC):
     based on the operation being performed. The provider is called synchronously
     before each namespace operation.
 
-    For RestNamespace, context keys that start with `headers.` are converted to
-    HTTP headers by stripping the prefix. For example, `{"headers.Authorization":
+    For RestNamespace, context keys that start with `header.` are converted to
+    HTTP headers by stripping the prefix. For example, `{"header.Authorization":
     "Bearer token"}` becomes the `Authorization: Bearer token` header.
 
     Example
@@ -149,13 +154,13 @@ class DynamicContextProvider(ABC):
     ...
     ...     def provide_context(self, info: dict) -> dict:
     ...         return {
-    ...             "headers.Authorization": f"Bearer {self.api_key}",
+    ...             "header.Authorization": f"Bearer {self.api_key}",
     ...         }
     ...
     >>> # Create provider instance and use directly
     >>> provider = MyProvider(api_key="secret")
     >>> provider.provide_context({"operation": "list_tables", "object_id": "ns"})
-    {'headers.Authorization': 'Bearer secret'}
+    {'header.Authorization': 'Bearer secret'}
     """
 
     @abstractmethod
@@ -173,7 +178,7 @@ class DynamicContextProvider(ABC):
         -------
         dict
             Context key-value pairs. For HTTP headers, use keys with the
-            "headers." prefix (e.g., "headers.Authorization").
+            "header." prefix (e.g., "header.Authorization").
         """
         pass
 
@@ -356,7 +361,7 @@ class DirectoryNamespace(LanceNamespace):
     ...     def __init__(self, token: str):
     ...         self.token = token
     ...     def provide_context(self, info: dict) -> dict:
-    ...         return {"headers.Authorization": f"Bearer {self.token}"}
+    ...         return {"header.Authorization": f"Bearer {self.token}"}
     ...
     >>> provider = MyProvider(token="secret-token")
     >>> with tempfile.TemporaryDirectory() as tmpdir:
@@ -412,8 +417,11 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.drop_namespace(request.model_dump())
         return DropNamespaceResponse.from_dict(response_dict)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
-        self._inner.namespace_exists(request.model_dump())
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
+        response_dict = self._inner.namespace_exists(request.model_dump())
+        return NamespaceExistsResponse.from_dict(response_dict)
 
     # Table operations
 
@@ -429,8 +437,9 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.register_table(request.model_dump())
         return RegisterTableResponse.from_dict(response_dict)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
-        self._inner.table_exists(request.model_dump())
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
+        response_dict = self._inner.table_exists(request.model_dump())
+        return TableExistsResponse.from_dict(response_dict)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
         response_dict = self._inner.drop_table(request.model_dump())
@@ -522,7 +531,9 @@ class DirectoryNamespace(LanceNamespace):
 
     # Data manipulation operations
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         """Count the number of rows in a table, optionally filtered by a predicate.
 
         Parameters
@@ -532,10 +543,11 @@ class DirectoryNamespace(LanceNamespace):
 
         Returns
         -------
-        int
-            The number of rows matching the criteria
+        CountTableRowsResponse
+            The response containing the row count
         """
-        return self._inner.count_table_rows(request.model_dump())
+        response_dict = self._inner.count_table_rows(request.model_dump())
+        return CountTableRowsResponse.from_dict(response_dict)
 
     def insert_into_table(
         self, request: InsertIntoTableRequest, request_data: bytes
@@ -615,7 +627,7 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.delete_from_table(request.model_dump())
         return DeleteFromTableResponse.from_dict(response_dict)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request: QueryTableRequest | dict) -> QueryTableResponse:
         """Query a table and return results as Arrow IPC.
 
         Parameters
@@ -626,12 +638,13 @@ class DirectoryNamespace(LanceNamespace):
 
         Returns
         -------
-        bytes
-            Arrow IPC file format containing the query results
+        QueryTableResponse
+            Response containing Arrow IPC file format query results
         """
-        if hasattr(request, "model_dump"):
+        if not isinstance(request, dict):
             request = request.model_dump()
-        return self._inner.query_table(request)
+        response_dict = self._inner.query_table(request)
+        return QueryTableResponse.from_dict(response_dict)
 
     # Index operations
 
@@ -941,7 +954,7 @@ class RestNamespace(LanceNamespace):
     ...     def __init__(self, api_key: str):
     ...         self.api_key = api_key
     ...     def provide_context(self, info: dict) -> dict:
-    ...         return {"headers.Authorization": f"Bearer {self.api_key}"}
+    ...         return {"header.Authorization": f"Bearer {self.api_key}"}
     ...
     >>> provider = AuthProvider(api_key="my-secret-key")
     >>> ns = lance.namespace.RestNamespace(
@@ -1003,8 +1016,11 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.drop_namespace(request.model_dump())
         return DropNamespaceResponse.from_dict(response_dict)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
-        self._inner.namespace_exists(request.model_dump())
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
+        response_dict = self._inner.namespace_exists(request.model_dump())
+        return NamespaceExistsResponse.from_dict(response_dict)
 
     # Table operations
 
@@ -1020,8 +1036,9 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.register_table(request.model_dump())
         return RegisterTableResponse.from_dict(response_dict)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
-        self._inner.table_exists(request.model_dump())
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
+        response_dict = self._inner.table_exists(request.model_dump())
+        return TableExistsResponse.from_dict(response_dict)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
         response_dict = self._inner.drop_table(request.model_dump())
@@ -1113,7 +1130,9 @@ class RestNamespace(LanceNamespace):
 
     # Data manipulation operations
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         """Count the number of rows in a table, optionally filtered by a predicate.
 
         Parameters
@@ -1123,10 +1142,11 @@ class RestNamespace(LanceNamespace):
 
         Returns
         -------
-        int
-            The number of rows matching the criteria
+        CountTableRowsResponse
+            The response containing the row count
         """
-        return self._inner.count_table_rows(request.model_dump())
+        response_dict = self._inner.count_table_rows(request.model_dump())
+        return CountTableRowsResponse.from_dict(response_dict)
 
     def insert_into_table(
         self, request: InsertIntoTableRequest, request_data: bytes
@@ -1206,7 +1226,7 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.delete_from_table(request.model_dump())
         return DeleteFromTableResponse.from_dict(response_dict)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request: QueryTableRequest | dict) -> QueryTableResponse:
         """Query a table and return results as Arrow IPC.
 
         Parameters
@@ -1217,12 +1237,13 @@ class RestNamespace(LanceNamespace):
 
         Returns
         -------
-        bytes
-            Arrow IPC file format containing the query results
+        QueryTableResponse
+            Response containing Arrow IPC file format query results
         """
-        if hasattr(request, "model_dump"):
+        if not isinstance(request, dict):
             request = request.model_dump()
-        return self._inner.query_table(request)
+        response_dict = self._inner.query_table(request)
+        return QueryTableResponse.from_dict(response_dict)
 
     # Index operations
 

--- a/python/python/tests/test_namespace_dir.py
+++ b/python/python/tests/test_namespace_dir.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import uuid
 from threading import Lock
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import lance
 import lance.namespace
@@ -27,6 +27,7 @@ import pytest
 from lance.namespace import LanceNamespace
 from lance_namespace import (
     CountTableRowsRequest,
+    CountTableRowsResponse,
     CreateNamespaceRequest,
     CreateNamespaceResponse,
     CreateTableBranchRequest,
@@ -67,10 +68,13 @@ from lance_namespace import (
     ListTableVersionsRequest,
     ListTableVersionsResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
     QueryTableRequest,
+    QueryTableResponse,
     RegisterTableRequest,
     RegisterTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
     connect,
 )
 from lance_namespace.errors import (
@@ -107,7 +111,9 @@ class CustomNamespace(LanceNamespace):
     ) -> DescribeNamespaceResponse:
         return self._inner.describe_namespace(request)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         return self._inner.namespace_exists(request)
 
     def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
@@ -117,9 +123,9 @@ class CustomNamespace(LanceNamespace):
         return self._inner.list_namespaces(request)
 
     def create_table(
-        self, request: CreateTableRequest, data: bytes
+        self, request: CreateTableRequest, request_data: bytes
     ) -> CreateTableResponse:
-        return self._inner.create_table(request, data)
+        return self._inner.create_table(request, request_data)
 
     def declare_table(self, request: DeclareTableRequest) -> DeclareTableResponse:
         return self._inner.declare_table(request)
@@ -127,7 +133,7 @@ class CustomNamespace(LanceNamespace):
     def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
         return self._inner.describe_table(request)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         return self._inner.table_exists(request)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
@@ -184,7 +190,9 @@ class CustomNamespace(LanceNamespace):
     ) -> ListTableIndicesResponse:
         return self._inner.list_table_indices(request)
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         return self._inner.count_table_rows(request)
 
     def insert_into_table(
@@ -192,7 +200,7 @@ class CustomNamespace(LanceNamespace):
     ) -> InsertIntoTableResponse:
         return self._inner.insert_into_table(request, request_data)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request) -> QueryTableResponse:
         # Accept both QueryTableRequest and dict, like DirectoryNamespace does
         if hasattr(request, "model_dump"):
             request = request.model_dump()
@@ -1416,7 +1424,7 @@ class TestDataManipulation:
 
         # Count rows
         count_req = CountTableRowsRequest(id=["workspace", "test_table"])
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 3
 
     def test_count_table_rows_with_filter(self, temp_ns_client):
@@ -1434,7 +1442,7 @@ class TestDataManipulation:
         count_req = CountTableRowsRequest(
             id=["workspace", "test_table"], predicate="age > 28"
         )
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 2  # Alice (30) and Charlie (35)
 
     def test_insert_into_table(self, temp_ns_client):
@@ -1464,7 +1472,7 @@ class TestDataManipulation:
 
         # Verify row count increased
         count_req = CountTableRowsRequest(id=["workspace", "test_table"])
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 5
 
     def test_query_table(self, temp_ns_client):
@@ -1479,8 +1487,10 @@ class TestDataManipulation:
         temp_ns_client.create_table(create_req, ipc_data)
 
         # Query table with empty vector (for non-vector queries)
-        query_req = QueryTableRequest(id=["workspace", "test_table"], k=10, vector={})
-        result_bytes = temp_ns_client.query_table(query_req)
+        query_req = QueryTableRequest(
+            id=["workspace", "test_table"], k=10, vector=cast("Any", {})
+        )
+        result_bytes = temp_ns_client.query_table(query_req).data
         assert result_bytes is not None
         assert len(result_bytes) > 0
 
@@ -1504,9 +1514,12 @@ class TestDataManipulation:
 
         # Query with filter and empty vector
         query_req = QueryTableRequest(
-            id=["workspace", "test_table"], filter="age >= 30", k=10, vector={}
+            id=["workspace", "test_table"],
+            filter="age >= 30",
+            k=10,
+            vector=cast("Any", {}),
         )
-        result_bytes = temp_ns_client.query_table(query_req)
+        result_bytes = temp_ns_client.query_table(query_req).data
         reader = pa.ipc.open_file(pa.BufferReader(result_bytes))
         result_table = reader.read_all()
         assert result_table.num_rows == 2  # Alice and Charlie

--- a/python/python/tests/test_namespace_integration.py
+++ b/python/python/tests/test_namespace_integration.py
@@ -56,9 +56,11 @@ from lance_namespace import (
     ListTableVersionsRequest,
     ListTableVersionsResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
     RegisterTableRequest,
     RegisterTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
 )
 
 
@@ -86,7 +88,9 @@ class CustomNamespace(LanceNamespace):
     ) -> DescribeNamespaceResponse:
         return self._inner.describe_namespace(request)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         return self._inner.namespace_exists(request)
 
     def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
@@ -96,9 +100,9 @@ class CustomNamespace(LanceNamespace):
         return self._inner.list_namespaces(request)
 
     def create_table(
-        self, request: CreateTableRequest, data: bytes
+        self, request: CreateTableRequest, request_data: bytes
     ) -> CreateTableResponse:
-        return self._inner.create_table(request, data)
+        return self._inner.create_table(request, request_data)
 
     def declare_table(self, request: DeclareTableRequest) -> DeclareTableResponse:
         return self._inner.declare_table(request)
@@ -106,7 +110,7 @@ class CustomNamespace(LanceNamespace):
     def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
         return self._inner.describe_table(request)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         return self._inner.table_exists(request)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:

--- a/python/python/tests/test_namespace_rest.py
+++ b/python/python/tests/test_namespace_rest.py
@@ -697,8 +697,8 @@ class TestDynamicContextProvider:
             def provide_context(self, info):
                 call_count["count"] += 1
                 return {
-                    "headers.Authorization": "Bearer test-token",
-                    "headers.X-Request-Id": f"req-{info.get('operation', 'unknown')}",
+                    "header.Authorization": "Bearer test-token",
+                    "header.X-Request-Id": f"req-{info.get('operation', 'unknown')}",
                 }
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -727,7 +727,7 @@ class TestDynamicContextProvider:
         class ExplicitProvider(lance.namespace.DynamicContextProvider):
             def provide_context(self, info):
                 explicit_called["called"] = True
-                return {"headers.Authorization": "Bearer explicit"}
+                return {"header.Authorization": "Bearer explicit"}
 
         with tempfile.TemporaryDirectory() as tmpdir:
             backend_config = {"root": tmpdir}

--- a/python/python/tests/torch_tests/test_distance.py
+++ b/python/python/tests/torch_tests/test_distance.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -133,6 +135,10 @@ def test_l2_distance_f16_bf16_cuda():
     assert dists.shape == (128, 512)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Torch CPU fp16/bfloat16 crashes Windows CI",
+)
 def test_l2_distance_f16_bf16_cpu():
     DIM = 32
     # Make sure it happens on CPU

--- a/python/src/namespace.rs
+++ b/python/src/namespace.rs
@@ -20,9 +20,9 @@ use lance_namespace::models::{
     ExplainTableQueryPlanRequest, GetTableStatsRequest, GetTableTagVersionRequest,
     InsertIntoTableRequest, ListTableIndicesRequest, ListTableTagsRequest,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest,
-    MergeInsertIntoTableRequest, QueryTableRequest, RefreshMaterializedViewRequest,
-    RestoreTableRequest, UpdateTableRequest, UpdateTableSchemaMetadataRequest,
-    UpdateTableTagRequest,
+    MergeInsertIntoTableRequest, QueryTableRequest, QueryTableResponse,
+    RefreshMaterializedViewRequest, RestoreTableRequest, UpdateTableRequest,
+    UpdateTableSchemaMetadataRequest, UpdateTableTagRequest,
 };
 use lance_namespace_impls::RestNamespaceBuilder;
 use lance_namespace_impls::{ConnectBuilder, RestAdapter, RestAdapterConfig, RestAdapterHandle};
@@ -40,7 +40,7 @@ use crate::session::Session;
 /// Python-implemented dynamic context provider.
 ///
 /// Wraps a Python object that has a `provide_context(info: dict) -> dict` method.
-/// For RestNamespace, context keys that start with `headers.` are converted to
+/// For RestNamespace, context keys that start with `header.` are converted to
 /// HTTP headers by stripping the prefix.
 pub struct PyDynamicContextProvider {
     provider: Py<PyAny>,
@@ -113,6 +113,20 @@ fn dict_to_hashmap(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<String, String>
         map.insert(key_str, value_str);
     }
     Ok(map)
+}
+
+fn pythonize_query_table_response<'py>(
+    py: Python<'py>,
+    response: &QueryTableResponse,
+) -> PyResult<Bound<'py, PyAny>> {
+    let dict = PyDict::new(py);
+    if let Some(context) = &response.context {
+        dict.set_item("context", pythonize(py, context)?)?;
+    }
+    if let Some(data) = &response.data {
+        dict.set_item("data", PyBytes::new(py, data))?;
+    }
+    Ok(dict.into_any())
 }
 
 /// Python wrapper for DirectoryNamespace
@@ -226,12 +240,16 @@ impl PyDirectoryNamespace {
         pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
-    fn namespace_exists(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn namespace_exists<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request = depythonize(request)?;
-        crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.namespace_exists(request))?
             .infer_error()?;
-        Ok(())
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     // Table operations
@@ -272,12 +290,16 @@ impl PyDirectoryNamespace {
         pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
-    fn table_exists(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn table_exists<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request = depythonize(request)?;
-        crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.table_exists(request))?
             .infer_error()?;
-        Ok(())
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     fn drop_table<'py>(
@@ -432,12 +454,16 @@ impl PyDirectoryNamespace {
 
     // Data manipulation operations
 
-    fn count_table_rows(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<i64> {
+    fn count_table_rows<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request: CountTableRowsRequest = depythonize(request)?;
-        let count = crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.count_table_rows(request))?
             .infer_error()?;
-        Ok(count)
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     fn insert_into_table<'py>(
@@ -496,12 +522,12 @@ impl PyDirectoryNamespace {
         &self,
         py: Python<'py>,
         request: &Bound<'_, PyAny>,
-    ) -> PyResult<Bound<'py, PyBytes>> {
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request: QueryTableRequest = depythonize(request)?;
         let response = crate::rt()
             .block_on(Some(py), self.inner.query_table(request))?
             .infer_error()?;
-        Ok(PyBytes::new(py, &response))
+        pythonize_query_table_response(py, &response)
     }
 
     // Index operations
@@ -831,9 +857,9 @@ impl PyRestNamespace {
     /// # Arguments
     ///
     /// * `context_provider` - Optional object with `provide_context(info: dict) -> dict` method
-    ///   for providing dynamic per-request context. Context keys that start with `headers.`
+    ///   for providing dynamic per-request context. Context keys that start with `header.`
     ///   are converted to HTTP headers by stripping the prefix. For example,
-    ///   `{"headers.Authorization": "Bearer token"}` becomes the `Authorization` header.
+    ///   `{"header.Authorization": "Bearer token"}` becomes the `Authorization` header.
     /// * `**properties` - Namespace configuration properties (uri, delimiter, header.*, etc.)
     #[new]
     #[pyo3(signature = (context_provider = None, **properties))]
@@ -926,12 +952,16 @@ impl PyRestNamespace {
         pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
-    fn namespace_exists(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn namespace_exists<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request = depythonize(request)?;
-        crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.namespace_exists(request))?
             .infer_error()?;
-        Ok(())
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     // Table operations
@@ -972,12 +1002,16 @@ impl PyRestNamespace {
         pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
-    fn table_exists(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn table_exists<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request = depythonize(request)?;
-        crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.table_exists(request))?
             .infer_error()?;
-        Ok(())
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     fn drop_table<'py>(
@@ -1132,12 +1166,16 @@ impl PyRestNamespace {
 
     // Data manipulation operations
 
-    fn count_table_rows(&self, py: Python, request: &Bound<'_, PyAny>) -> PyResult<i64> {
+    fn count_table_rows<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request: CountTableRowsRequest = depythonize(request)?;
-        let count = crate::rt()
+        let response = crate::rt()
             .block_on(Some(py), self.inner.count_table_rows(request))?
             .infer_error()?;
-        Ok(count)
+        pythonize(py, &response).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     fn insert_into_table<'py>(
@@ -1196,12 +1234,12 @@ impl PyRestNamespace {
         &self,
         py: Python<'py>,
         request: &Bound<'_, PyAny>,
-    ) -> PyResult<Bound<'py, PyBytes>> {
+    ) -> PyResult<Bound<'py, PyAny>> {
         let request: QueryTableRequest = depythonize(request)?;
         let response = crate::rt()
             .block_on(Some(py), self.inner.query_table(request))?
             .infer_error()?;
-        Ok(PyBytes::new(py, &response))
+        pythonize_query_table_response(py, &response)
     }
 
     // Index operations

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -978,19 +978,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.8.6"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/f38747c9610ade83dd9a99a0470b9432b6f21ce4e2bb5524edbe66f626fd/lance_namespace-0.9.0-py3-none-any.whl", hash = "sha256:f785ff10927e4ce0db69986576670fedd37f8a33521e8a4630c6be22db8061b2", size = 13501, upload-time = "2026-07-01T07:42:39.372Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.8.6"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -998,9 +998,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ab/c8754da0a1efc817f8480100cfe12b7e04034df834759de8ecf02beff3cc/lance_namespace_urllib3_client-0.9.0-py3-none-any.whl", hash = "sha256:be819c8cffb1e460a3a504dbf52d1ca009560a48e7202b8c4279998e4adf9fe4", size = 405586, upload-time = "2026-07-01T07:42:40.503Z" },
 ]
 
 [[package]]
@@ -2348,7 +2348,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.8.5,<0.9" },
+    { name = "lance-namespace", specifier = ">=0.9,<0.10" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },

--- a/rust/lance-namespace-impls/src/connect.rs
+++ b/rust/lance-namespace-impls/src/connect.rs
@@ -63,7 +63,7 @@ use crate::context::DynamicContextProvider;
 /// impl DynamicContextProvider for MyProvider {
 ///     fn provide_context(&self, info: &OperationInfo) -> HashMap<String, String> {
 ///         let mut ctx = HashMap::new();
-///         ctx.insert("headers.Authorization".to_string(), "Bearer token".to_string());
+///         ctx.insert("header.Authorization".to_string(), "Bearer token".to_string());
 ///         ctx
 ///     }
 /// }
@@ -152,7 +152,7 @@ impl ConnectBuilder {
     ///
     /// The provider will be called before each operation to generate
     /// additional context. For RestNamespace, context keys that start with
-    /// `headers.` are converted to HTTP headers by stripping the prefix.
+    /// `header.` are converted to HTTP headers by stripping the prefix.
     ///
     /// # Arguments
     ///

--- a/rust/lance-namespace-impls/src/context.rs
+++ b/rust/lance-namespace-impls/src/context.rs
@@ -21,8 +21,8 @@
 //! impl DynamicContextProvider for MyProvider {
 //!     fn provide_context(&self, info: &OperationInfo) -> HashMap<String, String> {
 //!         let mut context = HashMap::new();
-//!         context.insert("headers.Authorization".to_string(), format!("Bearer {}", get_current_token()));
-//!         context.insert("headers.X-Request-Id".to_string(), generate_request_id());
+//!         context.insert("header.Authorization".to_string(), format!("Bearer {}", get_current_token()));
+//!         context.insert("header.X-Request-Id".to_string(), generate_request_id());
 //!         context
 //!     }
 //! }
@@ -32,9 +32,9 @@
 //!     .build();
 //! ```
 //!
-//! For RestNamespace, context keys that start with `headers.` are converted to HTTP headers
-//! by stripping the prefix. For example, `{"headers.Authorization": "Bearer abc123"}`
-//! becomes the `Authorization: Bearer abc123` header. Keys without the `headers.` prefix
+//! For RestNamespace, context keys that start with `header.` are converted to HTTP headers
+//! by stripping the prefix. For example, `{"header.Authorization": "Bearer abc123"}`
+//! becomes the `Authorization: Bearer abc123` header. Keys without the `header.` prefix
 //! are ignored for HTTP headers but may be used for other purposes.
 
 use std::collections::HashMap;
@@ -68,8 +68,8 @@ impl OperationInfo {
 /// based on the operation being performed. The provider is called synchronously
 /// before each namespace operation.
 ///
-/// For RestNamespace, context keys that start with `headers.` are converted to
-/// HTTP headers by stripping the prefix. For example, `{"headers.Authorization": "Bearer token"}`
+/// For RestNamespace, context keys that start with `header.` are converted to
+/// HTTP headers by stripping the prefix. For example, `{"header.Authorization": "Bearer token"}`
 /// becomes the `Authorization: Bearer token` header.
 ///
 /// ## Thread Safety
@@ -92,7 +92,7 @@ pub trait DynamicContextProvider: Send + Sync + std::fmt::Debug {
     /// # Returns
     ///
     /// Returns a HashMap of context key-value pairs. For HTTP headers, use keys
-    /// with the `headers.` prefix (e.g., `headers.Authorization`).
+    /// with the `header.` prefix (e.g., `header.Authorization`).
     /// Returns an empty HashMap if no additional context is needed.
     fn provide_context(&self, info: &OperationInfo) -> HashMap<String, String>;
 }

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -50,12 +50,12 @@ use lance_namespace::models::{
     AlterTableAlterColumnsResponse, AlterTableDropColumnsRequest, AlterTableDropColumnsResponse,
     AlterTransactionRequest, AlterTransactionResponse, AnalyzeTableQueryPlanRequest,
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse,
-    BranchContents as ModelBranchContents, CountTableRowsRequest, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableBranchRequest, CreateTableBranchResponse,
-    CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest, CreateTableResponse,
-    CreateTableScalarIndexResponse, CreateTableTagRequest, CreateTableTagResponse,
-    CreateTableVersionRequest, CreateTableVersionResponse, DeclareTableRequest,
-    DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
+    BranchContents as ModelBranchContents, CountTableRowsRequest, CountTableRowsResponse,
+    CreateNamespaceRequest, CreateNamespaceResponse, CreateTableBranchRequest,
+    CreateTableBranchResponse, CreateTableIndexRequest, CreateTableIndexResponse,
+    CreateTableRequest, CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
+    CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
+    DeclareTableRequest, DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
     DeleteTableBranchRequest, DeleteTableBranchResponse, DeleteTableTagRequest,
     DeleteTableTagResponse, DescribeNamespaceRequest, DescribeNamespaceResponse,
     DescribeTableIndexStatsRequest, DescribeTableIndexStatsResponse, DescribeTableRequest,
@@ -70,10 +70,11 @@ use lance_namespace::models::{
     ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
-    QueryTableRequest, QueryTableRequestColumns, QueryTableRequestVector, RestoreTableRequest,
-    RestoreTableResponse, TableExistsRequest, TableVersion, TagContents as ModelTagContents,
-    UpdateTableRequest, UpdateTableResponse, UpdateTableSchemaMetadataRequest,
-    UpdateTableSchemaMetadataResponse, UpdateTableTagRequest, UpdateTableTagResponse,
+    NamespaceExistsResponse, QueryTableRequest, QueryTableRequestColumns, QueryTableRequestVector,
+    QueryTableResponse, RestoreTableRequest, RestoreTableResponse, TableExistsRequest,
+    TableExistsResponse, TableVersion, TagContents as ModelTagContents, UpdateTableRequest,
+    UpdateTableResponse, UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse,
+    UpdateTableTagRequest, UpdateTableTagResponse,
 };
 
 use lance_core::{Error, Result, box_error};
@@ -2171,6 +2172,7 @@ impl DirectoryNamespace {
         }
 
         DescribeTransactionResponse {
+            context: None,
             status: effective_status,
             properties: Some(properties),
         }
@@ -2188,6 +2190,7 @@ impl DirectoryNamespace {
         };
 
         DescribeTableIndexStatsResponse {
+            context: None,
             distance_type: stats
                 .get("distance_type")
                 .and_then(|value| value.as_str())
@@ -2865,14 +2868,17 @@ impl LanceNamespace for DirectoryNamespace {
         .into())
     }
 
-    async fn namespace_exists(&self, request: NamespaceExistsRequest) -> Result<()> {
+    async fn namespace_exists(
+        &self,
+        request: NamespaceExistsRequest,
+    ) -> Result<NamespaceExistsResponse> {
         self.record_op("namespace_exists");
         if let Some(ref manifest_ns) = self.manifest_ns {
             return manifest_ns.namespace_exists(request).await;
         }
 
         if request.id.is_none() || request.id.as_ref().unwrap().is_empty() {
-            return Ok(());
+            return Ok(NamespaceExistsResponse::new());
         }
 
         Err(NamespaceError::NamespaceNotFound {
@@ -2972,7 +2978,7 @@ impl LanceNamespace for DirectoryNamespace {
         self.describe_table_impl(request).await
     }
 
-    async fn table_exists(&self, request: TableExistsRequest) -> Result<()> {
+    async fn table_exists(&self, request: TableExistsRequest) -> Result<TableExistsResponse> {
         self.record_op("table_exists");
         let is_root_level = request.id.as_ref().is_some_and(|id| id.len() == 1);
         let skip_manifest_for_root = self.dir_listing_enabled
@@ -2982,7 +2988,7 @@ impl LanceNamespace for DirectoryNamespace {
             && !skip_manifest_for_root
         {
             match manifest_ns.table_exists(request.clone()).await {
-                Ok(()) => return Ok(()),
+                Ok(response) => return Ok(response),
                 Err(e) if manifest_feature_flags::is_incompatible_manifest_error(&e) => {
                     // An incompatible manifest must surface "please upgrade"
                     // rather than degrading to a directory-listing view.
@@ -3015,7 +3021,7 @@ impl LanceNamespace for DirectoryNamespace {
             .into());
         }
 
-        Ok(())
+        Ok(TableExistsResponse::new())
     }
 
     async fn drop_table(&self, request: DropTableRequest) -> Result<DropTableResponse> {
@@ -3433,6 +3439,7 @@ impl LanceNamespace for DirectoryNamespace {
             .await?;
 
         Ok(ListTableVersionsResponse {
+            context: None,
             versions: table_versions,
             page_token: None,
         })
@@ -3570,6 +3577,7 @@ impl LanceNamespace for DirectoryNamespace {
         }
 
         Ok(CreateTableVersionResponse {
+            context: None,
             transaction_id: None,
             version: Some(Box::new(TableVersion {
                 version: version as i64,
@@ -3621,6 +3629,7 @@ impl LanceNamespace for DirectoryNamespace {
         };
 
         Ok(DescribeTableVersionResponse {
+            context: None,
             version: Box::new(table_version),
         })
     }
@@ -3673,6 +3682,7 @@ impl LanceNamespace for DirectoryNamespace {
             .await?;
 
         Ok(BatchDeleteTableVersionsResponse {
+            context: None,
             deleted_count: Some(total_deleted_count),
             transaction_id: None,
         })
@@ -3744,7 +3754,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|transaction| transaction.uuid);
 
-        Ok(CreateTableIndexResponse { transaction_id })
+        Ok(CreateTableIndexResponse {
+            context: None,
+            transaction_id,
+        })
     }
 
     async fn list_table_indices(
@@ -3837,6 +3850,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         let page_token = Self::paginate_indices(&mut indices, request.page_token, request.limit);
         Ok(ListTableIndicesResponse {
+            context: None,
             indexes: indices,
             page_token,
         })
@@ -4128,6 +4142,7 @@ impl LanceNamespace for DirectoryNamespace {
             .unwrap_or_else(|| "SUCCEEDED".to_string());
         let response = Self::transaction_response(version, &transaction, Some(sidecar));
         Ok(AlterTransactionResponse {
+            context: None,
             status: final_status,
             properties: response.properties,
         })
@@ -4151,6 +4166,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         let response = self.create_table_index(request).await?;
         Ok(CreateTableScalarIndexResponse {
+            context: None,
             transaction_id: response.transaction_id,
         })
     }
@@ -4212,7 +4228,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|transaction| transaction.uuid);
 
-        Ok(DropTableIndexResponse { transaction_id })
+        Ok(DropTableIndexResponse {
+            context: None,
+            transaction_id,
+        })
     }
 
     async fn list_all_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
@@ -4282,7 +4301,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|t| t.uuid);
 
-        Ok(RestoreTableResponse { transaction_id })
+        Ok(RestoreTableResponse {
+            context: None,
+            transaction_id,
+        })
     }
 
     async fn update_table_schema_metadata(
@@ -4323,6 +4345,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map(|t| t.uuid);
 
         Ok(UpdateTableSchemaMetadataResponse {
+            context: None,
             metadata: Some(updated_metadata),
             transaction_id,
         })
@@ -4497,7 +4520,10 @@ impl LanceNamespace for DirectoryNamespace {
         })
     }
 
-    async fn count_table_rows(&self, request: CountTableRowsRequest) -> Result<i64> {
+    async fn count_table_rows(
+        &self,
+        request: CountTableRowsRequest,
+    ) -> Result<CountTableRowsResponse> {
         self.record_op("count_table_rows");
         let table_uri = self.resolve_table_location(&request.id).await?;
         let dataset = self
@@ -4512,7 +4538,10 @@ impl LanceNamespace for DirectoryNamespace {
                     message: format!("Failed to count rows for table at '{}': {:?}", table_uri, e),
                 })?;
 
-        Ok(count as i64)
+        Ok(CountTableRowsResponse {
+            context: None,
+            count: Some(count as i64),
+        })
     }
 
     async fn insert_into_table(
@@ -4549,6 +4578,7 @@ impl LanceNamespace for DirectoryNamespace {
         }
 
         Ok(InsertIntoTableResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -4576,6 +4606,7 @@ impl LanceNamespace for DirectoryNamespace {
                 .await?;
             let version = dataset.version().version as i64;
             return Ok(MergeInsertIntoTableResponse {
+                context: None,
                 transaction_id: None,
                 num_updated_rows: Some(0),
                 num_inserted_rows: Some(num_rows as i64),
@@ -4646,6 +4677,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_mutation_error(e, "merge_insert_into_table", &table_uri))?;
 
         Ok(MergeInsertIntoTableResponse {
+            context: None,
             transaction_id: None,
             num_updated_rows: Some(stats.num_updated_rows as i64),
             num_inserted_rows: Some(stats.num_inserted_rows as i64),
@@ -4731,6 +4763,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         let version = result.new_dataset.version().version as i64;
         Ok(UpdateTableResponse {
+            context: None,
             transaction_id: None,
             updated_rows: result.rows_updated as i64,
             version,
@@ -4762,12 +4795,13 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_mutation_error(e, "delete_from_table", &table_uri))?;
 
         Ok(DeleteFromTableResponse {
+            context: None,
             transaction_id: None,
             version: Some(result.new_dataset.version().version as i64),
         })
     }
 
-    async fn query_table(&self, request: QueryTableRequest) -> Result<Bytes> {
+    async fn query_table(&self, request: QueryTableRequest) -> Result<QueryTableResponse> {
         use arrow::ipc::writer::FileWriter;
 
         self.record_op("query_table");
@@ -4998,7 +5032,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?;
         }
 
-        Ok(Bytes::from(buffer))
+        Ok(QueryTableResponse {
+            context: None,
+            data: Some(buffer),
+        })
     }
 
     async fn list_table_tags(
@@ -5028,6 +5065,7 @@ impl LanceNamespace for DirectoryNamespace {
             .collect();
 
         Ok(ListTableTagsResponse {
+            context: None,
             tags,
             page_token: None,
         })
@@ -5057,6 +5095,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_tag_error(e, &request.tag, &table_uri))?;
 
         Ok(GetTableTagVersionResponse {
+            context: None,
             version: contents.version as i64,
             branch: contents.branch,
         })
@@ -5095,6 +5134,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_tag_error(e, &request.tag, &table_uri))?;
 
         Ok(CreateTableTagResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -5123,6 +5163,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_tag_error(e, &request.tag, &table_uri))?;
 
         Ok(DeleteTableTagResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -5160,6 +5201,7 @@ impl LanceNamespace for DirectoryNamespace {
             .map_err(|e| Self::map_tag_error(e, &request.tag, &table_uri))?;
 
         Ok(UpdateTableTagResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -5229,6 +5271,7 @@ impl LanceNamespace for DirectoryNamespace {
             })?;
 
         Ok(CreateTableBranchResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -5273,6 +5316,7 @@ impl LanceNamespace for DirectoryNamespace {
             .collect();
 
         Ok(ListTableBranchesResponse {
+            context: None,
             branches,
             page_token: None,
         })
@@ -5310,6 +5354,7 @@ impl LanceNamespace for DirectoryNamespace {
             })?;
 
         Ok(DeleteTableBranchResponse {
+            context: None,
             transaction_id: None,
         })
     }
@@ -10676,7 +10721,10 @@ mod tests {
                 self.inner.describe_namespace(request).await
             }
 
-            async fn namespace_exists(&self, request: NamespaceExistsRequest) -> Result<()> {
+            async fn namespace_exists(
+                &self,
+                request: NamespaceExistsRequest,
+            ) -> Result<NamespaceExistsResponse> {
                 self.inner.namespace_exists(request).await
             }
 
@@ -10705,7 +10753,10 @@ mod tests {
                 self.inner.describe_table(request).await
             }
 
-            async fn table_exists(&self, request: TableExistsRequest) -> Result<()> {
+            async fn table_exists(
+                &self,
+                request: TableExistsRequest,
+            ) -> Result<TableExistsResponse> {
                 self.inner.table_exists(request).await
             }
 
@@ -11072,6 +11123,16 @@ mod tests {
             (namespace, temp_dir, table_id)
         }
 
+        fn count_value(response: CountTableRowsResponse) -> i64 {
+            response.count.expect("count response should contain count")
+        }
+
+        fn query_data(response: QueryTableResponse) -> Vec<u8> {
+            response
+                .data
+                .expect("query response should contain IPC bytes")
+        }
+
         #[tokio::test]
         async fn test_count_table_rows_basic() {
             let (namespace, _temp_dir, table_id) = create_ns_with_table().await;
@@ -11083,7 +11144,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let count = namespace.count_table_rows(request).await.unwrap();
+            let count = count_value(namespace.count_table_rows(request).await.unwrap());
             assert_eq!(count, 3);
         }
 
@@ -11098,7 +11159,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let count = namespace.count_table_rows(request).await.unwrap();
+            let count = count_value(namespace.count_table_rows(request).await.unwrap());
             assert_eq!(count, 2);
         }
 
@@ -11179,7 +11240,7 @@ mod tests {
                 predicate: None,
                 ..Default::default()
             };
-            let count = namespace.count_table_rows(count_req).await.unwrap();
+            let count = count_value(namespace.count_table_rows(count_req).await.unwrap());
             assert_eq!(count, 5);
         }
 
@@ -11227,7 +11288,7 @@ mod tests {
                 predicate: None,
                 ..Default::default()
             };
-            let count = namespace.count_table_rows(count_req).await.unwrap();
+            let count = count_value(namespace.count_table_rows(count_req).await.unwrap());
             assert_eq!(count, 2);
         }
 
@@ -11314,7 +11375,7 @@ mod tests {
                 predicate: None,
                 ..Default::default()
             };
-            let count = namespace.count_table_rows(count_req).await.unwrap();
+            let count = count_value(namespace.count_table_rows(count_req).await.unwrap());
             assert_eq!(count, 2);
         }
 
@@ -11331,7 +11392,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             // Decode IPC and verify
             let cursor = Cursor::new(bytes.to_vec());
@@ -11354,7 +11415,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11376,7 +11437,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11399,7 +11460,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11427,7 +11488,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11483,7 +11544,7 @@ mod tests {
                 predicate: None,
                 ..Default::default()
             };
-            let count = namespace.count_table_rows(count_req).await.unwrap();
+            let count = count_value(namespace.count_table_rows(count_req).await.unwrap());
             assert_eq!(count, 3);
 
             // Latest version should have 5 rows
@@ -11493,7 +11554,7 @@ mod tests {
                 predicate: None,
                 ..Default::default()
             };
-            let count = namespace.count_table_rows(count_req).await.unwrap();
+            let count = count_value(namespace.count_table_rows(count_req).await.unwrap());
             assert_eq!(count, 5);
         }
 
@@ -11544,7 +11605,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
             let batches: Vec<_> = reader.into_iter().map(|b| b.unwrap()).collect();
@@ -11561,7 +11622,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
             let batches: Vec<_> = reader.into_iter().map(|b| b.unwrap()).collect();
@@ -11657,7 +11718,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11686,7 +11747,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11714,7 +11775,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11745,7 +11806,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11787,7 +11848,7 @@ mod tests {
                 vector,
                 ..Default::default()
             };
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11812,7 +11873,7 @@ mod tests {
                 filter: Some("id > 1".to_string()),
                 ..Default::default()
             };
-            let bytes = namespace.query_table(request).await.unwrap();
+            let bytes = query_data(namespace.query_table(request).await.unwrap());
 
             let cursor = Cursor::new(bytes.to_vec());
             let reader = FileReader::try_new(cursor, None).unwrap();
@@ -11852,7 +11913,10 @@ mod tests {
                 predicate: Some("name = 'updated'".to_string()),
                 ..Default::default()
             };
-            assert_eq!(namespace.count_table_rows(count_req).await.unwrap(), 3);
+            assert_eq!(
+                count_value(namespace.count_table_rows(count_req).await.unwrap()),
+                3
+            );
         }
 
         #[tokio::test]
@@ -11876,7 +11940,10 @@ mod tests {
                 predicate: Some("name = 'Alice'".to_string()),
                 ..Default::default()
             };
-            assert_eq!(namespace.count_table_rows(untouched).await.unwrap(), 1);
+            assert_eq!(
+                count_value(namespace.count_table_rows(untouched).await.unwrap()),
+                1
+            );
 
             let touched = CountTableRowsRequest {
                 id: Some(table_id),
@@ -11884,7 +11951,10 @@ mod tests {
                 predicate: Some("name = 'matched'".to_string()),
                 ..Default::default()
             };
-            assert_eq!(namespace.count_table_rows(touched).await.unwrap(), 2);
+            assert_eq!(
+                count_value(namespace.count_table_rows(touched).await.unwrap()),
+                2
+            );
         }
 
         #[tokio::test]
@@ -11951,7 +12021,10 @@ mod tests {
                 ..Default::default()
             };
             // Original rows = 3; after deleting `id > 1` only row id=1 remains.
-            assert_eq!(namespace.count_table_rows(count_req).await.unwrap(), 1);
+            assert_eq!(
+                count_value(namespace.count_table_rows(count_req).await.unwrap()),
+                1
+            );
         }
 
         #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -49,8 +49,8 @@ use lance_namespace::models::{
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableRequest,
     DescribeTableResponse, DropNamespaceRequest, DropNamespaceResponse, DropTableRequest,
     DropTableResponse, ListNamespacesRequest, ListNamespacesResponse, ListTablesRequest,
-    ListTablesResponse, NamespaceExistsRequest, RegisterTableRequest, RegisterTableResponse,
-    TableExistsRequest,
+    ListTablesResponse, NamespaceExistsRequest, NamespaceExistsResponse, RegisterTableRequest,
+    RegisterTableResponse, TableExistsRequest, TableExistsResponse,
 };
 use lance_namespace::schema::arrow_schema_to_json;
 use lance_table::feature_flags::apply_feature_flags;
@@ -2824,7 +2824,7 @@ impl LanceNamespace for ManifestNamespace {
         }
     }
 
-    async fn table_exists(&self, request: TableExistsRequest) -> Result<()> {
+    async fn table_exists(&self, request: TableExistsRequest) -> Result<TableExistsResponse> {
         let table_id = request.id.as_ref().ok_or_else(|| {
             lance_core::Error::from(NamespaceError::InvalidInput {
                 message: "Table ID is required".to_string(),
@@ -2841,7 +2841,7 @@ impl LanceNamespace for ManifestNamespace {
         let object_id = Self::str_object_id(table_id);
         let exists = self.manifest_contains_object(&object_id).await?;
         if exists {
-            Ok(())
+            Ok(TableExistsResponse::new())
         } else {
             Err(NamespaceError::TableNotFound {
                 message: Self::format_table_id(table_id),
@@ -3322,7 +3322,10 @@ impl LanceNamespace for ManifestNamespace {
         Ok(DropNamespaceResponse::default())
     }
 
-    async fn namespace_exists(&self, request: NamespaceExistsRequest) -> Result<()> {
+    async fn namespace_exists(
+        &self,
+        request: NamespaceExistsRequest,
+    ) -> Result<NamespaceExistsResponse> {
         let namespace_id = request.id.as_ref().ok_or_else(|| {
             lance_core::Error::from(NamespaceError::InvalidInput {
                 message: "Namespace ID is required".to_string(),
@@ -3331,12 +3334,12 @@ impl LanceNamespace for ManifestNamespace {
 
         // Root namespace always exists
         if namespace_id.is_empty() {
-            return Ok(());
+            return Ok(NamespaceExistsResponse::new());
         }
 
         let object_id = namespace_id.join(DELIMITER);
         if self.manifest_contains_object(&object_id).await? {
-            Ok(())
+            Ok(NamespaceExistsResponse::new())
         } else {
             Err(NamespaceError::NamespaceNotFound {
                 message: object_id.to_string(),

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -22,12 +22,12 @@ use lance_namespace::models::{
     AlterTableBackfillColumnsResponse, AlterTableDropColumnsRequest, AlterTableDropColumnsResponse,
     AlterTransactionRequest, AlterTransactionResponse, AnalyzeTableQueryPlanRequest,
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse, CountTableRowsRequest,
-    CreateMaterializedViewRequest, CreateMaterializedViewResponse, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableBranchRequest, CreateTableBranchResponse,
-    CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest, CreateTableResponse,
-    CreateTableScalarIndexResponse, CreateTableTagRequest, CreateTableTagResponse,
-    CreateTableVersionRequest, CreateTableVersionResponse, DeclareTableRequest,
-    DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
+    CountTableRowsResponse, CreateMaterializedViewRequest, CreateMaterializedViewResponse,
+    CreateNamespaceRequest, CreateNamespaceResponse, CreateTableBranchRequest,
+    CreateTableBranchResponse, CreateTableIndexRequest, CreateTableIndexResponse,
+    CreateTableRequest, CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
+    CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
+    DeclareTableRequest, DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
     DeleteTableBranchRequest, DeleteTableBranchResponse, DeleteTableTagRequest,
     DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
@@ -42,11 +42,12 @@ use lance_namespace::models::{
     ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
-    QueryTableRequest, RefreshMaterializedViewRequest, RefreshMaterializedViewResponse,
-    RegisterTableRequest, RegisterTableResponse, RenameTableRequest, RenameTableResponse,
-    RestoreTableRequest, RestoreTableResponse, TableExistsRequest, UpdateTableRequest,
-    UpdateTableResponse, UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse,
-    UpdateTableTagRequest, UpdateTableTagResponse,
+    NamespaceExistsResponse, QueryTableRequest, QueryTableResponse, RefreshMaterializedViewRequest,
+    RefreshMaterializedViewResponse, RegisterTableRequest, RegisterTableResponse,
+    RenameTableRequest, RenameTableResponse, RestoreTableRequest, RestoreTableResponse,
+    TableExistsRequest, TableExistsResponse, UpdateTableRequest, UpdateTableResponse,
+    UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse, UpdateTableTagRequest,
+    UpdateTableTagResponse,
 };
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -54,6 +55,9 @@ use lance_core::{Error, Result};
 
 use lance_namespace::LanceNamespace;
 use lance_namespace::error::NamespaceError;
+
+const HEADER_CONTEXT_PREFIX: &str = "header.";
+const LEGACY_HEADERS_CONTEXT_PREFIX: &str = "headers.";
 
 /// HTTP client wrapper that supports per-request header injection.
 ///
@@ -89,7 +93,13 @@ impl RestClient {
     ///
     /// This method mutates the request's headers directly, which is more efficient
     /// than creating a new client with default_headers for each request.
-    fn apply_headers(&self, request: &mut reqwest::Request, operation: &str, object_id: &str) {
+    fn apply_headers(
+        &self,
+        request: &mut reqwest::Request,
+        operation: &str,
+        object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
+    ) {
         let request_headers = request.headers_mut();
 
         // First apply base headers
@@ -105,17 +115,28 @@ impl RestClient {
         if let Some(provider) = &self.context_provider {
             let info = OperationInfo::new(operation, object_id);
             let context = provider.provide_context(&info);
+            Self::apply_context_headers(request_headers, &context);
+        }
 
-            const HEADERS_PREFIX: &str = "headers.";
-            for (key, value) in context {
-                if let Some(header_name) = key.strip_prefix(HEADERS_PREFIX)
-                    && let (Ok(header_name), Ok(header_value)) = (
-                        HeaderName::from_str(header_name),
-                        HeaderValue::from_str(&value),
-                    )
-                {
-                    request_headers.insert(header_name, header_value);
-                }
+        if let Some(context) = request_context {
+            Self::apply_context_headers(request_headers, context);
+        }
+    }
+
+    fn apply_context_headers(
+        request_headers: &mut reqwest::header::HeaderMap,
+        context: &HashMap<String, String>,
+    ) {
+        for (key, value) in context {
+            if let Some(header_name) = key
+                .strip_prefix(HEADER_CONTEXT_PREFIX)
+                .or_else(|| key.strip_prefix(LEGACY_HEADERS_CONTEXT_PREFIX))
+                && let (Ok(header_name), Ok(header_value)) = (
+                    HeaderName::from_str(header_name),
+                    HeaderValue::from_str(value),
+                )
+            {
+                request_headers.insert(header_name, header_value);
             }
         }
     }
@@ -128,9 +149,10 @@ impl RestClient {
         req_builder: reqwest::RequestBuilder,
         operation: &str,
         object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
     ) -> std::result::Result<reqwest::Response, reqwest::Error> {
         let mut request = req_builder.build()?;
-        self.apply_headers(&mut request, operation, object_id);
+        self.apply_headers(&mut request, operation, object_id, request_context);
         self.client.execute(request).await
     }
 
@@ -225,7 +247,7 @@ impl RestNamespaceBuilder {
     /// It expects:
     /// - `uri`: The base URI for the REST API (required)
     /// - `delimiter`: Delimiter for object identifiers (optional, defaults to ".")
-    /// - `header.*` / `headers.*`: Additional headers (optional, prefix will be stripped)
+    /// - `header.*`: Additional headers (optional, prefix will be stripped)
     /// - `tls.cert_file`: Path to client certificate file (optional)
     /// - `tls.key_file`: Path to client private key file (optional)
     /// - `tls.ssl_ca_cert`: Path to CA certificate file (optional)
@@ -273,7 +295,7 @@ impl RestNamespaceBuilder {
             .cloned()
             .unwrap_or_else(|| Self::DEFAULT_DELIMITER.to_string());
 
-        // Extract headers (properties prefixed with "header." or "headers.")
+        // Extract headers (properties prefixed with "header." or legacy "headers.")
         let mut headers = HashMap::new();
         for (key, value) in &properties {
             if let Some(header_name) = key
@@ -386,9 +408,9 @@ impl RestNamespaceBuilder {
     /// Set a dynamic context provider for per-request context.
     ///
     /// The provider will be called before each HTTP request to generate
-    /// additional context. Context keys that start with `headers.` are converted
-    /// to HTTP headers by stripping the prefix. For example, `headers.Authorization`
-    /// becomes the `Authorization` header. Keys without the `headers.` prefix are ignored.
+    /// additional context. Context keys that start with `header.` are converted
+    /// to HTTP headers by stripping the prefix. For example, `header.Authorization`
+    /// becomes the `Authorization` header. Keys without the `header.` prefix are ignored.
     ///
     /// # Arguments
     ///
@@ -574,6 +596,74 @@ impl RestNamespace {
         }
     }
 
+    fn response_headers_to_context(
+        headers: &reqwest::header::HeaderMap,
+    ) -> Option<HashMap<String, String>> {
+        let context: HashMap<String, String> = headers
+            .iter()
+            .filter_map(|(name, value)| {
+                value.to_str().ok().map(|value| {
+                    (
+                        format!("{}{}", HEADER_CONTEXT_PREFIX, name.as_str()),
+                        value.to_string(),
+                    )
+                })
+            })
+            .collect();
+
+        if context.is_empty() {
+            None
+        } else {
+            Some(context)
+        }
+    }
+
+    fn request_context_from_body<T: Serialize>(body: &T) -> Option<HashMap<String, String>> {
+        let value = serde_json::to_value(body).ok()?;
+        let context = value.get("context")?.as_object()?;
+        let context: HashMap<String, String> = context
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+            .collect();
+
+        if context.is_empty() {
+            None
+        } else {
+            Some(context)
+        }
+    }
+
+    fn parse_json_response<T: DeserializeOwned>(
+        content: &str,
+        header_context: Option<HashMap<String, String>>,
+    ) -> Result<T> {
+        let mut value = serde_json::from_str::<serde_json::Value>(content).map_err(|e| {
+            NamespaceError::Internal {
+                message: format!("Failed to parse response: {:?}", e),
+            }
+        })?;
+
+        if let (serde_json::Value::Object(object), Some(header_context)) =
+            (&mut value, header_context)
+        {
+            let context_value = object
+                .entry("context")
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let serde_json::Value::Object(context_object) = context_value {
+                for (key, value) in header_context {
+                    context_object.insert(key, serde_json::Value::String(value));
+                }
+            }
+        }
+
+        serde_json::from_value(value).map_err(|e| {
+            NamespaceError::Internal {
+                message: format!("Failed to parse response: {:?}", e),
+            }
+            .into()
+        })
+    }
+
     /// Execute a GET request and parse JSON response.
     async fn get_json<T: DeserializeOwned>(
         &self,
@@ -581,17 +671,19 @@ impl RestNamespace {
         query: &[(&str, &str)],
         operation: &str,
         object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
     ) -> Result<T> {
         let url = format!("{}{}", self.rest_client.base_path(), path);
         let req_builder = self.rest_client.client().get(&url).query(query);
 
         let resp = self
             .rest_client
-            .execute(req_builder, operation, object_id)
+            .execute(req_builder, operation, object_id, request_context)
             .await
             .map_err(Self::request_error)?;
 
         let status = resp.status();
+        let header_context = Self::response_headers_to_context(resp.headers());
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
                 message: format!("Failed to read response body: {:?}", e),
@@ -599,15 +691,63 @@ impl RestNamespace {
         })?;
 
         if status.is_success() {
-            serde_json::from_str(&content).map_err(|e| {
-                NamespaceError::Internal {
-                    message: format!("Failed to parse response: {:?}", e),
-                }
-                .into()
-            })
+            Self::parse_json_response(&content, header_context)
         } else {
             Err(Self::parse_error_response(status, &content))
         }
+    }
+
+    async fn get_count_table_rows_response(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+        operation: &str,
+        object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
+    ) -> Result<CountTableRowsResponse> {
+        let url = format!("{}{}", self.rest_client.base_path(), path);
+        let req_builder = self.rest_client.client().get(&url).query(query);
+
+        let resp = self
+            .rest_client
+            .execute(req_builder, operation, object_id, request_context)
+            .await
+            .map_err(Self::request_error)?;
+
+        let status = resp.status();
+        let header_context = Self::response_headers_to_context(resp.headers());
+        let content = resp.text().await.map_err(|e| {
+            Error::from(NamespaceError::Internal {
+                message: format!("Failed to read response body: {:?}", e),
+            })
+        })?;
+
+        if !status.is_success() {
+            return Err(Self::parse_error_response(status, &content));
+        }
+
+        let trimmed = content.trim();
+        if trimmed.starts_with('{') {
+            let response: CountTableRowsResponse =
+                Self::parse_json_response(trimmed, header_context)?;
+            if response.count.is_none() {
+                return Err(NamespaceError::Internal {
+                    message: "count_table_rows response did not contain count".to_string(),
+                }
+                .into());
+            }
+            return Ok(response);
+        }
+
+        let count = trimmed
+            .parse::<i64>()
+            .map_err(|e| NamespaceError::Internal {
+                message: format!("Failed to parse count_table_rows response: {:?}", e),
+            })?;
+        Ok(CountTableRowsResponse {
+            context: header_context,
+            count: Some(count),
+        })
     }
 
     /// Execute a POST request with JSON body and parse JSON response.
@@ -619,16 +759,38 @@ impl RestNamespace {
         operation: &str,
         object_id: &str,
     ) -> Result<R> {
+        let request_context = Self::request_context_from_body(body);
+        self.post_json_with_context(
+            path,
+            query,
+            body,
+            operation,
+            object_id,
+            request_context.as_ref(),
+        )
+        .await
+    }
+
+    async fn post_json_with_context<T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+        body: &T,
+        operation: &str,
+        object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
+    ) -> Result<R> {
         let url = format!("{}{}", self.rest_client.base_path(), path);
         let req_builder = self.rest_client.client().post(&url).query(query).json(body);
 
         let resp = self
             .rest_client
-            .execute(req_builder, operation, object_id)
+            .execute(req_builder, operation, object_id, request_context)
             .await
             .map_err(Self::request_error)?;
 
         let status = resp.status();
+        let header_context = Self::response_headers_to_context(resp.headers());
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
                 message: format!("Failed to read response body: {:?}", e),
@@ -636,12 +798,44 @@ impl RestNamespace {
         })?;
 
         if status.is_success() {
-            serde_json::from_str(&content).map_err(|e| {
-                NamespaceError::Internal {
-                    message: format!("Failed to parse response: {:?}", e),
-                }
-                .into()
+            Self::parse_json_response(&content, header_context)
+        } else {
+            Err(Self::parse_error_response(status, &content))
+        }
+    }
+
+    async fn post_json_plain_response<T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+        body: &T,
+        operation: &str,
+        object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
+    ) -> Result<(R, Option<HashMap<String, String>>)> {
+        let url = format!("{}{}", self.rest_client.base_path(), path);
+        let req_builder = self.rest_client.client().post(&url).query(query).json(body);
+
+        let resp = self
+            .rest_client
+            .execute(req_builder, operation, object_id, request_context)
+            .await
+            .map_err(Self::request_error)?;
+
+        let status = resp.status();
+        let header_context = Self::response_headers_to_context(resp.headers());
+        let content = resp.text().await.map_err(|e| {
+            Error::from(NamespaceError::Internal {
+                message: format!("Failed to read response body: {:?}", e),
             })
+        })?;
+
+        if status.is_success() {
+            let response =
+                serde_json::from_str(&content).map_err(|e| NamespaceError::Internal {
+                    message: format!("Failed to parse response: {:?}", e),
+                })?;
+            Ok((response, header_context))
         } else {
             Err(Self::parse_error_response(status, &content))
         }
@@ -655,19 +849,20 @@ impl RestNamespace {
         body: &T,
         operation: &str,
         object_id: &str,
-    ) -> Result<()> {
+    ) -> Result<Option<HashMap<String, String>>> {
         let url = format!("{}{}", self.rest_client.base_path(), path);
         let req_builder = self.rest_client.client().post(&url).query(query).json(body);
+        let request_context = Self::request_context_from_body(body);
 
         let resp = self
             .rest_client
-            .execute(req_builder, operation, object_id)
+            .execute(req_builder, operation, object_id, request_context.as_ref())
             .await
             .map_err(Self::request_error)?;
 
         let status = resp.status();
         if status.is_success() {
-            Ok(())
+            Ok(Self::response_headers_to_context(resp.headers()))
         } else {
             let content = resp.text().await.map_err(|e| {
                 Error::from(NamespaceError::Internal {
@@ -686,17 +881,19 @@ impl RestNamespace {
         body: Vec<u8>,
         operation: &str,
         object_id: &str,
+        request_context: Option<&HashMap<String, String>>,
     ) -> Result<R> {
         let url = format!("{}{}", self.rest_client.base_path(), path);
         let req_builder = self.rest_client.client().post(&url).query(query).body(body);
 
         let resp = self
             .rest_client
-            .execute(req_builder, operation, object_id)
+            .execute(req_builder, operation, object_id, request_context)
             .await
             .map_err(Self::request_error)?;
 
         let status = resp.status();
+        let header_context = Self::response_headers_to_context(resp.headers());
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
                 message: format!("Failed to read response body: {:?}", e),
@@ -704,12 +901,7 @@ impl RestNamespace {
         })?;
 
         if status.is_success() {
-            serde_json::from_str(&content).map_err(|e| {
-                NamespaceError::Internal {
-                    message: format!("Failed to parse response: {:?}", e),
-                }
-                .into()
-            })
+            Self::parse_json_response(&content, header_context)
         } else {
             Err(Self::parse_error_response(status, &content))
         }
@@ -771,7 +963,14 @@ impl LanceNamespace for RestNamespace {
             limit_str = limit.to_string();
             query.push(("limit", limit_str.as_str()));
         }
-        self.get_json(&path, &query, "list_namespaces", &id).await
+        self.get_json(
+            &path,
+            &query,
+            "list_namespaces",
+            &id,
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn describe_namespace(
@@ -810,14 +1009,19 @@ impl LanceNamespace for RestNamespace {
             .await
     }
 
-    async fn namespace_exists(&self, request: NamespaceExistsRequest) -> Result<()> {
+    async fn namespace_exists(
+        &self,
+        request: NamespaceExistsRequest,
+    ) -> Result<NamespaceExistsResponse> {
         self.record_op("namespace_exists");
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
         let path = format!("/v1/namespace/{}/exists", encoded_id);
         let query = [("delimiter", self.delimiter.as_str())];
-        self.post_json_no_content(&path, &query, &request, "namespace_exists", &id)
-            .await
+        let context = self
+            .post_json_no_content(&path, &query, &request, "namespace_exists", &id)
+            .await?;
+        Ok(NamespaceExistsResponse { context })
     }
 
     async fn list_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
@@ -841,7 +1045,8 @@ impl LanceNamespace for RestNamespace {
             include_declared_str = include_declared.to_string();
             query.push(("include_declared", include_declared_str.as_str()));
         }
-        self.get_json(&path, &query, "list_tables", &id).await
+        self.get_json(&path, &query, "list_tables", &id, request.context.as_ref())
+            .await
     }
 
     async fn describe_table(&self, request: DescribeTableRequest) -> Result<DescribeTableResponse> {
@@ -879,14 +1084,16 @@ impl LanceNamespace for RestNamespace {
             .await
     }
 
-    async fn table_exists(&self, request: TableExistsRequest) -> Result<()> {
+    async fn table_exists(&self, request: TableExistsRequest) -> Result<TableExistsResponse> {
         self.record_op("table_exists");
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
         let path = format!("/v1/table/{}/exists", encoded_id);
         let query = [("delimiter", self.delimiter.as_str())];
-        self.post_json_no_content(&path, &query, &request, "table_exists", &id)
-            .await
+        let context = self
+            .post_json_no_content(&path, &query, &request, "table_exists", &id)
+            .await?;
+        Ok(TableExistsResponse { context })
     }
 
     async fn drop_table(&self, request: DropTableRequest) -> Result<DropTableResponse> {
@@ -912,13 +1119,23 @@ impl LanceNamespace for RestNamespace {
             .await
     }
 
-    async fn count_table_rows(&self, request: CountTableRowsRequest) -> Result<i64> {
+    async fn count_table_rows(
+        &self,
+        request: CountTableRowsRequest,
+    ) -> Result<CountTableRowsResponse> {
         self.record_op("count_table_rows");
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
         let path = format!("/v1/table/{}/count_rows", encoded_id);
         let query = [("delimiter", self.delimiter.as_str())];
-        self.get_json(&path, &query, "count_table_rows", &id).await
+        self.get_count_table_rows_response(
+            &path,
+            &query,
+            "count_table_rows",
+            &id,
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn create_table(
@@ -962,8 +1179,15 @@ impl LanceNamespace for RestNamespace {
             })?;
             query.push(("storage_options", storage_options_str.as_str()));
         }
-        self.post_binary_json(&path, &query, request_data.to_vec(), "create_table", &id)
-            .await
+        self.post_binary_json(
+            &path,
+            &query,
+            request_data.to_vec(),
+            "create_table",
+            &id,
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn declare_table(&self, request: DeclareTableRequest) -> Result<DeclareTableResponse> {
@@ -997,6 +1221,7 @@ impl LanceNamespace for RestNamespace {
             request_data.to_vec(),
             "insert_into_table",
             &id,
+            request.context.as_ref(),
         )
         .await
     }
@@ -1064,6 +1289,7 @@ impl LanceNamespace for RestNamespace {
             request_data.to_vec(),
             "merge_insert_into_table",
             &id,
+            request.context.as_ref(),
         )
         .await
     }
@@ -1091,7 +1317,7 @@ impl LanceNamespace for RestNamespace {
             .await
     }
 
-    async fn query_table(&self, request: QueryTableRequest) -> Result<Bytes> {
+    async fn query_table(&self, request: QueryTableRequest) -> Result<QueryTableResponse> {
         self.record_op("query_table");
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
@@ -1109,16 +1335,21 @@ impl LanceNamespace for RestNamespace {
 
         let resp = self
             .rest_client
-            .execute(req_builder, operation, &id)
+            .execute(req_builder, operation, &id, request.context.as_ref())
             .await
             .map_err(Self::request_error)?;
 
         let status = resp.status();
         if status.is_success() {
-            resp.bytes().await.map_err(|e| {
+            let context = Self::response_headers_to_context(resp.headers());
+            let bytes = resp.bytes().await.map_err(|e| {
                 Error::from(NamespaceError::Internal {
                     message: format!("Failed to read response bytes: {:?}", e),
                 })
+            })?;
+            Ok(QueryTableResponse {
+                context,
+                data: Some(bytes.to_vec()),
             })
         } else {
             let content = resp.text().await.map_err(|e| {
@@ -1250,7 +1481,14 @@ impl LanceNamespace for RestNamespace {
             include_declared_str = include_declared.to_string();
             query.push(("include_declared", include_declared_str.as_str()));
         }
-        self.get_json(path, &query, "list_all_tables", "").await
+        self.get_json(
+            path,
+            &query,
+            "list_all_tables",
+            "",
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn restore_table(&self, request: RestoreTableRequest) -> Result<RestoreTableResponse> {
@@ -1304,8 +1542,15 @@ impl LanceNamespace for RestNamespace {
             branch_str = branch.clone();
             query.push(("branch", branch_str.as_str()));
         }
-        self.post_json(&path, &query, &(), "list_table_versions", &id)
-            .await
+        self.post_json_with_context(
+            &path,
+            &query,
+            &(),
+            "list_table_versions",
+            &id,
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn create_table_version(
@@ -1355,18 +1600,26 @@ impl LanceNamespace for RestNamespace {
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
         let path = format!("/v1/table/{}/schema_metadata/update", encoded_id);
-        let query = [("delimiter", self.delimiter.as_str())];
+        let mut query = vec![("delimiter", self.delimiter.as_str())];
+        let branch_str;
+        if let Some(ref branch) = request.branch {
+            branch_str = branch.clone();
+            query.push(("branch", branch_str.as_str()));
+        }
+        let request_context = request.context.clone();
         let metadata = request.metadata.unwrap_or_default();
-        let result: HashMap<String, String> = self
-            .post_json(
+        let (result, context): (HashMap<String, String>, _) = self
+            .post_json_plain_response(
                 &path,
                 &query,
                 &metadata,
                 "update_table_schema_metadata",
                 &id,
+                request_context.as_ref(),
             )
             .await?;
         Ok(UpdateTableSchemaMetadataResponse {
+            context,
             metadata: Some(result),
             ..Default::default()
         })
@@ -1508,7 +1761,14 @@ impl LanceNamespace for RestNamespace {
             limit_str = limit.to_string();
             query.push(("limit", limit_str.as_str()));
         }
-        self.get_json(&path, &query, "list_table_tags", &id).await
+        self.get_json(
+            &path,
+            &query,
+            "list_table_tags",
+            &id,
+            request.context.as_ref(),
+        )
+        .await
     }
 
     async fn get_table_tag_version(
@@ -2076,7 +2336,7 @@ mod tests {
         // Create context provider
         let mut context_headers = HashMap::new();
         context_headers.insert(
-            "headers.X-Context-Token".to_string(),
+            "header.X-Context-Token".to_string(),
             "dynamic-token".to_string(),
         );
         let provider = Arc::new(TestContextProvider {
@@ -2120,7 +2380,7 @@ mod tests {
         // Create context provider
         let mut context_headers = HashMap::new();
         context_headers.insert(
-            "headers.X-Context-Token".to_string(),
+            "header.X-Context-Token".to_string(),
             "dynamic-token".to_string(),
         );
         let provider = Arc::new(TestContextProvider {
@@ -2162,7 +2422,7 @@ mod tests {
         // Context provider that overrides Authorization header
         let mut context_headers = HashMap::new();
         context_headers.insert(
-            "headers.Authorization".to_string(),
+            "header.Authorization".to_string(),
             "Bearer context-override-token".to_string(),
         );
         let provider = Arc::new(TestContextProvider {

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -7,17 +7,18 @@
 //! allowing it to be accessed via HTTP. The server implements the Lance REST Namespace
 //! specification.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
     Json, Router, ServiceExt,
     body::Bytes,
     extract::{FromRequest, Path, Query, Request, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use serde::{Deserialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::sync::watch;
 use tower::Layer;
 use tower_http::normalize_path::NormalizePathLayer;
@@ -27,6 +28,9 @@ use lance_core::{Error, Result};
 use lance_namespace::LanceNamespace;
 use lance_namespace::error::NamespaceError;
 use lance_namespace::models::*;
+
+const HEADER_CONTEXT_PREFIX: &str = "header.";
+const LEGACY_HEADERS_CONTEXT_PREFIX: &str = "headers.";
 
 /// Configuration for the REST server
 #[derive(Debug, Clone)]
@@ -381,6 +385,83 @@ fn error_to_response(err: Error) -> Response {
     }
 }
 
+fn http_headers_to_context(headers: &HeaderMap) -> Option<HashMap<String, String>> {
+    let context: HashMap<String, String> = headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|value| {
+                (
+                    format!("{}{}", HEADER_CONTEXT_PREFIX, name.as_str()),
+                    value.to_string(),
+                )
+            })
+        })
+        .collect();
+
+    if context.is_empty() {
+        None
+    } else {
+        Some(context)
+    }
+}
+
+fn merge_headers_into_context(context: &mut Option<HashMap<String, String>>, headers: &HeaderMap) {
+    let Some(header_context) = http_headers_to_context(headers) else {
+        return;
+    };
+
+    context
+        .get_or_insert_with(HashMap::new)
+        .extend(header_context);
+}
+
+fn add_context_headers(headers: &mut HeaderMap, context: Option<&HashMap<String, String>>) {
+    let Some(context) = context else {
+        return;
+    };
+
+    for (key, value) in context {
+        if let Some(header_name) = key
+            .strip_prefix(HEADER_CONTEXT_PREFIX)
+            .or_else(|| key.strip_prefix(LEGACY_HEADERS_CONTEXT_PREFIX))
+            && let (Ok(header_name), Ok(header_value)) = (
+                HeaderName::from_bytes(header_name.as_bytes()),
+                HeaderValue::from_str(value),
+            )
+        {
+            headers.insert(header_name, header_value);
+        }
+    }
+}
+
+fn model_context<T: Serialize>(model: &T) -> Option<HashMap<String, String>> {
+    let value = serde_json::to_value(model).ok()?;
+    let context = value.get("context")?.as_object()?;
+    let context: HashMap<String, String> = context
+        .iter()
+        .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+        .collect();
+
+    if context.is_empty() {
+        None
+    } else {
+        Some(context)
+    }
+}
+
+fn response_with_context(
+    mut response: Response,
+    context: Option<&HashMap<String, String>>,
+) -> Response {
+    add_context_headers(response.headers_mut(), context);
+    response
+}
+
+fn json_response_with_model_context<T: Serialize>(status: StatusCode, model: T) -> Response {
+    let context = model_context(&model);
+    response_with_context((status, Json(model)).into_response(), context.as_ref())
+}
+
 // ============================================================================
 // Namespace Operation Handlers
 // ============================================================================
@@ -394,9 +475,10 @@ async fn create_namespace(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_namespace(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -412,11 +494,11 @@ async fn list_namespaces(
         page_token: params.page_token,
         limit: params.limit,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_namespaces(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -430,9 +512,10 @@ async fn describe_namespace(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.describe_namespace(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -446,9 +529,10 @@ async fn drop_namespace(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.drop_namespace(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -462,9 +546,13 @@ async fn namespace_exists(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.namespace_exists(request).await {
-        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Ok(response) => response_with_context(
+            StatusCode::NO_CONTENT.into_response(),
+            response.context.as_ref(),
+        ),
         Err(e) => error_to_response(e),
     }
 }
@@ -485,11 +573,11 @@ async fn list_tables(
         limit: params.limit,
         include_declared: params.include_declared,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_tables(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -503,9 +591,10 @@ async fn register_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.register_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -519,6 +608,7 @@ async fn describe_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
     if params.with_table_uri.is_some() {
         request.with_table_uri = params.with_table_uri;
     }
@@ -530,7 +620,7 @@ async fn describe_table(
     }
 
     match backend.describe_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -544,9 +634,13 @@ async fn table_exists(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.table_exists(request).await {
-        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Ok(response) => response_with_context(
+            StatusCode::NO_CONTENT.into_response(),
+            response.context.as_ref(),
+        ),
         Err(e) => error_to_response(e),
     }
 }
@@ -560,11 +654,11 @@ async fn drop_table(
     let request = DropTableRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.drop_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -578,9 +672,10 @@ async fn deregister_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.deregister_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -648,11 +743,11 @@ async fn create_table(
         properties,
         storage_options,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.create_table(request, body).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -666,9 +761,10 @@ async fn declare_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.declare_table(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -690,11 +786,12 @@ async fn insert_into_table(
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         mode: params.mode.clone(),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.insert_into_table(request, body).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -730,11 +827,12 @@ async fn merge_insert_into_table(
         timeout: params.timeout,
         use_index: params.use_index,
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.merge_insert_into_table(request, body).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -748,9 +846,10 @@ async fn update_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.update_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -764,9 +863,10 @@ async fn delete_from_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.delete_from_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -780,9 +880,16 @@ async fn query_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.query_table(request).await {
-        Ok(bytes) => (StatusCode::OK, bytes).into_response(),
+        Ok(response) => {
+            let data = response.data.unwrap_or_default();
+            response_with_context(
+                (StatusCode::OK, Bytes::from(data)).into_response(),
+                response.context.as_ref(),
+            )
+        }
         Err(e) => error_to_response(e),
     }
 }
@@ -798,11 +905,25 @@ async fn count_table_rows(
         version: None,
         predicate: None,
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.count_table_rows(request).await {
-        Ok(count) => (StatusCode::OK, Json(serde_json::json!({ "count": count }))).into_response(),
+        Ok(response) => {
+            let Some(count) = response.count else {
+                return error_to_response(
+                    NamespaceError::Internal {
+                        message: "count_table_rows response did not contain count".to_string(),
+                    }
+                    .into(),
+                );
+            };
+            response_with_context(
+                (StatusCode::OK, Json(count)).into_response(),
+                response.context.as_ref(),
+            )
+        }
         Err(e) => error_to_response(e),
     }
 }
@@ -820,9 +941,10 @@ async fn rename_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.rename_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -836,9 +958,10 @@ async fn restore_table(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.restore_table(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -856,11 +979,11 @@ async fn list_table_versions(
         descending: params.descending,
         branch: params.branch,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_table_versions(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -875,6 +998,7 @@ async fn create_table_version(
     let request = CreateTableVersionRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         version: body.version,
         manifest_path: body.manifest_path,
         manifest_size: body.manifest_size,
@@ -885,7 +1009,7 @@ async fn create_table_version(
     };
 
     match backend.create_table_version(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -902,11 +1026,11 @@ async fn describe_table_version(
         version: body.version,
         branch: body.branch,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.describe_table_version(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -921,13 +1045,13 @@ async fn batch_delete_table_versions(
     let request = BatchDeleteTableVersionsRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ranges: body.ranges,
         branch: body.branch,
-        ..Default::default()
     };
 
     match backend.batch_delete_table_versions(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -941,11 +1065,12 @@ async fn get_table_stats(
     let request = GetTableStatsRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.get_table_stats(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -961,11 +1086,11 @@ async fn list_all_tables(
         limit: params.limit,
         include_declared: params.include_declared,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_all_tables(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -983,9 +1108,10 @@ async fn create_table_index(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_table_index(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -999,9 +1125,10 @@ async fn create_table_scalar_index(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_table_scalar_index(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1016,9 +1143,10 @@ async fn list_table_indices(
     let mut request = body.unwrap_or_default();
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.list_table_indices(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1040,11 +1168,12 @@ async fn describe_table_index_stats(
         version: None,
         index_name: Some(params.index_name),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.describe_table_index_stats(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1059,11 +1188,12 @@ async fn drop_table_index(
         id: Some(parse_id(&params.id, query.delimiter.as_deref())),
         index_name: Some(params.index_name),
         identity: extract_identity(&headers),
+        context: http_headers_to_context(&headers),
         ..Default::default()
     };
 
     match backend.drop_table_index(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1081,9 +1211,10 @@ async fn alter_table_add_columns(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.alter_table_add_columns(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1097,9 +1228,10 @@ async fn alter_table_alter_columns(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.alter_table_alter_columns(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1113,9 +1245,10 @@ async fn alter_table_backfill_columns(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.alter_table_backfill_columns(request).await {
-        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::ACCEPTED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1129,9 +1262,10 @@ async fn refresh_materialized_view(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.refresh_materialized_view(request).await {
-        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::ACCEPTED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1145,9 +1279,10 @@ async fn create_materialized_view(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_materialized_view(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1161,9 +1296,10 @@ async fn alter_table_drop_columns(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.alter_table_drop_columns(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1177,9 +1313,10 @@ async fn update_table_schema_metadata(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.update_table_schema_metadata(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1199,11 +1336,11 @@ async fn list_table_tags(
         page_token: params.page_token,
         limit: params.limit,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_table_tags(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1217,9 +1354,10 @@ async fn get_table_tag_version(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.get_table_tag_version(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1233,9 +1371,10 @@ async fn create_table_tag(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_table_tag(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1249,9 +1388,10 @@ async fn delete_table_tag(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.delete_table_tag(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1265,9 +1405,10 @@ async fn update_table_tag(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.update_table_tag(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1285,9 +1426,10 @@ async fn create_table_branch(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.create_table_branch(request).await {
-        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::CREATED, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1303,11 +1445,11 @@ async fn list_table_branches(
         page_token: params.page_token,
         limit: params.limit,
         identity: extract_identity(&headers),
-        ..Default::default()
+        context: http_headers_to_context(&headers),
     };
 
     match backend.list_table_branches(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1321,9 +1463,10 @@ async fn delete_table_branch(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.delete_table_branch(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1341,6 +1484,7 @@ async fn explain_table_query_plan(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.explain_table_query_plan(request).await {
         Ok(plan) => (StatusCode::OK, plan).into_response(),
@@ -1357,6 +1501,7 @@ async fn analyze_table_query_plan(
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.analyze_table_query_plan(request).await {
         Ok(plan) => (StatusCode::OK, plan).into_response(),
@@ -1385,9 +1530,10 @@ async fn describe_transaction(
         request.id = Some(vec![id]);
     }
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.describe_transaction(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -1407,9 +1553,10 @@ async fn alter_transaction(
         request.id = Some(vec![id]);
     }
     request.identity = extract_identity(&headers);
+    merge_headers_into_context(&mut request.context, &headers);
 
     match backend.alter_transaction(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => json_response_with_model_context(StatusCode::OK, response),
         Err(e) => error_to_response(e),
     }
 }
@@ -3106,11 +3253,11 @@ mod tests {
             // Create context provider that adds custom headers
             let mut context_headers = HashMap::new();
             context_headers.insert(
-                "headers.X-Custom-Auth".to_string(),
+                "header.X-Custom-Auth".to_string(),
                 "test-auth-token".to_string(),
             );
             context_headers.insert(
-                "headers.X-Request-Source".to_string(),
+                "header.X-Request-Source".to_string(),
                 "integration-test".to_string(),
             );
 

--- a/rust/lance-namespace/src/namespace.rs
+++ b/rust/lance-namespace/src/namespace.rs
@@ -13,12 +13,12 @@ use lance_namespace_reqwest_client::models::{
     AlterTableBackfillColumnsResponse, AlterTableDropColumnsRequest, AlterTableDropColumnsResponse,
     AlterTransactionRequest, AlterTransactionResponse, AnalyzeTableQueryPlanRequest,
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse, CountTableRowsRequest,
-    CreateMaterializedViewRequest, CreateMaterializedViewResponse, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableBranchRequest, CreateTableBranchResponse,
-    CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest, CreateTableResponse,
-    CreateTableScalarIndexResponse, CreateTableTagRequest, CreateTableTagResponse,
-    CreateTableVersionRequest, CreateTableVersionResponse, DeclareTableRequest,
-    DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
+    CountTableRowsResponse, CreateMaterializedViewRequest, CreateMaterializedViewResponse,
+    CreateNamespaceRequest, CreateNamespaceResponse, CreateTableBranchRequest,
+    CreateTableBranchResponse, CreateTableIndexRequest, CreateTableIndexResponse,
+    CreateTableRequest, CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
+    CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
+    DeclareTableRequest, DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
     DeleteTableBranchRequest, DeleteTableBranchResponse, DeleteTableTagRequest,
     DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
@@ -33,11 +33,12 @@ use lance_namespace_reqwest_client::models::{
     ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
-    QueryTableRequest, RefreshMaterializedViewRequest, RefreshMaterializedViewResponse,
-    RegisterTableRequest, RegisterTableResponse, RenameTableRequest, RenameTableResponse,
-    RestoreTableRequest, RestoreTableResponse, TableExistsRequest, UpdateTableRequest,
-    UpdateTableResponse, UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse,
-    UpdateTableTagRequest, UpdateTableTagResponse,
+    NamespaceExistsResponse, QueryTableRequest, QueryTableResponse, RefreshMaterializedViewRequest,
+    RefreshMaterializedViewResponse, RegisterTableRequest, RegisterTableResponse,
+    RenameTableRequest, RenameTableResponse, RestoreTableRequest, RestoreTableResponse,
+    TableExistsRequest, TableExistsResponse, UpdateTableRequest, UpdateTableResponse,
+    UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse, UpdateTableTagRequest,
+    UpdateTableTagResponse,
 };
 
 /// Base trait for Lance Namespace implementations.
@@ -114,7 +115,10 @@ pub trait LanceNamespace: Send + Sync + std::fmt::Debug {
     /// # Errors
     ///
     /// Returns [`crate::ErrorCode::NamespaceNotFound`] if the namespace does not exist.
-    async fn namespace_exists(&self, _request: NamespaceExistsRequest) -> Result<()> {
+    async fn namespace_exists(
+        &self,
+        _request: NamespaceExistsRequest,
+    ) -> Result<NamespaceExistsResponse> {
         Err(Error::not_supported("namespace_exists not implemented"))
     }
 
@@ -140,7 +144,7 @@ pub trait LanceNamespace: Send + Sync + std::fmt::Debug {
     }
 
     /// Check if a table exists.
-    async fn table_exists(&self, _request: TableExistsRequest) -> Result<()> {
+    async fn table_exists(&self, _request: TableExistsRequest) -> Result<TableExistsResponse> {
         Err(Error::not_supported("table_exists not implemented"))
     }
 
@@ -158,7 +162,10 @@ pub trait LanceNamespace: Send + Sync + std::fmt::Debug {
     }
 
     /// Count rows in a table.
-    async fn count_table_rows(&self, _request: CountTableRowsRequest) -> Result<i64> {
+    async fn count_table_rows(
+        &self,
+        _request: CountTableRowsRequest,
+    ) -> Result<CountTableRowsResponse> {
         Err(Error::not_supported("count_table_rows not implemented"))
     }
 
@@ -210,7 +217,7 @@ pub trait LanceNamespace: Send + Sync + std::fmt::Debug {
     }
 
     /// Query a table.
-    async fn query_table(&self, _request: QueryTableRequest) -> Result<Bytes> {
+    async fn query_table(&self, _request: QueryTableRequest) -> Result<QueryTableResponse> {
         Err(Error::not_supported("query_table not implemented"))
     }
 


### PR DESCRIPTION
## Summary

- Upgrade Lance Namespace dependencies to 0.9.0 across Rust, Python, and Java.
- Propagate namespace request/response context through Rust REST mappings and response models.
- Update Python and Java wrappers/tests, including binary-safe JNI query-table response handling.