### PR TITLE
perf(arrow): zero-copy BFloat16Array::from(Vec<bf16>) via Buffer::from_vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -3483,6 +3497,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -4492,6 +4507,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "bytemuck",
  "bytes",
  "futures",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,10 +103,14 @@ aws-sdk-s3 = { version = "1.38.0", default-features = false }
 half = { "version" = "2.1", default-features = false, features = [
     "num-traits",
     "std",
+    "bytemuck",
 ] }
 lance-bitpacking = { version = "=9.0.0-beta.12", path = "./rust/compression/bitpacking" }
 bitpacking = "0.9"
 bitvec = "1"
+bytemuck = { version = "1", default-features = false, features = [
+    "extern_crate_alloc",
+] }
 bytes = "1.11.1"
 byteorder = "1.5"
 clap = { version = "4", features = ["derive"] }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -1011,6 +1011,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -2863,6 +2877,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -3729,6 +3744,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "bytemuck",
  "bytes",
  "futures",
  "getrandom 0.2.17",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1191,6 +1191,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -3252,6 +3266,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -4132,6 +4147,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "bytemuck",
  "bytes",
  "futures",
  "getrandom 0.2.17",

--- a/rust/lance-arrow/Cargo.toml
+++ b/rust/lance-arrow/Cargo.toml
@@ -21,6 +21,7 @@ arrow-ipc = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
+bytemuck = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 half = { workspace = true }

--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -7,7 +7,7 @@ use std::fmt::Formatter;
 use std::slice;
 
 use arrow_array::{Array, FixedSizeBinaryArray, builder::BooleanBufferBuilder};
-use arrow_buffer::MutableBuffer;
+use arrow_buffer::{Buffer, MutableBuffer};
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType, Field as ArrowField};
 use half::bf16;
