### PR TITLE
feat: support merge_insert when source omits blob columns

### DIFF
--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -39,6 +39,7 @@ pub struct LanceTableProvider {
     row_id_idx: Option<usize>,
     row_addr_idx: Option<usize>,
     ordered: bool,
+    blob_handling: Option<lance_core::datatypes::BlobHandling>,
 }
 
 impl LanceTableProvider {
@@ -69,7 +70,17 @@ impl LanceTableProvider {
             row_id_idx,
             row_addr_idx,
             ordered,
+            blob_handling: None,
         }
+    }
+
+    /// Overrides how blob columns are read during [`TableProvider::scan`].
+    ///
+    /// When unset, the underlying dataset scan uses its default
+    /// [`BlobHandling`](lance_core::datatypes::BlobHandling) policy.
+    pub fn with_blob_handling(mut self, handling: lance_core::datatypes::BlobHandling) -> Self {
+        self.blob_handling = Some(handling);
+        self
     }
 
     pub fn dataset(&self) -> Arc<Dataset> {
@@ -95,6 +106,10 @@ impl TableProvider for LanceTableProvider {
         limit: Option<usize>,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         let mut scan = self.dataset.scan();
+        if let Some(handling) = self.blob_handling.clone() {
+            scan.blob_handling(handling);
+        }
+
         match projection {
             Some(projection) if projection.is_empty() => {
                 scan.empty_project()?;
@@ -159,13 +174,7 @@ pub trait SessionContextExt {
         with_row_id: bool,
         with_row_addr: bool,
     ) -> datafusion::common::Result<DataFrame>;
-    /// Creates a DataFrame for reading a Lance dataset without ordering
-    fn read_lance_unordered(
-        &self,
-        dataset: Arc<Dataset>,
-        with_row_id: bool,
-        with_row_addr: bool,
-    ) -> datafusion::common::Result<DataFrame>;
+
     /// Creates a DataFrame for reading a stream of data
     ///
     /// This dataframe may only be queried once, future queries will fail
@@ -222,20 +231,6 @@ impl SessionContextExt for SessionContext {
             dataset,
             with_row_id,
             with_row_addr,
-        )))
-    }
-
-    fn read_lance_unordered(
-        &self,
-        dataset: Arc<Dataset>,
-        with_row_id: bool,
-        with_row_addr: bool,
-    ) -> datafusion::common::Result<DataFrame> {
-        self.read_table(Arc::new(LanceTableProvider::new_with_ordering(
-            dataset,
-            with_row_id,
-            with_row_addr,
-            false,
         )))
     }
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1194,10 +1194,11 @@ async fn build_user_view_struct(
     )?)
 }
 
-async fn transform_blob_v2_batch(
+pub(crate) async fn transform_blob_v2_batch(
     dataset: &Arc<Dataset>,
     schema: &lance_core::datatypes::Schema,
     batch: RecordBatch,
+    keep_row_addr: bool,
 ) -> Result<RecordBatch> {
     let row_addr_idx = batch
         .schema()
@@ -1221,7 +1222,7 @@ async fn transform_blob_v2_batch(
 
     let batch_schema = batch.schema();
     for (col_idx, field) in batch_schema.fields().iter().enumerate() {
-        if field.name() == lance_core::ROW_ADDR {
+        if field.name() == lance_core::ROW_ADDR && !keep_row_addr {
             continue;
         }
 
@@ -1245,6 +1246,15 @@ async fn transform_blob_v2_batch(
                     batch.column(col_idx).data_type()
                 ))
             })?;
+
+        // Merge-insert may supply a blob v2 value directly from the source.
+        // Those values are already in the writer's user view and do not refer
+        // to a row in the target dataset, unlike descriptor values from scans.
+        if struct_arr.column_by_name("kind").is_none() {
+            new_columns.push(batch.column(col_idx).clone());
+            new_fields.push(field.clone());
+            continue;
+        }
 
         let column_name = field.name();
         let descriptor = BlobV2Descriptor::try_from_struct(struct_arr, column_name)?;
@@ -1665,7 +1675,7 @@ async fn rewrite_files(
                 let schema = dataset_schema.clone();
                 async move {
                     let batch = batch_result?;
-                    transform_blob_v2_batch(&dataset, &schema, batch)
+                    transform_blob_v2_batch(&dataset, &schema, batch, false)
                         .await
                         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))
                 }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1821,7 +1821,25 @@ impl MergeInsertJob {
         // Goal: we shouldn't have to add new branches in this code to handle
         //       indexed vs non-indexed cases. That should be handled by optimizer rules.
         let session_ctx = SessionContext::new();
-        let scan = session_ctx.read_lance_unordered(self.dataset.clone(), true, true)?;
+        let binary_blob_field_ids = self
+            .dataset
+            .schema()
+            .fields_pre_order()
+            .filter(|field| field.is_blob() && !field.is_blob_v2())
+            .map(|field| field.id as u32)
+            .collect();
+        let target_provider = Arc::new(
+            crate::datafusion::dataframe::LanceTableProvider::new_with_ordering(
+                self.dataset.clone(),
+                true,
+                true,
+                false,
+            )
+            .with_blob_handling(lance_core::datatypes::BlobHandling::SomeBlobsBinary(
+                binary_blob_field_ids,
+            )),
+        );
+        let scan = session_ctx.read_table(target_provider)?;
         // Wrap column names in double quotes to preserve case (DataFusion lowercases unquoted identifiers)
         let on_cols = self
             .params

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -11963,4 +11963,140 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             merge_result
         );
     }
