### PR TITLE
fix: update crossbeam-epoch for cargo deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Update `crossbeam-epoch` in `Cargo.lock` to 0.9.20 to satisfy RUSTSEC-2026-0204.
- Leave direct dependency manifests unchanged because the relevant direct deps are already resolved to their latest published versions.

Validated locally with `cargo-deny 0.19.0`, `cargo fmt --all --check`, and `cargo check --workspace --tests --benches --locked`.