### PR TITLE
docs: update MemWAL format spec

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -34,7 +34,8 @@ Append-only tables without a primary key do not rely on last-write-wins conflict
 
 The MemWAL index is a system index entry on the base table.
 It has `name = "__lance_mem_wal"`, no indexed fields, and no index files.
-The current implementation sets `IndexMetadata.files` to `None` and stores all index data in the `MemWalIndexDetails` protobuf message in `IndexMetadata.index_details`.
+`IndexMetadata.files` is `None`.
+All MemWAL index data is stored in the `MemWalIndexDetails` protobuf message in `IndexMetadata.index_details`.
 
 The index stores:
 
@@ -62,7 +63,7 @@ It serves two purposes:
 1. It buffers data and per-MemTable indexes before a flushed generation is written.
 2. It lets readers access data that has not been flushed yet when strong consistency is required.
 
-The complete in-memory layout is implementation-specific.
+The storage format does not prescribe the in-memory MemTable layout.
 Conceptually, a MemTable is an append log of Arrow record batches.
 Later appends have larger in-memory row positions.
 For primary-key tables, in-memory reads use the largest visible row position as the newest row for a key.
@@ -143,7 +144,7 @@ If a flush attempt fails, a retry writes a different directory instead of reusin
 The shard manifest records the successful directory name in `flushed_generations.path`.
 
 The generation directory is a standard Lance dataset written with the base table's data storage version.
-The current implementation writes one fragment per flushed generation.
+Each flushed generation is written as one fragment.
 Additional MemWAL sidecars may be present:
 
 ```text
@@ -303,7 +304,8 @@ pa.schema([
 ])
 ```
 
-The current Lance Rust implementation keeps MemWAL index data inline and discovers the latest shard set by listing `_mem_wal/` shard directories and reading shard manifests.
+The MemWAL index data is stored inline.
+Readers discover the latest shard set by listing `_mem_wal/` shard directories and reading shard manifests.
 
 <details>
 <summary>MemWalIndexDetails protobuf message</summary>
@@ -330,7 +332,7 @@ Each `ShardingField` contains:
 - `result_type`: Arrow type name for the computed value.
 - `parameters`: transform-specific string parameters.
 
-The current implementation supports these built-in transforms:
+The supported built-in transforms are:
 
 - `unsharded`: takes no source columns, always returns `int32` value 0, and creates one shard.
 - `bucket`: takes one source column and `num_buckets`, hashes the value, and returns an `int32` bucket id in `[0, num_buckets)`.
@@ -395,14 +397,14 @@ Test vectors for `num_buckets = 8`:
 - `float32`: `1.25 -> 0`.
 - `float64`: `1.25 -> 0`.
 
-The current bucket transform supports scalar boolean, integer, floating-point, date32, time, timestamp, utf8, and large_utf8 source types.
-The current identity transform supports scalar boolean, integer, utf8, and large_utf8 source types.
+The `bucket` transform supports scalar boolean, integer, floating-point, date32, time, timestamp, utf8, and large_utf8 source types.
+The `identity` transform supports scalar boolean, integer, utf8, and large_utf8 source types.
 
-The `year`, `month`, `day`, `hour`, `multi_bucket`, and `truncate` transform names are not part of the current implemented MemWAL writer path.
+The `year`, `month`, `day`, `hour`, `multi_bucket`, and `truncate` transform names are not supported MemWAL sharding transforms and must not be used in `ShardingSpec.transform`.
 
 ## Storage Layout
 
