### PR TITLE
fix(fts): deduplicate list results by row

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2,13 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use lance_core::utils::row_addr_remap::RowAddrRemap;
+use std::cmp::min;
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::{
-    cmp::{Reverse, min},
-    collections::BinaryHeap,
-};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     ops::Range,
@@ -109,6 +106,7 @@ pub const BLOCK_MAX_SCORE_COL: &str = "_block_max_score";
 pub const NUM_TOKEN_COL: &str = "_num_tokens";
 pub const SCORE_COL: &str = "_score";
 pub const TOKEN_SET_FORMAT_KEY: &str = "token_set_format";
+pub const DOCS_HAVE_DUPLICATE_ROW_IDS_KEY: &str = "docs_have_duplicate_row_ids";
 pub const POSTING_TAIL_CODEC_KEY: &str = "posting_tail_codec";
 pub const POSITIONS_LAYOUT_KEY: &str = "positions_layout";
 pub const POSITIONS_CODEC_KEY: &str = "positions_codec";
@@ -417,6 +415,21 @@ pub(super) fn parse_format_version_from_metadata(
     } else {
         Ok(InvertedListFormatVersion::V1)
     }
+}
+
+pub(super) fn parse_docs_have_duplicate_row_ids(
+    metadata: &HashMap<String, String>,
+) -> Result<bool> {
+    metadata
+        .get(DOCS_HAVE_DUPLICATE_ROW_IDS_KEY)
+        .map(|value| {
+            value.parse::<bool>().map_err(|err| {
+                Error::index(format!(
+                    "failed to parse {DOCS_HAVE_DUPLICATE_ROW_IDS_KEY}: {err}"
+                ))
+            })
+        })
+        .unwrap_or(Ok(false))
 }
 
 #[derive(Clone)]
@@ -773,8 +786,7 @@ impl InvertedIndex {
         }
 
         fn push_scored_candidate(
-            candidates: &mut BinaryHeap<Reverse<ScoredDoc>>,
-            limit: usize,
+            candidates: &mut HashMap<u64, f32>,
             addr: CandidateAddr,
             score: f32,
         ) -> Result<()> {
@@ -789,18 +801,37 @@ impl InvertedIndex {
                 }
             };
 
-            if candidates.len() < limit {
-                candidates.push(Reverse(ScoredDoc::new(row_id, score)));
-            } else if candidates.peek().unwrap().0.score.0 < score {
-                candidates.pop();
-                candidates.push(Reverse(ScoredDoc::new(row_id, score)));
-            }
+            candidates
+                .entry(row_id)
+                .and_modify(|existing| {
+                    if score > *existing {
+                        *existing = score;
+                    }
+                })
+                .or_insert(score);
             Ok(())
+        }
+
+        fn sorted_top_rows(candidates: HashMap<u64, f32>, limit: usize) -> (Vec<u64>, Vec<f32>) {
+            let mut candidates = candidates
+                .into_iter()
+                .map(|(row_id, score)| ScoredDoc::new(row_id, score))
+                .collect::<Vec<_>>();
+            candidates.sort_unstable_by(|a, b| {
+                b.score.cmp(&a.score).then_with(|| a.row_id.cmp(&b.row_id))
+            });
+            if candidates.len() > limit {
+                candidates.truncate(limit);
+            }
+            candidates
+                .into_iter()
+                .map(|doc| (doc.row_id, doc.score.0))
+                .unzip()
         }
 
         let mask = prefilter.mask();
 
-        let mut candidates = BinaryHeap::new();
+        let mut candidates = HashMap::new();
         // Shared top-k floor across this query's partitions. Seeded to -inf so
         // the first real score wins; each partition publishes its local k-th
         // and prunes against the running global k-th (a lower bound on the true
@@ -835,7 +866,14 @@ impl InvertedIndex {
                         // row_id/num_tokens download for it.
                         return Result::Ok(PartitionCandidates::empty());
                     }
-                    let docs_for_wand = part.docs.docs_for_wand(mask.as_ref()).await?;
+                    // Row-level top-k needs row_id visibility inside WAND only
+                    // when this docs file actually contains duplicate row_ids.
+                    // Unique-row partitions keep the deferred num_tokens-only
+                    // path and resolve the surviving top-k doc_ids afterwards.
+                    let docs_for_wand = part
+                        .docs
+                        .docs_for_wand(mask.as_ref(), part.docs.has_duplicate_row_ids())
+                        .await?;
                     let max_position = postings
                         .iter()
                         .map(|posting| posting.term_index() as usize)
@@ -926,7 +964,7 @@ impl InvertedIndex {
                         score += idf_by_position[term_index as usize]
                             * scorer.doc_weight(freq, doc_length);
                     }
-                    push_scored_candidate(&mut candidates, limit, addr, score)?;
+                    push_scored_candidate(&mut candidates, addr, score)?;
                 }
             } else {
                 let grouped_positions = grouped_expansions
@@ -965,16 +1003,12 @@ impl InvertedIndex {
                             score += idf_weight * scorer.doc_weight(freq, doc_length);
                         }
                     }
-                    push_scored_candidate(&mut candidates, limit, addr, score)?;
+                    push_scored_candidate(&mut candidates, addr, score)?;
                 }
             }
         }
 
