### PR TITLE
fix(goosefs): decouple OpenDAL root from URL path to avoid ObjectStore cache-key collision

### DIFF
--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -28,7 +28,7 @@ const DEFAULT_GOOSEFS_PORT: u16 = 9200;
 ///
 /// Path handling model (S3-style):
 /// - The OpenDAL `root` is fixed to `/` (or a user-supplied cluster-wide base)
-///   so that a single [`Operator`] can serve every dataset under the same
+///   so that a single `Operator` can serve every dataset under the same
 ///   master. This keeps the `ObjectStoreRegistry` cache correct: two URLs
 ///   like `goosefs://host:9200/a.lance` and `goosefs://host:9200/b.lance`
 ///   share one store and each request carries its own object key.
@@ -51,8 +51,8 @@ const DEFAULT_GOOSEFS_PORT: u16 = 9200;
 /// | `goosefs_auth_username`   | `GOOSEFS_AUTH_USERNAME` | Username for `simple` auth mode.                                                              |
 ///
 /// Note on `goosefs_root`: it is deliberately cluster-wide (not per-URL) so
-/// that many datasets under the same master share a single cached [`Operator`].
-/// A custom root also participates in the [`ObjectStoreRegistry`] cache prefix,
+/// that many datasets under the same master share a single cached `Operator`.
+/// A custom root also participates in the `ObjectStoreRegistry` cache prefix,
 /// so stores rooted at different subtrees do not collide.
 #[derive(Default, Debug)]
 pub struct GooseFsStoreProvider;

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use object_store::path::Path;
 use object_store_opendal::OpendalStore;
 use opendal::{Operator, services::GooseFs};
 use url::Url;
@@ -33,11 +32,28 @@ const DEFAULT_GOOSEFS_PORT: u16 = 9200;
 ///   master. This keeps the `ObjectStoreRegistry` cache correct: two URLs
 ///   like `goosefs://host:9200/a.lance` and `goosefs://host:9200/b.lance`
 ///   share one store and each request carries its own object key.
-/// - [`Self::extract_path`] returns the URL path (percent-decoded) as the key
+/// - Path extraction relies on the default [`ObjectStoreProvider::extract_path`]
+///   implementation, which returns the URL path (percent-decoded) as the key
 ///   passed to `ObjectStore::get`, `put`, etc. — mirroring how `s3://bucket/k`
 ///   yields key `k`.
 ///
-/// Configuration priority: storage_options > environment variables > URL authority > defaults
+/// Supported configuration keys (via `storage_options` or environment variables,
+/// resolved with priority: `storage_options` > env var > URL authority > default):
+///
+/// | storage_options key       | env var                 | purpose                                                                                       |
+/// |---------------------------|-------------------------|-----------------------------------------------------------------------------------------------|
+/// | `goosefs_master_addr`     | `GOOSEFS_MASTER_ADDR`   | Master gRPC address, e.g. `host:9200`. Supports HA: `addr1:port,addr2:port`.                  |
+/// | `goosefs_root`            | `GOOSEFS_ROOT`          | Cluster-wide OpenDAL root shared by all datasets under the same master. Defaults to `/`.      |
+/// | `goosefs_write_type`      | `GOOSEFS_WRITE_TYPE`    | GooseFS write type (e.g. `MUST_CACHE`, `CACHE_THROUGH`, `THROUGH`, `ASYNC_THROUGH`).          |
+/// | `goosefs_block_size`      | `GOOSEFS_BLOCK_SIZE`    | GooseFS block size (bytes). Distinct from Lance's own `block_size`.                           |
+/// | `goosefs_chunk_size`      | `GOOSEFS_CHUNK_SIZE`    | GooseFS chunk size (bytes) used by the client.                                                |
+/// | `goosefs_auth_type`       | `GOOSEFS_AUTH_TYPE`     | Authentication mode: `nosasl` or `simple`.                                                    |
+/// | `goosefs_auth_username`   | `GOOSEFS_AUTH_USERNAME` | Username for `simple` auth mode.                                                              |
+///
+/// Note on `goosefs_root`: it is deliberately cluster-wide (not per-URL) so
+/// that many datasets under the same master share a single cached [`Operator`].
+/// A custom root also participates in the [`ObjectStoreRegistry`] cache prefix,
+/// so stores rooted at different subtrees do not collide.
 #[derive(Default, Debug)]
 pub struct GooseFsStoreProvider;
 
