### PR TITLE
feat(index): share IVF partition scans across batch vector queries

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -210,6 +210,49 @@ def test_ann_with_refine(test_dataset, benchmark):
     assert result.num_rows > 0
 
 
+N_BATCH_QUERIES = 32
+
+
+@pytest.mark.benchmark(group="query_ann_batch")
+def test_batch_ann_search(test_dataset, benchmark):
+    # One request carrying all query vectors: the index shares each partition's
+    # scan across the batch (issue #6822).
+    queries = np.random.randn(N_BATCH_QUERIES, N_DIMS).astype(np.float32)
+    result = benchmark(
+        test_dataset.to_table,
+        columns=[],
+        with_row_id=True,
+        nearest=dict(
+            column="vector",
+            q=queries,
+            k=100,
+            nprobes=10,
+        ),
+    )
+    assert result.num_rows > 0
+
+
+@pytest.mark.benchmark(group="query_ann_batch")
+def test_repeated_single_ann_search(test_dataset, benchmark):
+    # Baseline: the same query vectors issued one indexed search at a time.
+    queries = np.random.randn(N_BATCH_QUERIES, N_DIMS).astype(np.float32)
+
+    def run():
+        for q in queries:
+            test_dataset.to_table(
+                columns=[],
+                with_row_id=True,
+                nearest=dict(
+                    column="vector",
+                    q=q,
+                    k=100,
+                    nprobes=10,
+                ),
+            )
+
+    benchmark(run)
+
+
 @pytest.mark.benchmark(group="query_ann")
 @pytest.mark.parametrize("selectivity", (0.25, 0.75))
 @pytest.mark.parametrize("prefilter", (False, True))

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -241,6 +241,46 @@ def test_batch_flat_query_matches_repeated_single_queries(dataset, queries):
     )
 
 
+@pytest.mark.parametrize("metric", ["l2", "cosine"])
+@pytest.mark.parametrize("query_count", [3, 1], ids=["three_queries", "single_query"])
+def test_batch_indexed_query_matches_repeated_single_queries(
+    dataset, metric, query_count
+):
+    indexed = dataset.create_index(
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=16,
+        metric=metric,
+    )
+    # Give the query vectors deliberately different magnitudes: a cosine batch
+    # that normalized the whole concatenated key by one global norm would scale
+    # them unequally and diverge from per-query single search.
+    scales = np.linspace(0.1, 10.0, query_count).reshape(-1, 1)
+    queries = (np.random.randn(query_count, 128) * scales).astype(np.float32)
+    k = 5
+
+    # nprobes covers every partition so the shared-scan batch path and the
+    # repeated single-query path search the same partitions deterministically.
+    nearest_kwargs = {"use_index": True, "nprobes": 4}
+    batch = indexed.to_table(
+        columns=["id"],
+        nearest={"column": "vector", "q": queries, "k": k, **nearest_kwargs},
+    )
+
+    assert batch.column_names == ["query_index", "id", "_distance"]
+    assert batch["query_index"].to_pylist() == sum(
+        [[i] * k for i in range(query_count)], []
+    )
+
+    _assert_batch_matches_single_queries(
+        indexed,
+        queries,
+        k=k,
+        nearest_kwargs=nearest_kwargs,
+    )
+
+
 def _assert_batch_matches_single_queries(ds, queries, k, nearest_kwargs):
     batch = ds.to_table(
         columns=["id"],

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -355,6 +355,54 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
         )))
     }
 
+    /// Whether this index can search multiple query vectors in a single pass
+    /// via [`VectorIndex::search_partitions_batch`], reading each partition's
+    /// storage once and scoring every query that probes it.
+    ///
+    /// Defaults to `false`; callers should fall back to repeated single-query
+    /// search for indices that return `false`.
+    fn supports_batch_partition_search(&self) -> bool {
+        false
+    }
+
+    /// Search a batch of query vectors against a shared set of partitions.
+    ///
+    /// `query.key` holds all query vectors concatenated (length
+    /// `query_count * dim`, where `query_count == partitions_per_query.len()`).
+    /// `partitions_per_query[i]` / `q_c_dists_per_query[i]` are the ranked
+    /// partition ids and query-to-centroid distances for query `i`.
+    ///
+    /// Returns one [RecordBatch] per query (in query order) with the
+    /// [`VECTOR_RESULT_SCHEMA`] (`_distance`, `_rowid`) and at most `query.k`
+    /// rows each. Implementations should read each distinct partition's storage
+    /// only once and score every query assigned to it against the loaded data.
+    ///
+    /// The default implementation returns an error; callers must gate on
+    /// [`VectorIndex::supports_batch_partition_search`].
+    #[allow(clippy::too_many_arguments)]
+    async fn search_partitions_batch(
+        self: Arc<Self>,
+        query: Query,
+        partitions_per_query: Vec<Arc<UInt32Array>>,
+        q_c_dists_per_query: Vec<Arc<Float32Array>>,
+        pre_filter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+    ) -> Result<Vec<RecordBatch>>
+    where
+        Self: 'static,
+    {
+        let _ = (
+            query,
+            partitions_per_query,
+            q_c_dists_per_query,
+            pre_filter,
+            metrics,
+        );
+        Err(Error::not_supported(
+            "batch partition search is not supported for this index",
+        ))
+    }
+
     /// If the index is loadable by IVF, so it can be a sub-index that
     /// is loaded on demand by IVF.
     fn is_loadable(&self) -> bool;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5545,8 +5545,8 @@ impl Scanner {
     /// - no refine step (the batch path does not yet rerank);
     /// - fixed nprobes (`minimum_nprobes == maximum_nprobes`) — see below;
     /// - every segment an IVF index with a flat-style sub-index (i.e. not HNSW);
-    /// - all target fragments indexed (or `fast_search`, which ignores
-    ///   unindexed fragments).
+    /// - every target fragment covered by the *selected* `index_segments` (or
+    ///   `fast_search`, which searches only the selected segments anyway).
     ///
     /// The fixed-nprobes requirement is a *correctness* gate, not just an
     /// optimization. The shared-scan path searches exactly `minimum_nprobes`
@@ -5625,11 +5625,47 @@ impl Scanner {
         if self.fast_search {
             return Ok(true);
         }
-        // The batch node only searches indexed partitions, so any unindexed
-        // target fragment would silently drop rows; fall back in that case.
-        let unindexed_fragments =
-            self.retain_target_fragments(self.dataset.unindexed_fragments(index_name).await?);
-        Ok(unindexed_fragments.is_empty())
+        // The batch node only searches the selected `index_segments`, so any
+        // target fragment those segments do not cover would silently drop rows
+        // (the single-query path re-scores such fragments on a flat fallback in
+        // `knn_combined`). Measure coverage against the selected segments -- not
+        // the whole logical index -- so a subset selected via
+        // `with_index_segments` cannot hide a fragment that an unselected
+        // segment happens to cover; fall back whenever any remain.
+        let uncovered_fragments = self
+            .fragments_missing_from_index_segments(index_name, index_segments)
+            .await?;
+        Ok(uncovered_fragments.is_empty())
+    }
+
+    /// Target fragments the given `index_segments` do not cover.
+    ///
+    /// The ANN scan reads only the selected segments' partitions, so these are
+    /// exactly the fragments the single-query path re-scores on a flat fallback
+    /// in [`Self::knn_combined`]. Coverage is measured against the *selected*
+    /// segments rather than every segment of the logical index (which
+    /// `Dataset::unindexed_fragments` would do): a caller may select a subset
+    /// via [`with_index_segments`](Self::with_index_segments) while another,
+    /// unselected segment covers one of the requested fragments.
+    async fn fragments_missing_from_index_segments(
+        &self,
+        index_name: &str,
+        index_segments: &[IndexMetadata],
+    ) -> Result<Vec<Fragment>> {
+        if let Some(target_fragments) = &self.fragments {
+            let indexed_fragments = self.get_indexed_frags(index_segments);
+            Ok(target_fragments
+                .iter()
+                .filter(|fragment| !indexed_fragments.contains(fragment.id as u32))
+                .cloned()
+                .collect())
+        } else if self.index_segments.is_some() {
+            // An explicit segment selection with no fragment restriction searches
+            // exactly those segments; there is nothing to fall back for.
+            Ok(Vec::new())
+        } else {
+            self.dataset.unindexed_fragments(index_name).await
+        }
     }
 
     async fn batch_indexed_vector_search(
@@ -5748,18 +5784,9 @@ impl Scanner {
         mut knn_node: Arc<dyn ExecutionPlan>,
         filter_plan: &ExprFilterPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let fallback_fragments = if let Some(target_fragments) = &self.fragments {
-            let indexed_fragments = self.get_indexed_frags(indexed_segments);
-            target_fragments
-                .iter()
-                .filter(|fragment| !indexed_fragments.contains(fragment.id as u32))
-                .cloned()
-                .collect::<Vec<_>>()
-        } else if self.index_segments.is_some() {
-            Vec::new()
-        } else {
-            self.dataset.unindexed_fragments(index_name).await?
-        };
+        let fallback_fragments = self
+            .fragments_missing_from_index_segments(index_name, indexed_segments)
+            .await?;
 
         let has_fallback = !fallback_fragments.is_empty();
         let has_stale = !stale_rows.is_empty();
@@ -9773,6 +9800,23 @@ mod test {
             plan
         );
 
+        // The batch node loads each probed partition once and scores every query
+        // that probes it, so it must report the *distinct* partitions read: with
+        // 2 partitions and nprobes(2), both queries probe both partitions, so the
+        // union is 2 -- not the per-query sum (2 queries x 2 = 4), and never 0
+        // (which is what a dropped metric would show). This guards the observed
+        // `partitions_searched` against silently regressing to either.
+        let analyzed = scan.analyze_plan().await.unwrap();
+        let batch_line = analyzed
+            .lines()
+            .find(|line| line.contains("ANNIvfBatch"))
+            .expect("analyzed plan should contain the ANNIvfBatch node");
+        assert!(
+            batch_line.contains("partitions_searched=2"),
+            "batch node must report the distinct partitions searched, got:\n{}",
+            batch_line
+        );
+
         let batch = scan.try_into_batch().await.unwrap();
         assert_query_index_field(&batch);
         assert_eq!(
@@ -10054,6 +10098,80 @@ mod test {
                 "nprobes(0) query {query_index}: batch rows must match single-query rows"
             );
         }
+    }
+
+    /// The shared-scan fast path is only equivalent to repeated single-query
+    /// search when the selected `index_segments` cover every requested fragment.
+    /// With one segment per fragment, requesting both fragments but selecting
+    /// only the first segment leaves fragment 1 covered solely by the
+    /// *unselected* segment: the batch node would search just the selected
+    /// segment and silently drop it. Eligibility must be computed from the
+    /// selected segments' coverage (as `knn_combined` does), not the whole
+    /// logical index, so the scanner falls back to the per-query loop, which
+    /// re-scores the uncovered fragment on the flat path and returns every row.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_partial_segment_selection_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, false)
+            .await
+            .unwrap();
+        // One segment per fragment: segment_ids[0] covers fragment 0 (i=0..200),
+        // segment_ids[1] covers fragment 1 (i=200..400).
+        let segment_ids = test_ds.make_segmented_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let fragments = dataset.fragments();
+        assert_eq!(fragments.len(), 2, "base dataset should have two fragments");
+
+        let (queries, _query_values) = batch_knn_two_queries();
+        // k covers every row in both requested fragments (200 each), so a
+        // complete search returns 400 rows per query.
+        let k = 400;
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(2);
+        // Request both indexed fragments but select only the segment covering
+        // fragment 0; fragment 1 is covered only by the unselected segment.
+        scan.with_fragments(vec![fragments[0].clone(), fragments[1].clone()]);
+        scan.with_index_segments(vec![segment_ids[0]]).unwrap();
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "a requested fragment outside the selected segments must force a fallback, \
+             not a shared scan that drops it, got:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        assert_eq!(
+            batch.num_rows(),
+            2 * k,
+            "each query must return all 400 rows across both requested fragments"
+        );
+        let query_indices = batch[QUERY_INDEX_COL].as_primitive::<Int32Type>();
+        for query_index in 0..2 {
+            let rows_for_query = query_indices
+                .iter()
+                .filter(|value| *value == Some(query_index))
+                .count();
+            assert_eq!(
+                rows_for_query, k,
+                "query_index {query_index} must cover both fragments (got {rows_for_query})"
+            );
+        }
+        // Fragment 0 (i in 0..200) comes from the selected segment; fragment 1
+        // (i in 200..400) must appear via the flat fallback.
+        let i_array = batch["i"].as_primitive::<Int32Type>();
+        assert!(
+            i_array
+                .iter()
+                .any(|v| v.is_some_and(|val| (0..200).contains(&val)))
+                && i_array
+                    .iter()
+                    .any(|v| v.is_some_and(|val| (200..400).contains(&val))),
+            "results must include rows from both the selected segment and the flat-fallback fragment"
+        );
     }
 
     /// A wide batch probes more distinct partitions than one streaming chunk holds

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -123,7 +123,8 @@ use crate::io::exec::{
     AddRowAddrExec, FilterPlan as ExprFilterPlan, KNNVectorDistanceExec, LancePushdownScanExec,
     LanceScanExec, Planner, PreFilterSource, RowAddrMaskFilterExec, ScanConfig, TakeExec,
     knn::{
-        KnnBatchParams, QUERY_INDEX_COL, knn_empty_result_schema, new_knn_exec, query_index_field,
+        KnnBatchParams, QUERY_INDEX_COL, knn_empty_result_schema, new_knn_batch_exec, new_knn_exec,
+        query_index_field,
     },
     project,
 };