-The current MemWAL storage layout is:
+The MemWAL storage layout is:
 
 ```text
 {table_path}/

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -191,6 +191,41 @@ The `_pk_index/` sidecar is not a maintained user index, is not registered in th
 Its identity is its immutable generation path.
 Readers open it directly from `{generation_path}/_pk_index`.
 
+The `_pk_index/` directory is a Lance scalar BTree index store:
+
+```text
+_pk_index/
+├── page_data.lance
+└── page_lookup.lance
+```
+
+Readers load this directory as a BTree index using `BTreeIndexDetails` with default parameters.
+The logical rows indexed by the BTree are sorted pairs:
+
+```python
+pa.schema([
+    pa.field("value", <primary-key-index-type>, nullable=True),
+    pa.field("_rowid", pa.uint64(), nullable=False),
+])
+```
+
+For a single-column primary key, `value` has the Arrow type of the primary-key column and stores the primary-key scalar directly.
+For a composite primary key, `value` is `binary` and stores an order-preserving tuple encoding of all primary-key columns in primary-key column order.
+Each tuple column is encoded as:
+
+- `0x00` for null.
+- `0x01` followed by the non-null value encoding otherwise.
+
+Supported non-null value encodings are:
+
+- Signed integers and date values: sign-flipped 8-byte big-endian integer bytes.
+- Unsigned integers: 8-byte big-endian unsigned integer bytes.
+- Boolean: one byte, `0x00` for false and `0x01` for true.
+- UTF-8 and binary values: raw bytes, with each `0x00` byte escaped as `0x00 0xff`, followed by a `0x00 0x00` terminator.
+
+This encoding is injective and preserves primary-key tuple ordering under lexicographic byte comparison.
+Composite primary-key columns must use one of the supported encodings above.
+
 The sidecar row ids are in the same forward row-position space as the data files, deletion vector, and maintained user indexes.
 The sidecar is used for cross-generation membership and block-list checks.
 It is not used to choose the newest row inside the same flushed generation; the deletion vector has already hidden older same-generation duplicates.

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -1,7 +1,7 @@
 # MemTable & WAL Specification (Experimental)
 
-Lance MemTable & WAL (MemWAL) is an experimental Log-Structured-Merge architecture for Lance tables.
-It supports high-throughput streaming writes while preserving indexed read paths for scans, point lookups, vector search, and full-text search.
+Lance MemTable & WAL (MemWAL) specification describes a Log-Structured-Merge (LSM) tree architecture for Lance tables, enabling high-performance streaming write workloads while maintaining indexed read performance for key workloads including
+scan, point lookup, vector search and full-text search.
 
 ## Overall Architecture
 

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -1,193 +1,242 @@
 # MemTable & WAL Specification (Experimental)
 
-Lance MemTable & WAL (MemWAL) specification describes a Log-Structured-Merge (LSM) tree architecture for Lance tables, enabling high-performance streaming write workloads while maintaining indexed read performance for key workloads including
-scan, point lookup, vector search and full-text search.
+Lance MemTable & WAL (MemWAL) is an experimental Log-Structured-Merge architecture for Lance tables.
+It supports high-throughput streaming writes while preserving indexed read paths for scans, point lookups, vector search, and full-text search.
 
 ## Overall Architecture
 
 ![MemWAL Overview](../../images/mem_wal_overview.png)
 
-A Lance table is called a **base table** under the context of the MemWAL spec.
-It may have an [unenforced primary key](index.md#unenforced-primary-key) defined in the table schema.
-Primary keys are required for primary-key lookups and last-write-wins upsert semantics,
-but append-only MemWAL tables may omit them.
+A Lance table is called the **base table** in this document.
+The base table may have an [unenforced primary key](index.md#unenforced-primary-key) in its schema.
+Primary keys are required for primary-key lookups and last-write-wins upsert semantics.
+Append-only MemWAL tables may omit a primary key.
 
-On top of the base table, the MemWAL spec defines a set of shards.
-Writers write to shards, and data in each shard is merged into the base table asynchronously.
-An index is kept in the base table for readers to quickly discover the state of all shards at a point of time.
+MemWAL adds a set of shards on top of the base table.
+Writers append to shards.
+Each shard keeps recent data in an in-memory MemTable, persists writes to a per-shard WAL, flushes MemTables as small Lance datasets, and later merges those flushed generations into the base table.
+
+The base table manifest contains one MemWAL system index entry named `__lance_mem_wal`.
+This index stores MemWAL configuration and global progress metadata inline in `IndexMetadata.index_details`.
+Each shard's own manifest remains authoritative for shard-local mutable state.
 
 ### MemWAL Shard
 
-A **MemWAL Shard** is the main unit to horizontally scale out writes.
+A **MemWAL shard** is the unit of horizontal write scaling.
+Each shard has exactly one active writer epoch at a time.
+Writers claim a shard, append WAL entries, update the in-memory MemTable, and publish flushed MemTable generations by updating the shard manifest.
 
-Each shard has exactly one active writer at any time.
-Writers claim a shard and then write data to that shard.
-Data in each shard is expected to be merged into the base table asynchronously.
-
-For tables with a primary key, rows of the same primary key must be written to one and only one shard.
-If two shards contain rows with the same primary key, the following scenario can cause data corruption:
-
-1. Shard A receives a write with primary key `pk=1` at time T1
-2. Shard B receives a write with primary key `pk=1` at time T2 (T2 > T1)
-3. The row in shard B is merged into the base table first
-4. The row in shard A is merged into the base table second
-5. The row from Shard A (older) now overwrites the row from Shard B (newer)
-
-This violates the expected "last write wins" semantics.
-By ensuring each primary key is assigned to exactly one shard via the sharding spec,
-merge order between shards becomes irrelevant for correctness.
-Append-only tables without a primary key do not rely on last-write-wins conflict resolution
-and may shard by any deterministic append key or partitioning column.
-
-See [MemWAL Shard Architecture](#shard-architecture) for the complete shard architecture.
+For primary-key tables, all rows for the same primary key must map to the same shard.
+If one primary key can appear in multiple shards, asynchronous merge order between shards can make an older row overwrite a newer row.
+Append-only tables without a primary key do not rely on last-write-wins conflict resolution and may use any deterministic shard assignment suitable for the workload.
 
 ### MemWAL Index
 
-A **MemWAL Index** is the centralized structure for all MemWAL metadata on top of a base table.
-A table has at most one MemWAL index. It stores:
+The MemWAL index is a system index entry on the base table.
+It has `name = "__lance_mem_wal"`, no indexed fields, and no index files.
+The current implementation sets `IndexMetadata.files` to `None` and stores all index data in the `MemWalIndexDetails` protobuf message in `IndexMetadata.index_details`.
 
-- **Configuration**: Sharding specs defining how rows map to shards, and which indexes to maintain
-- **Merge progress**: Last generation merged to base table for each shard
-- **Index catchup progress**: Which merged generation each base table index has been rebuilt to cover
-- **Shard snapshots**: Point-in-time snapshot of shard states for read optimization
+The index stores:
 
-The index is the source of truth for **configuration**, **merge progress** and **index catchup progress**
-Writers and mergers read the MemWAL index to get these configurations before writing.
+- **Configuration**: `sharding_specs`, `maintained_indexes`, and `writer_config_defaults`.
+- **Merge progress**: `merged_generations`, the last generation merged into the base table for each shard.
+- **Index catchup progress**: `index_catchup`, the merged generation covered by each base-table index.
+- **Shard snapshots**: optional point-in-time snapshot fields for read optimization.
 
-Each [shard's manifest](#shard-manifest) is authoritative for its own state.
-Readers may use **shard snapshots** as a read-only optimization to see a point-in-time view of shards without opening each shard manifest.
-Readers that need the latest shard set must discover shard directories in storage and read each shard's latest manifest.
-
-See [MemWAL Index Details](#memwal-index-details) for the complete structure.
+Shard snapshots are not authoritative.
+Readers that need the latest shard set list `_mem_wal/` and read each shard's latest manifest.
 
 ## Shard Architecture
 
 ![Shard Architecture](../../images/mem_wal_regional.png)
 
-Within a shard, writes are stored in an **in-memory table (MemTable)**.
-It is also written to the shard's **Write-Ahead Log (WAL)** for durability guarantee.
-The MemTable is periodically **flushed** to storage based on memory pressure and other conditions.
-**Flushed MemTables** in storage are then asynchronously **merged** into the base table.
+Within a shard, writes first enter an in-memory **MemTable** and are durably appended to the shard **write-ahead log (WAL)**.
+The MemTable is periodically **flushed** to storage as a Lance dataset.
+Flushed MemTables are asynchronously **merged** into the base table.
 
 ### MemTable
 
-A MemTable holds rows inserted into the shard before flushing to storage.
-It serves 2 purposes:
+A MemTable holds rows inserted into a shard before those rows are flushed to storage.
+It serves two purposes:
 
-1. build up data and related indexes to be flushed to storage as a flushed MemTable
-2. allow a reader to potentially access data that is not flushed to storage yet
+1. It buffers data and per-MemTable indexes before a flushed generation is written.
+2. It lets readers access data that has not been flushed yet when strong consistency is required.
 
-#### MemTable Format
+The complete in-memory layout is implementation-specific.
+Conceptually, a MemTable is an append log of Arrow record batches.
+Later appends have larger in-memory row positions.
+For primary-key tables, in-memory reads use the largest visible row position as the newest row for a key.
 
-The complete in-memory format of a MemTable is implementation-specific and out of the scope of this spec.
-The Lance core Rust SDK maintains one default implementation and is available through all its language binding SDKs,
-but integrations are free to build their own MemTable format depending on the specific use cases,
-as long as it follows the MemWAL storage layout, reader and writer requirements when flushing MemTable.
+### MemTable Generation
 
-Conceptually, because Lance uses [Arrow as its in-memory data exchange format](https://arrow.apache.org/docs/format/index.html),
-for the ease of explanation in this spec, we will treat MemTable as a list of Arrow record batches,
-and each write into the MemTable is a new Arrow record batch.
+Each MemTable has a monotonically increasing generation number starting from 1.
+When generation `N` is flushed and discarded, the next MemTable uses generation `N + 1`.
 
-#### MemTable Generation
+Generation numbers order data freshness within one shard:
 
-Based on conditions like memory limit and durability requirements,
-a MemTable needs to be **flushed** to storage and discarded.
-When that happens, new writes go to a new MemTable and the cycle repeats.
-Each MemTable is assigned a monotonically increasing generation number starting from 1.
-When MemTable of generation `N` is discarded, the next MemTable gets assigned generation `N+1`.
+- Base table data has generation 0.
+- Higher MemWAL generations are newer.
+- Within the active in-memory generation, higher row positions are newer.
+- Within a flushed generation, flush-time deletion vectors hide older duplicate primary-key rows, so readers see at most the newest row for each primary key.
 
-### WAL
+## WAL
 
-WAL serves as the durable storage of all MemTables in a shard.
-It consists of data in MemTables ordered by generation.
-Every time we write to the WAL, we call it a **WAL Flush**.
+The WAL is the durable append log for a shard.
+Every durable WAL append creates one **WAL entry**.
 
-#### WAL Durability
+### WAL Entry Positions
 
-When a write is flushed to WAL, the specific write becomes durable.
-Otherwise, if the MemTable is lost, data is also lost.
+WAL entry positions are 1-based.
+The first data entry is position 1.
+Position 0 is reserved as the sentinel value meaning no WAL entry has been covered.
 
-Multiple writes can be batched together in a single WAL flush to reduce WAL flush frequency and improve throughput.
-The more writes a single WAL flush batches, the longer it takes for a write to be durable.
+Writers append WAL entries in increasing position order.
+If entry `N` is not fully written, entry `N + 1` must not exist.
+Recovery replays from `replay_after_wal_entry_position + 1`.
 
-The whole LSM tree's durability is determined by the durability of the WAL.
-For example, if WAL is stored in Amazon S3, it has 99.999999999% durability.
-If it is stored in local disk, the data will be lost if the local disk is damaged.
+### WAL Entry Format
 
-#### WAL Entry
+Each WAL entry is an Apache Arrow IPC stream file.
+The Arrow schema metadata includes:
 
-Each time a WAL flush happens, it adds a new **WAL Entry** to the WAL.
-In other words, a WAL consists of an ordered list of WAL entries starting from position 0.
-Writer must flush WAL entries in sequential order from lower to higher position.
-If WAL entry `N` is not flushed fully, WAL entry `N+1` must not exist in storage.
+- `writer_epoch`: decimal string containing the writer epoch that created the entry.
+- `fence_sentinel`: optional marker for a data-less fence sentinel entry.
 
-#### WAL Replay
+A normal WAL entry contains one or more record batches.
+A fence sentinel entry contains no batches and is skipped during replay.
+Sentinels are used so an older writer collides on the next WAL position and discovers that it has been fenced.
 
-**Replaying** a WAL means to read data in the WAL from a lower to a higher position.
-This is commonly used to recover the latest MemTable after it is lost,
-by reading from the start position of the latest MemTable generation till the highest position in the WAL,
-assuming proper fencing to guard against multiple writers to the same shard.
+### WAL Storage Layout
 
-See [Writer Fencing](#writer-fencing) for the full fencing mechanism.
+WAL entries live under `_mem_wal/{shard_id}/wal/`.
+Filenames use bit-reversed 64-bit binary names with the `.arrow` suffix:
 
-#### WAL Entry Format
+```text
+_mem_wal/{shard_id}/wal/{bit_reversed_position}.arrow
+```
 
-Each WAL entry is a file in storage following the [Apache Arrow IPC stream format](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format) to store the batch of writes in the MemTable.
-The writer epoch is stored in the stream's Arrow schema metadata with key `writer_epoch` for fencing validation during replay.
+The bit-reversal spreads sequential positions across object-store keyspace.
+For example, position 5 is encoded as:
 
-#### WAL Storage Layout
+```text
+1010000000000000000000000000000000000000000000000000000000000000.arrow
+```
 
-Each WAL entry is stored within the WAL directory of the shard located at `_mem_wal/{shard_id}/wal`.
+## Flushed MemTable
 
-WAL files use bit-reversed 64-bit binary naming to distribute files evenly across the directory keyspace.
-This optimizes S3 throughput by spreading sequential writes across S3's internal partitions, minimizing throttling.
-The filename is the bit-reversed binary representation of the entry ID with suffix `.arrow`.
-For example, entry ID 5 (binary `000...101`) becomes `1010000000000000000000000000000000000000000000000000000000000000.arrow`.
+A flushed MemTable is a persisted MemTable generation.
+It is stored as a Lance dataset under its shard directory.
 
-### Flushed MemTable
+!!! note
+    This structure is similar to a sorted string table in other LSM implementations, but MemWAL flushed generations are not sorted by key.
 
-A flushed MemTable is created by flushing the MemTable to storage.
-In Lance MemWAL spec, a flushed MemTable must be a Lance table following the Lance table format spec.
+### Flushed MemTable Storage Layout
 
-!!!note
-This is called Sorted String Table (SSTable) or Sorted Run in many LSM-tree literatures and implementations.
-However, since our MemTable is not sorted, we just use the term flushed MemTable to avoid confusion.
+Generation `i` is flushed to:
 
-#### Flushed MemTable Storage Layout
+```text
+_mem_wal/{shard_id}/{random8}_gen_{i}/
+```
 
-The MemTable of generation `i` is flushed to `_mem_wal/{shard_id}/{random_hex}_gen_{i}/` directory,
-where `{random_hex}` is a random 8-character hex value generated at flush time.
-The random hex value is necessary to ensure if one MemTable flush attempt fails,
-The retry can use another directory.
-The content within the generation directory follows the [Lance table storage layout](layout.md).
+`{random8}` is an 8-character random hex value generated for each flush attempt.
+If a flush attempt fails, a retry writes a different directory instead of reusing a partially written one.
+The shard manifest records the successful directory name in `flushed_generations.path`.
 
-#### Merging MemTable to Base Table
+The generation directory is a standard Lance dataset written with the base table's data storage version.
+The current implementation writes one fragment per flushed generation.
+Additional MemWAL sidecars may be present:
 
-Generation numbers determine merge order of flushed MemTable into base table:
-lower numbers represent older data and must be merged to the base table first to preserve correct upsert semantics.
+```text
+{random8}_gen_{i}/
+├── _versions/
+│   └── {version}.manifest
+├── _deletions/                         # Present when within-generation dedup deletes rows
+├── _indices/                           # Present when maintained user indexes are built
+│   └── {index_uuid}/
+├── _pk_index/                          # Primary-key sidecar BTree, not a manifest index
+└── bloom_filter.bin                    # Primary-key bloom filter
+```
 
-Within a single flushed MemTable for a primary-key table,
-if there are multiple rows of the same primary key, the row that is last inserted wins.
-Append-only tables without a primary key retain all inserted rows.
+The exact Lance dataset internals follow the [Lance table storage layout](layout.md).
 
-### Shard Manifest
+### Flushed Row Order
 
-Each shard has a manifest file. This is the source of truth for the state of a shard.
+Flushed MemTable rows are written in forward insert order.
+Physical row offsets increase with write time.
+For a duplicate primary key within one flushed generation, the newest row has the largest physical offset.
 
-#### Shard Manifest Contents
+Primary-key flushed generations use a deletion vector to expose last-write-wins semantics.
+During flush, the writer scans rows in forward order, keeps the last occurrence of each primary key, and marks all earlier duplicate offsets deleted.
+The deletion vector is attached to fragment 0 in the generation manifest.
+
+Append-only flushed generations without a primary key do not perform primary-key deduplication and retain every row.
+
+### Tombstone Rows
+
+Delete operations are represented as rows with the internal `_tombstone` column.
+Tombstone rows follow the same forward row ordering and deletion-vector rules as ordinary rows.
+If the newest row for a primary key is a tombstone, the deletion vector keeps that tombstone row and hides older rows for the key.
+Read planning then filters `_tombstone = false`, so the key is absent from query results.
+
+### Flushed Primary-Key Sidecars
+
+Primary-key flushed generations write two sidecars:
+
+- `bloom_filter.bin` stores the generation's primary-key bloom filter and lets point lookups skip generations that cannot contain the queried key.
+- `_pk_index/` stores a standalone BTree over primary-key values to forward row ids.
+
+The `_pk_index/` sidecar is not registered in the generation manifest and has no manifest UUID.
+Its identity is its immutable generation path.
+Readers open it directly from `{generation_path}/_pk_index`.
+
+The sidecar row ids are in the same forward row-position space as the data files, deletion vector, and maintained user indexes.
+The sidecar is used for cross-generation membership and block-list checks.
+It is not used to choose the newest row inside the same flushed generation; the deletion vector has already hidden older same-generation duplicates.
+
+### Maintained User Indexes
+
+When the MemWAL index lists `maintained_indexes`, flush may build matching indexes inside the flushed generation.
+These index files live in the generation's `_indices/{index_uuid}/` directory and are recorded in the generation manifest.
+
+These indexes use the same row-position space as the forward-written data files.
+If the generation has a primary key, the generation deletion vector masks stale duplicate rows for indexed reads as well.
+
+### Merging Flushed Generations
+
+Flushed generations are merged into the base table in ascending generation order within each shard.
+Lower generation numbers are older and must merge before higher generation numbers.
+The base table merge uses merge-insert semantics so newer rows overwrite older rows for the same primary key.
+
+## Shard Manifest
+
+Each shard has a versioned manifest.
+The latest shard manifest is the source of truth for shard-local state.
+
+### Shard Manifest Contents
 
 The manifest contains:
 
-- **Fencing state**: `writer_epoch` as the latest writer fencing token, see [Writer Fencing](#writer-fencing) for more details.
-- **Shard assignment**: `shard_spec_id` and `shard_field_values` record how this shard maps to its sharding spec. `shard_field_values` is a map from shard field id to the raw Arrow scalar bytes of the computed value; the matching `ShardingField.result_type` in the `ShardingSpec` determines how to interpret each entry (e.g., 4 little-endian bytes for int32, raw UTF-8 bytes for utf8).
-- **WAL pointers**: `replay_after_wal_entry_position` (last entry position flushed to MemTable, 0-based), `wal_entry_position_last_seen` (last entry position seen at manifest update, 0-based)
-- **Generation trackers**: `current_generation` (next generation to flush), `flushed_generations` list of generation number and directory path pairs (e.g., generation 1 at `a1b2c3d4_gen_1`)
+- **Identity**: `shard_id`, `shard_spec_id`, and `shard_field_entries`.
+- **Fencing state**: `writer_epoch`.
+- **WAL pointers**: `replay_after_wal_entry_position` and `wal_entry_position_last_seen`.
+- **Generation state**: `current_generation` and `flushed_generations`.
+- **Lifecycle state**: `status`, either `ACTIVE` or `SEALED`.
 
-Note: `wal_entry_position_last_seen` is a hint that may be stale since it's not updated on WAL write.
-It is updated opportunistically by any reader that can update the shard manifest.
-The manifest itself is atomically written, but recovery must try to get newer WAL files to find the actual state beyond this hint.
+`shard_field_entries` stores computed shard field values as raw Arrow scalar bytes keyed by `ShardingField.field_id`.
+The matching `ShardingField.result_type` determines how to decode each value.
+For example, `int32` values are four little-endian bytes and `utf8` values are raw UTF-8 bytes.
 
-The manifest is serialized as a protobuf binary file using the `ShardManifest` message.
+`replay_after_wal_entry_position` is the most recent 1-based WAL position covered by a flushed generation.
+The default value 0 means no WAL entry has been covered and recovery starts at position 1.
+
+`wal_entry_position_last_seen` is a best-effort hint for the most recent WAL position observed at manifest update time.
+It is not authoritative because it is not updated on every WAL write.
+Recovery must still probe or list WAL files to find the actual tail.
+
+`status = SEALED` marks a reversible in-flight drop-table operation.
+Sealed shards refuse new writer claims.
+
+The manifest is serialized as the `ShardManifest` protobuf message.
 
 <details>
 <summary>ShardManifest protobuf message</summary>
@@ -198,61 +247,63 @@ The manifest is serialized as a protobuf binary file using the `ShardManifest` m
 
 </details>
 
-#### Shard Manifest Versioning
+### Shard Manifest Versioning
 
-Manifests are versioned starting from 1 and immutable.
-Each update creates a new manifest file at the next version number.
-Updates use put-if-not-exists or file rename to ensure atomicity depending on the storage system.
-If two processes compete, one wins and the other retries.
+Manifest versions start at 1.
+Each update writes a new immutable protobuf file:
 
-To commit a manifest version:
+```text
+_mem_wal/{shard_id}/manifest/{bit_reversed_version}.binpb
+```
 
-1. Compute the next version number
-2. Write the manifest to `{bit_reversed_version}.binpb` using put-if-not-exists
-3. In parallel best-effort write to `version_hint.json` with `{"version": <new_version>}` (failure is acceptable)
+Writers use put-if-not-exists or atomic rename, depending on storage support.
+If two processes race to write the same next version, one wins and the other reloads and retries.
 
-To read the latest manifest version:
+After a successful version write, the writer best-effort updates:
 
-1. Read `version_hint.json` to get the latest version hint. If not found, start from version 1
-2. Check existence for subsequent versions from the starting version
-3. Continue until a version is not found
-4. The latest version is the last found version
+```json
+{"version": <new_version>}
+```
 
-!!!note
-This works because the write rate to shard manifests is significantly lower than read rates. Shard manifests are only updated when shard metadata changes (MemTable flush), not on every write. This ensures HEAD requests will eventually terminate and find the latest version.
+in:
 
-#### Shard Manifest Storage Layout
+```text
+_mem_wal/{shard_id}/manifest/version_hint.json
+```
 
-All shard manifest versions are stored in `_mem_wal/{shard_id}/manifest` directory.
-
-Each shard manifest version file uses bit-reversed 64-bit binary naming, the same scheme as WAL files.
-For example, version 5 becomes `1010000000000000000000000000000000000000000000000000000000000000.binpb`.
+Readers use `version_hint.json` as a starting point and then probe subsequent versions until a version is missing.
+The latest manifest is the last existing version.
 
 ## MemWAL Index Details
 
-The MemWAL Index uses the [standard index storage](../index/index.md#index-storage) at `_indices/{UUID}/`.
+The MemWAL index is stored inline in the base table's `IndexMetadata`.
+It is a system index with no file directory.
+The `index_details` field contains a `MemWalIndexDetails` protobuf message.
 
-The index stores its data in two parts:
+Important fields:
 
-1. **Index details** (`index_details` in `IndexMetadata`): Contains configuration, merge progress, and snapshot metadata
-2. **Shard snapshots**: Stored as a Lance file or inline, depending on shard count
+- `sharding_specs`: sharding configuration used by writers and shard pruning.
+- `maintained_indexes`: names of base-table indexes to maintain in MemTables and flushed generations.
+- `writer_config_defaults`: string map of default writer configuration values persisted for all writers.
+- `merged_generations`: per-shard merge progress, updated atomically with base-table merge commits.
+- `index_catchup`: per-index coverage progress after data has merged to the base table.
+- `snapshot_ts_millis`, `num_shards`, and `inline_snapshots`: optional shard snapshot fields for read optimization.
 
-### Index Details
+If a shard is absent from `index_catchup` for an index, that index is assumed to be fully caught up for the shard.
 
-The `index_details` field in `IndexMetadata` contains a `MemWalIndexDetails` protobuf message with the following key fields:
+Shard snapshots, when present, use the following Lance file schema:
 
-- **Configuration fields** (`sharding_specs`, `maintained_indexes`) are the source of truth for MemWAL configuration.
-  Writers read these fields to determine how to partition data and which indexes to maintain.
-- **Merge progress** (`merged_generations`) tracks the last generation merged to the base table for each shard.
-  This field is updated atomically with merge-insert data commits, enabling conflict resolution when multiple mergers operate concurrently.
-  Each entry contains the shard UUID and generation number.
-- **Index catchup progress** (`index_catchup`) tracks which merged generation each base table index has been rebuilt to cover.
-  When data is merged from a flushed MemTable to the base table, the base table's indexes may be rebuilt asynchronously.
-  During this window, queries should use the flushed MemTable's pre-built indexes instead of scanning unindexed data in the base table.
-  See [Indexed Read Plan](#indexed-read-plan) for details.
-- **Shard snapshot fields** (`snapshot_ts_millis`, `num_shards`, `inline_snapshots`) provide a snapshot of shard states.
-  The actual shard manifests remain authoritative for shard state.
-  When `num_shards` is 0, the `inline_snapshots` field may be `None` or an empty Lance file with 0 rows but proper schema.
+```python
+pa.schema([
+    pa.field("shard_id", pa.utf8(), nullable=False),
+    pa.field("shard_spec_id", pa.uint32(), nullable=False),
+    # One field per ShardingField in the relevant ShardingSpec.
+    # Field name: "shard_field_{field_id}".
+    # Field type: ShardingField.result_type.
+])
+```
+
+The current Lance Rust implementation keeps MemWAL index data inline and discovers the latest shard set by listing `_mem_wal/` shard directories and reading shard manifests.
 
 <details>
 <summary>MemWalIndexDetails protobuf message</summary>
@@ -263,428 +314,320 @@ The `index_details` field in `IndexMetadata` contains a `MemWalIndexDetails` pro
 
 </details>
 
-### Shard Identifier
+## Sharding
 
-Each shard has a unique UUID identifier within the table.
-When a new shard is created, implementations may assign either a random UUID or
-a deterministic UUID derived from the shard assignment when deterministic
-writer fencing is required.
+A **ShardingSpec** defines how rows map to shards.
+Each spec has a positive `spec_id` and one or more `ShardingField` entries.
+Each shard manifest records the `shard_spec_id` and the computed shard field values for that shard.
+`spec_id = 0` means the shard was manually created and is not governed by a sharding spec.
 
-### Shard Discovery
+Each `ShardingField` contains:
 
-The MemWAL index can store shard snapshots for read optimization, but those snapshots may lag the latest shard set.
-Implementations that need to discover the current shard set should list `_mem_wal/` shard directories and read each shard's latest [shard manifest](#shard-manifest).
+- `field_id`: stable identifier for the computed shard field.
+- `source_ids`: field IDs of source columns in the Lance schema.
+- `transform`: well-known transform name, when using built-in transform evaluation.
+- `expression`: reserved custom expression text, mutually exclusive with `transform`.
+- `result_type`: Arrow type name for the computed value.
+- `parameters`: transform-specific string parameters.
 
-Each shard manifest records the shard UUID, sharding spec ID, and computed shard field values needed to map the shard back to a sharding spec assignment.
+The current implementation supports these built-in transforms:
 
-### Sharding Spec
+- `unsharded`: takes no source columns, always returns `int32` value 0, and creates one shard.
+- `bucket`: takes one source column and `num_buckets`, hashes the value, and returns an `int32` bucket id in `[0, num_buckets)`.
+- `identity`: takes one source column and returns the raw scalar value as the shard value.
 
-A **Sharding Spec** defines how all rows in a table are logically divided into different shards,
-enabling automatic shard assignment and query-time shard pruning.
+`bucket` computes a deterministic 32-bit hash with seed 0 and then computes:
 
-Each sharding spec has:
+```text
+(hash & i32::MAX) % num_buckets
+```
 
-- **Spec ID**: A positive integer that uniquely identifies this spec within the MemWAL index. IDs are never reused.
-- **Sharding fields**: An array of field definitions that determine how to compute shard values.
+`num_buckets` must be in `[1, 1024]`.
+Null bucket values hash to 0 and therefore map to bucket 0.
 
-Each shard is bound to a specific sharding spec ID, recorded in its [manifest](#shard-manifest).
-Shards without a spec ID (`spec_id = 0`) are manually-created shards not governed by any spec.
+The hash uses 32-bit wrapping arithmetic with these mixing functions.
+Right shifts in `fmix` are logical shifts of the `u32` bit pattern.
 
-A sharding spec's field array consists of **sharding field** definitions.
-Each sharding field has the following properties:
+```text
+mix_k1(k) = rotl32(k * 0xcc9e2d51, 15) * 0x1b873593
+mix_h1(h, k) = rotl32(h ^ k, 13) * 5 + 0xe6546b64
+fmix(h, len) =
+    h = h ^ len
+    h = (h ^ (h >> 16)) * 0x85ebca6b
+    h = (h ^ (h >> 13)) * 0xc2b2ae35
+    h ^ (h >> 16)
+```
 
-| Property      | Description                                                               |
-| ------------- | ------------------------------------------------------------------------- |
-| `field_id`    | Unique string identifier for this sharding field                         |
-| `source_ids`  | Array of field IDs referencing source columns in the schema               |
-| `transform`   | A well-known shard expression, specify this or `expression`              |
-| `expression`  | A DataFusion SQL expression for custom logic, specify this or `transform` |
-| `result_type` | The output type of the shard value                                       |
+Signed and unsigned casts use two's-complement wrapping.
+Values are normalized and hashed as follows:
 
-#### Shard Expression
+- `bool`: `false` as `0`, `true` as `1`, then `hash_i32`.
+- `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32`, `date32`, `time32`: cast to `i32`, then `hash_i32`.
+- `int64`, `uint64`, `timestamp`, `time64`: cast to `i64`, then `hash_i64`.
+- `float32`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7fc00000`; other values use IEEE 754 bits cast to `i32`, then `hash_i32`.
+- `float64`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7ff8000000000000`; other values use IEEE 754 bits cast to `i64`, then `hash_i64`.
+- `utf8` and `large_utf8`: hash the UTF-8 bytes with `hash_bytes`.
 
-A **Shard Expression** is a [DataFusion SQL expression](https://datafusion.apache.org/user-guide/sql/index.html) that derives a shard value from source column(s).
-Source columns are referenced as `col0`, `col1`, etc., corresponding to the order of field IDs in `source_ids`.
+The helper hashes are:
 
-Shard expressions must satisfy the following requirements:
+```text
+hash_i32(v) = fmix(mix_h1(0, mix_k1(v)), 4)
 
