### PR TITLE
perf(dataset): reuse session-cached manifest on checkout

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -765,6 +765,11 @@ impl Dataset {
         uri: &str,
         session: &Session,
     ) -> Result<Arc<Manifest>> {
+        if manifest_location.size.is_none() {
+            return Ok(Arc::new(
+                Self::load_manifest(object_store, manifest_location, uri, session).await?,
+            ));
+        }
         let metadata_cache = session.metadata_cache.for_dataset(uri);
         let manifest_key = ManifestKey {
             version: manifest_location.version,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -599,7 +599,7 @@ impl Dataset {
             return Ok(self.clone());
         }
 
-        let manifest = Self::load_manifest(
+        let manifest = Self::get_manifest(
             self.object_store.as_ref(),
             &manifest_location,
             &new_location.uri,
@@ -625,7 +625,7 @@ impl Dataset {
             self.object_store.clone(),
             new_location.path,
             new_location.uri,
-            Arc::new(manifest),
+            manifest,
             manifest_location,
             self.session.clone(),
             self.commit_handler.clone(),

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -37,7 +37,7 @@ use lance_file::{
     version::LanceFileVersion,
     writer::{FileWriter, FileWriterOptions},
 };
-use lance_io::assert_io_eq;
+use lance_io::{assert_io_eq, assert_io_gt};
 use lance_table::feature_flags;
 use lance_table::format::BasePath;
 use object_store::ObjectStoreExt;
@@ -869,6 +869,69 @@ async fn test_load_manifest_iops() {
     // The manifest body is served from the cache instead of being read from storage.
     let io_stats = _dataset.object_store.as_ref().io_stats_incremental();
     assert_io_eq!(io_stats, read_iops, 1);
+}
+
+#[tokio::test]
+async fn test_checkout_reuses_cached_manifest() {
+    let test_uri = TempStrDir::default();
+    let session = Arc::new(Session::default());
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let make_batches = || {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+        RecordBatchIterator::new(vec![Ok(batch)], schema.clone())
+    };
+
+    // v1: committing on this Session caches the v1 manifest.
+    Dataset::write(
+        make_batches(),
+        &test_uri,
+        Some(WriteParams {
+            session: Some(session.clone()),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // v2 (append): the dataset now points at v2, but the v1 manifest stays in
+    // the Session cache from the write above.
+    let dataset = Dataset::write(
+        make_batches(),
+        &test_uri,
+        Some(WriteParams {
+            session: Some(session.clone()),
+            mode: WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.manifest().version, 2);
+
+    // Cache hit: checking out v1 resolves the manifest location (1 head) and
+    // reuses the cached manifest body, so no manifest read is issued.
+    let _ = dataset.object_store.as_ref().io_stats_incremental(); // reset
+    let ds_v1 = dataset.checkout_version(1u64).await.unwrap();
+    assert_eq!(ds_v1.manifest().version, 1);
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(io_stats, read_iops, 1);
+
+    // Cache miss: clearing the metadata cache forces the same checkout to read
+    // the manifest body from storage again, costing more than the lone head.
+    session.file_metadata_cache().clear().await;
+    let _ = dataset.object_store.as_ref().io_stats_incremental(); // reset
+    let ds_v1_cold = dataset.checkout_version(1u64).await.unwrap();
+    assert_eq!(ds_v1_cold.manifest().version, 1);
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_gt!(io_stats, read_iops, 1);
 }
 
 #[rstest]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -897,25 +897,48 @@ async fn test_checkout_removed_version_not_served_from_cache() {
     .await
     .unwrap();
 
-    // A cached manifest for a version removed from storage (keyed without an
-    // e_tag) must not be served: the checkout has to fail, not return the zombie.
-    let mut zombie = dataset.manifest().clone();
-    zombie.version = 999;
-    session
-        .metadata_cache
-        .for_dataset(&dataset.uri)
-        .insert_with_key(
-            &ManifestKey {
-                version: 999,
-                e_tag: None,
-            },
-            Arc::new(zombie),
-        )
-        .await;
+    let version = dataset.manifest().version;
+    let location = dataset.manifest_location().clone();
+    let cache = session.metadata_cache.for_dataset(&dataset.uri);
 
     assert!(
-        dataset.checkout_version(999u64).await.is_err(),
-        "checkout of a version absent from storage must not be served from cache"
+        cache
+            .get_with_key(&ManifestKey {
+                version,
+                e_tag: location.e_tag.as_deref(),
+            })
+            .await
+            .is_some(),
+        "manifest should be cached after the write"
+    );
+    dataset.checkout_version(version).await.unwrap();
+
+    // Remove the version from storage, as cleanup (or a manual delete) would.
+    dataset.object_store.delete(&location.path).await.unwrap();
+
+    let resolved = dataset
+        .commit_handler
+        .resolve_version_location(&dataset.base, version, &dataset.object_store.inner)
+        .await
+        .unwrap();
+    assert!(
+        resolved.size.is_none(),
+        "resolving a removed version must fall back to a size-less location, got {:?}",
+        resolved.size
+    );
+
+    cache
+        .insert_with_key(
+            &ManifestKey {
+                version,
+                e_tag: None,
+            },
+            Arc::new(dataset.manifest().clone()),
+        )
+        .await;
+    assert!(
+        dataset.checkout_version(version).await.is_err(),
+        "checkout of a version removed from storage must not be served from cache"
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -12,6 +12,7 @@ use crate::dataset::WriteMode::Overwrite;
 use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::{ManifestWriteConfig, write_manifest_file};
 use crate::session::Session;
+use crate::session::caches::ManifestKey;
 use crate::{Dataset, Error, Result};
 use lance_table::format::DataStorageFormat;
 
@@ -932,6 +933,131 @@ async fn test_checkout_reuses_cached_manifest() {
     assert_eq!(ds_v1_cold.manifest().version, 1);
     let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     assert_io_gt!(io_stats, read_iops, 1);
+}
+
+#[tokio::test]
+async fn test_checkout_removed_version_not_served_from_cache() {
+    // Regression: a version that no longer exists in storage (e.g. removed by
+    // auto-cleanup) must never be served from the session metadata cache.
+    // Version resolution falls back to an unchecked location (no `size`) for a
+    // missing version, and the cache key collapses to `manifest/{version}` when
+    // the store's head yields no e_tag, so a stale cached entry would otherwise
+    // be returned instead of surfacing a NotFound.
+    let test_uri = TempStrDir::default();
+    let session = Arc::new(Session::default());
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+    )
+    .unwrap();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+        &test_uri,
+        Some(WriteParams {
+            session: Some(session.clone()),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Seed a zombie manifest for a version absent from storage, keyed without an
+    // e_tag to mimic a store whose head yields none (the key collapses to
+    // `manifest/999`, exactly what a missing version resolves to). Give it the
+    // matching version so it stands in for a version that was cached and then
+    // removed (the realistic auto-cleanup scenario).
+    let mut zombie = dataset.manifest().clone();
+    zombie.version = 999;
+    session
+        .metadata_cache
+        .for_dataset(&dataset.uri)
+        .insert_with_key(
+            &ManifestKey {
+                version: 999,
+                e_tag: None,
+            },
+            Arc::new(zombie),
+        )
+        .await;
+
+    // The checkout must fail rather than return the cached zombie manifest.
+    assert!(
+        dataset.checkout_version(999u64).await.is_err(),
+        "checkout of a version absent from storage must not be served from cache"
+    );
+}
+
+#[tokio::test]
+async fn test_open_removed_version_not_served_from_cache() {
+    // Regression: the same zombie-cache hazard applies to opening a specific
+    // version by URI (`DatasetBuilder::with_version`), not just checkout — both
+    // resolve a missing version to an unchecked location and go through
+    // `get_manifest`.
+    let test_uri = TempStrDir::default();
+    let session = Arc::new(Session::default());
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+    )
+    .unwrap();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+        &test_uri,
+        Some(WriteParams {
+            session: Some(session.clone()),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Open once through the builder to learn the exact URI it caches under
+    // (`from_uri` re-normalizes the input, so it may differ from the URI the
+    // writer recorded).
+    let opened = DatasetBuilder::from_uri(dataset.uri.as_str())
+        .with_session(session.clone())
+        .load()
+        .await
+        .unwrap();
+
+    // Seed a zombie manifest for a version absent from storage under that exact
+    // URI, keyed without an e_tag. Give it the matching version so it passes the
+    // builder's version-consistency check and would be returned if the cache
+    // were trusted — i.e. a version that was cached and then removed.
+    let mut zombie = opened.manifest().clone();
+    zombie.version = 999;
+    session
+        .metadata_cache
+        .for_dataset(&opened.uri)
+        .insert_with_key(
+            &ManifestKey {
+                version: 999,
+                e_tag: None,
+            },
+            Arc::new(zombie),
+        )
+        .await;
+
+    // Opening the absent version by URI must fail, not return the cached zombie.
+    let result = DatasetBuilder::from_uri(dataset.uri.as_str())
+        .with_version(999u64)
+        .with_session(session.clone())
+        .load()
+        .await;
+    assert!(
+        result.is_err(),
+        "opening a version absent from storage must not be served from cache"
+    );
 }
 
 #[rstest]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -38,7 +38,7 @@ use lance_file::{
     version::LanceFileVersion,
     writer::{FileWriter, FileWriterOptions},
 };
-use lance_io::{assert_io_eq, assert_io_gt};
+use lance_io::assert_io_eq;
 use lance_table::feature_flags;
 use lance_table::format::BasePath;
 use object_store::ObjectStoreExt;
@@ -873,69 +873,6 @@ async fn test_load_manifest_iops() {
 }
 
 #[tokio::test]
-async fn test_checkout_reuses_cached_manifest() {
-    let test_uri = TempStrDir::default();
-    let session = Arc::new(Session::default());
-    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-        "i",
-        DataType::Int32,
-        false,
-    )]));
-    let make_batches = || {
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
-        )
-        .unwrap();
-        RecordBatchIterator::new(vec![Ok(batch)], schema.clone())
-    };
-
-    // v1: committing on this Session caches the v1 manifest.
-    Dataset::write(
-        make_batches(),
-        &test_uri,
-        Some(WriteParams {
-            session: Some(session.clone()),
-            ..Default::default()
-        }),
-    )
-    .await
-    .unwrap();
-
-    // v2 (append): the dataset now points at v2, but the v1 manifest stays in
-    // the Session cache from the write above.
-    let dataset = Dataset::write(
-        make_batches(),
-        &test_uri,
-        Some(WriteParams {
-            session: Some(session.clone()),
-            mode: WriteMode::Append,
-            ..Default::default()
-        }),
-    )
-    .await
-    .unwrap();
-    assert_eq!(dataset.manifest().version, 2);
-
-    // Cache hit: checking out v1 resolves the manifest location (1 head) and
-    // reuses the cached manifest body, so no manifest read is issued.
-    let _ = dataset.object_store.as_ref().io_stats_incremental(); // reset
-    let ds_v1 = dataset.checkout_version(1u64).await.unwrap();
-    assert_eq!(ds_v1.manifest().version, 1);
-    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-    assert_io_eq!(io_stats, read_iops, 1);
-
-    // Cache miss: clearing the metadata cache forces the same checkout to read
-    // the manifest body from storage again, costing more than the lone head.
-    session.file_metadata_cache().clear().await;
-    let _ = dataset.object_store.as_ref().io_stats_incremental(); // reset
-    let ds_v1_cold = dataset.checkout_version(1u64).await.unwrap();
-    assert_eq!(ds_v1_cold.manifest().version, 1);
-    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-    assert_io_gt!(io_stats, read_iops, 1);
-}
-
-#[tokio::test]
 async fn test_checkout_removed_version_not_served_from_cache() {
     let test_uri = TempStrDir::default();
     let session = Arc::new(Session::default());
@@ -960,6 +897,8 @@ async fn test_checkout_removed_version_not_served_from_cache() {
     .await
     .unwrap();
 
+    // A cached manifest for a version removed from storage (keyed without an
+    // e_tag) must not be served: the checkout has to fail, not return the zombie.
     let mut zombie = dataset.manifest().clone();
     zombie.version = 999;
     session
@@ -974,70 +913,9 @@ async fn test_checkout_removed_version_not_served_from_cache() {
         )
         .await;
 
-    // The checkout must fail rather than return the cached zombie manifest.
     assert!(
         dataset.checkout_version(999u64).await.is_err(),
         "checkout of a version absent from storage must not be served from cache"
-    );
-}
-
-#[tokio::test]
-async fn test_open_removed_version_not_served_from_cache() {
-    let test_uri = TempStrDir::default();
-    let session = Arc::new(Session::default());
-    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-        "i",
-        DataType::Int32,
-        false,
-    )]));
-    let batch = RecordBatch::try_new(
-        schema.clone(),
-        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
-    )
-    .unwrap();
-    let dataset = Dataset::write(
-        RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
-        &test_uri,
-        Some(WriteParams {
-            session: Some(session.clone()),
-            ..Default::default()
-        }),
-    )
-    .await
-    .unwrap();
-
-    // Open once through the builder to learn the exact URI it caches under
-    // (`from_uri` re-normalizes the input, so it may differ from the URI the
-    // writer recorded).
-    let opened = DatasetBuilder::from_uri(dataset.uri.as_str())
-        .with_session(session.clone())
-        .load()
-        .await
-        .unwrap();
-
-    let mut zombie = opened.manifest().clone();
-    zombie.version = 999;
-    session
-        .metadata_cache
-        .for_dataset(&opened.uri)
-        .insert_with_key(
-            &ManifestKey {
-                version: 999,
-                e_tag: None,
-            },
-            Arc::new(zombie),
-        )
-        .await;
-
-    // Opening the absent version by URI must fail, not return the cached zombie.
-    let result = DatasetBuilder::from_uri(dataset.uri.as_str())
-        .with_version(999u64)
-        .with_session(session.clone())
-        .load()
-        .await;
-    assert!(
-        result.is_err(),
-        "opening a version absent from storage must not be served from cache"
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -937,12 +937,6 @@ async fn test_checkout_reuses_cached_manifest() {
 
 #[tokio::test]
 async fn test_checkout_removed_version_not_served_from_cache() {
-    // Regression: a version that no longer exists in storage (e.g. removed by
-    // auto-cleanup) must never be served from the session metadata cache.
-    // Version resolution falls back to an unchecked location (no `size`) for a
-    // missing version, and the cache key collapses to `manifest/{version}` when
-    // the store's head yields no e_tag, so a stale cached entry would otherwise
-    // be returned instead of surfacing a NotFound.
     let test_uri = TempStrDir::default();
     let session = Arc::new(Session::default());
     let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
@@ -966,11 +960,6 @@ async fn test_checkout_removed_version_not_served_from_cache() {
     .await
     .unwrap();
 
-    // Seed a zombie manifest for a version absent from storage, keyed without an
-    // e_tag to mimic a store whose head yields none (the key collapses to
-    // `manifest/999`, exactly what a missing version resolves to). Give it the
-    // matching version so it stands in for a version that was cached and then
-    // removed (the realistic auto-cleanup scenario).
     let mut zombie = dataset.manifest().clone();
     zombie.version = 999;
     session
@@ -994,10 +983,6 @@ async fn test_checkout_removed_version_not_served_from_cache() {
 
 #[tokio::test]
 async fn test_open_removed_version_not_served_from_cache() {
-    // Regression: the same zombie-cache hazard applies to opening a specific
-    // version by URI (`DatasetBuilder::with_version`), not just checkout — both
-    // resolve a missing version to an unchecked location and go through
-    // `get_manifest`.
     let test_uri = TempStrDir::default();
     let session = Arc::new(Session::default());
     let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
@@ -1030,10 +1015,6 @@ async fn test_open_removed_version_not_served_from_cache() {
         .await
         .unwrap();
 
-    // Seed a zombie manifest for a version absent from storage under that exact
-    // URI, keyed without an e_tag. Give it the matching version so it passes the
-    // builder's version-consistency check and would be returned if the cache
-    // were trusted — i.e. a version that was cached and then removed.
     let mut zombie = opened.manifest().clone();
     zombie.version = 999;
     session

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -629,8 +629,11 @@ mod tests {
         assert_eq!(new_ds.manifest().version, 7);
         // Session should still be re-used
         // However, the dataset needs to be loaded and the read version checked out.
+        // The read version's manifest body is served from the session cache (it
+        // was cached when v1 was first created), so the checkout only pays the
+        // version-resolution head, not a manifest read.
         let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-        assert_io_eq!(io_stats, read_iops, 4, "load dataset + check version");
+        assert_io_eq!(io_stats, read_iops, 3, "load dataset + check version");
         assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
 
         // Commit transaction with URI and new session. Re-use the store

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -341,7 +341,10 @@ async fn test_ddb_open_iops() {
     // Checkout original version
     dataset.checkout_version(1).await.unwrap();
     let io_stats = dataset.object_store.as_ref().io_stats_incremental();
-    // Checkout: 1 IOPS: manifest file
-    assert_io_eq!(io_stats, read_iops, 1);
+    // Checkout: 0 read IOPS. Version 1's manifest was already loaded and cached
+    // on this Session when the dataset was opened above, so the checkout serves
+    // the manifest body from the metadata cache. Version resolution is handled
+    // in DynamoDB and issues no S3 read.
+    assert_io_eq!(io_stats, read_iops, 0);
     assert_io_eq!(io_stats, write_iops, 0);
 }


### PR DESCRIPTION
Checking out a version or branch (`Dataset::checkout_version` / `checkout_branch`) always read the manifest from storage, even when that same version was already loaded on the Session.

This path now goes through the session metadata cache (keyed by `version` + `e_tag`), reusing a cached manifest on a hit and only reading + caching on a miss — the same helper (`get_manifest`) already used by URI-open and `load_new_transactions`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version checkout reliability when manifests are no longer available in storage.
  * Prevented removed dataset versions from being served from cache.
  * Reduced unnecessary read I/O during dataset checkout and open operations, improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->