### PR TITLE
chore(fsst): drop duplicate arrow-array dev-dependency

### DIFF
--- a/rust/compression/fsst/Cargo.toml
+++ b/rust/compression/fsst/Cargo.toml
@@ -16,7 +16,6 @@ arrow-array.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-arrow-array.workspace = true
 test-log.workspace = true
 tokio.workspace = true
 


### PR DESCRIPTION
## What

`arrow-array` was declared in both `[dependencies]` and `[dev-dependencies]` of the `fsst` crate. A normal dependency is already visible to tests, examples, and benches, so the `[dev-dependencies]` entry was redundant. This drops the duplicate line.

## Tests

No behavior change — purely a dependency-manifest cleanup. `cargo test -p fsst`, `cargo build -p fsst --example benchmark`, and `cargo clippy -p fsst --tests --benches -- -D warnings` are green. No lockfile change, since `arrow-array` remains a workspace dependency.