-1. **Deterministic**: The same input value must always produce the same output value.
-2. **Stateless**: The expression must not depend on external state (e.g., current time, random values, session variables).
-3. **Type-promotion resistant**: The expression must produce the same result for equivalent values regardless of their numeric type (e.g., `int32(5)` and `int64(5)` must yield the same shard value).
-4. **Column removal resistant**: If a source field ID is not found in the schema, the column should be interpreted as NULL.
-5. **NULL-safe**: The expression should properly handle NULL inputs and have defined behavior (e.g., return NULL if input is NULL for single-column expressions).
-6. **Consistent with result type**: The expression's return type must be consistent with `result_type` in non-NULL cases.
+hash_i64(v) =
+    low = low 32 bits of v as i32
+    high = high 32 bits of v as i32
+    fmix(mix_h1(mix_h1(0, mix_k1(low)), mix_k1(high)), 8)
 
-#### Shard Transform
+hash_bytes(bytes) =
+    h = 0
+    for each complete 4-byte little-endian chunk:
+        h = mix_h1(h, mix_k1(chunk_as_i32))
+    for each remaining byte:
+        h = mix_h1(h, mix_k1(sign_extend_i8(byte)))
+    fmix(h, byte_length)
+```
 
-A **Shard Transform** is a well-known shard expression with a predefined name.
-When a transform is specified, the expression is derived automatically.
+Test vectors for `num_buckets = 8`:
 
-| Transform      | Parameters    | Shard Expression                                         | Result Type    |
-| -------------- | ------------- | --------------------------------------------------------- | -------------- |
-| `identity`     | (none)        | `col0`                                                    | same as source |
-| `year`         | (none)        | `date_part('year', col0)`                                 | `int32`        |
-| `month`        | (none)        | `date_part('month', col0)`                                | `int32`        |
-| `day`          | (none)        | `date_part('day', col0)`                                  | `int32`        |
-| `hour`         | (none)        | `date_part('hour', col0)`                                 | `int32`        |
-| `bucket`       | `num_buckets` | `abs(murmur3(col0)) % N`                                  | `int32`        |
-| `multi_bucket` | `num_buckets` | `abs(murmur3_multi(col0, col1, ...)) % N`                 | `int32`        |
-| `truncate`     | `width`       | `left(col0, W)` (string) or `col0 - (col0 % W)` (numeric) | same as source |
+- `int32` or `date32`: `1 -> 2`, `2 -> 7`, `null -> 0`, `3 -> 1`.
+- `utf8`: `"a" -> 1`, `"b" -> 5`, `null -> 0`.
+- `bool`: `true -> 2`.
+- `float32`: `1.25 -> 0`.
+- `float64`: `1.25 -> 0`.
 
-The `bucket` and `multi_bucket` transforms use Murmur3 hash functions:
+The current bucket transform supports scalar boolean, integer, floating-point, date32, time, timestamp, utf8, and large_utf8 source types.
+The current identity transform supports scalar boolean, integer, utf8, and large_utf8 source types.
 
-- **`murmur3(col)`**: Computes the 32-bit Murmur3 hash (x86 variant, seed 0) of a single column. Returns a signed 32-bit integer. Returns NULL if input is NULL.
-- **`murmur3_multi(col0, col1, ...)`**: Computes the Murmur3 hash across multiple columns. Returns a signed 32-bit integer. NULL fields are ignored during hashing; returns NULL only if all inputs are NULL.
-
-The hash result is wrapped with `abs()` and modulo `N` to produce a non-negative bucket number in the range `[0, N)`.
-
-### Shard Snapshot Storage
-
-Shard snapshots are stored using one of two strategies based on the number of shards:
-
-| Shard Count       | Storage Strategy    | Location                                  |
-| ------------------ | ------------------- | ----------------------------------------- |
-| <= 100 (threshold) | Inline              | `inline_snapshots` field in index details |
-| > 100              | External Lance file | `_indices/{UUID}/index.lance`             |
-
-The threshold (100 shards) is implementation-defined and may vary.
-
-**Inline storage**: For small shard counts, snapshots are serialized as a Lance file and stored in the `inline_snapshots` field.
-This keeps the index metadata compact while avoiding an additional file read for common cases.
-
-**External Lance file**: For large shard counts, snapshots are stored as a Lance file at `_indices/{UUID}/index.lance`.
-This file uses standard Lance format with the shard snapshot schema, enabling efficient columnar access and compression.
-
-### Shard Snapshot Arrow Schema
-
-Shard snapshots are stored as a Lance file with one row per shard.
-The snapshot schema is optimized for shard discovery. Full mutable shard state
-remains in the authoritative shard manifest files.
-
-| Column                   | Type          | Description                                                                                                |
-| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------- |
-| `shard_id`               | `utf8`        | Shard UUID string                                                                                          |
-| `shard_spec_id`          | `uint32`      | Sharding spec ID (0 if manual)                                                                             |
-| `shard_field_{field_id}` | varies        | One column per sharding field defined in the sharding spec, typed to match the field's `ShardingField.result_type`. |
-
-For example, with a sharding spec containing a field `user_bucket` of type `int32`:
-
-| Column                     | Type    | Description                  |
-| -------------------------- | ------- | ---------------------------- |
-| ...                        | ...     | (base columns above)         |
-| `shard_field_user_bucket`  | `int32` | Bucket value for this shard |
-
-This schema records the fields needed to map each shard back to its sharding spec
-assignment. Readers that need fencing epochs, WAL positions, or flushed
-generation state must read the latest shard manifests directly.
+The `year`, `month`, `day`, `hour`, `multi_bucket`, and `truncate` transform names are not part of the current implemented MemWAL writer path.
 
 ## Storage Layout
 
-Here is a recap of the storage layout with all the files and concepts defined so far:
+The current MemWAL storage layout is:
 
-```
+```text
 {table_path}/
+├── _versions/
+│   └── ...                              # Base table manifests, including __lance_mem_wal index metadata
 ├── _indices/
-│   └── {index_uuid}/                    # MemWAL Index (uses standard index storage)
-│       └── index.lance                  # Serialized shard snapshots (Lance file)
-│
+│   └── ...                              # Ordinary base table index files; MemWAL index has no files
 └── _mem_wal/
-    └── {shard_id}/                   # Shard directory (UUID v4)
+    └── {shard_id}/
         ├── manifest/
-        │   ├── {bit_reversed_version}.binpb     # Serialized shard manifest (bit-reversed naming)
-        │   └── version_hint.json                # Version hint file
+        │   ├── {bit_reversed_version}.binpb
+        │   └── version_hint.json
         ├── wal/
-        │   ├── {bit_reversed_entry_id}.arrow    # WAL data files (bit-reversed naming)
+        │   ├── {bit_reversed_position}.arrow
         │   └── ...
-        └── {random_hash}_gen_{i}/        # Flushed MemTable (generation i, random prefix)
+        └── {random8}_gen_{generation}/
             ├── _versions/
-            │   └── {version}.manifest    # Table manifest (V2 naming scheme)
-            ├── _indices/                 # Indexes
-            │   ├── {vector_index}/
-            │   └── {scalar_index}/
-            └── bloom_filter.bin          # Primary key bloom filter
+            │   └── {version}.manifest
+            ├── _deletions/
+            ├── _indices/
+            │   └── {index_uuid}/
+            ├── _pk_index/
+            └── bloom_filter.bin
 ```
