### PR TITLE
fix(encoding): select RLE widths by encoded size

### DIFF
--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -1906,6 +1906,32 @@ mod tests {
     }
 
     #[test]
+    fn test_rle_v2_miniblock_keeps_u8_run_lengths_before_v2_3() {
+        for version in [LanceFileVersion::V2_1, LanceFileVersion::V2_2] {
+            let mut metadata = HashMap::new();
+            metadata.insert(RLE_THRESHOLD_META_KEY.to_string(), "1.0".to_string());
+            metadata.insert(BSS_META_KEY.to_string(), "off".to_string());
+            let mut field = create_test_field("test_column", DataType::Int32);
+            field.metadata = metadata;
+
+            let values = vec![7i32; 1000];
+            let mut data = FixedWidthDataBlock {
+                bits_per_value: 32,
+                data: LanceBuffer::reinterpret_vec(values),
+                num_values: 1000,
+                block_info: BlockInfo::default(),
+            };
+            data.compute_stat();
+            let data = DataBlock::FixedWidth(data);
+
+            let strategy = DefaultCompressionStrategy::new().with_version(version);
+            let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+            let (_compressed, encoding) = compressor.compress(data).unwrap();
+            assert_eq!(rle_run_length_bits(&encoding), 8, "version={version}");
+        }
+    }
+
+    #[test]
     fn test_rle_v2_uses_selected_width_cost_before_bitpacking() {
         let mut metadata = HashMap::new();
         metadata.insert(RLE_THRESHOLD_META_KEY.to_string(), "1.0".to_string());
@@ -2227,6 +2253,25 @@ mod tests {
             }
             _ => panic!("expected fixed-width block"),
         }
