### PR TITLE
perf(fts): cache the num_tokens-only DocSet on LazyDocSet

### DIFF
--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -74,6 +74,11 @@ pub struct DeferredDocSet {
     row_ids_col: OnceCell<Arc<UInt64Array>>,
     /// Full DocSet, materialized on first `ensure_loaded`.
     full: OnceCell<Arc<DocSet>>,
+    /// num_tokens-only DocSet, materialized on first
+    /// `ensure_num_tokens_loaded`. Cached because wand scoring calls this
+    /// once per query per partition; rebuilding it copied the whole
+    /// num_tokens column (tens of MB per partition) on every query.
+    tokens_only: OnceCell<Arc<DocSet>>,
 }
 
 impl std::fmt::Debug for LazyDocSet {
@@ -103,6 +108,10 @@ impl lance_core::deepsize::DeepSizeOf for LazyDocSet {
                     .get()
                     .map(|d| d.deep_size_of_children(ctx))
                     .unwrap_or(0)
+                    + d.tokens_only
+                        .get()
+                        .map(|d| d.deep_size_of_children(ctx))
+                        .unwrap_or(0)
                     + d.num_tokens_col
                         .get()
                         .map(|arr| arr.len() * std::mem::size_of::<u32>())
@@ -134,6 +143,7 @@ impl LazyDocSet {
             num_tokens_col: OnceCell::new(),
             row_ids_col: OnceCell::new(),
             full: OnceCell::new(),
+            tokens_only: OnceCell::new(),
         }))
     }
 
@@ -319,8 +329,14 @@ impl DeferredDocSet {
         if let Some(full) = self.full.get() {
             return Ok(full.clone());
         }
-        let num_tokens = self.num_tokens_column().await?;
-        let docs = Arc::new(DocSet::from_num_tokens_only(num_tokens.as_ref()));
+        let docs = self
+            .tokens_only
+            .get_or_try_init(|| async {
+                let num_tokens = self.num_tokens_column().await?;
+                Result::Ok(Arc::new(DocSet::from_num_tokens_only(num_tokens.as_ref())))
+            })
+            .await?
+            .clone();
         let _ = self.total_tokens.set(docs.total_tokens_num());
         Ok(docs)
     }


### PR DESCRIPTION
`ensure_num_tokens_loaded` rebuilt the num_tokens-only `DocSet` from the
cached arrow column on every call, copying the whole column (tens of MB per
partition) once per query per partition. Materialize it once in a `OnceCell`
like the full DocSet, and account for it in `deep_size_of`.

## Measured vs its merge-base

Per-branch-tip wheels on the 200M-doc legacy index (338 partitions), 1000
queries × 8 concurrent, 400G index cache. The rebuild only happens while a
partition's DocSet is deferred (not yet fully materialized), so the win shows
on the not-yet-prewarmed path, and the fix is exactly neutral once the index
is warm:

| protocol | query | base | this PR |
|---|---|---|---|
| no prewarm, steady-state passes | single-term k10 | 0.304s / 27 qps | **0.076s / 105 qps (4.0×)** |
| no prewarm, steady-state passes | 3-word OR k10 | 0.359s / 22 qps | **0.179s / 45 qps (2.0×)** |
| prewarmed | single-term k10 | 0.027s | 0.027s (neutral) |
| prewarmed | 3-word OR k10 / k100 | 0.133s / 0.258s | 0.133s / 0.257s (neutral) |

In the stacked V3 setup (#7466 and its followers) partitions serve queries
from the tokens-only DocSet indefinitely, where this same rebuild dominated
hot single-term queries (250ms → 3ms when the cache landed there).

Independent of the block-size/impact PR stack; applies to any FTS query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