+
+Some flushed-generation subdirectories are conditional.
+For example, `_deletions/` is present only when the generation manifest references a deletion vector, `_indices/` is present only when maintained user indexes are built, and `_pk_index/` plus `bloom_filter.bin` are meaningful for primary-key tables.
 
 ## Implementation Expectation
 
-This specification describes the storage layout for the LSM tree architecture. Implementations are free to use any approach to fulfill the storage layout requirements. Once data is written to the expected storage layout, the reader and writer expectations apply.
+This document specifies the storage layout and observable reader and writer invariants.
+Implementations may choose different in-memory structures, buffering policies, background scheduling, and query execution plans.
 
-The specification defines:
+An implementation is compatible when it:
 
-- **Storage layout**: The directory structure, file formats, and naming conventions for WAL entries, flushed MemTables, shard manifests, and the MemWAL index
-- **Durability guarantees**: How data is persisted through WAL entries and flushed MemTables
-- **Consistency model**: How readers and writers coordinate through manifests and epoch-based fencing
-
-Implementations may choose different approaches for:
-
-- In-memory data structures and indexing
-- Buffering strategies before WAL flush
-- Background task scheduling and concurrency
-- Query execution strategies
-
-As long as the storage layout is correct and the documented invariants are maintained, implementations can optimize for their specific use cases.
+1. Writes WAL entries, shard manifests, flushed generations, and MemWAL index metadata using the documented layout.
+2. Preserves WAL position, writer fencing, and manifest versioning invariants.
+3. Exposes last-write-wins semantics for primary-key tables.
+4. Preserves append-only semantics for tables without primary keys.
+5. Maintains generation ordering when merging flushed MemTables into the base table.
 
 ## Writer Expectations
 
