### PR TITLE
feat(transaction): experimental action-based transaction format skeleton

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -115,6 +115,11 @@ message Manifest {
   // * 1 << 3: table config is present
   // * 1 << 4: dataset uses multiple base paths
   // * 1 << 5: transaction file writes are disabled
+  // * 1 << 6: dataset uses one or more experimental features, named in
+  //           experimental_reader_features / experimental_writer_features. This
+  //           bit is the fail-closed anchor: implementations that predate a
+  //           given experiment reject the dataset on this bit alone, without
+  //           needing to parse the feature names.
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -207,6 +212,24 @@ message Manifest {
 
   // The branch of the dataset. None means main branch.
   optional string branch = 20;
+
+  // Names of experimental features this dataset relies on for reading.
+  //
+  // EXPERIMENTAL: this is the forward-looking capability list that pairs with
+  // the `1 << 6` reader feature-flag bit. A reader that does not recognize
+  // every name listed here must refuse to read the dataset. Feature names are
+  // stable, lowercase-kebab identifiers (e.g. "action-transactions"). A name
+  // is removed from this list once its feature graduates to a dedicated
+  // feature-flag bit, or when the experiment is abandoned and its data is no
+  // longer written. Empty for datasets that use no experimental features.
+  repeated string experimental_reader_features = 22;
+
+  // Names of experimental features this dataset relies on for writing.
+  //
+  // EXPERIMENTAL: the writer-side counterpart of experimental_reader_features,
+  // pairing with the `1 << 6` writer feature-flag bit. A writer that does not
+  // recognize every name listed here must refuse to commit to the dataset.
+  repeated string experimental_writer_features = 23;
 } // Manifest
 
 // external dataset base path

--- a/protos/transaction_experimental.proto
+++ b/protos/transaction_experimental.proto
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+syntax = "proto3";
+
+import "table.proto";
+
+package lance.table;
+
+// EXPERIMENTAL — Action-based transactions (milestone "Action-based
+// Transactions (UserOperation)"; design discussion #5960).
+//
+// This file defines the *unstable* wire format for compound, action-based
+// transactions. It is doubly gated and MUST NOT be treated as a stable format:
+//
+//   1. Rust: only compiled under the non-default `unstable-action-transactions`
+//      Cargo feature, so it is absent from released artifacts.
+//   2. On disk: any dataset that writes one of these transactions sets the
+//      FLAG_ACTION_TRANSACTIONS writer feature flag, so libraries that do not
+//      understand it refuse to commit.
+//
+// The messages here carry NO backwards- or forwards-compatibility guarantee
+// and may change or be removed in any release. Once the format is finalized
+// and ratified by PMC vote, these messages will be promoted into
+// transaction.proto and the guarantee will attach then.
+
+// A user-facing, composable transaction: an ordered list of user actions that
+// commit atomically as a single manifest change.
+//
+// When promoted, this becomes a variant of the top-level `Transaction` in
+// transaction.proto (replacing the single-`Operation` model):
+//
+//   Transaction {
+//     oneof operation {
+//       ...existing operations...
+//       UserOperation user_operation = N;  // <-- actions land here
+//     }
+//   }
+message UserOperation {
+  // Human-readable description, e.g. "INSERT INTO t VALUES (1)".
+  string description = 1;
+  // Unique identifier for this operation, matching Transaction.uuid semantics.
+  string uuid = 2;
+  // The dataset version this operation was planned against.
+  uint64 read_version = 3;
+  // The ordered list of user actions applied by this operation.
+  repeated UserAction actions = 4;
+}
+
+// A single user-recognizable step within a UserOperation (e.g. "append batch",
+// "rebuild index"), carrying a description and the granular actions it expands
+// to. Action lists are flattened when applied to the manifest.
+message UserAction {
+  // Human-readable description of this step.
+  string description = 1;
+  // The granular manifest changes this step expands to.
+  repeated Action actions = 2;
+}
+
+// A granular change to the manifest. Traditional operations decompose into an
+// ordered list of these.
+//
+// EXPERIMENTAL: only `AddFragments` is defined so far, as a proof of shape.
+// The remaining actions (RemoveFragments, UpdateDeletionVector, AddIndex, ...)
+// land in follow-up vertical slices.
+message Action {
+  oneof action {
+    AddFragments add_fragments = 1;
+  }
+}
+
+// Append new fragments to the table.
+//
+// Covers: Append, the "add new rows" part of Overwrite, and new fragments
+// produced by compaction.
+message AddFragments {
+  // The new fragments to append. Fragment IDs are not carried here; they are
+  // assigned at apply time from the manifest's counters (late binding).
+  repeated DataFragment fragments = 1;
+}

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -60,6 +60,10 @@ protobuf-src = { version = "2.1", optional = true }
 
 [features]
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]
+# EXPERIMENTAL: action-based (UserOperation) transactions. Unstable wire format
+# with no compatibility guarantee; not compiled into default builds. See
+# protos/transaction_experimental.proto.
+unstable-action-transactions = []
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance-table/build.rs
+++ b/rust/lance-table/build.rs
@@ -12,18 +12,23 @@ fn main() -> Result<()> {
         std::env::set_var("PROTOC", protobuf_src::protoc());
     }
 