@@ -5417,7 +5418,16 @@ impl Scanner {
 
         if let Some((index_name, index_segments, index_metric)) = index_and_segments {
             if self.is_batch_nearest {
-                return self.batch_indexed_vector_search(filter_plan, &q).await;
+                validate_distance_type_for(index_metric, &element_type)?;
+                return self
+                    .batch_indexed_vector_search(
+                        filter_plan,
+                        &q,
+                        &index_name,
+                        &index_segments,
+                        index_metric,
+                    )
+                    .await;
             }
 
             log::trace!("index found for vector search");
@@ -5527,11 +5537,107 @@ impl Scanner {
         }
     }
 
+    /// Whether a batch (multi-query) vector search can use the shared-scan
+    /// indexed fast path ([`new_knn_batch_exec`]) instead of running one indexed
+    /// search per query vector.
+    ///
+    /// Requires all of:
+    /// - no refine step (the batch path does not yet rerank);
+    /// - fixed nprobes (`minimum_nprobes == maximum_nprobes`) — see below;
+    /// - every segment an IVF index with a flat-style sub-index (i.e. not HNSW);
+    /// - all target fragments indexed (or `fast_search`, which ignores
+    ///   unindexed fragments).
+    ///
+    /// The fixed-nprobes requirement is a *correctness* gate, not just an
+    /// optimization. The shared-scan path searches exactly `minimum_nprobes`
+    /// partitions per query, but the single-query path is adaptive: it applies a
+    /// k-dependent `early_pruning` floor and then expands probes up to
+    /// `maximum_nprobes` (late search) when a query has fewer than `k` results.
+    /// When `minimum_nprobes == maximum_nprobes` neither adjustment can fire
+    /// (pruning is capped at the maximum, and the late-search range is empty), so
+    /// the batch result is provably identical to repeated single-query search.
+    /// With adaptive nprobes the two would diverge, so we fall back to the
+    /// per-query loop, which reuses the real adaptive search and stays exact.
+    ///
+    /// Extending the shared-scan path to adaptive nprobes (a batched early/late
+    /// search) is left as a follow-up.
+    async fn batch_index_search_supported(
+        &self,
+        index_name: &str,
+        index_segments: &[IndexMetadata],
+        q: &Query,
+    ) -> Result<bool> {
+        if matches!(q.refine_factor, Some(rf) if rf > 1) {
+            return Ok(false);
+        }
+        // Only fixed nprobes is provably equivalent to single-query search; see
+        // the method docs. Adaptive nprobes falls back to the per-query loop.
+        if q.maximum_nprobes != Some(q.minimum_nprobes) {
+            return Ok(false);
+        }
+        // Decide from the index metadata (no I/O) rather than opening the index
+        // to call `supports_batch_partition_search()`: this is a planning-time
+        // gate and the single-query path likewise avoids opening the index here.
+        // An IVF index with a flat-style sub-index (i.e. not HNSW) is exactly the
+        // set for which `supports_batch_partition_search()` is true; the exec
+        // re-checks that trait as a defensive invariant. Legacy segments without
+        // details fall back.
+        let all_ivf_flat_style = index_segments.iter().all(|index| {
+            index
+                .index_details
+                .as_ref()
+                .filter(|details| !details.value.is_empty())
+                .map(|details| {
+                    let index_type =
+                        crate::index::vector::details::derive_vector_index_type(details);
+                    index_type.starts_with("IVF_") && !index_type.contains("HNSW")
+                })
+                .unwrap_or(false)
+        });
+        if !all_ivf_flat_style {
+            return Ok(false);
+        }
+        if self.fast_search {
+            return Ok(true);
+        }
+        // The batch node only searches indexed partitions, so any unindexed
+        // target fragment would silently drop rows; fall back in that case.
+        let unindexed_fragments =
+            self.retain_target_fragments(self.dataset.unindexed_fragments(index_name).await?);
+        Ok(unindexed_fragments.is_empty())
+    }
+
     async fn batch_indexed_vector_search(
         &self,
         filter_plan: &ExprFilterPlan,
         q: &Query,
+        index_name: &str,
+        index_segments: &[IndexMetadata],
+        index_metric: MetricType,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Fast path: when every index segment is an IVF index with a flat-style
+        // sub-index (IVF_FLAT/PQ/SQ/RQ), search all query vectors in a single
+        // pass that reads each partition's storage once and shares the prefilter
+        // across the batch. HNSW, refine, and mixed indexed/unindexed scans fall
+        // back to the per-query loop below, which never regresses behavior.
+        if self
+            .batch_index_search_supported(index_name, index_segments, q)
+            .await?
+        {
+            let mut batch_query = q.clone();
+            batch_query.metric_type = Some(index_metric);
+            let prefilter_source = self
+                .prefilter_source(filter_plan, self.get_indexed_frags(index_segments))
+                .await?;
+            return new_knn_batch_exec(
+                self.dataset.clone(),
+                index_segments,
+                &batch_query,
+                self.nearest_query_count,
+                prefilter_source,
+            );
+        }
+
         let query_dim = q.key.len() / self.nearest_query_count;
         let mut query_plans = Vec::with_capacity(self.nearest_query_count);
 
@@ -7099,8 +7205,10 @@ pub mod test_dataset {
         IndexType,
         scalar::{ScalarIndexParams, inverted::tokenizer::InvertedIndexParams},
         vector::{
+            hnsw::builder::HnswBuildParams,
             ivf::IvfBuildParams,
             kmeans::{KMeansParams, train_kmeans},
+            sq::builder::SQBuildParams,
         },
     };
     use lance_linalg::distance::DistanceType;
@@ -7202,7 +7310,30 @@ pub mod test_dataset {
         }
 
         pub async fn make_vector_index(&mut self) -> Result<()> {
-            let params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 2);
+            self.make_vector_index_with_metric(MetricType::L2).await
+        }
+
+        pub async fn make_vector_index_with_metric(&mut self, metric: MetricType) -> Result<()> {
+            let params = VectorIndexParams::ivf_pq(2, 8, 2, metric, 2);
+            self.dataset
+                .create_index(
+                    &["vec"],
+                    IndexType::Vector,
+                    Some("idx".to_string()),
+                    &params,
+                    true,
+                )
+                .await?;
+            Ok(())
+        }
+
+        pub async fn make_ivf_hnsw_index(&mut self) -> Result<()> {
+            let params = VectorIndexParams::with_ivf_hnsw_sq_params(
+                MetricType::L2,
+                IvfBuildParams::new(2),
+                HnswBuildParams::default(),
+                SQBuildParams::default(),
+            );
             self.dataset
                 .create_index(
                     &["vec"],
@@ -9122,6 +9253,7 @@ mod test {
         k: usize,
         use_index: bool,
         distance_range: Option<(Option<f32>, Option<f32>)>,
+        nprobes: Option<usize>,
     ) {
         let query_count = query_values.len() / 32;
         assert_eq!(batch.num_rows(), query_count * k);
@@ -9132,6 +9264,12 @@ mod test {
             let mut scan = dataset.scan();
             scan.nearest("vec", &query, k).unwrap();
             scan.use_index(use_index);
+            // Pin nprobes to match the batch query: the single-query indexed path
+            // otherwise adaptively expands nprobes, which would make equivalence
+            // depend on data distribution rather than be guaranteed.
+            if let Some(nprobes) = nprobes {
+                scan.nprobes(nprobes);
+            }
             if let Some((lower, upper)) = distance_range {
                 scan.distance_range(lower, upper);
             }
@@ -9210,7 +9348,8 @@ mod test {
                 "query_index {query_index} should have exactly {k} rows"
             );
         }
-        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, false, None).await;
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, false, None, None)
+            .await;
 
         let mut scan_with_vec = dataset.scan();
         scan_with_vec.nearest("vec", &queries, k).unwrap();
@@ -9227,6 +9366,7 @@ mod test {
             &query_values,
             k,
             false,
+            None,
             None,
         )
         .await;
@@ -9281,7 +9421,8 @@ mod test {
         assert_query_index_field(&batch);
         assert!(batch.schema().column_with_name("i").is_some());
         assert!(batch.schema().column_with_name(DIST_COL).is_some());
-        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, false, None).await;
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, false, None, None)
+            .await;
 
         let mut scan_rowid_only = dataset.scan();
         scan_rowid_only.nearest("vec", &queries, k).unwrap();
@@ -9567,6 +9708,7 @@ mod test {
             2,
             false,
             Some((Some(1.0), None)),
+            None,
         )
         .await;
     }