-A writer operates on a single shard and is responsible for:
+A writer operates on one shard and is responsible for:
 
-1. Claiming the shard using epoch-based fencing
-2. Writing data to WAL entries and flushed MemTables following the [storage layout](#storage-layout)
-3. Maintaining the shard manifest to track WAL and generation progress
+1. Claiming the shard with epoch-based fencing.
+2. Appending WAL entries in sequential 1-based positions.
+3. Maintaining in-memory MemTable state.
+4. Flushing MemTable generations to Lance datasets.
+5. Updating the shard manifest after a generation is durably flushed.
 
 ### Writer Fencing
 
-Writers use epoch-based fencing to ensure single-writer semantics per shard.
+Writers use `writer_epoch` to enforce single-writer semantics per shard.
 
 To claim a shard:
 
-1. Load the latest shard manifest
-2. Increment `writer_epoch` by one
-3. Atomically write a new manifest version
-4. If the write fails (another writer claimed the epoch), reload and retry with a higher epoch
+1. Load the latest shard manifest.
+2. Verify the shard is `ACTIVE`.
+3. Increment `writer_epoch`.
+4. Atomically write a new manifest version.
+5. If the manifest write loses a race, reload and retry.
 
-Before any manifest update, a writer must verify its `writer_epoch` remains valid:
+Before a manifest update, a writer verifies its local epoch is still current:
 
-- If `local_writer_epoch == stored_writer_epoch`: The writer is still active and may proceed
-- If `local_writer_epoch < stored_writer_epoch`: The writer has been fenced and must abort
+- If `local_writer_epoch == stored_writer_epoch`, the writer may proceed.
+- If `local_writer_epoch < stored_writer_epoch`, the writer has been fenced and must abort.
 
-For a concrete example, see [Appendix 1: Writer Fencing Example](#appendix-1-writer-fencing-example).
+WAL append conflicts also detect fencing.
+If an older writer collides with a newer writer's WAL entry at the same position, it reloads the manifest and observes the higher epoch.
+Fence sentinel entries make this collision path explicit without storing data batches.
 
 ## Background Job Expectations
 
-Background jobs handle merging flushed MemTables to the base table and garbage collection.
+Background jobs merge flushed generations into the base table and remove obsolete shard data.
 
 ### MemTable Merger
 
-Flushed MemTables must be merged to the base table in **ascending generation order** within each shard. This ordering is essential for correct upsert semantics: newer generations must overwrite older ones.
+Flushed MemTables must merge into the base table in ascending generation order within each shard.
+The merge uses Lance merge-insert semantics and updates `merged_generations[shard_id]` atomically with the base-table commit.
 
-The merge uses Lance's merge-insert operation with atomic transaction semantics:
+On commit conflict, a merger reloads the conflicting base-table version:
 
-- `merged_generations[shard_id]` is updated atomically with the data commit
-- On commit conflict, check the conflicting commit's `merged_generations` to determine if the generation was already merged
-
-For a concrete example, see [Appendix 2: Concurrent Merger Example](#appendix-2-concurrent-merger-example).
+- If the committed `merged_generations[shard_id]` is already greater than or equal to the generation being merged, the merger skips that generation.
+- Otherwise, the merger retries from the latest base-table version.
 
 ### Garbage Collector
 
-The garbage collector removes obsolete data from shard directories. Flushed MemTables and their referenced WAL files may be deleted after:
+The garbage collector may remove obsolete flushed generations after:
 
-1. The generation has been merged to the base table (`generation <= merged_generations[shard_id]`)
-2. All maintained indexes have caught up (`generation <= min(index_catchup[I].caught_up_generation)`)
-3. No retained base table version references the generation for time travel
+1. The generation has been merged to the base table.
+2. Every maintained index has caught up to cover the merged generation, or the generation is no longer needed for indexed reads.
+3. No retained base-table version needs the generation for time travel or consistency.
 
-!!!warning
-    Deleting WAL files weakens [writer fencing](#writer-fencing) and can lead to silent acknowledgement of lost writes.
+!!! warning
+    Deleting WAL files can weaken writer fencing.
 
-    Fencing detects a stalled writer when its `put-if-not-exists` for the next WAL entry collides with a newer writer's entry at the same position — only that collision triggers the epoch check. If GC has already removed the WAL file at that position, the stalled writer's PUT lands on empty space and succeeds against its old `writer_epoch`. The entry is acknowledged to the client, but the new manifest's `replay_after_wal_entry_position` has already advanced past it, so the data is never replayed.
-
-    Implementations that GC WAL files must compensate, for example by re-checking fence state after each successful WAL write, encoding the writer epoch into the WAL filename so positions are partitioned by epoch, or otherwise guaranteeing a stalled writer cannot land at a position that has been or will be GC'd.
+    Fencing detects a stalled writer when its put-if-not-exists for the next WAL entry collides with a newer writer's entry at the same position.
+    If garbage collection has removed that WAL file, the stalled writer may write into empty space with an old `writer_epoch`.
+    Implementations that garbage collect WAL files must compensate by re-checking fence state after WAL writes, partitioning WAL positions by epoch, or otherwise preventing stale writers from landing at positions that have been garbage collected.
 
 ## Reader Expectations
 
 ### LSM Tree Merging Read
 
-For tables with a primary key, readers **MUST** merge results from multiple data sources
-(base table, flushed MemTables, in-memory MemTables) by primary key to ensure correctness.
+For primary-key tables, readers merge rows from the base table, flushed MemTables, and optionally in-memory MemTables by primary key.
+The newest row wins.
 
-When the same primary key exists in multiple sources, the reader must keep only the newest version based on:
+Freshness ordering within one shard is:
 
-1. **Generation number** (`_gen`): Higher generation wins. The base table has generation 0, MemTables have positive integers starting from 1.
-2. **Row address** (`_rowaddr`): Within the same generation, higher row address wins (later writes within a batch overwrite earlier ones).
+1. Higher generation wins.
+2. Within the active in-memory generation, higher row position wins.
+3. Within a flushed generation, the generation's deletion vector has already hidden older duplicate primary-key rows.
 
-The ordering for "newest" is: highest `_gen` first, then highest `_rowaddr`.
-
-This deduplication is essential because:
-
-- A row updated in a MemTable also exists (with older data) in the base table
-- A flushed MemTable that has been merged to the base table may not yet be garbage collected, causing the same row to appear in both
-- A single write batch may contain multiple updates to the same primary key
-
-Without proper merging, queries would return duplicate or stale rows.
+The base table has generation 0.
+MemWAL generations are positive.
+This ordering applies only to sources selected for the same read plan.
+Readers must not include a flushed generation that is already covered by the base table according to `merged_generations[shard_id]`, because otherwise the positive MemWAL generation would incorrectly outrank base-table rows during deduplication.
+Rows from different shards do not need primary-key deduplication if the sharding spec guarantees that each primary key maps to exactly one shard.
 
 Append-only tables without a primary key do not perform primary-key deduplication.
-Readers should include the relevant base table, flushed MemTables, and in-memory MemTables
-according to the requested consistency level; duplicate values are treated as distinct appended rows.
+Rows from all selected sources are distinct appended rows.
+
+### Tombstones
+
+Readers must treat `_tombstone = true` rows as delete markers.
+In flushed generations, deletion vectors first resolve same-generation duplicate primary keys.
+Then query planning filters tombstone rows from user-visible results.
+In active in-memory MemTables, the newest visible row position for a primary key wins; if that row is a tombstone, the key is absent.
 
 ### Reader Consistency
 
-Reader consistency depends on two factors:
+Reader consistency depends on:
 
-1. access to in-memory MemTables
-2. the source of shard metadata (either through MemWAL index or shard manifests)
+1. Whether the reader can access active in-memory MemTables.
+2. Whether shard metadata comes from latest shard manifests or from an older MemWAL index snapshot.
 
-Strong consistency requires access to in-memory MemTables for all shards involved in the query and reading shard manifests directly.
-Otherwise, the query is eventually consistent due to missing unflushed data or stale MemWAL Index snapshots.
+Strong consistency requires active in-memory MemTable access for relevant shards and direct reads of latest shard manifests.
+Otherwise, reads are eventually consistent because unflushed data or newly-created shards may be absent from the read plan.
 
-!!!note
-Reading a stale MemWAL Index does not impact correctness, only freshness:
+Reading a stale MemWAL index snapshot does not corrupt last-write-wins ordering, but it can reduce freshness:
 
-    - **Merged MemTable still in index**: If a flushed MemTable has been merged to the base table but still shows in the MemWAL index, readers query both. This results in some inefficiency for querying the same data twice, but [LSM-tree merging](#lsm-tree-merging-read) ensures correct results since both contain the same data. The inefficiency is also compensated by the fact that the data is covered by index and we rarely end up scanning both data.
-    - **Garbage collected MemTable still in index**: If a flushed MemTable has been garbage collected, but is still in the MemWAL index, readers would fail to open it and skip it. This is also safe because if it is garbage collected, the data must already exist in the base table.
-    - **Newly flushed MemTable not in index**: If a newly flushed MemTable is added after the snapshot was built, it is not queried. The result is eventually consistent but correct for the snapshot's point in time.
+- If a merged flushed generation is still listed, readers must skip it when `generation <= merged_generations[shard_id]`.
+  For primary-key tables, including it would let an older flushed row outrank newer base-table contents because MemWAL generations are positive and the base table is modeled as generation 0.
+  For append-only tables, including it would return the same append twice.
+- If a garbage-collected flushed generation is still listed, readers may skip it after failing to open it because its data must already be in the base table or be filtered out by `merged_generations`.
+- If a newly flushed generation is not listed, the read is consistent with the older snapshot but may miss fresher data.
+
+Readers that require latest shard membership should list `_mem_wal/` and read shard manifests instead of relying only on snapshots.
 
 ### Query Planning
 
-#### MemTable Collection
+A query planner collects sources from:
 
-The query planner collects datasets from multiple sources and assembles them for unified query execution.
-Datasets come from:
+1. The base table.
+2. Flushed MemTables that are not yet safely replaceable by base-table indexed reads.
+3. Active in-memory MemTables, when available and required by the requested consistency level.
 
-1. base table (representing already-merged data)
-2. flushed MemTables (persisted but not yet merged)
-3. optionally in-memory MemTables (if accessible).
+Each source is tagged with its shard and generation.
+For primary-key reads, the planner applies LSM deduplication across selected sources.
+For append-only reads, the planner concatenates selected sources without primary-key deduplication.
 
-Each dataset is tagged with a generation number: 0 for the base table, and positive integers for MemTable generations.
-Within a shard, the generation number determines data freshness, with higher numbers representing newer data.
-For primary-key tables, rows from different shards do not need deduplication
-since each primary key maps to exactly one shard.
-Append-only tables without a primary key do not require cross-shard primary-key deduplication.
+Bloom filters and `_pk_index/` sidecars help prune flushed generations during point lookups and cross-generation deduplication.
 
-The planner also collects bloom filters from each generation for staleness detection during search queries.
+### Shard Pruning
 
-#### Shard Pruning
+When sharding specs are available, the planner evaluates query predicates against shard fields and skips shards whose computed shard values cannot match.
 
-Before executing queries, if sharding spec is available,
-the planner evaluates filter predicates against sharding specs to determine which shards may contain matching data.
-This pruning step reduces the number of shards to scan.
+For example, with `bucket(user_id, 10)` and predicate `user_id = 123`:
 
-For each filter predicate:
+1. Compute the bucket id for `123`.
+2. Scan only shards whose manifest has the same computed bucket value.
+3. Skip all other bucket shards.
 
-1. Extract predicates on columns used in sharding specs
-2. Evaluate which shard values can satisfy the predicate
-3. Prune shards whose values cannot match
+### Indexed Read Plan
 
-For example, with a sharding spec using `bucket(user_id, 10)` and a filter `user_id = 123`:
+When data is merged from a flushed MemTable into the base table, base-table indexes may lag behind the data commit.
+`index_catchup` records which merged generation each base-table index covers.
 
-1. Compute `bucket(123, 10) = 3`
-2. Only scan shards with bucket value 3
-3. Skip all other shards
-
-Shard pruning applies to both scan queries and prefilters in search queries.
-
-#### Indexed Read Plan
-
-When data is merged from a flushed MemTable to the base table, the base table's indexes are rebuilt asynchronously by the base table index builders.
-During this window, the merged data exists in the base table but is not yet covered by the base table's indexes.
-
-Without special handling, indexed queries would fall back to expensive full scans for the unindexed part of the base table.
-To maintain indexed read performance, the query planner should use `index_catchup` progress to determine the optimal data source for each query.
-
-The key insight is that flushed MemTables serve as a bridge between the base table's index catchup and the current merged state.
-For a query that requires a specific index for acceleration, when `index_gen < merged_gen`,
-the generations in the gap `(index_gen, merged_gen]` have data already merged in the base table but are not covered by the base table's index.
-Since flushed MemTables contain pre-built indexes (created during [MemTable flush](#flushed-memtable)), queries can use these indexes instead of scanning unindexed data in the base table.
-This ensures all reads remain indexed regardless of how far behind the async index builder is.
+If an indexed query needs index `I` and `I` has only caught up to generation `G` while `merged_generations[shard_id]` is higher, the planner should read the gap from flushed-generation indexes instead of scanning unindexed base-table rows.
+Once index `I` catches up, the planner can use the base-table index for those merged rows.
 
 ## Appendices
 
 ### Appendix 1: Writer Fencing Example
 
-This example demonstrates how epoch-based fencing prevents data corruption when two writers compete for the same shard.
+Initial shard manifest:
 
-#### Initial State
-
+```text
+version: 1
+writer_epoch: 5
+replay_after_wal_entry_position: 10
+wal_entry_position_last_seen: 12
+status: ACTIVE
 ```
-Shard manifest (version 1):
-  writer_epoch: 5
-  replay_after_wal_entry_position: 10
-  wal_entry_position_last_seen: 12
-```
 
-#### Scenario
+Writer A loads version 1, claims epoch 6, and writes manifest version 2.
+It appends WAL entries 13, 14, and 15 with `writer_epoch = 6`.
 
-| Step | Writer A                                      | Writer B                                  | Manifest State     |
-| ---- | --------------------------------------------- | ----------------------------------------- | ------------------ |
-| 1    | Loads manifest, sees epoch=5                  |                                           | epoch=5, version=1 |
-| 2    | Increments to epoch=6, writes manifest v2     |                                           | epoch=6, version=2 |
-| 3    | Starts writing WAL entries 13, 14, 15         |                                           |                    |
-| 4    |                                               | Loads manifest v2, sees epoch=6           | epoch=6, version=2 |
-| 5    |                                               | Increments to epoch=7, writes manifest v3 | epoch=7, version=3 |
-| 6    |                                               | Starts writing WAL entries 16, 17         |                    |
-| 7    | Tries to flush MemTable, loads manifest       |                                           |                    |
-| 8    | Sees epoch=7, but local epoch=6               |                                           |                    |
-| 9    | **Writer A is fenced!** Aborts all operations |                                           |                    |
-| 10   |                                               | Continues writing normally                | epoch=7, version=3 |
+Writer B then loads version 2, claims epoch 7, and writes manifest version 3.
+It appends WAL entries 16 and 17 with `writer_epoch = 7`.
 
-#### What Happens to Writer A's WAL Entries?
+When Writer A later tries to flush or update the shard manifest, it reloads the manifest and sees stored epoch 7 while its local epoch is 6.
+Writer A is fenced and must abort.
 
-Writer A wrote WAL entries 13, 14, 15 with `writer_epoch=6` in their schema metadata.
-
-When Writer B performs crash recovery or MemTable flush:
-
-1. Reads WAL entries sequentially starting from `replay_after_wal_entry_position + 1` (entry 11, since positions are 0-based)
-2. For each entry, checks existence using HEAD request on the bit-reversed filename
-3. Continues until an entry is not found (e.g., entry 18 doesn't exist)
-4. Finds entries 13, 14, 15, 16, 17
-5. Reads each file's `writer_epoch` from schema metadata
-6. Entries 13, 14, 15 have `writer_epoch=6` which is <= current epoch (7) -> **valid, will be replayed**
-7. Entries 16, 17 have `writer_epoch=7` -> **valid, will be replayed**
-
-#### Key Points
-
-1. **No data loss**: Writer A's entries are not discarded. They were written with a valid epoch at the time and will be included in recovery.
-
-2. **Consistency preserved**: Writer A is prevented from making further writes that could conflict with Writer B.
-
-3. **Orphaned files are safe**: WAL files from fenced writers remain on storage and are replayed by the new writer. They are only garbage collected after being included in a flushed MemTable that has been merged.
-
-4. **Epoch validation timing**: Writers check their epoch before manifest updates (MemTable flush), not on every WAL write. This keeps the hot path fast while ensuring consistency at commit boundaries.
+Recovery starts from `replay_after_wal_entry_position + 1`, which is entry 11.
+Entries 13, 14, 15, 16, and 17 are valid replay inputs because they were written by epochs that were valid at write time and are not greater than the current shard epoch.
 
 ### Appendix 2: Concurrent Merger Example
 
-This example demonstrates how MemWAL Index and conflict resolution handle concurrent mergers safely.
+Initial state:
 
-#### Initial State
-
-```
-MemWAL Index:
+```text
+MemWAL index:
   merged_generations: {shard: 5}
 
-Shard manifest (version 1):
+Shard manifest:
   current_generation: 8
-  flushed_generations: [(6, "abc123_gen_6"), (7, "def456_gen_7")]
+  flushed_generations:
+    - generation: 6, path: "abc12345_gen_6"
+    - generation: 7, path: "def67890_gen_7"
 ```
 
-#### Scenario 1: Racing on the Same Generation
+Two mergers both try to merge generation 6.
+Merger A commits first and updates `merged_generations[shard]` to 6 in the same base-table commit as the data.
+Merger B then hits a commit conflict, reloads the latest MemWAL index, sees `merged_generations[shard] >= 6`, skips generation 6, and continues with generation 7.
 
-Two mergers both try to merge generation 6 concurrently.
-
-| Step | Merger A                  | Merger B                       | MemWAL Index     |
-| ---- | ------------------------- | ------------------------------ | ---------------- |
-| 1    | Reads index: merged_gen=5 |                                | merged_gen=5     |
-| 2    | Reads shard manifest     |                                |                  |
-| 3    | Starts merging gen 6      |                                |                  |
-| 4    |                           | Reads index: merged_gen=5      | merged_gen=5     |
-| 5    |                           | Reads shard manifest          |                  |
-| 6    |                           | Starts merging gen 6           |                  |
-| 7    | Commits (merged_gen=6)    |                                | **merged_gen=6** |
-| 8    |                           | Tries to commit                |                  |
-| 9    |                           | **Conflict**: reads new index  |                  |
-| 10   |                           | Sees merged_gen=6 >= 6, aborts |                  |
-| 11   |                           | Reloads, continues to gen 7    |                  |
-
-Merger B's conflict resolution detected that generation 6 was already merged by checking the MemWAL Index in the conflicting commit.
-
-#### Scenario 2: Crash After Table Commit
-
-Merger A crashes after committing to the table.
-
-| Step | Merger A                  | Merger B                         | MemWAL Index     |
-| ---- | ------------------------- | -------------------------------- | ---------------- |
-| 1    | Reads index: merged_gen=5 |                                  | merged_gen=5     |
-| 2    | Merges gen 6, commits     |                                  | **merged_gen=6** |
-| 3    | **CRASH**                 |                                  | merged_gen=6     |
-| 4    |                           | Reads index: merged_gen=6        | merged_gen=6     |
-| 5    |                           | Reads shard manifest            |                  |
-| 6    |                           | **Skips gen 6** (already merged) |                  |
-| 7    |                           | Merges gen 7, commits            | **merged_gen=7** |
-
-The MemWAL Index is the single source of truth. Merger B correctly used it to determine that generation 6 was already merged.
-
-#### Key Points
-
-1. **Single source of truth**: `merged_generations` is the authoritative source for merge progress, updated atomically with data.
-
-2. **Conflict resolution uses MemWAL Index**: When a commit conflicts, the merger checks the conflicting commit's MemWAL Index.
-
-3. **No progress regression**: Because MemWAL Index is updated atomically with data, concurrent mergers cannot regress the merge progress.
+The MemWAL index is the authoritative merge-progress record because it is committed atomically with the base-table data changes.

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -181,12 +181,13 @@ Read planning then filters `_tombstone = false`, so the key is absent from query
 
 ### Flushed Primary-Key Sidecars
 
-Primary-key flushed generations write two sidecars:
+Primary-key MemTables maintain an implicit BTree for primary-key deduplication, independent of `maintained_indexes`.
+When a primary-key MemTable is flushed, the flushed generation writes two primary-key sidecars:
 
 - `bloom_filter.bin` stores the generation's primary-key bloom filter and lets point lookups skip generations that cannot contain the queried key.
 - `_pk_index/` stores a standalone BTree over primary-key values to forward row ids.
 
-The `_pk_index/` sidecar is not registered in the generation manifest and has no manifest UUID.
+The `_pk_index/` sidecar is not a maintained user index, is not registered in the generation manifest, and has no manifest UUID.
 Its identity is its immutable generation path.
 Readers open it directly from `{generation_path}/_pk_index`.
 
@@ -198,6 +199,7 @@ It is not used to choose the newest row inside the same flushed generation; the 
 
 When the MemWAL index lists `maintained_indexes`, flush may build matching indexes inside the flushed generation.
 These index files live in the generation's `_indices/{index_uuid}/` directory and are recorded in the generation manifest.
+The implicit primary-key BTree sidecar is not included in `maintained_indexes` and does not live under `_indices/`.
 
 These indexes use the same row-position space as the forward-written data files.
 If the generation has a primary key, the generation deletion vector masks stale duplicate rows for indexed reads as well.

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -200,17 +200,26 @@ _pk_index/
 ```
 
 Readers load this directory as a BTree index using `BTreeIndexDetails` with default parameters.
-The logical rows indexed by the BTree are sorted pairs:
+The primary-key index type is the Arrow type of the primary-key column for a single-column primary key, or `Binary` for a composite primary key.
 
-```python
-pa.schema([
-    pa.field("value", <primary-key-index-type>, nullable=True),
-    pa.field("_rowid", pa.uint64(), nullable=False),
-])
-```
+The `page_lookup.lance` file has the following schema:
 
-For a single-column primary key, `value` has the Arrow type of the primary-key column and stores the primary-key scalar directly.
-For a composite primary key, `value` is `binary` and stores an order-preserving tuple encoding of all primary-key columns in primary-key column order.
+| Column       | Type                    | Nullable | Description                                    |
+|--------------|-------------------------|----------|------------------------------------------------|
+| `min`        | {PrimaryKeyIndexType}   | true     | Minimum primary-key index value in the page    |
+| `max`        | {PrimaryKeyIndexType}   | true     | Maximum primary-key index value in the page    |
+| `null_count` | UInt32                  | false    | Number of null values in the page              |
+| `page_idx`   | UInt32                  | false    | Page number pointing into `page_data.lance`    |
+
+The `page_data.lance` file has the following schema:
+
+| Column   | Type                  | Nullable | Description                                                       |
+|----------|-----------------------|----------|-------------------------------------------------------------------|
+| `values` | {PrimaryKeyIndexType} | true     | Sorted primary-key index values                                   |
+| `ids`    | UInt64                | false    | Forward row ids corresponding to each primary-key index value     |
+
+For a single-column primary key, the indexed value stores the primary-key scalar directly.
+For a composite primary key, the indexed value stores an order-preserving binary tuple encoding of all primary-key columns in primary-key column order.
 Each tuple column is encoded as:
 
 - `0x00` for null.
@@ -331,15 +340,11 @@ If a shard is absent from `index_catchup` for an index, that index is assumed to
 
 Shard snapshots, when present, use the following Lance file schema:
 
-```python
-pa.schema([
-    pa.field("shard_id", pa.utf8(), nullable=False),
-    pa.field("shard_spec_id", pa.uint32(), nullable=False),
-    # One field per ShardingField in the relevant ShardingSpec.
-    # Field name: "shard_field_{field_id}".
-    # Field type: ShardingField.result_type.
-])
-```
+| Column                     | Type                         | Nullable | Description                                            |
+|----------------------------|------------------------------|----------|--------------------------------------------------------|
+| `shard_id`                 | Utf8                         | false    | Shard UUID string                                      |
+| `shard_spec_id`            | UInt32                       | false    | Sharding spec that produced the shard                  |
+| `shard_field_{field_id}`   | `ShardingField.result_type`  | false    | Computed shard field value for the given sharding field |
 
 The MemWAL index data is stored inline.
 Readers discover the latest shard set by listing `_mem_wal/` shard directories and reading shard manifests.

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -388,56 +388,7 @@ The supported built-in transforms are:
 
 `num_buckets` must be in `[1, 1024]`.
 Null bucket values hash to 0 and therefore map to bucket 0.
-
-The hash uses 32-bit wrapping arithmetic with these mixing functions.
-Right shifts in `fmix` are logical shifts of the `u32` bit pattern.
-
-```text
-mix_k1(k) = rotl32(k * 0xcc9e2d51, 15) * 0x1b873593
-mix_h1(h, k) = rotl32(h ^ k, 13) * 5 + 0xe6546b64
-fmix(h, len) =
-    h = h ^ len
-    h = (h ^ (h >> 16)) * 0x85ebca6b
-    h = (h ^ (h >> 13)) * 0xc2b2ae35
-    h ^ (h >> 16)
-```
-
-Signed and unsigned casts use two's-complement wrapping.
-Values are normalized and hashed as follows:
-
-- `bool`: `false` as `0`, `true` as `1`, then `hash_i32`.
-- `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32`, `date32`, `time32`: cast to `i32`, then `hash_i32`.
-- `int64`, `uint64`, `timestamp`, `time64`: cast to `i64`, then `hash_i64`.
-- `float32`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7fc00000`; other values use IEEE 754 bits cast to `i32`, then `hash_i32`.
-- `float64`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7ff8000000000000`; other values use IEEE 754 bits cast to `i64`, then `hash_i64`.
-- `utf8` and `large_utf8`: hash the UTF-8 bytes with `hash_bytes`.
-
-The helper hashes are:
-
-```text
-hash_i32(v) = fmix(mix_h1(0, mix_k1(v)), 4)
-
-hash_i64(v) =
-    low = low 32 bits of v as i32
-    high = high 32 bits of v as i32
-    fmix(mix_h1(mix_h1(0, mix_k1(low)), mix_k1(high)), 8)
-
-hash_bytes(bytes) =
-    h = 0
-    for each complete 4-byte little-endian chunk:
-        h = mix_h1(h, mix_k1(chunk_as_i32))
-    for each remaining byte:
-        h = mix_h1(h, mix_k1(sign_extend_i8(byte)))
-    fmix(h, byte_length)
-```
-
-Test vectors for `num_buckets = 8`:
-
-- `int32` or `date32`: `1 -> 2`, `2 -> 7`, `null -> 0`, `3 -> 1`.
-- `utf8`: `"a" -> 1`, `"b" -> 5`, `null -> 0`.
-- `bool`: `true -> 2`.
-- `float32`: `1.25 -> 0`.
-- `float64`: `1.25 -> 0`.
+See [Appendix 3: Bucket Hashing](#appendix-3-bucket-hashing) for the exact hash algorithm and test vectors.
 
 The `bucket` transform supports scalar boolean, integer, floating-point, date32, time, timestamp, utf8, and large_utf8 source types.
 The `identity` transform supports scalar boolean, integer, utf8, and large_utf8 source types.
@@ -675,3 +626,55 @@ Merger A commits first and updates `merged_generations[shard]` to 6 in the same 
 Merger B then hits a commit conflict, reloads the latest MemWAL index, sees `merged_generations[shard] >= 6`, skips generation 6, and continues with generation 7.
 
 The MemWAL index is the authoritative merge-progress record because it is committed atomically with the base-table data changes.
+
+### Appendix 3: Bucket Hashing
+
+The bucket transform hash uses 32-bit wrapping arithmetic with these mixing functions.
+Right shifts in `fmix` are logical shifts of the `u32` bit pattern.
+
+```text
+mix_k1(k) = rotl32(k * 0xcc9e2d51, 15) * 0x1b873593
+mix_h1(h, k) = rotl32(h ^ k, 13) * 5 + 0xe6546b64
+fmix(h, len) =
+    h = h ^ len
+    h = (h ^ (h >> 16)) * 0x85ebca6b
+    h = (h ^ (h >> 13)) * 0xc2b2ae35
+    h ^ (h >> 16)
+```
+
+Signed and unsigned casts use two's-complement wrapping.
+Values are normalized and hashed as follows:
+
+- `bool`: `false` as `0`, `true` as `1`, then `hash_i32`.
+- `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32`, `date32`, `time32`: cast to `i32`, then `hash_i32`.
+- `int64`, `uint64`, `timestamp`, `time64`: cast to `i64`, then `hash_i64`.
+- `float32`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7fc00000`; other values use IEEE 754 bits cast to `i32`, then `hash_i32`.
+- `float64`: `-0.0` and `+0.0` normalize to bits `0`; all NaNs normalize to `0x7ff8000000000000`; other values use IEEE 754 bits cast to `i64`, then `hash_i64`.
+- `utf8` and `large_utf8`: hash the UTF-8 bytes with `hash_bytes`.
+
+The helper hashes are:
+
+```text
+hash_i32(v) = fmix(mix_h1(0, mix_k1(v)), 4)
+
+hash_i64(v) =
+    low = low 32 bits of v as i32
+    high = high 32 bits of v as i32
+    fmix(mix_h1(mix_h1(0, mix_k1(low)), mix_k1(high)), 8)
+
+hash_bytes(bytes) =
+    h = 0
+    for each complete 4-byte little-endian chunk:
+        h = mix_h1(h, mix_k1(chunk_as_i32))
+    for each remaining byte:
+        h = mix_h1(h, mix_k1(sign_extend_i8(byte)))
+    fmix(h, byte_length)
+```
+
+Test vectors for `num_buckets = 8`:
+
+- `int32` or `date32`: `1 -> 2`, `2 -> 7`, `null -> 0`, `3 -> 1`.
+- `utf8`: `"a" -> 1`, `"b" -> 5`, `null -> 0`.
+- `bool`: `true -> 2`.
+- `float32`: `1.25 -> 0`.
+- `float64`: `1.25 -> 0`.


### PR DESCRIPTION
## Summary
- Update the MemWAL table-format spec to match the current inline index, WAL, shard manifest, flushed generation layout, and reader semantics.
- Document forward flushed row ordering, deletion-vector primary-key deduplication, sidecars, and implemented sharding transforms.

Validation: `git diff --check`; `cd docs && uv run mkdocs build`.