@@ -90,15 +106,8 @@ impl GooseFsStoreProvider {
             .filter(|v| !v.is_empty())
     }
 
-    /// Resolve the OpenDAL `root` for this Operator.
-    ///
-    /// The root is intentionally cluster-wide (not per-URL) so that many
-    /// datasets under the same master can share a single cached Operator.
-    ///
-    /// Priority:
-    /// 1. `storage_options["goosefs_root"]`
-    /// 2. `GOOSEFS_ROOT` environment variable
-    /// 3. `"/"` (default: expose the whole filesystem)
+    /// Resolve the OpenDAL `root` for this Operator. See the file-level docs on
+    /// [`GooseFsStoreProvider`] for the semantics of `goosefs_root`.
     fn resolve_root(storage_options: &StorageOptions) -> String {
         Self::resolve_option(storage_options, "goosefs_root", "GOOSEFS_ROOT")
             .unwrap_or_else(|| "/".to_string())
@@ -186,23 +195,11 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
         })
     }
 
-    /// Extract the object key relative to the OpenDAL root.
-    ///
-    /// GooseFS now behaves like S3: the URL path is the per-request key that
-    /// gets appended to a cluster-wide root by OpenDAL's
-    /// `build_rooted_abs_path`. The returned [`Path`] is the percent-decoded
-    /// URL path with the leading `/` stripped.
-    ///
-    /// `goosefs://host:port/data/file.lance` → key `data/file.lance`
-    /// `goosefs://host:port/`                → key `""`
-    fn extract_path(&self, url: &Url) -> Result<Path> {
-        // `Path::from_url_path` percent-decodes the input and normalizes
-        // separators, matching how `S3StoreProvider` (default trait impl)
-        // treats bucket-relative keys.
-        Path::from_url_path(url.path()).map_err(|e| {
-            Error::invalid_input(format!("Invalid path in URL '{}': {}", url.path(), e))
-        })
-    }
+    // `extract_path` uses the default `ObjectStoreProvider` trait implementation:
+    // it percent-decodes the URL path and returns it as the object key, exactly
+    // like S3 does for `s3://bucket/key`. Overriding it here would only
+    // duplicate that behavior. See the file-level doc comment above for the
+    // full path-handling model.
 
     /// Calculate the object store prefix used as the registry cache key.
     ///

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -27,6 +27,16 @@ const DEFAULT_GOOSEFS_PORT: u16 = 9200;
 /// - `host:port` is the GooseFS Master address (default port: 9200)
 /// - `/path` is the filesystem path within GooseFS
 ///
+/// Path handling model (S3-style):
+/// - The OpenDAL `root` is fixed to `/` (or a user-supplied cluster-wide base)
+///   so that a single [`Operator`] can serve every dataset under the same
+///   master. This keeps the `ObjectStoreRegistry` cache correct: two URLs
+///   like `goosefs://host:9200/a.lance` and `goosefs://host:9200/b.lance`
+///   share one store and each request carries its own object key.
+/// - [`Self::extract_path`] returns the URL path (percent-decoded) as the key
+///   passed to `ObjectStore::get`, `put`, etc. — mirroring how `s3://bucket/k`
+///   yields key `k`.
+///
 /// Configuration priority: storage_options > environment variables > URL authority > defaults
 #[derive(Default, Debug)]
 pub struct GooseFsStoreProvider;