@@ -9582,12 +9724,22 @@ mod test {
 
         let mut scan = dataset.scan();
         scan.nearest("vec", &queries, 2).unwrap();
+        // Probe both partitions (minimum == maximum) so the per-query top-k is
+        // merged across multiple partitions and the batch result is
+        // deterministically equivalent to repeated single-query search (which
+        // would otherwise adaptively expand nprobes).
+        scan.nprobes(2);
         scan.project(&["i"]).unwrap();
 
         let plan = scan.explain_plan(false).await.unwrap();
         assert!(
-            plan.contains("ANNSubIndex"),
-            "batch KNN should use the vector index when available, got:\n{}",
+            plan.contains("ANNIvfBatch"),
+            "IVF batch KNN should use the shared-scan batch node, got:\n{}",
+            plan
+        );
+        assert!(
+            !plan.contains("ANNSubIndex"),
+            "IVF batch KNN should not fall back to per-query ANN search, got:\n{}",
             plan
         );
         assert!(
@@ -9602,11 +9754,16 @@ mod test {
             batch[QUERY_INDEX_COL].as_primitive::<Int32Type>().values(),
             &[0, 0, 1, 1]
         );
+        // Shared-scan batch search must return the same rows/distances as
+        // issuing the queries one at a time against the index.
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, 2, true, None, Some(2))
+            .await;
 
         let batch = dataset
             .scan()
             .nearest("vec", &queries, 2)
             .unwrap()
+            .nprobes(2)
             .distance_range(Some(1.0), None)
             .project(&["i"])
             .unwrap()
@@ -9620,8 +9777,276 @@ mod test {
             2,
             true,
             Some((Some(1.0), None)),
+            Some(2),
         )
         .await;
+    }
+
+    /// `refine_factor` is not yet supported by the shared-scan batch path, so
+    /// the scanner must fall back to the per-query indexed loop and still
+    /// produce correctly grouped per-query results.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_refine_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, _query_values) = batch_knn_two_queries();
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, 2).unwrap();
+        scan.refine(2);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "refine must not use the shared-scan batch node, got:\n{}",
+            plan
+        );
+        assert!(
+            plan.contains("ANNSubIndex"),
+            "refine batch search should fall back to the per-query indexed loop, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        assert_eq!(
+            batch[QUERY_INDEX_COL].as_primitive::<Int32Type>().values(),
+            &[0, 0, 1, 1]
+        );
+    }
+
+    /// Without pinned nprobes the shared-scan fast path is not equivalent to
+    /// single-query search (the single-query path applies an adaptive
+    /// `early_pruning` floor and late-search expansion that the batch path does
+    /// not), so the scanner must fall back to the per-query loop, which reuses
+    /// the real adaptive search and stays exact.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_adaptive_nprobes_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 2;
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        // No nprobes() call: adaptive (minimum_nprobes=1, maximum_nprobes=None).
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "adaptive nprobes must not use the shared-scan batch node, got:\n{}",
+            plan
+        );
+        assert!(
+            plan.contains("ANNSubIndex"),
+            "adaptive nprobes batch search should fall back to the per-query loop, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        // The fallback runs real single-query searches, so it stays exact even
+        // with adaptive nprobes.
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, true, None, None)
+            .await;
+    }
+
+    /// IVF_HNSW is an unsupported index type for the shared-scan batch path (its
+    /// graph sub-index has no global top-k heap), so batch search must fall back
+    /// to the per-query indexed loop and still produce correct grouped results.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_hnsw_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_ivf_hnsw_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 2;
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(2);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "HNSW batch search must not use the shared-scan batch node, got:\n{}",
+            plan
+        );
+        assert!(
+            plan.contains("ANNSubIndex"),
+            "HNSW batch search should fall back to the per-query indexed loop, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, true, None, Some(2))
+            .await;
+    }
+
+    /// Regression test for cosine batch search: each query vector must be
+    /// normalized independently. The two queries below have very different
+    /// magnitudes, so normalizing the concatenated batch key by a single global
+    /// norm (the bug) would scale them unequally and diverge from per-query
+    /// single search.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_cosine_normalizes_per_query() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds
+            .make_vector_index_with_metric(MetricType::Cosine)
+            .await
+            .unwrap();
+        let dataset = &test_ds.dataset;
+
+        // q0: small-magnitude constant direction; q1: large-magnitude ramp.
+        let mut query_values = vec![0.05f32; 32];
+        query_values.extend((1..=32).map(|v| v as f32 * 3.0));
+        let queries =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(query_values.clone()), 32)
+                .unwrap();
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, 2).unwrap();
+        scan.nprobes(2);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ANNIvfBatch"),
+            "cosine IVF batch KNN should use the shared-scan batch node, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, 2, true, None, Some(2))
+            .await;
+    }
+
+    /// Batch indexed search builds a single shared prefilter for all queries;
+    /// results must match per-query single search with the same prefilter.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_with_prefilter() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 2;
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(2);
+        scan.filter("i > 100").unwrap();
+        scan.prefilter(true);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ANNIvfBatch"),
+            "prefiltered IVF batch KNN should use the shared-scan batch node, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        // The shared prefilter must exclude i <= 100 for every query.
+        assert!(
+            batch["i"]
+                .as_primitive::<Int32Type>()
+                .values()
+                .iter()
+                .all(|i| *i > 100),
+            "shared prefilter should remove rows with i <= 100"
+        );
+
+        let query_indices = batch[QUERY_INDEX_COL].as_primitive::<Int32Type>();
+        for query_index in 0..2 {
+            let query =
+                Float32Array::from(query_values[query_index * 32..(query_index + 1) * 32].to_vec());
+            let single = dataset
+                .scan()
+                .nearest("vec", &query, k)
+                .unwrap()
+                .nprobes(2)
+                .filter("i > 100")
+                .unwrap()
+                .prefilter(true)
+                .project(&["i"])
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let mask = BooleanArray::from_iter(
+                query_indices
+                    .iter()
+                    .map(|v| v.map(|v| v == query_index as i32)),
+            );
+            let slice = arrow::compute::filter_record_batch(&batch, &mask).unwrap();
+            assert_eq!(
+                slice["i"].as_primitive::<Int32Type>().values(),
+                single["i"].as_primitive::<Int32Type>().values(),
+                "prefiltered batch query {query_index} should match single-query search"
+            );
+        }
+    }
+
+    /// Batch indexed search must merge each query's top-k across multiple delta
+    /// indices, not just within a single delta.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_multiple_deltas() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        // Append new data and optimize with `append` to add a second delta
+        // index (rather than merging into the existing one).
+        test_ds.append_data_with_range(400, 480).await.unwrap();
+        test_ds
+            .dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        let dataset = &test_ds.dataset;
+        let segments = dataset.load_indices_by_name("idx").await.unwrap();
+        assert!(
+            segments.len() >= 2,
+            "expected multiple delta index segments to exercise cross-delta merge, got {}",
+            segments.len()
+        );
+
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 3;
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(2);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ANNIvfBatch"),
+            "multi-delta IVF batch KNN should use the shared-scan batch node, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, true, None, Some(2))
+            .await;
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5588,6 +5588,14 @@ impl Scanner {
         if q.minimum_nprobes == 0 {
             return Ok(false);
         }
+        // The per-query path threads a caller-supplied external row-address mask
+        // (`with_row_addr_prefilter`) into each query's prefilter via
+        // `with_external_mask`; the shared batch path builds one prefilter across
+        // the batch and does not carry that mask. Rather than silently returning
+        // masked-out rows, fall back to the per-query loop whenever a mask is set.
+        if self.external_row_mask.is_some() {
+            return Ok(false);
+        }
         // Decide from the index metadata (no I/O) rather than opening the index
         // to call `supports_batch_partition_search()`: this is a planning-time
         // gate and the single-query path likewise avoids opening the index here.
@@ -10096,6 +10104,75 @@ mod test {
                 batch_slice["i"].as_primitive::<Int32Type>().values(),
                 single["i"].as_primitive::<Int32Type>().values(),
                 "nprobes(0) query {query_index}: batch rows must match single-query rows"
+            );
+        }
+    }
+
+    /// A caller-supplied external row-address mask (`with_row_addr_prefilter`) is
+    /// applied per query on the single-query prefilter path (`with_external_mask`)
+    /// but is not carried by the shared batch scan. An otherwise batch-eligible
+    /// query must therefore fall back to the per-query loop when a mask is present,
+    /// and every returned row must honor the mask — otherwise the batch path would
+    /// silently return masked-out rows.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_external_mask_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, _query_values) = batch_knn_two_queries();
+        let k = 15;
+
+        // Same query shape as `test_batch_knn_indexed`: without a mask it is
+        // batch-eligible, so the mask is the only thing that forces the fallback.
+        let mut unmasked = dataset.scan();
+        unmasked.nearest("vec", &queries, k).unwrap();
+        unmasked.nprobes(2);
+        unmasked.project(&["i"]).unwrap();
+        let unmasked_plan = unmasked.explain_plan(false).await.unwrap();
+        assert!(
+            unmasked_plan.contains("ANNIvfBatch"),
+            "without a mask this query should use the shared-scan batch node, got:\n{unmasked_plan}"
+        );
+
+        // Build an allowlist from the dataset's row addresses (freshly created
+        // single fragment, so _rowid == row address).
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        let all_ids = batch_row_ids(&scan.try_into_batch().await.unwrap());
+        let allow: Vec<u64> = all_ids.iter().copied().step_by(2).collect();
+        let allow_set: BTreeSet<u64> = allow.iter().copied().collect();
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(2);
+        scan.with_row_addr_prefilter(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
+            allow.iter().copied(),
+        )));
+        scan.with_row_id();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "an external row mask must not use the shared-scan batch node, which \
+             does not carry the mask, got:\n{plan}"
+        );
+        assert!(
+            plan.contains("ANNSubIndex"),
+            "a masked batch query should fall back to the per-query indexed loop, got:\n{plan}"
+        );
+
+        // The fallback must honor the mask: every returned row is in the allowlist.
+        let got = batch_row_ids(&scan.try_into_batch().await.unwrap());
+        assert!(
+            !got.is_empty(),
+            "masked batch KNN should still return allowed rows"
+        );
+        for id in got {
+            assert!(
+                allow_set.contains(&id),
+                "returned _rowid {id} not in allowlist"
             );
         }
     }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5580,6 +5580,14 @@ impl Scanner {
         if q.maximum_nprobes != Some(q.minimum_nprobes) {
             return Ok(false);
         }
+        // `nprobes(0)` is not rejected by the query builder, so `min == max == 0`
+        // slips past the fixed-nprobes check above. The single-query path probes
+        // nothing and returns an empty result, whereas the batch node would probe
+        // one partition's worth of neighbors — a silent divergence. Fall back so
+        // the per-query loop defines the semantics of `nprobes(0)`.
+        if q.minimum_nprobes == 0 {
+            return Ok(false);
+        }
         // Decide from the index metadata (no I/O) rather than opening the index
         // to call `supports_batch_partition_search()`: this is a planning-time
         // gate and the single-query path likewise avoids opening the index here.
@@ -9984,6 +9992,126 @@ mod test {
         // with adaptive nprobes.
         assert_batch_matches_single_queries(dataset, &batch, &query_values, k, true, None, None)
             .await;
+    }
+
+    /// `nprobes(0)` is not rejected by the query builder, so `minimum_nprobes ==
+    /// maximum_nprobes == 0` slips past the fixed-nprobes gate. The single-query
+    /// path then probes nothing and returns an empty result, whereas the batch
+    /// node would clamp `nprobes` up to one partition — a silent divergence. The
+    /// scanner must fall back so the per-query loop defines the semantics of
+    /// `nprobes(0)`, and the grouped batch result must equal repeated single-query
+    /// search (both empty here).
+    #[tokio::test]
+    async fn test_batch_knn_indexed_zero_nprobes_falls_back() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        test_ds.make_vector_index().await.unwrap();
+        let dataset = &test_ds.dataset;
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 2;
+
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(0);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            !plan.contains("ANNIvfBatch"),
+            "nprobes(0) must not use the shared-scan batch node (which would clamp \
+             to one partition), got:\n{plan}"
+        );
+        assert!(
+            plan.contains("ANNSubIndex"),
+            "nprobes(0) batch search should fall back to the per-query indexed loop, got:\n{plan}"
+        );
+
+        // The fallback runs the real single-query path per query, so the grouped
+        // batch result must match issuing each query on its own with nprobes(0).
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_query_index_field(&batch);
+        let query_count = query_values.len() / 32;
+        for query_index in 0..query_count {
+            let query =
+                Float32Array::from(query_values[query_index * 32..(query_index + 1) * 32].to_vec());
+            let mut single_scan = dataset.scan();
+            single_scan.nearest("vec", &query, k).unwrap();
+            single_scan.nprobes(0);
+            single_scan.project(&["i"]).unwrap();
+            let single = single_scan.try_into_batch().await.unwrap();
+
+            let query_indices = batch[QUERY_INDEX_COL].as_primitive::<Int32Type>();
+            let mask = BooleanArray::from_iter(
+                query_indices
+                    .iter()
+                    .map(|value| value.map(|value| value == query_index as i32)),
+            );
+            let batch_slice = arrow::compute::filter_record_batch(&batch, &mask).unwrap();
+            assert_eq!(
+                batch_slice["i"].as_primitive::<Int32Type>().values(),
+                single["i"].as_primitive::<Int32Type>().values(),
+                "nprobes(0) query {query_index}: batch rows must match single-query rows"
+            );
+        }
+    }
+
+    /// A wide batch probes more distinct partitions than one streaming chunk holds
+    /// (`STREAMING_SEARCH_BATCH_SIZE` = 16), so `search_partitions_batch` scores
+    /// them in several `spawn_cpu` dispatches, threading the per-query top-k heaps
+    /// across chunk boundaries. The small indexes in the other tests fit in a
+    /// single chunk and never exercise that seam; here an exact (flat) index with
+    /// more partitions than the chunk size, probed in full, pins the multi-chunk
+    /// path to repeated single-query search.
+    #[tokio::test]
+    async fn test_batch_knn_indexed_streams_multiple_chunks() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
+            .await
+            .unwrap();
+        // More partitions than one streaming chunk so scoring spans multiple
+        // chunks; exact (flat) storage with every partition probed keeps the batch
+        // result an exact match for single-query search.
+        let num_partitions = 20;
+        let params = VectorIndexParams::ivf_flat(num_partitions, MetricType::L2);
+        test_ds
+            .dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        let dataset = &test_ds.dataset;
+
+        let (queries, query_values) = batch_knn_two_queries();
+        let k = 2;
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        // Probe every partition so both paths are exact regardless of centroid
+        // proximity, and so the batch spans multiple streaming chunks.
+        scan.nprobes(num_partitions);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ANNIvfBatch"),
+            "wide IVF batch KNN should use the shared-scan batch node, got:\n{plan}"
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        assert_batch_matches_single_queries(
+            dataset,
+            &batch,
+            &query_values,
+            k,
+            true,
+            None,
+            Some(num_partitions),
+        )
+        .await;
     }
 
     /// IVF_HNSW is an unsupported index type for the shared-scan batch path (its

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5567,7 +5567,12 @@ impl Scanner {
         index_segments: &[IndexMetadata],
         q: &Query,
     ) -> Result<bool> {
-        if matches!(q.refine_factor, Some(rf) if rf > 1) {
+        // Any refine factor sends the query onto a reranking path that the
+        // shared batch scan does not implement: the single-query path reranks
+        // with the original vectors even when the factor is 1, and rejects a
+        // factor of 0 outright (`Refine factor cannot be zero`). The batch path
+        // does neither, so fall back to the per-query loop for every `Some(_)`.
+        if q.refine_factor.is_some() {
             return Ok(false);
         }
         // Only fixed nprobes is provably equivalent to single-query search; see
@@ -5595,6 +5600,18 @@ impl Scanner {
                 .unwrap_or(false)
         });
         if !all_ivf_flat_style {
+            return Ok(false);
+        }
+        // The batch node searches only the index's own entries; unlike the
+        // single-query path it does not reconcile data overlays (which block
+        // overlay-stale rows from the ANN result and re-score them on a flat
+        // take path — see `overlay_stale_vector_rows` in `vector_search`). If any
+        // indexed row was updated by a newer overlay, the batch path would return
+        // that row's stale index entry, so fall back to the per-query loop. This
+        // must precede the `fast_search` shortcut below because the single-query
+        // path applies the overlay block even in fast-search mode. Cheap in the
+        // common case: returns an empty map when no target fragment has overlays.
+        if !self.overlay_stale_vector_rows(index_segments)?.is_empty() {
             return Ok(false);
         }
         if self.fast_search {
@@ -9782,9 +9799,105 @@ mod test {
         .await;
     }
 
-    /// `refine_factor` is not yet supported by the shared-scan batch path, so
-    /// the scanner must fall back to the per-query indexed loop and still
-    /// produce correctly grouped per-query results.
+    /// End-to-end contract: equal-distance neighbors come back in a canonical,
+    /// deterministic order — ascending row id within a distance tie — and the
+    /// shared-scan batch path returns exactly what repeated single-query search
+    /// does. A single-partition exact (IVF_FLAT) index queried with a vector that
+    /// matches a row duplicated once per fragment yields five neighbors tied at
+    /// distance 0; `k = 5` returns all of them, so their order is fixed solely by
+    /// the tie-break, which orders ties by ascending row id (here ascending `i`,
+    /// since the data is written in `i` order).
+    ///
+    /// This pins the user-visible ordering guarantee; it does not isolate a
+    /// single internal sort. The final `(distance, row_id)` order is enforced by
+    /// the downstream consumer, and the stable partition scan order in
+    /// `search_partitions_batch` only changes *which* tied row survives when a tie
+    /// is truncated across partitions — which this single-partition,
+    /// all-ties-fit-within-`k` case deliberately does not exercise.
+    #[rstest]
+    #[tokio::test]
+    async fn test_batch_knn_indexed_orders_ties_by_row_id(
+        #[values(false, true)] stable_row_ids: bool,
+    ) {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, stable_row_ids)
+            .await
+            .unwrap();
+        // Single partition + exact (flat) storage: distances are exact, so the
+        // vectors duplicated across fragments tie at distance 0, and both the
+        // batch and single-query paths scan the one partition. That isolates the
+        // tie-break as the only thing determining the emitted order.
+        let params = VectorIndexParams::ivf_flat(1, MetricType::L2);
+        test_ds
+            .dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+        let dataset = &test_ds.dataset;
+
+        let (queries, query_values) = batch_knn_two_queries();
+        // Each query exactly matches a vector that appears once per 80-row
+        // fragment (5 copies), all at distance 0. `k = 5` returns every tied
+        // copy, so no truncation can hide the ordering.
+        let k = 5;
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &queries, k).unwrap();
+        scan.nprobes(1);
+        scan.project(&["i"]).unwrap();
+
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ANNIvfBatch"),
+            "single-partition IVF batch KNN should use the shared-scan batch node, got:\n{}",
+            plan
+        );
+
+        let batch = scan.try_into_batch().await.unwrap();
+        // The batch node must return the same rows/distances as issuing each
+        // query on its own against the index.
+        assert_batch_matches_single_queries(dataset, &batch, &query_values, k, true, None, Some(1))
+            .await;
+
+        // Query 0 matches vector index 1, stored at i = 1, 81, 161, 241, 321
+        // (once per fragment). All tie at distance 0, so the canonical
+        // (distance, row_id) order surfaces them by ascending row id, which here
+        // is ascending `i`.
+        let query_indices = batch[QUERY_INDEX_COL].as_primitive::<Int32Type>();
+        let q0 = arrow::compute::filter_record_batch(
+            &batch,
+            &BooleanArray::from_iter(query_indices.iter().map(|value| Some(value == Some(0)))),
+        )
+        .unwrap();
+        assert_eq!(
+            q0["i"].as_primitive::<Int32Type>().values(),
+            &[1, 81, 161, 241, 321]
+        );
+        let q0_dists = q0[DIST_COL].as_primitive::<Float32Type>();
+        assert!(
+            q0_dists
+                .values()
+                .iter()
+                .all(|dist| *dist == q0_dists.value(0)),
+            "the five duplicated neighbors must be genuine ties, got distances {:?}",
+            q0_dists.values()
+        );
+    }
+
+    /// Any `refine_factor` sends the query onto a reranking path the shared-scan
+    /// batch node does not implement, so the scanner must fall back to the
+    /// per-query indexed loop and still produce correctly grouped results.
+    ///
+    /// All of `refine(0)`, `refine(1)`, and `refine(2)` must fall back:
+    /// `refine(1)` still reranks on the single-query path (a factor of 1 is not
+    /// a no-op), and `refine(0)` is rejected there with `Refine factor cannot be
+    /// zero` — the batch path would instead return empty results. Covering the
+    /// boundary factors guards the `refine_factor.is_some()` gate against
+    /// regressing back to a `> 1` check.
     #[tokio::test]
     async fn test_batch_knn_indexed_refine_falls_back() {
         let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, true)
