### PR TITLE
perf: speed up PQ distance lookup

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -111,6 +111,10 @@ name = "pq_dist_table"
 harness = false
 
 [[bench]]
+name = "pq_distance_lookup"
+harness = false
+
+[[bench]]
 name = "4bitpq_dist_table"
 harness = false
 

--- a/rust/lance-index/benches/pq_distance_lookup.rs
+++ b/rust/lance-index/benches/pq_distance_lookup.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark of PQ distance lookup for individual candidate vectors.
+
+use std::{hint::black_box, sync::Arc};
+
+use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use criterion::{Criterion, criterion_group, criterion_main};
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::ROW_ID_FIELD;
+use lance_index::vector::{
+    pq::ProductQuantizer,
+    storage::{DistCalculator, StorageBuilder, VectorStore},
+};
+use lance_linalg::distance::DistanceType;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+const DIM: usize = 512;
+const NUM_SUB_VECTORS: usize = 64;
+const TOTAL: usize = 65_536;
+const IDS_PER_ITER: usize = 16_384;
+
+fn random_f32_array(len: usize, seed: u64) -> Float32Array {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    Float32Array::from_iter_values((0..len).map(|_| rng.random_range(-1.0f32..1.0f32)))
+}
+
+fn create_storage() -> lance_index::vector::pq::storage::ProductQuantizationStorage {
+    let distance_type = DistanceType::Dot;
+    let codebook_values = random_f32_array(256 * DIM, 88);
+    let codebook = FixedSizeListArray::try_new_from_values(codebook_values, DIM as i32).unwrap();
+    let pq = ProductQuantizer::new(NUM_SUB_VECTORS, 8, DIM, codebook, distance_type);
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new(
+            "vec",
+            DataType::FixedSizeList(
+                Field::new_list_field(DataType::Float32, true).into(),
+                DIM as i32,
+            ),
+            true,
+        ),
+        ROW_ID_FIELD.clone(),
+    ]));
+    let vectors = random_f32_array(TOTAL * DIM, 3);
+    let row_ids = UInt64Array::from_iter_values((0..TOTAL).map(|v| v as u64));
+    let fsl = FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap();
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(fsl), Arc::new(row_ids)]).unwrap();
+
+    StorageBuilder::new("vec".to_owned(), distance_type, pq, None)
+        .unwrap()
+        .build(vec![batch])
+        .unwrap()
+}
+
+fn distance_lookup(c: &mut Criterion) {
+    let storage = create_storage();
+    let query = Arc::new(random_f32_array(DIM, 32));
+    let dist_calc = storage.dist_calculator(query, 0.0);
+    let ids = (0..IDS_PER_ITER)
+        .map(|i| ((i * 31) % TOTAL) as u32)
+        .collect::<Vec<_>>();
+
+    c.bench_function(
+        "pq_distance_lookup: 8bit,total=65536,pq=64,dim=512,ids=16384",
+        |b| {
+            b.iter(|| {
+                let mut total = 0.0;
+                for id in ids.iter().copied() {
+                    total += dist_calc.distance(black_box(id));
+                }
+                black_box(total);
+            })
+        },
+    );
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(30);
+    targets = distance_lookup
+);
+criterion_main!(benches);

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -834,39 +834,40 @@ impl PQDistCalculator {
             distance_type,
         }
     }
-
-    fn get_pq_code(&self, id: u32) -> impl Iterator<Item = usize> + '_ {
-        get_pq_code(
-            self.pq_code.values(),
-            self.num_bits,
-            self.num_sub_vectors,
-            id,
-        )
-        .map(|v| v as usize)
-    }
 }
 
 impl DistCalculator for PQDistCalculator {
     fn distance(&self, id: u32) -> f32 {
         let num_centroids = 2_usize.pow(self.num_bits);
-        let pq_code = self.get_pq_code(id);
+        let num_bytes = if self.num_bits == 4 {
+            self.num_sub_vectors / 2
+        } else {
+            self.num_sub_vectors
+        };
+        let pq_codes = self.pq_code.values();
+        let num_vectors = pq_codes.len() / num_bytes;
+        let code_offset = id as usize;
         let diff = self.num_sub_vectors as f32 - 1.0;
         let dist = if self.num_bits == 4 {
-            pq_code
-                .enumerate()
-                .map(|(i, c)| {
-                    let current_idx = c & 0x0F;
-                    let next_idx = c >> 4;
+            let mut dist = 0.0;
+            for byte_idx in 0..num_bytes {
+                let code = pq_codes[code_offset + byte_idx * num_vectors] as usize;
+                let current_idx = code & 0x0F;
+                let next_idx = code >> 4;
+                let current_sub_vector_idx = 2 * byte_idx;
+                let next_sub_vector_idx = current_sub_vector_idx + 1;
 
-                    self.distance_table[2 * i * num_centroids + current_idx]
-                        + self.distance_table[(2 * i + 1) * num_centroids + next_idx]
-                })
-                .sum()
+                dist += self.distance_table[current_sub_vector_idx * num_centroids + current_idx]
+                    + self.distance_table[next_sub_vector_idx * num_centroids + next_idx];
+            }
+            dist
         } else {
-            pq_code
-                .enumerate()
-                .map(|(i, c)| self.distance_table[i * num_centroids + c])
-                .sum()
+            let mut dist = 0.0;
+            for sub_vector_idx in 0..self.num_sub_vectors {
+                let code = pq_codes[code_offset + sub_vector_idx * num_vectors] as usize;
+                dist += self.distance_table[sub_vector_idx * num_centroids + code];
+            }
+            dist
         };
 
         if self.distance_type == DistanceType::Dot {


### PR DESCRIPTION
## Summary

- Speed up `PQDistCalculator::distance` by indexing transposed PQ codes directly instead of rebuilding an iterator with `skip(id).step_by(num_vectors)` for each candidate.
- Keep the existing PQ code layout, distance semantics, and public APIs unchanged.
- Add a focused Criterion benchmark for the per-candidate PQ distance lookup hot path.

## Benchmark

Benchmark command:

```bash
cargo bench -p lance-index --bench pq_distance_lookup -- --warm-up-time 3 --measurement-time 10
```

Focused before/after Criterion comparison with the same benchmark code:

- Base `6c291ab14555d327dda61860433034bce7586bd7`: `1.1122 ms` median estimate per 16,384 distance calls, interval `[1.0965 ms, 1.1290 ms]`
- Optimized: `1.0085 ms` median estimate per 16,384 distance calls, interval `[1.0005 ms, 1.0168 ms]`
- Criterion change: `[−10.390%, −9.3597%, −8.3427%]`, `p = 0.00 < 0.05`

The benchmark uses 8-bit PQ with `dim=512`, `num_sub_vectors=64`, `total=65,536`, and deterministic seeds.

## Validation

```bash
cargo fmt --all
cargo test -p lance-index vector::pq::storage -- --nocapture
cargo clippy -p lance-index --bench pq_distance_lookup -- -D warnings
cargo bench -p lance-index --bench pq_distance_lookup -- --warm-up-time 3 --measurement-time 10
```
