### PR TITLE
fix(index): serialize FTS position prewarm to avoid an IO-scheduler deadlock

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1265,7 +1265,20 @@ fn group_range_for_start_index(starts: &[u32], token_count: usize, group_idx: us
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
         let with_position = options.with_position;
-        let chunk_concurrency = self.store.io_parallelism().max(1);
+        // Position streams are dominated by a few huge hot-token rows, so
+        // position-bearing prewarm chunks routinely reach hundreds of MBs to
+        // GBs even though chunk sizing targets 128MB on the average token.
+        // The store shares one ScanScheduler across all partition files, and
+        // concurrent large `read_range`s can exhaust its backpressure window
+        // while every request still has undelivered pages (a request's later
+        // pages never pass the `min_in_flight` priority bypass); the prewarm
+        // then deadlocks. A single request in flight always delivers in
+        // order and recycles the window, so serialize position prewarm.
+        let chunk_concurrency = if with_position {
+            1
+        } else {
+            self.store.io_parallelism().max(1)
+        };
         for part in &self.partitions {
             part.inverted_list
                 .prewarm_posting_lists(with_position, chunk_concurrency)


### PR DESCRIPTION
## Problem

`prewarm_index(..., with_position=True)` deadlocks on position-bearing inverted indexes: all tokio workers park and the prewarm never completes (reproduced on a 50M-doc index; >14 min with zero progress before this fix, vs ~19 min to *fully* prewarm 162G after it).

Position streams are dominated by a few huge hot-token rows, so prewarm chunks sized for the 128MB average routinely span hundreds of MBs to GBs. Two or more such `read_range`s in flight on the store's shared `ScanScheduler` can exhaust its byte backpressure window while every request still has undelivered pages: a request's later pages never pass the `min_in_flight` priority bypass, so nothing can complete and nothing frees the window.

## Fix

A single request in flight always delivers in order and recycles the window, so position prewarm now runs its chunks serially. Position-less prewarm keeps the concurrent path (its chunks are bounded by the 128MB target and never wedge).

The scheduler-side wedge (concurrent large `read_range`s on one `ScanScheduler`) is a separate latent lance-io issue; this change removes the only known trigger.

## Verification

- Repro before/after on a 50M-doc 162G positions index: with_position prewarm hung (>840s timeout) → completes in ~19 min; position-less prewarm unchanged (~30s).
- `cargo test -p lance-index` (inverted suite), `cargo clippy -- -D warnings`, `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)