+    }
+
+    #[test]
+    fn test_rle_v2_block_keeps_u8_run_lengths_for_v2_2() {
+        let field = create_test_field("dict_indices", DataType::Int32);
+        let values = vec![42i32; 70_000];
+        let mut block = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 70_000,
+            block_info: BlockInfo::default(),
+        };
+        block.compute_stat();
+        let data = DataBlock::FixedWidth(block);
+
+        let strategy = DefaultCompressionStrategy::with_params(CompressionParams::new())
+            .with_version(LanceFileVersion::V2_2);
+        let (_compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        assert_eq!(rle_run_length_bits(&encoding), 8);
     }
 
     #[test]

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -26,7 +26,10 @@ use crate::{
     },
     data::{DataBlock, FixedWidthDataBlock, VariableWidthBlock},
     encodings::{
-        logical::primitive::{fullzip::PerValueCompressor, miniblock::MiniBlockCompressor},
+        logical::primitive::{
+            fullzip::PerValueCompressor,
+            miniblock::{MAX_MINIBLOCK_VALUES, MiniBlockCompressor},
+        },
         physical::{
             binary::{
                 BinaryBlockDecompressor, BinaryMiniBlockDecompressor, BinaryMiniBlockEncoder,
@@ -52,8 +55,8 @@ use crate::{
                 VariablePackedStructFieldKind,
             },
             rle::{
-                RleDecompressor, RleEncoder, RunLengthWidth, select_run_length_width,
-                select_run_length_width_and_size,
+                RleDecompressor, RleEncoder, RunLengthWidth, rle_encoded_size,
+                select_run_length_width,
             },
             value::{ValueDecompressor, ValueEncoder},
         },
@@ -81,6 +84,7 @@ const DEFAULT_RLE_COMPRESSION_THRESHOLD: f64 = 0.5;
 
 // Minimum block size (32kb) to trigger general block compression
 const MIN_BLOCK_SIZE_FOR_GENERAL_COMPRESSION: u64 = 32 * 1024;
+const RLE_BLOCK_HEADER_BYTES: u128 = std::mem::size_of::<u64>() as u128;
 
 /// Trait for compression algorithms that compress an entire block of data into one opaque
 /// and self-described chunk.
@@ -195,17 +199,16 @@ fn try_rle_for_mini_block(
     let num_values = data.num_values;
     let raw_bytes = (num_values as u128) * (type_size as u128);
     let (run_length_width, rle_bytes) = if use_rle_v2 {
-        select_run_length_width_and_size(&data.data, data.num_values, data.bits_per_value).ok()?
+        estimate_rle_width_and_size_from_data(data, Some(*MAX_MINIBLOCK_VALUES)).ok()?
     } else {
-        // Estimate the encoded size.
-        //
-        // Compatibility RLE stores (value, u8 run_length) pairs. Long runs are split into
-        // multiple entries of up to 255 values. We don't know the run length distribution here,
-        // so we conservatively account for splitting with an upper bound.
-        let estimated_pairs = (run_count.saturating_add(num_values / 255)).min(num_values);
         (
             RunLengthWidth::U8,
-            (estimated_pairs as u128) * ((type_size + 1) as u128),
+            estimate_rle_size_for_width_from_data(
+                data,
+                Some(*MAX_MINIBLOCK_VALUES),
+                RunLengthWidth::U8,
+            )
+            .ok()?,
         )
     };
 
@@ -245,20 +248,71 @@ fn try_rle_for_block(
         .rle_threshold
         .unwrap_or(DEFAULT_RLE_COMPRESSION_THRESHOLD);
 
-    if (run_count as f64) < (data.num_values as f64) * threshold {
-        let run_length_width = if use_rle_v2 {
-            select_run_length_width(&data.data, data.num_values, data.bits_per_value)?
-        } else {
-            RunLengthWidth::U8
-        };
-        let compressor = Box::new(RleEncoder::with_run_length_width(run_length_width));
-        let encoding = ProtobufUtils21::rle(
-            ProtobufUtils21::flat(bits, None),
-            ProtobufUtils21::flat(run_length_width.bits_per_value(), None),
-        );
-        return Ok(Some((compressor, encoding)));
+    let passes_threshold = match params.rle_threshold {
+        Some(_) => (run_count as f64) < (data.num_values as f64) * threshold,
+        None => true,
+    };
+
+    if !passes_threshold {
+        return Ok(None);
     }
-    Ok(None)
+
+    let raw_bytes = (data.num_values as u128) * ((bits / 8) as u128);
+    let (run_length_width, rle_payload_bytes) = if use_rle_v2 {
+        estimate_rle_width_and_size_from_data(data, None)?
+    } else {
+        (
+            RunLengthWidth::U8,
+            estimate_rle_size_for_width_from_data(data, None, RunLengthWidth::U8)?,
+        )
+    };
+    let rle_bytes = rle_payload_bytes.saturating_add(RLE_BLOCK_HEADER_BYTES);
+
+    if rle_bytes >= raw_bytes {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "bitpacking")]
+    {
+        if let Some(bitpack_bytes) = estimate_block_bitpacking_bytes(data)
+            && bitpack_bytes < rle_bytes
+        {
+            return Ok(None);
+        }
+    }
+
+    let compressor = Box::new(RleEncoder::with_run_length_width(run_length_width));
+    let encoding = ProtobufUtils21::rle(
+        ProtobufUtils21::flat(bits, None),
+        ProtobufUtils21::flat(run_length_width.bits_per_value(), None),
+    );
+    Ok(Some((compressor, encoding)))
+}
+
+fn estimate_rle_width_and_size_from_data(
+    data: &FixedWidthDataBlock,
+    max_segment_values: Option<u64>,
+) -> Result<(RunLengthWidth, u128)> {
+    select_run_length_width(
+        &data.data,
+        data.num_values,
+        data.bits_per_value,
+        max_segment_values,
+    )
+}
+
+fn estimate_rle_size_for_width_from_data(
+    data: &FixedWidthDataBlock,
+    max_segment_values: Option<u64>,
+    run_length_width: RunLengthWidth,
+) -> Result<u128> {
+    rle_encoded_size(
+        &data.data,
+        data.num_values,
+        data.bits_per_value,
+        max_segment_values,
+        run_length_width,
+    )
 }
 
 fn try_bitpack_for_mini_block(_data: &FixedWidthDataBlock) -> Option<Box<dyn MiniBlockCompressor>> {
@@ -341,6 +395,67 @@ fn try_bitpack_for_block(
         );
         Some((compressor, encoding))
     }
+}
+
+#[cfg(feature = "bitpacking")]
+fn estimate_block_bitpacking_bytes(data: &FixedWidthDataBlock) -> Option<u128> {
+    let bits = data.bits_per_value;
+    if !matches!(bits, 8 | 16 | 32 | 64) || data.num_values == 0 {
+        return None;
+    }
+
+    let bit_widths = data.expect_stat(Stat::BitWidth);
+    let widths = bit_widths.as_primitive::<UInt64Type>();
+    let max_bit_width = *widths.values().iter().max()?;
+    let word_bytes = (bits / 8) as u128;
+
+    let bitpacked_words = if data.num_values <= 1024 {
+        1 + (1024u128 * (max_bit_width as u128)) / (bits as u128)
+    } else {
+        estimate_out_of_line_bitpacking_words(data.num_values, max_bit_width, bits)?
+    };
+    let bitpacked_bytes = bitpacked_words.saturating_mul(word_bytes);
+    if bitpacked_bytes >= data.data_size() as u128 {
+        return None;
+    }
+
+    Some(bitpacked_bytes)
+}
+
+#[cfg(feature = "bitpacking")]
+fn estimate_out_of_line_bitpacking_words(
+    num_values: u64,
+    compressed_bits_per_value: u64,
+    bits_per_value: u64,
+) -> Option<u128> {
+    let num_values = usize::try_from(num_values).ok()?;
+    let compressed_bits_per_value = usize::try_from(compressed_bits_per_value).ok()?;
+    let bits_per_value = usize::try_from(bits_per_value).ok()?;
+    if compressed_bits_per_value >= bits_per_value {
+        return None;
+    }
+
+    let elems_per_chunk = 1024usize;
+    let num_chunks = num_values.div_ceil(elems_per_chunk);
+    let words_per_chunk = (elems_per_chunk * compressed_bits_per_value).div_ceil(bits_per_value);
+    let last_chunk_is_runt = !num_values.is_multiple_of(elems_per_chunk);
+
+    if !last_chunk_is_runt {
+        return Some((num_chunks * words_per_chunk) as u128);
+    }
+
+    let num_whole_chunks = num_chunks - 1;
+    let remaining_items = num_values - num_whole_chunks * elems_per_chunk;
+    let tail_bit_savings = bits_per_value - compressed_bits_per_value;
+    let padding_cost = compressed_bits_per_value * (elems_per_chunk - remaining_items);
+    let tail_pack_savings = tail_bit_savings * remaining_items;
+    let tail_words = if padding_cost < tail_pack_savings {
+        words_per_chunk
+    } else {
+        remaining_items
+    };
+
+    Some((num_whole_chunks * words_per_chunk + tail_words) as u128)
 }
 
 fn maybe_wrap_general_for_mini_block(
@@ -1175,6 +1290,23 @@ mod tests {
         DataBlock::FixedWidth(block)
     }
 
+    fn rle_run_length_bits(encoding: &CompressiveEncoding) -> u64 {
+        let Compression::Rle(rle) = encoding.compression.as_ref().unwrap() else {
+            panic!("expected RLE encoding");
+        };
+        let Compression::Flat(run_lengths) = rle
+            .run_lengths
+            .as_ref()
+            .unwrap()
+            .compression
+            .as_ref()
+            .unwrap()
+        else {
+            panic!("expected flat run lengths");
+        };
+        run_lengths.bits_per_value
+    }
+
     fn create_variable_width_block(
         bits_per_offset: u8,
         num_values: u64,
@@ -1324,6 +1456,60 @@ mod tests {
             debug_str.contains("OutOfLineBitpacking"),
             "expected OutOfLineBitpacking, got: {debug_str}"
         );
+    }
+
+    #[test]
+    fn test_rle_block_accounts_for_header_before_selecting() {
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
+        let field = create_test_field("small_constant", DataType::Int32);
+        let values = vec![42i32; 2];
+        let mut block = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 2,
+            block_info: BlockInfo::default(),
+        };
+        block.compute_stat();
+        let data = DataBlock::FixedWidth(block);
+
+        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+
+        assert!(format!("{compressor:?}").contains("ValueEncoder"));
+        assert!(matches!(
+            encoding.compression.as_ref(),
+            Some(Compression::Flat(_))
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_block_prefers_bitpacking_when_smaller() {
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
+        let field = create_test_field("levels", DataType::UInt16);
+
+        let mut values = Vec::with_capacity(2048);
+        for run_idx in 0..1024 {
+            values.extend(std::iter::repeat_n((run_idx % 2) as u16, 2));
+        }
+        let mut block = FixedWidthDataBlock {
+            bits_per_value: 16,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 2048,
+            block_info: BlockInfo::default(),
+        };
+        block.compute_stat();
+        let data = DataBlock::FixedWidth(block);
+
+        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let debug_str = format!("{compressor:?}");
+        assert!(
+            debug_str.contains("OutOfLineBitpacking"),
+            "expected OutOfLineBitpacking, got: {debug_str}"
+        );
+        assert!(matches!(
+            encoding.compression.as_ref(),
+            Some(Compression::OutOfLineBitpacking(_))
+        ));
     }
 
     #[test]
@@ -1716,20 +1902,7 @@ mod tests {
         let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
         let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
         let (_compressed, encoding) = compressor.compress(data).unwrap();
-        let Compression::Rle(rle) = encoding.compression.as_ref().unwrap() else {
-            panic!("expected RLE encoding");
-        };
-        let Compression::Flat(run_lengths) = rle
-            .run_lengths
-            .as_ref()
-            .unwrap()
-            .compression
-            .as_ref()
-            .unwrap()
-        else {
-            panic!("expected flat run lengths");
-        };
-        assert_eq!(run_lengths.bits_per_value, 16);
+        assert_eq!(rle_run_length_bits(&encoding), 16);
     }
 
     #[test]
@@ -1756,20 +1929,53 @@ mod tests {
         assert!(debug_str.contains("RleEncoder"));
 
         let (_compressed, encoding) = compressor.compress(data).unwrap();
-        let Compression::Rle(rle) = encoding.compression.as_ref().unwrap() else {
-            panic!("expected RLE encoding");
+        assert_eq!(rle_run_length_bits(&encoding), 16);
+    }
+
+    #[test]
+    fn test_rle_v2_sorted_dictionary_indices_select_u16_run_lengths() {
+        let field = create_test_field("dict_indices", DataType::Int32);
+
+        let mut values = Vec::with_capacity(1_200);
+        for value in 0..4 {
+            values.extend(std::iter::repeat_n(value, 300));
+        }
+        let mut data = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 1_200,
+            block_info: BlockInfo::default(),
         };
-        let Compression::Flat(run_lengths) = rle
-            .run_lengths
-            .as_ref()
-            .unwrap()
-            .compression
-            .as_ref()
-            .unwrap()
-        else {
-            panic!("expected flat run lengths");
+        data.compute_stat();
+        let data = DataBlock::FixedWidth(data);
+
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
+        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+        let (_compressed, encoding) = compressor.compress(data).unwrap();
+        assert_eq!(rle_run_length_bits(&encoding), 16);
+    }
+
+    #[test]
+    fn test_rle_v2_short_runs_keep_u8_run_lengths() {
+        let field = create_test_field("dict_indices", DataType::Int32);
+
+        let mut values = Vec::with_capacity(1_280);
+        for value in 0..10 {
+            values.extend(std::iter::repeat_n(value, 128));
+        }
+        let mut data = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 1_280,
+            block_info: BlockInfo::default(),
         };
-        assert_eq!(run_lengths.bits_per_value, 16);
+        data.compute_stat();
+        let data = DataBlock::FixedWidth(data);
+
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
+        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+        let (_compressed, encoding) = compressor.compress(data).unwrap();
+        assert_eq!(rle_run_length_bits(&encoding), 8);
     }
 
     #[test]
@@ -1986,6 +2192,41 @@ mod tests {
             !matches!(encoding.compression.as_ref(), Some(Compression::General(_))),
             "compression=none should disable automatic block general compression"
         );
+    }
+
+    #[test]
+    fn test_rle_v2_block_selects_u32_run_lengths() {
+        let field = create_test_field("dict_indices", DataType::Int32);
+        let expected_values = vec![42i32; 70_000];
+        let mut block = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(expected_values.clone()),
+            num_values: expected_values.len() as u64,
+            block_info: BlockInfo::default(),
+        };
+        block.compute_stat();
+        let data = DataBlock::FixedWidth(block);
+
+        let strategy = DefaultCompressionStrategy::with_params(CompressionParams::new())
+            .with_version(LanceFileVersion::V2_3);
+        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        assert_eq!(rle_run_length_bits(&encoding), 32);
+
+        let compressed = compressor.compress(data).unwrap();
+        let decompressor = DefaultDecompressionStrategy::default()
+            .create_block_decompressor(&encoding)
+            .unwrap();
+        let decoded = decompressor
+            .decompress(compressed, expected_values.len() as u64)
+            .unwrap();
+
+        match decoded {
+            DataBlock::FixedWidth(block) => {
+                let values = block.data.borrow_to_typed_slice::<i32>();
+                assert_eq!(values.as_ref(), expected_values);
+            }
+            _ => panic!("expected fixed-width block"),
+        }
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -132,26 +132,146 @@ impl RunLengthWidth {
     }
 }
 
-/// Select the lowest-cost run length width for a fixed-width data block.
+const RUN_LENGTH_WIDTHS: [RunLengthWidth; 3] =
+    [RunLengthWidth::U8, RunLengthWidth::U16, RunLengthWidth::U32];
+
+/// Select the lowest-cost run length width from precomputed entry counts.
+pub(crate) fn select_run_length_width_from_entries(
+    entries: &[u64],
+    bits_per_value: u64,
+) -> Result<(RunLengthWidth, u128)> {
+    if entries.len() != RUN_LENGTH_WIDTHS.len() {
+        return Err(Error::invalid_input_source(
+            format!(
+                "RLE run length entry statistics must have {} values, got {}",
+                RUN_LENGTH_WIDTHS.len(),
+                entries.len()
+            )
+            .into(),
+        ));
+    }
+
+    if !matches!(bits_per_value, 8 | 16 | 32 | 64) {
+        return Err(Error::invalid_input_source(
+            format!("RLE encoding bits_per_value must be 8, 16, 32, or 64, got {bits_per_value}")
+                .into(),
+        ));
+    }
+
+    let mut best_width = RUN_LENGTH_WIDTHS[0];
+    let mut best_cost = rle_encoded_size_from_entries(entries[0], bits_per_value, best_width);
+    for (&width, &entry_count) in RUN_LENGTH_WIDTHS.iter().zip(entries.iter()).skip(1) {
+        let cost = rle_encoded_size_from_entries(entry_count, bits_per_value, width);
+        if cost < best_cost {
+            best_width = width;
+            best_cost = cost;
+        }
+    }
+
+    Ok((best_width, best_cost))
+}
+
+pub(crate) fn rle_encoded_size_from_entries(
+    entry_count: u64,
+    bits_per_value: u64,
+    run_length_width: RunLengthWidth,
+) -> u128 {
+    let bytes_per_value = (bits_per_value / 8) as u128;
+    let bytes_per_length = run_length_width.bytes_per_value() as u128;
+    (entry_count as u128) * (bytes_per_value + bytes_per_length)
+}
+
+pub(crate) fn run_length_width_index(run_length_width: RunLengthWidth) -> usize {
+    match run_length_width {
+        RunLengthWidth::U8 => 0,
+        RunLengthWidth::U16 => 1,
+        RunLengthWidth::U32 => 2,
+    }
+}
+
 pub(crate) fn select_run_length_width(
     data: &LanceBuffer,
     num_values: u64,
     bits_per_value: u64,
-) -> Result<RunLengthWidth> {
-    select_run_length_width_and_size(data, num_values, bits_per_value).map(|(width, _)| width)
+    max_segment_values: Option<u64>,
+) -> Result<(RunLengthWidth, u128)> {
+    let entries = collect_run_length_entries(data, num_values, bits_per_value, max_segment_values)?;
+    select_run_length_width_from_entries(&entries, bits_per_value)
 }
 
-/// Select the lowest-cost run length width and return the encoded size estimate.
-pub(crate) fn select_run_length_width_and_size(
+pub(crate) fn rle_encoded_size(
     data: &LanceBuffer,
     num_values: u64,
     bits_per_value: u64,
-) -> Result<(RunLengthWidth, u128)> {
+    max_segment_values: Option<u64>,
+    run_length_width: RunLengthWidth,
+) -> Result<u128> {
+    let entries = collect_run_length_entries(data, num_values, bits_per_value, max_segment_values)?;
+    let width_idx = run_length_width_index(run_length_width);
+    Ok(rle_encoded_size_from_entries(
+        entries[width_idx],
+        bits_per_value,
+        run_length_width,
+    ))
+}
+
+fn collect_run_length_entries(
+    data: &LanceBuffer,
+    num_values: u64,
+    bits_per_value: u64,
+    max_segment_values: Option<u64>,
+) -> Result<[u64; 3]> {
+    let num_values = usize::try_from(num_values).map_err(|_| {
+        Error::invalid_input_source(
+            format!("RLE num_values does not fit in usize: {num_values}").into(),
+        )
+    })?;
+
+    macro_rules! collect_entries {
+        ($ty:ty) => {{
+            let type_size = std::mem::size_of::<$ty>();
+            let expected_bytes = num_values.checked_mul(type_size).ok_or_else(|| {
+                Error::invalid_input_source(
+                    format!(
+                        "RLE input byte length overflow: {num_values} values of {type_size} bytes"
+                    )
+                    .into(),
+                )
+            })?;
+            if data.len() != expected_bytes {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "RLE input data size mismatch: {} bytes for {} values of {} bytes",
+                        data.len(),
+                        num_values,
+                        type_size
+                    )
+                    .into(),
+                ));
+            }
+            let values = data.borrow_to_typed_slice::<$ty>();
+            let values = values.get(..num_values).ok_or_else(|| {
+                Error::invalid_input_source(
+                    format!(
+                        "RLE data has {} values but {} were expected",
+                        values.len(),
+                        num_values
+                    )
+                    .into(),
+                )
+            })?;
+            Ok(collect_run_length_entries_from_slice(
+                values,
+                max_segment_values,
+            ))
+        }};
+    }
+
     match bits_per_value {
-        8 => select_run_length_width_generic::<u8>(data, num_values),
-        16 => select_run_length_width_generic::<u16>(data, num_values),
-        32 => select_run_length_width_generic::<u32>(data, num_values),
-        64 => select_run_length_width_generic::<u64>(data, num_values),
+        8 => collect_entries!(u8),
+        16 => collect_entries!(u16),
+        32 => collect_entries!(u32),
+        64 => collect_entries!(u64),
         _ => Err(Error::invalid_input_source(
             format!("RLE encoding bits_per_value must be 8, 16, 32, or 64, got {bits_per_value}")
                 .into(),
@@ -159,80 +279,44 @@ pub(crate) fn select_run_length_width_and_size(
     }
 }
 
-fn select_run_length_width_generic<T>(
-    data: &LanceBuffer,
-    num_values: u64,
-) -> Result<(RunLengthWidth, u128)>
-where
-    T: bytemuck::Pod + PartialEq + Copy + ArrowNativeType,
-{
-    let num_values = usize::try_from(num_values).map_err(|_| {
-        Error::invalid_input_source(
-            format!("RLE num_values does not fit in usize: {num_values}").into(),
-        )
-    })?;
-    if num_values == 0 {
-        return Ok((RunLengthWidth::U8, 0));
+fn collect_run_length_entries_from_slice<T: PartialEq + Copy>(
+    values: &[T],
+    max_segment_values: Option<u64>,
+) -> [u64; 3] {
+    if values.is_empty() {
+        return [0; 3];
     }
 
-    let type_size = std::mem::size_of::<T>();
-    let expected_bytes = num_values.checked_mul(type_size).ok_or_else(|| {
-        Error::invalid_input_source(
-            format!("RLE input byte length overflow: {num_values} values of {type_size} bytes")
-                .into(),
-        )
-    })?;
-    if data.len() != expected_bytes {
-        return Err(Error::invalid_input_source(
-            format!(
-                "RLE input data size mismatch: {} bytes for {} values of {} bytes",
-                data.len(),
-                num_values,
-                type_size
-            )
-            .into(),
-        ));
-    }
+    let mut entries = [0u64; 3];
+    let mut prev = values[0];
+    let mut current_length = 1u64;
 
-    let values_ref = data.borrow_to_typed_slice::<T>();
-    let values: &[T] = values_ref.as_ref();
-    let mut costs = [0_u128; 3];
-
-    let mut current_value = values[0];
-    let mut current_length = 1_u64;
-    for &value in values.iter().skip(1) {
-        if value == current_value {
-            current_length += 1;
-        } else {
-            accumulate_width_costs(current_length, type_size, &mut costs);
-            current_value = value;
+    for &value in &values[1..] {
+        if value != prev {
+            accumulate_run_length_entries(current_length, max_segment_values, &mut entries);
+            prev = value;
             current_length = 1;
+        } else {
+            current_length += 1;
         }
     }
-    accumulate_width_costs(current_length, type_size, &mut costs);
+    accumulate_run_length_entries(current_length, max_segment_values, &mut entries);
 
-    let widths = [RunLengthWidth::U8, RunLengthWidth::U16, RunLengthWidth::U32];
-    let mut best_idx = 0usize;
-    let mut best_cost = costs[0];
-    for (idx, &cost) in costs.iter().enumerate().skip(1) {
-        if cost < best_cost {
-            best_idx = idx;
-            best_cost = cost;
-        }
-    }
-    Ok((widths[best_idx], best_cost))
+    entries
 }
 
-fn accumulate_width_costs(run_length: u64, type_size: usize, costs: &mut [u128; 3]) {
-    let widths = [RunLengthWidth::U8, RunLengthWidth::U16, RunLengthWidth::U32];
-    // The current encoder uses miniblock-sized chunks for both miniblock and block paths.
-    let max_segment_values = *MAX_MINIBLOCK_VALUES;
+pub(crate) fn accumulate_run_length_entries(
+    run_length: u64,
+    max_segment_values: Option<u64>,
+    entries: &mut [u64; 3],
+) {
+    let max_segment_values = max_segment_values.unwrap_or(run_length).max(1);
     let mut remaining = run_length;
     while remaining > 0 {
         let segment = remaining.min(max_segment_values);
-        for (idx, width) in widths.iter().enumerate() {
-            let entries = segment.div_ceil(width.max_run_length());
-            costs[idx] += (entries as u128) * ((type_size + width.bytes_per_value()) as u128);
+        for (idx, width) in RUN_LENGTH_WIDTHS.iter().enumerate() {
+            let entry_count = segment.div_ceil(width.max_run_length());
+            entries[idx] = entries[idx].saturating_add(entry_count);
         }
         remaining -= segment;
     }
@@ -368,6 +452,74 @@ impl RleEncoder {
             ],
             chunks,
         ))
+    }
+
+    fn encode_block_data(
+        &self,
+        data: &LanceBuffer,
+        num_values: u64,
+        bits_per_value: u64,
+    ) -> Result<Vec<LanceBuffer>> {
+        match bits_per_value {
+            8 => self.encode_block_data_generic::<u8>(data, num_values),
+            16 => self.encode_block_data_generic::<u16>(data, num_values),
+            32 => self.encode_block_data_generic::<u32>(data, num_values),
+            64 => self.encode_block_data_generic::<u64>(data, num_values),
+            _ => Err(Error::invalid_input_source(
+                format!(
+                    "RLE encoding bits_per_value must be 8, 16, 32, or 64, got {bits_per_value}"
+                )
+                .into(),
+            )),
+        }
+    }
+
+    fn encode_block_data_generic<T>(
+        &self,
+        data: &LanceBuffer,
+        num_values: u64,
+    ) -> Result<Vec<LanceBuffer>>
+    where
+        T: bytemuck::Pod + PartialEq + Copy + ArrowNativeType,
+    {
+        let num_values = usize::try_from(num_values).map_err(|_| {
+            Error::invalid_input_source(
+                format!("RLE num_values does not fit in usize: {num_values}").into(),
+            )
+        })?;
+        let type_size = std::mem::size_of::<T>();
+        let expected_bytes = num_values.checked_mul(type_size).ok_or_else(|| {
+            Error::invalid_input_source(
+                format!("RLE input byte length overflow: {num_values} values of {type_size} bytes")
+                    .into(),
+            )
+        })?;
+        if data.len() != expected_bytes {
+            return Err(Error::invalid_input_source(
+                format!(
+                    "RLE input data size mismatch: {} bytes for {} values of {} bytes",
+                    data.len(),
+                    num_values,
+                    type_size
+                )
+                .into(),
+            ));
+        }
+        if num_values == 0 {
+            return Ok(vec![LanceBuffer::empty(), LanceBuffer::empty()]);
+        }
+
+        let values_ref = data.borrow_to_typed_slice::<T>();
+        let values = values_ref.as_ref();
+        let estimated_runs = num_values / 10;
+        let mut all_values = Vec::with_capacity(estimated_runs * type_size);
+        let mut all_lengths =
+            Vec::with_capacity(estimated_runs * self.run_length_width.bytes_per_value());
+        self.encode_values(values, &mut all_values, &mut all_lengths);
+        Ok(vec![
+            LanceBuffer::from(all_values),
+            LanceBuffer::from(all_lengths),
+        ])
     }
 
     /// Encodes the largest valid mini-block prefix from `offset`.
@@ -566,8 +718,8 @@ impl BlockCompressor for RleEncoder {
                 let num_values = fixed_width.num_values;
                 let bits_per_value = fixed_width.bits_per_value;
 
-                let (all_buffers, _) =
-                    self.encode_data(&fixed_width.data, num_values, bits_per_value)?;
+                let all_buffers =
+                    self.encode_block_data(&fixed_width.data, num_values, bits_per_value)?;
 
                 let values_size = all_buffers[0].len() as u64;
 
@@ -896,13 +1048,9 @@ mod tests {
 
     #[test]
     fn test_select_run_length_width_prefers_u16_for_long_runs() {
-        let data = vec![7i32; 300];
-        let bytes = data
-            .iter()
-            .flat_map(|value| value.to_le_bytes())
-            .collect::<Vec<_>>();
-        let width =
-            select_run_length_width(&LanceBuffer::from(bytes), data.len() as u64, 32).unwrap();
+        let mut entries = [0u64; 3];
+        accumulate_run_length_entries(300, Some(*MAX_MINIBLOCK_VALUES), &mut entries);
+        let (width, _) = select_run_length_width_from_entries(&entries, 32).unwrap();
         assert_eq!(width, RunLengthWidth::U16);
     }
 


### PR DESCRIPTION
Fixes #7328.

This updates RLE v2 selection to estimate encoded size from actual run lengths during compression selection. Block RLE can now choose wider run-length widths for long runs, miniblock RLE keeps its chunk-boundary cost model, and RLE is skipped when header overhead or bitpacking would be smaller.