-        Ok(candidates
-            .into_sorted_vec()
-            .into_iter()
-            .map(|Reverse(doc)| (doc.row_id, doc.score.0))
-            .unzip())
+        Ok(sorted_top_rows(candidates, limit))
     }
 
     async fn load_legacy_index(
@@ -1406,7 +1440,8 @@ pub struct InvertedPartition {
     pub(crate) inverted_list: Arc<PostingListReader>,
     /// Per-doc row_id + num_tokens. Wrapped in `LazyDocSet` so partitions
     /// that don't contribute hits to a query never pay the full-array
-    /// download. Scoring paths call `ensure_loaded` before walking wand.
+    /// download. Scoring paths materialize row_ids only when row-level WAND
+    /// needs them for duplicate-row deduplication.
     pub(crate) docs: Arc<LazyDocSet>,
     token_set_format: TokenSetFormat,
 }
@@ -1456,13 +1491,17 @@ impl InvertedPartition {
         // the store + path instead of an open reader keeps a cached partition
         // from pinning a docs-file handle for its whole lifetime.
         let docs_path = doc_file_path(id);
-        let num_docs = store.open_index_file(&docs_path).await?.num_rows();
+        let docs_reader = store.open_index_file(&docs_path).await?;
+        let num_docs = docs_reader.num_rows();
+        let has_duplicate_row_ids =
+            parse_docs_have_duplicate_row_ids(&docs_reader.schema().metadata)?;
         let docs = Arc::new(LazyDocSet::new(
             store.clone(),
             docs_path,
             num_docs,
             false,
             frag_reuse_index,
+            has_duplicate_row_ids,
         ));
 
         Ok(Self {
@@ -1819,6 +1858,7 @@ impl InvertedPartition {
         // handle the num_tokens-only case.
         let scorer = IndexBM25Scorer::new(std::iter::once(self));
         let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
+            .with_duplicate_row_ids(self.docs.has_duplicate_row_ids())
             .with_shared_threshold(shared_threshold);
         let hits = wand.search(params, mask, metrics)?;
         Ok(hits)
@@ -5042,6 +5082,17 @@ impl DocSet {
         !self.row_ids.is_empty()
     }
 
+    pub(crate) fn has_duplicate_row_ids(&self) -> bool {
+        if self.row_ids.len() < 2 {
+            return false;
+        }
+        if self.row_ids.is_sorted() {
+            return self.row_ids.windows(2).any(|window| window[0] == window[1]);
+        }
+        let mut seen = HashSet::with_capacity(self.row_ids.len());
+        self.row_ids.iter().any(|row_id| !seen.insert(*row_id))
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&u64, &u32)> {
         self.row_ids.iter().zip(self.num_tokens.iter())
     }
@@ -5115,10 +5166,16 @@ impl DocSet {
         let row_id_col = UInt64Array::from_iter_values(self.row_ids.iter().cloned());
         let num_tokens_col = UInt32Array::from_iter_values(self.num_tokens.iter().cloned());
 
-        let schema = arrow_schema::Schema::new(vec![
-            arrow_schema::Field::new(ROW_ID, DataType::UInt64, false),
-            arrow_schema::Field::new(NUM_TOKEN_COL, DataType::UInt32, false),
-        ]);
+        let schema = arrow_schema::Schema::new_with_metadata(
+            vec![
+                arrow_schema::Field::new(ROW_ID, DataType::UInt64, false),
+                arrow_schema::Field::new(NUM_TOKEN_COL, DataType::UInt32, false),
+            ],
+            HashMap::from([(
+                DOCS_HAVE_DUPLICATE_ROW_IDS_KEY.to_owned(),
+                self.has_duplicate_row_ids().to_string(),
+            )]),
+        );
 
         let batch = RecordBatch::try_new(
             Arc::new(schema),
@@ -5552,8 +5609,8 @@ fn flat_bm25_score(
     counted_input: &RecordBatch,
     scorer: &MemBM25Scorer,
 ) -> Result<RecordBatch> {
-    let mut row_ids_builder = UInt64Builder::with_capacity(counted_input.num_rows());
-    let mut scores_builder = Float32Builder::with_capacity(counted_input.num_rows());
+    let mut row_order = Vec::new();
+    let mut row_scores = HashMap::new();
 
     let mut row_ids_iter = counted_input
         .column(FLAT_ROW_ID_COL_IDX)
@@ -5592,9 +5649,22 @@ fn flat_bm25_score(
             score += idf * (freq * (K1 + 1.0) / (freq + doc_norm));
         }
         if score > 0.0 {
-            row_ids_builder.append_value(row_id);
-            scores_builder.append_value(score);
+            if let Some(existing) = row_scores.get_mut(&row_id) {
+                if score > *existing {
+                    *existing = score;
+                }
+            } else {
+                row_order.push(row_id);
+                row_scores.insert(row_id, score);
+            }
         }
+    }
+
+    let mut row_ids_builder = UInt64Builder::with_capacity(row_order.len());
+    let mut scores_builder = Float32Builder::with_capacity(row_order.len());
+    for row_id in row_order {
+        row_ids_builder.append_value(row_id);
+        scores_builder.append_value(row_scores[&row_id]);
     }
 
     let row_ids = row_ids_builder.finish();
@@ -7758,6 +7828,63 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_bm25_search_deduplicates_row_ids_across_partitions() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let mut builder0 = InnerBuilder::new(0, false, TokenSetFormat::default());
+        builder0.tokens.add("needle".to_owned());
+        builder0.posting_lists.push(PostingListBuilder::new(false));
+        builder0.posting_lists[0].add(0, PositionRecorder::Count(3));
+        builder0.posting_lists[0].add(1, PositionRecorder::Count(1));
+        builder0.docs.append(100, 1);
+        builder0.docs.append(101, 1);
+        builder0.write(store.as_ref()).await.unwrap();
+
+        let mut builder1 = InnerBuilder::new(1, false, TokenSetFormat::default());
+        builder1.tokens.add("needle".to_owned());
+        builder1.posting_lists.push(PostingListBuilder::new(false));
+        builder1.posting_lists[0].add(0, PositionRecorder::Count(2));
+        builder1.posting_lists[0].add(1, PositionRecorder::Count(1));
+        builder1.docs.append(100, 1);
+        builder1.docs.append(102, 1);
+        builder1.write(store.as_ref()).await.unwrap();
+
+        write_test_metadata(&store, vec![0, 1], InvertedIndexParams::default()).await;
+        let cache = Arc::new(LanceCache::with_capacity(4096));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+
+        let tokens = Arc::new(Tokens::new(vec!["needle".to_string()], DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(2)));
+        let prefilter = Arc::new(NoFilter);
+        let metrics = Arc::new(NoOpMetricsCollector);
+
+        let (row_ids, scores) = index
+            .bm25_search(tokens, params, Operator::Or, prefilter, metrics, None)
+            .await
+            .unwrap();
+
+        assert_eq!(row_ids.len(), 2);
+        assert_eq!(row_ids[0], 100);
+        assert!(
+            matches!(row_ids[1], 101 | 102),
+            "the second row has the same score in both partitions, got {}",
+            row_ids[1]
+        );
+        assert_eq!(scores.len(), row_ids.len());
+        assert!(
+            scores[0] > scores[1],
+            "row 100 should keep the highest score across duplicate candidates"
+        );
+    }
+
     async fn write_test_metadata(
         store: &Arc<LanceIndexStore>,
         partition_ids: Vec<u64>,
@@ -7779,6 +7906,46 @@ mod tests {
             .await
             .unwrap();
         writer.finish_with_metadata(metadata).await.unwrap();
+    }
+
+    async fn write_docset_metadata_test_index(row_ids: &[u64]) -> Arc<InvertedIndex> {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
+        builder.tokens.add("alpha".to_owned());
+        let mut posting = PostingListBuilder::new(false);
+        for (doc_id, row_id) in row_ids.iter().copied().enumerate() {
+            posting.add(doc_id as u32, PositionRecorder::Count(1));
+            builder.docs.append(row_id, 1);
+        }
+        builder.posting_lists.push(posting);
+        builder.write(store.as_ref()).await.unwrap();
+        write_test_metadata(&store, vec![0], InvertedIndexParams::default()).await;
+        InvertedIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_docset_metadata_tracks_unique_row_ids() {
+        let index = write_docset_metadata_test_index(&[10, 11]).await;
+        assert!(!index.partitions[0].docs.has_duplicate_row_ids());
+    }
+
+    #[tokio::test]
+    async fn test_docset_metadata_tracks_duplicate_row_ids() {
+        let index = write_docset_metadata_test_index(&[10, 10, 11]).await;
+        assert!(index.partitions[0].docs.has_duplicate_row_ids());
+    }
+
+    #[test]
+    fn test_missing_docset_duplicate_metadata_defaults_to_fast_path() {
+        assert!(!parse_docs_have_duplicate_row_ids(&HashMap::new()).unwrap());
     }
 
     #[tokio::test]
@@ -8733,6 +8900,56 @@ mod tests {
             "same term frequency should score shorter document higher; short={}, long={}",
             scores.value(0),
             scores.value(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn flat_bm25_search_deduplicates_row_ids_by_max_score() {
+        let schema = Arc::new(Schema::new(vec![
+            ROW_ID_FIELD.clone(),
+            Field::new("text", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![100u64, 100, 101])),
+                Arc::new(StringArray::from(vec![
+                    "alpha filler filler filler",
+                    "alpha",
+                    "alpha",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let input: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(vec![Ok(batch)]),
+        ));
+        let tokenizer: Box<dyn LanceTokenizer> = Box::new(TextTokenizer::new(
+            TextAnalyzer::builder(SimpleTokenizer::default()).build(),
+        ));
+
+        let result_stream = flat_bm25_search_stream_with_metrics(
+            input,
+            "text".to_string(),
+            "alpha".to_string(),
+            tokenizer,
+            None,
+            100,
+            None,
+        )
+        .await
+        .unwrap();
+        let batches: Vec<_> = result_stream.try_collect().await.unwrap();
+        let scored = arrow::compute::concat_batches(&FTS_SCHEMA, &batches).unwrap();
+        let row_ids = scored[ROW_ID].as_primitive::<UInt64Type>();
+        let scores = scored[SCORE_COL].as_primitive::<Float32Type>();
+
+        assert_eq!(row_ids.values(), &[100, 101]);
+        assert!(
+            (scores.value(0) - scores.value(1)).abs() < 1e-6,
+            "row 100 should keep the score from its best matching element"
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -47,6 +47,7 @@ pub struct LoadedDocSet {
     docs: Arc<DocSet>,
     num_rows: usize,
     total_tokens: u64,
+    has_duplicate_row_ids: bool,
 }
 
 /// Store-backed DocSet view that loads on demand and caches.
@@ -64,6 +65,7 @@ pub struct DeferredDocSet {
     docs_path: String,
     is_legacy: bool,
     frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    has_duplicate_row_ids: bool,
     /// Doc count cached at construction so `len()` stays sync + IO-free.
     num_rows: usize,
     /// `sum(num_tokens)` cached on first compute.
@@ -83,10 +85,12 @@ impl std::fmt::Debug for LazyDocSet {
                 .debug_struct("LazyDocSet::Loaded")
                 .field("num_rows", &l.num_rows)
                 .field("total_tokens", &l.total_tokens)
+                .field("has_duplicate_row_ids", &l.has_duplicate_row_ids)
                 .finish(),
             Self::Deferred(d) => f
                 .debug_struct("LazyDocSet::Deferred")
                 .field("num_rows", &d.num_rows)
+                .field("has_duplicate_row_ids", &d.has_duplicate_row_ids)
                 .field("total_tokens_loaded", &d.total_tokens.initialized())
                 .field("full_loaded", &d.full.initialized())
                 .finish(),
@@ -123,12 +127,14 @@ impl LazyDocSet {
         num_rows: usize,
         is_legacy: bool,
         frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+        has_duplicate_row_ids: bool,
     ) -> Self {
         Self::Deferred(Box::new(DeferredDocSet {
             store,
             docs_path,
             is_legacy,
             frag_reuse_index,
+            has_duplicate_row_ids,
             num_rows,
             total_tokens: OnceCell::new(),
             num_tokens_col: OnceCell::new(),
@@ -142,10 +148,12 @@ impl LazyDocSet {
     pub fn from_loaded(docs: DocSet) -> Self {
         let num_rows = docs.len();
         let total_tokens = docs.total_tokens_num();
+        let has_duplicate_row_ids = docs.has_duplicate_row_ids();
         Self::Loaded(LoadedDocSet {
             docs: Arc::new(docs),
             num_rows,
             total_tokens,
+            has_duplicate_row_ids,
         })
     }
 
@@ -176,6 +184,13 @@ impl LazyDocSet {
         match self {
             Self::Loaded(_) => false,
             Self::Deferred(d) => d.frag_reuse_index.is_some(),
+        }
+    }
+
+    pub fn has_duplicate_row_ids(&self) -> bool {
+        match self {
+            Self::Loaded(l) => l.has_duplicate_row_ids,
+            Self::Deferred(d) => d.has_duplicate_row_ids,
         }
     }
 
@@ -213,8 +228,12 @@ impl LazyDocSet {
     /// AND no FragReuseIndex needs to filter row_ids; otherwise the
     /// full DocSet. Encapsulates the policy so callers don't have to
     /// rederive the conditions for the targeted-read fast path.
-    pub async fn docs_for_wand(&self, mask: &RowAddrMask) -> Result<Arc<DocSet>> {
-        if mask.is_select_all() && !self.has_frag_reuse_remap() {
+    pub async fn docs_for_wand(
+        &self,
+        mask: &RowAddrMask,
+        require_row_ids: bool,
+    ) -> Result<Arc<DocSet>> {
+        if !require_row_ids && mask.is_select_all() && !self.has_frag_reuse_remap() {
             self.ensure_num_tokens_loaded().await
         } else {
             self.ensure_loaded().await

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::{
     cell::UnsafeCell,
-    collections::{BinaryHeap, VecDeque},
+    collections::{BinaryHeap, HashMap, VecDeque},
 };
 use std::{cmp::Reverse, fmt::Debug};
 
@@ -574,6 +574,89 @@ pub struct DocCandidate {
     pub doc_length: u32,
 }
 
+type CandidateHeap = BinaryHeap<Reverse<RowHeapEntry>>;
+
+struct ElementCandidate {
+    freqs: Vec<(u32, u32)>,
+    doc_length: u32,
+    posting_doc_id: u64,
+}
+
+struct RowHeapEntry {
+    row_id: u64,
+    score: ScoredDoc,
+    elements: Vec<ElementCandidate>,
+}
+
+impl PartialEq for RowHeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.score == other.score
+    }
+}
+
+impl Eq for RowHeapEntry {}
+
+impl PartialOrd for RowHeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RowHeapEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score.cmp(&other.score)
+    }
+}
+
+struct RowCandidate {
+    row_id: u64,
+    score: f32,
+    elements: Vec<ElementCandidate>,
+}
+
+impl RowCandidate {
+    fn new(
+        row_id: u64,
+        score: f32,
+        freqs: Vec<(u32, u32)>,
+        doc_length: u32,
+        posting_doc_id: u64,
+    ) -> Self {
+        let mut candidate = Self {
+            row_id,
+            score,
+            elements: Vec::new(),
+        };
+        candidate.push_element(score, freqs, doc_length, posting_doc_id);
+        candidate
+    }
+
+    fn push_element(
+        &mut self,
+        score: f32,
+        freqs: Vec<(u32, u32)>,
+        doc_length: u32,
+        posting_doc_id: u64,
+    ) {
+        if score > self.score {
+            self.score = score;
+        }
+        self.elements.push(ElementCandidate {
+            freqs,
+            doc_length,
+            posting_doc_id,
+        });
+    }
+
+    fn into_heap_entry(self) -> Reverse<RowHeapEntry> {
+        Reverse(RowHeapEntry {
+            row_id: self.row_id,
+            score: ScoredDoc::new(self.row_id, self.score),
+            elements: self.elements,
+        })
+    }
+}
+
 struct HeadPosting {
     // Iterators that are already positioned on or after the next candidate doc.
     // The heap is ordered by smallest doc id so the top element determines
@@ -727,6 +810,7 @@ pub struct Wand<'a, S: Scorer> {
     and_candidates_pruned_before_return: usize,
     docs: &'a DocSet,
     scorer: S,
+    rows_may_have_duplicates: bool,
     // Shared cross-partition top-k floor. Each partition publishes its local
     // k-th score (`atomic_store_max_f32`) and prunes against the running value
     // -- a lower bound on the global k-th, so it never drops a real top-k doc.
@@ -791,6 +875,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
             and_candidates_pruned_before_return: 0,
             docs,
             scorer,
+            rows_may_have_duplicates: false,
             shared_threshold: None,
         }
     }
@@ -798,6 +883,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
     /// Share one cross-partition top-k floor across a query's partitions.
     pub(crate) fn with_shared_threshold(mut self, shared: Arc<AtomicU32>) -> Self {
         self.shared_threshold = Some(shared);
+        self
+    }
+
+    /// Override the duplicate-row-id metadata supplied by the caller.
+    pub(crate) fn with_duplicate_row_ids(mut self, has_duplicate_row_ids: bool) -> Self {
+        self.rows_may_have_duplicates = has_duplicate_row_ids;
         self
     }
 
@@ -826,6 +917,122 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
     }
 
+    fn push_row_candidate(
+        &mut self,
+        candidates: &mut CandidateHeap,
+        limit: usize,
+        candidate: RowCandidate,
+        params: &FtsSearchParams,
+    ) {
+        if candidates.len() < limit {
+            candidates.push(candidate.into_heap_entry());
+            if candidates.len() == limit {
+                let kth = candidates.peek().unwrap().0.score.score.0;
+                self.update_threshold(kth, params.wand_factor);
+            }
+        } else if candidate.score > candidates.peek().unwrap().0.score.score.0 {
+            candidates.pop();
+            candidates.push(candidate.into_heap_entry());
+            let kth = candidates.peek().unwrap().0.score.score.0;
+            self.update_threshold(kth, params.wand_factor);
+        }
+    }
+
+    fn flush_row_candidate(
+        &mut self,
+        candidates: &mut CandidateHeap,
+        limit: usize,
+        current_row: &mut Option<RowCandidate>,
+        params: &FtsSearchParams,
+    ) {
+        if let Some(candidate) = current_row.take() {
+            self.push_row_candidate(candidates, limit, candidate, params);
+        }
+    }
+
+    fn push_row_element(
+        row_candidates: &mut HashMap<u64, RowCandidate>,
+        row_id: u64,
+        score: f32,
+        freqs: Vec<(u32, u32)>,
+        doc_length: u32,
+        posting_doc_id: u64,
+    ) {
+        match row_candidates.get_mut(&row_id) {
+            Some(candidate) => candidate.push_element(score, freqs, doc_length, posting_doc_id),
+            None => {
+                row_candidates.insert(
+                    row_id,
+                    RowCandidate::new(row_id, score, freqs, doc_length, posting_doc_id),
+                );
+            }
+        }
+    }
+
+    fn top_row_candidates(
+        row_candidates: HashMap<u64, RowCandidate>,
+        limit: usize,
+    ) -> Vec<RowCandidate> {
+        let mut row_candidates = row_candidates.into_values().collect::<Vec<_>>();
+        row_candidates.sort_unstable_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.row_id.cmp(&b.row_id))
+        });
+        if row_candidates.len() > limit {
+            row_candidates.truncate(limit);
+        }
+        row_candidates
+    }
+
+    fn publish_shared_threshold(&self, row_candidates: &[RowCandidate], limit: usize) {
+        if row_candidates.len() == limit
+            && let (Some(shared), Some(kth)) =
+                (self.shared_threshold.as_ref(), row_candidates.last())
+        {
+            atomic_store_max_f32(shared, kth.score);
+        }
+    }
+
+    fn row_candidates_into_doc_candidates(row_candidates: Vec<RowCandidate>) -> Vec<DocCandidate> {
+        row_candidates
+            .into_iter()
+            .flat_map(|row| {
+                row.elements.into_iter().map(move |element| DocCandidate {
+                    addr: CandidateAddr::RowId(row.row_id),
+                    posting_doc_id: element.posting_doc_id,
+                    freqs: element.freqs,
+                    doc_length: element.doc_length,
+                })
+            })
+            .collect()
+    }
+
+    fn heap_into_doc_candidates(
+        candidates: CandidateHeap,
+        docs_has_row_ids: bool,
+    ) -> Vec<DocCandidate> {
+        let to_addr = |row_id_slot: u64| {
+            if docs_has_row_ids {
+                CandidateAddr::RowId(row_id_slot)
+            } else {
+                CandidateAddr::Pending(row_id_slot as u32)
+            }
+        };
+        candidates
+            .into_iter()
+            .flat_map(|Reverse(row)| {
+                let addr = to_addr(row.row_id);
+                row.elements.into_iter().map(move |element| DocCandidate {
+                    addr,
+                    posting_doc_id: element.posting_doc_id,
+                    freqs: element.freqs,
+                    doc_length: element.doc_length,
+                })
+            })
+            .collect()
+    }
+
     // search the top-k documents that contain the query
     // returns the row_id, frequency and doc length
     pub(crate) fn search(
@@ -839,9 +1046,11 @@ impl<'a, S: Scorer> Wand<'a, S> {
             return Ok(vec![]);
         }
 
+        let docs_has_row_ids = self.docs.has_row_ids();
         match (mask.max_len(), mask.iter_addrs()) {
             (Some(num_rows_matched), Some(row_ids))
-                if self.operator == Operator::Or
+                if docs_has_row_ids
+                    && self.operator == Operator::Or
                     && num_rows_matched * 100
                         <= FLAT_SEARCH_PERCENT_THRESHOLD.deref() * self.docs.len() as u64 =>
             {
@@ -854,9 +1063,11 @@ impl<'a, S: Scorer> Wand<'a, S> {
         // row_ids, wand emits candidates carrying just the
         // partition-local doc_id; the outer caller resolves them to
         // row_ids post-wand.
-        let docs_has_row_ids = self.docs.has_row_ids();
+        let aggregate_rows = docs_has_row_ids && self.rows_may_have_duplicates;
 
-        let mut candidates = BinaryHeap::with_capacity(std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut candidates: CandidateHeap =
+            BinaryHeap::with_capacity(std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut row_candidates = HashMap::new();
         let mut num_comparisons = 0;
         let mut and_search_stats = (self.operator == Operator::And).then_some(AndSearchStats {
             pruned_before_return_start: self.and_candidates_pruned_before_return,
@@ -901,7 +1112,6 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 }
                 continue;
             }
-
             let doc_length = match &doc {
                 DocInfo::Raw(doc) => self.docs.num_tokens(doc.doc_id),
                 DocInfo::Located(doc) => self.docs.num_tokens_by_row_id(doc.row_id),
@@ -929,35 +1139,31 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 self.score(doc_length)
             };
 
-            if candidates.len() < limit {
+            if aggregate_rows {
                 let freqs = self.iter_term_freqs().collect();
                 if let Some(and_stats) = and_search_stats.as_mut() {
                     and_stats.freqs_collected += 1;
                 }
-                candidates.push(Reverse((
-                    ScoredDoc::new(row_id, score),
+                Self::push_row_element(
+                    &mut row_candidates,
+                    row_id,
+                    score,
                     freqs,
                     doc_length,
                     posting_doc_id,
-                )));
-                if candidates.len() == limit {
-                    let kth = candidates.peek().unwrap().0.0.score.0;
-                    self.update_threshold(kth, params.wand_factor);
-                }
-            } else if score > candidates.peek().unwrap().0.0.score.0 {
+                );
+            } else if candidates.len() < limit || score > candidates.peek().unwrap().0.score.score.0
+            {
                 let freqs = self.iter_term_freqs().collect();
                 if let Some(and_stats) = and_search_stats.as_mut() {
                     and_stats.freqs_collected += 1;
                 }
-                candidates.pop();
-                candidates.push(Reverse((
-                    ScoredDoc::new(row_id, score),
-                    freqs,
-                    doc_length,
-                    posting_doc_id,
-                )));
-                let kth = candidates.peek().unwrap().0.0.score.0;
-                self.update_threshold(kth, params.wand_factor);
+                self.push_row_candidate(
+                    &mut candidates,
+                    limit,
+                    RowCandidate::new(row_id, score, freqs, doc_length, posting_doc_id),
+                    params,
+                );
             }
             if self.operator == Operator::Or {
                 self.push_back_leads(doc.doc_id() + 1);
@@ -984,28 +1190,17 @@ impl<'a, S: Scorer> Wand<'a, S> {
             metrics.record_freqs_collected(and_stats.freqs_collected);
         }
 
-        // The heap entry's `row_id` slot is either a real row_id
-        // (DocSet had row_ids) or the doc_id widened to u64
-        // (deferred). Tag it accordingly so the caller can match
-        // rather than guess.
-        let to_addr = |row_id_slot: u64| {
-            if docs_has_row_ids {
-                CandidateAddr::RowId(row_id_slot)
-            } else {
-                CandidateAddr::Pending(row_id_slot as u32)
-            }
-        };
-        Ok(candidates
-            .into_iter()
-            .map(
-                |Reverse((doc, freqs, doc_length, posting_doc_id))| DocCandidate {
-                    addr: to_addr(doc.row_id),
-                    posting_doc_id,
-                    freqs,
-                    doc_length,
-                },
-            )
-            .collect())
+        if aggregate_rows {
+            let row_candidates = Self::top_row_candidates(row_candidates, limit);
+            self.publish_shared_threshold(&row_candidates, limit);
+            Ok(Self::row_candidates_into_doc_candidates(row_candidates))
+        } else {
+            // The heap entry's `row_id` slot is either a real row_id
+            // (DocSet had row_ids) or the doc_id widened to u64
+            // (deferred). Tag it accordingly so the caller can match
+            // rather than guess.
+            Ok(Self::heap_into_doc_candidates(candidates, docs_has_row_ids))
+        }
     }
 
     fn flat_search(
@@ -1024,7 +1219,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
         // A list column maps one row id to several doc ids, so expand every
         // document the row owns — keying on a single doc id would drop matches
         // at non-last list positions (lancedb#3352).
-        let doc_ids = row_ids
+        let mut doc_ids = row_ids
             .flat_map(|row_addr| {
                 let row_id: u64 = row_addr.into();
                 self.docs
@@ -1032,7 +1227,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
                     .map(move |doc_id| (doc_id, row_id))
             })
             .sorted_unstable()
-            .collect::<Vec<_>>();
+            .peekable();
         let is_compressed = self
             .head
             .peek()
@@ -1045,8 +1240,17 @@ impl<'a, S: Scorer> Wand<'a, S> {
             .unwrap_or(false);
 
         let mut num_comparisons = 0;
-        let mut candidates = BinaryHeap::new();
-        for (doc_id, row_id) in doc_ids {
+        let mut candidates: CandidateHeap = BinaryHeap::new();
+        let mut row_candidates = HashMap::new();
+        let mut current_row = None;
+        while let Some((doc_id, row_id)) = doc_ids.next() {
+            if !self.rows_may_have_duplicates
+                && current_row
+                    .as_ref()
+                    .is_some_and(|candidate: &RowCandidate| candidate.row_id != row_id)
+            {
+                self.flush_row_candidate(&mut candidates, limit, &mut current_row, params);
+            }
             num_comparisons += 1;
             self.move_head_before_target_to_tail(doc_id);
             self.move_head_doc_to_lead(doc_id);
@@ -1092,48 +1296,53 @@ impl<'a, S: Scorer> Wand<'a, S> {
             self.collect_tail_matches(doc_id);
             let score = self.score(doc_length);
 
-            if candidates.len() < limit {
+            if self.rows_may_have_duplicates {
                 let freqs = self.iter_term_freqs().collect();
-                candidates.push(Reverse((
-                    ScoredDoc::new(row_id, score),
+                Self::push_row_element(
+                    &mut row_candidates,
+                    row_id,
+                    score,
                     freqs,
                     doc_length,
                     doc_id,
-                )));
-                if candidates.len() == limit {
-                    let kth = candidates.peek().unwrap().0.0.score.0;
-                    self.update_threshold(kth, params.wand_factor);
+                );
+            } else if candidates.len() < limit || score > candidates.peek().unwrap().0.score.score.0
+            {
+                let freqs = self.iter_term_freqs().collect();
+                match current_row.as_mut() {
+                    Some(candidate) => {
+                        candidate.push_element(score, freqs, doc_length, doc_id);
+                    }
+                    None => {
+                        current_row =
+                            Some(RowCandidate::new(row_id, score, freqs, doc_length, doc_id));
+                    }
                 }
-            } else if score > candidates.peek().unwrap().0.0.score.0 {
-                let freqs = self.iter_term_freqs().collect();
-                candidates.pop();
-                candidates.push(Reverse((
-                    ScoredDoc::new(row_id, score),
-                    freqs,
-                    doc_length,
-                    doc_id,
-                )));
-                let kth = candidates.peek().unwrap().0.0.score.0;
-                self.update_threshold(kth, params.wand_factor);
+                let is_row_end = match doc_ids.peek() {
+                    Some((_, next_row_id)) => *next_row_id != row_id,
+                    None => true,
+                };
+                if is_row_end {
+                    self.flush_row_candidate(&mut candidates, limit, &mut current_row, params);
+                }
             }
 
             self.advance_lead_to_head(doc_id + 1);
         }
+        if !self.rows_may_have_duplicates {
+            self.flush_row_candidate(&mut candidates, limit, &mut current_row, params);
+        }
         metrics.record_comparisons(num_comparisons);
 
-        // flat_search is driven by an explicit row_ids iterator, so
-        // every candidate already has a real row_id.
-        Ok(candidates
-            .into_iter()
-            .map(
-                |Reverse((doc, freqs, doc_length, posting_doc_id))| DocCandidate {
-                    addr: CandidateAddr::RowId(doc.row_id),
-                    posting_doc_id,
-                    freqs,
-                    doc_length,
-                },
-            )
-            .collect())
+        if self.rows_may_have_duplicates {
+            let row_candidates = Self::top_row_candidates(row_candidates, limit);
+            self.publish_shared_threshold(&row_candidates, limit);
+            Ok(Self::row_candidates_into_doc_candidates(row_candidates))
+        } else {
+            // flat_search is driven by an explicit row_ids iterator, so
+            // every candidate already has a real row_id.
+            Ok(Self::heap_into_doc_candidates(candidates, true))
+        }
     }
 
     // calculate the score of the current document
@@ -3238,7 +3447,8 @@ mod tests {
             vec![posting].into_iter(),
             &docs,
             InverseDocLengthScorer,
-        );
+        )
+        .with_duplicate_row_ids(true);
         wand.threshold = 0.5;
 
         let selected = vec![RowAddress::from(1_u64), RowAddress::from(2_u64)];
@@ -3305,7 +3515,8 @@ mod tests {
             vec![posting].into_iter(),
             &docs,
             InverseDocLengthScorer,
-        );
+        )
+        .with_duplicate_row_ids(true);
         wand.threshold = 0.5;
 
         let selected = vec![RowAddress::from(100_u64)];
@@ -3326,6 +3537,224 @@ mod tests {
             matches!(addrs.as_slice(), [CandidateAddr::RowId(100)]),
             "expected exactly row 100, got {addrs:?}"
         );
+    }
+
+    #[test]
+    fn test_search_deduplicates_list_row_candidates() {
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 100, 100, 101]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0, 1, 2, 3], 1.0, None, true),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, vec![posting].into_iter(), &docs, UnitScorer)
+            .with_duplicate_row_ids(true);
+
+        let result = wand
+            .search(
+                &FtsSearchParams::new().with_limit(Some(2)),
+                Arc::new(RowAddrMask::default()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        let mut row_ids = result
+            .into_iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(row_id) => row_id,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_ids.sort_unstable();
+        row_ids.dedup();
+
+        assert_eq!(row_ids, vec![100, 101]);
+    }
+
+    #[test]
+    fn test_search_deduplicates_non_contiguous_list_row_candidates() {
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 101, 100]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(vec![0, 1, 2], vec![10, 8, 9], 10.0, None, true),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, vec![posting].into_iter(), &docs, UnitScorer)
+            .with_duplicate_row_ids(true);
+
+        let result = wand
+            .search(
+                &FtsSearchParams::new().with_limit(Some(2)),
+                Arc::new(RowAddrMask::default()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        let mut row_ids = result
+            .iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(row_id) => row_id,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_ids.sort_unstable();
+        row_ids.dedup();
+
+        let mut row_100_doc_ids = result
+            .into_iter()
+            .filter_map(|doc| match doc.addr {
+                CandidateAddr::RowId(100) => Some(doc.posting_doc_id),
+                CandidateAddr::RowId(_) => None,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_100_doc_ids.sort_unstable();
+
+        assert_eq!(row_ids, vec![100, 101]);
+        assert_eq!(row_100_doc_ids, vec![0, 2]);
+    }
+
+    #[test]
+    fn test_search_returns_all_elements_for_selected_list_row() {
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 100, 101]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(vec![0, 1, 2], vec![2, 1, 1], 2.0, None, true),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, vec![posting].into_iter(), &docs, UnitScorer)
+            .with_duplicate_row_ids(true);
+
+        let result = wand
+            .search(
+                &FtsSearchParams::new().with_limit(Some(1)),
+                Arc::new(RowAddrMask::default()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        let mut posting_doc_ids = result
+            .into_iter()
+            .map(|doc| {
+                assert!(matches!(doc.addr, CandidateAddr::RowId(100)));
+                doc.posting_doc_id
+            })
+            .collect::<Vec<_>>();
+        posting_doc_ids.sort_unstable();
+
+        assert_eq!(posting_doc_ids, vec![0, 1]);
+    }
+
+    #[rstest]
+    fn test_flat_search_deduplicates_list_row_candidates(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 100, 100, 101]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0, 1, 2, 3], 1.0, None, is_compressed),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, vec![posting].into_iter(), &docs, UnitScorer)
+            .with_duplicate_row_ids(true);
+
+        let selected = vec![RowAddress::from(100_u64), RowAddress::from(101_u64)];
+        let result = wand
+            .flat_search(
+                &FtsSearchParams::new().with_limit(Some(2)),
+                Box::new(selected.into_iter()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        let mut row_ids = result
+            .into_iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(row_id) => row_id,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_ids.sort_unstable();
+        row_ids.dedup();
+
+        assert_eq!(row_ids, vec![100, 101]);
+    }
+
+    #[rstest]
+    fn test_flat_search_deduplicates_non_contiguous_list_row_candidates(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 101, 100]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(
+                vec![0, 1, 2],
+                vec![10, 8, 9],
+                10.0,
+                None,
+                is_compressed,
+            ),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, vec![posting].into_iter(), &docs, UnitScorer)
+            .with_duplicate_row_ids(true);
+
+        let selected = vec![RowAddress::from(100_u64), RowAddress::from(101_u64)];
+        let result = wand
+            .flat_search(
+                &FtsSearchParams::new().with_limit(Some(2)),
+                Box::new(selected.into_iter()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        let mut row_ids = result
+            .iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(row_id) => row_id,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_ids.sort_unstable();
+        row_ids.dedup();
+
+        let mut row_100_doc_ids = result
+            .into_iter()
+            .filter_map(|doc| match doc.addr {
+                CandidateAddr::RowId(100) => Some(doc.posting_doc_id),
+                CandidateAddr::RowId(_) => None,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        row_100_doc_ids.sort_unstable();
+
+        assert_eq!(row_ids, vec![100, 101]);
+        assert_eq!(row_100_doc_ids, vec![0, 2]);
     }
 
     #[test]

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -107,7 +107,10 @@ async fn search_segments(
     base_scorer: Arc<MemBM25Scorer>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
     let limit = params.limit.unwrap_or(usize::MAX);
-    let mut candidates = std::collections::BinaryHeap::new();
+    if limit == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let mut candidates = HashMap::new();
     let searches = indices
         .iter()
         .map(|index| {
@@ -136,19 +139,29 @@ async fn search_segments(
 
     while let Some((doc_ids, scores)) = searches.try_next().await? {
         for (row_id, score) in doc_ids.into_iter().zip(scores.into_iter()) {
-            if candidates.len() < limit {
-                candidates.push(std::cmp::Reverse(ScoredDoc::new(row_id, score)));
-            } else if candidates.peek().unwrap().0.score.0 < score {
-                candidates.pop();
-                candidates.push(std::cmp::Reverse(ScoredDoc::new(row_id, score)));
-            }
+            candidates
+                .entry(row_id)
+                .and_modify(|existing| {
+                    if score > *existing {
+                        *existing = score;
+                    }
+                })
+                .or_insert(score);
         }
     }
 
-    Ok(candidates
-        .into_sorted_vec()
+    let mut candidates = candidates
         .into_iter()
-        .map(|std::cmp::Reverse(doc)| (doc.row_id, doc.score.0))
+        .map(|(row_id, score)| ScoredDoc::new(row_id, score))
+        .collect::<Vec<_>>();
+    candidates.sort_unstable_by(|a, b| b.score.cmp(&a.score).then_with(|| a.row_id.cmp(&b.row_id)));
+    if candidates.len() > limit {
+        candidates.truncate(limit);
+    }
+
+    Ok(candidates
+        .into_iter()
+        .map(|doc| (doc.row_id, doc.score.0))
         .unzip())
 }
 

--- a/rust/lance/tests/query/inverted.rs
+++ b/rust/lance/tests/query/inverted.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+use arrow::datatypes::Float32Type;
+use arrow_array::builder::{ListBuilder, StringBuilder};
 use arrow_array::cast::AsArray;
 use arrow_array::{
     ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, StringArray, UInt32Array,
@@ -12,8 +14,8 @@ use lance::dataset::scanner::ColumnOrdering;
 use lance::dataset::{InsertBuilder, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance_index::IndexType;
-use lance_index::scalar::inverted::Language;
 use lance_index::scalar::inverted::query::{FtsQuery, PhraseQuery};
+use lance_index::scalar::inverted::{Language, SCORE_COL};
 use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
 use lance_table::format::IndexMetadata;
 
@@ -148,6 +150,63 @@ async fn test_inverted_phrase_query_with_positions() {
             test_fts(&original, &ds, "text", "lance database", None, true, true).await;
         })
         .await;
+}
+
+#[tokio::test]
+async fn test_inverted_list_utf8_returns_unique_rows_with_row_limit() {
+    let test_dir = tempfile::tempdir().unwrap();
+    let test_uri = test_dir.path().to_str().unwrap();
+
+    let mut tags = ListBuilder::new(StringBuilder::new());
+    for row in [
+        ["puppy", "puppy", "puppy"].as_slice(),
+        ["puppy"].as_slice(),
+        ["kitten"].as_slice(),
+    ] {
+        for value in row {
+            tags.values().append_value(*value);
+        }
+        tags.append(true);
+    }
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![0, 1, 2])) as ArrayRef),
+        ("tags", Arc::new(tags.finish()) as ArrayRef),
+    ])
+    .unwrap();
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema);
+    let mut ds = Dataset::write(reader, test_uri, None).await.unwrap();
+
+    let params = base_inverted_params(false);
+    ds.create_index(&["tags"], IndexType::Inverted, None, &params, true)
+        .await
+        .unwrap();
+
+    let query = FullTextSearchQuery::new("puppy".to_string())
+        .with_column("tags".to_string())
+        .unwrap()
+        .limit(Some(2));
+    let mut scanner = ds.scan();
+    scanner.full_text_search(query).unwrap();
+    let result = scanner.try_into_batch().await.unwrap();
+
+    assert_eq!(result.num_rows(), 2);
+    let ids = result
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<arrow::datatypes::Int32Type>();
+    let mut ids = ids.values().to_vec();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![0, 1]);
+
+    let scores = result
+        .column_by_name(SCORE_COL)
+        .unwrap()
+        .as_primitive::<Float32Type>();
+    assert!(
+        (scores.value(0) - scores.value(1)).abs() < 1e-6,
+        "row 0 should keep the score from one best matching list element"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #5887.

Related to #7246, which fixed a list FTS prefilter allowlist false-negative case. This PR fixes the remaining row-level result contract: `List<Utf8>` indexing can create multiple internal documents for the same row, but public FTS query results are rows.

The old path let document-level top-k run before row-level deduplication, which could return duplicate rows and could prune valid rows before deduplication.

This records whether each docs file actually contains duplicate row ids, preserves the num-tokens-only WAND fast path for unique-row docs, and switches duplicate-row cases to row-level max-score aggregation before top-k pruning.
