### PR TITLE
perf(index): list index segment files concurrently when committing segments

### DIFF
--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_core::cache::CacheKey;
 use lance_core::datatypes::Field;
@@ -278,8 +278,7 @@ pub(crate) async fn build_index_metadata_from_segments(
 
     prune_stale_segment_coverage(dataset, field_id, &mut segments, false, false).await?;
 
-    let mut new_indices = Vec::with_capacity(segments.len());
-    for segment in segments {
+    let new_indices = futures::stream::iter(segments.into_iter().map(|segment| async move {
         let (uuid, fragment_bitmap, fields, index_details, index_version, dataset_version) =
             segment.into_parts();
         let is_inverted_index = index_details.type_url.ends_with("InvertedIndexDetails");
@@ -299,12 +298,12 @@ pub(crate) async fn build_index_metadata_from_segments(
             crate::index::scalar::inverted::finalize_segment_files_if_needed(dataset, &metadata)
                 .await?;
         }
-        let index_dir = dataset.indices_dir().clone().join(uuid.to_string());
+        let index_dir = dataset.indices_dir().join(uuid.to_string());
         let mut files = list_index_files_with_sizes(&dataset.object_store, &index_dir).await?;
         if is_inverted_index {
             retain_committed_inverted_files(&mut files);
         }
-        new_indices.push(IndexMetadata {
+        Ok::<_, Error>(IndexMetadata {
             uuid,
             name: index_name.to_string(),
             fields,
@@ -315,8 +314,11 @@ pub(crate) async fn build_index_metadata_from_segments(
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(files),
-        });
-    }
+        })
+    }))
+    .buffered(dataset.object_store.io_parallelism())
+    .try_collect::<Vec<_>>()
+    .await?;
 
     Ok(new_indices)
 }


### PR DESCRIPTION
## Summary

`build_index_metadata_from_segments` listed each segment's index directory in a
serial loop, so committing N segments cost N sequential LIST round trips on the
object store. Distributed index builds can produce many segments, making this
step latency-bound on remote stores (S3/GCS/Azure).

This change runs the per-segment finalize + list work concurrently with
`buffered(io_parallelism())`, preserving output order and all validation.

## Performance

Micro-benchmark isolating the changed caller pattern: N index directories on an
in-memory object store wrapped with `ThrottleConfig` to simulate per-call LIST
latency; the *before* (serial loop) and *after* (`buffered(io_parallelism)`)
patterns both call the unchanged `list_index_files_with_sizes` helper.
`io_parallelism = 8`, 4 files per segment, multi-thread runtime.

| segments | LIST latency | before: serial | after: concurrent | speedup |
|---------:|-------------:|---------------:|------------------:|--------:|
|        8 |         20ms |       175.3 ms |           22.5 ms |  7.78x  |
|       32 |         20ms |       705.9 ms |           88.2 ms |  8.00x  |
|      128 |         20ms |      2837.2 ms |          350.1 ms |  8.10x  |
|      128 |         50ms |      6659.1 ms |          832.5 ms |  8.00x  |

Serial cost grows linearly with `N × latency`; concurrent cost scales as
`ceil(N / io_parallelism) × latency`, so the speedup tracks `io_parallelism`
and is independent of the per-call latency. On local/in-process stores where
LIST is nearly free the difference is negligible — the win is on high-latency
remote stores, which is exactly where distributed index commits run.

## Test plan

- [x] `cargo check -p lance --lib`
- [x] Micro-benchmark above (throttled in-memory store) — both paths return identical file counts
- [ ] Existing index commit tests remain green in CI