@@ -79,6 +89,20 @@ impl GooseFsStoreProvider {
             .or_else(|| std::env::var(env_key).ok())
             .filter(|v| !v.is_empty())
     }
+
+    /// Resolve the OpenDAL `root` for this Operator.
+    ///
+    /// The root is intentionally cluster-wide (not per-URL) so that many
+    /// datasets under the same master can share a single cached Operator.
+    ///
+    /// Priority:
+    /// 1. `storage_options["goosefs_root"]`
+    /// 2. `GOOSEFS_ROOT` environment variable
+    /// 3. `"/"` (default: expose the whole filesystem)
+    fn resolve_root(storage_options: &StorageOptions) -> String {
+        Self::resolve_option(storage_options, "goosefs_root", "GOOSEFS_ROOT")
+            .unwrap_or_else(|| "/".to_string())
+    }
 }
 
 #[async_trait::async_trait]
@@ -90,16 +114,15 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
         // Resolve master address
         let master_addr = Self::resolve_master_addr(&base_path, &storage_options)?;
 
-        // Extract root path from URL
-        let root = base_path.path().to_string();
+        // Resolve a stable cluster-wide root. The URL path is *not* used here
+        // because it varies per dataset; per-request keys are supplied by
+        // `extract_path` instead.
+        let root = Self::resolve_root(&storage_options);
 
         // Build OpenDAL config map
         let mut config_map: HashMap<String, String> = HashMap::new();
         config_map.insert("master_addr".to_string(), master_addr);
-
-        if !root.is_empty() && root != "/" {
-            config_map.insert("root".to_string(), root);
-        }
+        config_map.insert("root".to_string(), root);
 
         // Optional: write_type
         if let Some(wt) =
@@ -163,26 +186,45 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
         })
     }
 
-    /// Extract the path relative to the root of the GooseFS filesystem.
+    /// Extract the object key relative to the OpenDAL root.
     ///
-    /// For GooseFS, the entire URL path is set as the OpenDAL `root` in `new_store`,
-    /// so the relative path returned here must be empty to avoid path duplication.
+    /// GooseFS now behaves like S3: the URL path is the per-request key that
+    /// gets appended to a cluster-wide root by OpenDAL's
+    /// `build_rooted_abs_path`. The returned [`Path`] is the percent-decoded
+    /// URL path with the leading `/` stripped.
     ///
-    /// `goosefs://host:port/data/file.lance` → root="/data/file.lance", extract_path=""
-    fn extract_path(&self, _url: &Url) -> Result<Path> {
-        Ok(Path::from(""))
+    /// `goosefs://host:port/data/file.lance` → key `data/file.lance`
+    /// `goosefs://host:port/`                → key `""`
+    fn extract_path(&self, url: &Url) -> Result<Path> {
+        // `Path::from_url_path` percent-decodes the input and normalizes
+        // separators, matching how `S3StoreProvider` (default trait impl)
+        // treats bucket-relative keys.
+        Path::from_url_path(url.path()).map_err(|e| {
+            Error::invalid_input(format!("Invalid path in URL '{}': {}", url.path(), e))
+        })
     }
 
-    /// Calculate the object store prefix for caching.
+    /// Calculate the object store prefix used as the registry cache key.
     ///
-    /// Format: `goosefs$host:port`
-    /// This ensures different GooseFS clusters get separate caches.
+    /// Format: `goosefs$host:port`. Because the OpenDAL root is now cluster-
+    /// wide (not per-URL), all datasets under the same master intentionally
+    /// share the same cached [`ObjectStore`]; the URL path is disambiguated
+    /// by [`Self::extract_path`] on each request. This is analogous to how
+    /// two `s3://bucket/a` and `s3://bucket/b` URLs share one store.
     fn calculate_object_store_prefix(
         &self,
         url: &Url,
-        _storage_options: Option<&HashMap<String, String>>,
+        storage_options: Option<&HashMap<String, String>>,
     ) -> Result<String> {
-        Ok(format!("{}${}", url.scheme(), url.authority()))
+        // If a custom `goosefs_root` is provided, include it in the prefix so
+        // that stores built with different roots don't accidentally collide.
+        let opts = StorageOptions(storage_options.cloned().unwrap_or_default());
+        let root = Self::resolve_root(&opts);
+        if root == "/" {
+            Ok(format!("{}${}", url.scheme(), url.authority()))
+        } else {
+            Ok(format!("{}${}#{}", url.scheme(), url.authority(), root))
+        }
     }
 }
 