+
+    #[tokio::test]
+    async fn test_merge_insert_with_blob_v1_source_provides_blob() {
+        use arrow_array::LargeBinaryArray;
+        use arrow_schema::Schema as ArrowSchema;
+        use lance_arrow::BLOB_META_KEY;
+
+        let test_dir = TempStrDir::default();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("blobs", DataType::LargeBinary, true).with_metadata(HashMap::from([(
+                BLOB_META_KEY.to_string(),
+                "true".to_string(),
+            )])),
+            Field::new("id", DataType::Int64, true),
+            Field::new("other", DataType::Int64, true),
+        ]));
+        let make_batch = |blob_values: Vec<Option<&[u8]>>, ids, others| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(LargeBinaryArray::from(blob_values)),
+                    Arc::new(Int64Array::from(ids)),
+                    Arc::new(Int64Array::from(others)),
+                ],
+            )
+            .unwrap()
+        };
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(
+                    vec![Ok(make_batch(
+                        vec![Some(b"foo"), Some(b"bar")],
+                        vec![0, 1],
+                        vec![10, 20],
+                    ))],
+                    schema.clone(),
+                ),
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_1),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+        let source = Box::new(RecordBatchIterator::new(
+            vec![Ok(make_batch(
+                vec![Some(b"baz"), Some(b"qux")],
+                vec![1, 2],
+                vec![200, 300],
+            ))],
+            schema,
+        ));
+
+        let job = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap();
+        let (new_dataset, _) = job.execute_reader(source).await.unwrap();
+        let blobs = new_dataset
+            .take_blobs_by_indices(&[0, 1, 2], "blobs")
+            .await
+            .unwrap();
+        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"foo");
+        assert_eq!(blobs[1].read().await.unwrap().as_ref(), b"baz");
+        assert_eq!(blobs[2].read().await.unwrap().as_ref(), b"qux");
+    }
+
+    #[tokio::test]
+    async fn test_merge_insert_with_blob_v2_source_provides_blob() {
+        use crate::{BlobArrayBuilder, blob_field};
+        use arrow_schema::Schema as ArrowSchema;
+
+        let test_dir = TempStrDir::default();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            blob_field("blobs", true),
+            Field::new("id", DataType::Int64, true),
+            Field::new("other", DataType::Int64, true),
+        ]));
+        let make_batch = |blob_values: &[&[u8]], ids, others| {
+            let mut blobs = BlobArrayBuilder::new(blob_values.len());
+            for value in blob_values {
+                blobs.push_bytes(value).unwrap();
+            }
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    blobs.finish().unwrap(),
+                    Arc::new(Int64Array::from(ids)),
+                    Arc::new(Int64Array::from(others)),
+                ],
+            )
+            .unwrap()
+        };
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(
+                    vec![Ok(make_batch(&[b"foo", b"bar"], vec![0, 1], vec![10, 20]))],
+                    schema.clone(),
+                ),
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+        let source = Box::new(RecordBatchIterator::new(
+            vec![Ok(make_batch(
+                &[b"baz", b"qux"],
+                vec![1, 2],
+                vec![200, 300],
+            ))],
+            schema,
+        ));
+
+        let job = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap();
+        let (new_dataset, _) = job.execute_reader(source).await.unwrap();
+        let blobs = new_dataset
+            .take_blobs_by_indices(&[0, 1, 2], "blobs")
+            .await
+            .unwrap();
+        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"foo");
+        assert_eq!(blobs[1].read().await.unwrap().as_ref(), b"baz");
+        assert_eq!(blobs[2].read().await.unwrap().as_ref(), b"qux");
+    }
 }

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -49,6 +49,48 @@ use crate::{
 
 use super::apply_deletions;
 
+fn blob_v2_user_view_schema(
+    input_schema: arrow_schema::SchemaRef,
+    dataset_schema: &lance_core::datatypes::Schema,
+) -> arrow_schema::SchemaRef {
+    let fields = input_schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let Some(dataset_field) = dataset_schema
+                .field(field.name())
+                .filter(|dataset_field| dataset_field.is_blob_v2())
+            else {
+                return field.clone();
+            };
+            let is_descriptor = matches!(
+                field.data_type(),
+                arrow_schema::DataType::Struct(fields)
+                    if fields.iter().any(|child| child.name() == "kind")
+            );
+            if !is_descriptor {
+                return field.clone();
+            }
+            let logical_field = arrow_schema::Field::from(dataset_field);
+            Arc::new(
+                arrow_schema::Field::new(
+                    field.name(),
+                    lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
+                    field.is_nullable(),
+                )
+                .with_metadata(logical_field.metadata().clone()),
+            )
+        })
+        .collect::<Vec<_>>();
+    Arc::new(arrow_schema::Schema::new_with_metadata(
+        fields
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>(),
+        input_schema.metadata().clone(),
+    ))
+}
+
 /// Shared state for merge insert operations to simplify lock management
 struct MergeState {
     /// Row addresses that need to be deleted, due to a row update or delete action
@@ -864,6 +906,36 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
 
         // Execute the input plan to get the merge data stream
         let input_stream = self.input.execute(partition, context)?;
+        let has_blob_v2_columns = self
+            .dataset
+            .schema()
+            .fields_pre_order()
+            .any(|field| field.is_blob_v2());
+        let input_stream = if has_blob_v2_columns {
+            let input_schema = input_stream.schema();
+            let output_schema = blob_v2_user_view_schema(input_schema, self.dataset.schema());
+            let dataset = self.dataset.clone();
+            let dataset_schema = self.dataset.schema().clone();
+            let transformed = input_stream.then(move |batch_result| {
+                let dataset = dataset.clone();
+                let dataset_schema = dataset_schema.clone();
+                async move {
+                    let batch = batch_result?;
+                    crate::dataset::optimize::transform_blob_v2_batch(
+                        &dataset,
+                        &dataset_schema,
+                        batch,
+                        true,
+                    )
+                    .await
+                    .map_err(|error| DataFusionError::External(Box::new(error)))
+                }
+            });
+            Box::pin(RecordBatchStreamAdapter::new(output_schema, transformed))
+                as SendableRecordBatchStream
+        } else {
+            input_stream
+        };
 
         // Step 1: Create shared state and streaming processor for row addresses and write data
         // Get field IDs for the ON columns from the dataset schema


### PR DESCRIPTION
**merge_insert** directly invokes **session_ctx.read_lance_unordered** without specifying Blob column handling, which defaults to **BlobsDescriptions**. Consequently, DataFusion retrieves Blob data as a **Struct** type description when scanning the original dataset, causing a crash with "**LargeBinary vs Struct schema mismatch!**" because the table's logical schema expects LargeBinary.
Interestingly, this only happens if the input data for **merge_insert** lacks Blob columns; if Blob columns are present in the input, column pruning is triggered during the original data read, bypassing the Blob columns and masking the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable blob handling for scans via an optional `blob_handling` setting on the table provider.
  * Introduced a builder method to set blob handling when creating a provider with ordering.
* **Bug Fixes**
  * Improved merge-insert/upsert planning/execution for datasets with nullable blob-typed columns, preserving existing blob values and correctly nulling missing blobs on inserts.
* **Deprecations**
  * Deprecated the unordered read API in favor of the ordered read API.
* **Tests**
  * Added coverage for merge-insert/upsert with nullable blob columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->