@@ -164,19 +164,18 @@ impl FromIterator<bf16> for BFloat16Array {
 
 impl From<Vec<bf16>> for BFloat16Array {
     fn from(data: Vec<bf16>) -> Self {
-        let mut buffer = MutableBuffer::with_capacity(data.len() * 2);
-
-        // Write each value's little-endian bytes straight into the buffer. Going
-        // through an intermediate `Vec` per element would allocate once per value.
-        for val in &data {
-            buffer.extend_from_slice(&val.to_bits().to_le_bytes());
-        }
-
+        let len = data.len();
+        // Zero-copy: `bf16` is `#[repr(transparent)]` over `u16` and derives
+        // `bytemuck::Pod`, so `cast_vec` reinterprets the allocation in place —
+        // no per-element copy or heap alloc. The crate-root `compile_error!`
+        // pins `target_endian = "little"`, so the resulting bytes match the
+        // `FixedSizeBinary(2)` on-disk order Lance writes elsewhere.
+        let raw: Vec<u16> = bytemuck::cast_vec(data);
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(2))
-            .len(data.len())
-            .add_buffer(buffer.into());
-        // SAFETY: the buffer contains exactly `2 * data.len()` bytes — each
-        // `bf16` writes its two little-endian bytes once — matching the
+            .len(len)
+            .add_buffer(Buffer::from_vec(raw));
+        // SAFETY: the value buffer contains exactly `2 * len` bytes — one
+        // `u16` per element after the layout-compatible cast — matching the
         // `FixedSizeBinary(2)` storage layout. No null buffer is attached, so
         // every element is logically valid.
         let array_data = unsafe { array_data.build_unchecked() };
@@ -284,9 +283,10 @@ impl FloatArray<BFloat16Type> for FixedSizeBinaryArray {
     /// - `value_length()` must be 2 (the `FixedSizeBinary(2)` storage shape
     ///   used by [`BFloat16Array`]). Asserted at entry.
     /// - The value buffer must be at least 2-byte aligned. Lance's in-tree
-    ///   constructors always satisfy this (every value buffer goes through
-    ///   `MutableBuffer`, which is aligned to arrow-buffer's `ALIGNMENT`
-    ///   constant — ≥32 bytes on every supported target). Externally-built
+    ///   constructors always satisfy this: value buffers are built either via
+    ///   `MutableBuffer` (aligned to arrow-buffer's `ALIGNMENT` constant, ≥32
+    ///   bytes) or via `Buffer::from_vec::<u16>` (aligned to `align_of::<u16>()`
+    ///   == 2); both meet `bf16`'s 2-byte requirement. Externally-built
     ///   `FixedSizeBinaryArray`s arriving via FFI, IPC, or
     ///   `Buffer::from_custom_allocation` are not required by arrow-rs to be
     ///   aligned beyond a single byte; passing one to this method violates the
@@ -329,8 +329,8 @@ impl FloatArray<BFloat16Type> for FixedSizeBinaryArray {
         //   (arrow-data `data.rs`), so arrow-rs alone does not guarantee
         //   2-byte alignment. Lance's in-tree construction paths build value
         //   buffers via `MutableBuffer` (arrow-buffer `ALIGNMENT` constant,
-        //   ≥32 bytes on every supported target), which trivially satisfies
-        //   `bf16`'s 2-byte requirement.
+        //   ≥32 bytes) or `Buffer::from_vec::<u16>` (2-byte aligned), both of
+        //   which satisfy `bf16`'s 2-byte requirement.
         // - The returned slice borrows from `self`; the underlying ref-counted,
         //   immutable Arrow buffer cannot be mutated or freed for the slice's
         //   lifetime.
@@ -360,6 +360,16 @@ mod tests {
         let array2 = BFloat16Array::from(values.clone());
         assert_eq!(array, array2);
         assert_eq!(array.len(), 3);
+
+        // Pin the raw little-endian bytes emitted by `From<Vec<bf16>>` (rewritten to
+        // reinterpret the Vec via `bytemuck::cast_vec`), so a layout/byte-order
+        // regression is caught directly rather than only through Debug formatting.
+        // bf16 is the high 16 bits of the f32: 1.0->0x3F80, 2.0->0x4000, 3.0->0x4040.
+        let inner = array2.clone().into_inner();
+        let raw_bytes: Vec<u8> = (0..inner.len())
+            .flat_map(|i| inner.value(i).to_vec())
+            .collect();
+        assert_eq!(raw_bytes, vec![0x80, 0x3F, 0x00, 0x40, 0x40, 0x40]);
 
         let expected_fmt = "BFloat16Array\n[\n  1.0,\n  2.0,\n  3.0,\n]";
         assert_eq!(expected_fmt, format!("{:?}", array));


### PR DESCRIPTION
## What

Follow-up to #7500 (wjones127's suggestion in https://github.com/lance-format/lance/pull/7500#discussion_r3496927969). `BFloat16Array::from(Vec<bf16>)` still walked the input a second time, copying two bytes per element into a freshly allocated `MutableBuffer`. This hands the input `Vec` straight to `Buffer::from_vec`, so the existing allocation is reused as-is — no per-element copy, no `MutableBuffer::extend` loop.

`Buffer::from_vec` requires `T: ArrowNativeType`, which `bf16` does not implement (arrow-rs registers the trait only for `f16`/`f32`/`f64` among the float family; Apache Arrow has no bf16 primitive type, which is why Lance stores it as `FixedSizeBinary(2)`). The gap is bridged with `bytemuck::cast_vec::<bf16, u16>`, which reinterprets the allocation in place.

## Why it is sound

- `bf16` is `#[repr(transparent)]` over `u16` in `half` 2.7, so it has the same size (2) and alignment (2) as `u16`. `cast_vec` therefore hits its equal-size/equal-align path and reuses the allocation without realloc; a mismatch would panic, never reach UB.
- `half`'s `bytemuck` feature (enabled here) derives `Zeroable + Pod` on `bf16`, satisfying `cast_vec`'s trait bounds.
- The crate-root `#[cfg(not(target_endian = "little"))] compile_error!` added in #7511 ties the reinterpretation to little-endian hosts, matching the `FixedSizeBinary(2)` byte order Lance writes elsewhere. Big-endian builds fail to compile, so the output is byte-identical to the previous per-element `to_le_bytes()` path.

## Changes

- `From<Vec<bf16>>`: replace the `MutableBuffer` copy loop with `bytemuck::cast_vec` + `Buffer::from_vec`.
- `half`: add the `bytemuck` feature; add `bytemuck` (`default-features = false`, `extern_crate_alloc`) as a direct workspace dependency (already resolved transitively, now promoted).
- Refresh `python/Cargo.lock` and `java/lance-jni/Cargo.lock` (the workspace-excluded lockfiles) to record `bytemuck_derive`.
- `as_slice`'s alignment doc/SAFETY comment previously asserted every value buffer comes from `MutableBuffer` (≥32-byte aligned); reworded to also cover the new `Buffer::from_vec::<u16>` path (2-byte aligned), both of which satisfy `bf16`'s 2-byte requirement.

## Tests

`test_basics` now pins the raw little-endian bytes emitted by `From<Vec<bf16>>` (`[0x80,0x3F, 0x00,0x40, 0x40,0x40]` for `[1.0, 2.0, 3.0]`) via `FixedSizeBinaryArray::value`, so a layout or byte-order regression is caught directly rather than only through Debug formatting. The prior `assert_eq!(array, array2)` compared two outputs of the same `From` impl and could not catch a regression.

`cargo fmt`, `cargo clippy -p lance-arrow --tests --benches -- -D warnings`, and `cargo test -p lance-arrow` (93 unit + 6 doc tests) are green.
