### PR TITLE
fix(scanner): honor batch_readahead to bound v2 scan decode concurrency

### DIFF
--- a/java/src/main/java/org/lance/ipc/ScanOptions.java
+++ b/java/src/main/java/org/lance/ipc/ScanOptions.java
@@ -134,6 +134,8 @@ public class ScanOptions {
     Preconditions.checkArgument(
         !(filter.isPresent() && substraitFilter.isPresent()),
         "cannot set both substrait filter and string filter");
+    Preconditions.checkArgument(
+        batchReadahead > 0, "batchReadahead must be greater than 0, got %s", batchReadahead);
     this.fragmentIds = fragmentIds;
     this.batchSize = batchSize;
     this.columns = columns;

--- a/java/src/test/java/org/lance/ScannerTest.java
+++ b/java/src/test/java/org/lance/ScannerTest.java
@@ -422,25 +422,32 @@ public class ScannerTest {
       TestUtils.SimpleTestDataset testDataset =
           new TestUtils.SimpleTestDataset(allocator, datasetPath);
       testDataset.createEmptyDataset().close();
-      int totalRows = 1000;
-      int batchSize = 100;
-      int batchReadahead = 5;
-      try (Dataset dataset = testDataset.write(1, totalRows)) {
+
+      int totalRows = 2000;
+      int maxRowsPerFile = 100; // ~20 fragments
+      List<FragmentMetadata> fragments = testDataset.createNewFragment(totalRows, maxRowsPerFile);
+      assertTrue(fragments.size() > 1, "expected multiple fragments, got " + fragments.size());
+
+      FragmentOperation.Append append = new FragmentOperation.Append(fragments);
+      try (Dataset dataset = Dataset.commit(allocator, datasetPath, append, Optional.of(1L))) {
+        int batchReadahead = 2; // far below the default (num compute CPUs)
         try (LanceScanner scanner =
             dataset.newScan(
-                new ScanOptions.Builder()
-                    .batchSize(batchSize)
-                    .batchReadahead(batchReadahead)
-                    .build())) {
-          // This test is more about ensuring that the batchReadahead parameter is accepted
-          // and doesn't cause errors. The actual effect of batchReadahead might not be
-          // directly observable in this test.
+                new ScanOptions.Builder().batchSize(50).batchReadahead(batchReadahead).build())) {
           try (ArrowReader reader = scanner.scanBatches()) {
             int rowCount = 0;
+            long idSum = 0;
             while (reader.loadNextBatch()) {
-              rowCount += reader.getVectorSchemaRoot().getRowCount();
+              VectorSchemaRoot root = reader.getVectorSchemaRoot();
+              IntVector ids = (IntVector) root.getVector("id");
+              for (int i = 0; i < root.getRowCount(); i++) {
+                idSum += ids.get(i);
+              }
+              rowCount += root.getRowCount();
             }
             assertEquals(totalRows, rowCount);
+            // ids are the contiguous range [0, totalRows)
+            assertEquals((long) totalRows * (totalRows - 1) / 2, idSum);
           }
         }
       }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6183,10 +6183,12 @@ class ScannerBuilder:
 
     def batch_readahead(self, nbatches: Optional[int] = None) -> ScannerBuilder:
         """
-        This parameter is ignored when reading v2 files
+        Set the maximum number of batches to decode concurrently.
+
+        This parameter must be greater than zero.
         """
-        if nbatches is not None and int(nbatches) < 0:
-            raise ValueError("batch_readahead must be non-negative")
+        if nbatches is not None and int(nbatches) <= 0:
+            raise ValueError("batch_readahead must be greater than 0")
         self._batch_readahead = nbatches
         return self
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -91,7 +91,9 @@ use crate::index::scalar_logical::scalar_index_fragment_bitmap;
 use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
-use crate::io::exec::filtered_read::{FilteredReadExec, FilteredReadOptions};
+use crate::io::exec::filtered_read::{
+    FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
+};
 use crate::io::exec::fts::{
     BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
 };
@@ -1374,8 +1376,10 @@ impl Scanner {
         self
     }
 
-    /// Set the prefetch size.
-    /// Ignored in v2 and newer format
+    /// Set the number of batches to decode concurrently.
+    ///
+    /// This bounds the decode fan-out of the scan: at most this many batch-decode
+    /// tasks run in flight at once. Defaults to `get_num_compute_intensive_cpus()`.
     pub fn batch_readahead(&mut self, nbatches: usize) -> &mut Self {
         self.batch_readahead = nbatches;
         self
@@ -2876,6 +2880,11 @@ impl Scanner {
         if let Some(batch_size) = self.batch_size {
             read_options = read_options.with_batch_size(batch_size as u32);
         }
+
+        // Bound the decode fan-out by `batch_readahead`.
+        read_options = read_options.with_threading_mode(
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(self.batch_readahead),
+        );
 
         if let Some(file_reader_options) = self.resolved_file_reader_options() {
             read_options = read_options.with_file_reader_options(file_reader_options);
@@ -12372,6 +12381,36 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert_eq!(filtered.options().io_buffer_size_bytes, Some(7777));
+    }
+
+    #[tokio::test]
+    async fn test_batch_readahead_bounds_decode_concurrency() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_batch_readahead_concurrency", None)
+            .await
+            .unwrap();
+
+        // Default: threading mode falls back to get_num_compute_intensive_cpus().
+        let plan = dataset.scan().create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert_eq!(
+            filtered.options().threading_mode,
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(get_num_compute_intensive_cpus()),
+        );
+
+        // Explicit batch_readahead(N) bounds the decode fan-out to N.
+        let mut scanner = dataset.scan();
+        scanner.batch_readahead(3);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert_eq!(
+            filtered.options().threading_mode,
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(3),
+        );
     }
 
     // The env var key scopes serial_test's lock so this test only blocks others

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1380,6 +1380,8 @@ impl Scanner {
     ///
     /// This bounds the decode fan-out of the scan: at most this many batch-decode
     /// tasks run in flight at once. Defaults to `get_num_compute_intensive_cpus()`.
+    ///
+    /// `nbatches` must be greater than zero.
     pub fn batch_readahead(&mut self, nbatches: usize) -> &mut Self {
         self.batch_readahead = nbatches;
         self
@@ -2369,6 +2371,12 @@ impl Scanner {
     }
 
     fn validate_options(&self) -> Result<()> {
+        if self.batch_readahead == 0 {
+            return Err(Error::invalid_input_source(
+                "batch_readahead must be greater than 0, got 0".into(),
+            ));
+        }
+
         if self.include_deleted_rows && !self.projection_plan.physical_projection.with_row_id {
             return Err(Error::invalid_input_source(
                 "include_deleted_rows is set but with_row_id is false".into(),
@@ -12410,6 +12418,17 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         assert_eq!(
             filtered.options().threading_mode,
             FilteredReadThreadingMode::OnePartitionMultipleThreads(3),
+        );
+
+        let mut scanner = dataset.scan();
+        scanner.batch_readahead(0);
+        let Err(Error::InvalidInput { source, .. }) = scanner.create_plan().await else {
+            panic!("expected batch_readahead=0 to be rejected");
+        };
+        assert!(
+            source
+                .to_string()
+                .contains("batch_readahead must be greater than 0")
         );
     }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -360,11 +360,16 @@ impl FilteredReadStream {
             .clone()
             .unwrap_or_else(|| dataset.fragments().clone());
 
+        let decode_parallelism = match threading_mode {
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(n)
+            | FilteredReadThreadingMode::MultiplePartitions(n) => n,
+        };
         log::debug!(
-            "Filtered read on {} fragments with frag_readahead={} and io_parallelism={}",
+            "Filtered read on {} fragments with frag_readahead={}, io_parallelism={} and decode_parallelism={}",
             fragments.len(),
             fragment_readahead,
-            io_parallelism
+            io_parallelism,
+            decode_parallelism
         );
 
         // Ideally we don't need to collect here but if we don't we get "implementation of FnOnce is
@@ -1480,6 +1485,16 @@ impl FilteredReadOptions {
     /// Only read fragments covered by a scalar index result.
     pub fn with_only_indexed_fragments(mut self) -> Self {
         self.only_indexed_fragments = true;
+        self
+    }
+
+    /// Specify the threading mode to use for the scan.
+    ///
+    /// This controls how decode work is parallelized.  For the default single-partition
+    /// scan, the parameter of [`FilteredReadThreadingMode::OnePartitionMultipleThreads`]
+    /// bounds how many batch-decode tasks are buffered in flight (via `try_buffered`).
+    pub fn with_threading_mode(mut self, threading_mode: FilteredReadThreadingMode) -> Self {
+        self.threading_mode = threading_mode;
         self
     }
 }

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -3923,27 +3923,4 @@ mod tests {
 
         assert_eq!(default_result.num_rows(), capped_result.num_rows());
     }
-
-    /// A parallelism of 0 would make `try_buffered(0)` hang forever, so it must be
-    /// rejected when constructing the plan node.
-    #[test_log::test(tokio::test)]
-    async fn test_zero_parallelism_rejected() {
-        let fixture = TestFixture::new().await;
-
-        for mode in [
-            FilteredReadThreadingMode::OnePartitionMultipleThreads(0),
-            FilteredReadThreadingMode::MultiplePartitions(0),
-        ] {
-            let options =
-                FilteredReadOptions::basic_full_read(&fixture.dataset).with_threading_mode(mode);
-            let err = FilteredReadExec::try_new(fixture.dataset.clone(), options, None)
-                .unwrap_err()
-                .to_string();
-            assert!(
-                err.contains("must be greater than 0"),
-                "unexpected error: {}",
-                err
-            );
-        }
-    }
 }

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -360,16 +360,11 @@ impl FilteredReadStream {
             .clone()
             .unwrap_or_else(|| dataset.fragments().clone());
 
-        let decode_parallelism = match threading_mode {
-            FilteredReadThreadingMode::OnePartitionMultipleThreads(n)
-            | FilteredReadThreadingMode::MultiplePartitions(n) => n,
-        };
         log::debug!(
-            "Filtered read on {} fragments with frag_readahead={}, io_parallelism={} and decode_parallelism={}",
+            "Filtered read on {} fragments with frag_readahead={} and io_parallelism={}",
             fragments.len(),
             fragment_readahead,
-            io_parallelism,
-            decode_parallelism
+            io_parallelism
         );
 
         // Ideally we don't need to collect here but if we don't we get "implementation of FnOnce is
@@ -1493,6 +1488,9 @@ impl FilteredReadOptions {
     /// This controls how decode work is parallelized.  For the default single-partition
     /// scan, the parameter of [`FilteredReadThreadingMode::OnePartitionMultipleThreads`]
     /// bounds how many batch-decode tasks are buffered in flight (via `try_buffered`).
+    ///
+    /// The parallelism must be greater than 0.  A value of 0 is rejected by
+    /// [`FilteredReadExec::try_new`].
     pub fn with_threading_mode(mut self, threading_mode: FilteredReadThreadingMode) -> Self {
         self.threading_mode = threading_mode;
         self
@@ -1586,6 +1584,23 @@ impl FilteredReadExec {
         if options.projection.is_empty() {
             return Err(Error::invalid_input_source("no columns were selected and with_row_id / with_row_address is false, there is nothing to scan"
                 .into()));
+        }
+
+        // A parallelism of 0 would cause `try_buffered(0)` to hang forever instead of erroring
+        match options.threading_mode {
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(0) => {
+                return Err(Error::invalid_input_source(
+                    "FilteredReadThreadingMode::OnePartitionMultipleThreads must be greater than 0, got 0"
+                        .into(),
+                ));
+            }
+            FilteredReadThreadingMode::MultiplePartitions(0) => {
+                return Err(Error::invalid_input_source(
+                    "FilteredReadThreadingMode::MultiplePartitions must be greater than 0, got 0"
+                        .into(),
+                ));
+            }
+            _ => {}
         }
 
         if options.scan_range_after_filter.is_some() {
@@ -3907,5 +3922,28 @@ mod tests {
         let capped_result = concat_batches(&schema2, &batches2).unwrap();
 
         assert_eq!(default_result.num_rows(), capped_result.num_rows());
+    }
+
+    /// A parallelism of 0 would make `try_buffered(0)` hang forever, so it must be
+    /// rejected when constructing the plan node.
+    #[test_log::test(tokio::test)]
+    async fn test_zero_parallelism_rejected() {
+        let fixture = TestFixture::new().await;
+
+        for mode in [
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(0),
+            FilteredReadThreadingMode::MultiplePartitions(0),
+        ] {
+            let options =
+                FilteredReadOptions::basic_full_read(&fixture.dataset).with_threading_mode(mode);
+            let err = FilteredReadExec::try_new(fixture.dataset.clone(), options, None)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("must be greater than 0"),
+                "unexpected error: {}",
+                err
+            );
+        }
     }
 }


### PR DESCRIPTION
## Background & Motivation

Under concurrent-scan workloads like Spark, a single large worker (Executor) typically runs many Tasks in parallel (in Lance's read path, **1 Task = 1 fragment = 1 scan**). The problem: **each Task independently sizes its own scan concurrency from the core count of the current Executor / host**.

Concretely in Lance, the decode concurrency of the v2 read path `FilteredReadExec` (plan name `LanceRead`) — the `try_buffered(num_threads)` — is unconditionally set to `get_num_compute_intensive_cpus()` = `num_cpus − 2`.

```
total decode concurrency per Executor ≈ (concurrent Tasks) × (num_cpus − 2)
```

## Why It Was Deprecated, and the Gap It Left Behind

`Scanner.batch_readahead` is marked `Ignored in v2 and newer format` — a deliberate decision, not an oversight. In v1 it controlled two things: **prefetch depth** and **decode concurrency**. v2 replaced prefetch with a byte-budget model (`io_buffer_size` + `fragment_readahead`), so its prefetch role became meaningless and was rightly dropped.

The gap: v2 split the **decode-concurrency** role into `FilteredReadExec`'s threading mode (`try_buffered(num_threads)`), hard-coded to `get_num_compute_intensive_cpus()`. The only override today is the process-wide `LANCE_CPU_THREADS` env var — far too coarse, since it governs *every* compute-intensive path at once (vector/KNN search, index building, `take`, update/merge-insert, …), not just scan decode concurrency. With no per-scan knob, there's no way to rein in the over-parallelization above.


## What This Change Does & Its Impact

Have `new_filtered_read` pass `Scanner.batch_readahead` through as `FilteredReadThreadingMode::OnePartitionMultipleThreads(batch_readahead)`, reattaching `batch_readahead` to the decode-concurrency dimension that v2 had left without a knob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `batch_readahead` / `batchReadahead` values (0 or less) are now rejected consistently across Java, Python, and Rust.
  * Error messages now clearly state `batch_readahead` must be greater than 0.
  * Filtered scan execution now applies `batch_readahead` to control decoding parallelism more reliably.

* **Tests**
  * Strengthened `batch_readahead` tests to validate deterministic scanned content in addition to row counts.
  * Added Rust coverage for default behavior, custom values, and rejection of zero-parallelism configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->