### PR TITLE
docs(core): document spawn_cpu limitations and audit call sites

### DIFF
--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -19,7 +19,7 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 
 ## Concurrency
 
-- The closure passed to `spawn_cpu()` must only consume CPU and return — it must **never** wait on anything: **no channels** (blocking send/recv), **no I/O**, **no locks**, and no `block_on`/`.blocking_*`. The CPU pool can be a single thread on small hosts (`<= 3` CPUs), so a parked closure can deadlock the whole pool with a silent 0% hang. Keep the waiting in surrounding async code and hand only the pure-CPU work to `spawn_cpu()`. See the doc comment on `spawn_cpu` for the rationale.
+- The closure passed to `spawn_cpu()` must only consume CPU and return — it must **never** wait on anything: **no channels** (blocking send/recv), **no I/O**, **no locks**, and no `block_on`/`.blocking_*`. The CPU pool can collapse to a single worker in resource-constrained environments (`<= 3` CPUs), so a parked closure can deadlock the whole pool with a silent 0% hang. Keep the waiting in surrounding async code and hand only the pure-CPU work to `spawn_cpu()`. Only dispatch substantial work (rule of thumb: ~100µs+ of CPU); below that the pool overhead outweighs the benefit and the work is better left inline. See the doc comment on `spawn_cpu` for the rationale.
 
 ## API Design
 

--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -17,6 +17,10 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 - Delete obsolete internal (`pub(crate)` / private) methods in the same PR that introduces their replacements. For public API methods, follow the deprecation path in root AGENTS.md instead.
 - Choose log levels by audience: `debug!` for routine/high-frequency ops, `info!` for infrequent operator-visible state changes, `warn!` for unexpected conditions.
 
+## Concurrency
+
+- The closure passed to `spawn_cpu()` must only consume CPU and return — it must **never** wait on anything: **no channels** (blocking send/recv), **no I/O**, **no locks**, and no `block_on`/`.blocking_*`. The CPU pool can be a single thread on small hosts (`<= 3` CPUs), so a parked closure can deadlock the whole pool with a silent 0% hang. Keep the waiting in surrounding async code and hand only the pure-CPU work to `spawn_cpu()`. See the doc comment on `spawn_cpu` for the rationale.
+
 ## API Design
 
 - Use `with_`-prefixed builder methods for optional config (e.g., `MyStruct::new(required).with_option(v)`) — don't create separate constructor variants.

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -109,14 +109,23 @@ fn install_atfork() {}
 /// This can also be used to convert a big chunk of synchronous work into a future
 /// so that it can be run in parallel with something like StreamExt::buffered()
 ///
+/// # Only hand over substantial CPU work
+///
+/// Dispatching to the pool has real overhead (a `spawn_blocking` hop plus a oneshot
+/// channel round trip). As a rule of thumb the closure should be expected to do at
+/// least ~100µs of CPU work; below that the thread-pool overhead is likely to
+/// outweigh any parallelism benefit, and the work is better left inline.
+///
 /// # The task must never wait on anything
 ///
-/// The CPU pool is deliberately tiny: it is sized to
-/// [`get_num_compute_intensive_cpus`], which is `max(1, num_cpus - LANCE_IO_CORE_RESERVATION)`
-/// and collapses to a **single blocking thread** on machines with `<= 3` visible
-/// CPUs (1-vCPU VMs, CI runners, CPU-limited Kubernetes pods). A closure passed to
-/// `spawn_cpu` occupies one of these threads for its entire lifetime, including any
-/// time it spends *parked*. So the closure must only consume CPU and return; it must
+/// The CPU pool is sized to [`get_num_compute_intensive_cpus`], which is
+/// `max(1, num_cpus - LANCE_IO_CORE_RESERVATION)`. On a big host that is plenty of
+/// workers (e.g. 62 on a 64-core box), but in resource-constrained environments it can
+/// collapse to a **single blocking thread** — on machines with `<= 3` visible CPUs
+/// (1-vCPU VMs, CI runners, CPU-limited Kubernetes pods) the pool has exactly one
+/// worker. A closure passed to `spawn_cpu` occupies one of these threads for its entire
+/// lifetime, including any time it spends *parked*. So the closure must only consume
+/// CPU and return; it must
 /// **never** block, wait, or park. Concretely, the closure must not, directly or
 /// transitively:
 ///

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -108,6 +108,34 @@ fn install_atfork() {}
 ///
 /// This can also be used to convert a big chunk of synchronous work into a future
 /// so that it can be run in parallel with something like StreamExt::buffered()
