### PR TITLE
fix(blob): read empty blobs correctly under physical projection

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -121,6 +121,35 @@ def test_scan_blob_as_binary(tmp_path):
     assert tbl.column("blobs").to_pylist() == values
 
 
+def test_scan_blob_as_binary_with_empty_value(tmp_path):
+    # An empty (non-null, zero-length) blob encodes as descriptor
+    # position=0, size=0, which decodes to rep=0, def=0 -- the same as a real
+    # blob. If byte assignment keys off def==0, the empty value steals the
+    # buffer meant for the next real blob and every value after the first empty
+    # one reads back empty (or the scan errors). This interleaves an empty value
+    # with real blobs and a null to guard against that regression.
+    val1 = b"\x01" * 1024
+    val2 = b"\x02" * 10240
+    val3 = b"\x03" * 102400
+    # normal / empty / normal / null / normal
+    values = [val1, b"", val2, None, val3]
+    arr = pa.array(values, pa.large_binary())
+    table = pa.table(
+        [arr],
+        schema=pa.schema(
+            [
+                pa.field(
+                    "blobs", pa.large_binary(), metadata={"lance-encoding:blob": "true"}
+                )
+            ]
+        ),
+    )
+    ds = lance.write_dataset(table, tmp_path / "test_ds")
+
+    tbl = ds.scanner(columns=["blobs"], blob_handling="all_binary").to_table()
+    assert tbl.column("blobs").to_pylist() == values
+
+
 def test_fragment_scan_blob_as_binary(tmp_path):
     values = [b"foo", b"bar", b"baz"]
     arr = pa.array(values, pa.large_binary())

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -535,6 +535,40 @@ mod tests {
         .await;
     }
 