@@ -9794,28 +9907,42 @@ mod test {
         let dataset = &test_ds.dataset;
         let (queries, _query_values) = batch_knn_two_queries();
 
+        for refine_factor in [1u32, 2] {
+            let mut scan = dataset.scan();
+            scan.nearest("vec", &queries, 2).unwrap();
+            scan.refine(refine_factor);
+            scan.project(&["i"]).unwrap();
+
+            let plan = scan.explain_plan(false).await.unwrap();
+            assert!(
+                !plan.contains("ANNIvfBatch"),
+                "refine({refine_factor}) must not use the shared-scan batch node, got:\n{plan}"
+            );
+            assert!(
+                plan.contains("ANNSubIndex"),
+                "refine({refine_factor}) batch search should fall back to the per-query \
+                 indexed loop, got:\n{plan}"
+            );
+
+            let batch = scan.try_into_batch().await.unwrap();
+            assert_query_index_field(&batch);
+            assert_eq!(
+                batch[QUERY_INDEX_COL].as_primitive::<Int32Type>().values(),
+                &[0, 0, 1, 1],
+                "refine({refine_factor}) should still group results per query"
+            );
+        }
+
+        // refine(0) is rejected on the fallback (per-query) path; the batch path
+        // must not silently accept it and return empty results instead.
         let mut scan = dataset.scan();
         scan.nearest("vec", &queries, 2).unwrap();
-        scan.refine(2);
+        scan.refine(0);
         scan.project(&["i"]).unwrap();
-
-        let plan = scan.explain_plan(false).await.unwrap();
+        let result = scan.try_into_batch().await;
         assert!(
-            !plan.contains("ANNIvfBatch"),
-            "refine must not use the shared-scan batch node, got:\n{}",
-            plan
-        );
-        assert!(
-            plan.contains("ANNSubIndex"),
-            "refine batch search should fall back to the per-query indexed loop, got:\n{}",
-            plan
-        );
-
-        let batch = scan.try_into_batch().await.unwrap();
-        assert_query_index_field(&batch);
-        assert_eq!(
-            batch[QUERY_INDEX_COL].as_primitive::<Int32Type>().values(),
-            &[0, 0, 1, 1]
+            result.is_err(),
+            "refine(0) must error rather than fall through to an empty batch result"
         );
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -10086,6 +10086,18 @@ mod test {
             .unwrap();
         let dataset = &test_ds.dataset;
 
+        // Guard the premise of this test: `nprobes(num_partitions)` probes every
+        // partition, so the batch spans multiple streaming chunks only if the
+        // partition count exceeds the chunk size. If the default chunk size is
+        // ever raised past `num_partitions`, fail loudly here rather than let the
+        // test silently collapse to a single chunk and stop covering the seam.
+        let chunk_size = *crate::index::vector::ivf::v2::STREAMING_SEARCH_BATCH_SIZE;
+        assert!(
+            num_partitions > chunk_size,
+            "test needs more partitions ({num_partitions}) than the streaming chunk size \
+             ({chunk_size}) to span multiple chunks",
+        );
+
         let (queries, query_values) = batch_knn_two_queries();
         let k = 2;
         let mut scan = dataset.scan();

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -487,17 +487,10 @@ fn vec_query() -> Vec<f32> {
     vec![1.0_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 }
 
-/// 64-row two-fragment vector dataset with a single-partition IVF_FLAT index, then an overlay
-/// on fragment 1 that moves id=35 (offset 3) onto `far` (away from the query) and id=40
-/// (offset 8) onto the query. Built before the overlay, the index still believes id=35 is the
-/// query and has never seen id=40 near it. Every other base vector is orthogonal to the query.
-///
-/// Overlaying fragment 1 (ids 32..64) is deliberate: a physical address diverges from the
-/// stable row id there, so both the ANN prefilter block and the flat re-score take must operate
-/// in the row-id domain when `stable_row_ids` is enabled.
-async fn create_vector_overlay_dataset(stable_row_ids: bool) -> Dataset {
+/// 64-row two-fragment vector dataset with a single-partition IVF_FLAT index and no overlay.
+/// id=35 equals the query; every other base vector is orthogonal to and far from the query.
+async fn create_vector_index_dataset(stable_row_ids: bool) -> Dataset {
     let query = vec_query();
-    let far = vec![0.0_f32, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
 
     let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(64);
     for i in 0..64 {
@@ -545,6 +538,20 @@ async fn create_vector_overlay_dataset(stable_row_ids: bool) -> Dataset {
         .create_index(&["vec"], IndexType::Vector, None, &params, true)
         .await
         .unwrap();
+    dataset
+}
+
+/// [`create_vector_index_dataset`] plus an overlay on fragment 1 that moves id=35 (offset 3)
+/// onto `far` (away from the query) and id=40 (offset 8) onto the query. Built before the
+/// overlay, the index still believes id=35 is the query and has never seen id=40 near it.
+///
+/// Overlaying fragment 1 (ids 32..64) is deliberate: a physical address diverges from the
+/// stable row id there, so both the ANN prefilter block and the flat re-score take must operate
+/// in the row-id domain when `stable_row_ids` is enabled.
+async fn create_vector_overlay_dataset(stable_row_ids: bool) -> Dataset {
+    let query = vec_query();
+    let far = vec![0.0_f32, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let dataset = create_vector_index_dataset(stable_row_ids).await;
 
     commit_overlay(
         dataset,
@@ -622,6 +629,74 @@ async fn test_vector_overlay_stale_dropped_under_fast_search() {
     assert!(
         !ids.contains(&40),
         "fast_search skips re-score, so id=40 should be absent, got {ids:?}"
+    );
+}
+
+/// A batch (multi-vector) nearest query must fall back to the per-query indexed loop when a
+/// data overlay makes indexed vector rows stale. The shared-scan batch node (`ANNIvfBatch`)
+/// does not apply the overlay block or re-score moved rows, so `batch_index_search_supported`
+/// returns false and the per-query loop — which reconciles the overlay exactly as single-query
+/// search does — runs instead.
+///
+/// The no-overlay control confirms the shared-scan node *is* chosen otherwise (nprobes is
+/// pinned so no other gate fires), so the fallback is attributable to the overlay alone.
+#[rstest]
+#[tokio::test]
+async fn test_vector_batch_falls_back_on_overlay(#[values(false, true)] stable_row_ids: bool) {
+    // Two copies of the standard query, packed as a batch (multi-vector) nearest input.
+    let queries = fsl(vec![vec_query(), vec_query()], VEC_DIM);
+
+    // Control: without an overlay the shared-scan batch node handles the batch query.
+    let base = create_vector_index_dataset(stable_row_ids).await;
+    let mut scanner = base.scan();
+    scanner
+        .nearest("vec", queries.as_ref(), 3)
+        .unwrap()
+        .nprobes(1)
+        .project(&["id"])
+        .unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("ANNIvfBatch"),
+        "without an overlay the batch query should use the shared-scan node, got:\n{plan}"
+    );
+
+    // With an overlay on indexed vector rows the gate must fall back to the per-query loop.
+    let dataset = create_vector_overlay_dataset(stable_row_ids).await;
+    let mut scanner = dataset.scan();
+    scanner
+        .nearest("vec", queries.as_ref(), 3)
+        .unwrap()
+        .nprobes(1)
+        .project(&["id"])
+        .unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        !plan.contains("ANNIvfBatch"),
+        "an overlay on indexed rows must disable the shared-scan node, got:\n{plan}"
+    );
+    assert!(
+        plan.contains("ANNSubIndex"),
+        "the batch query should fall back to the per-query indexed loop, got:\n{plan}"
+    );
+
+    // Correctness: the fallback reconciles the overlay for the batch — id=40 (moved onto the
+    // query) is found and id=35 (moved away) is dropped, just like single-query search.
+    let results = scanner
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let ids = ids_from_batches(&results);
+    assert!(
+        ids.contains(&40),
+        "overlay-moved id=40 should be found via the fallback path, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&35),
+        "stale id=35 should be dropped via the fallback path, got {ids:?}"
     );
 }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2021,11 +2021,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         // partitions, so collecting every loaded partition before scoring would
         // make peak memory scale with the batch width — up to the whole index.
         // Streaming bounds resident partition storage to the load window plus one
-        // chunk, which is then dropped once scored. `buffered` preserves the
-        // sorted load order above, so scoring order (and thus tie-breaking) stays
-        // deterministic. Each chunk is scored in a single `spawn_cpu` dispatch
-        // that only touches CPU-bound state — the partition-loading `await`s stay
-        // in this async loop so no CPU-pool thread ever parks on I/O (#7642).
+        // chunk. `buffered` preserves the sorted load order above, so scoring order
+        // (and thus the k-th-distance tie-break) stays deterministic.
         let load_parallelism = get_num_compute_intensive_cpus().max(1);
         let load_index = self.clone();
         let load_metrics = metrics.clone();
@@ -2050,7 +2047,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             .map(|_| BinaryHeap::with_capacity(heap_capacity))
             .collect();
 
-        while let Some(chunk) = loaded_chunks.next().await {
+        // Score each chunk on the CPU pool while the next chunk loads. `spawn_cpu`
+        // dispatches the scoring immediately and only touches CPU-bound state, so
+        // `join!`-ing it with the next `loaded_chunks` pull keeps partition I/O in
+        // flight during scoring: the async task, never a CPU-pool thread, does the
+        // waiting (#7642), and the load stream is not paused (the pairing `spawn_cpu`'s
+        // docs recommend with `buffered`). Scoring stays sequential across chunks —
+        // each mutates the same per-query heaps — so a step costs about
+        // max(load, score) rather than their sum, and a scored chunk's storage is
+        // dropped before the next is scored, keeping peak memory bounded.
+        let mut pending = loaded_chunks.next().await;
+        while let Some(chunk) = pending {
             let chunk = chunk.into_iter().collect::<Result<Vec<_>>>()?;
             let index = self.clone();
             let pre_filter = pre_filter.clone();
@@ -2058,11 +2065,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             let raw_query_contexts = raw_query_contexts.clone();
             let scratch_pool = self.scratch_pool.clone();
             let search_metrics = metrics.clone();
-            // Score one chunk of loaded partitions into the shared per-query heaps
-            // and hand the heaps back for the next chunk. The chunk's partition
-            // storage is dropped when this dispatch returns, keeping peak memory
-            // bounded by the chunk size rather than the batch's whole probe set.
-            heaps = spawn_cpu(move || -> Result<Vec<BinaryHeap<OrderedNode<u64>>>> {
+            let score = spawn_cpu(move || -> Result<Vec<BinaryHeap<OrderedNode<u64>>>> {
                 scratch_pool.with_scratch(|scratch| -> Result<()> {
                     for (part_id, part_entry, probing_queries) in &chunk {
                         let partition_centroid = index.ivf.centroid(*part_id);
@@ -2092,8 +2095,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                     Ok(())
                 })?;
                 Ok(heaps)
-            })
-            .await?;
+            });
+            // Load the next chunk while this one is scored on the CPU pool.
+            let (scored, next) = futures::join!(score, loaded_chunks.next());
+            heaps = scored?;
+            pending = next;
         }
 
         heaps

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2005,7 +2005,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         let load_parallelism = get_num_compute_intensive_cpus().max(1);
         let load_index = self.clone();
         let load_metrics = metrics.clone();
-        let loaded = stream::iter(assignments)
+        let mut loaded = stream::iter(assignments)
             .map(move |(part_id, probing_queries)| {
                 let index = load_index.clone();
                 let metrics = load_metrics.clone();
@@ -2019,6 +2019,14 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             .buffered(load_parallelism)
             .try_collect::<Vec<_>>()
             .await?;
+        // Score partitions in a deterministic order. `assignments` is a HashMap,
+        // so its iteration order (and hence the order partitions accumulate into
+        // each per-query heap) is otherwise arbitrary. When several rows tie at
+        // the k-th distance, which one the capped heap keeps depends on insertion
+        // order, so a stable partition order is what makes the selected top-k
+        // deterministic across runs. (Any of the tied rows is an equally valid
+        // k-th neighbor, so this does not affect recall.)
+        loaded.sort_by_key(|(part_id, _, _)| *part_id);
 
         // Score the loaded partitions into one top-k heap per query.
         let use_query_residual = self.use_query_residual;

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1981,6 +1981,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             raw_query_contexts.push(self.prepare_rq_raw_query_context(&single_query.key)?);
             base_queries.push(single_query);
         }
+        // Shared across every chunk's scoring dispatch below, so wrap once in an
+        // `Arc` instead of cloning the whole `Vec` per chunk.
+        let base_queries = Arc::new(base_queries);
+        let raw_query_contexts = Arc::new(raw_query_contexts);
 
         // Invert the per-query partition lists so each distinct partition is
         // loaded once and scored against every query that probes it.
@@ -2000,12 +2004,32 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
 
         pre_filter.wait_for_ready().await?;
 
-        // Load each distinct partition's storage exactly once. This shared I/O
-        // is the whole point of batch search versus repeated single queries.
+        // Score partitions in a deterministic order. `assignments` is a HashMap,
+        // so its iteration order (and hence the order partitions accumulate into
+        // each per-query heap) is otherwise arbitrary. When several rows tie at
+        // the k-th distance, which one the capped heap keeps depends on insertion
+        // order, so a stable partition order is what makes the selected top-k
+        // deterministic across runs. (Any of the tied rows is an equally valid
+        // k-th neighbor, so this does not affect recall.)
+        let mut assignment_list: Vec<(u32, Vec<(usize, f32)>)> = assignments.into_iter().collect();
+        assignment_list.sort_by_key(|(part_id, _)| *part_id);
+
+        // Load each distinct partition's storage exactly once (the shared I/O
+        // that batch search exists to save), but *stream* the loaded partitions
+        // through scoring in chunks rather than materializing them all. A wide
+        // batch probes up to `min(query_count * nprobes, num_partitions)` distinct
+        // partitions, so collecting every loaded partition before scoring would
+        // make peak memory scale with the batch width — up to the whole index.
+        // Streaming bounds resident partition storage to the load window plus one
+        // chunk, which is then dropped once scored. `buffered` preserves the
+        // sorted load order above, so scoring order (and thus tie-breaking) stays
+        // deterministic. Each chunk is scored in a single `spawn_cpu` dispatch
+        // that only touches CPU-bound state — the partition-loading `await`s stay
+        // in this async loop so no CPU-pool thread ever parks on I/O (#7642).
         let load_parallelism = get_num_compute_intensive_cpus().max(1);
         let load_index = self.clone();
         let load_metrics = metrics.clone();
-        let mut loaded = stream::iter(assignments)
+        let mut loaded_chunks = stream::iter(assignment_list)
             .map(move |(part_id, probing_queries)| {
                 let index = load_index.clone();
                 let metrics = load_metrics.clone();
@@ -2017,64 +2041,65 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                 }
             })
             .buffered(load_parallelism)
-            .try_collect::<Vec<_>>()
-            .await?;
-        // Score partitions in a deterministic order. `assignments` is a HashMap,
-        // so its iteration order (and hence the order partitions accumulate into
-        // each per-query heap) is otherwise arbitrary. When several rows tie at
-        // the k-th distance, which one the capped heap keeps depends on insertion
-        // order, so a stable partition order is what makes the selected top-k
-        // deterministic across runs. (Any of the tied rows is an equally valid
-        // k-th neighbor, so this does not affect recall.)
-        loaded.sort_by_key(|(part_id, _, _)| *part_id);
+            .chunks(*STREAMING_SEARCH_BATCH_SIZE);
 
-        // Score the loaded partitions into one top-k heap per query.
         let use_query_residual = self.use_query_residual;
         let use_residual_scratch = self.use_residual_scratch;
         let heap_capacity = query.k * query.refine_factor.unwrap_or(1) as usize;
-        let scratch_pool = self.scratch_pool.clone();
-        let index = self.clone();
-        let search_metrics = metrics.clone();
-        let batches = spawn_cpu(move || -> Result<Vec<RecordBatch>> {
-            let mut heaps: Vec<BinaryHeap<OrderedNode<u64>>> = (0..query_count)
-                .map(|_| BinaryHeap::with_capacity(heap_capacity))
-                .collect();
-            scratch_pool.with_scratch(|scratch| -> Result<()> {
-                for (part_id, part_entry, probing_queries) in &loaded {
-                    let partition_centroid = index.ivf.centroid(*part_id);
-                    for (query_index, dist_q_c) in probing_queries {
-                        let mut single_query = base_queries[*query_index].clone();
-                        single_query.dist_q_c = *dist_q_c;
-                        let prepared = PreparedPartitionSearch::<S, Q> {
-                            query: single_query,
-                            pre_filter: pre_filter.clone(),
-                            partition_id: *part_id,
-                            partition_centroid: partition_centroid.clone(),
-                            rq_search_cache: index.rq_search_cache.clone(),
-                            raw_query_context: raw_query_contexts[*query_index].clone(),
-                            part_entry: part_entry.clone(),
-                            _marker: PhantomData,
-                        };
-                        Self::accumulate_prepared_partition_search(
-                            use_query_residual,
-                            use_residual_scratch,
-                            prepared,
-                            &mut heaps[*query_index],
-                            scratch,
-                            search_metrics.as_ref(),
-                        )?;
-                    }
-                }
-                Ok(())
-            })?;
-            heaps
-                .into_iter()
-                .map(Self::global_heap_to_batch)
-                .collect::<Result<Vec<_>>>()
-        })
-        .await?;
+        let mut heaps: Vec<BinaryHeap<OrderedNode<u64>>> = (0..query_count)
+            .map(|_| BinaryHeap::with_capacity(heap_capacity))
+            .collect();
 
-        Ok(batches)
+        while let Some(chunk) = loaded_chunks.next().await {
+            let chunk = chunk.into_iter().collect::<Result<Vec<_>>>()?;
+            let index = self.clone();
+            let pre_filter = pre_filter.clone();
+            let base_queries = base_queries.clone();
+            let raw_query_contexts = raw_query_contexts.clone();
+            let scratch_pool = self.scratch_pool.clone();
+            let search_metrics = metrics.clone();
+            // Score one chunk of loaded partitions into the shared per-query heaps
+            // and hand the heaps back for the next chunk. The chunk's partition
+            // storage is dropped when this dispatch returns, keeping peak memory
+            // bounded by the chunk size rather than the batch's whole probe set.
+            heaps = spawn_cpu(move || -> Result<Vec<BinaryHeap<OrderedNode<u64>>>> {
+                scratch_pool.with_scratch(|scratch| -> Result<()> {
+                    for (part_id, part_entry, probing_queries) in &chunk {
+                        let partition_centroid = index.ivf.centroid(*part_id);
+                        for (query_index, dist_q_c) in probing_queries {
+                            let mut single_query = base_queries[*query_index].clone();
+                            single_query.dist_q_c = *dist_q_c;
+                            let prepared = PreparedPartitionSearch::<S, Q> {
+                                query: single_query,
+                                pre_filter: pre_filter.clone(),
+                                partition_id: *part_id,
+                                partition_centroid: partition_centroid.clone(),
+                                rq_search_cache: index.rq_search_cache.clone(),
+                                raw_query_context: raw_query_contexts[*query_index].clone(),
+                                part_entry: part_entry.clone(),
+                                _marker: PhantomData,
+                            };
+                            Self::accumulate_prepared_partition_search(
+                                use_query_residual,
+                                use_residual_scratch,
+                                prepared,
+                                &mut heaps[*query_index],
+                                scratch,
+                                search_metrics.as_ref(),
+                            )?;
+                        }
+                    }
+                    Ok(())
+                })?;
+                Ok(heaps)
+            })
+            .await?;
+        }
+
+        heaps
+            .into_iter()
+            .map(Self::global_heap_to_batch)
+            .collect::<Result<Vec<_>>>()
     }
 
     fn is_loadable(&self) -> bool {

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1928,6 +1928,147 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         )))
     }
 
+    fn supports_batch_partition_search(&self) -> bool {
+        S::supports_global_topk_heap()
+    }
+
+    async fn search_partitions_batch(
+        self: Arc<Self>,
+        query: Query,
+        partitions_per_query: Vec<Arc<UInt32Array>>,
+        q_c_dists_per_query: Vec<Arc<Float32Array>>,
+        pre_filter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+    ) -> Result<Vec<RecordBatch>> {
+        if !S::supports_global_topk_heap() {
+            return Err(Error::not_supported(
+                "batch partition search requires a global top-k heap sub-index",
+            ));
+        }
+        let query_count = partitions_per_query.len();
+        if q_c_dists_per_query.len() != query_count {
+            return Err(Error::invalid_input(format!(
+                "batch partition search: {query_count} query partition lists but {} distance lists",
+                q_c_dists_per_query.len()
+            )));
+        }
+        if query_count == 0 {
+            return Ok(Vec::new());
+        }
+        if !query.key.len().is_multiple_of(query_count) {
+            return Err(Error::invalid_input(format!(
+                "batch partition search: query key length {} is not divisible by query count {query_count}",
+                query.key.len()
+            )));
+        }
+        let dim = query.key.len() / query_count;
+
+        // Per-query immutable search state: the query vector slice and the
+        // optional Rabit raw-query context both depend only on the query vector,
+        // so compute them once up front rather than per probed partition.
+        let mut base_queries = Vec::with_capacity(query_count);
+        let mut raw_query_contexts = Vec::with_capacity(query_count);
+        for query_index in 0..query_count {
+            if partitions_per_query[query_index].len() != q_c_dists_per_query[query_index].len() {
+                return Err(Error::invalid_input(format!(
+                    "batch partition search: query {query_index} has {} partitions but {} distances",
+                    partitions_per_query[query_index].len(),
+                    q_c_dists_per_query[query_index].len()
+                )));
+            }
+            let mut single_query = query.clone();
+            single_query.key = query.key.slice(query_index * dim, dim);
+            raw_query_contexts.push(self.prepare_rq_raw_query_context(&single_query.key)?);
+            base_queries.push(single_query);
+        }
+
+        // Invert the per-query partition lists so each distinct partition is
+        // loaded once and scored against every query that probes it.
+        let mut assignments: HashMap<u32, Vec<(usize, f32)>> = HashMap::new();
+        for (query_index, (parts, dists)) in partitions_per_query
+            .iter()
+            .zip(q_c_dists_per_query.iter())
+            .enumerate()
+        {
+            for (part_id, dist_q_c) in parts.values().iter().zip(dists.values().iter()) {
+                assignments
+                    .entry(*part_id)
+                    .or_default()
+                    .push((query_index, *dist_q_c));
+            }
+        }
+
+        pre_filter.wait_for_ready().await?;
+
+        // Load each distinct partition's storage exactly once. This shared I/O
+        // is the whole point of batch search versus repeated single queries.
+        let load_parallelism = get_num_compute_intensive_cpus().max(1);
+        let load_index = self.clone();
+        let load_metrics = metrics.clone();
+        let loaded = stream::iter(assignments)
+            .map(move |(part_id, probing_queries)| {
+                let index = load_index.clone();
+                let metrics = load_metrics.clone();
+                async move {
+                    let part_entry = index
+                        .load_partition(part_id as usize, true, metrics.as_ref())
+                        .await?;
+                    Result::Ok((part_id as usize, part_entry, probing_queries))
+                }
+            })
+            .buffered(load_parallelism)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        // Score the loaded partitions into one top-k heap per query.
+        let use_query_residual = self.use_query_residual;
+        let use_residual_scratch = self.use_residual_scratch;
+        let heap_capacity = query.k * query.refine_factor.unwrap_or(1) as usize;
+        let scratch_pool = self.scratch_pool.clone();
+        let index = self.clone();
+        let search_metrics = metrics.clone();
+        let batches = spawn_cpu(move || -> Result<Vec<RecordBatch>> {
+            let mut heaps: Vec<BinaryHeap<OrderedNode<u64>>> = (0..query_count)
+                .map(|_| BinaryHeap::with_capacity(heap_capacity))
+                .collect();
+            scratch_pool.with_scratch(|scratch| -> Result<()> {
+                for (part_id, part_entry, probing_queries) in &loaded {
+                    let partition_centroid = index.ivf.centroid(*part_id);
+                    for (query_index, dist_q_c) in probing_queries {
+                        let mut single_query = base_queries[*query_index].clone();
+                        single_query.dist_q_c = *dist_q_c;
+                        let prepared = PreparedPartitionSearch::<S, Q> {
+                            query: single_query,
+                            pre_filter: pre_filter.clone(),
+                            partition_id: *part_id,
+                            partition_centroid: partition_centroid.clone(),
+                            rq_search_cache: index.rq_search_cache.clone(),
+                            raw_query_context: raw_query_contexts[*query_index].clone(),
+                            part_entry: part_entry.clone(),
+                            _marker: PhantomData,
+                        };
+                        Self::accumulate_prepared_partition_search(
+                            use_query_residual,
+                            use_residual_scratch,
+                            prepared,
+                            &mut heaps[*query_index],
+                            scratch,
+                            search_metrics.as_ref(),
+                        )?;
+                    }
+                }
+                Ok(())
+            })?;
+            heaps
+                .into_iter()
+                .map(Self::global_heap_to_batch)
+                .collect::<Result<Vec<_>>>()
+        })
+        .await?;
+
+        Ok(batches)
+    }
+
     fn is_loadable(&self) -> bool {
         false
     }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -2652,9 +2652,38 @@ impl ExecutionPlan for ANNIvfBatchExec {
                     )
                     .await?;
 
+                // `search_partitions_batch` must return exactly one result batch
+                // per input query, in order, so `query_index` lines up with the
+                // `candidates` slot below. A mismatch means the index disagreed
+                // with the per-query fan-out and would otherwise silently drop or
+                // misattribute results (or panic on out-of-bounds indexing).
+                if per_query.len() != query_count {
+                    return Err(DataFusionError::Internal(format!(
+                        "batch partition search returned {} result batches for {} queries",
+                        per_query.len(),
+                        query_count
+                    )));
+                }
                 for (query_index, batch) in per_query.into_iter().enumerate() {
-                    let dists = batch.column(0).as_primitive::<Float32Type>();
-                    let row_ids = batch.column(1).as_primitive::<UInt64Type>();
+                    // Access by name rather than position: the result schema is
+                    // `VECTOR_RESULT_SCHEMA` (`_distance`, `_rowid`), and looking
+                    // up by name keeps this correct if that column order changes.
+                    let dists = batch
+                        .column_by_name(DIST_COL)
+                        .ok_or_else(|| {
+                            DataFusionError::Internal(format!(
+                                "batch partition search result missing '{DIST_COL}' column"
+                            ))
+                        })?
+                        .as_primitive::<Float32Type>();
+                    let row_ids = batch
+                        .column_by_name(ROW_ID)
+                        .ok_or_else(|| {
+                            DataFusionError::Internal(format!(
+                                "batch partition search result missing '{ROW_ID}' column"
+                            ))
+                        })?
+                        .as_primitive::<UInt64Type>();
                     candidates[query_index].extend(
                         dists
                             .values()

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -126,6 +126,58 @@ async fn find_partitions_on_cpu(
         .map_err(|e| DataFusionError::Execution(format!("Failed to find partitions: {}", e)))
 }
 
+/// Per-query IVF partition rankings: for each query, its probed-partition ids
+/// and the corresponding centroid distances, in query order.
+type BatchPartitionRankings = (Vec<Arc<UInt32Array>>, Vec<Arc<Float32Array>>);
+
+/// Rank every query vector in a batch against the IVF centroids on the CPU
+/// runtime.
+///
+/// [`VectorIndex::find_partitions`] is pure CPU work, and a wide batch over a
+/// large centroid set multiplies it enough to monopolize a Tokio worker and
+/// stall unrelated async progress. Dispatch the whole ranking loop as a single
+/// `spawn_cpu` job -- mirroring the single-query [`find_partitions_on_cpu`] --
+/// so it stays off the async executor threads.
+///
+/// `query.key` holds all `query_count` vectors concatenated and `dim` is the
+/// per-vector width. Returns each query's probed-partition list and the
+/// corresponding centroid distances, in query order.
+async fn find_partitions_batch_on_cpu(
+    index: Arc<dyn VectorIndex>,
+    query: Query,
+    query_count: usize,
+    dim: usize,
+) -> DataFusionResult<BatchPartitionRankings> {
+    spawn_cpu(move || -> Result<BatchPartitionRankings> {
+        let mut partitions_per_query = Vec::with_capacity(query_count);
+        let mut dists_per_query = Vec::with_capacity(query_count);
+        for query_index in 0..query_count {
+            let mut single_query = query.clone();
+            single_query.key = query.key.slice(query_index * dim, dim);
+            // Probe a fixed number of partitions per query. The scanner only
+            // routes here when `minimum_nprobes == maximum_nprobes` and
+            // `minimum_nprobes > 0` (see `Scanner::batch_index_search_supported`),
+            // so this is exactly what the single-query path would search -- no
+            // adaptive `early_pruning` floor or late-search expansion applies,
+            // making the batch result identical to repeated single-query search.
+            // No clamp is needed: the gate rejects `nprobes(0)` (which the
+            // single-query path treats as "probe nothing") rather than silently
+            // searching one partition here.
+            debug_assert!(
+                single_query.minimum_nprobes > 0,
+                "batch node reached with nprobes(0); the scanner gate should have fallen back"
+            );
+            single_query.maximum_nprobes = Some(single_query.minimum_nprobes);
+            let (partitions, q_c_dists) = index.find_partitions(&single_query)?;
+            partitions_per_query.push(Arc::new(partitions));
+            dists_per_query.push(Arc::new(q_c_dists));
+        }
+        Ok((partitions_per_query, dists_per_query))
+    })
+    .await
+    .map_err(|e| DataFusionError::Execution(format!("Failed to find partitions: {e}")))
+}
+
 fn normalize_query_for_index(index: &dyn VectorIndex, query: Query) -> DataFusionResult<Query> {
     if index.metric_type() != DistanceType::Cosine {
         return Ok(query);
@@ -2620,30 +2672,32 @@ impl ExecutionPlan for ANNIvfBatchExec {
                     dim,
                 )?;
 
-                let mut partitions_per_query = Vec::with_capacity(query_count);
-                let mut dists_per_query = Vec::with_capacity(query_count);
-                for query_index in 0..query_count {
-                    let mut single_query = normalized.clone();
-                    single_query.key = normalized.key.slice(query_index * dim, dim);
-                    // Probe a fixed number of partitions per query. The scanner
-                    // only routes here when `minimum_nprobes == maximum_nprobes`
-                    // and `minimum_nprobes > 0` (see
-                    // `Scanner::batch_index_search_supported`), so this is exactly
-                    // what the single-query path would search — no adaptive
-                    // `early_pruning` floor or late-search expansion applies,
-                    // making the batch result identical to repeated single-query
-                    // search. No clamp is needed: the gate rejects `nprobes(0)`
-                    // (which the single-query path treats as "probe nothing")
-                    // rather than silently searching one partition here.
-                    debug_assert!(
-                        single_query.minimum_nprobes > 0,
-                        "batch node reached with nprobes(0); the scanner gate should have fallen back"
-                    );
-                    single_query.maximum_nprobes = Some(single_query.minimum_nprobes);
-                    let (partitions, q_c_dists) = index.find_partitions(&single_query)?;
-                    partitions_per_query.push(Arc::new(partitions));
-                    dists_per_query.push(Arc::new(q_c_dists));
-                }
+                // Rank every query vector against the IVF centroids on the CPU
+                // runtime rather than inside this async future: the ranking is
+                // pure CPU and the batch width multiplies it, so a wide batch
+                // over a large centroid set could otherwise monopolize a Tokio
+                // worker. See `find_partitions_batch_on_cpu`.
+                let (partitions_per_query, dists_per_query) = find_partitions_batch_on_cpu(
+                    index.clone(),
+                    normalized.clone(),
+                    query_count,
+                    dim,
+                )
+                .await?;
+
+                // Record the partitions this delta actually reads. The batch
+                // node loads each probed partition once and scores every query
+                // that probes it, so the honest "partitions searched" count is
+                // the union across queries -- the shared I/O this node exists to
+                // save -- not the per-query sum. Mirrors the single-query
+                // ANNIvfSubIndexExec, which also records PARTITIONS_SEARCHED.
+                let distinct_partitions: RoaringBitmap = partitions_per_query
+                    .iter()
+                    .flat_map(|parts| parts.values().iter().copied())
+                    .collect();
+                metrics
+                    .partitions_searched
+                    .add(distinct_partitions.len() as usize);
 
                 let index_metrics: Arc<dyn MetricsCollector> =
                     Arc::new(metrics.index_metrics.clone());
@@ -3689,6 +3743,33 @@ mod tests {
         assert!(
             thread_name.contains("lance-cpu"),
             "expected find_partitions to run on the dedicated cpu runtime, got thread {thread_name}",
+        );
+    }
+
+    // Batch analogue of `test_find_partitions_runs_on_cpu_runtime`: the batch
+    // node's per-query centroid ranking multiplies the CPU cost, so it must also
+    // run on the dedicated cpu runtime rather than a Tokio async worker.
+    #[tokio::test]
+    async fn test_find_partitions_batch_runs_on_cpu_runtime() {
+        let thread_name = Arc::new(Mutex::new(None));
+        let index: Arc<dyn VectorIndex> = Arc::new(ThreadCapturingIndex {
+            thread_name: thread_name.clone(),
+            row_ids: Vec::new(),
+        });
+
+        // Two query vectors of dim 1 concatenated into one key.
+        let mut query = base_query();
+        query.key = Arc::new(Float32Array::from(vec![0.0f32, 1.0f32]));
+        let (partitions, dists) = find_partitions_batch_on_cpu(index, query, 2, 1)
+            .await
+            .unwrap();
+        assert_eq!(partitions.len(), 2, "one partition list per query");
+        assert_eq!(dists.len(), 2, "one distance list per query");
+
+        let thread_name = thread_name.lock().unwrap().clone().unwrap();
+        assert!(
+            thread_name.contains("lance-cpu"),
+            "expected batch find_partitions to run on the dedicated cpu runtime, got thread {thread_name}",
         );
     }
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Instant;
 
-use arrow::array::{Float32Builder, Int32Builder};
+use arrow::array::{Float32Builder, Int32Builder, UInt64Builder};
 use arrow::datatypes::{Float32Type, UInt32Type, UInt64Type};
 use arrow_array::{Array, Float32Array, UInt32Array, UInt64Array};
 use arrow_array::{
@@ -136,6 +136,37 @@ fn normalize_query_for_index(index: &dyn VectorIndex, query: Query) -> DataFusio
         .map_err(|e| DataFusionError::Execution(format!("Failed to normalize query: {e}")))?
         .0;
     query.key = key;
+    Ok(query)
+}
+
+/// Normalize a batch query's concatenated key for a cosine index.
+///
+/// `query.key` holds `query_count` vectors of length `dim` concatenated, so each
+/// vector must be normalized **independently** — normalizing the whole buffer
+/// would divide every vector by a single global norm that depends on the other
+/// queries in the batch, corrupting per-query cosine distances. Returns the
+/// query unchanged for non-cosine metrics.
+fn normalize_batch_query_for_index(
+    index: &dyn VectorIndex,
+    mut query: Query,
+    query_count: usize,
+    dim: usize,
+) -> DataFusionResult<Query> {
+    if index.metric_type() != DistanceType::Cosine {
+        return Ok(query);
+    }
+
+    let normalized: Vec<ArrayRef> = (0..query_count)
+        .map(|i| {
+            normalize_arrow(&query.key.slice(i * dim, dim))
+                .map(|(key, _)| key)
+                .map_err(|e| DataFusionError::Execution(format!("Failed to normalize query: {e}")))
+        })
+        .collect::<DataFusionResult<_>>()?;
+    let refs: Vec<&dyn Array> = normalized.iter().map(|a| a.as_ref()).collect();
+    query.key = arrow_select::concat::concat(&refs).map_err(|e| {
+        DataFusionError::Execution(format!("Failed to concat normalized query: {e}"))
+    })?;
     Ok(query)
 }
 
@@ -1101,6 +1132,47 @@ pub static KNN_PARTITION_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
         Field::new(INDEX_UUID_COLUMN, DataType::Utf8, false),
     ]))
 });
+
+/// Build the shared [`DatasetPreFilter`] for an ANN search node, executing the
+/// prefilter source (if any) for this partition. Used by both the single-query
+/// [`ANNIvfSubIndexExec`] and the batch [`ANNIvfBatchExec`] so the prefilter is
+/// wired identically (and, for a batch, built once and shared across queries).
+///
+/// `overlay_block`, when `Some`, excludes rows whose index entries may be stale
+/// due to a newer data overlay (see [`DatasetPreFilter::with_overlay_block`]).
+fn build_dataset_prefilter(
+    dataset: Arc<Dataset>,
+    indices: &[IndexMetadata],
+    prefilter_source: &PreFilterSource,
+    partition: usize,
+    context: Arc<datafusion::execution::context::TaskContext>,
+    overlay_block: Option<RowAddrMask>,
+    external_mask: Option<Arc<RowAddrMask>>,
+) -> DataFusionResult<Arc<DatasetPreFilter>> {
+    let prefilter_loader = match prefilter_source {
+        PreFilterSource::FilteredRowIds(src_node) => {
+            let stream = src_node.execute(partition, context)?;
+            Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
+        }
+        PreFilterSource::ScalarIndexQuery(src_node) => {
+            let stream = src_node.execute(partition, context)?;
+            Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
+        }
+        PreFilterSource::None => None,
+    };
+    // AND the external row-address mask into whatever the filter produced.
+    let prefilter_loader = match external_mask {
+        Some(mask) => {
+            Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
+        }
+        None => prefilter_loader,
+    };
+    let mut pre_filter = DatasetPreFilter::new(dataset, indices, prefilter_loader);
+    if let Some(overlay_block) = overlay_block {
+        pre_filter = pre_filter.with_overlay_block(overlay_block);
+    }
+    Ok(Arc::new(pre_filter))
+}
 
 /// Create a new ANN execution node. `overlay_block`, when `Some`, excludes rows whose index
 /// entries may be stale due to a newer data overlay (see [`ANNIvfSubIndexExec::with_overlay_block`]).
@@ -2166,32 +2238,15 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 async move { DataFusionResult::Ok(stream::iter(plan)) }
             })
             .try_flatten();
-        let prefilter_loader = match &prefilter_source {
-            PreFilterSource::FilteredRowIds(src_node) => {
-                let stream = src_node.execute(partition, context)?;
-                Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
-            }
-            PreFilterSource::ScalarIndexQuery(src_node) => {
-                let stream = src_node.execute(partition, context)?;
-                Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
-            }
-            PreFilterSource::None => None,
-        };
-
-        // AND the external row-address mask into whatever the filter produced.
-        let prefilter_loader = match self.external_mask.clone() {
-            Some(mask) => {
-                Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
-            }
-            None => prefilter_loader,
-        };
-        let pre_filter = {
-            let mut pf = DatasetPreFilter::new(ds.clone(), &indices, prefilter_loader);
-            if let Some(block) = self.overlay_block.clone() {
-                pf = pf.with_overlay_block(block);
-            }
-            Arc::new(pf)
-        };
+        let pre_filter = build_dataset_prefilter(
+            ds.clone(),
+            &indices,
+            &prefilter_source,
+            partition,
+            context,
+            self.overlay_block.clone(),
+            self.external_mask.clone(),
+        )?;
         let indices_by_uuid = Arc::new(
             indices
                 .iter()
@@ -2324,6 +2379,329 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
 
     fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+}
+
+/// Build a batch (multi-query) indexed vector search plan.
+///
+/// `query.key` must hold all `query_count` query vectors concatenated.
+pub fn new_knn_batch_exec(
+    dataset: Arc<Dataset>,
+    indices: &[IndexMetadata],
+    query: &Query,
+    query_count: usize,
+    prefilter_source: PreFilterSource,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(Arc::new(ANNIvfBatchExec::try_new(
+        dataset,
+        indices.to_vec(),
+        query.clone(),
+        query_count,
+        prefilter_source,
+    )?))
+}
+
+/// [ExecutionPlan] for batch (multi-query) IVF vector search.
+///
+/// Where the single-query path uses [`ANNIvfPartitionExec`] +
+/// [`ANNIvfSubIndexExec`], this node ranks every query vector against the IVF
+/// centroids and then asks the index to read each probed partition's storage
+/// once, scoring all queries that probe it
+/// (via [`VectorIndex::search_partitions_batch`]). The prefilter is built once
+/// and shared across all queries.
+///
+/// This is a separate node rather than a mode on the two single-query nodes
+/// because the two-node pipeline streams one partition-list per delta through a
+/// per-query top-k, whereas the shared scan must invert queries onto partitions
+/// and keep one heap per query in a single pass. It still reuses the underlying
+/// primitives (partition load, prefilter wiring via [`build_dataset_prefilter`],
+/// and the per-partition accumulate the index performs).
+///
+/// Output schema: `{query_index: Int32, _distance: Float32, _rowid: UInt64}`,
+/// sorted by `(query_index, _distance, _rowid)`, with up to `k` rows per query.
+///
+/// Per-query nprobes are honored statically from the ranking; the adaptive
+/// late-search expansion used by the single-query path is not applied, so recall
+/// matches repeated single-query search when `minimum_nprobes == maximum_nprobes`.
+#[derive(Debug)]
+pub struct ANNIvfBatchExec {
+    dataset: Arc<Dataset>,
+    indices: Vec<IndexMetadata>,
+    /// Vector query whose `key` holds all `query_count` vectors concatenated.
+    query: Query,
+    query_count: usize,
+    prefilter_source: PreFilterSource,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl ANNIvfBatchExec {
+    pub fn try_new(
+        dataset: Arc<Dataset>,
+        indices: Vec<IndexMetadata>,
+        query: Query,
+        query_count: usize,
+        prefilter_source: PreFilterSource,
+    ) -> Result<Self> {
+        if indices.is_empty() {
+            return Err(Error::index(
+                "ANNIvfBatchExec: no index found for query".to_string(),
+            ));
+        }
+        if query_count == 0 || !query.key.len().is_multiple_of(query_count) {
+            return Err(Error::invalid_input(format!(
+                "ANNIvfBatchExec: query key length {} is not divisible by query count {query_count}",
+                query.key.len()
+            )));
+        }
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(knn_empty_result_schema(true)),
+            Partitioning::RoundRobinBatch(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        ));
+        Ok(Self {
+            dataset,
+            indices,
+            query,
+            query_count,
+            prefilter_source,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+}
+
+impl DisplayAs for ANNIvfBatchExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "ANNIvfBatch: query_count={}, k={}, deltas={}",
+                    self.query_count,
+                    self.query.k,
+                    self.indices.len()
+                )
+            }
+            DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "ANNIvfBatch\nquery_count={}\nk={}\ndeltas={}",
+                    self.query_count,
+                    self.query.k,
+                    self.indices.len()
+                )
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for ANNIvfBatchExec {
+    fn name(&self) -> &str {
+        "ANNIvfBatchExec"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        knn_empty_result_schema(true)
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        match &self.prefilter_source {
+            PreFilterSource::None => vec![],
+            PreFilterSource::FilteredRowIds(src) => vec![src],
+            PreFilterSource::ScalarIndexQuery(src) => vec![src],
+        }
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let prefilter_source = match (&self.prefilter_source, children.len()) {
+            (PreFilterSource::None, 0) => PreFilterSource::None,
+            (PreFilterSource::FilteredRowIds(_), 1) => {
+                PreFilterSource::FilteredRowIds(children.pop().expect("length checked"))
+            }
+            (PreFilterSource::ScalarIndexQuery(_), 1) => {
+                PreFilterSource::ScalarIndexQuery(children.pop().expect("length checked"))
+            }
+            _ => {
+                return Err(DataFusionError::Internal(
+                    "ANNIvfBatchExec given an unexpected number of children".to_string(),
+                ));
+            }
+        };
+        Ok(Arc::new(Self {
+            dataset: self.dataset.clone(),
+            indices: self.indices.clone(),
+            query: self.query.clone(),
+            query_count: self.query_count,
+            prefilter_source,
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let schema = self.schema();
+        let ds = self.dataset.clone();
+        let column = self.query.column.clone();
+        let indices = self.indices.clone();
+        let query = self.query.clone();
+        let query_count = self.query_count;
+        let metrics = Arc::new(AnnIndexMetrics::new(&self.metrics, partition));
+        let metrics_clone = metrics.clone();
+        let timer = Instant::now();
+
+        let pre_filter = build_dataset_prefilter(
+            ds.clone(),
+            &indices,
+            &self.prefilter_source,
+            partition,
+            context,
+            // The batch node has no data overlay to reconcile against, so no
+            // stale-row block is applied (see `ANNIvfSubIndexExec::overlay_block`).
+            None,
+            // The batch node does not support an external row-address mask.
+            None,
+        )?;
+
+        let result_schema = schema.clone();
+        let fut = async move {
+            let dim = query.key.len() / query_count;
+            // Per-query candidate (distance, row_id) pairs accumulated across deltas.
+            let mut candidates: Vec<Vec<(f32, u64)>> = vec![Vec::new(); query_count];
+
+            for index_meta in &indices {
+                let index = ds
+                    .open_vector_index(&column, &index_meta.uuid, &metrics.index_metrics)
+                    .await?;
+                // The scanner's `batch_index_search_supported` gate decides which
+                // indices reach this node; this check only guards against that
+                // gate and the index implementation disagreeing (an internal
+                // invariant, not a user-facing error).
+                if !index.supports_batch_partition_search() {
+                    return Err(DataFusionError::Internal(format!(
+                        "ANNIvfBatchExec reached for index {} that does not support batch \
+                         partition search",
+                        index_meta.uuid
+                    )));
+                }
+                // Normalize each query vector independently (cosine only)
+                // before ranking; see normalize_batch_query_for_index.
+                let normalized = normalize_batch_query_for_index(
+                    index.as_ref(),
+                    query.clone(),
+                    query_count,
+                    dim,
+                )?;
+
+                let mut partitions_per_query = Vec::with_capacity(query_count);
+                let mut dists_per_query = Vec::with_capacity(query_count);
+                for query_index in 0..query_count {
+                    let mut single_query = normalized.clone();
+                    single_query.key = normalized.key.slice(query_index * dim, dim);
+                    // Probe a fixed number of partitions per query. The scanner
+                    // only routes here when `minimum_nprobes == maximum_nprobes`
+                    // (see `Scanner::batch_index_search_supported`), so this is
+                    // exactly what the single-query path would search — no
+                    // adaptive `early_pruning` floor or late-search expansion
+                    // applies, making the batch result identical to repeated
+                    // single-query search.
+                    let nprobes = single_query.minimum_nprobes.max(1);
+                    single_query.maximum_nprobes = Some(nprobes);
+                    let (partitions, q_c_dists) = index.find_partitions(&single_query)?;
+                    partitions_per_query.push(Arc::new(partitions));
+                    dists_per_query.push(Arc::new(q_c_dists));
+                }
+
+                let index_metrics: Arc<dyn MetricsCollector> =
+                    Arc::new(metrics.index_metrics.clone());
+                let pre_filter: Arc<dyn PreFilter> = pre_filter.clone();
+                let per_query = index
+                    .search_partitions_batch(
+                        normalized,
+                        partitions_per_query,
+                        dists_per_query,
+                        pre_filter,
+                        index_metrics,
+                    )
+                    .await?;
+
+                for (query_index, batch) in per_query.into_iter().enumerate() {
+                    let dists = batch.column(0).as_primitive::<Float32Type>();
+                    let row_ids = batch.column(1).as_primitive::<UInt64Type>();
+                    candidates[query_index].extend(
+                        dists
+                            .values()
+                            .iter()
+                            .copied()
+                            .zip(row_ids.values().iter().copied()),
+                    );
+                }
+            }
+
+            // Per-query top-k merge across deltas, tagged with query_index.
+            let mut query_index_builder = Int32Builder::new();
+            let mut distance_builder = Float32Builder::new();
+            let mut row_id_builder = UInt64Builder::new();
+            for (query_index, cands) in candidates.iter_mut().enumerate() {
+                cands.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+                cands.truncate(query.k);
+                for (distance, row_id) in cands.iter() {
+                    query_index_builder.append_value(query_index as i32);
+                    distance_builder.append_value(*distance);
+                    row_id_builder.append_value(*row_id);
+                }
+            }
+            let batch = RecordBatch::try_new(
+                result_schema,
+                vec![
+                    Arc::new(query_index_builder.finish()),
+                    Arc::new(distance_builder.finish()),
+                    Arc::new(row_id_builder.finish()),
+                ],
+            )?;
+            metrics.baseline_metrics.record_output(batch.num_rows());
+            DataFusionResult::Ok(batch)
+        };
+
+        let stream = stream::once(fut).finally(move || {
+            metrics_clone.index_metrics.flush_io();
+            metrics_clone
+                .baseline_metrics
+                .elapsed_compute()
+                .add_duration(timer.elapsed());
+            metrics_clone.baseline_metrics.done();
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream.boxed(),
+        )))
     }
 
     fn supports_limit_pushdown(&self) -> bool {

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -2627,13 +2627,19 @@ impl ExecutionPlan for ANNIvfBatchExec {
                     single_query.key = normalized.key.slice(query_index * dim, dim);
                     // Probe a fixed number of partitions per query. The scanner
                     // only routes here when `minimum_nprobes == maximum_nprobes`
-                    // (see `Scanner::batch_index_search_supported`), so this is
-                    // exactly what the single-query path would search — no
-                    // adaptive `early_pruning` floor or late-search expansion
-                    // applies, making the batch result identical to repeated
-                    // single-query search.
-                    let nprobes = single_query.minimum_nprobes.max(1);
-                    single_query.maximum_nprobes = Some(nprobes);
+                    // and `minimum_nprobes > 0` (see
+                    // `Scanner::batch_index_search_supported`), so this is exactly
+                    // what the single-query path would search — no adaptive
+                    // `early_pruning` floor or late-search expansion applies,
+                    // making the batch result identical to repeated single-query
+                    // search. No clamp is needed: the gate rejects `nprobes(0)`
+                    // (which the single-query path treats as "probe nothing")
+                    // rather than silently searching one partition here.
+                    debug_assert!(
+                        single_query.minimum_nprobes > 0,
+                        "batch node reached with nprobes(0); the scanner gate should have fallen back"
+                    );
+                    single_query.maximum_nprobes = Some(single_query.minimum_nprobes);
                     let (partitions, q_c_dists) = index.find_partitions(&single_query)?;
                     partitions_per_query.push(Arc::new(partitions));
                     dists_per_query.push(Arc::new(q_c_dists));


### PR DESCRIPTION
## Which issue does this PR close?

Closes #6822.

## Rationale for this change

Batch vector search (#6821, PR #6828) made indexed multi-query search *work* by looping the full single-query plan once per query vector — re-opening the index and rebuilding the prefilter for every query — and unioning the results. That throws away the main opportunity of a batch: query vectors mostly probe overlapping IVF partitions, so the same partition storage is read and decoded many times. This PR shares that index-level state across the batch.

## What changes are included in this PR?

The indexed/ANN path now reads each probed IVF partition's storage **once** and scores every query that probes it, with the prefilter built once and shared.

- **`VectorIndex` trait** (`lance-index`): defaulted `supports_batch_partition_search()` + `search_partitions_batch(...)` (default returns `not_supported`). Additive — no breaking change.
- **`IVFIndex`** (`ivf/v2.rs`): batch search for flat-style sub-indices (IVF_FLAT/PQ/SQ/RQ). Invert per-query partition lists, load each distinct partition once, accumulate one top-k heap per query, reusing `accumulate_prepared_partition_search` / `global_heap_to_batch`.
- **`ANNIvfBatchExec`** (`io/exec/knn.rs`): ranks each query against the centroids, runs the shared-scan batch search per delta, merges per-query top-k across deltas, emits `{query_index, _distance, _rowid}`. Prefilter wiring shared with the single-query node via `build_dataset_prefilter`.
- Each query vector is normalized **independently** for cosine (`normalize_batch_query_for_index`).

**Fallback matrix (no regression):**

| Case | Behavior |
| --- | --- |
| IVF_FLAT/PQ/SQ/RQ, fixed nprobes, fully indexed | shared-scan fast path |
| adaptive nprobes / `refine_factor` / IVF_HNSW_* / mixed indexed+unindexed | per-query indexed loop (exact) |

**Design notes (anticipating review):**

- **Why a new exec node, not a mode on the existing ANN nodes?** The two-node single-query pipeline streams one partition-list per delta through a per-query top-k; sharing the scan requires *inverting* queries onto partitions and keeping one heap **per query** in a single pass — a different dataflow. The new node reuses the underlying primitives (partition load, `build_dataset_prefilter`, the index's per-partition accumulate) and leaves the single-query nodes untouched.
- **Why gate on index-type metadata, not `supports_batch_partition_search()`?** The gate is a planning-time decision and the single-query path likewise doesn't open the index there; `derive_vector_index_type` reads metadata with no I/O. The opened index re-checks the trait as a defensive invariant.
- **nprobes gate (correctness).** The shared path searches exactly `minimum_nprobes` partitions/query, but the single-query path is adaptive (`early_pruning` floor + late-search expansion), so the two only match when nprobes is fixed. The fast path is gated to `minimum_nprobes == maximum_nprobes`; adaptive nprobes falls back to the per-query loop (verified: an unpinned batch diverged on every query before the gate, 0 divergence after). **Open question:** fixed-nprobes-first with batched early/late as a follow-up, or the full adaptive path in one PR?
- **Memory.** Peak = the union of probed partitions held during scoring — the same buffering the existing single-query global-heap path (`search_partitions`) uses, widened to the batch's partition union; per-delta output is k-bounded, so cross-delta accumulation is O(deltas × k).

## Are these changes tested?

Yes.

- `cargo test -p lance --lib test_batch_knn` — **15 tests**: plan shape, exact batch-vs-repeated-single equivalence (nprobes pinned), cosine regression, shared prefilter, multi-delta cross-delta merge, and explicit fallbacks for **refine, adaptive nprobes, and IVF_HNSW** (acceptance criterion: "unsupported index types have explicit behavior and tests").
- `cargo test -p lance --lib dataset::scanner::test::test_knn` (29) — no single-query regression (exercises the shared `build_dataset_prefilter`).
- `cargo fmt --all` && `cargo clippy -p lance -p lance-index --tests --benches -- -D warnings`.
- Python: `pytest -k batch` (L2 + cosine × three/single queries); index-type sweep (IVF_FLAT/PQ/SQ/HNSW_PQ/HNSW_SQ) matches repeated single-query; `ruff` clean; `pyright` clean on changed lines.
- Benchmark (`benchmarks/test_search.py`): batch vs repeated-single ANN; local run (50k rows, dim 128, IVF_PQ 64 partitions, m=32, k=10, nprobes=10) → **~2.5× faster** (ratio; absolute ms machine-dependent).

## Are there any user-facing changes?

No API changes. The batch-query surface (2-D / list query with a `query_index` output column) already shipped in #6828; this PR only changes how indexed batch queries execute, so Python and Java bindings are unaffected. It is a **performance improvement** for fixed-nprobes indexed batch search; results are identical to issuing the queries one at a time. No format or compatibility change.