+///
+/// # The task must never wait on anything
+///
+/// The CPU pool is deliberately tiny: it is sized to
+/// [`get_num_compute_intensive_cpus`], which is `max(1, num_cpus - LANCE_IO_CORE_RESERVATION)`
+/// and collapses to a **single blocking thread** on machines with `<= 3` visible
+/// CPUs (1-vCPU VMs, CI runners, CPU-limited Kubernetes pods). A closure passed to
+/// `spawn_cpu` occupies one of these threads for its entire lifetime, including any
+/// time it spends *parked*. So the closure must only consume CPU and return; it must
+/// **never** block, wait, or park. Concretely, the closure must not, directly or
+/// transitively:
+///
+/// * **No channels** — no blocking send/recv (`send_blocking`, blocking `recv`, etc.).
+///   A full/empty channel parks the thread, and whatever would drain/fill the channel
+///   may need the same pool to run.
+/// * **No I/O** — no file, network, or object-store reads/writes, and no disk spills.
+///   I/O parks the thread while making no progress on CPU work.
+/// * **No locks** — no acquiring a contended lock (or any lock that is held across an
+///   `.await` elsewhere). Waiting for the lock parks the thread.
+/// * **No `block_on` / `.blocking_*`** — never drive or wait on another async task
+///   from inside the closure.
+///
+/// If any of these hold, the parked thread can starve the exact work that would
+/// unblock it, deadlocking the whole pool with no timeout and no error — a silent
+/// hang at 0% CPU. (See <https://github.com/lancedb/lance/pull/7423>.) When work
+/// needs to wait on a channel/lock/I/O, keep the waiting in an async task and only
+/// hand the pure-CPU portion to `spawn_cpu`, e.g. build each batch with `spawn_cpu`
+/// and dispatch it with `tx.send(batch).await` in the surrounding async code.
 pub fn spawn_cpu<
     E: std::error::Error + Send + 'static,
     F: FnOnce() -> std::result::Result<R, E> + Send + 'static,


### PR DESCRIPTION
`spawn_cpu` runs work on a dedicated pool sized to `get_num_compute_intensive_cpus()`,
which collapses to a **single blocking thread** on hosts with `<= 3` CPUs. A closure
that ever *waits* — blocking channel send/recv, I/O, a contended lock, or `block_on` —
parks that thread and can starve the very work that would unblock it, deadlocking the
pool with a silent 0% hang. This is the failure fixed in #7423.

This PR writes the rule down and audits the call sites:

- Expand the `spawn_cpu` doc comment with the "must never wait on anything" rule
  (no channels / no I/O / no locks / no `block_on`), the rationale, and a pointer to
  the recommended pattern (keep the waiting in async code, hand only pure CPU work to
  `spawn_cpu`).
- Add a concise Concurrency rule to `rust/AGENTS.md`.

### Audit

All ~20 `spawn_cpu` call sites were reviewed, following transitive calls. Every
production site is clean (I/O/loading is awaited before the closure; the closures do
pure in-memory CPU work) except one:

- **IVF streaming partition search** (`ivf/v2.rs`): a single `spawn_cpu` closure does
  `blocking_recv` + `blocking_send` on capacity-1 channels. This is a deliberate
  optimization from #6475 (run a query's whole sequential search on one CPU worker to
  avoid per-partition fan-out, a measured 14–30% latency win), so fixing it trades a
  benchmarked perf win against small-host correctness and needs the #6475 author's
  input. Tracked in #7642 rather than fixed here.

The FTS builder site is already correct after #7423.

Closes #7637