+    /// Regression test: an empty (non-null, zero-length) blob is encoded as a
+    /// descriptor with `position == 0, size == 0`. On the decode side this
+    /// yields `rep == 0, def == 0`, which is indistinguishable from a real
+    /// blob's rep/def. The blob page loader must NOT decide whether to assign
+    /// fetched bytes based on `def == 0`; if it does, the empty blob steals a
+    /// byte buffer meant for a following real blob and every value after the
+    /// first empty one is read back as empty.
+    ///
+    /// Here `val2` and `val3` follow the empty value and would come back empty
+    /// under the buggy behavior.
+    #[tokio::test]
+    async fn test_blob_round_trip_with_empty_value() {
+        let blob_metadata =
+            HashMap::from([(lance_arrow::BLOB_META_KEY.to_string(), "true".to_string())]);
+
+        let val1: &[u8] = &vec![1u8; 1024]; // 1KB
+        let val2: &[u8] = &vec![2u8; 10240]; // 10KB
+        let val3: &[u8] = &vec![3u8; 102400]; // 100KB
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(val1),
+            Some(b"".as_ref()), // empty (non-null, zero-length) -- triggers the bug
+            Some(val2),         // would be read back empty before the fix
+            None,               // null
+            Some(val3),         // would be read back empty before the fix
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default().with_max_file_version(LanceFileVersion::V2_1),
+            blob_metadata,
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn test_blob_v2_external_round_trip() {
         let blob_metadata = HashMap::from([(

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -258,7 +258,7 @@ impl BlobPageScheduler {
             let bytes = read_fut.await?;
             let mut bytes_iter = bytes.into_iter();
             for blob in loaded_blobs.iter_mut() {
-                if blob.def == 0 {
+                if blob.has_data {
                     blob.set_bytes(bytes_iter.next().expect_ok()?);
                 }
             }
@@ -364,9 +364,9 @@ impl StructuralPageScheduler for BlobPageScheduler {
                 if size == 0 {
                     let rep = (position & 0xFFFF) as u16;
                     let def = ((position >> 16) & 0xFFFF) as u16;
-                    loaded_blobs.push(LoadedBlob::new(rep, def));
+                    loaded_blobs.push(LoadedBlob::new(rep, def, false));
                 } else {
-                    loaded_blobs.push(LoadedBlob::new(0, 0));
+                    loaded_blobs.push(LoadedBlob::new(0, 0, true));
                     ranges_to_read.push(position..(position + size));
                     bytes_so_far += size;
                 }
@@ -405,14 +405,25 @@ struct LoadedBlob {
     bytes: Option<Bytes>,
     rep: u16,
     def: u16,
+    /// Whether this blob has out-of-line data that must be assigned from the
+    /// I/O results (i.e. the descriptor had `size > 0`).
+    ///
+    /// This must NOT be inferred from `rep`/`def`: an empty (non-null,
+    /// zero-length) blob is encoded as `position == 0, size == 0`, which yields
+    /// `rep == 0, def == 0` -- identical to a real blob's rep/def. Keying byte
+    /// assignment off `def == 0` therefore made empty blobs steal a byte buffer
+    /// meant for a following real blob, corrupting every value after the first
+    /// empty one.
+    has_data: bool,
 }
 
 impl LoadedBlob {
-    fn new(rep: u16, def: u16) -> Self {
+    fn new(rep: u16, def: u16, has_data: bool) -> Self {
         Self {
             bytes: None,
             rep,
             def,
+            has_data,
         }
     }
 

--- a/rust/lance-encoding/src/previous/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/blob.rs
@@ -193,9 +193,18 @@ impl LogicalPageDecoder for BlobFieldDecoder {
             let end = (loaded_need + 1).min(self.num_rows) as usize;
             let positions = self.positions.values().slice(start, end - start);
             let sizes = self.sizes.values().slice(start, end - start);
+            // Only submit ranges for rows that actually have out-of-line data
+            // (`size > 0`). A zero-length row -- an empty blob (position=0,
+            // size=0) or a null (position=1, size=0) -- must NOT be submitted:
+            // its degenerate `x..x` range never "overlaps" anything in the
+            // scheduler's coalescing/reassembly step (`is_overlapping` is
+            // always false for an empty interval), so the scheduler would drop
+            // that entry and misalign the bytes for every subsequent row,
+            // reading them back empty. We splice empty `Bytes` back in below.
             let ranges = positions
                 .iter()
                 .zip(sizes.iter())
+                .filter(|(_, size)| **size != 0)
                 .map(|(position, size)| *position..(*position + *size))
                 .collect::<Vec<_>>();
             let validity = positions
@@ -206,10 +215,25 @@ impl LogicalPageDecoder for BlobFieldDecoder {
             // Run the I/O before mutating decoder state, so a failed load
             // leaves the decoder untouched and `wait_for_loaded` is the single,
             // clean point of failure.
-            let bytes = self
+            let loaded_bytes = self
                 .io
                 .submit_request(ranges, self.base_priority + start as u64)
                 .await?;
+            // Re-expand to one entry per row: fetched bytes for `size > 0` rows
+            // (in order), empty `Bytes` for the zero-length rows we skipped.
+            let mut loaded_iter = loaded_bytes.into_iter();
+            let bytes = sizes
+                .iter()
+                .map(|size| {
+                    if *size == 0 {
+                        Bytes::new()
+                    } else {
+                        loaded_iter
+                            .next()
+                            .expect("one loaded buffer per non-empty blob range")
+                    }
+                })
+                .collect::<Vec<_>>();
             self.validity.push_back(validity);
             self.loaded.extend(bytes);
             self.rows_loaded = end as u64;

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -996,6 +996,12 @@ impl FileScheduler {
                 let orig_range = &request[orig_index];
                 let byte_offset = updated_range.start as usize;
 
+                if orig_range.is_empty() {
+                    final_bytes.push(Bytes::new());
+                    orig_index += 1;
+                    continue;
+                }
+
                 if is_overlapping(updated_range, orig_range) {
                     // We need to undo the coalescing and splitting done earlier
                     let start = orig_range.start as usize - byte_offset;
@@ -1275,6 +1281,36 @@ mod tests {
             );
         }
         assert_eq!(11, scheduler.stats().iops);
+    }
+
+    #[tokio::test]
+    async fn test_empty_ranges_preserve_result_order() {
+        let tmp_file = TempObjFile::default();
+
+        let obj_store = Arc::new(ObjectStore::local());
+
+        const DATA_SIZE: u64 = 1024;
+        let some_data = (0..DATA_SIZE).map(|i| (i % 251) as u8).collect::<Vec<_>>();
+        obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+        let scheduler = ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
+
+        let file_scheduler = scheduler
+            .open_file(&tmp_file, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+
+        let bytes = file_scheduler
+            .submit_request(vec![0..0, 10..13, 20..20, 30..32, 32..32], 0)
+            .await
+            .unwrap();
+
+        assert_eq!(bytes.len(), 5);
+        assert!(bytes[0].is_empty());
+        assert_eq!(bytes[1], Bytes::copy_from_slice(&some_data[10..13]));
+        assert!(bytes[2].is_empty());
+        assert_eq!(bytes[3], Bytes::copy_from_slice(&some_data[30..32]));
+        assert!(bytes[4].is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #7598.

## Summary

- Track whether v2.1 blob descriptors actually have out-of-line data instead of inferring byte assignment from rep/def values.
- Skip zero-length blob I/O ranges in the v2.0 legacy blob decoder and re-expand empty bytes in row order.
- Preserve empty range result slots in `FileScheduler::submit_request`, matching the `EncodingsIo` contract.
- Add Rust and Python regression coverage for empty non-null blobs scanned as binary.

## Testing

- `cargo fmt --all`
- `cargo test -p lance-io scheduler::tests::test_empty_ranges_preserve_result_order`
- `cargo test -p lance-io scheduler::tests::test_split_coalesce`
- `cargo test -p lance-encoding test_blob_round_trip_with_empty_value`
- `cargo test -p lance-encoding previous::encodings::logical::blob::tests`
- `make install` from `python/`
- `uv run pytest python/tests/test_blob.py::test_scan_blob_as_binary_with_empty_value` from `python/`
- `uv run pytest python/tests/test_blob.py -k "scan_blob_as_binary"` from `python/`
- `uv run make lint` from `python/`

Not run: root `cargo clippy --all --tests --benches -- -D warnings` was not completed before opening this PR.
