### PR TITLE
fix: treat blob descriptors as opaque projections

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -179,6 +179,40 @@ def test_scan_blob_as_binary(tmp_path):
     assert tbl.column("blobs").to_pylist() == values
 
 
+def test_v2_0_blob_descriptor_projection_and_reads(tmp_path):
+    values = [b"abc", b"defgh", b"ijklmnop"]
+    blob_field = pa.field(
+        "blob", pa.large_binary(), metadata={"lance-encoding:blob": "true"}
+    )
+    schema = pa.schema([pa.field("id", pa.int32()), blob_field])
+    table = pa.table(
+        {"id": [0, 1, 2], "blob": values},
+        schema=schema,
+    )
+    ds = lance.write_dataset(table, tmp_path / "test_ds", data_storage_version="2.0")
+
+    for blob_handling in [None, "all_descriptions", "blobs_descriptions"]:
+        kwargs = {} if blob_handling is None else {"blob_handling": blob_handling}
+        descriptions = ds.scanner(columns=["blob"], **kwargs).to_table().column("blob")
+        chunk = descriptions.chunk(0)
+        assert chunk.type == pa.struct(
+            [
+                pa.field("position", pa.uint64()),
+                pa.field("size", pa.uint64()),
+            ]
+        )
+        assert chunk.field("size").to_pylist() == [3, 5, 8]
+
+    tbl = ds.scanner(columns=["blob"], blob_handling="all_binary").to_table()
+    assert tbl.column("blob").to_pylist() == values
+    assert [blob.read() for blob in ds.take_blobs("blob", indices=[0, 1, 2])] == values
+    assert ds.read_blobs("blob", indices=[0, 1, 2]) == [
+        (0, b"abc"),
+        (1, b"defgh"),
+        (2, b"ijklmnop"),
+    ]
+
+
 def test_fragment_scan_blob_as_binary(tmp_path):
     values = [b"foo", b"bar", b"baz"]
     arr = pa.array(values, pa.large_binary())

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -519,16 +519,20 @@ const FOOTER_LEN: usize = 40;
 
 // How a field maps onto physical columns, shared by the projection-building and
 // projection-validation walks so they stay in lockstep. In the 2.0 layout every
-// field (including structs and lists) has its own column; in 2.1 only leaves do,
-// and blob/packed-struct fields are opaque (a single column with no descent).
+// ordinary field (including structs and lists) has its own column; in 2.1 only
+// leaves do. Blob/packed-struct fields are opaque in all versions: they are a
+// single column with no descent, including unloaded blob descriptor schemas.
 // Returns `(contributes, recurse)`: whether the field has its own column and
 // whether to walk into its children. The DFS order is the field's own column (if
 // any) followed by its children, so a field's root (first) column is always the
 // first entry of its sub-slice.
 fn field_column_shape(field: &Field, is_structural: bool) -> (bool, bool) {
-    let contributes =
-        !is_structural || field.children.is_empty() || field.is_blob() || field.is_packed_struct();
-    let recurse = !is_structural || (!field.is_blob() && !field.is_packed_struct());
+    if field.is_blob() || field.is_packed_struct() {
+        return (true, false);
+    }
+
+    let contributes = !is_structural || field.children.is_empty();
+    let recurse = !field.children.is_empty();
     (contributes, recurse)
 }
 