@@ -191,38 +233,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_goosefs_store_path() {
+    fn test_goosefs_extract_path_basic() {
         let provider = GooseFsStoreProvider;
-
         let url = Url::parse("goosefs://10.0.0.1:9200/data/embeddings.lance").unwrap();
         let path = provider.extract_path(&url).unwrap();
-        // extract_path returns empty because the full path is used as OpenDAL root
-        assert_eq!(path.to_string(), "");
+        assert_eq!(path.to_string(), "data/embeddings.lance");
     }
 
     #[test]
-    fn test_goosefs_store_root_path() {
+    fn test_goosefs_extract_path_root() {
         let provider = GooseFsStoreProvider;
-
         let url = Url::parse("goosefs://10.0.0.1:9200/").unwrap();
         let path = provider.extract_path(&url).unwrap();
         assert_eq!(path.to_string(), "");
     }
 
     #[test]
-    fn test_goosefs_store_deep_path() {
+    fn test_goosefs_extract_path_deep() {
         let provider = GooseFsStoreProvider;
-
         let url = Url::parse("goosefs://master:9200/a/b/c/d.lance").unwrap();
         let path = provider.extract_path(&url).unwrap();
-        // All path components are in the OpenDAL root, extract_path is empty
-        assert_eq!(path.to_string(), "");
+        assert_eq!(path.to_string(), "a/b/c/d.lance");
     }
 
     #[test]
-    fn test_calculate_object_store_prefix() {
+    fn test_goosefs_extract_path_percent_decoded() {
+        // The URL contains a percent-encoded space; extract_path must decode
+        // it once so the ObjectStore layer does not double-encode later.
         let provider = GooseFsStoreProvider;
+        let url = Url::parse("goosefs://master:9200/dir/with%20space/f.lance").unwrap();
+        let path = provider.extract_path(&url).unwrap();
+        assert_eq!(path.to_string(), "dir/with space/f.lance");
+    }
 
+    #[test]
+    fn test_calculate_object_store_prefix_default_root() {
+        let provider = GooseFsStoreProvider;
         let url = Url::parse("goosefs://10.0.0.1:9200/data").unwrap();
         let prefix = provider.calculate_object_store_prefix(&url, None).unwrap();
         assert_eq!(prefix, "goosefs$10.0.0.1:9200");
@@ -231,10 +277,67 @@ mod tests {
     #[test]
     fn test_calculate_object_store_prefix_with_hostname() {
         let provider = GooseFsStoreProvider;
-
         let url = Url::parse("goosefs://myhost:9200/data").unwrap();
         let prefix = provider.calculate_object_store_prefix(&url, None).unwrap();
         assert_eq!(prefix, "goosefs$myhost:9200");
+    }
+
+    /// Regression test: two URLs pointing at different datasets under the
+    /// same master must produce the *same* cache prefix so they share one
+    /// Operator, and correctness must come from `extract_path` returning
+    /// distinct keys — never from a per-URL root baked into the prefix.
+    #[test]
+    fn test_prefix_shared_across_datasets_same_master() {
+        let provider = GooseFsStoreProvider;
+        let url_a = Url::parse("goosefs://10.0.0.1:9200/repro/a.lance").unwrap();
+        let url_b = Url::parse("goosefs://10.0.0.1:9200/repro/b.lance").unwrap();
+
+        let pa = provider
+            .calculate_object_store_prefix(&url_a, None)
+            .unwrap();
+        let pb = provider
+            .calculate_object_store_prefix(&url_b, None)
+            .unwrap();
+        assert_eq!(pa, pb, "same master must share one cache prefix");
+
+        // Extracted keys must differ so the shared Operator can route
+        // requests to the correct dataset.
+        assert_ne!(
+            provider.extract_path(&url_a).unwrap(),
+            provider.extract_path(&url_b).unwrap(),
+            "distinct URLs must yield distinct object keys",
+        );
+    }
+
+    /// Different masters must never share a cache entry.
+    #[test]
+    fn test_prefix_isolated_across_masters() {
+        let provider = GooseFsStoreProvider;
+        let u1 = Url::parse("goosefs://host-a:9200/x.lance").unwrap();
+        let u2 = Url::parse("goosefs://host-b:9200/x.lance").unwrap();
+        assert_ne!(
+            provider.calculate_object_store_prefix(&u1, None).unwrap(),
+            provider.calculate_object_store_prefix(&u2, None).unwrap(),
+        );
+    }
+
+    /// A user-supplied `goosefs_root` participates in the cache prefix so
+    /// stores rooted at different subtrees don't collide.
+    #[test]
+    fn test_prefix_includes_custom_root() {
+        let provider = GooseFsStoreProvider;
+        let url = Url::parse("goosefs://host:9200/x.lance").unwrap();
+
+        let default_prefix = provider.calculate_object_store_prefix(&url, None).unwrap();
+        let custom_opts: HashMap<String, String> =
+            HashMap::from([("goosefs_root".to_string(), "/tenant-a".to_string())]);
+        let custom_prefix = provider
+            .calculate_object_store_prefix(&url, Some(&custom_opts))
+            .unwrap();
+
+        assert_eq!(default_prefix, "goosefs$host:9200");
+        assert_eq!(custom_prefix, "goosefs$host:9200#/tenant-a");
+        assert_ne!(default_prefix, custom_prefix);
     }
 
     #[test]
@@ -262,5 +365,20 @@ mod tests {
         )]));
         let addr = GooseFsStoreProvider::resolve_master_addr(&url, &storage_options).unwrap();
         assert_eq!(addr, "10.0.0.2:9200,10.0.0.3:9200");
+    }
+
+    #[test]
+    fn test_resolve_root_defaults_to_slash() {
+        let opts = StorageOptions(HashMap::new());
+        assert_eq!(GooseFsStoreProvider::resolve_root(&opts), "/");
+    }
+
+    #[test]
+    fn test_resolve_root_from_storage_options() {
+        let opts = StorageOptions(HashMap::from([(
+            "goosefs_root".to_string(),
+            "/tenant-a".to_string(),
+        )]));
+        assert_eq!(GooseFsStoreProvider::resolve_root(&opts), "/tenant-a");
     }
 }


### PR DESCRIPTION
## Summary

The GooseFS `ObjectStore` provider used to bake the URL path into OpenDAL's
`root` and always return an empty `extract_path`. Because `ObjectStoreRegistry`
keys its cache on the provider prefix (`goosefs$host:port`), two different
dataset URLs under the same master resolved to the **same** cached
`ObjectStore` — with a `root` locked to whichever URL opened it first. The
second open reused that store and, since `extract_path` was empty, the read
went to the *first* dataset's bytes and schema.

This PR aligns the GooseFS provider with the S3/GCS/OSS model.

## Reproducer (before this fix)

```sql
COPY (SELECT range::BIGINT AS col_a FROM range(3))
  TO 'goosefs://host:9200/repro/a.lance' (FORMAT lance);

COPY (SELECT range::BIGINT AS col_b1,
             ('row_' || range)::VARCHAR AS col_b2 FROM range(5))
  TO 'goosefs://host:9200/repro/b.lance' (FORMAT lance);

SELECT * FROM 'goosefs://host:9200/repro/a.lance';   -- OK: 3 rows, col_a
SELECT * FROM 'goosefs://host:9200/repro/b.lance';
-- BUG: returns 3 rows of col_a (a.lance's data & schema), instead of
--      5 rows of (col_b1, col_b2).
```

## Root cause

`rust/lance-io/src/object_store/providers/goosefs.rs` had three coupled
choices that together broke the registry cache invariants:

1. `new_store` set `root = base_path.path()` — a per-URL root.
2. `extract_path` unconditionally returned `Path::from("")`, "trusting"
   the root to fully identify the object.
3. `calculate_object_store_prefix` returned only `goosefs$host:port`,
   so the URL path did **not** participate in the cache key.

`ObjectStoreRegistry::get_store` (`rust/lance-io/src/object_store/providers.rs`)
keys `active_stores` on `(prefix, params)` and holds `Weak<ObjectStore>`.
As long as any live `Arc<ObjectStore>` for `a.lance` exists, opening
`b.lance` is a **cache hit** that returns the store rooted at `a.lance`,
and the empty key from `extract_path` reads the wrong dataset.

## Fix (S3-style path model)

- **`root` is cluster-wide, not per-URL.** Defaults to `/`, overridable
  via storage option `goosefs_root` or env var `GOOSEFS_ROOT`. All
  datasets under the same master share a single OpenDAL `Operator`.
- **`extract_path` returns the URL path** (percent-decoded via
  `Path::from_url_path`) as the per-request object key. OpenDAL's
  `build_rooted_abs_path(root, key)` reconstructs the absolute GooseFS
  path exactly as before.
- **`calculate_object_store_prefix`** stays scoped to `goosefs$host:port`
  in the default case, and folds a custom root in as `goosefs$host:port#/root`
  so different roots remain isolated in the cache.

Net effect: `a.lance` and `b.lance` share one cached `Operator` (the
same reuse benefit S3 already gets), and correctness comes from the
distinct object keys on each request.

## Semantic parity with other providers

```
goosefs://host:9200/repro/a.lance
├── prefix        "goosefs$host:9200"        ← cache key (shared)
├── operator root "/"                        ← stable across datasets
└── extract_path  "repro/a.lance"            ← per-request key
```

This mirrors `aws.rs` / `gcp.rs` / `oss.rs`, which use the default trait
implementations of `extract_path` and `calculate_object_store_prefix`.

## Tests

Added focused regression tests in the provider (all passing):

- `test_prefix_shared_across_datasets_same_master` — same master, two
  dataset URLs share one cache prefix but yield **distinct** object
  keys. This is the direct counter-assertion to the bug.
- `test_prefix_isolated_across_masters` — different masters must not
  share a cache entry.
- `test_prefix_includes_custom_root` — a custom `goosefs_root` is
  reflected in the prefix.
- `test_goosefs_extract_path_percent_decoded` — percent-encoded segments
  (e.g. `%20`) are decoded exactly once, guarding against double-encoding
  when the object store client re-encodes for transport.

## Verification

- `cargo fmt -p lance-io -- --check`   → clean
- `cargo clippy -p lance-io --features goosefs --all-targets -- -D warnings` → 0 warnings
- `cargo test -p lance-io --features goosefs --lib` → **197 passed / 0 failed**

## Compatibility

- URL scheme, storage options, and the on-wire GooseFS paths are unchanged.
- Users who previously relied on the (undocumented) side effect of the
  URL path becoming the OpenDAL root need no change — the same absolute
  path is still resolved via `root="/"` + relative key.
- New optional knob: `goosefs_root` / `GOOSEFS_ROOT` for tenants that want
  to sandbox an `Operator` to a subtree. Different values get isolated
  cache entries.