+    // `mut` is used only when the experimental feature adds to the list below.
+    #[allow(unused_mut)]
+    let mut protos = vec![
+        "./protos/table.proto",
+        "./protos/transaction.proto",
+        "./protos/rowids.proto",
+    ];
+    // EXPERIMENTAL: only compile the action-based transaction messages when the
+    // unstable feature is enabled, so they are absent from default builds.
+    #[cfg(feature = "unstable-action-transactions")]
+    protos.push("./protos/transaction_experimental.proto");
+
     let mut prost_build = prost_build::Config::new();
     prost_build.extern_path(".lance.file", "::lance_file::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
-    prost_build.compile_protos(
-        &[
-            "./protos/table.proto",
-            "./protos/transaction.proto",
-            "./protos/rowids.proto",
-        ],
-        &["./protos"],
-    )?;
+    prost_build.compile_protos(&protos, &["./protos"])?;
 
     Ok(())
 }

--- a/rust/lance-table/design/experimental_feature_flags.md
+++ b/rust/lance-table/design/experimental_feature_flags.md
@@ -1,0 +1,173 @@
+# Proposal: A General Experimental-Feature Mechanism
+
+Status: **Proposed** (policy + format change; seeking PMC agreement)
+
+## Summary
+
+Add a single, general mechanism for shipping *experimental* format features
+without spending a scarce, permanent feature-flag bit per experiment:
+
+- Reserve **one** persisted feature-flag bit, `FLAG_EXPERIMENTAL` (`1 << 6`),
+  meaning "this dataset uses one or more experimental features."
+- Carry the actual feature identities in **free-form string lists** on the
+  manifest: `experimental_reader_features` and `experimental_writer_features`.
+- A build understands an experiment only if its name is in a compile-time
+  registry (gated by the experiment's Cargo feature). Unknown name → refuse.
+
+This lets experiments be **free-flowing** (mint/abandon names at will, unbounded
+namespace) while the permanent bitmap stays **conservative** (a bit is spent
+only when a feature graduates).
+
+## Motivation
+
+Feature flags today are two `u64` bitmaps (`reader_feature_flags`,
+`writer_feature_flags`) with a linear "first unknown bit" boundary: an
+implementation accepts a dataset iff no bit at or above the boundary is set.
+This is elegant for *stable* features, but it makes experimentation expensive:
+
+1. **Every persisted bit is burned forever.** Even an *abandoned* experiment's
+   bit can never be reused, because some dataset may have written it and reusing
+   the bit would misread that dataset. Experimental churn permanently pollutes a
+   scarce (64-bit), shared namespace.
+2. **Claiming a bit is high-ceremony**, which chills experimentation — reaching
+   for a permanent, format-committing bit for a maybe-throwaway idea feels
+   heavy, so people avoid trying things.
+
+Only *format-changing* experiments need a persisted flag at all (purely
+behavioral experiments are ordinary Cargo features / runtime config and never
+touch the bitmap). But for the ones that do, we want a cheap, safe, churnable
+path.
+
+## Design
+
+### The bit is the fail-closed anchor; the strings are the capability list
+
+`FLAG_EXPERIMENTAL` reuses bit 64, which was previously the first `FLAG_UNKNOWN`
+bit. This is safe to repurpose: until now, writing bit 64 made a dataset
+unreadable by *every* implementation, so no dataset in the wild has it set.
+
+- **Old implementations** (predating any experiment) still treat bit 64 as
+  unknown and reject the dataset on the bit alone — they never need to parse the
+  names. This is the whole reason the bit exists.
+- **New implementations** ignore the bit for admission and instead check the
+  string lists directly: a reader admits the dataset iff it understands every
+  name in `experimental_reader_features` (and likewise for writes).
+
+The bit is thus **backward-facing** (fail-closed for old readers) and the
+strings are **forward-facing** (precise capability negotiation for new readers).
+
+Why the bit is load-bearing and a string list alone is unsafe: a new manifest
+field is, by protobuf's rules, silently ignored by readers that don't know it.
+Without the bit, an old reader would skip the experimental-features field and
+happily misread experimental data. The bit forces the rejection.
+
+### Admission algorithm
+
+```text
+can_read(reader_flags, experimental_reader_features):
+    if any bit >= FLAG_UNKNOWN (128) is set:      # a non-experimental unknown
+        reject
+    if any name in experimental_reader_features is not in this build's registry:
+        reject
+    accept
+```
+
+`can_write` is identical over the writer flags/list. `FLAG_EXPERIMENTAL` itself
+is a *known* bit (below the new `FLAG_UNKNOWN = 128`), so it never trips the
+first check; gating is entirely by the name lists.
+
+### The registry
+
+Each build exposes the experimental features it understands via a compile-time
+list, populated only when the implementing Cargo feature is enabled:
+
+```rust
+pub fn known_experimental_features() -> &'static [&'static str] {
+    &[
+        #[cfg(feature = "unstable-action-transactions")]
+        "action-transactions",
+    ]
+}
+```
+
+A default release build understands *none*, so it rejects any dataset that
+declares an experimental feature — the desired conservative default.
+
+### Two independent layers of gating
+
+- **Cargo feature** (compile-time): keeps experimental *code* out of released
+  artifacts and out of the support/attack surface.
+- **`FLAG_EXPERIMENTAL` + name list** (persisted): keeps experimental *data*
+  safe across versions and implementations.
+
+They are orthogonal and both apply. The mechanism itself (bit semantics + name
+checking) is **not** Cargo-gated — it must be in every build so that all builds
+fail closed on experiments they lack.
+
+## Graduation and lifecycle
+
+- **Graduate:** when an experiment is ratified, it gets its own dedicated stable
+  feature-flag bit. Its name is dropped from `known_experimental_features`, and
+  new writes stop emitting the name (setting the new stable bit instead). Only
+  now does the feature consume a permanent bitmap slot — and only because it
+  earned one.
+- **Abandon:** drop the name from the registry. Datasets that used it become
+  unreadable by all builds (correctly — the feature is gone). No permanent bit
+  was ever spent.
+- **Debt control:** the registry is a single auditable list. An experimental
+  name that has not graduated within N releases should be removed. Experimental
+  code lives behind its Cargo feature in isolated modules, not threaded through
+  stable paths.
+
+Be **free-flowing in the string list, conservative at the bitmap.** The speed
+bump lands at graduation (a real compatibility commitment), not at
+experiment-start (where friction just deters trying things).
+
+## Alternatives considered
+
+- **A dedicated bit per experiment** (what the action-transactions skeleton PR
+  #7641 currently does). Simple, but every experiment permanently burns a scarce
+  bit even if abandoned. Fine for one feature; doesn't scale to a culture of
+  experimentation.
+- **A free-form field with no bit.** Unsafe: old readers silently ignore the
+  unknown field and misread experimental data. The reserved bit is required as
+  the fail-closed anchor.
+- **A long-lived feature branch instead of flags.** Different tool — it isolates
+  *code*, not *runtime/format behavior on a shared codebase*. It defers
+  integration (merge rot, big-bang review), blocks early opt-in dogfooding, and
+  *still* needs a persisted marker so branch-written data is identifiable and
+  rejectable. Branches remain the right tool for short throwaway spikes and
+  compose fine as the per-slice PR mechanism, but not as the isolation model for
+  a feature.
+
+## Prior art
+
+Delta Lake's "table features" made exactly this move: replacing a coarse,
+monotonic protocol-version integer with a named, split reader/writer feature set
+so that features could be added independently and negotiated by name. This
+proposal is the same shape, anchored to Lance's existing feature-flag bitmap for
+backward-compatible rejection.
+
+## Format change
+
+Two `repeated string` fields on `Manifest` (`table.proto`):
+`experimental_reader_features = 22`, `experimental_writer_features = 23`, plus
+documentation of bit `1 << 6` on `reader_feature_flags`. Backwards compatible
+(new field numbers, new bit that old readers already reject).
+
+## Impact on #7641 (action-based transactions)
+
+The action-transactions skeleton (#7641) currently claims a dedicated
+`FLAG_ACTION_TRANSACTIONS` bit. Once this mechanism lands, #7641 should adopt it
+instead: set `FLAG_EXPERIMENTAL` + list `"action-transactions"`, register that
+name under the `unstable-action-transactions` Cargo feature, and free the
+dedicated bit. This PR should land first.
+
+## Open questions
+
+- Naming convention for feature identifiers (proposed: lowercase-kebab, stable
+  across the experiment's life).
+- Whether to also expose the registry / active experimental features through the
+  Python and Java bindings for introspection.
+- Whether graduation should keep the old experimental name readable (dual-accept
+  during a transition window) or require a rewrite.

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -20,8 +20,44 @@ pub const FLAG_TABLE_CONFIG: u64 = 8;
 pub const FLAG_BASE_PATHS: u64 = 16;
 /// Disable writing transaction file under _transaction/, this flag is set when we only want to write inline transaction in manifest
 pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
-/// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 64;
+/// The dataset relies on one or more experimental features, named in the
+/// manifest's `experimental_reader_features` / `experimental_writer_features`.
+///
+/// This bit is the fail-closed anchor for the experimental-feature mechanism.
+/// It is set whenever the corresponding experimental feature list is non-empty.
+/// Libraries built before a given experiment existed treat bit 64 as unknown
+/// (it was previously `FLAG_UNKNOWN`) and reject the dataset without needing to
+/// parse the feature names. Libraries that understand the mechanism defer to the
+/// name lists via [`can_read_dataset`] / [`can_write_dataset`]. See
+/// `rust/lance-table/design/experimental_feature_flags.md`.
+pub const FLAG_EXPERIMENTAL: u64 = 64;
+/// The first bit that is unknown as a feature flag.
+pub const FLAG_UNKNOWN: u64 = 128;
+
+// The experimental bit must be a *known* bit so admission is gated by the name
+// lists, not the bitmap boundary.
+const _: () = assert!(FLAG_EXPERIMENTAL < FLAG_UNKNOWN);
+
+/// The experimental feature names this build understands.
+///
+/// Each name is registered here only when the Cargo feature that implements it
+/// is enabled, so a default build understands none and therefore rejects any
+/// dataset that declares an experimental feature. When an experiment graduates,
+/// its name moves out of this list and onto a dedicated feature-flag bit.
+pub fn known_experimental_features() -> &'static [&'static str] {
+    &[
+        // Register experimental feature names here, gated by their Cargo feature:
+        //   #[cfg(feature = "unstable-action-transactions")] "action-transactions",
+    ]
+}
+
+/// Whether every name in `experimental_features` is understood by this build.
+fn understands_experimental_features(experimental_features: &[String]) -> bool {
+    let known = known_experimental_features();
+    experimental_features
+        .iter()
+        .all(|feature| known.contains(&feature.as_str()))
+}
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(
@@ -74,15 +110,38 @@ pub fn apply_feature_flags(
     if disable_transaction_file {
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
+
+    // The experimental bit is the fail-closed anchor for the named experimental
+    // feature lists; keep it in sync with them.
+    if !manifest.experimental_reader_features.is_empty() {
+        manifest.reader_feature_flags |= FLAG_EXPERIMENTAL;
+    }
+    if !manifest.experimental_writer_features.is_empty() {
+        manifest.writer_feature_flags |= FLAG_EXPERIMENTAL;
+    }
     Ok(())
 }
 
-pub fn can_read_dataset(reader_flags: u64) -> bool {
-    reader_flags < FLAG_UNKNOWN
+/// Whether this build can read a dataset with the given reader feature flags and
+/// declared experimental reader features.
+///
+/// Rejects if any non-experimental unknown bit is set, or if any declared
+/// experimental feature is not understood by this build.
+pub fn can_read_dataset(reader_flags: u64, experimental_reader_features: &[String]) -> bool {
+    if reader_flags & !(FLAG_UNKNOWN - 1) != 0 {
+        // A bit at or above FLAG_UNKNOWN is set — a feature we don't know about.
+        return false;
+    }
+    understands_experimental_features(experimental_reader_features)
 }
 
-pub fn can_write_dataset(writer_flags: u64) -> bool {
-    writer_flags < FLAG_UNKNOWN
+/// Whether this build can write to a dataset with the given writer feature flags
+/// and declared experimental writer features. See [`can_read_dataset`].
+pub fn can_write_dataset(writer_flags: u64, experimental_writer_features: &[String]) -> bool {
+    if writer_flags & !(FLAG_UNKNOWN - 1) != 0 {
+        return false;
+    }
+    understands_experimental_features(experimental_writer_features)
 }
 
 pub fn has_deprecated_v2_feature_flag(writer_flags: u64) -> bool {
@@ -94,40 +153,99 @@ mod tests {
     use super::*;
     use crate::format::BasePath;
 
+    const NO_FEATURES: &[String] = &[];
+
     #[test]
     fn test_read_check() {
-        assert!(can_read_dataset(0));
-        assert!(can_read_dataset(super::FLAG_DELETION_FILES));
-        assert!(can_read_dataset(super::FLAG_STABLE_ROW_IDS));
-        assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
-        assert!(can_read_dataset(super::FLAG_TABLE_CONFIG));
-        assert!(can_read_dataset(super::FLAG_BASE_PATHS));
-        assert!(can_read_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
+        assert!(can_read_dataset(0, NO_FEATURES));
+        assert!(can_read_dataset(super::FLAG_DELETION_FILES, NO_FEATURES));
+        assert!(can_read_dataset(super::FLAG_STABLE_ROW_IDS, NO_FEATURES));
+        assert!(can_read_dataset(
+            super::FLAG_USE_V2_FORMAT_DEPRECATED,
+            NO_FEATURES
+        ));
+        assert!(can_read_dataset(super::FLAG_TABLE_CONFIG, NO_FEATURES));
+        assert!(can_read_dataset(super::FLAG_BASE_PATHS, NO_FEATURES));
+        assert!(can_read_dataset(
+            super::FLAG_DISABLE_TRANSACTION_FILE,
+            NO_FEATURES
+        ));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
-                | super::FLAG_USE_V2_FORMAT_DEPRECATED
+                | super::FLAG_USE_V2_FORMAT_DEPRECATED,
+            NO_FEATURES
         ));
-        assert!(!can_read_dataset(super::FLAG_UNKNOWN));
+        assert!(!can_read_dataset(super::FLAG_UNKNOWN, NO_FEATURES));
     }
 
     #[test]
     fn test_write_check() {
-        assert!(can_write_dataset(0));
-        assert!(can_write_dataset(super::FLAG_DELETION_FILES));
-        assert!(can_write_dataset(super::FLAG_STABLE_ROW_IDS));
-        assert!(can_write_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
-        assert!(can_write_dataset(super::FLAG_TABLE_CONFIG));
-        assert!(can_write_dataset(super::FLAG_BASE_PATHS));
-        assert!(can_write_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
+        assert!(can_write_dataset(0, NO_FEATURES));
+        assert!(can_write_dataset(super::FLAG_DELETION_FILES, NO_FEATURES));
+        assert!(can_write_dataset(super::FLAG_STABLE_ROW_IDS, NO_FEATURES));
+        assert!(can_write_dataset(
+            super::FLAG_USE_V2_FORMAT_DEPRECATED,
+            NO_FEATURES
+        ));
+        assert!(can_write_dataset(super::FLAG_TABLE_CONFIG, NO_FEATURES));
+        assert!(can_write_dataset(super::FLAG_BASE_PATHS, NO_FEATURES));
+        assert!(can_write_dataset(
+            super::FLAG_DISABLE_TRANSACTION_FILE,
+            NO_FEATURES
+        ));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT_DEPRECATED
                 | super::FLAG_TABLE_CONFIG
-                | super::FLAG_BASE_PATHS
+                | super::FLAG_BASE_PATHS,
+            NO_FEATURES
         ));
-        assert!(!can_write_dataset(super::FLAG_UNKNOWN));
+        assert!(!can_write_dataset(super::FLAG_UNKNOWN, NO_FEATURES));
+    }
+
+    #[test]
+    fn test_experimental_feature_admission() {
+        // A default build understands no experimental features, so any declared
+        // experimental feature is rejected on both read and write paths.
+        let declared = vec!["some-experiment".to_string()];
+        assert!(!can_read_dataset(FLAG_EXPERIMENTAL, &declared));
+        assert!(!can_write_dataset(FLAG_EXPERIMENTAL, &declared));
+
+        // The experimental bit with no declared features is harmless — there is
+        // nothing the reader could fail to understand. (Pre-mechanism libraries
+        // still reject bit 64, since their FLAG_UNKNOWN was 64.)
+        assert!(can_read_dataset(FLAG_EXPERIMENTAL, NO_FEATURES));
+        assert!(can_write_dataset(FLAG_EXPERIMENTAL, NO_FEATURES));
+    }
+
+    #[test]
+    fn test_apply_sets_experimental_flag() {
+        use crate::format::{DataStorageFormat, Manifest};
+        use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "x",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(vec![]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+        manifest.experimental_writer_features = vec!["some-experiment".to_string()];
+
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+
+        assert_ne!(manifest.writer_feature_flags & FLAG_EXPERIMENTAL, 0);
+        assert_eq!(manifest.reader_feature_flags & FLAG_EXPERIMENTAL, 0);
     }
 
     #[test]

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -46,8 +46,9 @@ const _: () = assert!(FLAG_EXPERIMENTAL < FLAG_UNKNOWN);
 /// its name moves out of this list and onto a dedicated feature-flag bit.
 pub fn known_experimental_features() -> &'static [&'static str] {
     &[
-        // Register experimental feature names here, gated by their Cargo feature:
-        //   #[cfg(feature = "unstable-action-transactions")] "action-transactions",
+        // Register experimental feature names here, gated by their Cargo feature.
+        #[cfg(feature = "unstable-action-transactions")]
+        crate::transaction::FEATURE_NAME,
     ]
 }
 
@@ -246,6 +247,28 @@ mod tests {
 
         assert_ne!(manifest.writer_feature_flags & FLAG_EXPERIMENTAL, 0);
         assert_eq!(manifest.reader_feature_flags & FLAG_EXPERIMENTAL, 0);
+    }
+
+    // Without the Cargo feature, the action-transactions experiment is not
+    // registered, so a dataset declaring it is rejected — this is what makes a
+    // default build refuse action-based transactions.
+    #[cfg(not(feature = "unstable-action-transactions"))]
+    #[test]
+    fn test_action_transactions_rejected_by_default() {
+        let declared = vec!["action-transactions".to_string()];
+        assert!(!can_read_dataset(FLAG_EXPERIMENTAL, &declared));
+        assert!(!can_write_dataset(FLAG_EXPERIMENTAL, &declared));
+    }
+
+    // With the Cargo feature, the experiment is registered and admitted.
+    #[cfg(feature = "unstable-action-transactions")]
+    #[test]
+    fn test_action_transactions_recognized() {
+        let name = crate::transaction::FEATURE_NAME;
+        assert!(known_experimental_features().contains(&name));
+        let declared = vec![name.to_string()];
+        assert!(can_read_dataset(FLAG_EXPERIMENTAL, &declared));
+        assert!(can_write_dataset(FLAG_EXPERIMENTAL, &declared));
     }
 
     #[test]

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -101,6 +101,19 @@ pub struct Manifest {
 
     /* external base paths */
     pub base_paths: HashMap<u32, BasePath>,
+
+    /// Names of experimental features this dataset relies on for reading.
+    ///
+    /// EXPERIMENTAL: pairs with the `FLAG_EXPERIMENTAL` reader feature-flag bit.
+    /// A reader that does not understand every name here must refuse the dataset.
+    /// Empty for datasets that use no experimental features.
+    pub experimental_reader_features: Vec<String>,
+
+    /// Names of experimental features this dataset relies on for writing.
+    ///
+    /// EXPERIMENTAL: the writer-side counterpart of
+    /// `experimental_reader_features`.
+    pub experimental_writer_features: Vec<String>,
 }
 
 // We use the most significant bit to indicate that a transaction is detached
@@ -196,6 +209,8 @@ impl Manifest {
             config: HashMap::new(),
             table_metadata: HashMap::new(),
             base_paths,
+            experimental_reader_features: Vec::new(),
+            experimental_writer_features: Vec::new(),
         }
     }
 
@@ -227,6 +242,8 @@ impl Manifest {
             config: previous.config.clone(),
             table_metadata: previous.table_metadata.clone(),
             base_paths: previous.base_paths.clone(),
+            experimental_reader_features: previous.experimental_reader_features.clone(),
+            experimental_writer_features: previous.experimental_writer_features.clone(),
         }
     }
 
@@ -289,6 +306,8 @@ impl Manifest {
                 base_paths
             },
             table_metadata: self.table_metadata.clone(),
+            experimental_reader_features: self.experimental_reader_features.clone(),
+            experimental_writer_features: self.experimental_writer_features.clone(),
         }
     }
 
@@ -931,6 +950,8 @@ impl TryFrom<pb::Manifest> for Manifest {
                 .iter()
                 .map(|item| (item.id, item.clone().into()))
                 .collect(),
+            experimental_reader_features: p.experimental_reader_features,
+            experimental_writer_features: p.experimental_writer_features,
         })
     }
 }
@@ -994,6 +1015,8 @@ impl From<&Manifest> for pb::Manifest {
                 })
                 .collect(),
             transaction_section: m.transaction_section.map(|i| i as u64),
