### PR TITLE
fix: preserve DataFile base_id in DataReplacement commits

### DIFF
--- a/python/python/tests/test_multi_base.py
+++ b/python/python/tests/test_multi_base.py
@@ -1248,3 +1248,125 @@ class TestWriteFragmentsWithTargetBases:
         dataset_root = Path(dataset_uri)
         data_files_root = list(dataset_root.glob("*.lance"))
         assert len(data_files_root) == 0, "Should not have data files in root"
+
+
+class TestDataReplacementWithBases:
+    """DataReplacement must preserve DataFile.base_id so replacement files can
+    live in (and resolve against) a storage base other than the dataset root."""
+
+    def setup_method(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.primary_uri = str(Path(self.test_dir) / "primary")
+        self.base1_uri = str(Path(self.test_dir) / "base1")
+        Path(self.base1_uri).mkdir(parents=True, exist_ok=True)
+
+    def teardown_method(self):
+        if hasattr(self, "test_dir"):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _make_two_base_dataset(self) -> "lance.LanceDataset":
+        """Fragment 0 at the dataset root, fragment 1 in base1; column a."""
+        ds = lance.write_dataset(
+            pa.table({"a": list(range(8))}),
+            self.primary_uri,
+            max_rows_per_file=8,
+        )
+        ds.add_bases([DatasetBasePath(self.base1_uri, name="b1", is_dataset_root=True)])
+        return lance.write_dataset(
+            pa.table({"a": list(range(8, 16))}),
+            self.primary_uri,
+            mode="append",
+            max_rows_per_file=8,
+            target_bases=["b1"],
+        )
+
+    def _write_bare_file(self, data_dir: str, data: pa.Table) -> str:
+        from lance.file import LanceFileWriter
+
+        name = f"{uuid.uuid4()}.lance"
+        Path(data_dir).mkdir(parents=True, exist_ok=True)
+        with LanceFileWriter(f"{data_dir}/{name}") as writer:
+            writer.write_batch(data)
+        return name
+
+    def _b_data_file(self, name: str, base_id=None) -> "lance.fragment.DataFile":
+        from lance.file import stable_version
+        from lance.fragment import DataFile
+
+        return DataFile(
+            path=name,
+            fields=[1],  # field id of column "b" (a=0, b=1)
+            column_indices=[0],
+            file_major_version=int(stable_version().split(".")[0]),
+            file_minor_version=int(stable_version().split(".")[1]),
+            base_id=base_id,
+        )
+
+    def test_data_replacement_new_column_into_base(self):
+        """The all-NULL-column special case: the new column's data file for a
+        base fragment is written into that base and must keep its base_id."""
+        ds = self._make_two_base_dataset()
+        ds.add_columns(pa.field("b", pa.int32()))
+        ds = lance.dataset(self.primary_uri)
+
+        root_name = self._write_bare_file(
+            f"{self.primary_uri}/data",
+            pa.table({"b": pa.array([x * 10 for x in range(8)], pa.int32())}),
+        )
+        base_name = self._write_bare_file(
+            f"{self.base1_uri}/data",
+            pa.table({"b": pa.array([x * 10 for x in range(8, 16)], pa.int32())}),
+        )
+
+        op = lance.LanceOperation.DataReplacement(
+            [
+                lance.LanceOperation.DataReplacementGroup(
+                    0, self._b_data_file(root_name)
+                ),
+                lance.LanceOperation.DataReplacementGroup(
+                    1, self._b_data_file(base_name, base_id=1)
+                ),
+            ]
+        )
+        ds = lance.LanceDataset.commit(self.primary_uri, op, read_version=ds.version)
+
+        frags = ds.get_fragments()
+        root_files = {f.path: f.base_id for f in frags[0].data_files()}
+        base_files = {f.path: f.base_id for f in frags[1].data_files()}
+        assert root_files[root_name] is None
+        assert base_files[base_name] == 1
+
+        table = ds.to_table()
+        assert table.column("b").to_pylist() == [x * 10 for x in range(16)]
+
+    def test_data_replacement_replace_existing_file_in_base(self):
+        """The replace-existing-file branch must take the new file's base_id."""
+        ds = self._make_two_base_dataset()
+        ds.add_columns(pa.field("b", pa.int32()))
+        ds = lance.dataset(self.primary_uri)
+
+        first = self._write_bare_file(
+            f"{self.base1_uri}/data",
+            pa.table({"b": pa.array([0] * 8, pa.int32())}),
+        )
+        op = lance.LanceOperation.DataReplacement(
+            [lance.LanceOperation.DataReplacementGroup(1, self._b_data_file(first, 1))]
+        )
+        ds = lance.LanceDataset.commit(self.primary_uri, op, read_version=ds.version)
+
+        # Replace the same column file again, still in base1.
+        second = self._write_bare_file(
+            f"{self.base1_uri}/data",
+            pa.table({"b": pa.array([x * 10 for x in range(8, 16)], pa.int32())}),
+        )
+        op = lance.LanceOperation.DataReplacement(
+            [lance.LanceOperation.DataReplacementGroup(1, self._b_data_file(second, 1))]
+        )
+        ds = lance.LanceDataset.commit(self.primary_uri, op, read_version=ds.version)
+
+        base_files = {f.path: f.base_id for f in ds.get_fragments()[1].data_files()}
+        assert base_files[second] == 1
+        assert first not in base_files
+        assert ds.to_table().column("b").to_pylist()[8:] == [
+            x * 10 for x in range(8, 16)
+        ]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2093,7 +2093,7 @@ impl Dataset {
     /// Resolve the data directory for a given base_id.
     ///
     /// If `base_id` is `None`, returns the default data directory.
-    fn data_file_dir_for_base(&self, base_id: Option<u32>) -> Result<Path> {
+    pub(crate) fn data_file_dir_for_base(&self, base_id: Option<u32>) -> Result<Path> {
         match base_id {
             Some(base_id) => {
                 let base_path = self.manifest.base_paths.get(&base_id).ok_or_else(|| {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2248,27 +2248,24 @@ impl Transaction {
                             && file.file_major_version == new_file.file_major_version
                             && file.file_minor_version == new_file.file_minor_version
                         {
-                            // assign the new file path / size to the fragment
+                            // assign the new file path / size / base to the fragment
                             file.path = new_file.path.clone();
                             file.file_size_bytes = new_file.file_size_bytes.clone();
+                            file.base_id = new_file.base_id;
                         }
                         columns_covered.extend(file.fields.iter());
                     }
                     // SPECIAL CASE: if the column(s) being replaced are not covered by the fragment
                     // Then it means it's a all-NULL column that is being replaced with real data
-                    // just add it to the final fragments
+                    // just add it to the final fragments. Push the DataFile as
+                    // given so every field (including base_id) is preserved.
                     if columns_covered.is_disjoint(&new_file.fields.iter().collect()) {
-                        new_frag.add_file(
-                            new_file.path.clone(),
-                            new_file.fields.to_vec(),
-                            new_file.column_indices.to_vec(),
-                            &LanceFileVersion::try_from_major_minor(
-                                new_file.file_major_version,
-                                new_file.file_minor_version,
-                            )
-                            .expect("Expected valid file version"),
-                            new_file.file_size_bytes.get(),
-                        );
+                        LanceFileVersion::try_from_major_minor(
+                            new_file.file_major_version,
+                            new_file.file_minor_version,
+                        )
+                        .expect("Expected valid file version");
+                        new_frag.files.push(new_file.clone());
                     }
 
                     // Nothing changed in the current fragment, which is not expected -- error out

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -592,17 +592,21 @@ pub(crate) async fn migrate_fragments(
 
             let mut data_files = fragment.files.clone();
 
-            // For each of the data files in the fragment, we need to get the file size
-            let object_store = dataset.object_store.as_ref();
+            // For each of the data files in the fragment, we need to get the file size.
+            // Resolve each file against its own storage base: multi-base datasets
+            // keep data files outside the dataset root (DataFile.base_id).
             let get_sizes = data_files
                 .iter()
                 .map(|file| {
                     if let Some(size) = file.file_size_bytes.get() {
                         Either::Left(futures::future::ready(Ok(size)))
                     } else {
-                        Either::Right(async {
+                        let dataset = dataset.clone();
+                        Either::Right(async move {
+                            let object_store = dataset.object_store_for_data_file(file).await?;
+                            let data_dir = dataset.data_file_dir_for_base(file.base_id)?;
                             object_store
-                                .size(&dataset.base.clone().join("data").join(file.path.clone()))
+                                .size(&data_dir.join(file.path.clone()))
                                 .map_ok(|size| {
                                     NonZero::new(size).ok_or_else(|| {
                                         Error::internal(format!("File {} has size 0", file.path))


### PR DESCRIPTION
## Problem

`DataReplacement` drops the new file's `base_id`, breaking replacement commits on multi-base datasets:

- The replace-existing-file branch copies `path`/`file_size_bytes` but not `base_id`.
- The all-NULL-column special case rebuilds the `DataFile` via `Fragment::add_file`, which hardcodes `base_id: None`.
- `migrate_fragments` stats every data file with an uncached size against `{root}/data`, so any commit touching a fragment with files in another base fails with a not-found error — e.g. adding a computed column to a fragment that lives in a secondary base.

## Changes

- `transaction.rs`: the replace branch copies `base_id`; the new-column special case pushes the provided `DataFile` as-is so every field is preserved (file version still validated).
- `io/commit.rs`: `migrate_fragments` resolves each file's size against the file's own base object store and data dir (`object_store_for_data_file` + `data_file_dir_for_base`).
- Python tests: `TestDataReplacementWithBases` covers committing a new column's file into a base and re-replacing an existing file in a base.