@@ -2574,7 +2578,11 @@ impl EncodedBatchReaderExt for EncodedBatch {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, pin::Pin, sync::Arc};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        pin::Pin,
+        sync::Arc,
+    };
 
     use arrow_array::{
         RecordBatch, UInt32Array,
@@ -2583,7 +2591,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
     use bytes::Bytes;
     use futures::{StreamExt, prelude::stream::TryStreamExt};
-    use lance_arrow::RecordBatchExt;
+    use lance_arrow::{BLOB_META_KEY, RecordBatchExt};
     use lance_core::{ArrowResult, datatypes::Schema};
     use lance_datagen::{BatchCount, ByteCount, RowCount, array, gen_batch};
     use lance_encoding::{
@@ -3882,6 +3890,38 @@ mod tests {
             msg.contains("differing lengths") && msg.contains('b'),
             "expected a child-length error naming 'b', got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_validate_v2_0_unloaded_blob_projection_is_opaque() {
+        let metadata = HashMap::from([(BLOB_META_KEY.to_string(), "true".to_string())]);
+        let arrow = ArrowSchema::new(vec![
+            Field::new("blob", DataType::LargeBinary, true).with_metadata(metadata),
+        ]);
+        let mut schema = Schema::try_from(&arrow).unwrap();
+        schema.fields[0].unloaded_mut();
+        let projection = ReaderProjection {
+            schema: Arc::new(schema),
+            column_indices: vec![0],
+        };
+        let column_len = |column: usize| {
+            assert_eq!(column, 0);
+            Ok(3)
+        };
+        let mut cursor = 0usize;
+
+        let rows = validate_field_length(
+            &projection.schema.fields[0],
+            false,
+            true,
+            &projection.column_indices,
+            &mut cursor,
+            &column_len,
+        )
+        .unwrap();
+
+        assert_eq!(rows, 3);
+        assert_eq!(cursor, 1);
     }
 
     #[test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2268,8 +2268,8 @@ mod tests {
     };
     use arrow_array::RecordBatch;
     use arrow_array::{
-        Array, ArrayRef, RecordBatchIterator, StringArray, StructArray, UInt8Array, UInt32Array,
-        UInt64Array,
+        Array, ArrayRef, Int32Array, LargeBinaryArray, RecordBatchIterator, StringArray,
+        StructArray, UInt8Array, UInt32Array, UInt64Array,
     };
     use arrow_schema::{DataType, Field, Schema};
     use async_trait::async_trait;
@@ -2278,10 +2278,13 @@ mod tests {
     use futures::{StreamExt, TryStreamExt, future::try_join_all};
     use lance_arrow::{
         ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
-        BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_PACK_FILE_SIZE_THRESHOLD_META_KEY,
+        BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_META_KEY, BLOB_PACK_FILE_SIZE_THRESHOLD_META_KEY,
         BLOB_V2_EXT_NAME, DataTypeExt,
     };
-    use lance_core::{datatypes::BlobKind, utils::blob::blob_path};
+    use lance_core::{
+        datatypes::{BlobHandling, BlobKind},
+        utils::blob::blob_path,
+    };
     use lance_io::object_store::{
         ObjectStore, ObjectStoreParams, ObjectStoreRegistry, StorageOptionsAccessor,
     };
@@ -3196,6 +3199,101 @@ mod tests {
             .await
             .unwrap();
         assert!(descriptors.column(0).data_type().is_struct());
+    }
+
+    #[tokio::test]
+    async fn test_v2_0_legacy_blob_descriptor_projection_and_reads() {
+        let test_dir = TempStrDir::default();
+        let blob_meta = HashMap::from([(BLOB_META_KEY.to_string(), "true".to_string())]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("blob", DataType::LargeBinary, true).with_metadata(blob_meta),
+        ]));
+        let payloads = [
+            b"abc".as_slice(),
+            b"defgh".as_slice(),
+            b"ijklmnop".as_slice(),
+        ];
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![0, 1, 2])) as ArrayRef,
+                Arc::new(LargeBinaryArray::from_iter_values(payloads)) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(batch)], schema),
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_0),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+
+        for blob_handling in [
+            None,
+            Some(BlobHandling::BlobsDescriptions),
+            Some(BlobHandling::AllDescriptions),
+        ] {
+            let mut scanner = dataset.scan();
+            if let Some(blob_handling) = blob_handling {
+                scanner.blob_handling(blob_handling);
+            }
+            let descriptors = scanner
+                .project(&["blob"])
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let descriptor = descriptors.column(0).as_struct();
+            assert_eq!(descriptor.fields().len(), 2);
+            assert_eq!(descriptor.fields()[0].name(), "position");
+            assert_eq!(descriptor.fields()[1].name(), "size");
+            let sizes = descriptor
+                .column_by_name("size")
+                .unwrap()
+                .as_primitive::<UInt64Type>();
+            assert_eq!(sizes.values(), &[3, 5, 8]);
+        }
+
+        let mut scanner = dataset.scan();
+        scanner.blob_handling(BlobHandling::AllBinary);
+        let bytes = scanner
+            .project(&["blob"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let bytes = bytes.column(0).as_binary::<i64>();
+        for (idx, expected) in payloads.iter().enumerate() {
+            assert_eq!(bytes.value(idx), *expected);
+        }
+
+        let blob_files = dataset
+            .take_blobs_by_indices(&[0, 1, 2], "blob")
+            .await
+            .unwrap();
+        assert_eq!(blob_files.len(), payloads.len());
+        for (blob_file, expected) in blob_files.iter().zip(payloads) {
+            assert_eq!(blob_file.read().await.unwrap().as_ref(), expected);
+        }
+
+        let read_blobs = dataset
+            .read_blobs("blob")
+            .unwrap()
+            .with_row_indices(vec![0, 1, 2])
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(read_blobs.len(), payloads.len());
+        for (read_blob, expected) in read_blobs.iter().zip(payloads) {
+            assert_eq!(read_blob.data.as_ref(), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7617.

The issue was caused by unloaded blob descriptor schemas being treated like ordinary V2.0 structs during reader projection validation. Blob descriptor views are backed by a single physical blob column, so the reader should not recurse into descriptor child fields such as `position` and `size` when consuming projection column indices.

This keeps blob and packed-struct fields opaque across file versions and adds regression coverage for descriptor scans, binary blob scans, `take_blobs`, and `read_blobs`.

Validation note: Rust formatting, full workspace clippy, and targeted Rust/Python regressions pass. `uv run make lint` still fails on this macOS environment because pyright checks existing TensorFlow imports while `tensorflow` is configured as a Linux-only dependency in `python/pyproject.toml`.