+            experimental_reader_features: m.experimental_reader_features.clone(),
+            experimental_writer_features: m.experimental_writer_features.clone(),
         }
     }
 }

--- a/rust/lance-table/src/lib.rs
+++ b/rust/lance-table/src/lib.rs
@@ -6,4 +6,8 @@ pub mod format;
 pub mod io;
 pub mod rowids;
 pub mod system_index;
+/// EXPERIMENTAL: action-based (`UserOperation`) transactions. Gated behind the
+/// non-default `unstable-action-transactions` feature; unstable wire format.
+#[cfg(feature = "unstable-action-transactions")]
+pub mod transaction;
 pub mod utils;

--- a/rust/lance-table/src/transaction.rs
+++ b/rust/lance-table/src/transaction.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! EXPERIMENTAL: action-based (`UserOperation`) transactions.
+//!
+//! This module is a skeleton for the "Action-based Transactions" milestone
+//! (design discussion #5960). It models a transaction as an ordered list of
+//! granular [`Action`]s that commit atomically, which is what enables compound
+//! commits such as *append data + create index* in a single manifest change.
+//!
+//! # Stability
+//!
+//! Everything here is **unstable and gated** — it compiles only under the
+//! non-default `unstable-action-transactions` Cargo feature, so it is absent
+//! from released artifacts. It is the first consumer of the general
+//! experimental-feature mechanism: a dataset that persists one of these
+//! transactions declares the [`FEATURE_NAME`] experimental feature, which sets
+//! the `FLAG_EXPERIMENTAL` bit so that libraries which do not understand the
+//! format refuse to commit. The wire format
+//! (`protos/transaction_experimental.proto`) carries no compatibility guarantee
+//! and may change or be removed in any release until it is finalized and
+//! ratified by PMC vote, at which point it graduates to its own feature-flag
+//! bit. See `rust/lance-table/design/experimental_feature_flags.md`.
+//!
+//! # Scope
+//!
+//! Only [`AddFragments`] is implemented, as a proof of shape. The remaining
+//! actions and the translation/conflict-resolution machinery land in follow-up
+//! vertical slices.
+
+use lance_core::deepsize::DeepSizeOf;
+use lance_core::{Error, Result};
+
+use crate::format::{Fragment, pb};
+
+/// The experimental-feature name a dataset declares when its transaction log
+/// uses action-based transactions. Registered in
+/// [`crate::feature_flags::known_experimental_features`] under this crate's
+/// `unstable-action-transactions` feature.
+pub const FEATURE_NAME: &str = "action-transactions";
+
+/// A user-facing, composable transaction: an ordered list of [`UserAction`]s
+/// that commit atomically as a single manifest change.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct UserOperation {
+    /// Human-readable description, e.g. `"INSERT INTO t VALUES (1)"`.
+    pub description: String,
+    /// Unique identifier for this operation.
+    pub uuid: String,
+    /// The dataset version this operation was planned against.
+    pub read_version: u64,
+    /// The ordered list of user actions applied by this operation.
+    pub actions: Vec<UserAction>,
+}
+
+/// A single user-recognizable step within a [`UserOperation`] (e.g. "append
+/// batch", "rebuild index"), carrying a description and the granular actions it
+/// expands to. Action lists are flattened when applied to the manifest.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct UserAction {
+    /// Human-readable description of this step.
+    pub description: String,
+    /// The granular manifest changes this step expands to.
+    pub actions: Vec<Action>,
+}
+
+/// A granular change to the manifest. Traditional operations decompose into an
+/// ordered list of these.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+#[non_exhaustive]
+pub enum Action {
+    /// Append new fragments to the table.
+    AddFragments(AddFragments),
+}
+
+/// Append new fragments to the table.
+///
+/// Covers Append, the "add new rows" part of Overwrite, and new fragments
+/// produced by compaction.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct AddFragments {
+    /// The new fragments to append. Fragment IDs are assigned at apply time
+    /// from the manifest's counters (late binding), not carried here.
+    pub fragments: Vec<Fragment>,
+}
+
+impl From<&AddFragments> for pb::AddFragments {
+    fn from(action: &AddFragments) -> Self {
+        Self {
+            fragments: action
+                .fragments
+                .iter()
+                .map(pb::DataFragment::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::AddFragments> for AddFragments {
+    type Error = Error;
+
+    fn try_from(proto: pb::AddFragments) -> Result<Self> {
+        Ok(Self {
+            fragments: proto
+                .fragments
+                .into_iter()
+                .map(Fragment::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+impl From<&Action> for pb::Action {
+    fn from(action: &Action) -> Self {
+        let action = match action {
+            Action::AddFragments(add) => pb::action::Action::AddFragments(add.into()),
+        };
+        Self {
+            action: Some(action),
+        }
+    }
+}
+
+impl TryFrom<pb::Action> for Action {
+    type Error = Error;
+
+    fn try_from(proto: pb::Action) -> Result<Self> {
+        match proto.action {
+            Some(pb::action::Action::AddFragments(add)) => Ok(Self::AddFragments(add.try_into()?)),
+            None => Err(Error::invalid_input(
+                "Action protobuf has no variant set".to_string(),
+            )),
+        }
+    }
+}
+
+impl From<&UserAction> for pb::UserAction {
+    fn from(user_action: &UserAction) -> Self {
+        Self {
+            description: user_action.description.clone(),
+            actions: user_action.actions.iter().map(pb::Action::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::UserAction> for UserAction {
+    type Error = Error;
+
+    fn try_from(proto: pb::UserAction) -> Result<Self> {
+        Ok(Self {
+            description: proto.description,
+            actions: proto
+                .actions
+                .into_iter()
+                .map(Action::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+impl From<&UserOperation> for pb::UserOperation {
+    fn from(op: &UserOperation) -> Self {
+        Self {
+            description: op.description.clone(),
+            uuid: op.uuid.clone(),
+            read_version: op.read_version,
+            actions: op.actions.iter().map(pb::UserAction::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::UserOperation> for UserOperation {
+    type Error = Error;
+
+    fn try_from(proto: pb::UserOperation) -> Result<Self> {
+        Ok(Self {
+            description: proto.description,
+            uuid: proto.uuid,
+            read_version: proto.read_version,
+            actions: proto
+                .actions
+                .into_iter()
+                .map(UserAction::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_operation_roundtrips_through_protobuf() {
+        let op = UserOperation {
+            description: "INSERT INTO t VALUES (1)".to_string(),
+            uuid: "test-uuid".to_string(),
+            read_version: 7,
+            actions: vec![UserAction {
+                description: "append batch".to_string(),
+                actions: vec![Action::AddFragments(AddFragments {
+                    fragments: vec![Fragment::new(0), Fragment::new(1)],
+                })],
+            }],
+        };
+
+        let proto = pb::UserOperation::from(&op);
+        let roundtripped = UserOperation::try_from(proto).unwrap();
+
+        assert_eq!(op, roundtripped);
+    }
+}

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -163,6 +163,9 @@ huggingface = ["lance-io/huggingface"]
 geo = ["lance-datafusion/geo", "lance-index/geo"]
 # Enable slow integration tests (disabled by default in CI)
 slow_tests = []
+# EXPERIMENTAL: action-based (UserOperation) transactions. Unstable wire format
+# with no compatibility guarantee; not compiled into default builds.
+unstable-action-transactions = ["lance-table/unstable-action-transactions"]
 # Compile the RocksDB comparison arm of the (disabled) mem_wal_kv_point_lookup
 # bench. Commented out so it stays out of CI's all-features build.
 # bench-rocksdb = ["dep:rocksdb"]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -695,7 +695,10 @@ impl Dataset {
             read_struct(object_reader.as_ref(), offset).await
         }?;
 
-        if !can_read_dataset(manifest.reader_feature_flags) {
+        if !can_read_dataset(
+            manifest.reader_feature_flags,
+            &manifest.experimental_reader_features,
+        ) {
             let message = format!(
                 "This dataset cannot be read by this version of Lance. \
                  Please upgrade Lance to read this dataset.\n Flags: {}",

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -343,7 +343,10 @@ impl<'a> InsertBuilder<'a> {
 
         // Feature flags
         if let WriteDestination::Dataset(dataset) = &context.dest
-            && !can_write_dataset(dataset.manifest.writer_feature_flags)
+            && !can_write_dataset(
+                dataset.manifest.writer_feature_flags,
+                &dataset.manifest.experimental_writer_features,
+            )
         {
             let message = format!(
                 "This dataset cannot be written by this version of Lance. \


### PR DESCRIPTION
Skeleton establishing the *shape and safety gating* of action-based
(`UserOperation`) transactions — the first slice of the Action-based
Transactions milestone (discussion #5960).

## Stacked on #7646

This PR is **stacked on #7646** (the general experimental-feature mechanism).
Its first commit belongs to #7646; review that PR first. Action-based
transactions are the first *consumer* of that mechanism rather than claiming a
dedicated feature-flag bit:

- A dataset using action-based transactions declares the `"action-transactions"`
  experimental feature, registered in `known_experimental_features()` only under
  the `unstable-action-transactions` Cargo feature.
- That sets `FLAG_EXPERIMENTAL`, so libraries that don't understand it fail
  closed. On graduation (PMC vote), the name moves onto its own dedicated bit.

## Double gating

1. **Cargo feature** — everything is behind the non-default
   `unstable-action-transactions` feature, so it is not compiled into released
   builds at all.
2. **Experimental feature flag** — via `FLAG_EXPERIMENTAL` + the
   `"action-transactions"` name, as above.

## What's here (the skeleton commit)

- `protos/transaction_experimental.proto` — `UserOperation` / `UserAction` /
  `Action` (with `AddFragments` only, as a proof of shape), in a separate proto
  file so canonical `transaction.proto` stays clean until promotion. Compiled
  only under the feature.
- `lance_table::transaction` — Rust `UserOperation` / `UserAction` / `Action` /
  `AddFragments` types with protobuf conversions, a roundtrip test, and the
  `FEATURE_NAME` constant.
- Registration of `"action-transactions"` in the experimental-feature registry,
  with admission tests for both default-build (rejected) and feature-on
  (recognized).

## What's NOT here (follow-up vertical slices)

- Translation from `Operation`, `apply`, and conflict resolution.
- Wiring into the commit path / public API (nothing yet *populates* the
  experimental feature list).
- The remaining actions beyond `AddFragments`.

Part of #5960. Precedes the proto PMC vote (#6455), which will promote the
finalized messages into `transaction.proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)