### PR TITLE
feat(fts): impact skip data for posting lists

### DIFF
--- a/rust/lance-index/protos-cache/cache.proto
+++ b/rust/lance-index/protos-cache/cache.proto
@@ -31,6 +31,8 @@ message CompressedPostingHeader {
   // Number of documents in each compressed posting block. Older cache entries
   // omit this field and decode as the legacy 128-doc block size.
   uint32 block_size = 6;
+  // Whether an impact IPC section follows the posting/position sections.
+  bool has_impacts = 7;
 }
 
 // Header for a serialized `PlainPostingList` cache entry. Followed by an Arrow

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -4,6 +4,7 @@
 pub mod builder;
 mod cache_codec;
 mod encoding;
+mod impact;
 mod index;
 mod iter;
 pub mod json;

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1805,10 +1805,26 @@ pub fn inverted_list_schema_for_version_with_block_size(
     format_version: InvertedListFormatVersion,
     block_size: usize,
 ) -> SchemaRef {
+    inverted_list_schema_for_version_with_block_size_and_impacts(
+        with_position,
+        format_version,
+        block_size,
+        true,
+    )
+}
+
+pub(crate) fn inverted_list_schema_for_version_with_block_size_and_impacts(
+    with_position: bool,
+    format_version: InvertedListFormatVersion,
+    block_size: usize,
+    with_impacts: bool,
+) -> SchemaRef {
     validate_format_version_block_size(format_version, block_size)
         .expect("invalid FTS format version for posting block size");
     match format_version {
-        InvertedListFormatVersion::V1 => inverted_list_schema_v1(with_position, block_size),
+        InvertedListFormatVersion::V1 => {
+            inverted_list_schema_v1(with_position, block_size, with_impacts)
+        }
         InvertedListFormatVersion::V2 | InvertedListFormatVersion::V3 => {
             inverted_list_schema_with_tail_codec_and_position_codec(
                 with_position,
@@ -1816,12 +1832,17 @@ pub fn inverted_list_schema_for_version_with_block_size(
                 PostingTailCodec::VarintDelta,
                 Some(PositionStreamCodec::PackedDelta),
                 block_size,
+                with_impacts,
             )
         }
     }
 }
 
-fn inverted_list_schema_v1(with_position: bool, block_size: usize) -> SchemaRef {
+fn inverted_list_schema_v1(
+    with_position: bool,
+    block_size: usize,
+    with_impacts: bool,
+) -> SchemaRef {
     let mut fields = vec![
         arrow_schema::Field::new(
             POSTING_COL,
@@ -1835,6 +1856,17 @@ fn inverted_list_schema_v1(with_position: bool, block_size: usize) -> SchemaRef 
         arrow_schema::Field::new(MAX_SCORE_COL, datatypes::DataType::Float32, false),
         arrow_schema::Field::new(LENGTH_COL, datatypes::DataType::UInt32, false),
     ];
+    if with_impacts {
+        fields.push(arrow_schema::Field::new(
+            IMPACT_COL,
+            datatypes::DataType::List(Arc::new(Field::new(
+                "item",
+                datatypes::DataType::LargeBinary,
+                true,
+            ))),
+            false,
+        ));
+    }
     if with_position {
         fields.push(arrow_schema::Field::new(
             POSITION_COL,
@@ -1877,6 +1909,7 @@ pub fn inverted_list_schema_with_tail_codec(
         posting_tail_codec,
         Some(PositionStreamCodec::PackedDelta),
         LEGACY_BLOCK_SIZE,
+        false,
     )
 }
 
@@ -1886,6 +1919,7 @@ fn inverted_list_schema_with_tail_codec_and_position_codec(
     posting_tail_codec: PostingTailCodec,
     position_codec: Option<PositionStreamCodec>,
     block_size: usize,
+    with_impacts: bool,
 ) -> SchemaRef {
     let mut fields = vec![
         // we compress the posting lists (including row ids and frequencies),
@@ -1902,6 +1936,17 @@ fn inverted_list_schema_with_tail_codec_and_position_codec(
         arrow_schema::Field::new(MAX_SCORE_COL, datatypes::DataType::Float32, false),
         arrow_schema::Field::new(LENGTH_COL, datatypes::DataType::UInt32, false),
     ];
+    if with_impacts {
+        fields.push(arrow_schema::Field::new(
+            IMPACT_COL,
+            datatypes::DataType::List(Arc::new(Field::new(
+                "item",
+                datatypes::DataType::LargeBinary,
+                true,
+            ))),
+            false,
+        ));
+    }
     if with_position {
         fields.push(arrow_schema::Field::new(
             COMPRESSED_POSITION_COL,

--- a/rust/lance-index/src/scalar/inverted/cache_codec.rs
+++ b/rust/lance-index/src/scalar/inverted/cache_codec.rs
@@ -14,12 +14,13 @@
 //! - the compressed posting list: an IPC section for `blocks`, then the
 //!   position sections (legacy IPC, or shared block-offsets IPC + a raw blob of
 //!   the [`SharedPositionStream`] byte buffer, which has its own portable
-//!   encoding);
+//!   encoding), then an optional impact IPC section;
 //! - the plain posting list: an IPC section of `(row_ids, frequencies)`, then
 //!   an optional legacy position IPC section;
 //! - a packed posting-list group: one IPC section containing the original
-//!   `List<LargeBinary>` posting rows; prewarmed groups omit score/length
-//!   metadata and inject it from the posting reader into query-local views;
+//!   `List<LargeBinary>` posting rows and optional impact rows; prewarmed groups
+//!   omit score/length metadata and inject it from the posting reader into
+//!   query-local views;
 //! - the standalone [`Positions`] codec: the position sections alone.
 //!
 //! All sections read back zero-copy via [`lance_arrow::ipc`]. This is the FTS
@@ -42,6 +43,7 @@ use crate::cache_pb::{
     PostingTailCodec as PbPostingTailCodec,
 };
 
+use super::impact::ImpactSkipData;
 use super::index::{
     CompressedPositionStorage, CompressedPostingList, PlainPostingList, PositionStreamCodec,
     Positions, PostingList, PostingListGroup, PostingListGroupStorage, PostingTailCodec,
@@ -119,6 +121,7 @@ const BLOCK_OFFSETS_COLUMN: &str = "block_offsets";
 const ROW_IDS_COLUMN: &str = "row_ids";
 const FREQUENCIES_COLUMN: &str = "frequencies";
 const BLOCKS_COLUMN: &str = "blocks";
+const IMPACTS_COLUMN: &str = "impacts";
 
 fn legacy_positions_batch(list: &ListArray) -> Result<RecordBatch> {
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -132,7 +135,8 @@ fn legacy_positions_batch(list: &ListArray) -> Result<RecordBatch> {
 fn read_legacy_positions(r: &mut CacheEntryReader<'_>) -> Result<ListArray> {
     let batch = r.read_ipc()?;
     Ok(batch
-        .column(0)
+        .column_by_name(POSITION_LIST_COLUMN)
+        .ok_or_else(|| Error::io("legacy position column is missing".to_string()))?
         .as_any()
         .downcast_ref::<ListArray>()
         .ok_or_else(|| Error::io("legacy position column is not a ListArray".to_string()))?
@@ -180,7 +184,8 @@ fn read_position_sections(
         PbPositionStorage::Shared => {
             let batch = r.read_ipc()?;
             let block_offsets = batch
-                .column(0)
+                .column_by_name(BLOCK_OFFSETS_COLUMN)
+                .ok_or_else(|| Error::io("block_offsets column is missing".to_string()))?
                 .as_primitive_opt::<UInt32Type>()
                 .ok_or_else(|| Error::io("block_offsets column is not UInt32".to_string()))?
                 .values()
@@ -202,7 +207,11 @@ fn read_position_sections(
 
 impl CacheCodecImpl for PostingList {
     const TYPE_ID: &'static str = "lance.fts.PostingList";
-    const CURRENT_VERSION: u32 = 2;
+    // Version 3 adds the optional impact IPC section. Main already used v2 for
+    // configurable posting block sizes, so impact data needs a distinct
+    // version to keep older readers from accepting a body with an extra
+    // section they cannot consume.
+    const CURRENT_VERSION: u32 = 3;
 
     fn serialize(&self, w: &mut CacheEntryWriter<'_>) -> Result<()> {
         match self {
@@ -219,7 +228,7 @@ impl CacheCodecImpl for PostingList {
 
     fn deserialize(r: &mut CacheEntryReader<'_>) -> Result<Self> {
         match r.version() {
-            1 | Self::CURRENT_VERSION => deserialize_posting_list_body(r),
+            1 | 2 | Self::CURRENT_VERSION => deserialize_posting_list_body(r),
             other => Err(Error::io(format!(
                 "unsupported PostingList cache version: {other}"
             ))),
@@ -269,13 +278,15 @@ fn deserialize_plain(r: &mut CacheEntryReader<'_>) -> Result<PlainPostingList> {
 
     let batch = r.read_ipc()?;
     let row_ids = batch
-        .column(0)
+        .column_by_name(ROW_IDS_COLUMN)
+        .ok_or_else(|| Error::io("row_ids column is missing".to_string()))?
         .as_primitive_opt::<UInt64Type>()
         .ok_or_else(|| Error::io("row_ids column is not UInt64".to_string()))?
         .values()
         .clone();
     let frequencies = batch
-        .column(1)
+        .column_by_name(FREQUENCIES_COLUMN)
+        .ok_or_else(|| Error::io("frequencies column is missing".to_string()))?
         .as_primitive_opt::<Float32Type>()
         .ok_or_else(|| Error::io("frequencies column is not Float32".to_string()))?
         .values()
@@ -325,6 +336,7 @@ fn serialize_compressed(
         position_storage: position_storage as i32,
         position_stream_codec: position_stream_codec as i32,
         block_size: posting.block_size as u32,
+        has_impacts: posting.impacts.is_some(),
     };
     w.write_header(&header)?;
 
@@ -339,6 +351,15 @@ fn serialize_compressed(
     if let Some(storage) = &posting.positions {
         write_position_sections(w, storage)?;
     }
+    if let Some(impacts) = &posting.impacts {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            IMPACTS_COLUMN,
+            DataType::LargeBinary,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(impacts.entries().clone())])?;
+        w.write_ipc(&batch)?;
+    }
     Ok(())
 }
 
@@ -348,7 +369,8 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
 
     let batch = r.read_ipc()?;
     let blocks = batch
-        .column(0)
+        .column_by_name(BLOCKS_COLUMN)
+        .ok_or_else(|| Error::io("blocks column is missing".to_string()))?
         .as_any()
         .downcast_ref::<LargeBinaryArray>()
         .ok_or_else(|| Error::io("blocks column is not a LargeBinaryArray".to_string()))?
@@ -361,6 +383,23 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
     } else {
         validate_block_size(header.block_size as usize)?
     };
+    let impacts = if r.version() >= 3 && header.has_impacts {
+        let batch = r.read_ipc()?;
+        let entries = batch
+            .column_by_name(IMPACTS_COLUMN)
+            .ok_or_else(|| Error::io("impacts column is missing".to_string()))?
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .ok_or_else(|| Error::io("impacts column is not a LargeBinaryArray".to_string()))?
+            .clone();
+        Some(ImpactSkipData::new(
+            entries,
+            blocks.len(),
+            super::impact::ImpactFormat::for_block_size(block_size),
+        )?)
+    } else {
+        None
+    };
 
     Ok(CompressedPostingList::new(
         blocks,
@@ -369,6 +408,7 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
         posting_tail_codec,
         block_size,
         positions,
+        impacts,
     ))
 }
 
@@ -380,10 +420,12 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
 /// packed group writes one IPC batch; materialized groups retain the v1 inline
 /// member framing used by legacy and position-bearing prewarm paths. Version 3
 /// marks packed groups whose IPC schema can carry configurable posting block
-/// sizes while retaining the version-2 body framing.
+/// sizes while retaining the version-2 body framing. Version 4 adds optional
+/// impact data, either as an inline section for materialized members or as a
+/// column in the packed IPC batch.
 impl CacheCodecImpl for PostingListGroup {
     const TYPE_ID: &'static str = "lance.fts.PostingListGroup";
-    const CURRENT_VERSION: u32 = 3;
+    const CURRENT_VERSION: u32 = 4;
 
     fn serialize(&self, w: &mut CacheEntryWriter<'_>) -> Result<()> {
         let count = u32::try_from(self.len())
@@ -409,7 +451,7 @@ impl CacheCodecImpl for PostingListGroup {
     fn deserialize(r: &mut CacheEntryReader<'_>) -> Result<Self> {
         match r.version() {
             1 => return deserialize_materialized_group(r),
-            2 | Self::CURRENT_VERSION => {}
+            2 | 3 | Self::CURRENT_VERSION => {}
             other => {
                 return Err(Error::io(format!(
                     "unsupported PostingListGroup cache version: {other}"
@@ -503,10 +545,13 @@ mod tests {
     use lance_core::Result;
     use lance_core::cache::{CacheCodecImpl, CacheEntryReader, CacheEntryWriter};
 
+    use crate::cache_pb::{CompressedPostingHeader, PostingTailCodec as PbPostingTailCodec};
+
+    use super::super::impact::{ImpactSkipData, ImpactSkipDataBuilder};
     use super::super::index::{
-        CompressedPositionStorage, CompressedPostingList, POSTING_BLOCK_SIZE_KEY, POSTING_COL,
-        PlainPostingList, PositionStreamCodec, Positions, PostingList, PostingListGroup,
-        PostingTailCodec, SharedPositionStream,
+        CompressedPositionStorage, CompressedPostingList, IMPACT_COL, POSTING_BLOCK_SIZE_KEY,
+        POSTING_COL, PlainPostingList, PositionStreamCodec, Positions, PostingList,
+        PostingListGroup, PostingTailCodec, SharedPositionStream,
     };
     use super::super::tokenizer::LEGACY_BLOCK_SIZE;
 
@@ -550,6 +595,44 @@ mod tests {
             .unwrap()
     }
 
+    fn packed_group_with_impacts(
+        postings: &[Vec<Vec<u8>>],
+        impacts: &[ImpactSkipData],
+        posting_tail_codec: PostingTailCodec,
+        block_size: usize,
+    ) -> PostingListGroup {
+        assert_eq!(postings.len(), impacts.len());
+        let posting_batch = packed_batch(postings, Some(block_size));
+        let mut impacts_builder = ListBuilder::new(LargeBinaryBuilder::new());
+        for impacts in impacts {
+            for entry_idx in 0..impacts.entries().len() {
+                impacts_builder
+                    .values()
+                    .append_value(impacts.entries().value(entry_idx));
+            }
+            impacts_builder.append(true);
+        }
+        let impacts = impacts_builder.finish();
+        let fields = vec![
+            Field::new(
+                POSTING_COL,
+                posting_batch.column(0).data_type().clone(),
+                false,
+            ),
+            Field::new(IMPACT_COL, impacts.data_type().clone(), false),
+        ];
+        let schema = Arc::new(Schema::new_with_metadata(
+            fields,
+            posting_batch.schema_ref().metadata().clone(),
+        ));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![posting_batch.column(0).clone(), Arc::new(impacts)],
+        )
+        .unwrap();
+        PostingListGroup::new_packed(batch, posting_tail_codec).unwrap()
+    }
+
     fn assert_plain_eq(a: &PlainPostingList, b: &PlainPostingList) {
         assert_eq!(a.row_ids.as_ref(), b.row_ids.as_ref());
         assert_eq!(a.frequencies.as_ref(), b.frequencies.as_ref());
@@ -579,6 +662,20 @@ mod tests {
         }
     }
 
+    fn impact_skip_data(level0_len: usize, block_size: usize) -> ImpactSkipData {
+        let mut builder = ImpactSkipDataBuilder::with_capacity(level0_len, block_size);
+        for block_idx in 0..level0_len {
+            let doc_base = block_idx as u32 * 10;
+            builder
+                .append_block(&[
+                    (doc_base + 1, block_idx as u32 + 1, 10),
+                    (doc_base + 9, block_idx as u32 + 2, 8),
+                ])
+                .unwrap();
+        }
+        builder.finish().unwrap()
+    }
+
     /// Serialize a codec body (no envelope) into a standalone buffer.
     fn body_bytes<T: CacheCodecImpl>(entry: &T) -> Bytes {
         let mut buf = Vec::new();
@@ -591,6 +688,34 @@ mod tests {
     fn from_body<T: CacheCodecImpl>(data: &Bytes) -> Result<T> {
         let mut r = CacheEntryReader::new(data, 0, T::CURRENT_VERSION);
         T::deserialize(&mut r)
+    }
+
+    fn from_body_version<T: CacheCodecImpl>(data: &Bytes, version: u32) -> Result<T> {
+        let mut r = CacheEntryReader::new(data, 0, version);
+        T::deserialize(&mut r)
+    }
+
+    fn compressed_body_with_ipc_sections(
+        blocks: &RecordBatch,
+        impacts: Option<&RecordBatch>,
+    ) -> Bytes {
+        let mut buf = Vec::new();
+        let mut w = CacheEntryWriter::new(&mut buf);
+        w.write_u8(super::POSTING_VARIANT_COMPRESSED).unwrap();
+        w.write_header(&CompressedPostingHeader {
+            max_score: 1.0,
+            length: 1,
+            posting_tail_codec: PbPostingTailCodec::VarintDelta as i32,
+            block_size: 256,
+            has_impacts: impacts.is_some(),
+            ..Default::default()
+        })
+        .unwrap();
+        w.write_ipc(blocks).unwrap();
+        if let Some(impacts) = impacts {
+            w.write_ipc(impacts).unwrap();
+        }
+        Bytes::from(buf)
     }
 
     fn roundtrip_posting_list(entry: &PostingList) -> PostingList {
@@ -650,8 +775,15 @@ mod tests {
             Some(&[1u8, 2, 3, 4, 5][..]),
             Some(&[6, 7, 8, 9, 10][..]),
         ]);
-        let posting =
-            CompressedPostingList::new(blocks, 3.5, 42, PostingTailCodec::VarintDelta, 256, None);
+        let posting = CompressedPostingList::new(
+            blocks,
+            3.5,
+            42,
+            PostingTailCodec::VarintDelta,
+            256,
+            None,
+            None,
+        );
         let entry = PostingList::Compressed(posting.clone());
         match roundtrip_posting_list(&entry) {
             PostingList::Compressed(restored) => {
@@ -667,6 +799,73 @@ mod tests {
     }
 
     #[test]
+    fn compressed_posting_list_impacts_roundtrip() {
+        let blocks = LargeBinaryArray::from_opt_vec(vec![
+            Some(&[1u8, 2, 3, 4, 5][..]),
+            Some(&[6, 7, 8, 9, 10][..]),
+        ]);
+        let impacts = impact_skip_data(blocks.len(), 256);
+        let posting = CompressedPostingList::new(
+            blocks,
+            3.5,
+            42,
+            PostingTailCodec::VarintDelta,
+            256,
+            None,
+            Some(impacts.clone()),
+        );
+        let entry = PostingList::Compressed(posting);
+        match roundtrip_posting_list(&entry) {
+            PostingList::Compressed(restored) => {
+                let restored = restored.impacts.expect("impacts should roundtrip");
+                assert_eq!(restored.level0_len(), impacts.level0_len());
+                assert_eq!(restored.level1_len(), impacts.level1_len());
+                assert_eq!(restored.entries(), impacts.entries());
+            }
+            PostingList::Plain(_) => panic!("expected Compressed variant"),
+        }
+    }
+
+    #[test]
+    fn compressed_posting_list_missing_ipc_columns_returns_error() {
+        let empty = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        assert!(
+            from_body::<PostingList>(&compressed_body_with_ipc_sections(&empty, None)).is_err()
+        );
+
+        let blocks = LargeBinaryArray::from_opt_vec(vec![Some(&[1_u8, 2, 3][..])]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            super::BLOCKS_COLUMN,
+            blocks.data_type().clone(),
+            false,
+        )]));
+        let blocks = RecordBatch::try_new(schema, vec![Arc::new(blocks)]).unwrap();
+        assert!(
+            from_body::<PostingList>(&compressed_body_with_ipc_sections(&blocks, Some(&empty)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn compressed_posting_list_v1_cache_without_impacts_decodes() {
+        let posting = CompressedPostingList::new(
+            LargeBinaryArray::from_opt_vec(vec![Some(&[1u8, 2, 3][..])]),
+            1.25,
+            5,
+            PostingTailCodec::Fixed32,
+            crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            None,
+            None,
+        );
+        let data = body_bytes(&PostingList::Compressed(posting));
+        let restored = from_body_version::<PostingList>(&data, 1).unwrap();
+        let PostingList::Compressed(restored) = restored else {
+            panic!("expected Compressed variant");
+        };
+        assert!(restored.impacts.is_none());
+    }
+
+    #[test]
     fn compressed_posting_list_legacy_positions_roundtrip() {
         let blocks = LargeBinaryArray::from_opt_vec(vec![Some(&[1u8, 2, 3][..])]);
         let posting = CompressedPostingList::new(
@@ -678,6 +877,7 @@ mod tests {
             Some(CompressedPositionStorage::LegacyPerDoc(legacy_positions(
                 &[&[0, 4, 8]],
             ))),
+            None,
         );
         let entry = PostingList::Compressed(posting.clone());
         match roundtrip_posting_list(&entry) {
@@ -711,6 +911,7 @@ mod tests {
                 PostingTailCodec::VarintDelta,
                 256,
                 Some(CompressedPositionStorage::SharedStream(stream)),
+                None,
             );
             let entry = PostingList::Compressed(posting.clone());
             match roundtrip_posting_list(&entry) {
@@ -742,6 +943,7 @@ mod tests {
             Some(CompressedPositionStorage::SharedStream(
                 expected_stream.clone(),
             )),
+            None,
         );
         let serialized = body_bytes(&PostingList::Compressed(posting));
 
@@ -774,6 +976,7 @@ mod tests {
             7,
             PostingTailCodec::VarintDelta,
             256,
+            None,
             None,
         ));
 
@@ -853,6 +1056,7 @@ mod tests {
             PostingTailCodec::VarintDelta,
             LEGACY_BLOCK_SIZE,
             None,
+            None,
         ));
         let mut legacy_body = Vec::new();
         let mut writer = CacheEntryWriter::new(&mut legacy_body);
@@ -865,6 +1069,100 @@ mod tests {
         let restored = PostingListGroup::deserialize(&mut reader).unwrap();
         assert!(!restored.is_packed());
         assert_eq!(restored.len(), 1);
+    }
+
+    #[test]
+    fn posting_list_group_impacted_compressed_members_roundtrip() {
+        let first = CompressedPostingList::new(
+            LargeBinaryArray::from_opt_vec(vec![Some(&[1u8, 2, 3][..]), Some(&[4u8, 5, 6][..])]),
+            3.0,
+            256,
+            PostingTailCodec::VarintDelta,
+            LEGACY_BLOCK_SIZE,
+            None,
+            Some(impact_skip_data(2, LEGACY_BLOCK_SIZE)),
+        );
+        let second = CompressedPostingList::new(
+            LargeBinaryArray::from_opt_vec(vec![Some(&[7u8, 8, 9][..])]),
+            5.0,
+            128,
+            PostingTailCodec::Fixed32,
+            256,
+            Some(CompressedPositionStorage::SharedStream(
+                SharedPositionStream::new(
+                    PositionStreamCodec::PackedDelta,
+                    vec![0u32, 12],
+                    Bytes::from(vec![0xABu8; 32]),
+                ),
+            )),
+            Some(impact_skip_data(1, 256)),
+        );
+        let members = vec![
+            PostingList::Compressed(first.clone()),
+            PostingList::Compressed(second.clone()),
+        ];
+        let group = PostingListGroup::new(members);
+        let restored = from_body::<PostingListGroup>(&body_bytes(&group)).unwrap();
+        assert!(!restored.is_packed());
+        assert_eq!(restored.len(), 2);
+
+        let expected = [&first, &second];
+        for (slot, expected) in expected.iter().enumerate() {
+            let restored = restored.posting_list(slot, None, None).unwrap().unwrap();
+            let PostingList::Compressed(restored) = restored else {
+                panic!("expected compressed member");
+            };
+            assert_eq!(restored.blocks, expected.blocks);
+            assert_eq!(restored.length, expected.length);
+            assert_eq!(restored.max_score, expected.max_score);
+            assert_eq!(restored.posting_tail_codec, expected.posting_tail_codec);
+            assert_eq!(restored.block_size, expected.block_size);
+            assert_eq!(
+                restored.impacts.as_ref().unwrap().entries(),
+                expected.impacts.as_ref().unwrap().entries()
+            );
+            match (&expected.positions, &restored.positions) {
+                (Some(expected), Some(restored)) => {
+                    assert_position_storage_eq(expected, restored);
+                }
+                (None, None) => {}
+                _ => panic!("position storage mismatch"),
+            }
+        }
+    }
+
+    #[test]
+    fn packed_posting_list_group_impacts_roundtrip() {
+        let postings = vec![vec![vec![1, 2, 3], vec![4, 5, 6]], vec![vec![7, 8, 9]]];
+        let expected_impacts = vec![impact_skip_data(2, 256), impact_skip_data(1, 256)];
+        let group = packed_group_with_impacts(
+            &postings,
+            &expected_impacts,
+            PostingTailCodec::VarintDelta,
+            256,
+        );
+
+        let restored = from_body::<PostingListGroup>(&body_bytes(&group)).unwrap();
+        assert!(restored.is_packed());
+        assert_eq!(restored.len(), expected_impacts.len());
+        for (slot, expected) in expected_impacts.iter().enumerate() {
+            let posting = restored
+                .posting_list(slot, Some(3.0), Some(256))
+                .unwrap()
+                .unwrap();
+            let PostingList::Compressed(posting) = posting else {
+                panic!("expected compressed packed posting");
+            };
+            let actual = posting.impacts.as_ref().expect("impacts should roundtrip");
+            assert_eq!(actual.entries(), expected.entries());
+            assert_eq!(actual.level0_len(), expected.level0_len());
+            assert_eq!(
+                actual.level1_doc_up_to(0),
+                expected.level1_doc_up_to(0),
+                "impact entries should remain decodable with the packed block size",
+            );
+            assert!(actual.level1_doc_up_to(0).is_some());
+        }
     }
 
     #[test]
@@ -927,11 +1225,11 @@ mod tests {
 
         type ArcAny = Arc<dyn std::any::Any + Send + Sync>;
 
-        struct PostingListV1Codec(PostingList);
+        struct PostingListV2Codec(PostingList);
 
-        impl CacheCodecImpl for PostingListV1Codec {
+        impl CacheCodecImpl for PostingListV2Codec {
             const TYPE_ID: &'static str = <PostingList as CacheCodecImpl>::TYPE_ID;
-            const CURRENT_VERSION: u32 = 1;
+            const CURRENT_VERSION: u32 = 2;
 
             fn serialize(&self, w: &mut CacheEntryWriter<'_>) -> Result<()> {
                 self.0.serialize(w)
@@ -942,11 +1240,11 @@ mod tests {
             }
         }
 
-        struct PostingListGroupV2Codec(PostingListGroup);
+        struct PostingListGroupV3Codec(PostingListGroup);
 
-        impl CacheCodecImpl for PostingListGroupV2Codec {
+        impl CacheCodecImpl for PostingListGroupV3Codec {
             const TYPE_ID: &'static str = <PostingListGroup as CacheCodecImpl>::TYPE_ID;
-            const CURRENT_VERSION: u32 = 2;
+            const CURRENT_VERSION: u32 = 3;
 
             fn serialize(&self, w: &mut CacheEntryWriter<'_>) -> Result<()> {
                 self.0.serialize(w)
@@ -1057,6 +1355,7 @@ mod tests {
                 PostingTailCodec::VarintDelta,
                 256,
                 Some(CompressedPositionStorage::SharedStream(stream)),
+                None,
             ))
         }
 
@@ -1095,14 +1394,13 @@ mod tests {
         /// it must borrow the cache entry's aligned input buffer.
         #[test]
         fn packed_group_sections_are_zero_copy_through_envelope() {
-            let group = packed_group(
-                &[
-                    vec![vec![9; 48], vec![9; 48]],
-                    vec![vec![1; 48], vec![1; 48]],
-                ],
-                PostingTailCodec::VarintDelta,
-                Some(256),
-            );
+            let postings = vec![
+                vec![vec![9; 48], vec![9; 48]],
+                vec![vec![1; 48], vec![1; 48]],
+            ];
+            let impacts = vec![impact_skip_data(2, 256), impact_skip_data(2, 256)];
+            let group =
+                packed_group_with_impacts(&postings, &impacts, PostingTailCodec::VarintDelta, 256);
 
             let group_codec = CacheCodec::from_impl::<PostingListGroup>();
             let any: ArcAny = Arc::new(group);
@@ -1131,7 +1429,17 @@ mod tests {
                     assert!(
                         points_in(buf.as_ptr() as usize),
                         "group member blocks buffer was realigned out of the input — \
-                         misaligned IPC section",
+                        misaligned IPC section",
+                    );
+                }
+                let impacts = member
+                    .impacts
+                    .as_ref()
+                    .expect("packed impacts should decode");
+                for buf in impacts.entries().to_data().buffers() {
+                    assert!(
+                        points_in(buf.as_ptr() as usize),
+                        "group member impact buffer was realigned out of the input",
                     );
                 }
             }
@@ -1210,13 +1518,13 @@ mod tests {
         }
 
         #[test]
-        fn old_codecs_reject_new_v3_envelopes_as_version_too_new() {
+        fn old_codecs_reject_new_impact_envelopes_as_version_too_new() {
             let posting = Bytes::from(serialize_entry(compressed_with_shared_positions()));
-            match CacheCodec::from_impl::<PostingListV1Codec>().deserialize(&posting) {
+            match CacheCodec::from_impl::<PostingListV2Codec>().deserialize(&posting) {
                 CacheDecode::Miss(reason) => {
                     assert_eq!(reason, CacheMissReason::VersionTooNew)
                 }
-                CacheDecode::Hit(_) => panic!("v1 PostingList codec accepted a v2 envelope"),
+                CacheDecode::Hit(_) => panic!("v2 PostingList codec accepted a v3 envelope"),
             }
 
             let group = packed_group(
@@ -1225,14 +1533,51 @@ mod tests {
                 Some(256),
             );
             let group = Bytes::from(serialize_typed_entry(group));
-            match CacheCodec::from_impl::<PostingListGroupV2Codec>().deserialize(&group) {
+            match CacheCodec::from_impl::<PostingListGroupV3Codec>().deserialize(&group) {
                 CacheDecode::Miss(reason) => {
                     assert_eq!(reason, CacheMissReason::VersionTooNew)
                 }
                 CacheDecode::Hit(_) => {
-                    panic!("v2 PostingListGroup codec accepted a v3 envelope")
+                    panic!("v3 PostingListGroup codec accepted a v4 envelope")
                 }
             }
+        }
+
+        #[test]
+        fn current_codecs_read_previous_main_versions() {
+            let previous_posting = PostingListV2Codec(compressed_with_shared_positions());
+            let previous_posting = Bytes::from(serialize_typed_entry(previous_posting));
+            let restored = codec().deserialize(&previous_posting).hit().unwrap();
+            let restored = restored.downcast::<PostingList>().unwrap();
+            let PostingList::Compressed(restored) = restored.as_ref() else {
+                panic!("expected compressed posting");
+            };
+            assert_eq!(restored.block_size, 256);
+            assert!(restored.impacts.is_none());
+
+            let previous_group = PostingListGroupV3Codec(packed_group(
+                &[vec![vec![1, 2, 3]], vec![vec![4, 5, 6]]],
+                PostingTailCodec::VarintDelta,
+                Some(256),
+            ));
+            let previous_group = Bytes::from(serialize_typed_entry(previous_group));
+            let restored = CacheCodec::from_impl::<PostingListGroup>()
+                .deserialize(&previous_group)
+                .hit()
+                .unwrap()
+                .downcast::<PostingListGroup>()
+                .unwrap();
+            assert!(restored.is_packed());
+            assert_eq!(restored.len(), 2);
+            let PostingList::Compressed(restored) = restored
+                .posting_list(0, Some(2.0), Some(3))
+                .unwrap()
+                .unwrap()
+            else {
+                panic!("expected compressed packed posting");
+            };
+            assert_eq!(restored.block_size, 256);
+            assert!(restored.impacts.is_none());
         }
 
         #[test]

--- a/rust/lance-index/src/scalar/inverted/cache_codec.rs
+++ b/rust/lance-index/src/scalar/inverted/cache_codec.rs
@@ -392,11 +392,7 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
             .downcast_ref::<LargeBinaryArray>()
             .ok_or_else(|| Error::io("impacts column is not a LargeBinaryArray".to_string()))?
             .clone();
-        Some(ImpactSkipData::new(
-            entries,
-            blocks.len(),
-            super::impact::ImpactFormat::for_block_size(block_size),
-        )?)
+        Some(ImpactSkipData::new(entries, blocks.len())?)
     } else {
         None
     };

--- a/rust/lance-index/src/scalar/inverted/impact.rs
+++ b/rust/lance-index/src/scalar/inverted/impact.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::mem::{size_of, size_of_val};
+use std::mem::size_of;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use arrow_array::builder::LargeBinaryBuilder;
@@ -20,7 +20,6 @@ const SMALL_FRONTIER_FREQ_LIMIT: usize = 256;
 /// reports whether a one-byte norm delta follows. The norm itself is the
 /// quantized `u8` document-length code; the common `norm_delta == 1` case needs
 /// no norm byte.
-
 #[derive(Debug, Clone)]
 pub struct ImpactSkipData {
     entries: LargeBinaryArray,
@@ -221,10 +220,14 @@ impl ImpactSkipData {
     /// yet. The Arrow impact entries are owned by the enclosing batch and are
     /// deliberately excluded so packed-group cache accounting counts them once.
     pub(crate) fn derived_cache_bytes(&self) -> usize {
-        size_of_val(&*self.entry_doc_up_tos)
+        Self::derived_cache_bytes_for_entries(self.entries.len())
+    }
+
+    pub(crate) fn derived_cache_bytes_for_entries(entry_count: usize) -> usize {
+        entry_count * size_of::<u32>()
             + size_of::<Mutex<LastKeyedImpactBounds>>()
             + size_of::<ImpactBounds>()
-            + self.entries.len() * size_of::<f32>()
+            + entry_count * size_of::<f32>()
     }
 
     #[cfg(test)]
@@ -253,24 +256,6 @@ impl ImpactSkipData {
         }
     }
 
-    /// Max score of the docs covered by the level0 entry of `block_idx`,
-    /// answered from the baked bounds slab.
-    // Only tests exercise the uncached form until the maxscore rework
-    // (stacked follow-up) anchors its block-max caches on it.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub fn level0_score<S: Scorer + ?Sized>(
-        &self,
-        block_idx: usize,
-        query_weight: f32,
-        scorer: &S,
-    ) -> f32 {
-        if block_idx >= self.level0_len || query_weight <= 0.0 {
-            return 0.0;
-        }
-        let mut cache = ImpactScoreCache::default();
-        cache.entry_score(self, block_idx, query_weight, scorer)
-    }
-
     pub fn level0_score_cached<S: Scorer + ?Sized>(
         &self,
         block_idx: usize,
@@ -284,24 +269,6 @@ impl ImpactSkipData {
         cache.entry_score(self, block_idx, query_weight, scorer)
     }
 
-    #[cfg(test)]
-    pub fn max_score_up_to<S, F>(
-        &self,
-        start_block_idx: usize,
-        up_to: u64,
-        _block_least_doc_id: F,
-        query_weight: f32,
-        scorer: &S,
-    ) -> ImpactScore
-    where
-        S: Scorer + ?Sized,
-        F: FnMut(usize) -> u32,
-    {
-        self.max_score_up_to_with(start_block_idx, up_to, |impacts, entry_idx| {
-            impacts.entry_score(entry_idx, query_weight, scorer)
-        })
-    }
-
     pub fn max_score_up_to_cached<S>(
         &self,
         start_block_idx: usize,
@@ -312,20 +279,6 @@ impl ImpactSkipData {
     ) -> ImpactScore
     where
         S: Scorer + ?Sized,
-    {
-        self.max_score_up_to_with(start_block_idx, up_to, |impacts, entry_idx| {
-            cache.entry_score(impacts, entry_idx, query_weight, scorer)
-        })
-    }
-
-    fn max_score_up_to_with<E>(
-        &self,
-        start_block_idx: usize,
-        up_to: u64,
-        mut entry_score: E,
-    ) -> ImpactScore
-    where
-        E: FnMut(&Self, usize) -> f32,
     {
         let mut block_idx = start_block_idx;
         let mut max_score = 0.0_f32;
@@ -345,7 +298,12 @@ impl ImpactSkipData {
                         };
                     }
                     doc_up_to if u64::from(doc_up_to) <= up_to => {
-                        max_score = max_score.max(entry_score(self, level1_entry_idx));
+                        max_score = max_score.max(cache.entry_score(
+                            self,
+                            level1_entry_idx,
+                            query_weight,
+                            scorer,
+                        ));
                         entries_scanned += 1;
                         block_idx = group_end;
                         continue;
@@ -354,7 +312,7 @@ impl ImpactSkipData {
                 }
             }
 
-            max_score = max_score.max(entry_score(self, block_idx));
+            max_score = max_score.max(cache.entry_score(self, block_idx, query_weight, scorer));
             entries_scanned += 1;
             match self.entry_doc_up_tos[block_idx] {
                 u32::MAX => {
@@ -373,28 +331,6 @@ impl ImpactSkipData {
             score: max_score,
             entries_scanned,
         }
-    }
-
-    #[cfg(test)]
-    fn entry_score<S: Scorer + ?Sized>(
-        &self,
-        entry_idx: usize,
-        query_weight: f32,
-        scorer: &S,
-    ) -> f32 {
-        if query_weight <= 0.0 {
-            return 0.0;
-        }
-        let bytes = self.entries.value(entry_idx);
-        let mut max_doc_weight = 0.0_f32;
-        if for_each_entry_pair(bytes, |freq, doc_len| {
-            max_doc_weight = max_doc_weight.max(scorer.doc_weight(freq, doc_len));
-        })
-        .is_err()
-        {
-            return f32::INFINITY;
-        }
-        query_weight * max_doc_weight
     }
 }
 
@@ -778,7 +714,8 @@ mod tests {
         assert_eq!(impacts.level0_len(), 40);
         assert_eq!(impacts.level1_len(), 2);
         let scorer = MemBM25Scorer::new(400, 40, HashMap::from([(String::from("token"), 40usize)]));
-        let score = impacts.max_score_up_to(0, 31, |idx| idx as u32, 1.0, &scorer);
+        let mut cache = ImpactScoreCache::default();
+        let score = impacts.max_score_up_to_cached(0, 31, 1.0, &scorer, &mut cache);
         assert!(score.entries_scanned < IMPACT_LEVEL1_BLOCKS);
         assert!(score.score > 0.0);
     }
@@ -879,25 +816,6 @@ mod tests {
     }
 
     #[test]
-    fn impact_score_cache_matches_uncached_scores() {
-        let blocks = (0..40)
-            .map(|block| vec![(block as u32, 1 + block as u32 % 3, 10)])
-            .collect::<Vec<_>>();
-        let impacts = build_impact_skip_data(&blocks).unwrap();
-        let scorer = MemBM25Scorer::new(400, 40, HashMap::from([(String::from("token"), 40usize)]));
-        let mut cache = ImpactScoreCache::default();
-
-        let uncached_level0 = impacts.level0_score(3, 1.0, &scorer);
-        let cached_level0 = impacts.level0_score_cached(3, 1.0, &scorer, &mut cache);
-        assert_eq!(cached_level0, uncached_level0);
-
-        let uncached = impacts.max_score_up_to(0, 31, |idx| idx as u32, 1.0, &scorer);
-        let cached = impacts.max_score_up_to_cached(0, 31, 1.0, &scorer, &mut cache);
-        assert_eq!(cached.score, uncached.score);
-        assert_eq!(cached.entries_scanned, uncached.entries_scanned);
-    }
-
-    #[test]
     fn impact_bounds_follow_changed_bm25_average_doc_length() {
         let impacts = build_impact_skip_data(&[vec![(0, 1, 100)]]).unwrap();
         let low_avgdl = MemBM25Scorer::new(1, 1, HashMap::new());
@@ -948,7 +866,7 @@ mod tests {
     }
 
     #[test]
-    fn impact_entries_are_decoded_lazily() {
+    fn malformed_unscanned_entry_does_not_poison_range_score() {
         let level0_0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
         let malformed_level0_1 = vec![1, 2, 3];
         let level1 = encode_impact_entry(&[(0, 1, 10), (1, 1, 10)]).unwrap();
@@ -959,12 +877,12 @@ mod tests {
         ]);
         let impacts = ImpactSkipData::new(entries, 2).unwrap();
         let scorer = MemBM25Scorer::new(10, 10, HashMap::from([(String::from("token"), 2usize)]));
+        let mut cache = ImpactScoreCache::default();
 
-        let score = impacts.max_score_up_to(0, 0, |_| 0, 1.0, &scorer);
+        let score = impacts.max_score_up_to_cached(0, 0, 1.0, &scorer, &mut cache);
         assert!(score.score.is_finite());
         assert_eq!(score.entries_scanned, 1);
 
-        let mut cache = ImpactScoreCache::default();
         assert_eq!(
             impacts.level0_score_cached(1, 1.0, &scorer, &mut cache),
             f32::INFINITY
@@ -1026,8 +944,13 @@ mod tests {
         let impacts = build_impact_skip_data(&blocks).unwrap();
         assert_eq!(impacts.level1_doc_up_to(0), Some(767));
         let scorer = MemBM25Scorer::new(400, 768, HashMap::from([(String::from("t"), 768usize)]));
-        assert!(impacts.level0_score(0, 1.0, &scorer).is_finite());
-        let level1 = impacts.max_score_up_to(0, 767, |idx| (idx * 256) as u32, 1.0, &scorer);
+        let mut cache = ImpactScoreCache::default();
+        assert!(
+            impacts
+                .level0_score_cached(0, 1.0, &scorer, &mut cache)
+                .is_finite()
+        );
+        let level1 = impacts.max_score_up_to_cached(0, 767, 1.0, &scorer, &mut cache);
         assert!(level1.score.is_finite() && level1.score > 0.0);
     }
 
@@ -1055,6 +978,7 @@ mod tests {
         let impacts = build_impact_skip_data(&blocks).unwrap();
         let scorer = MemBM25Scorer::new(474, 31, HashMap::from([(String::from("token"), 4usize)]));
         let query_weight = scorer.query_weight("token");
+        let mut cache = ImpactScoreCache::default();
 
         for start_block_idx in 0..blocks.len() {
             let up_to = blocks
@@ -1065,12 +989,12 @@ mod tests {
                 .map(|(doc_id, _, _)| *doc_id)
                 .max()
                 .unwrap();
-            let upper_bound = impacts.max_score_up_to(
+            let upper_bound = impacts.max_score_up_to_cached(
                 start_block_idx,
                 u64::from(up_to),
-                |idx| blocks[idx][0].0,
                 query_weight,
                 &scorer,
+                &mut cache,
             );
             let exact_max = blocks
                 .iter()

--- a/rust/lance-index/src/scalar/inverted/impact.rs
+++ b/rust/lance-index/src/scalar/inverted/impact.rs
@@ -13,34 +13,18 @@ use super::scorer::Scorer;
 pub const IMPACT_LEVEL1_BLOCKS: usize = 32;
 const SMALL_FRONTIER_FREQ_LIMIT: usize = 256;
 
-/// On-disk encoding of one impact entry.
+/// On-disk encoding of one impact entry, shared by every posting block size.
 ///
-/// `FixedU32` (128-doc blocks): [doc_up_to u32][pair_count u32][(freq u32,
-/// doc_len u32)...]. `Varint` (256-doc blocks, format V3): [doc_up_to varint]
-/// [pair_count varint][(freq delta varint, doc_len varint)...] with the
-/// frontier's freqs delta-encoded in ascending order — pairs shrink from 8
-/// bytes to ~2-3.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ImpactFormat {
-    FixedU32,
-    Varint,
-}
-
-impl ImpactFormat {
-    pub fn for_block_size(block_size: usize) -> Self {
-        if block_size == 256 {
-            Self::Varint
-        } else {
-            Self::FixedU32
-        }
-    }
-}
+/// Entries contain `[doc_up_to varint][pair_count varint][pairs...]`. Each
+/// pair stores a varint whose high bits are `freq_delta - 1` and whose low bit
+/// reports whether a one-byte norm delta follows. The norm itself is the
+/// quantized `u8` document-length code; the common `norm_delta == 1` case needs
+/// no norm byte.
 
 #[derive(Debug, Clone)]
 pub struct ImpactSkipData {
     entries: LargeBinaryArray,
     level0_len: usize,
-    format: ImpactFormat,
     // Last doc id covered by each entry (level0 entries then level1 entries),
     // decoded once at construction. Level1 markers are fully validated because
     // WAND may use them to skip a group; u32::MAX marks malformed entries.
@@ -54,9 +38,7 @@ pub struct ImpactSkipData {
 
 impl PartialEq for ImpactSkipData {
     fn eq(&self, other: &Self) -> bool {
-        self.entries == other.entries
-            && self.level0_len == other.level0_len
-            && self.format == other.format
+        self.entries == other.entries && self.level0_len == other.level0_len
     }
 }
 
@@ -119,14 +101,8 @@ impl ImpactScoreCache {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-struct ImpactEntryHeader {
-    doc_up_to: u32,
-    pair_count: usize,
-}
-
 impl ImpactSkipData {
-    pub fn new(entries: LargeBinaryArray, level0_len: usize, format: ImpactFormat) -> Result<Self> {
+    pub fn new(entries: LargeBinaryArray, level0_len: usize) -> Result<Self> {
         let expected_len = level0_len + level1_len(level0_len);
         if entries.len() != expected_len {
             return Err(Error::index(format!(
@@ -143,9 +119,9 @@ impl ImpactSkipData {
                 }
                 let bytes = entries.value(entry_idx);
                 let doc_up_to = if entry_idx < level0_len {
-                    decode_level0_entry_doc_up_to(bytes, format)
+                    decode_level0_entry_doc_up_to(bytes)
                 } else {
-                    decode_entry_doc_up_to(bytes, format)
+                    decode_entry_doc_up_to(bytes)
                 };
                 doc_up_to.unwrap_or(u32::MAX)
             })
@@ -153,7 +129,6 @@ impl ImpactSkipData {
         Ok(Self {
             entries,
             level0_len,
-            format,
             entry_doc_up_tos,
             last_keyed_bounds: Arc::new(Mutex::new(None)),
         })
@@ -198,12 +173,6 @@ impl ImpactSkipData {
     }
 
     fn compute_bounds<S: Scorer + ?Sized>(&self, scorer: &S) -> ImpactBounds {
-        // V3 (Varint impacts <=> 256-doc blocks) scores with quantized doc
-        // lengths, so bake the bounds against the same quantized lengths.
-        // Quantization is monotone, so pareto dominance among the stored
-        // (freq, doc_len) frontier pairs is preserved and the frontier max
-        // still bounds every doc in the range.
-        let quantized = self.format == ImpactFormat::Varint;
         let per_entry = (0..self.entries.len())
             .map(|entry_idx| {
                 if self.entries.is_null(entry_idx) {
@@ -211,14 +180,7 @@ impl ImpactSkipData {
                 }
                 let bytes = self.entries.value(entry_idx);
                 let mut max_doc_weight = 0.0_f32;
-                match for_each_entry_pair(bytes, self.format, |freq, doc_len| {
-                    let doc_len = if quantized {
-                        super::index::dequantize_doc_length(super::index::quantize_doc_length(
-                            doc_len,
-                        ))
-                    } else {
-                        doc_len
-                    };
+                match for_each_entry_pair(bytes, |freq, doc_len| {
                     max_doc_weight = max_doc_weight.max(scorer.doc_weight(freq, doc_len));
                 }) {
                     Ok(()) => max_doc_weight,
@@ -425,7 +387,7 @@ impl ImpactSkipData {
         }
         let bytes = self.entries.value(entry_idx);
         let mut max_doc_weight = 0.0_f32;
-        if for_each_entry_pair(bytes, self.format, |freq, doc_len| {
+        if for_each_entry_pair(bytes, |freq, doc_len| {
             max_doc_weight = max_doc_weight.max(scorer.doc_weight(freq, doc_len));
         })
         .is_err()
@@ -441,7 +403,6 @@ pub struct ImpactSkipDataBuilder {
     level0_len: usize,
     level1_entries: Vec<Vec<u8>>,
     level1_docs: Vec<(u32, u32, u32)>,
-    format: ImpactFormat,
 }
 
 impl ImpactSkipDataBuilder {
@@ -454,12 +415,11 @@ impl ImpactSkipDataBuilder {
             level0_len: 0,
             level1_entries: Vec::with_capacity(level1_len(level0_blocks)),
             level1_docs: Vec::with_capacity(IMPACT_LEVEL1_BLOCKS * block_size),
-            format: ImpactFormat::for_block_size(block_size),
         }
     }
 
     pub fn append_block(&mut self, docs: &[(u32, u32, u32)]) -> Result<()> {
-        let bytes = encode_impact_entry(docs, self.format)?;
+        let bytes = encode_impact_entry(docs)?;
         self.entries.append_value(bytes.as_slice());
         self.level0_len += 1;
         self.level1_docs.extend_from_slice(docs);
@@ -476,11 +436,11 @@ impl ImpactSkipDataBuilder {
         for entry in self.level1_entries {
             self.entries.append_value(entry.as_slice());
         }
-        ImpactSkipData::new(self.entries.finish(), self.level0_len, self.format)
+        ImpactSkipData::new(self.entries.finish(), self.level0_len)
     }
 
     fn flush_level1(&mut self) -> Result<()> {
-        let bytes = encode_impact_entry(self.level1_docs.as_slice(), self.format)?;
+        let bytes = encode_impact_entry(self.level1_docs.as_slice())?;
         self.level1_entries.push(bytes);
         self.level1_docs.clear();
         Ok(())
@@ -497,7 +457,7 @@ pub fn build_impact_skip_data(blocks: &[Vec<(u32, u32, u32)>]) -> Result<ImpactS
     builder.finish()
 }
 
-fn encode_impact_entry(docs: &[(u32, u32, u32)], format: ImpactFormat) -> Result<Vec<u8>> {
+fn encode_impact_entry(docs: &[(u32, u32, u32)]) -> Result<Vec<u8>> {
     if docs.is_empty() {
         return Err(Error::index(
             "cannot encode an empty impact entry".to_owned(),
@@ -507,117 +467,182 @@ fn encode_impact_entry(docs: &[(u32, u32, u32)], format: ImpactFormat) -> Result
         .last()
         .map(|(doc_id, _, _)| *doc_id)
         .expect("non-empty impact entry was validated above");
-    let frontier = impact_frontier(docs);
+    let frontier = quantized_impact_frontier(docs);
     let pair_count = u32::try_from(frontier.len()).map_err(|_| {
         Error::index("impact frontier too large to encode as u32 pair count".to_string())
     })?;
-    let mut bytes = Vec::with_capacity(8 + frontier.len() * 8);
-    match format {
-        ImpactFormat::FixedU32 => {
-            bytes.extend_from_slice(&doc_up_to.to_le_bytes());
-            bytes.extend_from_slice(&pair_count.to_le_bytes());
-            for (freq, doc_len) in frontier {
-                bytes.extend_from_slice(&freq.to_le_bytes());
-                bytes.extend_from_slice(&doc_len.to_le_bytes());
-            }
+    let mut bytes = Vec::with_capacity(5 + frontier.len() * 2);
+    super::encoding::encode_varint_u32(&mut bytes, doc_up_to);
+    super::encoding::encode_varint_u32(&mut bytes, pair_count);
+    let mut previous_freq = 0u32;
+    let mut previous_norm = 0u8;
+    for (pair_idx, (freq, norm)) in frontier.into_iter().enumerate() {
+        let freq_delta_minus_one = freq
+            .checked_sub(previous_freq)
+            .and_then(|delta| delta.checked_sub(1))
+            .ok_or_else(|| {
+                Error::index(format!(
+                    "impact frequencies must be positive and strictly increasing: previous={previous_freq}, current={freq}"
+                ))
+            })?;
+        let norm_delta = norm.checked_sub(previous_norm).ok_or_else(|| {
+            Error::index(format!(
+                "impact norms must be non-decreasing: previous={previous_norm}, current={norm}"
+            ))
+        })?;
+        if pair_idx > 0 && norm_delta == 0 {
+            return Err(Error::index(format!(
+                "impact norms must be strictly increasing after quantization: norm={norm}"
+            )));
         }
-        ImpactFormat::Varint => {
-            super::encoding::encode_varint_u32(&mut bytes, doc_up_to);
-            super::encoding::encode_varint_u32(&mut bytes, pair_count);
-            let mut previous_freq = 0u32;
-            for (freq, doc_len) in frontier {
-                super::encoding::encode_varint_u32(&mut bytes, freq - previous_freq);
-                super::encoding::encode_varint_u32(&mut bytes, doc_len);
-                previous_freq = freq;
-            }
+
+        let has_explicit_norm_delta = norm_delta != 1;
+        let packed_freq_delta =
+            (u64::from(freq_delta_minus_one) << 1) | u64::from(has_explicit_norm_delta);
+        encode_varint_u64(&mut bytes, packed_freq_delta);
+        if has_explicit_norm_delta {
+            bytes.push(norm_delta);
         }
+        previous_freq = freq;
+        previous_norm = norm;
     }
     Ok(bytes)
 }
 
-fn decode_entry_doc_up_to(bytes: &[u8], format: ImpactFormat) -> Result<u32> {
-    match format {
-        ImpactFormat::FixedU32 => {
-            let header = decode_header(bytes)?;
-            if header.pair_count == 0 {
-                return Err(Error::index(
-                    "impact entry must contain at least one frontier pair".to_owned(),
-                ));
-            }
-            Ok(header.doc_up_to)
-        }
-        ImpactFormat::Varint => {
-            let mut offset = 0usize;
-            let doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
-            // Level-1 doc ids drive whole-group skips, so only publish a doc
-            // id after validating the complete entry. A truncated entry may
-            // still have a valid first varint.
-            for_each_entry_pair(bytes, format, |_, _| {})?;
-            Ok(doc_up_to)
-        }
-    }
+fn decode_entry_doc_up_to(bytes: &[u8]) -> Result<u32> {
+    let mut offset = 0usize;
+    let doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+    // Level-1 doc ids drive whole-group skips, so only publish a doc id after
+    // validating the complete entry. A truncated entry may still have a valid
+    // first varint.
+    for_each_entry_pair(bytes, |_, _| {})?;
+    Ok(doc_up_to)
 }
 
-fn decode_level0_entry_doc_up_to(bytes: &[u8], format: ImpactFormat) -> Result<u32> {
-    match format {
-        // Fixed entries validate their complete layout from the header in O(1).
-        ImpactFormat::FixedU32 => decode_entry_doc_up_to(bytes, format),
-        // A malformed level0 frontier bakes an INFINITY score before this
-        // marker can terminate a range scan, so avoid parsing every frontier
-        // twice on the query-load path. Level1 entries are fully validated.
-        ImpactFormat::Varint => {
-            let mut offset = 0usize;
-            super::encoding::decode_varint_u32(bytes, &mut offset)
-        }
-    }
+fn decode_level0_entry_doc_up_to(bytes: &[u8]) -> Result<u32> {
+    // A malformed level0 frontier bakes an INFINITY score before this marker
+    // can terminate a range scan, so avoid parsing every frontier twice on the
+    // query-load path. Level1 entries are fully validated.
+    let mut offset = 0usize;
+    super::encoding::decode_varint_u32(bytes, &mut offset)
 }
 
 /// Walk an entry's (freq, doc_len) frontier pairs, validating the layout.
-fn for_each_entry_pair(
-    bytes: &[u8],
-    format: ImpactFormat,
-    mut visit: impl FnMut(u32, u32),
-) -> Result<()> {
-    match format {
-        ImpactFormat::FixedU32 => {
-            let header = decode_header(bytes)?;
-            if header.pair_count == 0 {
-                return Err(Error::index(
-                    "impact entry must contain at least one frontier pair".to_owned(),
-                ));
-            }
-            let mut offset = 8usize;
-            for _ in 0..header.pair_count {
-                visit(read_u32_le(bytes, offset), read_u32_le(bytes, offset + 4));
-                offset += 8;
-            }
+fn for_each_entry_pair(bytes: &[u8], mut visit: impl FnMut(u32, u32)) -> Result<()> {
+    let mut offset = 0usize;
+    let _doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+    let pair_count = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+    if pair_count == 0 {
+        return Err(Error::index(
+            "impact entry must contain at least one frontier pair".to_owned(),
+        ));
+    }
+
+    let mut previous_freq = 0u32;
+    let mut previous_norm = 0u16;
+    for pair_idx in 0..pair_count {
+        let packed_freq_delta = decode_varint_u64(bytes, &mut offset)?;
+        let freq_delta_minus_one = u32::try_from(packed_freq_delta >> 1)
+            .map_err(|_| Error::index("impact freq delta exceeds u32".to_owned()))?;
+        let freq_delta = freq_delta_minus_one
+            .checked_add(1)
+            .ok_or_else(|| Error::index("impact freq delta overflow".to_owned()))?;
+        let freq = previous_freq
+            .checked_add(freq_delta)
+            .ok_or_else(|| Error::index("impact frequency overflow".to_owned()))?;
+
+        let has_explicit_norm_delta = packed_freq_delta & 1 != 0;
+        let norm_delta = if has_explicit_norm_delta {
+            let norm_delta = bytes.get(offset).copied().ok_or_else(|| {
+                Error::index("unexpected EOF while decoding impact norm delta".to_owned())
+            })?;
+            offset += 1;
+            norm_delta
+        } else {
+            1
+        };
+        if pair_idx > 0 && norm_delta == 0 {
+            return Err(Error::index(
+                "impact norms must be strictly increasing".to_owned(),
+            ));
         }
-        ImpactFormat::Varint => {
-            let mut offset = 0usize;
-            let _doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
-            let pair_count = super::encoding::decode_varint_u32(bytes, &mut offset)?;
-            if pair_count == 0 {
-                return Err(Error::index(
-                    "impact entry must contain at least one frontier pair".to_owned(),
-                ));
-            }
-            let mut freq = 0u32;
-            for _ in 0..pair_count {
-                freq = freq
-                    .checked_add(super::encoding::decode_varint_u32(bytes, &mut offset)?)
-                    .ok_or_else(|| Error::index("impact freq delta overflow".to_owned()))?;
-                let doc_len = super::encoding::decode_varint_u32(bytes, &mut offset)?;
-                visit(freq, doc_len);
-            }
-            if offset != bytes.len() {
-                return Err(Error::index(format!(
-                    "impact varint entry has {} trailing bytes",
-                    bytes.len() - offset
-                )));
-            }
-        }
+
+        let norm = previous_norm
+            .checked_add(u16::from(norm_delta))
+            .filter(|norm| *norm <= u16::from(u8::MAX))
+            .ok_or_else(|| Error::index("impact norm delta overflow".to_owned()))?;
+        let norm = norm as u8;
+        visit(freq, super::index::dequantize_doc_length(norm));
+        previous_freq = freq;
+        previous_norm = u16::from(norm);
+    }
+    if offset != bytes.len() {
+        return Err(Error::index(format!(
+            "impact entry has {} trailing bytes",
+            bytes.len() - offset
+        )));
     }
     Ok(())
+}
+
+#[inline]
+fn encode_varint_u64(dst: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        dst.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    dst.push(value as u8);
+}
+
+#[inline]
+fn decode_varint_u64(src: &[u8], offset: &mut usize) -> Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    while *offset < src.len() {
+        let byte = src[*offset];
+        *offset += 1;
+        if shift == 63 && byte & 0xFE != 0 {
+            return Err(Error::index(
+                "invalid u64 varint in impact entry".to_owned(),
+            ));
+        }
+        value |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift > 63 {
+            return Err(Error::index(
+                "invalid u64 varint in impact entry".to_owned(),
+            ));
+        }
+    }
+    Err(Error::index(
+        "unexpected EOF while decoding impact entry".to_owned(),
+    ))
+}
+
+fn quantized_impact_frontier(docs: &[(u32, u32, u32)]) -> Vec<(u32, u8)> {
+    let raw_frontier = impact_frontier(docs);
+    let mut frontier: Vec<(u32, u8)> = Vec::with_capacity(raw_frontier.len());
+    for (freq, doc_len) in raw_frontier {
+        let norm = super::index::quantize_doc_length(doc_len);
+        match frontier.last_mut() {
+            Some((last_freq, last_norm)) if *last_norm == norm => {
+                // At the same quantized norm, the larger frequency dominates.
+                *last_freq = freq;
+            }
+            Some((_, last_norm)) => {
+                debug_assert!(
+                    *last_norm < norm,
+                    "raw impact frontier document lengths must be increasing"
+                );
+                frontier.push((freq, norm));
+            }
+            None => frontier.push((freq, norm)),
+        }
+    }
+    frontier
 }
 
 fn impact_frontier(docs: &[(u32, u32, u32)]) -> Vec<(u32, u32)> {
@@ -674,39 +699,6 @@ fn frontier_from_min_doc_lens(min_doc_lens: Vec<(u32, u32)>) -> Vec<(u32, u32)> 
     }
     frontier.reverse();
     frontier
-}
-
-fn decode_header(bytes: &[u8]) -> Result<ImpactEntryHeader> {
-    if bytes.len() < 8 {
-        return Err(Error::index(format!(
-            "impact entry too short: {} bytes",
-            bytes.len()
-        )));
-    }
-    let pair_count = read_u32_le(bytes, 4) as usize;
-    let expected_len = pair_count
-        .checked_mul(8)
-        .and_then(|pairs_len| 8usize.checked_add(pairs_len))
-        .ok_or_else(|| Error::index("impact entry length overflow".to_owned()))?;
-    if bytes.len() != expected_len {
-        return Err(Error::index(format!(
-            "impact entry length mismatch: got {} bytes, expected {} for {} pairs",
-            bytes.len(),
-            expected_len,
-            pair_count
-        )));
-    }
-    Ok(ImpactEntryHeader {
-        doc_up_to: read_u32_le(bytes, 0),
-        pair_count,
-    })
-}
-
-#[inline]
-fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
-    let mut value = [0u8; 4];
-    value.copy_from_slice(&bytes[offset..offset + 4]);
-    u32::from_le_bytes(value)
 }
 
 fn level1_len(level0_len: usize) -> usize {
@@ -766,6 +758,18 @@ mod tests {
     }
 
     #[test]
+    fn quantized_impact_frontier_drops_equal_norms() {
+        let docs = vec![(0, 1, 16), (1, 2, 17), (2, 3, 24)];
+        assert_eq!(
+            quantized_impact_frontier(&docs),
+            vec![
+                (2, super::super::index::quantize_doc_length(17)),
+                (3, super::super::index::quantize_doc_length(24)),
+            ]
+        );
+    }
+
+    #[test]
     fn impact_max_score_can_use_level1_entry() {
         let blocks = (0..40)
             .map(|block| vec![(block as u32, 1 + block as u32 % 3, 10)])
@@ -796,20 +800,20 @@ mod tests {
 
     #[test]
     fn impact_level1_doc_up_to_returns_none_for_malformed_entry() {
-        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let level0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
         let malformed_level1 = vec![1, 2, 3];
         let entries = LargeBinaryArray::from_opt_vec(vec![
             Some(level0.as_slice()),
             Some(malformed_level1.as_slice()),
         ]);
-        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::FixedU32).unwrap();
+        let impacts = ImpactSkipData::new(entries, 1).unwrap();
 
         assert_eq!(impacts.level1_doc_up_to(0), None);
     }
 
     #[test]
-    fn impact_level1_doc_up_to_validates_complete_varint_entry() {
-        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::Varint).unwrap();
+    fn impact_level1_doc_up_to_validates_complete_entry() {
+        let level0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
         // A complete first varint is not enough: the pair count and frontier
         // are required before this doc id can safely drive a group skip.
         let truncated_level1 = [31_u8];
@@ -817,7 +821,7 @@ mod tests {
             Some(level0.as_slice()),
             Some(truncated_level1.as_slice()),
         ]);
-        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::Varint).unwrap();
+        let impacts = ImpactSkipData::new(entries, 1).unwrap();
 
         assert_eq!(impacts.level1_doc_up_to(0), None);
     }
@@ -825,30 +829,21 @@ mod tests {
     #[test]
     fn empty_impact_frontiers_are_malformed_bounds() {
         let scorer = MemBM25Scorer::new(10, 1, HashMap::new());
-        for format in [ImpactFormat::FixedU32, ImpactFormat::Varint] {
-            let level0 = encode_impact_entry(&[(0, 1, 10)], format).unwrap();
-            let empty_level1 = match format {
-                ImpactFormat::FixedU32 => {
-                    let mut bytes = 0_u32.to_le_bytes().to_vec();
-                    bytes.extend_from_slice(&0_u32.to_le_bytes());
-                    bytes
-                }
-                ImpactFormat::Varint => vec![0, 0],
-            };
-            let entries = LargeBinaryArray::from_opt_vec(vec![
-                Some(level0.as_slice()),
-                Some(empty_level1.as_slice()),
-            ]);
-            let impacts = ImpactSkipData::new(entries, 1, format).unwrap();
-            let mut cache = ImpactScoreCache::default();
+        let level0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
+        let empty_level1 = [0, 0];
+        let entries = LargeBinaryArray::from_opt_vec(vec![
+            Some(level0.as_slice()),
+            Some(empty_level1.as_slice()),
+        ]);
+        let impacts = ImpactSkipData::new(entries, 1).unwrap();
+        let mut cache = ImpactScoreCache::default();
 
-            assert_eq!(impacts.level1_doc_up_to(0), None);
-            assert!(
-                impacts
-                    .global_max_doc_weight_cached(&scorer, &mut cache)
-                    .is_infinite()
-            );
-        }
+        assert_eq!(impacts.level1_doc_up_to(0), None);
+        assert!(
+            impacts
+                .global_max_doc_weight_cached(&scorer, &mut cache)
+                .is_infinite()
+        );
         assert!(
             ImpactSkipDataBuilder::with_capacity(1, 128)
                 .append_block(&[])
@@ -858,8 +853,8 @@ mod tests {
 
     #[test]
     fn null_impact_entry_is_an_infinite_bound_even_with_hidden_bytes() {
-        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
-        let level1 = encode_impact_entry(&[(0, 2, 8)], ImpactFormat::FixedU32).unwrap();
+        let level0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
+        let level1 = encode_impact_entry(&[(0, 2, 8)]).unwrap();
         let mut values = level0.clone();
         values.extend_from_slice(&level1);
         let entries = LargeBinaryArray::new(
@@ -871,7 +866,7 @@ mod tests {
             Buffer::from_vec(values),
             Some(NullBuffer::from(vec![true, false])),
         );
-        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::FixedU32).unwrap();
+        let impacts = ImpactSkipData::new(entries, 1).unwrap();
         let scorer = MemBM25Scorer::new(10, 1, HashMap::new());
         let mut cache = ImpactScoreCache::default();
 
@@ -912,9 +907,14 @@ mod tests {
 
         let low_bound = impacts.global_max_doc_weight_cached(&low_avgdl, &mut low_cache);
         let high_bound = impacts.global_max_doc_weight_cached(&high_avgdl, &mut high_cache);
+        let quantized_doc_length = super::super::index::dequantize_doc_length(
+            super::super::index::quantize_doc_length(100),
+        );
 
-        assert!((low_bound - low_avgdl.doc_weight(1, 100)).abs() < 1e-6);
-        assert!((high_bound - high_avgdl.doc_weight(1, 100)).abs() < 1e-6);
+        assert!((low_bound - low_avgdl.doc_weight(1, quantized_doc_length)).abs() < 1e-6);
+        assert!((high_bound - high_avgdl.doc_weight(1, quantized_doc_length)).abs() < 1e-6);
+        assert!(low_bound >= low_avgdl.doc_weight(1, 100));
+        assert!(high_bound >= high_avgdl.doc_weight(1, 100));
         assert!(
             high_bound > low_bound,
             "larger avgdl must recompute a larger bound: low={low_bound}, high={high_bound}"
@@ -949,16 +949,15 @@ mod tests {
 
     #[test]
     fn impact_entries_are_decoded_lazily() {
-        let level0_0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let level0_0 = encode_impact_entry(&[(0, 1, 10)]).unwrap();
         let malformed_level0_1 = vec![1, 2, 3];
-        let level1 =
-            encode_impact_entry(&[(0, 1, 10), (1, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let level1 = encode_impact_entry(&[(0, 1, 10), (1, 1, 10)]).unwrap();
         let entries = LargeBinaryArray::from_opt_vec(vec![
             Some(level0_0.as_slice()),
             Some(malformed_level0_1.as_slice()),
             Some(level1.as_slice()),
         ]);
-        let impacts = ImpactSkipData::new(entries, 2, ImpactFormat::FixedU32).unwrap();
+        let impacts = ImpactSkipData::new(entries, 2).unwrap();
         let scorer = MemBM25Scorer::new(10, 10, HashMap::from([(String::from("token"), 2usize)]));
 
         let score = impacts.max_score_up_to(0, 0, |_| 0, 1.0, &scorer);
@@ -973,29 +972,54 @@ mod tests {
     }
 
     #[test]
-    fn impact_varint_entries_roundtrip_and_match_fixed() {
-        let docs = vec![(3, 1, 100), (9, 2, 40), (200, 7, 80), (4095, 130, 900)];
-        let fixed = encode_impact_entry(&docs, ImpactFormat::FixedU32).unwrap();
-        let varint = encode_impact_entry(&docs, ImpactFormat::Varint).unwrap();
-        assert!(varint.len() < fixed.len());
-        assert_eq!(
-            decode_entry_doc_up_to(&fixed, ImpactFormat::FixedU32).unwrap(),
-            decode_entry_doc_up_to(&varint, ImpactFormat::Varint).unwrap()
-        );
-        let mut fixed_pairs = Vec::new();
-        for_each_entry_pair(&fixed, ImpactFormat::FixedU32, |f, l| {
-            fixed_pairs.push((f, l))
-        })
-        .unwrap();
-        let mut varint_pairs = Vec::new();
-        for_each_entry_pair(&varint, ImpactFormat::Varint, |f, l| {
-            varint_pairs.push((f, l))
-        })
-        .unwrap();
-        assert_eq!(fixed_pairs, varint_pairs);
-        assert!(!fixed_pairs.is_empty());
+    fn impact_entries_store_quantized_norm_deltas() {
+        let docs = vec![(7, 1, 1), (9, 2, 2), (12, 3, 5)];
+        let encoded = encode_impact_entry(&docs).unwrap();
 
-        // a 256-doc-block skip data goes through the varint path end to end
+        // doc_up_to=12, pair_count=3, two implicit +1 norm deltas, then an
+        // explicit +3 norm delta folded behind the frequency varint's low bit.
+        assert_eq!(encoded, vec![12, 3, 0, 0, 1, 3]);
+
+        let mut pairs = Vec::new();
+        for_each_entry_pair(&encoded, |freq, doc_len| pairs.push((freq, doc_len))).unwrap();
+        assert_eq!(pairs, vec![(1, 1), (2, 2), (3, 5)]);
+    }
+
+    #[test]
+    fn malformed_norm_deltas_are_rejected() {
+        // doc_up_to=0, pair_count=1, and the pair flag promises a norm byte
+        // that is not present.
+        let truncated = [0, 1, 1];
+        let error = for_each_entry_pair(&truncated, |_, _| {}).unwrap_err();
+        assert!(matches!(&error, Error::Index { .. }));
+        assert!(error.to_string().contains("impact norm delta"));
+
+        // The first pair reaches norm 255, so an implicit +1 on the second
+        // pair must fail instead of wrapping back to zero.
+        let overflowing = [0, 2, 1, 255, 0];
+        let error = for_each_entry_pair(&overflowing, |_, _| {}).unwrap_err();
+        assert!(matches!(&error, Error::Index { .. }));
+        assert!(error.to_string().contains("impact norm delta overflow"));
+    }
+
+    #[test]
+    fn impact_entries_roundtrip_quantized_frontier() {
+        let docs = vec![(3, 1, 100), (9, 2, 40), (200, 7, 80), (4095, 130, 900)];
+        let encoded = encode_impact_entry(&docs).unwrap();
+        assert_eq!(decode_entry_doc_up_to(&encoded).unwrap(), 4095);
+        let mut decoded_pairs = Vec::new();
+        for_each_entry_pair(&encoded, |freq, doc_len| {
+            decoded_pairs.push((freq, doc_len))
+        })
+        .unwrap();
+        let expected_pairs = quantized_impact_frontier(&docs)
+            .into_iter()
+            .map(|(freq, norm)| (freq, super::super::index::dequantize_doc_length(norm)))
+            .collect::<Vec<_>>();
+        assert_eq!(decoded_pairs, expected_pairs);
+        assert!(!decoded_pairs.is_empty());
+
+        // A 256-doc-block skip data goes through the shared codec end to end.
         let blocks: Vec<Vec<(u32, u32, u32)>> = (0..3)
             .map(|b| (0..256).map(|i| (b * 256 + i, 1 + i % 5, 10)).collect())
             .collect();
@@ -1005,6 +1029,19 @@ mod tests {
         assert!(impacts.level0_score(0, 1.0, &scorer).is_finite());
         let level1 = impacts.max_score_up_to(0, 767, |idx| (idx * 256) as u32, 1.0, &scorer);
         assert!(level1.score.is_finite() && level1.score > 0.0);
+    }
+
+    #[test]
+    fn v2_and_v3_impacts_use_identical_encoding() {
+        let docs = vec![(3, 1, 100), (9, 2, 40), (200, 7, 80)];
+        let mut v2_builder = ImpactSkipDataBuilder::with_capacity(1, 128);
+        v2_builder.append_block(&docs).unwrap();
+        let v2 = v2_builder.finish().unwrap();
+        let mut v3_builder = ImpactSkipDataBuilder::with_capacity(1, 256);
+        v3_builder.append_block(&docs).unwrap();
+        let v3 = v3_builder.finish().unwrap();
+
+        assert_eq!(v2.entries(), v3.entries());
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/impact.rs
+++ b/rust/lance-index/src/scalar/inverted/impact.rs
@@ -1,0 +1,1055 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::mem::{size_of, size_of_val};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use arrow_array::builder::LargeBinaryBuilder;
+use arrow_array::{Array, LargeBinaryArray};
+use lance_core::{Error, Result};
+
+use super::scorer::Scorer;
+
+pub const IMPACT_LEVEL1_BLOCKS: usize = 32;
+const SMALL_FRONTIER_FREQ_LIMIT: usize = 256;
+
+/// On-disk encoding of one impact entry.
+///
+/// `FixedU32` (128-doc blocks): [doc_up_to u32][pair_count u32][(freq u32,
+/// doc_len u32)...]. `Varint` (256-doc blocks, format V3): [doc_up_to varint]
+/// [pair_count varint][(freq delta varint, doc_len varint)...] with the
+/// frontier's freqs delta-encoded in ascending order — pairs shrink from 8
+/// bytes to ~2-3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImpactFormat {
+    FixedU32,
+    Varint,
+}
+
+impl ImpactFormat {
+    pub fn for_block_size(block_size: usize) -> Self {
+        if block_size == 256 {
+            Self::Varint
+        } else {
+            Self::FixedU32
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImpactSkipData {
+    entries: LargeBinaryArray,
+    level0_len: usize,
+    format: ImpactFormat,
+    // Last doc id covered by each entry (level0 entries then level1 entries),
+    // decoded once at construction. Level1 markers are fully validated because
+    // WAND may use them to skip a group; u32::MAX marks malformed entries.
+    entry_doc_up_tos: Arc<[u32]>,
+    // The most recently baked bounds with a stable scorer key. Each query holds
+    // its own Arc in ImpactScoreCache, so replacing this slot for another scorer
+    // cannot change bounds already in use. Scorers without a key never enter the
+    // shared slot. Malformed entries bake to INFINITY so pruning stays safe.
+    last_keyed_bounds: Arc<Mutex<LastKeyedImpactBounds>>,
+}
+
+impl PartialEq for ImpactSkipData {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+            && self.level0_len == other.level0_len
+            && self.format == other.format
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ImpactScore {
+    pub score: f32,
+    pub entries_scanned: usize,
+}
+
+#[derive(Debug)]
+struct ImpactBounds {
+    per_entry: Box<[f32]>,
+    global: f32,
+}
+
+type LastKeyedImpactBounds = Option<(u64, Arc<ImpactBounds>)>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImpactBoundsCacheKey {
+    Keyed(u64),
+    QueryLocal,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ImpactScoreCache {
+    key: Option<ImpactBoundsCacheKey>,
+    bounds: Option<Arc<ImpactBounds>>,
+}
+
+impl ImpactScoreCache {
+    fn bounds<'a, S: Scorer + ?Sized>(
+        &'a mut self,
+        impacts: &ImpactSkipData,
+        scorer: &S,
+    ) -> &'a ImpactBounds {
+        let scorer_key = scorer.doc_weight_cache_key();
+        let cache_key = scorer_key
+            .map(ImpactBoundsCacheKey::Keyed)
+            .unwrap_or(ImpactBoundsCacheKey::QueryLocal);
+        if self.key != Some(cache_key) {
+            self.key = Some(cache_key);
+            self.bounds = None;
+        }
+
+        self.bounds
+            .get_or_insert_with(|| impacts.bounds_for_scorer(scorer, scorer_key))
+    }
+
+    fn entry_score<S: Scorer + ?Sized>(
+        &mut self,
+        impacts: &ImpactSkipData,
+        entry_idx: usize,
+        query_weight: f32,
+        scorer: &S,
+    ) -> f32 {
+        if query_weight <= 0.0 {
+            return 0.0;
+        }
+        query_weight * self.bounds(impacts, scorer).per_entry[entry_idx]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ImpactEntryHeader {
+    doc_up_to: u32,
+    pair_count: usize,
+}
+
+impl ImpactSkipData {
+    pub fn new(entries: LargeBinaryArray, level0_len: usize, format: ImpactFormat) -> Result<Self> {
+        let expected_len = level0_len + level1_len(level0_len);
+        if entries.len() != expected_len {
+            return Err(Error::index(format!(
+                "impact entry count mismatch: got {}, expected {} for {} level0 blocks",
+                entries.len(),
+                expected_len,
+                level0_len
+            )));
+        }
+        let entry_doc_up_tos = (0..entries.len())
+            .map(|entry_idx| {
+                if entries.is_null(entry_idx) {
+                    return u32::MAX;
+                }
+                let bytes = entries.value(entry_idx);
+                let doc_up_to = if entry_idx < level0_len {
+                    decode_level0_entry_doc_up_to(bytes, format)
+                } else {
+                    decode_entry_doc_up_to(bytes, format)
+                };
+                doc_up_to.unwrap_or(u32::MAX)
+            })
+            .collect::<Arc<[u32]>>();
+        Ok(Self {
+            entries,
+            level0_len,
+            format,
+            entry_doc_up_tos,
+            last_keyed_bounds: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    fn keyed_bounds_guard(&self) -> MutexGuard<'_, LastKeyedImpactBounds> {
+        match self.last_keyed_bounds.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn bounds_for_scorer<S: Scorer + ?Sized>(
+        &self,
+        scorer: &S,
+        scorer_key: Option<u64>,
+    ) -> Arc<ImpactBounds> {
+        let Some(scorer_key) = scorer_key else {
+            return Arc::new(self.compute_bounds(scorer));
+        };
+
+        {
+            let cached = self.keyed_bounds_guard();
+            if let Some((cached_key, bounds)) = cached.as_ref()
+                && *cached_key == scorer_key
+            {
+                return bounds.clone();
+            }
+        }
+
+        // Compute outside the mutex. Concurrent misses may duplicate this work,
+        // but only the short publication/check below holds the shared lock.
+        let computed = Arc::new(self.compute_bounds(scorer));
+        let mut cached = self.keyed_bounds_guard();
+        if let Some((cached_key, bounds)) = cached.as_ref()
+            && *cached_key == scorer_key
+        {
+            return bounds.clone();
+        }
+        *cached = Some((scorer_key, computed.clone()));
+        computed
+    }
+
+    fn compute_bounds<S: Scorer + ?Sized>(&self, scorer: &S) -> ImpactBounds {
+        // V3 (Varint impacts <=> 256-doc blocks) scores with quantized doc
+        // lengths, so bake the bounds against the same quantized lengths.
+        // Quantization is monotone, so pareto dominance among the stored
+        // (freq, doc_len) frontier pairs is preserved and the frontier max
+        // still bounds every doc in the range.
+        let quantized = self.format == ImpactFormat::Varint;
+        let per_entry = (0..self.entries.len())
+            .map(|entry_idx| {
+                if self.entries.is_null(entry_idx) {
+                    return f32::INFINITY;
+                }
+                let bytes = self.entries.value(entry_idx);
+                let mut max_doc_weight = 0.0_f32;
+                match for_each_entry_pair(bytes, self.format, |freq, doc_len| {
+                    let doc_len = if quantized {
+                        super::index::dequantize_doc_length(super::index::quantize_doc_length(
+                            doc_len,
+                        ))
+                    } else {
+                        doc_len
+                    };
+                    max_doc_weight = max_doc_weight.max(scorer.doc_weight(freq, doc_len));
+                }) {
+                    Ok(()) => max_doc_weight,
+                    Err(_) => f32::INFINITY,
+                }
+            })
+            .collect::<Box<[f32]>>();
+        // The level1 entries cover every block, so their max is the list-wide
+        // max doc weight; zero-entry lists fall back to the empty level0 slab.
+        let global = if per_entry.len() > self.level0_len {
+            per_entry[self.level0_len..]
+                .iter()
+                .copied()
+                .fold(0.0_f32, f32::max)
+        } else {
+            per_entry.iter().copied().fold(0.0_f32, f32::max)
+        };
+        ImpactBounds { per_entry, global }
+    }
+
+    /// List-wide max doc weight, from the scorer-specific cached bounds. The
+    /// tightest valid global score bound is `query_weight * this`, matching what
+    /// the non-impact format stores as `max_score` at build time.
+    pub fn global_max_doc_weight_cached<S: Scorer + ?Sized>(
+        &self,
+        scorer: &S,
+        cache: &mut ImpactScoreCache,
+    ) -> f32 {
+        cache.bounds(self, scorer).global
+    }
+
+    pub fn entries(&self) -> &LargeBinaryArray {
+        &self.entries
+    }
+
+    /// Conservative heap charge for query-independent derived state and one
+    /// shared keyed-bound slab, whether or not that slab has been initialized
+    /// yet. The Arrow impact entries are owned by the enclosing batch and are
+    /// deliberately excluded so packed-group cache accounting counts them once.
+    pub(crate) fn derived_cache_bytes(&self) -> usize {
+        size_of_val(&*self.entry_doc_up_tos)
+            + size_of::<Mutex<LastKeyedImpactBounds>>()
+            + size_of::<ImpactBounds>()
+            + self.entries.len() * size_of::<f32>()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shares_derived_state_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.entry_doc_up_tos, &other.entry_doc_up_tos)
+            && Arc::ptr_eq(&self.last_keyed_bounds, &other.last_keyed_bounds)
+    }
+
+    #[cfg(test)]
+    pub fn level0_len(&self) -> usize {
+        self.level0_len
+    }
+
+    #[cfg(test)]
+    pub fn level1_len(&self) -> usize {
+        level1_len(self.level0_len)
+    }
+
+    pub(crate) fn level1_doc_up_to(&self, group_idx: usize) -> Option<u32> {
+        if group_idx >= level1_len(self.level0_len) {
+            return None;
+        }
+        match self.entry_doc_up_tos[self.level0_len + group_idx] {
+            u32::MAX => None,
+            doc_up_to => Some(doc_up_to),
+        }
+    }
+
+    /// Max score of the docs covered by the level0 entry of `block_idx`,
+    /// answered from the baked bounds slab.
+    // Only tests exercise the uncached form until the maxscore rework
+    // (stacked follow-up) anchors its block-max caches on it.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn level0_score<S: Scorer + ?Sized>(
+        &self,
+        block_idx: usize,
+        query_weight: f32,
+        scorer: &S,
+    ) -> f32 {
+        if block_idx >= self.level0_len || query_weight <= 0.0 {
+            return 0.0;
+        }
+        let mut cache = ImpactScoreCache::default();
+        cache.entry_score(self, block_idx, query_weight, scorer)
+    }
+
+    pub fn level0_score_cached<S: Scorer + ?Sized>(
+        &self,
+        block_idx: usize,
+        query_weight: f32,
+        scorer: &S,
+        cache: &mut ImpactScoreCache,
+    ) -> f32 {
+        if block_idx >= self.level0_len {
+            return 0.0;
+        }
+        cache.entry_score(self, block_idx, query_weight, scorer)
+    }
+
+    #[cfg(test)]
+    pub fn max_score_up_to<S, F>(
+        &self,
+        start_block_idx: usize,
+        up_to: u64,
+        _block_least_doc_id: F,
+        query_weight: f32,
+        scorer: &S,
+    ) -> ImpactScore
+    where
+        S: Scorer + ?Sized,
+        F: FnMut(usize) -> u32,
+    {
+        self.max_score_up_to_with(start_block_idx, up_to, |impacts, entry_idx| {
+            impacts.entry_score(entry_idx, query_weight, scorer)
+        })
+    }
+
+    pub fn max_score_up_to_cached<S>(
+        &self,
+        start_block_idx: usize,
+        up_to: u64,
+        query_weight: f32,
+        scorer: &S,
+        cache: &mut ImpactScoreCache,
+    ) -> ImpactScore
+    where
+        S: Scorer + ?Sized,
+    {
+        self.max_score_up_to_with(start_block_idx, up_to, |impacts, entry_idx| {
+            cache.entry_score(impacts, entry_idx, query_weight, scorer)
+        })
+    }
+
+    fn max_score_up_to_with<E>(
+        &self,
+        start_block_idx: usize,
+        up_to: u64,
+        mut entry_score: E,
+    ) -> ImpactScore
+    where
+        E: FnMut(&Self, usize) -> f32,
+    {
+        let mut block_idx = start_block_idx;
+        let mut max_score = 0.0_f32;
+        let mut entries_scanned = 0usize;
+
+        while block_idx < self.level0_len {
+            let group_idx = block_idx / IMPACT_LEVEL1_BLOCKS;
+            let group_start = group_idx * IMPACT_LEVEL1_BLOCKS;
+            let group_end = ((group_idx + 1) * IMPACT_LEVEL1_BLOCKS).min(self.level0_len);
+            if block_idx == group_start {
+                let level1_entry_idx = self.level0_len + group_idx;
+                match self.entry_doc_up_tos[level1_entry_idx] {
+                    u32::MAX => {
+                        return ImpactScore {
+                            score: f32::INFINITY,
+                            entries_scanned: entries_scanned + 1,
+                        };
+                    }
+                    doc_up_to if u64::from(doc_up_to) <= up_to => {
+                        max_score = max_score.max(entry_score(self, level1_entry_idx));
+                        entries_scanned += 1;
+                        block_idx = group_end;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+
+            max_score = max_score.max(entry_score(self, block_idx));
+            entries_scanned += 1;
+            match self.entry_doc_up_tos[block_idx] {
+                u32::MAX => {
+                    return ImpactScore {
+                        score: f32::INFINITY,
+                        entries_scanned,
+                    };
+                }
+                doc_up_to if u64::from(doc_up_to) >= up_to => break,
+                _ => {}
+            }
+            block_idx += 1;
+        }
+
+        ImpactScore {
+            score: max_score,
+            entries_scanned,
+        }
+    }
+
+    #[cfg(test)]
+    fn entry_score<S: Scorer + ?Sized>(
+        &self,
+        entry_idx: usize,
+        query_weight: f32,
+        scorer: &S,
+    ) -> f32 {
+        if query_weight <= 0.0 {
+            return 0.0;
+        }
+        let bytes = self.entries.value(entry_idx);
+        let mut max_doc_weight = 0.0_f32;
+        if for_each_entry_pair(bytes, self.format, |freq, doc_len| {
+            max_doc_weight = max_doc_weight.max(scorer.doc_weight(freq, doc_len));
+        })
+        .is_err()
+        {
+            return f32::INFINITY;
+        }
+        query_weight * max_doc_weight
+    }
+}
+
+pub struct ImpactSkipDataBuilder {
+    entries: LargeBinaryBuilder,
+    level0_len: usize,
+    level1_entries: Vec<Vec<u8>>,
+    level1_docs: Vec<(u32, u32, u32)>,
+    format: ImpactFormat,
+}
+
+impl ImpactSkipDataBuilder {
+    pub fn with_capacity(level0_blocks: usize, block_size: usize) -> Self {
+        Self {
+            entries: LargeBinaryBuilder::with_capacity(
+                level0_blocks + level1_len(level0_blocks),
+                0,
+            ),
+            level0_len: 0,
+            level1_entries: Vec::with_capacity(level1_len(level0_blocks)),
+            level1_docs: Vec::with_capacity(IMPACT_LEVEL1_BLOCKS * block_size),
+            format: ImpactFormat::for_block_size(block_size),
+        }
+    }
+
+    pub fn append_block(&mut self, docs: &[(u32, u32, u32)]) -> Result<()> {
+        let bytes = encode_impact_entry(docs, self.format)?;
+        self.entries.append_value(bytes.as_slice());
+        self.level0_len += 1;
+        self.level1_docs.extend_from_slice(docs);
+        if self.level0_len.is_multiple_of(IMPACT_LEVEL1_BLOCKS) {
+            self.flush_level1()?;
+        }
+        Ok(())
+    }
+
+    pub fn finish(mut self) -> Result<ImpactSkipData> {
+        if !self.level1_docs.is_empty() {
+            self.flush_level1()?;
+        }
+        for entry in self.level1_entries {
+            self.entries.append_value(entry.as_slice());
+        }
+        ImpactSkipData::new(self.entries.finish(), self.level0_len, self.format)
+    }
+
+    fn flush_level1(&mut self) -> Result<()> {
+        let bytes = encode_impact_entry(self.level1_docs.as_slice(), self.format)?;
+        self.level1_entries.push(bytes);
+        self.level1_docs.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub fn build_impact_skip_data(blocks: &[Vec<(u32, u32, u32)>]) -> Result<ImpactSkipData> {
+    let block_size = blocks.iter().map(Vec::len).max().unwrap_or(0).max(1);
+    let mut builder = ImpactSkipDataBuilder::with_capacity(blocks.len(), block_size);
+    for block in blocks {
+        builder.append_block(block)?;
+    }
+    builder.finish()
+}
+
+fn encode_impact_entry(docs: &[(u32, u32, u32)], format: ImpactFormat) -> Result<Vec<u8>> {
+    if docs.is_empty() {
+        return Err(Error::index(
+            "cannot encode an empty impact entry".to_owned(),
+        ));
+    }
+    let doc_up_to = docs
+        .last()
+        .map(|(doc_id, _, _)| *doc_id)
+        .expect("non-empty impact entry was validated above");
+    let frontier = impact_frontier(docs);
+    let pair_count = u32::try_from(frontier.len()).map_err(|_| {
+        Error::index("impact frontier too large to encode as u32 pair count".to_string())
+    })?;
+    let mut bytes = Vec::with_capacity(8 + frontier.len() * 8);
+    match format {
+        ImpactFormat::FixedU32 => {
+            bytes.extend_from_slice(&doc_up_to.to_le_bytes());
+            bytes.extend_from_slice(&pair_count.to_le_bytes());
+            for (freq, doc_len) in frontier {
+                bytes.extend_from_slice(&freq.to_le_bytes());
+                bytes.extend_from_slice(&doc_len.to_le_bytes());
+            }
+        }
+        ImpactFormat::Varint => {
+            super::encoding::encode_varint_u32(&mut bytes, doc_up_to);
+            super::encoding::encode_varint_u32(&mut bytes, pair_count);
+            let mut previous_freq = 0u32;
+            for (freq, doc_len) in frontier {
+                super::encoding::encode_varint_u32(&mut bytes, freq - previous_freq);
+                super::encoding::encode_varint_u32(&mut bytes, doc_len);
+                previous_freq = freq;
+            }
+        }
+    }
+    Ok(bytes)
+}
+
+fn decode_entry_doc_up_to(bytes: &[u8], format: ImpactFormat) -> Result<u32> {
+    match format {
+        ImpactFormat::FixedU32 => {
+            let header = decode_header(bytes)?;
+            if header.pair_count == 0 {
+                return Err(Error::index(
+                    "impact entry must contain at least one frontier pair".to_owned(),
+                ));
+            }
+            Ok(header.doc_up_to)
+        }
+        ImpactFormat::Varint => {
+            let mut offset = 0usize;
+            let doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+            // Level-1 doc ids drive whole-group skips, so only publish a doc
+            // id after validating the complete entry. A truncated entry may
+            // still have a valid first varint.
+            for_each_entry_pair(bytes, format, |_, _| {})?;
+            Ok(doc_up_to)
+        }
+    }
+}
+
+fn decode_level0_entry_doc_up_to(bytes: &[u8], format: ImpactFormat) -> Result<u32> {
+    match format {
+        // Fixed entries validate their complete layout from the header in O(1).
+        ImpactFormat::FixedU32 => decode_entry_doc_up_to(bytes, format),
+        // A malformed level0 frontier bakes an INFINITY score before this
+        // marker can terminate a range scan, so avoid parsing every frontier
+        // twice on the query-load path. Level1 entries are fully validated.
+        ImpactFormat::Varint => {
+            let mut offset = 0usize;
+            super::encoding::decode_varint_u32(bytes, &mut offset)
+        }
+    }
+}
+
+/// Walk an entry's (freq, doc_len) frontier pairs, validating the layout.
+fn for_each_entry_pair(
+    bytes: &[u8],
+    format: ImpactFormat,
+    mut visit: impl FnMut(u32, u32),
+) -> Result<()> {
+    match format {
+        ImpactFormat::FixedU32 => {
+            let header = decode_header(bytes)?;
+            if header.pair_count == 0 {
+                return Err(Error::index(
+                    "impact entry must contain at least one frontier pair".to_owned(),
+                ));
+            }
+            let mut offset = 8usize;
+            for _ in 0..header.pair_count {
+                visit(read_u32_le(bytes, offset), read_u32_le(bytes, offset + 4));
+                offset += 8;
+            }
+        }
+        ImpactFormat::Varint => {
+            let mut offset = 0usize;
+            let _doc_up_to = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+            let pair_count = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+            if pair_count == 0 {
+                return Err(Error::index(
+                    "impact entry must contain at least one frontier pair".to_owned(),
+                ));
+            }
+            let mut freq = 0u32;
+            for _ in 0..pair_count {
+                freq = freq
+                    .checked_add(super::encoding::decode_varint_u32(bytes, &mut offset)?)
+                    .ok_or_else(|| Error::index("impact freq delta overflow".to_owned()))?;
+                let doc_len = super::encoding::decode_varint_u32(bytes, &mut offset)?;
+                visit(freq, doc_len);
+            }
+            if offset != bytes.len() {
+                return Err(Error::index(format!(
+                    "impact varint entry has {} trailing bytes",
+                    bytes.len() - offset
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn impact_frontier(docs: &[(u32, u32, u32)]) -> Vec<(u32, u32)> {
+    let max_freq = docs.iter().map(|(_, freq, _)| *freq).max().unwrap_or(0) as usize;
+    if max_freq <= SMALL_FRONTIER_FREQ_LIMIT {
+        return impact_frontier_small_freq(docs, max_freq);
+    }
+
+    impact_frontier_sparse_freq(docs)
+}
+
+fn impact_frontier_small_freq(docs: &[(u32, u32, u32)], max_freq: usize) -> Vec<(u32, u32)> {
+    let mut min_doc_len_by_freq = [u32::MAX; SMALL_FRONTIER_FREQ_LIMIT + 1];
+    for (_, freq, doc_len) in docs {
+        min_doc_len_by_freq[*freq as usize] = min_doc_len_by_freq[*freq as usize].min(*doc_len);
+    }
+
+    let min_doc_lens = min_doc_len_by_freq[..=max_freq]
+        .iter()
+        .enumerate()
+        .filter_map(|(freq, doc_len)| (*doc_len != u32::MAX).then_some((freq as u32, *doc_len)))
+        .collect::<Vec<_>>();
+    frontier_from_min_doc_lens(min_doc_lens)
+}
+
+fn impact_frontier_sparse_freq(docs: &[(u32, u32, u32)]) -> Vec<(u32, u32)> {
+    let mut pairs = docs
+        .iter()
+        .map(|(_, freq, doc_len)| (*freq, *doc_len))
+        .collect::<Vec<_>>();
+    pairs.sort_unstable_by_key(|(freq, _)| *freq);
+
+    let mut min_doc_lens: Vec<(u32, u32)> = Vec::with_capacity(pairs.len());
+    for (freq, doc_len) in pairs {
+        match min_doc_lens.last_mut() {
+            Some((last_freq, last_doc_len)) if *last_freq == freq => {
+                *last_doc_len = (*last_doc_len).min(doc_len);
+            }
+            _ => min_doc_lens.push((freq, doc_len)),
+        }
+    }
+
+    frontier_from_min_doc_lens(min_doc_lens)
+}
+
+fn frontier_from_min_doc_lens(min_doc_lens: Vec<(u32, u32)>) -> Vec<(u32, u32)> {
+    let mut best_doc_len = u32::MAX;
+    let mut frontier = Vec::with_capacity(min_doc_lens.len());
+    for (freq, doc_len) in min_doc_lens.into_iter().rev() {
+        if doc_len < best_doc_len {
+            frontier.push((freq, doc_len));
+            best_doc_len = doc_len;
+        }
+    }
+    frontier.reverse();
+    frontier
+}
+
+fn decode_header(bytes: &[u8]) -> Result<ImpactEntryHeader> {
+    if bytes.len() < 8 {
+        return Err(Error::index(format!(
+            "impact entry too short: {} bytes",
+            bytes.len()
+        )));
+    }
+    let pair_count = read_u32_le(bytes, 4) as usize;
+    let expected_len = pair_count
+        .checked_mul(8)
+        .and_then(|pairs_len| 8usize.checked_add(pairs_len))
+        .ok_or_else(|| Error::index("impact entry length overflow".to_owned()))?;
+    if bytes.len() != expected_len {
+        return Err(Error::index(format!(
+            "impact entry length mismatch: got {} bytes, expected {} for {} pairs",
+            bytes.len(),
+            expected_len,
+            pair_count
+        )));
+    }
+    Ok(ImpactEntryHeader {
+        doc_up_to: read_u32_le(bytes, 0),
+        pair_count,
+    })
+}
+
+#[inline]
+fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
+    let mut value = [0u8; 4];
+    value.copy_from_slice(&bytes[offset..offset + 4]);
+    u32::from_le_bytes(value)
+}
+
+fn level1_len(level0_len: usize) -> usize {
+    level0_len.div_ceil(IMPACT_LEVEL1_BLOCKS)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+
+    use super::*;
+    use crate::scalar::inverted::scorer::{MemBM25Scorer, Scorer};
+
+    struct KeyedCountingScorer {
+        key: u64,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Scorer for KeyedCountingScorer {
+        fn query_weight(&self, _token: &str) -> f32 {
+            1.0
+        }
+
+        fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32 {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            freq as f32 / doc_tokens as f32
+        }
+
+        fn doc_weight_cache_key(&self) -> Option<u64> {
+            Some(self.key)
+        }
+    }
+
+    #[test]
+    fn impact_entry_frontier_drops_dominated_pairs() {
+        let docs = vec![(0, 1, 10), (1, 1, 8), (2, 2, 9), (3, 3, 20)];
+        assert_eq!(impact_frontier(&docs), vec![(1, 8), (2, 9), (3, 20)]);
+    }
+
+    #[test]
+    fn impact_entry_frontier_handles_sparse_large_frequencies() {
+        let docs = vec![
+            (0, 1, 100),
+            (1, 1, 80),
+            (2, 512, 90),
+            (3, 1_000, 120),
+            (4, 1_000, 110),
+        ];
+        assert_eq!(
+            impact_frontier(&docs),
+            vec![(1, 80), (512, 90), (1_000, 110)]
+        );
+    }
+
+    #[test]
+    fn impact_max_score_can_use_level1_entry() {
+        let blocks = (0..40)
+            .map(|block| vec![(block as u32, 1 + block as u32 % 3, 10)])
+            .collect::<Vec<_>>();
+        let impacts = build_impact_skip_data(&blocks).unwrap();
+        assert_eq!(impacts.level0_len(), 40);
+        assert_eq!(impacts.level1_len(), 2);
+        let scorer = MemBM25Scorer::new(400, 40, HashMap::from([(String::from("token"), 40usize)]));
+        let score = impacts.max_score_up_to(0, 31, |idx| idx as u32, 1.0, &scorer);
+        assert!(score.entries_scanned < IMPACT_LEVEL1_BLOCKS);
+        assert!(score.score > 0.0);
+    }
+
+    #[test]
+    fn impact_level1_doc_up_to_reports_full_and_partial_groups() {
+        let blocks = (0..40)
+            .map(|block| vec![(block as u32, 1, 10)])
+            .collect::<Vec<_>>();
+        let impacts = build_impact_skip_data(&blocks).unwrap();
+
+        assert_eq!(
+            impacts.level1_doc_up_to(0),
+            Some((IMPACT_LEVEL1_BLOCKS - 1) as u32)
+        );
+        assert_eq!(impacts.level1_doc_up_to(1), Some(39));
+        assert_eq!(impacts.level1_doc_up_to(2), None);
+    }
+
+    #[test]
+    fn impact_level1_doc_up_to_returns_none_for_malformed_entry() {
+        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let malformed_level1 = vec![1, 2, 3];
+        let entries = LargeBinaryArray::from_opt_vec(vec![
+            Some(level0.as_slice()),
+            Some(malformed_level1.as_slice()),
+        ]);
+        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::FixedU32).unwrap();
+
+        assert_eq!(impacts.level1_doc_up_to(0), None);
+    }
+
+    #[test]
+    fn impact_level1_doc_up_to_validates_complete_varint_entry() {
+        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::Varint).unwrap();
+        // A complete first varint is not enough: the pair count and frontier
+        // are required before this doc id can safely drive a group skip.
+        let truncated_level1 = [31_u8];
+        let entries = LargeBinaryArray::from_opt_vec(vec![
+            Some(level0.as_slice()),
+            Some(truncated_level1.as_slice()),
+        ]);
+        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::Varint).unwrap();
+
+        assert_eq!(impacts.level1_doc_up_to(0), None);
+    }
+
+    #[test]
+    fn empty_impact_frontiers_are_malformed_bounds() {
+        let scorer = MemBM25Scorer::new(10, 1, HashMap::new());
+        for format in [ImpactFormat::FixedU32, ImpactFormat::Varint] {
+            let level0 = encode_impact_entry(&[(0, 1, 10)], format).unwrap();
+            let empty_level1 = match format {
+                ImpactFormat::FixedU32 => {
+                    let mut bytes = 0_u32.to_le_bytes().to_vec();
+                    bytes.extend_from_slice(&0_u32.to_le_bytes());
+                    bytes
+                }
+                ImpactFormat::Varint => vec![0, 0],
+            };
+            let entries = LargeBinaryArray::from_opt_vec(vec![
+                Some(level0.as_slice()),
+                Some(empty_level1.as_slice()),
+            ]);
+            let impacts = ImpactSkipData::new(entries, 1, format).unwrap();
+            let mut cache = ImpactScoreCache::default();
+
+            assert_eq!(impacts.level1_doc_up_to(0), None);
+            assert!(
+                impacts
+                    .global_max_doc_weight_cached(&scorer, &mut cache)
+                    .is_infinite()
+            );
+        }
+        assert!(
+            ImpactSkipDataBuilder::with_capacity(1, 128)
+                .append_block(&[])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn null_impact_entry_is_an_infinite_bound_even_with_hidden_bytes() {
+        let level0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let level1 = encode_impact_entry(&[(0, 2, 8)], ImpactFormat::FixedU32).unwrap();
+        let mut values = level0.clone();
+        values.extend_from_slice(&level1);
+        let entries = LargeBinaryArray::new(
+            OffsetBuffer::new(ScalarBuffer::from(vec![
+                0_i64,
+                level0.len() as i64,
+                values.len() as i64,
+            ])),
+            Buffer::from_vec(values),
+            Some(NullBuffer::from(vec![true, false])),
+        );
+        let impacts = ImpactSkipData::new(entries, 1, ImpactFormat::FixedU32).unwrap();
+        let scorer = MemBM25Scorer::new(10, 1, HashMap::new());
+        let mut cache = ImpactScoreCache::default();
+
+        assert_eq!(impacts.level1_doc_up_to(0), None);
+        assert!(
+            impacts
+                .global_max_doc_weight_cached(&scorer, &mut cache)
+                .is_infinite()
+        );
+    }
+
+    #[test]
+    fn impact_score_cache_matches_uncached_scores() {
+        let blocks = (0..40)
+            .map(|block| vec![(block as u32, 1 + block as u32 % 3, 10)])
+            .collect::<Vec<_>>();
+        let impacts = build_impact_skip_data(&blocks).unwrap();
+        let scorer = MemBM25Scorer::new(400, 40, HashMap::from([(String::from("token"), 40usize)]));
+        let mut cache = ImpactScoreCache::default();
+
+        let uncached_level0 = impacts.level0_score(3, 1.0, &scorer);
+        let cached_level0 = impacts.level0_score_cached(3, 1.0, &scorer, &mut cache);
+        assert_eq!(cached_level0, uncached_level0);
+
+        let uncached = impacts.max_score_up_to(0, 31, |idx| idx as u32, 1.0, &scorer);
+        let cached = impacts.max_score_up_to_cached(0, 31, 1.0, &scorer, &mut cache);
+        assert_eq!(cached.score, uncached.score);
+        assert_eq!(cached.entries_scanned, uncached.entries_scanned);
+    }
+
+    #[test]
+    fn impact_bounds_follow_changed_bm25_average_doc_length() {
+        let impacts = build_impact_skip_data(&[vec![(0, 1, 100)]]).unwrap();
+        let low_avgdl = MemBM25Scorer::new(1, 1, HashMap::new());
+        let high_avgdl = MemBM25Scorer::new(100, 1, HashMap::new());
+        let mut low_cache = ImpactScoreCache::default();
+        let mut high_cache = ImpactScoreCache::default();
+
+        let low_bound = impacts.global_max_doc_weight_cached(&low_avgdl, &mut low_cache);
+        let high_bound = impacts.global_max_doc_weight_cached(&high_avgdl, &mut high_cache);
+
+        assert!((low_bound - low_avgdl.doc_weight(1, 100)).abs() < 1e-6);
+        assert!((high_bound - high_avgdl.doc_weight(1, 100)).abs() < 1e-6);
+        assert!(
+            high_bound > low_bound,
+            "larger avgdl must recompute a larger bound: low={low_bound}, high={high_bound}"
+        );
+    }
+
+    #[test]
+    fn impact_bounds_reuse_same_scorer_key_across_queries() {
+        let impacts = build_impact_skip_data(&[vec![(0, 2, 10)]]).unwrap();
+        let cloned = impacts.clone();
+        assert!(impacts.shares_derived_state_with(&cloned));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let scorer = KeyedCountingScorer {
+            key: 7,
+            calls: calls.clone(),
+        };
+        let mut first_query = ImpactScoreCache::default();
+        let mut second_query = ImpactScoreCache::default();
+
+        let first = impacts.global_max_doc_weight_cached(&scorer, &mut first_query);
+        let baked_calls = calls.load(Ordering::Relaxed);
+        assert!(baked_calls > 0);
+        let second = cloned.global_max_doc_weight_cached(&scorer, &mut second_query);
+
+        assert_eq!(second, first);
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            baked_calls,
+            "the same keyed bounds should be shared across query caches"
+        );
+    }
+
+    #[test]
+    fn impact_entries_are_decoded_lazily() {
+        let level0_0 = encode_impact_entry(&[(0, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let malformed_level0_1 = vec![1, 2, 3];
+        let level1 =
+            encode_impact_entry(&[(0, 1, 10), (1, 1, 10)], ImpactFormat::FixedU32).unwrap();
+        let entries = LargeBinaryArray::from_opt_vec(vec![
+            Some(level0_0.as_slice()),
+            Some(malformed_level0_1.as_slice()),
+            Some(level1.as_slice()),
+        ]);
+        let impacts = ImpactSkipData::new(entries, 2, ImpactFormat::FixedU32).unwrap();
+        let scorer = MemBM25Scorer::new(10, 10, HashMap::from([(String::from("token"), 2usize)]));
+
+        let score = impacts.max_score_up_to(0, 0, |_| 0, 1.0, &scorer);
+        assert!(score.score.is_finite());
+        assert_eq!(score.entries_scanned, 1);
+
+        let mut cache = ImpactScoreCache::default();
+        assert_eq!(
+            impacts.level0_score_cached(1, 1.0, &scorer, &mut cache),
+            f32::INFINITY
+        );
+    }
+
+    #[test]
+    fn impact_varint_entries_roundtrip_and_match_fixed() {
+        let docs = vec![(3, 1, 100), (9, 2, 40), (200, 7, 80), (4095, 130, 900)];
+        let fixed = encode_impact_entry(&docs, ImpactFormat::FixedU32).unwrap();
+        let varint = encode_impact_entry(&docs, ImpactFormat::Varint).unwrap();
+        assert!(varint.len() < fixed.len());
+        assert_eq!(
+            decode_entry_doc_up_to(&fixed, ImpactFormat::FixedU32).unwrap(),
+            decode_entry_doc_up_to(&varint, ImpactFormat::Varint).unwrap()
+        );
+        let mut fixed_pairs = Vec::new();
+        for_each_entry_pair(&fixed, ImpactFormat::FixedU32, |f, l| {
+            fixed_pairs.push((f, l))
+        })
+        .unwrap();
+        let mut varint_pairs = Vec::new();
+        for_each_entry_pair(&varint, ImpactFormat::Varint, |f, l| {
+            varint_pairs.push((f, l))
+        })
+        .unwrap();
+        assert_eq!(fixed_pairs, varint_pairs);
+        assert!(!fixed_pairs.is_empty());
+
+        // a 256-doc-block skip data goes through the varint path end to end
+        let blocks: Vec<Vec<(u32, u32, u32)>> = (0..3)
+            .map(|b| (0..256).map(|i| (b * 256 + i, 1 + i % 5, 10)).collect())
+            .collect();
+        let impacts = build_impact_skip_data(&blocks).unwrap();
+        assert_eq!(impacts.level1_doc_up_to(0), Some(767));
+        let scorer = MemBM25Scorer::new(400, 768, HashMap::from([(String::from("t"), 768usize)]));
+        assert!(impacts.level0_score(0, 1.0, &scorer).is_finite());
+        let level1 = impacts.max_score_up_to(0, 767, |idx| (idx * 256) as u32, 1.0, &scorer);
+        assert!(level1.score.is_finite() && level1.score > 0.0);
+    }
+
+    #[test]
+    fn impact_upper_bound_covers_real_scores() {
+        let blocks = vec![
+            vec![(0, 1, 100), (3, 2, 40), (7, 4, 80)],
+            vec![(9, 3, 15), (10, 1, 5), (12, 5, 30)],
+            vec![(16, 2, 10), (18, 6, 70), (21, 3, 12)],
+            vec![(24, 1, 4), (28, 7, 100), (30, 2, 8)],
+        ];
+        let impacts = build_impact_skip_data(&blocks).unwrap();
+        let scorer = MemBM25Scorer::new(474, 31, HashMap::from([(String::from("token"), 4usize)]));
+        let query_weight = scorer.query_weight("token");
+
+        for start_block_idx in 0..blocks.len() {
+            let up_to = blocks
+                .iter()
+                .skip(start_block_idx)
+                .take(2)
+                .flatten()
+                .map(|(doc_id, _, _)| *doc_id)
+                .max()
+                .unwrap();
+            let upper_bound = impacts.max_score_up_to(
+                start_block_idx,
+                u64::from(up_to),
+                |idx| blocks[idx][0].0,
+                query_weight,
+                &scorer,
+            );
+            let exact_max = blocks
+                .iter()
+                .skip(start_block_idx)
+                .flatten()
+                .take_while(|(doc_id, _, _)| *doc_id <= up_to)
+                .map(|(_, freq, doc_len)| query_weight * scorer.doc_weight(*freq, *doc_len))
+                .fold(0.0_f32, f32::max);
+            assert!(
+                upper_bound.score + 1e-6 >= exact_max,
+                "upper bound {} should cover exact max {} from block {} up to doc {}",
+                upper_bound.score,
+                exact_max,
+                start_block_idx,
+                up_to
+            );
+        }
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -7057,7 +7057,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
     use lance_tokenizer::{Language, SimpleTokenizer, StopWordFilter, TextAnalyzer};
@@ -9491,74 +9491,215 @@ mod tests {
         doc_writer.finish().await.unwrap();
     }
 
-    #[tokio::test]
-    async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
+    async fn load_global_scoring_test_index(
+        second_partition_has_impacts: bool,
+    ) -> (TempObjDir, Arc<InvertedIndex>) {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
             tmpdir.clone(),
             Arc::new(LanceCache::no_cache()),
         ));
-
-        let mut impact_builder = InnerBuilder::new_with_format_version(
-            0,
-            false,
-            TokenSetFormat::default(),
-            InvertedListFormatVersion::V1,
-        );
-        impact_builder.tokens.add("alpha".to_owned());
-        impact_builder
-            .posting_lists
-            .push(PostingListBuilder::new_with_posting_tail_codec(
+        let partition_specs = [
+            (0, 100, 5_000, 101..111, 5_000, true),
+            (1, 200, 1_000, 201..301, 1, second_partition_has_impacts),
+        ];
+        for (
+            partition_id,
+            matching_row_id,
+            matching_doc_length,
+            other_row_ids,
+            other_doc_length,
+            with_impacts,
+        ) in partition_specs
+        {
+            let mut builder = InnerBuilder::new_with_format_version(
+                partition_id,
                 false,
-                InvertedListFormatVersion::V1.posting_tail_codec(),
-            ));
-        impact_builder.posting_lists[0].add(0, PositionRecorder::Count(1));
-        impact_builder.docs.append(100, 5_000);
-        for row_id in 101..111 {
-            impact_builder.docs.append(row_id, 5_000);
+                TokenSetFormat::default(),
+                InvertedListFormatVersion::V1,
+            );
+            builder.tokens.add("alpha".to_owned());
+            builder
+                .posting_lists
+                .push(PostingListBuilder::new_with_posting_tail_codec(
+                    false,
+                    InvertedListFormatVersion::V1.posting_tail_codec(),
+                ));
+            builder.posting_lists[0].add(0, PositionRecorder::Count(1));
+            builder.docs.append(matching_row_id, matching_doc_length);
+            for row_id in other_row_ids {
+                builder.docs.append(row_id, other_doc_length);
+            }
+            write_test_partition_with_optional_impacts(
+                &store,
+                partition_id,
+                builder,
+                TokenSetFormat::default(),
+                with_impacts,
+            )
+            .await;
         }
-        write_test_partition_with_optional_impacts(
-            &store,
-            0,
-            impact_builder,
-            TokenSetFormat::default(),
-            true,
-        )
-        .await;
-
-        let mut legacy_builder = InnerBuilder::new_with_format_version(
-            1,
-            false,
-            TokenSetFormat::default(),
-            InvertedListFormatVersion::V1,
-        );
-        legacy_builder.tokens.add("alpha".to_owned());
-        legacy_builder
-            .posting_lists
-            .push(PostingListBuilder::new_with_posting_tail_codec(
-                false,
-                InvertedListFormatVersion::V1.posting_tail_codec(),
-            ));
-        legacy_builder.posting_lists[0].add(0, PositionRecorder::Count(1));
-        legacy_builder.docs.append(200, 1_000);
-        for row_id in 201..301 {
-            legacy_builder.docs.append(row_id, 1);
-        }
-        write_test_partition_with_optional_impacts(
-            &store,
-            1,
-            legacy_builder,
-            TokenSetFormat::default(),
-            false,
-        )
-        .await;
 
         write_test_metadata(&store, vec![0, 1], InvertedIndexParams::default()).await;
-        let cache = Arc::new(LanceCache::with_capacity(4096));
-        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+        let cache = LanceCache::with_capacity(4096);
+        let index = InvertedIndex::load(store, None, &cache).await.unwrap();
+        (tmpdir, index)
+    }
+
+    async fn search_test_impact_partition(
+        partition: &InvertedPartition,
+        tokens: &Tokens,
+        params: &FtsSearchParams,
+        scorer: Arc<MemBM25Scorer>,
+        shared_threshold: Arc<AtomicU32>,
+    ) -> Vec<DocCandidate> {
+        let LoadedPostings {
+            postings,
+            grouped_expansions,
+            impact_safe,
+        } = partition
+            .load_posting_lists(
+                tokens,
+                params,
+                Operator::Or,
+                scorer.as_ref(),
+                &NoOpMetricsCollector,
+            )
             .await
             .unwrap();
+        assert!(impact_safe);
+        assert!(grouped_expansions.is_empty());
+
+        let mask = NoFilter.mask();
+        let docs_for_wand = partition.docs.docs_for_wand(mask.as_ref()).await.unwrap();
+        let mut candidates = partition
+            .bm25_search(
+                docs_for_wand.as_ref(),
+                params,
+                Operator::Or,
+                mask,
+                postings,
+                Some(scorer),
+                &NoOpMetricsCollector,
+                shared_threshold,
+            )
+            .unwrap();
+        resolve_deferred_candidates(&partition.docs, &mut candidates)
+            .await
+            .unwrap();
+        candidates
+    }
+
+    #[tokio::test]
+    async fn test_impact_partitions_share_global_threshold_without_pruning_winner() {
+        // Partition 0 wins under its local corpus statistics but loses under
+        // the global statistics. If its local score escapes into the shared
+        // floor, partition 1 will incorrectly prune the real global winner.
+        let (_tmpdir, index) = load_global_scoring_test_index(true).await;
+        let first_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 0)
+            .unwrap();
+        let second_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 1)
+            .unwrap();
+
+        let tokens = Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
+        let scorer = Arc::new(
+            index
+                .bm25_base_scorer(tokens.as_ref(), params.as_ref())
+                .await
+                .unwrap(),
+        );
+        first_partition
+            .inverted_list
+            .ensure_metadata_loaded()
+            .await
+            .unwrap();
+        second_partition
+            .inverted_list
+            .ensure_metadata_loaded()
+            .await
+            .unwrap();
+        let first_local_scorer = IndexBM25Scorer::new(std::iter::once(first_partition.as_ref()));
+        let second_local_scorer = IndexBM25Scorer::new(std::iter::once(second_partition.as_ref()));
+        let first_local_score =
+            first_local_scorer.query_weight("alpha") * first_local_scorer.doc_weight(1, 5_000);
+        let second_local_score =
+            second_local_scorer.query_weight("alpha") * second_local_scorer.doc_weight(1, 1_000);
+        assert!(first_local_score > second_local_score);
+        let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+
+        // Search sequentially so partition 0 deterministically publishes its
+        // score before partition 1 evaluates its impact upper bound.
+        let first_candidates = search_test_impact_partition(
+            first_partition,
+            tokens.as_ref(),
+            params.as_ref(),
+            scorer.clone(),
+            shared_threshold.clone(),
+        )
+        .await;
+        assert_eq!(first_candidates.len(), 1);
+        assert!(matches!(
+            first_candidates[0].addr,
+            CandidateAddr::RowId(100)
+        ));
+        let first_score =
+            scorer.query_weight("alpha") * scorer.doc_weight(1, first_candidates[0].doc_length);
+        let published_threshold = f32::from_bits(shared_threshold.load(Ordering::Relaxed));
+        assert!(
+            (published_threshold - first_score).abs() < 1e-6,
+            "published threshold: {published_threshold}, expected global score: {first_score}"
+        );
+
+        let second_candidates = search_test_impact_partition(
+            second_partition,
+            tokens.as_ref(),
+            params.as_ref(),
+            scorer.clone(),
+            shared_threshold.clone(),
+        )
+        .await;
+        assert_eq!(second_candidates.len(), 1);
+        assert!(matches!(
+            second_candidates[0].addr,
+            CandidateAddr::RowId(200)
+        ));
+        let second_score =
+            scorer.query_weight("alpha") * scorer.doc_weight(1, second_candidates[0].doc_length);
+        assert!(
+            second_score > first_score,
+            "second score: {second_score}, first score: {first_score}"
+        );
+        assert!(
+            (f32::from_bits(shared_threshold.load(Ordering::Relaxed)) - second_score).abs() < 1e-6
+        );
+
+        let (row_ids, scores) = index
+            .bm25_search(
+                tokens,
+                params,
+                Operator::Or,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(row_ids, vec![200]);
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0] - second_score).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
+        let (_tmpdir, index) = load_global_scoring_test_index(false).await;
 
         let impact_partition = index
             .partitions

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -975,7 +975,7 @@ impl InvertedIndex {
                             tokens.as_ref(),
                             params.as_ref(),
                             operator,
-                            Some(impact_scorer.as_ref()),
+                            impact_scorer.as_ref(),
                             metrics.as_ref(),
                         )
                         .await?;
@@ -1959,7 +1959,7 @@ impl InvertedPartition {
         tokens: &Tokens,
         params: &FtsSearchParams,
         operator: Operator,
-        impact_scorer: Option<&MemBM25Scorer>,
+        impact_scorer: &MemBM25Scorer,
         metrics: &dyn MetricsCollector,
     ) -> Result<LoadedPostings> {
         let is_fuzzy = matches!(params.fuzziness, Some(n) if n != 0);
@@ -2038,18 +2038,18 @@ impl InvertedPartition {
         }
 
         if !is_fuzzy_and_query {
-            let impact_safe = impact_scorer.is_some()
-                && loaded_postings
-                    .iter()
-                    .all(|(_, _, _, posting)| posting.has_impacts());
+            let impact_safe = loaded_postings
+                .iter()
+                .all(|(_, _, _, posting)| posting.has_impacts());
             return Ok(LoadedPostings {
                 postings: loaded_postings
                     .into_iter()
                     .map(|(token_id, token, position, posting)| {
-                        let query_weight = impact_scorer
-                            .filter(|_| impact_safe)
-                            .map(|scorer| scorer.query_weight(&token))
-                            .unwrap_or_else(|| idf(posting.len(), num_docs));
+                        let query_weight = if impact_safe {
+                            impact_scorer.query_weight(&token)
+                        } else {
+                            idf(posting.len(), num_docs)
+                        };
                         PostingIterator::with_query_weight(
                             token,
                             token_id,
@@ -4033,7 +4033,7 @@ impl PostingListGroup {
                     "packed posting group column {IMPACT_COL} must not contain nulls"
                 )));
             }
-            let mut total_impact_entries = 0usize;
+            let mut derived_cache_bytes = 0usize;
             for slot in 0..batch.num_rows() {
                 let posting_blocks = postings.value_length(slot) as usize;
                 let impact_entries = impacts.value_length(slot) as usize;
@@ -4044,7 +4044,9 @@ impl PostingListGroup {
                         "packed posting group impact slot {slot} has {impact_entries} entries, expected {expected_impact_entries} for {posting_blocks} posting blocks"
                     )));
                 }
-                total_impact_entries = total_impact_entries.saturating_add(impact_entries);
+                derived_cache_bytes = derived_cache_bytes.saturating_add(
+                    ImpactSkipData::derived_cache_bytes_for_entries(impact_entries),
+                );
             }
 
             let states: Arc<[OnceLock<Box<ImpactSkipData>>]> = (0..batch.num_rows())
@@ -4054,22 +4056,12 @@ impl PostingListGroup {
             // Account up front for every allocation that the lazy states can
             // eventually retain. The impact entry bytes themselves remain in
             // `batch` and are already charged exactly once above.
-            // `ImpactSkipData` owns one mutex-backed keyed-bounds slot. Use a
-            // deliberately wider Arc payload here as a conservative stand-in
-            // for that private allocation, plus the bounds slab metadata.
-            let keyed_bounds_metadata_bytes =
-                std::mem::size_of::<std::sync::Mutex<Option<(u64, Arc<[f32]>)>>>()
-                    .saturating_add(std::mem::size_of::<(Box<[f32]>, f32)>());
             let per_slot_bytes = std::mem::size_of::<OnceLock<Box<ImpactSkipData>>>()
-                .saturating_add(std::mem::size_of::<ImpactSkipData>())
-                .saturating_add(keyed_bounds_metadata_bytes)
-                .saturating_add(std::mem::size_of::<f32>());
-            let per_entry_bytes =
-                std::mem::size_of::<u32>().saturating_add(std::mem::size_of::<f32>());
+                .saturating_add(std::mem::size_of::<ImpactSkipData>());
             let capacity_bytes = states
                 .len()
                 .saturating_mul(per_slot_bytes)
-                .saturating_add(total_impact_entries.saturating_mul(per_entry_bytes));
+                .saturating_add(derived_cache_bytes);
             (Some(states), capacity_bytes)
         } else {
             (None, 0)
@@ -4758,6 +4750,7 @@ impl CompressedPostingList {
         block[0..4].try_into().map(f32::from_le_bytes).unwrap()
     }
 
+    #[inline]
     pub fn block_least_doc_id(&self, block_idx: usize) -> u32 {
         self.block_first_docs()[block_idx]
     }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -4210,16 +4210,12 @@ impl PostingListGroup {
                                 "packed posting group impact slot {slot} is not LargeBinary"
                             ))
                         })?;
-                        let impacts = state.get_or_init(|| {
-                            Box::new(
-                                ImpactSkipData::new(
-                                    entries.clone(),
-                                    blocks.len(),
-                                    super::impact::ImpactFormat::for_block_size(group.block_size),
-                                )
-                                .expect("packed impact entry count was validated at construction"),
-                            )
-                        });
+                        let impacts =
+                            state.get_or_init(|| {
+                                Box::new(ImpactSkipData::new(entries.clone(), blocks.len()).expect(
+                                    "packed impact entry count was validated at construction",
+                                ))
+                            });
                         Some(impacts.as_ref().clone())
                     }
                     (None, None) => None,
@@ -4724,11 +4720,7 @@ impl CompressedPostingList {
             .column_by_name(IMPACT_COL)
             .map(|col| {
                 let entries = col.as_list::<i32>().value(0).as_binary::<i64>().clone();
-                ImpactSkipData::new(
-                    entries,
-                    blocks.len(),
-                    super::impact::ImpactFormat::for_block_size(block_size),
-                )
+                ImpactSkipData::new(entries, blocks.len())
             })
             .transpose()?;
 
@@ -6074,12 +6066,11 @@ impl Ord for RawDocInfo {
     }
 }
 
-/// Lucene SmallFloat-style doc-length quantization for V3 (256-doc block)
-/// scoring: a 4-mantissa-bit float-like byte code. Values 0-7 are exact;
-/// larger values keep their top four significand bits (relative error
-/// <= 6.25%) and decode to their bucket floor. The floor only ever shortens
-/// a doc, and a shorter doc only raises its BM25 weight, so bounds baked
-/// from quantized lengths stay valid upper bounds of quantized scores.
+/// Lucene SmallFloat-style doc-length quantization for V3 scoring and impact
+/// norms: a 4-mantissa-bit float-like byte code. Values 0-7 are exact; larger
+/// values keep their top four significand bits (relative error <= 6.25%) and
+/// decode to their bucket floor. The floor only ever shortens a doc, so impact
+/// bounds remain conservative for exact-scoring V2 as well as quantized V3.
 pub(super) fn quantize_doc_length(value: u32) -> u8 {
     let num_bits = 32 - value.leading_zeros();
     if num_bits < 4 {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -54,14 +54,16 @@ use tokio::{sync::OnceCell, task::spawn_blocking};
 use tracing::{info, instrument, warn};
 
 use super::encoding::{MAX_POSTING_BLOCK_SIZE, PositionBlockBuilder};
+use super::impact::{IMPACT_LEVEL1_BLOCKS, ImpactSkipData, ImpactSkipDataBuilder};
 use super::iter::PostingListIterator;
 use super::lazy_docset::LazyDocSet;
 use super::tokenizer::{LEGACY_BLOCK_SIZE, validate_block_size};
 use super::{InvertedIndexBuilder, InvertedIndexParams, wand::*};
 use super::{
     builder::{
-        BLOCK_SIZE, ScoredDoc, doc_file_path, inverted_list_schema_for_version_with_block_size,
-        posting_file_path, token_file_path,
+        BLOCK_SIZE, ScoredDoc, doc_file_path,
+        inverted_list_schema_for_version_with_block_size_and_impacts, posting_file_path,
+        token_file_path,
     },
     iter::PlainPostingListIterator,
     query::*,
@@ -106,6 +108,7 @@ pub const POSITION_COL: &str = "_position";
 pub const COMPRESSED_POSITION_COL: &str = "_compressed_position";
 pub const POSITION_BLOCK_OFFSET_COL: &str = "_position_block_offset";
 pub const POSTING_COL: &str = "_posting";
+pub const IMPACT_COL: &str = "_impacts";
 pub const MAX_SCORE_COL: &str = "_max_score";
 pub const LENGTH_COL: &str = "_length";
 pub const BLOCK_MAX_SCORE_COL: &str = "_block_max_score";
@@ -287,6 +290,7 @@ impl PartitionCandidates {
 struct LoadedPostings {
     postings: Vec<PostingIterator>,
     grouped_expansions: Vec<GroupedExpansionTerms>,
+    impact_safe: bool,
 }
 
 impl LoadedPostings {
@@ -294,6 +298,7 @@ impl LoadedPostings {
         Self {
             postings: Vec::new(),
             grouped_expansions: Vec::new(),
+            impact_safe: false,
         }
     }
 }
@@ -904,12 +909,13 @@ impl InvertedIndex {
         // hits per-token `posting_len`; building a `MemBM25Scorer` with
         // precomputed per-term IDFs avoids the v2 bulk metadata pull.
         let local_scorer;
-        let scorer: &dyn Scorer = if let Some(base_scorer) = base_scorer {
+        let scorer: &MemBM25Scorer = if let Some(base_scorer) = base_scorer {
             base_scorer
         } else {
             local_scorer = self.bm25_scorer_for_final_tokens(tokens.as_ref()).await?;
             &local_scorer
         };
+        let impact_scorer = Arc::new(scorer.clone());
 
         let limit = params.limit.unwrap_or(usize::MAX);
         if limit == 0 {
@@ -948,8 +954,9 @@ impl InvertedIndex {
         // Shared top-k floor across this query's partitions. Seeded to -inf so
         // the first real score wins; each partition publishes its local k-th
         // and prunes against the running global k-th (a lower bound on the true
-        // global k-th — see `Wand::shared_threshold`).
-        let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+        // global k-th - see `Wand::shared_threshold`).
+        let impact_shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+        let legacy_shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
         let parts = self
             .partitions
             .iter()
@@ -959,19 +966,23 @@ impl InvertedIndex {
                 let params = params.clone();
                 let mask = mask.clone();
                 let metrics = metrics.clone();
-                let shared_threshold = shared_threshold.clone();
+                let impact_scorer = impact_scorer.clone();
+                let impact_shared_threshold = impact_shared_threshold.clone();
+                let legacy_shared_threshold = legacy_shared_threshold.clone();
                 async move {
                     let loaded_postings = part
                         .load_posting_lists(
                             tokens.as_ref(),
                             params.as_ref(),
                             operator,
+                            Some(impact_scorer.as_ref()),
                             metrics.as_ref(),
                         )
                         .await?;
                     let LoadedPostings {
                         postings,
                         grouped_expansions,
+                        impact_safe,
                     } = loaded_postings;
                     if postings.is_empty() {
                         // No hits in this partition; its DocSet stays
@@ -995,6 +1006,7 @@ impl InvertedIndex {
                     let metrics = metrics.clone();
                     let part_for_wand = part.clone();
                     let has_grouped_expansions = !grouped_expansions.is_empty();
+                    let use_impact_path = impact_safe && !has_grouped_expansions;
                     let wand_params = if has_grouped_expansions {
                         let mut rescoring_params = params.as_ref().clone();
                         rescoring_params.limit =
@@ -1005,9 +1017,12 @@ impl InvertedIndex {
                     };
                     let partition_threshold = if has_grouped_expansions {
                         Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()))
+                    } else if use_impact_path {
+                        impact_shared_threshold
                     } else {
-                        shared_threshold
+                        legacy_shared_threshold
                     };
+                    let wand_scorer = use_impact_path.then(|| impact_scorer.clone());
                     let candidates = spawn_cpu(move || {
                         let candidates = part_for_wand.bm25_search(
                             docs_for_wand.as_ref(),
@@ -1015,6 +1030,7 @@ impl InvertedIndex {
                             operator,
                             mask,
                             postings,
+                            wand_scorer,
                             metrics.as_ref(),
                             partition_threshold,
                         )?;
@@ -1943,6 +1959,7 @@ impl InvertedPartition {
         tokens: &Tokens,
         params: &FtsSearchParams,
         operator: Operator,
+        impact_scorer: Option<&MemBM25Scorer>,
         metrics: &dyn MetricsCollector,
     ) -> Result<LoadedPostings> {
         let is_fuzzy = matches!(params.fuzziness, Some(n) if n != 0);
@@ -2021,11 +2038,18 @@ impl InvertedPartition {
         }
 
         if !is_fuzzy_and_query {
+            let impact_safe = impact_scorer.is_some()
+                && loaded_postings
+                    .iter()
+                    .all(|(_, _, _, posting)| posting.has_impacts());
             return Ok(LoadedPostings {
                 postings: loaded_postings
                     .into_iter()
                     .map(|(token_id, token, position, posting)| {
-                        let query_weight = idf(posting.len(), num_docs);
+                        let query_weight = impact_scorer
+                            .filter(|_| impact_safe)
+                            .map(|scorer| scorer.query_weight(&token))
+                            .unwrap_or_else(|| idf(posting.len(), num_docs));
                         PostingIterator::with_query_weight(
                             token,
                             token_id,
@@ -2037,6 +2061,7 @@ impl InvertedPartition {
                     })
                     .collect(),
                 grouped_expansions: Vec::new(),
+                impact_safe,
             });
         }
 
@@ -2104,6 +2129,7 @@ impl InvertedPartition {
         Ok(LoadedPostings {
             postings: grouped_postings,
             grouped_expansions,
+            impact_safe: false,
         })
     }
 
@@ -2119,6 +2145,7 @@ impl InvertedPartition {
         operator: Operator,
         mask: Arc<RowAddrMask>,
         postings: Vec<PostingIterator>,
+        impact_scorer: Option<Arc<MemBM25Scorer>>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
     ) -> Result<Vec<DocCandidate>> {
@@ -2129,10 +2156,16 @@ impl InvertedPartition {
         // Caller selects the DocSet shape via `LazyDocSet::docs_for_wand`
         // and passes it in here; wand uses `docs.has_row_ids()` to
         // handle the num_tokens-only case.
-        let scorer = IndexBM25Scorer::new(std::iter::once(self));
-        let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
-            .with_shared_threshold(shared_threshold);
-        let hits = wand.search(params, mask, metrics)?;
+        let hits = if let Some(scorer) = impact_scorer {
+            let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
+                .with_shared_threshold(shared_threshold);
+            wand.search(params, mask, metrics)?
+        } else {
+            let scorer = IndexBM25Scorer::new(std::iter::once(self));
+            let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
+                .with_shared_threshold(shared_threshold);
+            wand.search(params, mask, metrics)?
+        };
         Ok(hits)
     }
 
@@ -2551,6 +2584,7 @@ pub struct PostingListReader {
     metadata: PostingMetadata,
 
     has_position: bool,
+    has_impacts: bool,
     posting_tail_codec: PostingTailCodec,
     block_size: usize,
     positions_layout: PositionsLayout,
@@ -2652,6 +2686,7 @@ impl PostingListReader {
         let posting_tail_codec = parse_posting_tail_codec(&reader.schema().metadata)?;
         let block_size = parse_posting_block_size(&reader.schema().metadata)?;
         let has_position = positions_layout != PositionsLayout::None;
+        let has_impacts = reader.schema().field(IMPACT_COL).is_some();
         let metadata = if reader.schema().field(POSTING_COL).is_none() {
             let (offsets, max_scores) = Self::load_metadata(reader.schema())?;
             PostingMetadata::LegacyV1 {
@@ -2671,6 +2706,7 @@ impl PostingListReader {
             reader,
             metadata,
             has_position,
+            has_impacts,
             posting_tail_codec,
             block_size,
             positions_layout,
@@ -2850,7 +2886,7 @@ impl PostingListReader {
             self.posting_batch_legacy(token_id, with_position).await
         } else {
             let token_id = token_id as usize;
-            let columns = if with_position {
+            let mut columns = if with_position {
                 match self.positions_layout {
                     PositionsLayout::SharedStream(_) => {
                         vec![
@@ -2865,6 +2901,9 @@ impl PostingListReader {
             } else {
                 vec![POSTING_COL]
             };
+            if self.has_impacts {
+                columns.push(IMPACT_COL);
+            }
             let batch = self
                 .reader
                 .read_range(token_id..token_id + 1, Some(&columns))
@@ -2909,11 +2948,14 @@ impl PostingListReader {
             Some((start, end)) => {
                 let group = self
                     .index_cache
-                    .get_or_insert_with_key(PostingListGroupKey { start, end }, || async move {
-                        metrics.record_part_load();
-                        info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_SCALAR_PART, index_type="inverted", part_id=start);
-                        self.load_posting_list_group(start, end).await
-                    })
+                    .get_or_insert_with_key(
+                        posting_list_group_cache_key(start, end, self.has_impacts),
+                        || async move {
+                            metrics.record_part_load();
+                            info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_SCALAR_PART, index_type="inverted", part_id=start);
+                            self.load_posting_list_group(start, end).await
+                        },
+                    )
                     .await?;
                 let (max_score, length) = if group.needs_external_metadata() {
                     self.posting_metadata_for_token(token_id).await?
@@ -2933,19 +2975,22 @@ impl PostingListReader {
             // entry per token.
             None => self
                 .index_cache
-                .get_or_insert_with_key(PostingListKey { token_id }, || async move {
-                    metrics.record_part_load();
-                    info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_SCALAR_PART, index_type="inverted", part_id=token_id);
-                    // Fetch the posting batch and this token's (max_score,
-                    // length) in parallel; for cold v2 partitions this is one
-                    // single-row metadata read plus one posting-row read,
-                    // instead of pulling the full per-token metadata table.
-                    let (batch, (max_score, length)) = futures::try_join!(
-                        self.posting_batch(token_id, false),
-                        self.posting_metadata_for_token(token_id),
-                    )?;
-                    self.posting_list_from_batch(&batch, max_score, length)
-                })
+                .get_or_insert_with_key(
+                    posting_list_cache_key(token_id, self.has_impacts),
+                    || async move {
+                        metrics.record_part_load();
+                        info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_SCALAR_PART, index_type="inverted", part_id=token_id);
+                        // Fetch the posting batch and this token's (max_score,
+                        // length) in parallel; for cold v2 partitions this is one
+                        // single-row metadata read plus one posting-row read,
+                        // instead of pulling the full per-token metadata table.
+                        let (batch, (max_score, length)) = futures::try_join!(
+                            self.posting_batch(token_id, false),
+                            self.posting_metadata_for_token(token_id),
+                        )?;
+                        self.posting_list_from_batch(&batch, max_score, length)
+                    },
+                )
                 .await?
                 .as_ref()
                 .clone(),
@@ -2972,12 +3017,13 @@ impl PostingListReader {
     /// Positions are excluded; phrase queries load them on demand via
     /// [`Self::read_positions`].
     async fn load_posting_list_group(&self, start: u32, end: u32) -> Result<PostingListGroup> {
+        let mut columns = vec![POSTING_COL, MAX_SCORE_COL, LENGTH_COL];
+        if self.has_impacts {
+            columns.push(IMPACT_COL);
+        }
         let batch = self
             .reader
-            .read_range(
-                start as usize..end as usize,
-                Some(&[POSTING_COL, MAX_SCORE_COL, LENGTH_COL]),
-            )
+            .read_range(start as usize..end as usize, Some(&columns))
             .await?;
         PostingListGroup::new_packed_with_block_size(
             batch.shrink_to_fit()?,
@@ -3146,7 +3192,7 @@ impl PostingListReader {
                         for (start, end, group) in groups {
                             self.index_cache
                                 .insert_with_key(
-                                    &PostingListGroupKey { start, end },
+                                    &posting_list_group_cache_key(start, end, self.has_impacts),
                                     Arc::new(group),
                                 )
                                 .await;
@@ -3345,7 +3391,10 @@ impl PostingListReader {
                     self.cache_positions(&mut posting_list, token_id, with_position)
                         .await;
                     self.index_cache
-                        .insert_with_key(&PostingListKey { token_id }, Arc::new(posting_list))
+                        .insert_with_key(
+                            &posting_list_cache_key(token_id, self.has_impacts),
+                            Arc::new(posting_list),
+                        )
                         .await;
                 }
             }
@@ -3366,7 +3415,10 @@ impl PostingListReader {
                     let hi = end as usize - tok_start;
                     let group = PostingListGroup::new(chunk_postings[lo..hi].to_vec());
                     self.index_cache
-                        .insert_with_key(&PostingListGroupKey { start, end }, Arc::new(group))
+                        .insert_with_key(
+                            &posting_list_group_cache_key(start, end, self.has_impacts),
+                            Arc::new(group),
+                        )
                         .await;
                 }
             }
@@ -3536,6 +3588,9 @@ impl PostingListReader {
                 }
             }
         }
+        if self.has_impacts {
+            base_columns.push(IMPACT_COL);
+        }
         base_columns
     }
 }
@@ -3676,6 +3731,52 @@ impl CacheKey for PostingListGroupKey {
     }
 }
 
+/// Internal cache-key decorator that isolates impact-bearing posting values
+/// without changing the source-compatible public posting key structs.
+#[derive(Debug, Clone)]
+struct ImpactAwareCacheKey<K> {
+    inner: K,
+    has_impacts: bool,
+}
+
+impl<K: CacheKey> CacheKey for ImpactAwareCacheKey<K> {
+    type ValueType = K::ValueType;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        if self.has_impacts {
+            format!("{}-impacts", self.inner.key()).into()
+        } else {
+            self.inner.key()
+        }
+    }
+
+    fn type_name() -> &'static str {
+        K::type_name()
+    }
+
+    fn codec() -> Option<CacheCodec> {
+        K::codec()
+    }
+}
+
+fn posting_list_cache_key(token_id: u32, has_impacts: bool) -> ImpactAwareCacheKey<PostingListKey> {
+    ImpactAwareCacheKey {
+        inner: PostingListKey { token_id },
+        has_impacts,
+    }
+}
+
+fn posting_list_group_cache_key(
+    start: u32,
+    end: u32,
+    has_impacts: bool,
+) -> ImpactAwareCacheKey<PostingListGroupKey> {
+    ImpactAwareCacheKey {
+        inner: PostingListGroupKey { start, end },
+        has_impacts,
+    }
+}
+
 #[derive(Debug, Clone, DeepSizeOf)]
 struct PostingMetadataValue {
     max_score: f32,
@@ -3812,6 +3913,10 @@ pub(super) struct PackedPostingListGroup {
     pub(super) batch: RecordBatch,
     pub(super) posting_tail_codec: PostingTailCodec,
     pub(super) block_size: usize,
+    first_docs_states: Arc<[OnceLock<Box<[u32]>>]>,
+    first_docs_state_capacity_bytes: usize,
+    impact_states: Option<Arc<[OnceLock<Box<ImpactSkipData>>]>>,
+    impact_state_capacity_bytes: usize,
 }
 
 impl DeepSizeOf for PostingListGroup {
@@ -3822,7 +3927,9 @@ impl DeepSizeOf for PostingListGroup {
                 .columns()
                 .iter()
                 .map(|column| sliced_cache_bytes(column.as_ref()))
-                .sum(),
+                .sum::<usize>()
+                .saturating_add(group.first_docs_state_capacity_bytes)
+                .saturating_add(group.impact_state_capacity_bytes),
             PostingListGroupStorage::Materialized(posting_lists) => {
                 posting_lists.deep_size_of_children(context)
             }
@@ -3893,6 +4000,80 @@ impl PostingListGroup {
                 "packed posting group column must not contain nulls".to_string(),
             ));
         }
+        let total_posting_blocks = (0..batch.num_rows())
+            .map(|slot| postings.value_length(slot) as usize)
+            .sum::<usize>();
+        let first_docs_states: Arc<[OnceLock<Box<[u32]>>]> = (0..batch.num_rows())
+            .map(|_| OnceLock::new())
+            .collect::<Vec<_>>()
+            .into();
+        // Reserve the compact per-slot state slab and the block-head arrays it
+        // can lazily retain, so warming these derived values cannot grow the
+        // cache beyond its admission charge.
+        let first_docs_state_capacity_bytes = first_docs_states
+            .len()
+            .saturating_mul(std::mem::size_of::<OnceLock<Box<[u32]>>>())
+            .saturating_add(total_posting_blocks.saturating_mul(std::mem::size_of::<u32>()));
+        let (impact_states, impact_state_capacity_bytes) = if let Some(impacts) =
+            batch.column_by_name(IMPACT_COL)
+        {
+            let impacts = impacts.as_list_opt::<i32>().ok_or_else(|| {
+                Error::index(format!(
+                    "packed posting group column {IMPACT_COL} must be List<LargeBinary>"
+                ))
+            })?;
+            if impacts.values().data_type() != &DataType::LargeBinary {
+                return Err(Error::index(format!(
+                    "packed posting group column {IMPACT_COL} must contain LargeBinary values, got {}",
+                    impacts.values().data_type()
+                )));
+            }
+            if impacts.null_count() != 0 {
+                return Err(Error::index(format!(
+                    "packed posting group column {IMPACT_COL} must not contain nulls"
+                )));
+            }
+            let mut total_impact_entries = 0usize;
+            for slot in 0..batch.num_rows() {
+                let posting_blocks = postings.value_length(slot) as usize;
+                let impact_entries = impacts.value_length(slot) as usize;
+                let expected_impact_entries =
+                    posting_blocks.saturating_add(posting_blocks.div_ceil(IMPACT_LEVEL1_BLOCKS));
+                if impact_entries != expected_impact_entries {
+                    return Err(Error::index(format!(
+                        "packed posting group impact slot {slot} has {impact_entries} entries, expected {expected_impact_entries} for {posting_blocks} posting blocks"
+                    )));
+                }
+                total_impact_entries = total_impact_entries.saturating_add(impact_entries);
+            }
+
+            let states: Arc<[OnceLock<Box<ImpactSkipData>>]> = (0..batch.num_rows())
+                .map(|_| OnceLock::new())
+                .collect::<Vec<_>>()
+                .into();
+            // Account up front for every allocation that the lazy states can
+            // eventually retain. The impact entry bytes themselves remain in
+            // `batch` and are already charged exactly once above.
+            // `ImpactSkipData` owns one mutex-backed keyed-bounds slot. Use a
+            // deliberately wider Arc payload here as a conservative stand-in
+            // for that private allocation, plus the bounds slab metadata.
+            let keyed_bounds_metadata_bytes =
+                std::mem::size_of::<std::sync::Mutex<Option<(u64, Arc<[f32]>)>>>()
+                    .saturating_add(std::mem::size_of::<(Box<[f32]>, f32)>());
+            let per_slot_bytes = std::mem::size_of::<OnceLock<Box<ImpactSkipData>>>()
+                .saturating_add(std::mem::size_of::<ImpactSkipData>())
+                .saturating_add(keyed_bounds_metadata_bytes)
+                .saturating_add(std::mem::size_of::<f32>());
+            let per_entry_bytes =
+                std::mem::size_of::<u32>().saturating_add(std::mem::size_of::<f32>());
+            let capacity_bytes = states
+                .len()
+                .saturating_mul(per_slot_bytes)
+                .saturating_add(total_impact_entries.saturating_mul(per_entry_bytes));
+            (Some(states), capacity_bytes)
+        } else {
+            (None, 0)
+        };
         match (
             batch.column_by_name(MAX_SCORE_COL),
             batch.column_by_name(LENGTH_COL),
@@ -3929,6 +4110,10 @@ impl PostingListGroup {
                 batch,
                 posting_tail_codec,
                 block_size,
+                first_docs_states,
+                first_docs_state_capacity_bytes,
+                impact_states,
+                impact_state_capacity_bytes,
             }),
         })
     }
@@ -4004,20 +4189,65 @@ impl PostingListGroup {
                         Error::index("packed posting group requires length metadata".to_string())
                     })?,
                 };
-                Ok(Some(PostingList::Compressed(CompressedPostingList::new(
-                    blocks.clone(),
-                    max_score,
-                    length,
-                    group.posting_tail_codec,
-                    group.block_size,
-                    None,
-                ))))
+                let impacts = match (
+                    group.impact_states.as_ref(),
+                    group.batch.column_by_name(IMPACT_COL),
+                ) {
+                    (Some(states), Some(column)) => {
+                        let state = states.get(slot).ok_or_else(|| {
+                            Error::index(format!(
+                                "packed posting group impact state missing slot {slot}"
+                            ))
+                        })?;
+                        let impact_lists = column.as_list_opt::<i32>().ok_or_else(|| {
+                            Error::index(format!(
+                                "packed posting group column {IMPACT_COL} must be List<LargeBinary>"
+                            ))
+                        })?;
+                        let entries = impact_lists.value(slot);
+                        let entries = entries.as_binary_opt::<i64>().ok_or_else(|| {
+                            Error::index(format!(
+                                "packed posting group impact slot {slot} is not LargeBinary"
+                            ))
+                        })?;
+                        let impacts = state.get_or_init(|| {
+                            Box::new(
+                                ImpactSkipData::new(
+                                    entries.clone(),
+                                    blocks.len(),
+                                    super::impact::ImpactFormat::for_block_size(group.block_size),
+                                )
+                                .expect("packed impact entry count was validated at construction"),
+                            )
+                        });
+                        Some(impacts.as_ref().clone())
+                    }
+                    (None, None) => None,
+                    _ => {
+                        return Err(Error::internal(
+                            "packed posting group impact column/state mismatch".to_string(),
+                        ));
+                    }
+                };
+                Ok(Some(PostingList::Compressed(
+                    CompressedPostingList::new(
+                        blocks.clone(),
+                        max_score,
+                        length,
+                        group.posting_tail_codec,
+                        group.block_size,
+                        None,
+                        impacts,
+                    )
+                    .with_packed_first_docs(group.first_docs_states.clone(), slot),
+                )))
             }
         }
     }
 }
 
 #[derive(Debug, Clone, DeepSizeOf)]
+#[allow(clippy::large_enum_variant)]
 pub enum PostingList {
     Plain(PlainPostingList),
     Compressed(CompressedPostingList),
@@ -4082,7 +4312,7 @@ impl PostingList {
                     posting_tail_codec,
                     block_size,
                     shared_position_codec,
-                );
+                )?;
                 Ok(Self::Compressed(posting))
             }
             None => {
@@ -4100,6 +4330,13 @@ impl PostingList {
         match self {
             Self::Plain(posting) => posting.positions.is_some(),
             Self::Compressed(posting) => posting.positions.is_some(),
+        }
+    }
+
+    pub fn has_impacts(&self) -> bool {
+        match self {
+            Self::Plain(_) => false,
+            Self::Compressed(posting) => posting.impacts.is_some(),
         }
     }
 
@@ -4313,6 +4550,50 @@ impl PlainPostingList {
 }
 
 #[derive(Debug, Clone)]
+enum FirstDocsState {
+    Standalone(Arc<OnceLock<Box<[u32]>>>),
+    Packed {
+        states: Arc<[OnceLock<Box<[u32]>>]>,
+        slot: usize,
+    },
+}
+
+impl FirstDocsState {
+    fn standalone() -> Self {
+        Self::Standalone(Arc::new(OnceLock::new()))
+    }
+
+    fn state(&self) -> &OnceLock<Box<[u32]>> {
+        match self {
+            Self::Standalone(state) => state,
+            Self::Packed { states, slot } => &states[*slot],
+        }
+    }
+
+    fn get_or_init(&self, initialize: impl FnOnce() -> Box<[u32]>) -> &[u32] {
+        self.state().get_or_init(initialize)
+    }
+
+    fn capacity_bytes(
+        &self,
+        block_count: usize,
+        context: &mut lance_core::deepsize::Context,
+    ) -> usize {
+        if context.mark_seen(self.state() as *const _ as usize) {
+            std::mem::size_of::<OnceLock<Box<[u32]>>>()
+                .saturating_add(block_count.saturating_mul(std::mem::size_of::<u32>()))
+        } else {
+            0
+        }
+    }
+
+    #[cfg(test)]
+    fn shares_state_with(&self, other: &Self) -> bool {
+        std::ptr::eq(self.state(), other.state())
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct CompressedPostingList {
     pub max_score: f32,
     pub length: u32,
@@ -4323,9 +4604,10 @@ pub struct CompressedPostingList {
     pub posting_tail_codec: PostingTailCodec,
     pub block_size: usize,
     pub positions: Option<CompressedPositionStorage>,
+    pub(crate) impacts: Option<ImpactSkipData>,
     // First doc id per block, baked lazily and shared across per-query clones
     // of the cached list. See `block_first_docs`.
-    first_docs: Arc<OnceLock<Box<[u32]>>>,
+    first_docs: FirstDocsState,
 }
 
 impl PartialEq for CompressedPostingList {
@@ -4336,6 +4618,7 @@ impl PartialEq for CompressedPostingList {
             && self.posting_tail_codec == other.posting_tail_codec
             && self.block_size == other.block_size
             && self.positions == other.positions
+            && self.impacts == other.impacts
     }
 }
 
@@ -4347,17 +4630,27 @@ impl DeepSizeOf for CompressedPostingList {
                 .as_ref()
                 .map(|positions| positions.deep_size_of_children(context))
                 .unwrap_or(0)
+            + self
+                .impacts
+                .as_ref()
+                .map(|impacts| {
+                    sliced_cache_bytes(impacts.entries())
+                        .saturating_add(impacts.derived_cache_bytes())
+                })
+                .unwrap_or(0)
+            + self.first_docs.capacity_bytes(self.blocks.len(), context)
     }
 }
 
 impl CompressedPostingList {
-    pub fn new(
+    pub(crate) fn new(
         blocks: LargeBinaryArray,
         max_score: f32,
         length: u32,
         posting_tail_codec: PostingTailCodec,
         block_size: usize,
         positions: Option<CompressedPositionStorage>,
+        impacts: Option<ImpactSkipData>,
     ) -> Self {
         debug_assert!(block_size.is_power_of_two());
         Self {
@@ -4367,8 +4660,15 @@ impl CompressedPostingList {
             posting_tail_codec,
             block_size,
             positions,
-            first_docs: Arc::new(OnceLock::new()),
+            impacts,
+            first_docs: FirstDocsState::standalone(),
         }
+    }
+
+    fn with_packed_first_docs(mut self, states: Arc<[OnceLock<Box<[u32]>>]>, slot: usize) -> Self {
+        debug_assert!(slot < states.len());
+        self.first_docs = FirstDocsState::Packed { states, slot };
+        self
     }
 
     /// Block sizes are validated powers of two, so per-doc hot loops derive
@@ -4391,7 +4691,7 @@ impl CompressedPostingList {
         posting_tail_codec: PostingTailCodec,
         block_size: usize,
         shared_position_codec: Option<PositionStreamCodec>,
-    ) -> Self {
+    ) -> Result<Self> {
         debug_assert_eq!(batch.num_rows(), 1);
         let blocks = batch[POSTING_COL]
             .as_list::<i32>()
@@ -4420,16 +4720,28 @@ impl CompressedPostingList {
                 )
             })
         };
+        let impacts = batch
+            .column_by_name(IMPACT_COL)
+            .map(|col| {
+                let entries = col.as_list::<i32>().value(0).as_binary::<i64>().clone();
+                ImpactSkipData::new(
+                    entries,
+                    blocks.len(),
+                    super::impact::ImpactFormat::for_block_size(block_size),
+                )
+            })
+            .transpose()?;
 
-        Self {
+        Ok(Self {
             max_score,
             length,
             blocks,
             posting_tail_codec,
             block_size,
             positions,
-            first_docs: Arc::new(OnceLock::new()),
-        }
+            impacts,
+            first_docs: FirstDocsState::standalone(),
+        })
     }
 
     pub fn iter(&self) -> CompressedPostingListIterator {
@@ -4481,8 +4793,14 @@ impl CompressedPostingList {
                         .map(u32::from_le_bytes)
                         .unwrap()
                 })
-                .collect()
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
         })
+    }
+
+    #[cfg(test)]
+    fn shares_first_docs_with(&self, other: &Self) -> bool {
+        self.first_docs.shares_state_with(&other.first_docs)
     }
 }
 
@@ -4617,6 +4935,7 @@ pub struct PostingListBuilder {
 pub(super) struct PostingListBatchBuilder {
     schema: SchemaRef,
     postings: ListBuilder<LargeBinaryBuilder>,
+    impacts: Option<ListBuilder<LargeBinaryBuilder>>,
     max_scores: Float32Builder,
     lengths: UInt32Builder,
     positions: BatchPositionsBuilder,
@@ -4663,9 +4982,14 @@ impl PostingListBatchBuilder {
                 capacity,
             ))
         };
+        let impacts = schema
+            .field_with_name(IMPACT_COL)
+            .ok()
+            .map(|_| ListBuilder::with_capacity(LargeBinaryBuilder::new(), capacity));
         Self {
             schema,
             postings: ListBuilder::with_capacity(LargeBinaryBuilder::new(), capacity),
+            impacts,
             max_scores: Float32Builder::with_capacity(capacity),
             lengths: UInt32Builder::with_capacity(capacity),
             positions,
@@ -4684,6 +5008,7 @@ impl PostingListBatchBuilder {
     fn append(
         &mut self,
         compressed: LargeBinaryArray,
+        impacts: Option<&ImpactSkipData>,
         max_score: f32,
         length: u32,
         positions: Option<&CompressedPositionStorage>,
@@ -4695,6 +5020,19 @@ impl PostingListBatchBuilder {
             }
         }
         self.postings.append(true);
+        if let Some(impacts_builder) = &mut self.impacts {
+            let impacts = impacts.ok_or_else(|| {
+                Error::index(format!(
+                    "impacts builder missing impact data for posting length {}",
+                    length
+                ))
+            })?;
+            let values = impacts_builder.values();
+            for index in 0..impacts.entries().len() {
+                values.append_value(impacts.entries().value(index));
+            }
+            impacts_builder.append(true);
+        }
         self.max_scores.append_value(max_score);
         self.lengths.append_value(length);
 
@@ -4759,6 +5097,9 @@ impl PostingListBatchBuilder {
             Arc::new(self.max_scores.finish()) as ArrayRef,
             Arc::new(self.lengths.finish()) as ArrayRef,
         ];
+        if let Some(impacts) = &mut self.impacts {
+            columns.push(Arc::new(impacts.finish()) as ArrayRef);
+        }
         match &mut self.positions {
             BatchPositionsBuilder::None => {}
             BatchPositionsBuilder::Legacy(position_lists) => {
@@ -5169,6 +5510,7 @@ impl PostingListBuilder {
     fn build_batch(
         self,
         compressed: LargeBinaryArray,
+        impacts: Option<ImpactSkipData>,
         max_score: f32,
         schema: SchemaRef,
         positions: Option<CompressedPositionStorage>,
@@ -5187,6 +5529,22 @@ impl PostingListBuilder {
                 length as u32,
             ))) as ArrayRef,
         ];
+        if schema.field_with_name(IMPACT_COL).is_ok() {
+            let impacts = impacts.ok_or_else(|| {
+                Error::index(format!(
+                    "impact column requested without impact data for posting length {}",
+                    length
+                ))
+            })?;
+            let impact_offsets =
+                OffsetBuffer::new(ScalarBuffer::from(vec![0, impacts.entries().len() as i32]));
+            columns.push(Arc::new(ListArray::try_new(
+                Arc::new(Field::new("item", datatypes::DataType::LargeBinary, true)),
+                impact_offsets,
+                Arc::new(impacts.entries().clone()),
+                None,
+            )?) as ArrayRef);
+        }
         columns.extend(Self::build_position_columns(positions)?);
 
         let batch = RecordBatch::try_new(schema, columns)?;
@@ -5257,13 +5615,19 @@ impl PostingListBuilder {
             tail_entries: tail_entries.as_slice(),
             tail_position_block: with_positions.then(|| tail_positions.finish()),
         };
-        let (compressed, shared_positions, max_score) =
+        let (compressed, shared_positions, max_score, impacts) =
             Self::build_compressed_with_scores_from_parts(parts, docs)?;
         let positions = match legacy_positions {
             Some(positions) => Some(CompressedPositionStorage::LegacyPerDoc(positions)),
             None => shared_positions.map(CompressedPositionStorage::SharedStream),
         };
-        batch_builder.append(compressed, max_score, len, positions.as_ref())
+        batch_builder.append(
+            compressed,
+            Some(&impacts),
+            max_score,
+            len,
+            positions.as_ref(),
+        )
     }
 
     fn extend_tail_components(
@@ -5280,7 +5644,12 @@ impl PostingListBuilder {
     fn build_compressed_with_scores_from_parts(
         parts: PostingListParts<'_>,
         docs: &DocSet,
-    ) -> Result<(LargeBinaryArray, Option<SharedPositionStream>, f32)> {
+    ) -> Result<(
+        LargeBinaryArray,
+        Option<SharedPositionStream>,
+        f32,
+        ImpactSkipData,
+    )> {
         let PostingListParts {
             with_positions,
             posting_tail_codec,
@@ -5296,6 +5665,9 @@ impl PostingListBuilder {
         let mut max_score = f32::MIN;
         let mut doc_ids = Vec::with_capacity(block_size);
         let mut frequencies = Vec::with_capacity(block_size);
+        let mut impact_block = Vec::with_capacity(block_size);
+        let mut impact_builder =
+            ImpactSkipDataBuilder::with_capacity(length.div_ceil(block_size), block_size);
 
         for index in 0..encoded_blocks.len() {
             let block = encoded_blocks.block(index);
@@ -5307,13 +5679,15 @@ impl PostingListBuilder {
                 &mut frequencies,
                 block_size,
             );
-            let block_score = compute_block_score(
+            let block_score = compute_block_score_and_impact_block(
                 docs,
                 avgdl,
                 idf_scale,
                 doc_ids.iter().copied(),
                 frequencies.iter().copied(),
+                &mut impact_block,
             );
+            impact_builder.append_block(impact_block.as_slice())?;
             max_score = max_score.max(block_score);
             if super::encoding::posting_block_score_prefix_len(block_size) > 0 {
                 encoded_blocks.set_block_score(index, block_score);
@@ -5322,13 +5696,15 @@ impl PostingListBuilder {
 
         if !tail_entries.is_empty() {
             Self::extend_tail_components(tail_entries, &mut doc_ids, &mut frequencies);
-            let block_score = compute_block_score(
+            let block_score = compute_block_score_and_impact_block(
                 docs,
                 avgdl,
                 idf_scale,
                 doc_ids.iter().copied(),
                 frequencies.iter().copied(),
+                &mut impact_block,
             );
+            impact_builder.append_block(impact_block.as_slice())?;
             max_score = max_score.max(block_score);
             encoded_blocks.append_remainder_block_with_codec(
                 doc_ids.as_slice(),
@@ -5348,10 +5724,12 @@ impl PostingListBuilder {
             }
         }
 
+        let impacts = impact_builder.finish()?;
         Ok((
             encoded_blocks.into_array(),
             with_positions.then(|| encoded_position_blocks.into_stream()),
             max_score,
+            impacts,
         ))
     }
 
@@ -5417,10 +5795,11 @@ impl PostingListBuilder {
             self.posting_tail_codec,
             self.block_size,
         )?;
-        let schema = inverted_list_schema_for_version_with_block_size(
+        let schema = inverted_list_schema_for_version_with_block_size_and_impacts(
             self.has_positions(),
             format_version,
             self.block_size,
+            false,
         );
         let legacy_positions =
             if self.with_positions && !format_version.uses_shared_position_stream() {
@@ -5478,7 +5857,7 @@ impl PostingListBuilder {
             Some(positions) => Some(CompressedPositionStorage::LegacyPerDoc(positions)),
             None => shared_positions.map(CompressedPositionStorage::SharedStream),
         };
-        builder.build_batch(compressed, max_score, schema, positions)
+        builder.build_batch(compressed, None, max_score, schema, positions)
     }
 
     pub fn to_batch_with_docs(self, docs: &DocSet, schema: SchemaRef) -> Result<RecordBatch> {
@@ -5520,7 +5899,7 @@ impl PostingListBuilder {
             tail_entries: tail_entries.as_slice(),
             tail_position_block: with_positions.then(|| tail_positions.finish()),
         };
-        let (compressed, shared_positions, max_score) =
+        let (compressed, shared_positions, max_score, impacts) =
             Self::build_compressed_with_scores_from_parts(parts, docs)?;
         let builder = Self {
             with_positions,
@@ -5540,7 +5919,7 @@ impl PostingListBuilder {
             Some(positions) => Some(CompressedPositionStorage::LegacyPerDoc(positions)),
             None => shared_positions.map(CompressedPositionStorage::SharedStream),
         };
-        builder.build_batch(compressed, max_score, schema, positions)
+        builder.build_batch(compressed, Some(impacts), max_score, schema, positions)
     }
 
     pub fn remap(&mut self, removed: &[u32]) {
@@ -5568,19 +5947,23 @@ impl PostingListBuilder {
     }
 }
 
-fn compute_block_score(
+fn compute_block_score_and_impact_block(
     docs: &DocSet,
     avgdl: f32,
     idf_scale: f32,
     doc_ids: impl Iterator<Item = u32>,
     frequencies: impl Iterator<Item = u32>,
+    impact_block: &mut Vec<(u32, u32, u32)>,
 ) -> f32 {
+    impact_block.clear();
     let mut block_max_score = f32::MIN;
     for (doc_id, freq) in doc_ids.zip(frequencies) {
-        let doc_norm = K1 * (1.0 - B + B * docs.num_tokens(doc_id) as f32 / avgdl);
-        let freq = freq as f32;
-        let score = freq / (freq + doc_norm);
+        let doc_len = docs.num_tokens(doc_id);
+        let doc_norm = K1 * (1.0 - B + B * doc_len as f32 / avgdl);
+        let freq_f32 = freq as f32;
+        let score = freq_f32 / (freq_f32 + doc_norm);
         block_max_score = block_max_score.max(score);
+        impact_block.push((doc_id, freq, doc_len));
     }
     block_max_score * idf_scale
 }
@@ -6670,7 +7053,10 @@ mod tests {
     use crate::prefilter::NoFilter;
     use crate::scalar::ScalarIndex;
     use crate::scalar::inverted::builder::{
-        InnerBuilder, InvertedIndexBuilder, PositionRecorder, inverted_list_schema,
+        InnerBuilder, InvertedIndexBuilder, PositionRecorder, doc_file_path, inverted_list_schema,
+        inverted_list_schema_for_version_with_block_size,
+        inverted_list_schema_for_version_with_block_size_and_impacts, posting_file_path,
+        token_file_path,
     };
     use crate::scalar::inverted::encoding::{
         compress_positions, compress_posting_list_with_tail_codec,
@@ -6773,6 +7159,57 @@ mod tests {
         assert!(err.to_string().contains("block_size"));
     }
 
+    #[test]
+    fn test_posting_builder_writes_impacts_for_supported_block_sizes() {
+        for block_size in [128, 256] {
+            let format_version = default_fts_format_version_for_block_size(block_size).unwrap();
+            let num_docs = block_size * 33 + 1;
+            let mut docs = DocSet::default();
+            let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                false,
+                format_version.posting_tail_codec(),
+                block_size,
+            );
+            for doc_id in 0..num_docs {
+                docs.append(doc_id as u64, (doc_id % 5 + 1) as u32);
+                posting.add(
+                    doc_id as u32,
+                    PositionRecorder::Count((doc_id % 3 + 1) as u32),
+                );
+            }
+            let schema =
+                inverted_list_schema_for_version_with_block_size(false, format_version, block_size);
+            let batch = posting.to_batch_with_docs(&docs, schema).unwrap();
+            assert!(batch.column_by_name(IMPACT_COL).is_some());
+            let max_score = batch[MAX_SCORE_COL].as_primitive::<Float32Type>().value(0);
+            let length = batch[LENGTH_COL].as_primitive::<UInt32Type>().value(0);
+            let posting = PostingList::from_batch(&batch, Some(max_score), Some(length)).unwrap();
+            let PostingList::Compressed(posting) = posting else {
+                panic!("expected compressed posting list");
+            };
+            let impacts = posting.impacts.expect("posting should include impacts");
+            assert_eq!(impacts.level0_len(), posting.blocks.len());
+            assert_eq!(impacts.level1_len(), posting.blocks.len().div_ceil(32));
+            assert_eq!(
+                impacts.entries().len(),
+                impacts.level0_len() + impacts.level1_len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_posting_builder_without_impact_column_roundtrips_without_impacts() {
+        let mut posting = PostingListBuilder::new(false);
+        for doc_id in 0..BLOCK_SIZE + 3 {
+            posting.add(doc_id as u32, PositionRecorder::Count(1));
+        }
+        let batch = posting.to_batch(vec![1.0, 1.0]).unwrap();
+        assert!(batch.column_by_name(IMPACT_COL).is_none());
+        let posting =
+            PostingList::from_batch(&batch, Some(1.0), Some((BLOCK_SIZE + 3) as u32)).unwrap();
+        assert!(!posting.has_impacts());
+    }
+
     #[tokio::test]
     async fn test_build_search_uses_configured_posting_block_size() {
         let tmpdir = TempObjDir::default();
@@ -6824,6 +7261,16 @@ mod tests {
         };
         assert_eq!(posting.block_size, block_size);
         assert_eq!(posting.blocks.len(), num_docs.div_ceil(block_size));
+        let impacts = posting
+            .impacts
+            .as_ref()
+            .expect("newly written posting list should include impacts");
+        assert_eq!(impacts.level0_len(), posting.blocks.len());
+        assert_eq!(impacts.level1_len(), posting.blocks.len().div_ceil(32));
+        assert_eq!(
+            impacts.entries().len(),
+            impacts.level0_len() + impacts.level1_len()
+        );
 
         let tokens = Arc::new(Tokens::new(vec!["needle".to_owned()], DocType::Text));
         let params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
@@ -7567,6 +8014,10 @@ mod tests {
             !inverted_list.is_legacy_layout(),
             "test should use modern posting layout"
         );
+        assert!(
+            inverted_list.has_impacts,
+            "modern posting fixture should include impact skip data"
+        );
 
         inverted_list.prewarm_posting_lists(false, 2).await.unwrap();
 
@@ -7575,7 +8026,11 @@ mod tests {
         let (start, end) = inverted_list.group_range_for_token(0).unwrap();
         let group = inverted_list
             .index_cache
-            .get_with_key(&PostingListGroupKey { start, end })
+            .get_with_key(&posting_list_group_cache_key(
+                start,
+                end,
+                inverted_list.has_impacts,
+            ))
             .await
             .unwrap();
 
@@ -7595,6 +8050,13 @@ mod tests {
         else {
             panic!("expected compressed posting list for token 0");
         };
+        let PostingList::Compressed(alpha_again) = group
+            .posting_list(0, alpha_score, alpha_len)
+            .unwrap()
+            .unwrap()
+        else {
+            panic!("expected compressed posting list for repeated token 0 access");
+        };
         let (beta_score, beta_len) = inverted_list.bulk_metadata_for_token(1);
         let PostingList::Compressed(beta) = group
             .posting_list(1, beta_score, beta_len)
@@ -7604,6 +8066,27 @@ mod tests {
             panic!("expected compressed posting list for token 1");
         };
 
+        assert!(
+            alpha.impacts.is_some() && beta.impacts.is_some(),
+            "packed prewarm must preserve impact skip data"
+        );
+        assert!(
+            alpha
+                .impacts
+                .as_ref()
+                .unwrap()
+                .shares_derived_state_with(alpha_again.impacts.as_ref().unwrap()),
+            "repeated packed slot access must share decoded impact state"
+        );
+        assert!(
+            alpha.shares_first_docs_with(&alpha_again),
+            "repeated packed slot access must share decoded block heads"
+        );
+        assert_eq!(
+            alpha.block_first_docs().as_ptr(),
+            alpha_again.block_first_docs().as_ptr(),
+            "packed block heads should be decoded only once per slot"
+        );
         assert_eq!(
             alpha.blocks.values().as_ptr(),
             beta.blocks.values().as_ptr(),
@@ -7646,12 +8129,20 @@ mod tests {
 
         let first_group = posting_reader
             .index_cache
-            .get_with_key(&PostingListGroupKey { start: 0, end: 2 })
+            .get_with_key(&posting_list_group_cache_key(
+                0,
+                2,
+                posting_reader.has_impacts,
+            ))
             .await
             .unwrap();
         let second_group = posting_reader
             .index_cache
-            .get_with_key(&PostingListGroupKey { start: 2, end: 4 })
+            .get_with_key(&posting_list_group_cache_key(
+                2,
+                4,
+                posting_reader.has_impacts,
+            ))
             .await
             .unwrap();
         let (first_score, first_len) = posting_reader.bulk_metadata_for_token(0);
@@ -7844,7 +8335,11 @@ mod tests {
             let (start, end) = inverted_list.group_range_for_token(0).unwrap();
             let group = inverted_list
                 .index_cache
-                .get_with_key(&PostingListGroupKey { start, end })
+                .get_with_key(&posting_list_group_cache_key(
+                    start,
+                    end,
+                    inverted_list.has_impacts,
+                ))
                 .await
                 .expect("v3 prewarm should populate the packed group cache");
             assert!(group.is_packed());
@@ -7855,6 +8350,10 @@ mod tests {
                 panic!("expected compressed v3 posting list");
             };
             assert_eq!(posting.block_size, 256);
+            assert!(
+                posting.impacts.is_some(),
+                "v3 packed prewarm must preserve impact skip data"
+            );
         }
 
         // (2) Correctness: every token's posting list round-trips with exactly
@@ -7972,7 +8471,11 @@ mod tests {
             let (start, end) = inverted_list.group_range_for_token(token_id).unwrap();
             let group = inverted_list
                 .index_cache
-                .get_with_key(&PostingListGroupKey { start, end })
+                .get_with_key(&posting_list_group_cache_key(
+                    start,
+                    end,
+                    inverted_list.has_impacts,
+                ))
                 .await
                 .unwrap();
             let slot = (token_id - start) as usize;
@@ -8456,7 +8959,11 @@ mod tests {
         let (start, end) = inverted_list.group_range_for_token(0).unwrap();
         let group = inverted_list
             .index_cache
-            .get_with_key(&PostingListGroupKey { start, end })
+            .get_with_key(&posting_list_group_cache_key(
+                start,
+                end,
+                inverted_list.has_impacts,
+            ))
             .await
             .unwrap();
         assert!(group.is_packed(), "cold v2 group should use packed storage");
@@ -8490,8 +8997,8 @@ mod tests {
         let packed_size = group.deep_size_of();
         let materialized_size = PostingListGroup::new(materialized).deep_size_of();
         assert!(
-            packed_size * 2 < materialized_size,
-            "packed group deep_size_of {packed_size}B should be less than half of the \
+            packed_size * 4 < materialized_size * 3,
+            "packed group deep_size_of {packed_size}B should be at least 25% smaller than the \
              {materialized_size}B materialized graph for {posting_count} postings"
         );
     }
@@ -8548,6 +9055,7 @@ mod tests {
             SLICE_LEN as u32,
             PostingTailCodec::Fixed32,
             LEGACY_BLOCK_SIZE,
+            None,
             None,
         );
 
@@ -8695,7 +9203,11 @@ mod tests {
         let (start, end) = inverted_list.group_range_for_token(0).unwrap();
         let group = inverted_list
             .index_cache
-            .get_with_key(&PostingListGroupKey { start, end })
+            .get_with_key(&posting_list_group_cache_key(
+                start,
+                end,
+                inverted_list.has_impacts,
+            ))
             .await
             .unwrap();
         assert!(
@@ -8945,6 +9457,178 @@ mod tests {
             .await
             .unwrap();
         writer.finish_with_metadata(metadata).await.unwrap();
+    }
+
+    async fn write_test_partition_with_optional_impacts(
+        store: &Arc<LanceIndexStore>,
+        partition_id: u64,
+        mut builder: InnerBuilder,
+        token_set_format: TokenSetFormat,
+        with_impacts: bool,
+    ) {
+        let format_version = InvertedListFormatVersion::V1;
+        let block_size = LEGACY_BLOCK_SIZE;
+        let docs = std::mem::take(&mut builder.docs);
+        let schema = inverted_list_schema_for_version_with_block_size_and_impacts(
+            false,
+            format_version,
+            block_size,
+            with_impacts,
+        );
+
+        let mut posting_writer = store
+            .new_index_file(&posting_file_path(partition_id), schema.clone())
+            .await
+            .unwrap();
+        for posting_list in std::mem::take(&mut builder.posting_lists) {
+            let batch = posting_list
+                .to_batch_with_docs(&docs, schema.clone())
+                .unwrap();
+            posting_writer.write_record_batch(batch).await.unwrap();
+        }
+        posting_writer.finish().await.unwrap();
+
+        let token_batch = std::mem::take(&mut builder.tokens)
+            .to_batch(token_set_format)
+            .unwrap();
+        let mut token_writer = store
+            .new_index_file(&token_file_path(partition_id), token_batch.schema())
+            .await
+            .unwrap();
+        token_writer.write_record_batch(token_batch).await.unwrap();
+        token_writer.finish().await.unwrap();
+
+        let doc_batch = docs.to_batch().unwrap();
+        let mut doc_writer = store
+            .new_index_file(&doc_file_path(partition_id), doc_batch.schema())
+            .await
+            .unwrap();
+        doc_writer.write_record_batch(doc_batch).await.unwrap();
+        doc_writer.finish().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let mut impact_builder = InnerBuilder::new_with_format_version(
+            0,
+            false,
+            TokenSetFormat::default(),
+            InvertedListFormatVersion::V1,
+        );
+        impact_builder.tokens.add("alpha".to_owned());
+        impact_builder
+            .posting_lists
+            .push(PostingListBuilder::new_with_posting_tail_codec(
+                false,
+                InvertedListFormatVersion::V1.posting_tail_codec(),
+            ));
+        impact_builder.posting_lists[0].add(0, PositionRecorder::Count(1));
+        impact_builder.docs.append(100, 5_000);
+        for row_id in 101..111 {
+            impact_builder.docs.append(row_id, 5_000);
+        }
+        write_test_partition_with_optional_impacts(
+            &store,
+            0,
+            impact_builder,
+            TokenSetFormat::default(),
+            true,
+        )
+        .await;
+
+        let mut legacy_builder = InnerBuilder::new_with_format_version(
+            1,
+            false,
+            TokenSetFormat::default(),
+            InvertedListFormatVersion::V1,
+        );
+        legacy_builder.tokens.add("alpha".to_owned());
+        legacy_builder
+            .posting_lists
+            .push(PostingListBuilder::new_with_posting_tail_codec(
+                false,
+                InvertedListFormatVersion::V1.posting_tail_codec(),
+            ));
+        legacy_builder.posting_lists[0].add(0, PositionRecorder::Count(1));
+        legacy_builder.docs.append(200, 1_000);
+        for row_id in 201..301 {
+            legacy_builder.docs.append(row_id, 1);
+        }
+        write_test_partition_with_optional_impacts(
+            &store,
+            1,
+            legacy_builder,
+            TokenSetFormat::default(),
+            false,
+        )
+        .await;
+
+        write_test_metadata(&store, vec![0, 1], InvertedIndexParams::default()).await;
+        let cache = Arc::new(LanceCache::with_capacity(4096));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+
+        let impact_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 0)
+            .unwrap();
+        let legacy_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 1)
+            .unwrap();
+
+        let impact_posting = impact_partition
+            .inverted_list
+            .posting_list(0, false, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(impact_posting.has_impacts());
+
+        let legacy_posting = legacy_partition
+            .inverted_list
+            .posting_list(0, false, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(!legacy_posting.has_impacts());
+
+        let tokens = Arc::new(Tokens::new(vec!["alpha".to_string()], DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
+        let (row_ids, scores) = index
+            .bm25_search(
+                tokens.clone(),
+                params.clone(),
+                Operator::Or,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(row_ids, vec![200]);
+        assert_eq!(row_ids.len(), scores.len());
+
+        let scorer = index
+            .bm25_base_scorer(tokens.as_ref(), params.as_ref())
+            .await
+            .unwrap();
+        let expected_score = scorer.query_weight("alpha") * scorer.doc_weight(1, 1_000);
+        assert!(
+            (scores[0] - expected_score).abs() < 1e-6,
+            "score: {}, expected: {}",
+            scores[0],
+            expected_score
+        );
     }
 
     #[tokio::test]
@@ -10325,7 +11009,11 @@ mod tests {
             assert!(
                 posting_reader
                     .index_cache
-                    .get_with_key(&PostingListGroupKey { start, end })
+                    .get_with_key(&posting_list_group_cache_key(
+                        start,
+                        end,
+                        posting_reader.has_impacts,
+                    ))
                     .await
                     .is_some(),
                 "prewarm did not populate group [{start}, {end}) that the read \
@@ -10461,7 +11149,11 @@ mod tests {
             let (start, end) = posting_reader.group_range_for_token(token_id).unwrap();
             let group = posting_reader
                 .index_cache
-                .get_with_key(&PostingListGroupKey { start, end })
+                .get_with_key(&posting_list_group_cache_key(
+                    start,
+                    end,
+                    posting_reader.has_impacts,
+                ))
                 .await
                 .unwrap_or_else(|| {
                     panic!(
@@ -10475,7 +11167,10 @@ mod tests {
             assert!(
                 posting_reader
                     .index_cache
-                    .get_with_key(&PostingListKey { token_id })
+                    .get_with_key(&posting_list_cache_key(
+                        token_id,
+                        posting_reader.has_impacts,
+                    ))
                     .await
                     .is_none(),
                 "synthetic prewarm should not populate per-token entry {token_id}",

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -3,6 +3,7 @@
 
 use super::InvertedPartition;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 // the Scorer trait is used to calculate the score of a token in a document
 // in general, the score is calculated as:
@@ -10,6 +11,40 @@ use std::collections::HashMap;
 pub trait Scorer: Send + Sync {
     fn query_weight(&self, token: &str) -> f32;
     fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32;
+
+    /// Finite upper bound for every non-negative value returned by
+    /// [`Self::doc_weight`]. Returning `None` disables score-independent
+    /// pruning where the posting format has no stored impact bounds.
+    fn doc_weight_upper_bound(&self) -> Option<f32> {
+        None
+    }
+
+    /// Stable identity for the corpus-level inputs used by [`Self::doc_weight`].
+    ///
+    /// Implementations should return `Some` only when equal keys guarantee the
+    /// same document weight for every `(freq, doc_tokens)` pair. Scorers without
+    /// such an identity keep impact bounds in the query-local cache only.
+    fn doc_weight_cache_key(&self) -> Option<u64> {
+        None
+    }
+}
+
+impl<T: Scorer + ?Sized> Scorer for Arc<T> {
+    fn query_weight(&self, token: &str) -> f32 {
+        self.as_ref().query_weight(token)
+    }
+
+    fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32 {
+        self.as_ref().doc_weight(freq, doc_tokens)
+    }
+
+    fn doc_weight_upper_bound(&self) -> Option<f32> {
+        self.as_ref().doc_weight_upper_bound()
+    }
+
+    fn doc_weight_cache_key(&self) -> Option<u64> {
+        self.as_ref().doc_weight_cache_key()
+    }
 }
 
 // BM25 parameters
@@ -82,6 +117,14 @@ impl Scorer for MemBM25Scorer {
         let doc_norm = K1 * (1.0 - B + B * doc_tokens / self.avg_doc_length());
         (K1 + 1.0) * freq / (freq + doc_norm)
     }
+
+    fn doc_weight_upper_bound(&self) -> Option<f32> {
+        Some(K1 + 1.0)
+    }
+
+    fn doc_weight_cache_key(&self) -> Option<u64> {
+        Some(u64::from(self.avg_doc_length().to_bits()))
+    }
 }
 
 pub struct IndexBM25Scorer<'a> {
@@ -145,6 +188,14 @@ impl Scorer for IndexBM25Scorer<'_> {
         let doc_tokens = doc_tokens as f32;
         let doc_norm = K1 * (1.0 - B + B * doc_tokens / self.avg_doc_length);
         (K1 + 1.0) * freq / (freq + doc_norm)
+    }
+
+    fn doc_weight_upper_bound(&self) -> Option<f32> {
+        Some(K1 + 1.0)
+    }
+
+    fn doc_weight_cache_key(&self) -> Option<u64> {
+        Some(u64::from(self.avg_doc_length.to_bits()))
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -98,7 +98,6 @@ struct CompressedState {
     position_offsets: Vec<usize>,
     block_max_window: BlockMaxWindow,
     current_block_max_score: Option<(usize, f32)>,
-    block_least_doc_ids: Vec<Option<u32>>,
 }
 
 impl CompressedState {
@@ -113,7 +112,6 @@ impl CompressedState {
             position_offsets: Vec::new(),
             block_max_window: BlockMaxWindow::new(),
             current_block_max_score: None,
-            block_least_doc_ids: Vec::new(),
         }
     }
 
@@ -323,22 +321,6 @@ impl Ord for PostingIterator {
 }
 
 impl PostingIterator {
-    #[inline]
-    fn block_least_doc_id(&self, list: &CompressedPostingList, block_idx: usize) -> u32 {
-        let compressed = unsafe { &mut *self.compressed_state_ptr() };
-        if compressed.block_least_doc_ids.len() < list.blocks.len() {
-            compressed
-                .block_least_doc_ids
-                .resize(list.blocks.len(), None);
-        }
-        if let Some(doc_id) = compressed.block_least_doc_ids[block_idx] {
-            return doc_id;
-        }
-        let doc_id = list.block_least_doc_id(block_idx);
-        compressed.block_least_doc_ids[block_idx] = Some(doc_id);
-        doc_id
-    }
-
     fn block_idx_for_doc(
         &self,
         list: &CompressedPostingList,
@@ -347,7 +329,7 @@ impl PostingIterator {
     ) -> usize {
         let mut linear_skips = 0;
         while block_idx + 1 < list.blocks.len() && linear_skips < LINEAR_BLOCK_SKIP_LIMIT {
-            if self.block_least_doc_id(list, block_idx + 1) > least_id {
+            if list.block_least_doc_id(block_idx + 1) > least_id {
                 return block_idx;
             }
             block_idx += 1;
@@ -404,7 +386,7 @@ impl PostingIterator {
         let mut right = right;
         while left < right {
             let mid = left + (right - left) / 2;
-            if self.block_least_doc_id(list, mid) <= least_id {
+            if list.block_least_doc_id(mid) <= least_id {
                 left = mid + 1;
             } else {
                 right = mid;
@@ -770,7 +752,7 @@ impl PostingIterator {
     fn block_first_doc(&self) -> Option<u64> {
         match self.list {
             PostingList::Compressed(ref list) => {
-                Some(self.block_least_doc_id(list, self.block_idx) as u64)
+                Some(list.block_least_doc_id(self.block_idx) as u64)
             }
             PostingList::Plain(ref plain) => plain.row_ids.get(self.index).cloned(),
         }
@@ -783,7 +765,7 @@ impl PostingIterator {
                 if self.block_idx + 1 >= list.blocks.len() {
                     return None;
                 }
-                Some(self.block_least_doc_id(list, self.block_idx + 1) as u64)
+                Some(list.block_least_doc_id(self.block_idx + 1) as u64)
             }
             PostingList::Plain(ref plain) => plain.row_ids.get(self.index + 1).cloned(),
         }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -22,6 +22,7 @@ use crate::metrics::MetricsCollector;
 
 use super::{
     CompressedPositionStorage,
+    impact::{IMPACT_LEVEL1_BLOCKS, ImpactScoreCache, ImpactSkipData},
     query::Operator,
     scorer::{K1, idf},
 };
@@ -38,12 +39,36 @@ use super::{
 use super::{DocInfo, builder::BLOCK_SIZE};
 
 const TERMINATED_DOC_ID: u64 = u64::MAX;
+const LINEAR_BLOCK_SKIP_LIMIT: usize = 8;
 pub static FLAT_SEARCH_PERCENT_THRESHOLD: LazyLock<u64> = LazyLock::new(|| {
     std::env::var("LANCE_FLAT_SEARCH_PERCENT_THRESHOLD")
         .unwrap_or_else(|_| "10".to_string())
         .parse::<u64>()
         .unwrap_or(10)
 });
+
+#[inline]
+fn conservative_bm25_upper_bound(query_weight: f32) -> f32 {
+    if query_weight <= 0.0 {
+        0.0
+    } else {
+        query_weight * (K1 + 1.0)
+    }
+}
+
+#[inline]
+fn scorer_upper_bound<S: Scorer + ?Sized>(query_weight: f32, scorer: &S) -> f32 {
+    if query_weight.is_nan() {
+        return f32::INFINITY;
+    }
+    if query_weight <= 0.0 {
+        return 0.0;
+    }
+    match scorer.doc_weight_upper_bound() {
+        Some(bound) if bound.is_finite() && bound >= 0.0 => query_weight * bound,
+        _ => f32::INFINITY,
+    }
+}
 
 pub struct PostingIterator {
     token: String,
@@ -55,6 +80,7 @@ pub struct PostingIterator {
     index: usize,
     // the index of current block, this can be changed by `next() and shallow_next()`
     block_idx: usize,
+    current_doc: Option<DocInfo>,
     approximate_upper_bound: f32,
 
     // for compressed posting list
@@ -71,6 +97,8 @@ struct CompressedState {
     position_values: Vec<u32>,
     position_offsets: Vec<usize>,
     block_max_window: BlockMaxWindow,
+    current_block_max_score: Option<(usize, f32)>,
+    block_least_doc_ids: Vec<Option<u32>>,
 }
 
 impl CompressedState {
@@ -84,6 +112,8 @@ impl CompressedState {
             position_values: Vec::new(),
             position_offsets: Vec::new(),
             block_max_window: BlockMaxWindow::new(),
+            current_block_max_score: None,
+            block_least_doc_ids: Vec::new(),
         }
     }
 
@@ -133,6 +163,7 @@ struct BlockMaxWindow {
     start_block_idx: usize,
     next_block_idx: usize,
     max_scores: VecDeque<(usize, f32)>,
+    impact_score_cache: ImpactScoreCache,
 }
 
 struct BlockMaxScore {
@@ -146,6 +177,7 @@ impl BlockMaxWindow {
             start_block_idx: 0,
             next_block_idx: 0,
             max_scores: VecDeque::new(),
+            impact_score_cache: ImpactScoreCache::default(),
         }
     }
 
@@ -155,12 +187,28 @@ impl BlockMaxWindow {
         self.max_scores.clear();
     }
 
-    fn max_score_up_to(
+    fn max_score_up_to<S: Scorer + ?Sized>(
         &mut self,
         list: &CompressedPostingList,
         start_block_idx: usize,
         up_to: u64,
+        query_weight: f32,
+        scorer: &S,
     ) -> BlockMaxScore {
+        if let Some(impacts) = &list.impacts {
+            let score = impacts.max_score_up_to_cached(
+                start_block_idx,
+                up_to,
+                query_weight,
+                scorer,
+                &mut self.impact_score_cache,
+            );
+            return BlockMaxScore {
+                score: score.score,
+                blocks_scanned: score.entries_scanned,
+            };
+        }
+
         if start_block_idx >= list.blocks.len() {
             self.reset(start_block_idx);
             return BlockMaxScore {
@@ -181,6 +229,17 @@ impl BlockMaxWindow {
             self.reset(start_block_idx);
             return BlockMaxScore {
                 score: 0.0,
+                blocks_scanned: 0,
+            };
+        }
+
+        // V3 postings score quantized doc lengths, which can be shorter than
+        // the exact lengths used to bake a legacy max score. Without impacts,
+        // use the score-independent BM25 ceiling instead of that stale bound.
+        if list.block_size == MAX_POSTING_BLOCK_SIZE {
+            self.reset(start_block_idx);
+            return BlockMaxScore {
+                score: scorer_upper_bound(query_weight, scorer),
                 blocks_scanned: 0,
             };
         }
@@ -265,6 +324,96 @@ impl Ord for PostingIterator {
 
 impl PostingIterator {
     #[inline]
+    fn block_least_doc_id(&self, list: &CompressedPostingList, block_idx: usize) -> u32 {
+        let compressed = unsafe { &mut *self.compressed_state_ptr() };
+        if compressed.block_least_doc_ids.len() < list.blocks.len() {
+            compressed
+                .block_least_doc_ids
+                .resize(list.blocks.len(), None);
+        }
+        if let Some(doc_id) = compressed.block_least_doc_ids[block_idx] {
+            return doc_id;
+        }
+        let doc_id = list.block_least_doc_id(block_idx);
+        compressed.block_least_doc_ids[block_idx] = Some(doc_id);
+        doc_id
+    }
+
+    fn block_idx_for_doc(
+        &self,
+        list: &CompressedPostingList,
+        mut block_idx: usize,
+        least_id: u32,
+    ) -> usize {
+        let mut linear_skips = 0;
+        while block_idx + 1 < list.blocks.len() && linear_skips < LINEAR_BLOCK_SKIP_LIMIT {
+            if self.block_least_doc_id(list, block_idx + 1) > least_id {
+                return block_idx;
+            }
+            block_idx += 1;
+            linear_skips += 1;
+        }
+
+        if block_idx + 1 >= list.blocks.len() {
+            return block_idx;
+        }
+
+        if let Some(impacts) = list.impacts.as_ref()
+            && let Some(block_idx) =
+                self.block_idx_for_doc_with_impacts(list, impacts, block_idx, least_id)
+        {
+            return block_idx;
+        }
+
+        self.block_idx_for_doc_by_least_doc_id(list, block_idx, least_id, list.blocks.len())
+    }
+
+    fn block_idx_for_doc_with_impacts(
+        &self,
+        list: &CompressedPostingList,
+        impacts: &ImpactSkipData,
+        mut block_idx: usize,
+        least_id: u32,
+    ) -> Option<usize> {
+        while block_idx + 1 < list.blocks.len() {
+            let group_idx = (block_idx + 1) / IMPACT_LEVEL1_BLOCKS;
+            let group_end = ((group_idx + 1) * IMPACT_LEVEL1_BLOCKS).min(list.blocks.len());
+            let group_doc_up_to = impacts.level1_doc_up_to(group_idx)?;
+            if group_doc_up_to < least_id {
+                block_idx = group_end - 1;
+                continue;
+            }
+            if group_doc_up_to == least_id {
+                return Some(group_end - 1);
+            }
+            return Some(
+                self.block_idx_for_doc_by_least_doc_id(list, block_idx, least_id, group_end),
+            );
+        }
+        Some(block_idx)
+    }
+
+    fn block_idx_for_doc_by_least_doc_id(
+        &self,
+        list: &CompressedPostingList,
+        block_idx: usize,
+        least_id: u32,
+        right: usize,
+    ) -> usize {
+        let mut left = block_idx + 1;
+        let mut right = right;
+        while left < right {
+            let mid = left + (right - left) / 2;
+            if self.block_least_doc_id(list, mid) <= least_id {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        left - 1
+    }
+
+    #[inline]
     fn compressed_state_ptr(&self) -> *mut CompressedState {
         debug_assert!(self.compressed.is_some());
         // this method is called very frequently, so we prefer to use `UnsafeCell` instead of
@@ -312,9 +461,15 @@ impl PostingIterator {
         list: PostingList,
         num_doc: usize,
     ) -> Self {
-        let approximate_upper_bound = match list.max_score() {
-            Some(max_score) => max_score,
-            None => idf(list.len(), num_doc) * (K1 + 1.0),
+        let approximate_upper_bound = match &list {
+            PostingList::Compressed(posting) if posting.impacts.is_some() => f32::INFINITY,
+            PostingList::Compressed(posting) if posting.block_size == MAX_POSTING_BLOCK_SIZE => {
+                conservative_bm25_upper_bound(query_weight)
+            }
+            _ => match list.max_score() {
+                Some(max_score) => max_score,
+                None => idf(list.len(), num_doc) * (K1 + 1.0),
+            },
         };
         let compressed = match &list {
             PostingList::Compressed(list) => {
@@ -323,7 +478,7 @@ impl PostingIterator {
             PostingList::Plain(_) => None,
         };
 
-        Self {
+        let mut posting = Self {
             token,
             token_id,
             position,
@@ -331,9 +486,12 @@ impl PostingIterator {
             list,
             index: 0,
             block_idx: 0,
+            current_doc: None,
             approximate_upper_bound,
             compressed,
-        }
+        };
+        posting.refresh_current_doc();
+        posting
     }
 
     #[inline]
@@ -351,8 +509,37 @@ impl PostingIterator {
         self.approximate_upper_bound
     }
 
+    /// Tightest known list-wide score bound. Impact lists answer from the
+    /// baked doc-weight slab (the data-driven equivalent of the max_score the
+    /// non-impact format bakes at build time); everything else falls back to
+    /// `approximate_upper_bound`. A finite, tight global bound is what lets
+    /// lagging iterators park in the WAND tail instead of being force-advanced
+    /// on every candidate.
     #[inline]
-    fn score<S: Scorer>(&self, scorer: &S, freq: u32, doc_length: u32) -> f32 {
+    fn global_upper_bound<S: Scorer + ?Sized>(&self, scorer: &S) -> f32 {
+        if self.query_weight <= 0.0 {
+            return 0.0;
+        }
+        if let PostingList::Compressed(ref list) = self.list
+            && let Some(impacts) = list.impacts.as_ref()
+        {
+            let compressed = unsafe { &mut *self.compressed_state_ptr() };
+            return self.query_weight
+                * impacts.global_max_doc_weight_cached(
+                    scorer,
+                    &mut compressed.block_max_window.impact_score_cache,
+                );
+        }
+        if let PostingList::Compressed(ref list) = self.list
+            && list.block_size == MAX_POSTING_BLOCK_SIZE
+        {
+            return scorer_upper_bound(self.query_weight, scorer);
+        }
+        self.approximate_upper_bound
+    }
+
+    #[inline]
+    fn score<S: Scorer + ?Sized>(&self, scorer: &S, freq: u32, doc_length: u32) -> f32 {
         self.query_weight * scorer.doc_weight(freq, doc_length)
     }
 
@@ -368,11 +555,16 @@ impl PostingIterator {
 
     #[inline]
     fn doc(&self) -> Option<DocInfo> {
+        self.current_doc
+    }
+
+    fn refresh_current_doc(&mut self) {
         if self.empty() {
-            return None;
+            self.current_doc = None;
+            return;
         }
 
-        match self.list {
+        let current_doc = match self.list {
             PostingList::Compressed(ref list) => {
                 let block_idx = self.index >> list.block_shift();
                 let block_offset = self.index & list.block_mask();
@@ -385,7 +577,8 @@ impl PostingIterator {
                 Some(doc)
             }
             PostingList::Plain(ref list) => Some(DocInfo::Located(list.doc(self.index))),
-        }
+        };
+        self.current_doc = current_doc;
     }
 
     fn position_cursor(&self) -> Option<PositionCursor<'_>> {
@@ -455,12 +648,7 @@ impl PostingIterator {
                 debug_assert!(least_id <= u32::MAX as u64);
                 let least_id = least_id as u32;
                 let shift = list.block_shift();
-                let mut block_idx = self.index >> shift;
-                while block_idx + 1 < list.blocks.len()
-                    && list.block_least_doc_id(block_idx + 1) <= least_id
-                {
-                    block_idx += 1;
-                }
+                let block_idx = self.block_idx_for_doc(list, self.index >> shift, least_id);
                 self.index = self.index.max(block_idx << shift);
                 let length = list.length as usize;
                 while self.index < length {
@@ -473,18 +661,27 @@ impl PostingIterator {
                     let new_offset = block_offset + offset_in_block;
                     if new_offset < compressed.doc_ids.len() {
                         self.index = (block_idx << shift) + new_offset;
-                        break;
+                        self.block_idx = block_idx;
+                        self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                            doc_id: compressed.doc_ids[new_offset],
+                            frequency: compressed.freqs[new_offset],
+                        }));
+                        return;
                     }
                     if block_idx + 1 >= list.blocks.len() {
                         self.index = length;
+                        self.block_idx = self.index >> shift;
+                        self.current_doc = None;
                         break;
                     }
                     self.index = (block_idx + 1) << shift;
                 }
                 self.block_idx = self.index >> shift;
+                self.current_doc = None;
             }
             PostingList::Plain(ref list) => {
                 self.index += list.row_ids[self.index..].partition_point(|&id| id < least_id);
+                self.current_doc = (!self.empty()).then(|| DocInfo::Located(list.doc(self.index)));
             }
         }
     }
@@ -494,11 +691,7 @@ impl PostingIterator {
             PostingList::Compressed(ref list) => {
                 debug_assert!(least_id <= u32::MAX as u64);
                 let least_id = least_id as u32;
-                while self.block_idx + 1 < list.blocks.len()
-                    && list.block_least_doc_id(self.block_idx + 1) <= least_id
-                {
-                    self.block_idx += 1;
-                }
+                self.block_idx = self.block_idx_for_doc(list, self.block_idx, least_id);
             }
             PostingList::Plain(_) => {
                 // we don't have block max score for legacy index,
@@ -508,21 +701,51 @@ impl PostingIterator {
     }
 
     #[inline]
-    fn block_max_score(&self) -> f32 {
+    fn block_max_score<S: Scorer + ?Sized>(&self, scorer: &S) -> f32 {
         match self.list {
-            PostingList::Compressed(ref list) => list.block_max_score(self.block_idx),
+            PostingList::Compressed(ref list) => {
+                if let Some(impacts) = list.impacts.as_ref() {
+                    let compressed = unsafe { &mut *self.compressed_state_ptr() };
+                    if let Some((block_idx, score)) = compressed.current_block_max_score
+                        && block_idx == self.block_idx
+                    {
+                        return score;
+                    }
+
+                    let score = impacts.level0_score_cached(
+                        self.block_idx,
+                        self.query_weight,
+                        scorer,
+                        &mut compressed.block_max_window.impact_score_cache,
+                    );
+                    compressed.current_block_max_score = Some((self.block_idx, score));
+                    return score;
+                }
+                if list.block_size == MAX_POSTING_BLOCK_SIZE {
+                    return scorer_upper_bound(self.query_weight, scorer);
+                }
+                list.block_max_score(self.block_idx)
+            }
             PostingList::Plain(_) => self.approximate_upper_bound,
         }
     }
 
     #[inline]
-    fn block_max_score_up_to_with_stats(&mut self, up_to: u64) -> BlockMaxScore {
+    fn block_max_score_up_to_with_stats<S: Scorer + ?Sized>(
+        &mut self,
+        up_to: u64,
+        scorer: &S,
+    ) -> BlockMaxScore {
         match self.list {
             PostingList::Compressed(ref list) => {
                 let compressed = unsafe { &mut *self.compressed_state_ptr() };
-                compressed
-                    .block_max_window
-                    .max_score_up_to(list, self.block_idx, up_to)
+                compressed.block_max_window.max_score_up_to(
+                    list,
+                    self.block_idx,
+                    up_to,
+                    self.query_weight,
+                    scorer,
+                )
             }
             PostingList::Plain(_) => BlockMaxScore {
                 score: self.approximate_upper_bound,
@@ -547,7 +770,7 @@ impl PostingIterator {
     fn block_first_doc(&self) -> Option<u64> {
         match self.list {
             PostingList::Compressed(ref list) => {
-                Some(list.block_least_doc_id(self.block_idx) as u64)
+                Some(self.block_least_doc_id(list, self.block_idx) as u64)
             }
             PostingList::Plain(ref plain) => plain.row_ids.get(self.index).cloned(),
         }
@@ -560,7 +783,7 @@ impl PostingIterator {
                 if self.block_idx + 1 >= list.blocks.len() {
                     return None;
                 }
-                Some(list.block_least_doc_id(self.block_idx + 1) as u64)
+                Some(self.block_least_doc_id(list, self.block_idx + 1) as u64)
             }
             PostingList::Plain(ref plain) => plain.row_ids.get(self.index + 1).cloned(),
         }
@@ -1188,7 +1411,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
         let remaining_upper_bound = remaining
             .iter()
-            .map(|posting| posting.block_max_score())
+            .map(|posting| posting.block_max_score(&self.scorer))
             .sum::<f32>();
         first.score(&self.scorer, doc.frequency(), doc_length) + remaining_upper_bound
             <= self.threshold
@@ -1375,7 +1598,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
         let narrow_max_score = self
             .lead
             .iter()
-            .map(|posting| posting.block_max_score())
+            .map(|posting| posting.block_max_score(&self.scorer))
             .sum::<f32>();
 
         if narrow_max_score >= self.threshold {
@@ -1398,7 +1621,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
             let mut wide_max_score = 0.0;
             let mut range_blocks_scanned = 0;
             for posting in &mut self.lead {
-                let block_max = posting.block_max_score_up_to_with_stats(lead_up_to);
+                let block_max = posting.block_max_score_up_to_with_stats(lead_up_to, &self.scorer);
                 wide_max_score += block_max.score;
                 range_blocks_scanned += block_max.blocks_scanned;
             }
@@ -1460,9 +1683,19 @@ impl<'a, S: Scorer> Wand<'a, S> {
     // Move all head iterators that are already known to be behind `target`
     // into `tail`, possibly overflowing low-value entries back into `head`.
     fn move_head_before_target_to_tail(&mut self, target: u64) {
+        if self.threshold <= 0.0 {
+            while matches!(self.head_doc(), Some(doc_id) if doc_id < target) {
+                if let Some(mut posting) = self.head.pop().map(|posting| posting.posting) {
+                    posting.next(target);
+                    self.push_head(posting);
+                }
+            }
+            return;
+        }
+
         while matches!(self.head_doc(), Some(doc_id) if doc_id < target) {
             if let Some(posting) = self.head.pop() {
-                let upper_bound = posting.posting.approximate_upper_bound();
+                let upper_bound = posting.posting.global_upper_bound(&self.scorer);
                 if let Some(mut evicted) =
                     self.insert_tail_with_overflow(posting.posting, upper_bound)
                 {
@@ -1481,12 +1714,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
         let lead: f32 = self
             .lead
             .iter()
-            .map(|posting| posting.block_max_score())
+            .map(|posting| posting.block_max_score(&self.scorer))
             .sum();
         let head: f32 = self
             .head
             .iter()
-            .map(|posting| posting.posting.block_max_score())
+            .map(|posting| posting.posting.block_max_score(&self.scorer))
             .sum();
         lead + head + self.tail_max_score
     }
@@ -1499,12 +1732,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
         let mut sum = self
             .lead
             .iter()
-            .map(|posting| posting.block_max_score())
+            .map(|posting| posting.block_max_score(&self.scorer))
             .sum::<f32>();
         let mut possible_matches = self.lead.len();
         for posting in &self.tail {
             if matches!(posting.posting.block_first_doc(), Some(block_doc) if block_doc <= target) {
-                sum += posting.posting.block_max_score();
+                sum += posting.posting.block_max_score(&self.scorer);
                 possible_matches += 1;
             }
         }
@@ -1570,7 +1803,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 Some(block_doc) if block_doc <= target => {
                     tail_posting
                         .posting
-                        .block_max_score_up_to_with_stats(up_to)
+                        .block_max_score_up_to_with_stats(up_to, &self.scorer)
                         .score
                 }
                 _ => 0.0,
@@ -1707,9 +1940,9 @@ impl<'a, S: Scorer> Wand<'a, S> {
             && posting.is_compressed()
             && self.up_to.is_some_and(|up_to| target <= up_to)
         {
-            posting.block_max_score()
+            posting.block_max_score(&self.scorer)
         } else {
-            posting.approximate_upper_bound()
+            posting.global_upper_bound(&self.scorer)
         }
     }
 
@@ -1744,6 +1977,14 @@ impl<'a, S: Scorer> Wand<'a, S> {
         // into lagging iterators. Entries that do not stay in `tail` are
         // advanced to `target` and returned to `head`.
         // pop() drains in place, keeping self.lead's capacity for reuse.
+        if self.threshold <= 0.0 {
+            while let Some(mut posting) = self.lead.pop() {
+                posting.next(target);
+                self.push_head(posting);
+            }
+            return;
+        }
+
         while let Some(posting) = self.lead.pop() {
             let upper_bound = self.lead_to_tail_upper_bound(&posting, target);
             if let Some(mut evicted) = self.insert_tail_with_overflow(posting, upper_bound) {
@@ -1991,13 +2232,17 @@ mod tests {
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use super::super::impact::build_impact_skip_data;
     use super::*;
-    use crate::scalar::inverted::scorer::IndexBM25Scorer;
+    use crate::scalar::inverted::scorer::{IndexBM25Scorer, MemBM25Scorer};
     use crate::{
         metrics::{MetricsCollector, NoOpMetricsCollector},
         scalar::inverted::{
-            CompressedPostingList, PlainPostingList, PostingListBuilder, builder::PositionRecorder,
-            encoding::compress_posting_list,
+            CompressedPostingList, PlainPostingList, PostingListBuilder,
+            builder::PositionRecorder,
+            encoding::{
+                compress_posting_list, compress_posting_list_with_tail_codec_and_block_size,
+            },
         },
     };
 
@@ -2162,6 +2407,7 @@ mod tests {
                 crate::scalar::inverted::PostingTailCodec::VarintDelta,
                 crate::scalar::inverted::LEGACY_BLOCK_SIZE,
                 None,
+                None,
             ))
         } else {
             PostingList::Plain(PlainPostingList::new(
@@ -2171,6 +2417,75 @@ mod tests {
                 None,
             ))
         }
+    }
+
+    fn generate_impact_posting_list_with_freqs(
+        doc_ids: Vec<u32>,
+        freqs: Vec<u32>,
+        doc_lengths: Vec<u32>,
+    ) -> PostingList {
+        generate_impact_posting_list_with_freqs_and_block_size(
+            doc_ids,
+            freqs,
+            doc_lengths,
+            crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+        )
+    }
+
+    fn generate_impact_posting_list_with_freqs_and_block_size(
+        doc_ids: Vec<u32>,
+        freqs: Vec<u32>,
+        doc_lengths: Vec<u32>,
+        block_size: usize,
+    ) -> PostingList {
+        assert_eq!(doc_ids.len(), freqs.len());
+        assert_eq!(doc_ids.len(), doc_lengths.len());
+        let block_max_scores = vec![0.0; doc_ids.len().div_ceil(block_size)];
+        let blocks = compress_posting_list_with_tail_codec_and_block_size(
+            doc_ids.len(),
+            doc_ids.iter(),
+            freqs.iter(),
+            block_max_scores.into_iter(),
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            block_size,
+        )
+        .unwrap();
+        let impact_blocks = doc_ids
+            .chunks(block_size)
+            .zip(freqs.chunks(block_size))
+            .zip(doc_lengths.chunks(block_size))
+            .map(|((doc_ids, freqs), doc_lengths)| {
+                doc_ids
+                    .iter()
+                    .copied()
+                    .zip(freqs.iter().copied())
+                    .zip(doc_lengths.iter().copied())
+                    .map(|((doc_id, freq), doc_length)| (doc_id, freq, doc_length))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let impacts = build_impact_skip_data(impact_blocks.as_slice()).unwrap();
+        PostingList::Compressed(CompressedPostingList::new(
+            blocks,
+            0.0,
+            doc_ids.len() as u32,
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            block_size,
+            None,
+            Some(impacts),
+        ))
+    }
+
+    fn generate_contiguous_impact_posting_list_with_block_size(
+        total: usize,
+        block_size: usize,
+    ) -> PostingList {
+        generate_impact_posting_list_with_freqs_and_block_size(
+            (0..total as u32).collect(),
+            vec![1; total],
+            vec![1; total],
+            block_size,
+        )
     }
 
     fn generate_posting_list_with_positions(
@@ -2668,6 +2983,56 @@ mod tests {
     }
 
     #[test]
+    fn test_non_positive_threshold_advances_without_impact_bound_scoring() {
+        let mut docs = DocSet::default();
+        for doc_id in 0..3 {
+            docs.append(doc_id, 1);
+        }
+        let make_posting = || {
+            PostingIterator::with_query_weight(
+                String::from("term"),
+                0,
+                0,
+                1.0,
+                generate_impact_posting_list_with_freqs(
+                    vec![0, 1, 2],
+                    vec![1, 1, 1],
+                    vec![1, 1, 1],
+                ),
+                docs.len(),
+            )
+        };
+        let scored = Arc::new(AtomicUsize::new(0));
+
+        let mut wand = Wand::new(
+            Operator::Or,
+            std::iter::once(make_posting()),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        );
+        wand.move_head_before_target_to_tail(1);
+        assert_eq!(wand.head_doc(), Some(1));
+        assert!(wand.tail.is_empty());
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
+
+        let mut wand = Wand::new(
+            Operator::Or,
+            std::iter::once(make_posting()),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        );
+        wand.move_head_doc_to_lead(0);
+        wand.push_back_leads(1);
+        assert_eq!(wand.head_doc(), Some(1));
+        assert!(wand.tail.is_empty());
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
     fn test_or_plain_tail_does_not_advance_headless_window() {
         let mut docs = DocSet::default();
         for doc_id in 0..4 {
@@ -2997,7 +3362,7 @@ mod tests {
         posting.shallow_next(0);
         assert_eq!(
             posting
-                .block_max_score_up_to_with_stats((3 * BLOCK_SIZE - 1) as u64)
+                .block_max_score_up_to_with_stats((3 * BLOCK_SIZE - 1) as u64, &UnitScorer)
                 .score,
             4.0
         );
@@ -3005,7 +3370,7 @@ mod tests {
         posting.shallow_next((2 * BLOCK_SIZE) as u64);
         assert_eq!(
             posting
-                .block_max_score_up_to_with_stats((4 * BLOCK_SIZE - 1) as u64)
+                .block_max_score_up_to_with_stats((4 * BLOCK_SIZE - 1) as u64, &UnitScorer)
                 .score,
             5.0
         );
@@ -3013,10 +3378,145 @@ mod tests {
         posting.shallow_next((4 * BLOCK_SIZE) as u64);
         assert_eq!(
             posting
-                .block_max_score_up_to_with_stats((5 * BLOCK_SIZE - 1) as u64)
+                .block_max_score_up_to_with_stats((5 * BLOCK_SIZE - 1) as u64, &UnitScorer)
                 .score,
             3.0
         );
+    }
+
+    #[test]
+    fn test_impact_level1_skip_keeps_boundary_equality_in_group() {
+        for block_size in [crate::scalar::inverted::LEGACY_BLOCK_SIZE, 256] {
+            let total = (IMPACT_LEVEL1_BLOCKS + 1) * block_size;
+            let mut posting = PostingIterator::new(
+                String::from("term"),
+                0,
+                0,
+                generate_contiguous_impact_posting_list_with_block_size(total, block_size),
+                total,
+            );
+            let target = (IMPACT_LEVEL1_BLOCKS * block_size - 1) as u64;
+
+            posting.shallow_next(target);
+            assert_eq!(posting.block_idx, IMPACT_LEVEL1_BLOCKS - 1);
+
+            posting.next(target);
+            assert_eq!(posting.block_idx, IMPACT_LEVEL1_BLOCKS - 1);
+            assert_eq!(posting.doc().map(|doc| doc.doc_id()), Some(target));
+        }
+    }
+
+    #[test]
+    fn test_impact_level1_skip_handles_partial_final_group() {
+        for block_size in [crate::scalar::inverted::LEGACY_BLOCK_SIZE, 256] {
+            let total = (IMPACT_LEVEL1_BLOCKS + 3) * block_size + 17;
+            let mut posting = PostingIterator::new(
+                String::from("term"),
+                0,
+                0,
+                generate_contiguous_impact_posting_list_with_block_size(total, block_size),
+                total,
+            );
+            let target = (total - 1) as u64;
+            let expected_block = total.div_ceil(block_size) - 1;
+
+            posting.shallow_next(target);
+            assert_eq!(posting.block_idx, expected_block);
+
+            posting.next(target);
+            assert_eq!(posting.block_idx, expected_block);
+            assert_eq!(posting.doc().map(|doc| doc.doc_id()), Some(target));
+        }
+    }
+
+    #[test]
+    fn test_impact_level1_skip_reaches_far_target_doc() {
+        for block_size in [crate::scalar::inverted::LEGACY_BLOCK_SIZE, 256] {
+            let total = (IMPACT_LEVEL1_BLOCKS * 3 + 5) * block_size;
+            let target_block = IMPACT_LEVEL1_BLOCKS * 2 + 2;
+            let target = (target_block * block_size + 17) as u64;
+            let mut posting = PostingIterator::new(
+                String::from("term"),
+                0,
+                0,
+                generate_contiguous_impact_posting_list_with_block_size(total, block_size),
+                total,
+            );
+
+            posting.shallow_next(target);
+            assert_eq!(posting.block_idx, target_block);
+
+            posting.next(target);
+            assert_eq!(posting.block_idx, target_block);
+            assert_eq!(posting.doc().map(|doc| doc.doc_id()), Some(target));
+        }
+    }
+
+    #[test]
+    fn test_compressed_impact_block_max_score_memoizes_current_block() {
+        let total = 2 * BLOCK_SIZE as u32;
+        let doc_ids = (0..total).collect::<Vec<_>>();
+        let freqs = doc_ids
+            .iter()
+            .map(|doc_id| if *doc_id < BLOCK_SIZE as u32 { 1 } else { 2 })
+            .collect::<Vec<_>>();
+        let doc_lengths = vec![1; total as usize];
+        let posting_list = generate_impact_posting_list_with_freqs(doc_ids, freqs, doc_lengths);
+        let mut posting =
+            PostingIterator::new(String::from("term"), 0, 0, posting_list, total as usize);
+        let scored = Arc::new(AtomicUsize::new(0));
+        let scorer = CountingScorer {
+            scored: scored.clone(),
+        };
+
+        let first_score = posting.block_max_score(&scorer);
+        assert_eq!(first_score, 1.0);
+        // Baking the query-local doc-weight bounds visits every frontier pair
+        // once (two level0 entries plus one level1 entry for this list).
+        let baked = scored.load(Ordering::Relaxed);
+        assert!(baked >= 2);
+        {
+            let compressed = unsafe { &mut *posting.compressed_state_ptr() };
+            assert_eq!(compressed.current_block_max_score, Some((0, first_score)));
+        }
+
+        let second_score = posting.block_max_score(&scorer);
+        assert_eq!(second_score, first_score);
+        assert_eq!(
+            scored.load(Ordering::Relaxed),
+            baked,
+            "repeated block max scores must not recompute doc weights"
+        );
+
+        posting.shallow_next(BLOCK_SIZE as u64);
+        let next_block_score = posting.block_max_score(&scorer);
+        assert_eq!(next_block_score, 2.0);
+        assert_eq!(
+            scored.load(Ordering::Relaxed),
+            baked,
+            "other blocks answer from the baked bounds without rescoring"
+        );
+    }
+
+    #[rstest]
+    #[case(0.0)]
+    #[case(-1.0)]
+    fn test_non_positive_query_weight_skips_global_impact_bound(#[case] query_weight: f32) {
+        let posting = PostingIterator::with_query_weight(
+            String::from("term"),
+            0,
+            0,
+            query_weight,
+            generate_impact_posting_list_with_freqs(vec![0], vec![1], vec![1]),
+            1,
+        );
+        let scored = Arc::new(AtomicUsize::new(0));
+        let scorer = CountingScorer {
+            scored: scored.clone(),
+        };
+
+        assert_eq!(posting.global_upper_bound(&scorer), 0.0);
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -3355,10 +3855,92 @@ mod tests {
 
         let posting = PostingIterator::new(String::from("test"), 0, 0, posting_list, 1);
 
-        let actual = posting.block_max_score();
+        let actual = posting.block_max_score(&UnitScorer);
         assert!(
             (actual - expected).abs() < 1e-6,
             "block max score should match stored value"
+        );
+    }
+
+    #[test]
+    fn test_v3_without_impacts_uses_conservative_quantized_score_bound() {
+        let exact_doc_length = 300;
+        let quantized_doc_length = super::super::index::dequantize_doc_length(
+            super::super::index::quantize_doc_length(exact_doc_length),
+        );
+        assert!(quantized_doc_length < exact_doc_length);
+
+        let scorer = Arc::new(MemBM25Scorer::new(100, 1, Default::default()));
+        let stored_exact_score = scorer.doc_weight(1, exact_doc_length);
+        let quantized_score = scorer.doc_weight(1, quantized_doc_length);
+        assert!(quantized_score > stored_exact_score);
+
+        let doc_ids = [0_u32];
+        let frequencies = [1_u32];
+        let blocks = compress_posting_list_with_tail_codec_and_block_size(
+            doc_ids.len(),
+            doc_ids.iter(),
+            frequencies.iter(),
+            std::iter::once(stored_exact_score),
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            MAX_POSTING_BLOCK_SIZE,
+        )
+        .unwrap();
+        let posting_list = PostingList::Compressed(CompressedPostingList::new(
+            blocks,
+            stored_exact_score,
+            doc_ids.len() as u32,
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            MAX_POSTING_BLOCK_SIZE,
+            None,
+            None,
+        ));
+        let mut posting =
+            PostingIterator::new(String::from("term"), 0, 0, posting_list, doc_ids.len());
+        let expected_bound = K1 + 1.0;
+
+        assert_eq!(posting.approximate_upper_bound(), expected_bound);
+        assert_eq!(posting.global_upper_bound(&scorer), expected_bound);
+        assert_eq!(posting.block_max_score(&scorer), expected_bound);
+        assert_eq!(
+            posting.block_max_score_up_to_with_stats(0, &scorer).score,
+            expected_bound
+        );
+        assert!(expected_bound >= quantized_score);
+    }
+
+    #[test]
+    fn test_v3_without_impacts_unknown_scorer_uses_infinite_bound() {
+        let doc_ids = [0_u32];
+        let frequencies = [10_u32];
+        let blocks = compress_posting_list_with_tail_codec_and_block_size(
+            doc_ids.len(),
+            doc_ids.iter(),
+            frequencies.iter(),
+            std::iter::once(10.0),
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            MAX_POSTING_BLOCK_SIZE,
+        )
+        .unwrap();
+        let posting_list = PostingList::Compressed(CompressedPostingList::new(
+            blocks,
+            10.0,
+            doc_ids.len() as u32,
+            crate::scalar::inverted::PostingTailCodec::VarintDelta,
+            MAX_POSTING_BLOCK_SIZE,
+            None,
+            None,
+        ));
+        let mut posting =
+            PostingIterator::new(String::from("term"), 0, 0, posting_list, doc_ids.len());
+
+        assert!(posting.global_upper_bound(&UnitScorer).is_infinite());
+        assert!(posting.block_max_score(&UnitScorer).is_infinite());
+        assert!(
+            posting
+                .block_max_score_up_to_with_stats(0, &UnitScorer)
+                .score
+                .is_infinite()
         );
     }
 


### PR DESCRIPTION
Builds on the merged configurable posting block size work in #7466. Format discussion: #7606.

Store per-block `(freq, doc_len)` impact frontiers alongside compressed posting blocks, plus one level-1 entry per 32 blocks, and drive block-max WAND pruning from them instead of build-time scores that can become stale as index statistics drift.

- Both 128- and 256-doc blocks use the same compact impact codec: quantized `u8` document-length norms, delta-encoded frequencies, and an omitted norm byte for the common `+1` delta.
- Scorer-specific bounds bake once into cache-shared state; query-local caches reuse the slab without sharing stale bounds across different corpus statistics.
- Impact data survives packed prewarm and persistent-cache round trips. Posting-list cache versions are bumped while older versions remain readable.
- Packed posting views share both impact-derived state and the block-head cache introduced by #7466.
- Malformed or missing impact entries fall back to conservative infinite bounds instead of enabling unsafe WAND skips.
- Public posting cache-key struct literals remain source-compatible; impact-bearing entries use an internal namespaced key.
- V3 indexes without impacts retain the finite BM25 ceiling, while custom scorers without a declared safe bound fall back to `INFINITY`.

The query benchmark below predates this codec follow-up; the V3 scoring bounds are unchanged, but impact size and decode cost need to be remeasured.

## Benchmark

Measured before this restack against #7466 using per-branch-tip wheels: 200M-doc V3/256 index, 24 partitions, 1000 warm queries at 8 concurrent requests.

| query | #7466 list-max fallback | this PR |
|---|---|---|
| OR 3w k10 | 0.363s / 22 qps | **0.103s / 76 qps (3.5x)** |
| OR 3w k100 | 0.392s / 20 qps | **0.198s / 40 qps (2.0x)** |
| AND 3w k10 | 0.547s / 15 qps | **0.115s / 69 qps (4.8x)** |
| AND 3w k100 | 0.558s / 14 qps | **0.245s / 33 qps (2.3x)** |

## Validation

- `cargo test -p lance-index`: 773 passed, 2 ignored; doctest passed
- After the final rebase to current `main`, `cargo test -p lance-index --lib scalar::inverted`: 249 passed
- `cargo check --workspace --tests --benches`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full-text search now optionally uses impact skip data to improve block-max scoring and pruning when index partitions provide it.
  - Impacts are carried through compressed and packed posting data, with impacts-aware WAND routing and scorer-weighted bound caching.

- **Bug Fixes**
  - Improved decoding/validation of impacts envelopes, including safe behavior for malformed, null, or truncated data.
  - More robust posting component extraction and cache-key isolation to prevent mixing impact vs non-impact partitions.

- **Tests**
  - Expanded roundtrip, cache isolation, and backward/forward compatibility tests for impact-enabled and legacy postings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->