### PR TITLE
feat: compress RLE child buffers

### DIFF
--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -213,7 +213,7 @@ fn try_rle_for_mini_block(
         )
     };
 
-    let use_child_encodings = version.resolve() >= LanceFileVersion::V2_2;
+    let use_child_encodings = version.resolve() >= LanceFileVersion::V2_3;
     let child_compression = if use_child_encodings {
         rle_child_compression_config(params)
     } else {
@@ -2171,51 +2171,60 @@ mod tests {
 
     #[test]
     #[cfg(any(feature = "lz4", feature = "zstd"))]
-    fn test_rle_miniblock_v2_1_keeps_flat_children_when_compression_requested() {
-        let mut params = CompressionParams::new();
-        params.columns.insert(
-            "dict_indices".to_string(),
-            CompressionFieldParams {
-                compression: Some(if cfg!(feature = "lz4") { "lz4" } else { "zstd" }.to_string()),
-                rle_threshold: Some(1.0),
-                bss: Some(BssMode::Off),
-                ..Default::default()
-            },
-        );
-        let strategy =
-            DefaultCompressionStrategy::with_params(params).with_version(LanceFileVersion::V2_1);
-        let field = create_test_field("dict_indices", DataType::UInt32);
+    fn test_rle_miniblock_released_versions_keep_flat_children_when_compression_requested() {
+        for version in [LanceFileVersion::V2_1, LanceFileVersion::V2_2] {
+            let mut params = CompressionParams::new();
+            params.columns.insert(
+                "dict_indices".to_string(),
+                CompressionFieldParams {
+                    compression: Some(
+                        if cfg!(feature = "lz4") { "lz4" } else { "zstd" }.to_string(),
+                    ),
+                    rle_threshold: Some(1.0),
+                    bss: Some(BssMode::Off),
+                    ..Default::default()
+                },
+            );
+            let strategy = DefaultCompressionStrategy::with_params(params).with_version(version);
+            let field = create_test_field("dict_indices", DataType::UInt32);
 
-        let mut values = Vec::with_capacity(8192 * 4);
-        for value in 0..8192u32 {
-            values.extend(std::iter::repeat_n(value, 4));
+            let mut values = Vec::with_capacity(8192 * 4);
+            for value in 0..8192u32 {
+                values.extend(std::iter::repeat_n(value, 4));
+            }
+            let mut data = FixedWidthDataBlock {
+                bits_per_value: 32,
+                data: LanceBuffer::reinterpret_vec(values),
+                num_values: 8192 * 4,
+                block_info: BlockInfo::default(),
+            };
+            data.compute_stat();
+            let data = DataBlock::FixedWidth(data);
+
+            let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+            let (_compressed, encoding) = compressor.compress(data).unwrap();
+            let rle = expect_rle_encoding(&encoding);
+
+            assert!(
+                matches!(
+                    rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+                    Compression::Flat(_)
+                ),
+                "version={version}"
+            );
+            assert!(
+                matches!(
+                    rle.run_lengths
+                        .as_ref()
+                        .unwrap()
+                        .compression
+                        .as_ref()
+                        .unwrap(),
+                    Compression::Flat(_)
+                ),
+                "version={version}"
+            );
         }
-        let mut data = FixedWidthDataBlock {
-            bits_per_value: 32,
-            data: LanceBuffer::reinterpret_vec(values),
-            num_values: 8192 * 4,
-            block_info: BlockInfo::default(),
-        };
-        data.compute_stat();
-        let data = DataBlock::FixedWidth(data);
-
-        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
-        let (_compressed, encoding) = compressor.compress(data).unwrap();
-        let rle = expect_rle_encoding(&encoding);
-
-        assert!(matches!(
-            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
-            Compression::Flat(_)
-        ));
-        assert!(matches!(
-            rle.run_lengths
-                .as_ref()
-                .unwrap()
-                .compression
-                .as_ref()
-                .unwrap(),
-            Compression::Flat(_)
-        ));
     }
 
     #[test]
@@ -2283,7 +2292,7 @@ mod tests {
         data.compute_stat();
         let data = DataBlock::FixedWidth(data);
 
-        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_2);
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
         let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
         let debug_str = format!("{compressor:?}");
         assert!(

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -55,8 +55,8 @@ use crate::{
                 VariablePackedStructFieldKind,
             },
             rle::{
-                RleDecompressor, RleEncoder, RunLengthWidth, rle_encoded_size,
-                select_run_length_width,
+                RleChildDecompressor, RleDecompressor, RleEncoder, RunLengthWidth,
+                rle_encoded_size, select_run_length_width,
             },
             value::{ValueDecompressor, ValueEncoder},
         },
@@ -221,11 +221,23 @@ fn try_rle_for_mini_block(
                 return None;
             }
         }
-        return Some(Box::new(RleEncoder::with_run_length_width(
+        let child_compression = rle_child_compression_config(params);
+        return Some(Box::new(RleEncoder::with_child_compression(
             run_length_width,
+            child_compression,
+            child_compression,
         )));
     }
     None
+}
+
+fn rle_child_compression_config(params: &CompressionFieldParams) -> Option<CompressionConfig> {
+    let raw = params.compression.as_deref()?;
+    if matches!(raw, "none" | "fsst") {
+        return None;
+    }
+    let scheme = CompressionScheme::from_str(raw).ok()?;
+    Some(CompressionConfig::new(scheme, params.compression_level))
 }
 
 fn try_rle_for_block(
@@ -951,13 +963,10 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 // compression.
                 Ok(Box::new(ValueDecompressor::from_fsl(fsl)))
             }
-            Compression::Rle(rle) => {
-                let (bits_per_value, run_length_width) = validate_rle_compression(rle)?;
-                Ok(Box::new(RleDecompressor::with_run_length_width(
-                    bits_per_value,
-                    run_length_width,
-                )))
-            }
+            Compression::Rle(rle) => Ok(Box::new(create_rle_decompressor(
+                rle,
+                decompression_strategy,
+            )?)),
             Compression::ByteStreamSplit(bss) => {
                 let Compression::Flat(values) =
                     bss.values.as_ref().unwrap().compression.as_ref().unwrap()
@@ -1144,19 +1153,15 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
 
                 Ok(Box::new(general_decompressor))
             }
-            Compression::Rle(rle) => {
-                let (bits_per_value, run_length_width) = validate_rle_compression(rle)?;
-                Ok(Box::new(RleDecompressor::with_run_length_width(
-                    bits_per_value,
-                    run_length_width,
-                )))
-            }
+            Compression::Rle(rle) => Ok(Box::new(create_rle_decompressor(rle, self)?)),
             _ => todo!(),
         }
     }
 }
-/// Validates RLE compression format and extracts value and run length widths.
-fn validate_rle_compression(rle: &crate::format::pb21::Rle) -> Result<(u64, RunLengthWidth)> {
+fn create_rle_decompressor(
+    rle: &crate::format::pb21::Rle,
+    decompression_strategy: &dyn DecompressionStrategy,
+) -> Result<RleDecompressor> {
     let values = rle
         .values
         .as_ref()
@@ -1166,42 +1171,162 @@ fn validate_rle_compression(rle: &crate::format::pb21::Rle) -> Result<(u64, RunL
         .as_ref()
         .ok_or_else(|| Error::invalid_input("RLE compression missing run lengths encoding"))?;
 
-    let values = values
-        .compression
-        .as_ref()
-        .ok_or_else(|| Error::invalid_input("RLE compression missing values compression"))?;
-    let Compression::Flat(values) = values else {
-        return Err(Error::invalid_input(
-            "RLE compression only supports flat values",
-        ));
-    };
+    let values = create_rle_child_decompressor(values, "values", decompression_strategy)?;
+    let run_lengths =
+        create_rle_child_decompressor(run_lengths, "run lengths", decompression_strategy)?;
 
-    let run_lengths = run_lengths
-        .compression
-        .as_ref()
-        .ok_or_else(|| Error::invalid_input("RLE compression missing run lengths compression"))?;
-    let Compression::Flat(run_lengths) = run_lengths else {
-        return Err(Error::invalid_input(
-            "RLE compression only supports flat run lengths",
-        ));
-    };
-
-    if !matches!(values.bits_per_value, 8 | 16 | 32 | 64) {
+    if !matches!(values.bits_per_value(), 8 | 16 | 32 | 64) {
         return Err(Error::invalid_input(format!(
             "RLE compression only supports 8, 16, 32, or 64-bit values, got {}",
-            values.bits_per_value
+            values.bits_per_value()
         )));
     }
 
     let run_length_width =
-        RunLengthWidth::from_bits(run_lengths.bits_per_value).ok_or_else(|| {
+        RunLengthWidth::from_bits(run_lengths.bits_per_value()).ok_or_else(|| {
             Error::invalid_input(format!(
                 "RLE compression only supports 8, 16, or 32-bit run lengths, got {}",
-                run_lengths.bits_per_value
+                run_lengths.bits_per_value()
             ))
         })?;
 
-    Ok((values.bits_per_value, run_length_width))
+    if values.requires_num_values() && run_lengths.requires_num_values() {
+        return Err(Error::invalid_input(
+            "RLE values and run lengths child encodings cannot both require the run count",
+        ));
+    }
+
+    if values.is_identity() && run_lengths.is_identity() {
+        return Ok(RleDecompressor::with_run_length_width(
+            values.bits_per_value(),
+            run_length_width,
+        ));
+    }
+
+    Ok(RleDecompressor::with_child_decompressors(
+        values.bits_per_value(),
+        run_length_width,
+        values,
+        run_lengths,
+    ))
+}
+
+fn create_rle_child_decompressor(
+    encoding: &CompressiveEncoding,
+    role: &str,
+    decompression_strategy: &dyn DecompressionStrategy,
+) -> Result<RleChildDecompressor> {
+    let compression = encoding
+        .compression
+        .as_ref()
+        .ok_or_else(|| Error::invalid_input(format!("RLE {role} missing child compression")))?;
+    let (bits_per_value, requires_num_values, needs_decompressor) =
+        validate_rle_child_compression(compression, role)?;
+
+    if needs_decompressor {
+        Ok(RleChildDecompressor::block(
+            bits_per_value,
+            decompression_strategy.create_block_decompressor(encoding)?,
+            requires_num_values,
+        ))
+    } else {
+        Ok(RleChildDecompressor::flat(bits_per_value))
+    }
+}
+
+fn validate_rle_child_compression(
+    compression: &Compression,
+    role: &str,
+) -> Result<(u64, bool, bool)> {
+    match compression {
+        Compression::Flat(flat) => Ok((flat.bits_per_value, false, false)),
+        Compression::General(general) => {
+            general.compression.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} general child missing compression config"
+                ))
+            })?;
+            let values = general.values.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!("RLE {role} general child missing inner encoding"))
+            })?;
+            let inner = values.compression.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} general child missing inner compression"
+                ))
+            })?;
+            let (bits_per_value, requires_num_values) =
+                validate_rle_block_child_inner(inner, role)?;
+            Ok((bits_per_value, requires_num_values, true))
+        }
+        Compression::OutOfLineBitpacking(out_of_line) => {
+            let values = out_of_line.values.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} bitpacking child missing values encoding"
+                ))
+            })?;
+            let Compression::Flat(_) = values.compression.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} bitpacking child missing values compression"
+                ))
+            })?
+            else {
+                return Err(Error::invalid_input(format!(
+                    "RLE {role} bitpacking child only supports flat values"
+                )));
+            };
+            Ok((out_of_line.uncompressed_bits_per_value, true, true))
+        }
+        other => Err(Error::invalid_input(format!(
+            "RLE {role} only supports flat, general, or out-of-line bitpacking child encodings, got {}",
+            compression_name(other)
+        ))),
+    }
+}
+
+fn validate_rle_block_child_inner(compression: &Compression, role: &str) -> Result<(u64, bool)> {
+    match compression {
+        Compression::Flat(flat) => Ok((flat.bits_per_value, false)),
+        Compression::OutOfLineBitpacking(out_of_line) => {
+            let values = out_of_line.values.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} bitpacking child missing values encoding"
+                ))
+            })?;
+            let Compression::Flat(_) = values.compression.as_ref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE {role} bitpacking child missing values compression"
+                ))
+            })?
+            else {
+                return Err(Error::invalid_input(format!(
+                    "RLE {role} bitpacking child only supports flat values"
+                )));
+            };
+            Ok((out_of_line.uncompressed_bits_per_value, true))
+        }
+        other => Err(Error::invalid_input(format!(
+            "RLE {role} general child only supports flat or out-of-line bitpacking inner encodings, got {}",
+            compression_name(other)
+        ))),
+    }
+}
+
+fn compression_name(compression: &Compression) -> &'static str {
+    match compression {
+        Compression::Flat(_) => "flat",
+        Compression::Variable(_) => "variable",
+        Compression::Fsst(_) => "fsst",
+        Compression::OutOfLineBitpacking(_) => "out-of-line bitpacking",
+        Compression::InlineBitpacking(_) => "inline bitpacking",
+        Compression::General(_) => "general",
+        Compression::Constant(_) => "constant",
+        Compression::Dictionary(_) => "dictionary",
+        Compression::ByteStreamSplit(_) => "byte stream split",
+        Compression::PackedStruct(_) => "packed struct",
+        Compression::FixedSizeList(_) => "fixed-size list",
+        Compression::VariablePackedStruct(_) => "variable packed struct",
+        Compression::Rle(_) => "rle",
+    }
 }
 
 #[cfg(test)]

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -171,6 +171,7 @@ fn try_bss_for_mini_block(
 
 fn try_rle_for_mini_block(
     data: &FixedWidthDataBlock,
+    version: LanceFileVersion,
     params: &CompressionFieldParams,
     use_rle_v2: bool,
 ) -> Option<Box<dyn MiniBlockCompressor>> {
@@ -212,22 +213,46 @@ fn try_rle_for_mini_block(
         )
     };
 
-    if rle_bytes < raw_bytes {
-        #[cfg(feature = "bitpacking")]
-        {
-            if let Some(bitpack_bytes) = estimate_inline_bitpacking_bytes(data)
-                && (bitpack_bytes as u128) < rle_bytes
-            {
-                return None;
-            }
+    let use_child_encodings = version.resolve() >= LanceFileVersion::V2_2;
+    let child_compression = if use_child_encodings {
+        rle_child_compression_config(params)
+    } else {
+        None
+    };
+    let use_child_bitpacking = use_child_encodings;
+    let rle_encoder = || {
+        if use_child_encodings {
+            RleEncoder::with_child_encoding(
+                run_length_width,
+                child_compression,
+                child_compression,
+                use_child_bitpacking,
+            )
+        } else {
+            RleEncoder::with_run_length_width(run_length_width)
         }
-        let child_compression = rle_child_compression_config(params);
-        return Some(Box::new(RleEncoder::with_child_encoding(
-            run_length_width,
-            child_compression,
-            child_compression,
-            true,
-        )));
+    };
+
+    #[cfg(feature = "bitpacking")]
+    let bitpack_bytes = estimate_inline_bitpacking_bytes(data).map(u128::from);
+    #[cfg(not(feature = "bitpacking"))]
+    let bitpack_bytes = None::<u128>;
+
+    let mut selected_rle_bytes = rle_bytes;
+    let should_estimate_child_size = use_child_encodings
+        && (child_compression.is_some() || cfg!(feature = "bitpacking"))
+        && (rle_bytes >= raw_bytes || bitpack_bytes.is_some_and(|bytes| bytes < rle_bytes));
+    if should_estimate_child_size {
+        selected_rle_bytes = rle_encoder().selected_payload_size(data).ok()?;
+    }
+
+    if selected_rle_bytes < raw_bytes {
+        if let Some(bitpack_bytes) = bitpack_bytes
+            && bitpack_bytes < selected_rle_bytes
+        {
+            return None;
+        }
+        return Some(Box::new(rle_encoder()));
     }
     None
 }
@@ -606,7 +631,7 @@ impl DefaultCompressionStrategy {
         }
 
         let base = try_bss_for_mini_block(data, params)
-            .or_else(|| try_rle_for_mini_block(data, params, self.use_rle_v2()))
+            .or_else(|| try_rle_for_mini_block(data, self.version, params, self.use_rle_v2()))
             .or_else(|| try_bitpack_for_mini_block(data))
             .unwrap_or_else(|| Box::new(ValueEncoder::default()));
 
@@ -1433,6 +1458,20 @@ mod tests {
         run_lengths.bits_per_value
     }
 
+    fn expect_rle_encoding(encoding: &CompressiveEncoding) -> &crate::format::pb21::Rle {
+        match encoding.compression.as_ref().unwrap() {
+            Compression::Rle(rle) => rle,
+            Compression::General(general) => {
+                let inner = general.values.as_ref().unwrap();
+                let Compression::Rle(rle) = inner.compression.as_ref().unwrap() else {
+                    panic!("expected wrapped RLE encoding");
+                };
+                rle
+            }
+            other => panic!("expected RLE encoding, got {}", compression_name(other)),
+        }
+    }
+
     fn create_variable_width_block(
         bits_per_offset: u8,
         num_values: u64,
@@ -2131,6 +2170,55 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn test_rle_miniblock_v2_1_keeps_flat_children_when_compression_requested() {
+        let mut params = CompressionParams::new();
+        params.columns.insert(
+            "dict_indices".to_string(),
+            CompressionFieldParams {
+                compression: Some(if cfg!(feature = "lz4") { "lz4" } else { "zstd" }.to_string()),
+                rle_threshold: Some(1.0),
+                bss: Some(BssMode::Off),
+                ..Default::default()
+            },
+        );
+        let strategy =
+            DefaultCompressionStrategy::with_params(params).with_version(LanceFileVersion::V2_1);
+        let field = create_test_field("dict_indices", DataType::UInt32);
+
+        let mut values = Vec::with_capacity(8192 * 4);
+        for value in 0..8192u32 {
+            values.extend(std::iter::repeat_n(value, 4));
+        }
+        let mut data = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 8192 * 4,
+            block_info: BlockInfo::default(),
+        };
+        data.compute_stat();
+        let data = DataBlock::FixedWidth(data);
+
+        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+        let (_compressed, encoding) = compressor.compress(data).unwrap();
+        let rle = expect_rle_encoding(&encoding);
+
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            Compression::Flat(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            Compression::Flat(_)
+        ));
+    }
+
+    #[test]
     #[cfg(feature = "bitpacking")]
     fn test_rle_miniblock_strategy_bitpacks_child_values_when_smaller() {
         let field = create_test_field("dict_indices", DataType::Int32);
@@ -2157,6 +2245,54 @@ mod tests {
         let Compression::Rle(rle) = encoding.compression.as_ref().unwrap() else {
             panic!("expected RLE encoding");
         };
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            Compression::OutOfLineBitpacking(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            Compression::Flat(_)
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_miniblock_keeps_child_bitpacked_rle_when_smaller_than_inline_bitpacking() {
+        let field = create_test_field("int_score", DataType::UInt64);
+
+        let mut values = Vec::with_capacity(8192 * 8);
+        for run_idx in 0..8192 {
+            let value = match run_idx % 3 {
+                0 => 3u64,
+                1 => 4u64,
+                _ => 5u64,
+            };
+            values.extend(std::iter::repeat_n(value, 8));
+        }
+        let mut data = FixedWidthDataBlock {
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 8192 * 8,
+            block_info: BlockInfo::default(),
+        };
+        data.compute_stat();
+        let data = DataBlock::FixedWidth(data);
+
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_2);
+        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+        let debug_str = format!("{compressor:?}");
+        assert!(
+            debug_str.contains("RleEncoder"),
+            "expected RLE to beat inline bitpacking after child selection, got: {debug_str}"
+        );
+
+        let (_compressed, encoding) = compressor.compress(data).unwrap();
+        let rle = expect_rle_encoding(&encoding);
         assert!(matches!(
             rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
             Compression::OutOfLineBitpacking(_)

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -222,10 +222,11 @@ fn try_rle_for_mini_block(
             }
         }
         let child_compression = rle_child_compression_config(params);
-        return Some(Box::new(RleEncoder::with_child_compression(
+        return Some(Box::new(RleEncoder::with_child_encoding(
             run_length_width,
             child_compression,
             child_compression,
+            true,
         )));
     }
     None
@@ -2127,6 +2128,48 @@ mod tests {
         let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
         let (_compressed, encoding) = compressor.compress(data).unwrap();
         assert_eq!(rle_run_length_bits(&encoding), 8);
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_miniblock_strategy_bitpacks_child_values_when_smaller() {
+        let field = create_test_field("dict_indices", DataType::Int32);
+
+        let mut values = Vec::with_capacity(8192 * 4);
+        for value in 0..8192 {
+            values.extend(std::iter::repeat_n(value, 4));
+        }
+        let mut data = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 8192 * 4,
+            block_info: BlockInfo::default(),
+        };
+        data.compute_stat();
+        let data = DataBlock::FixedWidth(data);
+
+        let strategy = DefaultCompressionStrategy::new().with_version(LanceFileVersion::V2_3);
+        let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
+        let debug_str = format!("{compressor:?}");
+        assert!(debug_str.contains("RleEncoder"));
+
+        let (_compressed, encoding) = compressor.compress(data).unwrap();
+        let Compression::Rle(rle) = encoding.compression.as_ref().unwrap() else {
+            panic!("expected RLE encoding");
+        };
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            Compression::OutOfLineBitpacking(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            Compression::Flat(_)
+        ));
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -65,6 +65,7 @@ use crate::encodings::logical::primitive::miniblock::{
     MAX_MINIBLOCK_BYTES, MAX_MINIBLOCK_VALUES, MiniBlockChunk, MiniBlockCompressed,
     MiniBlockCompressor,
 };
+use crate::encodings::physical::block::{CompressionConfig, GeneralBufferCompressor};
 use crate::format::ProtobufUtils21;
 use crate::format::pb21::CompressiveEncoding;
 
@@ -326,6 +327,8 @@ pub(crate) fn accumulate_run_length_entries(
 #[derive(Debug)]
 pub struct RleEncoder {
     run_length_width: RunLengthWidth,
+    values_compression: Option<CompressionConfig>,
+    run_lengths_compression: Option<CompressionConfig>,
 }
 
 impl Default for RleEncoder {
@@ -338,11 +341,29 @@ impl RleEncoder {
     pub fn new() -> Self {
         Self {
             run_length_width: RunLengthWidth::U8,
+            values_compression: None,
+            run_lengths_compression: None,
         }
     }
 
     pub(crate) fn with_run_length_width(run_length_width: RunLengthWidth) -> Self {
-        Self { run_length_width }
+        Self {
+            run_length_width,
+            values_compression: None,
+            run_lengths_compression: None,
+        }
+    }
+
+    pub(crate) fn with_child_compression(
+        run_length_width: RunLengthWidth,
+        values_compression: Option<CompressionConfig>,
+        run_lengths_compression: Option<CompressionConfig>,
+    ) -> Self {
+        Self {
+            run_length_width,
+            values_compression,
+            run_lengths_compression,
+        }
     }
 
     fn encode_data(
@@ -678,6 +699,74 @@ impl RleEncoder {
 
         total_chunks * (type_size + self.run_length_width.bytes_per_value())
     }
+
+    fn maybe_compress_child_buffer(
+        buffers: &mut [LanceBuffer],
+        chunks: &mut [MiniBlockChunk],
+        buffer_index: usize,
+        bits_per_value: u64,
+        compression: Option<CompressionConfig>,
+    ) -> Result<CompressiveEncoding> {
+        let flat = ProtobufUtils21::flat(bits_per_value, None);
+        let Some(compression) = compression else {
+            return Ok(flat);
+        };
+        if buffers.is_empty() || buffers[buffer_index].is_empty() {
+            return Ok(flat);
+        }
+
+        let compressor = GeneralBufferCompressor::get_compressor(compression)?;
+        let original = &buffers[buffer_index];
+        let mut compressed = Vec::new();
+        let mut offset = 0usize;
+        let mut total_original_size = 0usize;
+        let mut compressed_sizes = Vec::with_capacity(chunks.len());
+
+        for chunk in chunks.iter() {
+            let chunk_size = chunk.buffer_sizes[buffer_index] as usize;
+            let end = offset.checked_add(chunk_size).ok_or_else(|| {
+                Error::invalid_input_source("RLE child buffer offset overflow".into())
+            })?;
+            if end > original.len() {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "RLE child buffer {} chunk size exceeds buffer length: end {}, len {}",
+                        buffer_index,
+                        end,
+                        original.len()
+                    )
+                    .into(),
+                ));
+            }
+
+            let start = compressed.len();
+            compressor.compress(&original.as_ref()[offset..end], &mut compressed)?;
+            let compressed_size = compressed.len() - start;
+            let compressed_size = u32::try_from(compressed_size).map_err(|_| {
+                Error::invalid_input_source(
+                    format!(
+                        "RLE child buffer {} compressed chunk is too large: {} bytes",
+                        buffer_index, compressed_size
+                    )
+                    .into(),
+                )
+            })?;
+            compressed_sizes.push(compressed_size);
+            total_original_size += chunk_size;
+            offset = end;
+        }
+
+        if compressed.len() >= total_original_size {
+            return Ok(flat);
+        }
+
+        buffers[buffer_index] = LanceBuffer::from(compressed);
+        for (chunk, compressed_size) in chunks.iter_mut().zip(compressed_sizes) {
+            chunk.buffer_sizes[buffer_index] = compressed_size;
+        }
+
+        ProtobufUtils21::wrapped(compression, flat)
+    }
 }
 
 impl MiniBlockCompressor for RleEncoder {
@@ -687,8 +776,23 @@ impl MiniBlockCompressor for RleEncoder {
                 let num_values = fixed_width.num_values;
                 let bits_per_value = fixed_width.bits_per_value;
 
-                let (all_buffers, chunks) =
+                let (mut all_buffers, mut chunks) =
                     self.encode_data(&fixed_width.data, num_values, bits_per_value)?;
+
+                let values_encoding = Self::maybe_compress_child_buffer(
+                    &mut all_buffers,
+                    &mut chunks,
+                    0,
+                    bits_per_value,
+                    self.values_compression,
+                )?;
+                let run_lengths_encoding = Self::maybe_compress_child_buffer(
+                    &mut all_buffers,
+                    &mut chunks,
+                    1,
+                    self.run_length_width.bits_per_value(),
+                    self.run_lengths_compression,
+                )?;
 
                 let compressed = MiniBlockCompressed {
                     data: all_buffers,
@@ -696,10 +800,7 @@ impl MiniBlockCompressor for RleEncoder {
                     num_values,
                 };
 
-                let encoding = ProtobufUtils21::rle(
-                    ProtobufUtils21::flat(bits_per_value, None),
-                    ProtobufUtils21::flat(self.run_length_width.bits_per_value(), None),
-                );
+                let encoding = ProtobufUtils21::rle(values_encoding, run_lengths_encoding);
 
                 Ok((compressed, encoding))
             }
@@ -741,6 +842,125 @@ impl BlockCompressor for RleEncoder {
 pub struct RleDecompressor {
     bits_per_value: u64,
     run_length_width: RunLengthWidth,
+    values: RleChildDecompressor,
+    run_lengths: RleChildDecompressor,
+}
+
+#[derive(Debug)]
+pub(crate) struct RleChildDecompressor {
+    bits_per_value: u64,
+    inner: RleChildDecompressorInner,
+}
+
+#[derive(Debug)]
+enum RleChildDecompressorInner {
+    Flat,
+    Block {
+        decompressor: Box<dyn BlockDecompressor>,
+        requires_num_values: bool,
+    },
+}
+
+impl RleChildDecompressor {
+    pub(crate) fn flat(bits_per_value: u64) -> Self {
+        Self {
+            bits_per_value,
+            inner: RleChildDecompressorInner::Flat,
+        }
+    }
+
+    pub(crate) fn block(
+        bits_per_value: u64,
+        decompressor: Box<dyn BlockDecompressor>,
+        requires_num_values: bool,
+    ) -> Self {
+        Self {
+            bits_per_value,
+            inner: RleChildDecompressorInner::Block {
+                decompressor,
+                requires_num_values,
+            },
+        }
+    }
+
+    pub(crate) fn bits_per_value(&self) -> u64 {
+        self.bits_per_value
+    }
+
+    pub(crate) fn requires_num_values(&self) -> bool {
+        match &self.inner {
+            RleChildDecompressorInner::Flat => false,
+            RleChildDecompressorInner::Block {
+                requires_num_values,
+                ..
+            } => *requires_num_values,
+        }
+    }
+
+    pub(crate) fn is_identity(&self) -> bool {
+        matches!(self.inner, RleChildDecompressorInner::Flat)
+    }
+
+    fn decode(
+        &self,
+        data: LanceBuffer,
+        num_values: Option<u64>,
+        label: &str,
+    ) -> Result<LanceBuffer> {
+        match &self.inner {
+            RleChildDecompressorInner::Flat => Ok(data),
+            RleChildDecompressorInner::Block {
+                decompressor,
+                requires_num_values,
+            } => {
+                let num_values = if *requires_num_values {
+                    num_values.ok_or_else(|| {
+                        Error::invalid_input_source(
+                            format!("RLE {label} child compression requires the run count").into(),
+                        )
+                    })?
+                } else {
+                    num_values.unwrap_or(0)
+                };
+                let decoded = decompressor.decompress(data, num_values)?;
+                self.extract_fixed_width(decoded, num_values, label)
+            }
+        }
+    }
+
+    fn extract_fixed_width(
+        &self,
+        data: DataBlock,
+        expected_num_values: u64,
+        label: &str,
+    ) -> Result<LanceBuffer> {
+        match data {
+            DataBlock::FixedWidth(block) => {
+                if block.bits_per_value != self.bits_per_value {
+                    return Err(Error::invalid_input_source(
+                        format!(
+                            "RLE {label} child decoded {}-bit values, expected {}",
+                            block.bits_per_value, self.bits_per_value
+                        )
+                        .into(),
+                    ));
+                }
+                if expected_num_values != 0 && block.num_values != expected_num_values {
+                    return Err(Error::invalid_input_source(
+                        format!(
+                            "RLE {label} child decoded {} values, expected {}",
+                            block.num_values, expected_num_values
+                        )
+                        .into(),
+                    ));
+                }
+                Ok(block.data)
+            }
+            _ => Err(Error::invalid_input_source(
+                format!("RLE {label} child decoded to a non fixed-width block").into(),
+            )),
+        }
+    }
 }
 
 impl RleDecompressor {
@@ -748,6 +968,8 @@ impl RleDecompressor {
         Self {
             bits_per_value,
             run_length_width: RunLengthWidth::U8,
+            values: RleChildDecompressor::flat(bits_per_value),
+            run_lengths: RleChildDecompressor::flat(RunLengthWidth::U8.bits_per_value()),
         }
     }
 
@@ -758,6 +980,22 @@ impl RleDecompressor {
         Self {
             bits_per_value,
             run_length_width,
+            values: RleChildDecompressor::flat(bits_per_value),
+            run_lengths: RleChildDecompressor::flat(run_length_width.bits_per_value()),
+        }
+    }
+
+    pub(crate) fn with_child_decompressors(
+        bits_per_value: u64,
+        run_length_width: RunLengthWidth,
+        values: RleChildDecompressor,
+        run_lengths: RleChildDecompressor,
+    ) -> Self {
+        Self {
+            bits_per_value,
+            run_length_width,
+            values,
+            run_lengths,
         }
     }
 
@@ -781,14 +1019,17 @@ impl RleDecompressor {
             ));
         }
 
-        let values_buffer = &data[0];
-        let lengths_buffer = &data[1];
+        let mut data_iter = data.into_iter();
+        let values_buffer = data_iter.next().unwrap();
+        let lengths_buffer = data_iter.next().unwrap();
+        let (values_buffer, lengths_buffer) =
+            self.decode_child_buffers(values_buffer, lengths_buffer)?;
 
         let decoded_data = match self.bits_per_value {
-            8 => self.decode_generic::<u8>(values_buffer, lengths_buffer, num_values)?,
-            16 => self.decode_generic::<u16>(values_buffer, lengths_buffer, num_values)?,
-            32 => self.decode_generic::<u32>(values_buffer, lengths_buffer, num_values)?,
-            64 => self.decode_generic::<u64>(values_buffer, lengths_buffer, num_values)?,
+            8 => self.decode_generic::<u8>(&values_buffer, &lengths_buffer, num_values)?,
+            16 => self.decode_generic::<u16>(&values_buffer, &lengths_buffer, num_values)?,
+            32 => self.decode_generic::<u32>(&values_buffer, &lengths_buffer, num_values)?,
+            64 => self.decode_generic::<u64>(&values_buffer, &lengths_buffer, num_values)?,
             _ => {
                 return Err(Error::invalid_input_source(
                     format!(
@@ -806,6 +1047,68 @@ impl RleDecompressor {
             num_values,
             block_info: BlockInfo::default(),
         }))
+    }
+
+    fn decode_child_buffers(
+        &self,
+        values_buffer: LanceBuffer,
+        lengths_buffer: LanceBuffer,
+    ) -> Result<(LanceBuffer, LanceBuffer)> {
+        let values_requires_num_runs = self.values.requires_num_values();
+        let lengths_requires_num_runs = self.run_lengths.requires_num_values();
+        if values_requires_num_runs && lengths_requires_num_runs {
+            return Err(Error::invalid_input_source(
+                "RLE values and run lengths child compression both require the run count".into(),
+            ));
+        }
+
+        if values_requires_num_runs {
+            let lengths_buffer = self
+                .run_lengths
+                .decode(lengths_buffer, None, "run lengths")?;
+            let num_runs = Self::num_child_values(
+                &lengths_buffer,
+                self.run_lengths.bits_per_value(),
+                "run lengths",
+            )?;
+            let values_buffer = self
+                .values
+                .decode(values_buffer, Some(num_runs), "values")?;
+            Ok((values_buffer, lengths_buffer))
+        } else if lengths_requires_num_runs {
+            let values_buffer = self.values.decode(values_buffer, None, "values")?;
+            let num_runs =
+                Self::num_child_values(&values_buffer, self.values.bits_per_value(), "values")?;
+            let lengths_buffer =
+                self.run_lengths
+                    .decode(lengths_buffer, Some(num_runs), "run lengths")?;
+            Ok((values_buffer, lengths_buffer))
+        } else {
+            let values_buffer = self.values.decode(values_buffer, None, "values")?;
+            let lengths_buffer = self
+                .run_lengths
+                .decode(lengths_buffer, None, "run lengths")?;
+            Ok((values_buffer, lengths_buffer))
+        }
+    }
+
+    fn num_child_values(buffer: &LanceBuffer, bits_per_value: u64, label: &str) -> Result<u64> {
+        let bytes_per_value = usize::try_from(bits_per_value / 8).map_err(|_| {
+            Error::invalid_input_source(
+                format!("RLE {label} child bit width is too large: {bits_per_value}").into(),
+            )
+        })?;
+        if bytes_per_value == 0 || !buffer.len().is_multiple_of(bytes_per_value) {
+            return Err(Error::invalid_input_source(
+                format!(
+                    "RLE {label} child decoded to {} bytes, not divisible by {}",
+                    buffer.len(),
+                    bytes_per_value
+                )
+                .into(),
+            ));
+        }
+        Ok((buffer.len() / bytes_per_value) as u64)
     }
 
     fn decode_generic<T>(
@@ -963,9 +1266,14 @@ impl BlockDecompressor for RleDecompressor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compression::{DecompressionStrategy, DefaultDecompressionStrategy};
     use crate::data::DataBlock;
     use crate::encodings::logical::primitive::miniblock::MAX_MINIBLOCK_VALUES;
-    use crate::{buffer::LanceBuffer, compression::BlockDecompressor};
+    use crate::encodings::physical::block::{CompressionConfig, CompressionScheme};
+    use crate::{
+        buffer::LanceBuffer,
+        compression::{BlockCompressor, BlockDecompressor},
+    };
     use arrow_array::Int32Array;
     // ========== Core Functionality Tests ==========
 
@@ -1044,6 +1352,241 @@ mod tests {
             }
             _ => panic!("Expected FixedWidth block"),
         }
+    }
+
+    #[test]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn test_rle_miniblock_compressed_values_child() {
+        let compression = test_general_compression();
+        let encoder =
+            RleEncoder::with_child_compression(RunLengthWidth::U8, Some(compression), None);
+        let array = Int32Array::from(repeating_runs(1024, 4));
+        let (compressed, encoding) =
+            MiniBlockCompressor::compress(&encoder, DataBlock::from_array(array)).unwrap();
+
+        let rle = expect_rle(&encoding);
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::General(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::Flat(_)
+        ));
+
+        let decompressor = DefaultDecompressionStrategy::default()
+            .create_miniblock_decompressor(&encoding, &DefaultDecompressionStrategy::default())
+            .unwrap();
+        let decoded =
+            MiniBlockDecompressor::decompress(decompressor.as_ref(), compressed.data, 1024 * 4)
+                .unwrap();
+        assert_decoded_i32_eq(decoded, &repeating_runs(1024, 4));
+    }
+
+    #[test]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn test_rle_miniblock_compressed_run_lengths_child() {
+        let compression = test_general_compression();
+        let encoder =
+            RleEncoder::with_child_compression(RunLengthWidth::U8, None, Some(compression));
+        let expected = repeating_runs(1024, 4);
+        let (compressed, encoding) = MiniBlockCompressor::compress(
+            &encoder,
+            DataBlock::from_array(Int32Array::from(expected.clone())),
+        )
+        .unwrap();
+
+        let rle = expect_rle(&encoding);
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::Flat(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::General(_)
+        ));
+
+        let decompressor = DefaultDecompressionStrategy::default()
+            .create_miniblock_decompressor(&encoding, &DefaultDecompressionStrategy::default())
+            .unwrap();
+        let decoded =
+            MiniBlockDecompressor::decompress(decompressor.as_ref(), compressed.data, 1024 * 4)
+                .unwrap();
+        assert_decoded_i32_eq(decoded, &expected);
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_miniblock_bitpacked_run_lengths_child() {
+        use crate::encodings::physical::bitpacking::OutOfLineBitpacking;
+
+        let expected = repeating_runs(1024, 4);
+        let (compressed, _) = MiniBlockCompressor::compress(
+            &RleEncoder::new(),
+            DataBlock::from_array(Int32Array::from(expected.clone())),
+        )
+        .unwrap();
+        let run_lengths = compressed.data[1].clone();
+        let num_runs = run_lengths.len() as u64;
+        let run_lengths_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 8,
+            data: run_lengths,
+            num_values: num_runs,
+            block_info: BlockInfo::default(),
+        });
+        let bitpacked_run_lengths =
+            BlockCompressor::compress(&OutOfLineBitpacking::new(3, 8), run_lengths_block).unwrap();
+        let encoding = ProtobufUtils21::rle(
+            ProtobufUtils21::flat(32, None),
+            ProtobufUtils21::out_of_line_bitpacking(8, ProtobufUtils21::flat(3, None)),
+        );
+
+        let decompressor = DefaultDecompressionStrategy::default()
+            .create_miniblock_decompressor(&encoding, &DefaultDecompressionStrategy::default())
+            .unwrap();
+        let decoded = MiniBlockDecompressor::decompress(
+            decompressor.as_ref(),
+            vec![compressed.data[0].clone(), bitpacked_run_lengths],
+            expected.len() as u64,
+        )
+        .unwrap();
+        assert_decoded_i32_eq(decoded, &expected);
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_rejects_two_count_dependent_child_encodings() {
+        let encoding = ProtobufUtils21::rle(
+            ProtobufUtils21::out_of_line_bitpacking(32, ProtobufUtils21::flat(3, None)),
+            ProtobufUtils21::out_of_line_bitpacking(8, ProtobufUtils21::flat(3, None)),
+        );
+
+        let err = DefaultDecompressionStrategy::default()
+            .create_miniblock_decompressor(&encoding, &DefaultDecompressionStrategy::default())
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot both require the run count")
+        );
+    }
+
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn test_general_compression() -> CompressionConfig {
+        if cfg!(feature = "zstd") {
+            CompressionConfig::new(CompressionScheme::Zstd, Some(3))
+        } else {
+            CompressionConfig::new(CompressionScheme::Lz4, None)
+        }
+    }
+
+    fn repeating_runs(num_runs: usize, run_length: usize) -> Vec<i32> {
+        let mut values = Vec::with_capacity(num_runs * run_length);
+        for run in 0..num_runs {
+            values.extend(std::iter::repeat_n((run % 8) as i32, run_length));
+        }
+        values
+    }
+
+    fn expect_rle(encoding: &CompressiveEncoding) -> &crate::format::pb21::Rle {
+        match encoding.compression.as_ref().unwrap() {
+            crate::format::pb21::compressive_encoding::Compression::Rle(rle) => rle,
+            other => panic!("expected RLE encoding, got {other:?}"),
+        }
+    }
+
+    fn assert_decoded_i32_eq(decoded: DataBlock, expected: &[i32]) {
+        match decoded {
+            DataBlock::FixedWidth(block) => {
+                let values = block.data.borrow_to_typed_slice::<i32>();
+                assert_eq!(values.as_ref(), expected);
+            }
+            _ => panic!("Expected FixedWidth block"),
+        }
+    }
+
+    #[test]
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn test_rle_miniblock_compressed_children_multiple_chunks() {
+        let compression = test_general_compression();
+        let encoder = RleEncoder::with_child_compression(
+            RunLengthWidth::U8,
+            Some(compression),
+            Some(compression),
+        );
+        let expected = repeating_runs(8192, 4);
+        let (compressed, encoding) = MiniBlockCompressor::compress(
+            &encoder,
+            DataBlock::from_array(Int32Array::from(expected.clone())),
+        )
+        .unwrap();
+
+        assert!(compressed.chunks.len() > 1);
+        let rle = expect_rle(&encoding);
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::General(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::General(_)
+        ));
+
+        let decoded = decompress_i32_chunks(&compressed, &encoding);
+        assert_eq!(decoded, expected);
+    }
+
+    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    fn decompress_i32_chunks(
+        compressed: &MiniBlockCompressed,
+        encoding: &CompressiveEncoding,
+    ) -> Vec<i32> {
+        let strategy = DefaultDecompressionStrategy::default();
+        let decompressor = strategy
+            .create_miniblock_decompressor(encoding, &strategy)
+            .unwrap();
+        let mut offsets = vec![0usize; compressed.data.len()];
+        let mut values_processed = 0u64;
+        let mut decoded_values = Vec::new();
+
+        for chunk in &compressed.chunks {
+            let chunk_values = chunk.num_values(values_processed, compressed.num_values);
+            let mut chunk_buffers = Vec::with_capacity(chunk.buffer_sizes.len());
+            for (idx, size) in chunk.buffer_sizes.iter().enumerate() {
+                let size = *size as usize;
+                chunk_buffers.push(compressed.data[idx].slice_with_length(offsets[idx], size));
+                offsets[idx] += size;
+            }
+
+            let decoded = decompressor
+                .decompress(chunk_buffers, chunk_values)
+                .unwrap();
+            match decoded {
+                DataBlock::FixedWidth(block) => {
+                    let values = block.data.borrow_to_typed_slice::<i32>();
+                    decoded_values.extend_from_slice(values.as_ref());
+                }
+                _ => panic!("Expected FixedWidth block"),
+            }
+            values_processed += chunk_values;
+        }
+
+        assert_eq!(values_processed, compressed.num_values);
+        decoded_values
     }
 
     #[test]
@@ -1566,6 +2109,30 @@ mod tests {
         ); // 20% variety
         let arr = Arc::new(Int32Array::from(values)) as Arc<dyn Array>;
         check_round_trip_encoding_of_data(vec![arr], &test_cases, metadata).await;
+
+        #[cfg(any(feature = "lz4", feature = "zstd"))]
+        {
+            let mut metadata = HashMap::new();
+            metadata.insert(
+                "lance-encoding:rle-threshold".to_string(),
+                "0.8".to_string(),
+            );
+            metadata.insert("lance-encoding:bss".to_string(), "off".to_string());
+            metadata.insert(
+                "lance-encoding:compression".to_string(),
+                if cfg!(feature = "zstd") {
+                    "zstd".to_string()
+                } else {
+                    "lz4".to_string()
+                },
+            );
+            let mut values = Vec::with_capacity(2048 * 4);
+            for run in 0..2048 {
+                values.extend(std::iter::repeat_n(i32::MIN + (run % 8), 4));
+            }
+            let arr = Arc::new(Int32Array::from(values)) as Arc<dyn Array>;
+            check_round_trip_encoding_of_data(vec![arr], &test_cases, metadata).await;
+        }
     }
 
     /// Generator that produces repetitive patterns suitable for RLE

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -990,6 +990,34 @@ impl RleEncoder {
             best.expect("flat RLE child candidates should always be selectable");
         (values[value_idx].clone(), run_lengths[length_idx].clone())
     }
+
+    pub(crate) fn selected_payload_size(&self, data: &FixedWidthDataBlock) -> Result<u128> {
+        let (all_buffers, chunks) =
+            self.encode_data(&data.data, data.num_values, data.bits_per_value)?;
+        if all_buffers.is_empty() {
+            return Ok(0);
+        }
+
+        let values_candidates = Self::child_candidates(
+            &all_buffers,
+            &chunks,
+            0,
+            data.bits_per_value,
+            self.values_compression,
+            self.use_child_bitpacking,
+        )?;
+        let run_lengths_candidates = Self::child_candidates(
+            &all_buffers,
+            &chunks,
+            1,
+            self.run_length_width.bits_per_value(),
+            self.run_lengths_compression,
+            self.use_child_bitpacking,
+        )?;
+        let (values, run_lengths) =
+            Self::select_child_candidates(values_candidates, run_lengths_candidates);
+        Ok((values.size as u128).saturating_add(run_lengths.size as u128))
+    }
 }
 
 impl RleChildCandidate {

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -329,6 +329,16 @@ pub struct RleEncoder {
     run_length_width: RunLengthWidth,
     values_compression: Option<CompressionConfig>,
     run_lengths_compression: Option<CompressionConfig>,
+    use_child_bitpacking: bool,
+}
+
+#[derive(Clone)]
+struct RleChildCandidate {
+    encoding: CompressiveEncoding,
+    data: LanceBuffer,
+    chunk_sizes: Vec<u32>,
+    size: usize,
+    requires_num_values: bool,
 }
 
 impl Default for RleEncoder {
@@ -343,6 +353,7 @@ impl RleEncoder {
             run_length_width: RunLengthWidth::U8,
             values_compression: None,
             run_lengths_compression: None,
+            use_child_bitpacking: false,
         }
     }
 
@@ -351,18 +362,21 @@ impl RleEncoder {
             run_length_width,
             values_compression: None,
             run_lengths_compression: None,
+            use_child_bitpacking: false,
         }
     }
 
-    pub(crate) fn with_child_compression(
+    pub(crate) fn with_child_encoding(
         run_length_width: RunLengthWidth,
         values_compression: Option<CompressionConfig>,
         run_lengths_compression: Option<CompressionConfig>,
+        use_child_bitpacking: bool,
     ) -> Self {
         Self {
             run_length_width,
             values_compression,
             run_lengths_compression,
+            use_child_bitpacking,
         }
     }
 
@@ -700,20 +714,34 @@ impl RleEncoder {
         total_chunks * (type_size + self.run_length_width.bytes_per_value())
     }
 
-    fn maybe_compress_child_buffer(
-        buffers: &mut [LanceBuffer],
-        chunks: &mut [MiniBlockChunk],
+    fn flat_child_candidate(
+        buffers: &[LanceBuffer],
+        chunks: &[MiniBlockChunk],
         buffer_index: usize,
         bits_per_value: u64,
-        compression: Option<CompressionConfig>,
-    ) -> Result<CompressiveEncoding> {
-        let flat = ProtobufUtils21::flat(bits_per_value, None);
-        let Some(compression) = compression else {
-            return Ok(flat);
-        };
-        if buffers.is_empty() || buffers[buffer_index].is_empty() {
-            return Ok(flat);
+    ) -> RleChildCandidate {
+        RleChildCandidate {
+            encoding: ProtobufUtils21::flat(bits_per_value, None),
+            data: buffers[buffer_index].clone(),
+            chunk_sizes: chunks
+                .iter()
+                .map(|chunk| chunk.buffer_sizes[buffer_index])
+                .collect(),
+            size: buffers[buffer_index].len(),
+            requires_num_values: false,
         }
+    }
+
+    fn general_child_candidate(
+        buffers: &[LanceBuffer],
+        chunks: &[MiniBlockChunk],
+        buffer_index: usize,
+        bits_per_value: u64,
+        compression: CompressionConfig,
+    ) -> Result<Option<RleChildCandidate>> {
+        if buffers.is_empty() || buffers[buffer_index].is_empty() {
+            return Ok(None);
+        };
 
         let compressor = GeneralBufferCompressor::get_compressor(compression)?;
         let original = &buffers[buffer_index];
@@ -757,15 +785,217 @@ impl RleEncoder {
         }
 
         if compressed.len() >= total_original_size {
-            return Ok(flat);
+            return Ok(None);
         }
 
-        buffers[buffer_index] = LanceBuffer::from(compressed);
-        for (chunk, compressed_size) in chunks.iter_mut().zip(compressed_sizes) {
-            chunk.buffer_sizes[buffer_index] = compressed_size;
+        let encoding =
+            ProtobufUtils21::wrapped(compression, ProtobufUtils21::flat(bits_per_value, None))?;
+        Ok(Some(
+            RleChildCandidate {
+                encoding,
+                data: LanceBuffer::from(compressed),
+                chunk_sizes: compressed_sizes,
+                size: 0,
+                requires_num_values: false,
+            }
+            .with_size_from_data(),
+        ))
+    }
+
+    #[cfg(feature = "bitpacking")]
+    fn bitpacked_child_candidate(
+        buffers: &[LanceBuffer],
+        chunks: &[MiniBlockChunk],
+        buffer_index: usize,
+        bits_per_value: u64,
+    ) -> Result<Option<RleChildCandidate>> {
+        let original = &buffers[buffer_index];
+        if original.is_empty() {
+            return Ok(None);
+        }
+        let packed_bits = Self::required_bits(original, bits_per_value)?;
+        if packed_bits >= bits_per_value {
+            return Ok(None);
         }
 
-        ProtobufUtils21::wrapped(compression, flat)
+        let compressor = crate::encodings::physical::bitpacking::OutOfLineBitpacking::new(
+            packed_bits,
+            bits_per_value,
+        );
+        let mut packed = Vec::new();
+        let mut offset = 0usize;
+        let mut packed_sizes = Vec::with_capacity(chunks.len());
+        let bytes_per_value = usize::try_from(bits_per_value / 8).map_err(|_| {
+            Error::invalid_input_source(
+                format!("RLE child bit width is too large: {bits_per_value}").into(),
+            )
+        })?;
+
+        for chunk in chunks {
+            let chunk_size = chunk.buffer_sizes[buffer_index] as usize;
+            let end = offset.checked_add(chunk_size).ok_or_else(|| {
+                Error::invalid_input_source("RLE child buffer offset overflow".into())
+            })?;
+            if end > original.len() {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "RLE child buffer {} chunk size exceeds buffer length: end {}, len {}",
+                        buffer_index,
+                        end,
+                        original.len()
+                    )
+                    .into(),
+                ));
+            }
+            if bytes_per_value == 0 || !chunk_size.is_multiple_of(bytes_per_value) {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "RLE child buffer {} chunk has invalid size {} for {} bits per value",
+                        buffer_index, chunk_size, bits_per_value
+                    )
+                    .into(),
+                ));
+            }
+
+            let child_values = (chunk_size / bytes_per_value) as u64;
+            let block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                bits_per_value,
+                data: original.slice_with_length(offset, chunk_size),
+                num_values: child_values,
+                block_info: BlockInfo::default(),
+            });
+            let chunk_packed = BlockCompressor::compress(&compressor, block)?;
+            let packed_size = u32::try_from(chunk_packed.len()).map_err(|_| {
+                Error::invalid_input_source(
+                    format!(
+                        "RLE child buffer {} bitpacked chunk is too large: {} bytes",
+                        buffer_index,
+                        chunk_packed.len()
+                    )
+                    .into(),
+                )
+            })?;
+            packed_sizes.push(packed_size);
+            packed.extend_from_slice(chunk_packed.as_ref());
+            offset = end;
+        }
+
+        if packed.len() >= original.len() {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            RleChildCandidate {
+                encoding: ProtobufUtils21::out_of_line_bitpacking(
+                    bits_per_value,
+                    ProtobufUtils21::flat(packed_bits, None),
+                ),
+                data: LanceBuffer::from(packed),
+                chunk_sizes: packed_sizes,
+                size: 0,
+                requires_num_values: true,
+            }
+            .with_size_from_data(),
+        ))
+    }
+
+    #[cfg(feature = "bitpacking")]
+    fn required_bits(buffer: &LanceBuffer, bits_per_value: u64) -> Result<u64> {
+        let max_value = match bits_per_value {
+            8 => buffer.as_ref().iter().map(|value| *value as u64).max(),
+            16 => buffer
+                .as_ref()
+                .chunks_exact(2)
+                .map(|value| u16::from_le_bytes(value.try_into().unwrap()) as u64)
+                .max(),
+            32 => buffer
+                .as_ref()
+                .chunks_exact(4)
+                .map(|value| u32::from_le_bytes(value.try_into().unwrap()) as u64)
+                .max(),
+            64 => buffer
+                .as_ref()
+                .chunks_exact(8)
+                .map(|value| u64::from_le_bytes(value.try_into().unwrap()))
+                .max(),
+            _ => {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "RLE child bitpacking only supports 8, 16, 32, or 64-bit values, got {bits_per_value}"
+                    )
+                    .into(),
+                ));
+            }
+        }
+        .unwrap_or(0);
+        Ok((u64::BITS - max_value.leading_zeros()).max(1) as u64)
+    }
+
+    fn child_candidates(
+        buffers: &[LanceBuffer],
+        chunks: &[MiniBlockChunk],
+        buffer_index: usize,
+        bits_per_value: u64,
+        compression: Option<CompressionConfig>,
+        use_child_bitpacking: bool,
+    ) -> Result<Vec<RleChildCandidate>> {
+        #[cfg(not(feature = "bitpacking"))]
+        let _ = use_child_bitpacking;
+        let mut candidates = vec![Self::flat_child_candidate(
+            buffers,
+            chunks,
+            buffer_index,
+            bits_per_value,
+        )];
+        if let Some(compression) = compression
+            && let Some(candidate) = Self::general_child_candidate(
+                buffers,
+                chunks,
+                buffer_index,
+                bits_per_value,
+                compression,
+            )?
+        {
+            candidates.push(candidate);
+        }
+        #[cfg(feature = "bitpacking")]
+        {
+            if use_child_bitpacking
+                && let Some(candidate) =
+                    Self::bitpacked_child_candidate(buffers, chunks, buffer_index, bits_per_value)?
+            {
+                candidates.push(candidate);
+            }
+        }
+        Ok(candidates)
+    }
+
+    fn select_child_candidates(
+        values: Vec<RleChildCandidate>,
+        run_lengths: Vec<RleChildCandidate>,
+    ) -> (RleChildCandidate, RleChildCandidate) {
+        let mut best: Option<(usize, usize, usize)> = None;
+        for (value_idx, value) in values.iter().enumerate() {
+            for (length_idx, length) in run_lengths.iter().enumerate() {
+                if value.requires_num_values && length.requires_num_values {
+                    continue;
+                }
+                let size = value.size + length.size;
+                if best.is_none_or(|(_, _, best_size)| size < best_size) {
+                    best = Some((value_idx, length_idx, size));
+                }
+            }
+        }
+        let (value_idx, length_idx, _) =
+            best.expect("flat RLE child candidates should always be selectable");
+        (values[value_idx].clone(), run_lengths[length_idx].clone())
+    }
+}
+
+impl RleChildCandidate {
+    fn with_size_from_data(mut self) -> Self {
+        self.size = self.data.len();
+        self
     }
 }
 
@@ -776,31 +1006,55 @@ impl MiniBlockCompressor for RleEncoder {
                 let num_values = fixed_width.num_values;
                 let bits_per_value = fixed_width.bits_per_value;
 
-                let (mut all_buffers, mut chunks) =
+                let (all_buffers, chunks) =
                     self.encode_data(&fixed_width.data, num_values, bits_per_value)?;
+                if all_buffers.is_empty() {
+                    let compressed = MiniBlockCompressed {
+                        data: all_buffers,
+                        chunks,
+                        num_values,
+                    };
+                    let encoding = ProtobufUtils21::rle(
+                        ProtobufUtils21::flat(bits_per_value, None),
+                        ProtobufUtils21::flat(self.run_length_width.bits_per_value(), None),
+                    );
+                    return Ok((compressed, encoding));
+                }
 
-                let values_encoding = Self::maybe_compress_child_buffer(
-                    &mut all_buffers,
-                    &mut chunks,
+                let values_candidates = Self::child_candidates(
+                    &all_buffers,
+                    &chunks,
                     0,
                     bits_per_value,
                     self.values_compression,
+                    self.use_child_bitpacking,
                 )?;
-                let run_lengths_encoding = Self::maybe_compress_child_buffer(
-                    &mut all_buffers,
-                    &mut chunks,
+                let run_lengths_candidates = Self::child_candidates(
+                    &all_buffers,
+                    &chunks,
                     1,
                     self.run_length_width.bits_per_value(),
                     self.run_lengths_compression,
+                    self.use_child_bitpacking,
                 )?;
+                let (values, run_lengths) =
+                    Self::select_child_candidates(values_candidates, run_lengths_candidates);
+                let chunks = chunks
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, chunk)| MiniBlockChunk {
+                        buffer_sizes: vec![values.chunk_sizes[idx], run_lengths.chunk_sizes[idx]],
+                        log_num_values: chunk.log_num_values,
+                    })
+                    .collect();
 
                 let compressed = MiniBlockCompressed {
-                    data: all_buffers,
+                    data: vec![values.data, run_lengths.data],
                     chunks,
                     num_values,
                 };
 
-                let encoding = ProtobufUtils21::rle(values_encoding, run_lengths_encoding);
+                let encoding = ProtobufUtils21::rle(values.encoding, run_lengths.encoding);
 
                 Ok((compressed, encoding))
             }
@@ -1359,7 +1613,7 @@ mod tests {
     fn test_rle_miniblock_compressed_values_child() {
         let compression = test_general_compression();
         let encoder =
-            RleEncoder::with_child_compression(RunLengthWidth::U8, Some(compression), None);
+            RleEncoder::with_child_encoding(RunLengthWidth::U8, Some(compression), None, false);
         let array = Int32Array::from(repeating_runs(1024, 4));
         let (compressed, encoding) =
             MiniBlockCompressor::compress(&encoder, DataBlock::from_array(array)).unwrap();
@@ -1393,7 +1647,7 @@ mod tests {
     fn test_rle_miniblock_compressed_run_lengths_child() {
         let compression = test_general_compression();
         let encoder =
-            RleEncoder::with_child_compression(RunLengthWidth::U8, None, Some(compression));
+            RleEncoder::with_child_encoding(RunLengthWidth::U8, None, Some(compression), false);
         let expected = repeating_runs(1024, 4);
         let (compressed, encoding) = MiniBlockCompressor::compress(
             &encoder,
@@ -1518,10 +1772,11 @@ mod tests {
     #[cfg(any(feature = "lz4", feature = "zstd"))]
     fn test_rle_miniblock_compressed_children_multiple_chunks() {
         let compression = test_general_compression();
-        let encoder = RleEncoder::with_child_compression(
+        let encoder = RleEncoder::with_child_encoding(
             RunLengthWidth::U8,
             Some(compression),
             Some(compression),
+            false,
         );
         let expected = repeating_runs(8192, 4);
         let (compressed, encoding) = MiniBlockCompressor::compress(
@@ -1550,7 +1805,66 @@ mod tests {
         assert_eq!(decoded, expected);
     }
 
-    #[cfg(any(feature = "lz4", feature = "zstd"))]
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_miniblock_bitpacks_values_child_when_smaller() {
+        let encoder = RleEncoder::with_child_encoding(RunLengthWidth::U8, None, None, true);
+        let expected = monotonic_runs(2048, 4);
+        let (compressed, encoding) = MiniBlockCompressor::compress(
+            &encoder,
+            DataBlock::from_array(Int32Array::from(expected.clone())),
+        )
+        .unwrap();
+
+        let rle = expect_rle(&encoding);
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::OutOfLineBitpacking(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::Flat(_)
+        ));
+
+        let decoded = decompress_i32_chunks(&compressed, &encoding);
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_rle_miniblock_bitpacks_run_lengths_when_values_do_not_shrink() {
+        let encoder = RleEncoder::with_child_encoding(RunLengthWidth::U8, None, None, true);
+        let expected = high_entropy_runs(2048, 4);
+        let (compressed, encoding) = MiniBlockCompressor::compress(
+            &encoder,
+            DataBlock::from_array(Int32Array::from(expected.clone())),
+        )
+        .unwrap();
+
+        let rle = expect_rle(&encoding);
+        assert!(matches!(
+            rle.values.as_ref().unwrap().compression.as_ref().unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::Flat(_)
+        ));
+        assert!(matches!(
+            rle.run_lengths
+                .as_ref()
+                .unwrap()
+                .compression
+                .as_ref()
+                .unwrap(),
+            crate::format::pb21::compressive_encoding::Compression::OutOfLineBitpacking(_)
+        ));
+
+        let decoded = decompress_i32_chunks(&compressed, &encoding);
+        assert_eq!(decoded, expected);
+    }
+
     fn decompress_i32_chunks(
         compressed: &MiniBlockCompressed,
         encoding: &CompressiveEncoding,
@@ -1587,6 +1901,28 @@ mod tests {
 
         assert_eq!(values_processed, compressed.num_values);
         decoded_values
+    }
+
+    #[cfg(feature = "bitpacking")]
+    fn monotonic_runs(num_runs: usize, run_length: usize) -> Vec<i32> {
+        let mut values = Vec::with_capacity(num_runs * run_length);
+        for run in 0..num_runs {
+            values.extend(std::iter::repeat_n(run as i32, run_length));
+        }
+        values
+    }
+
+    #[cfg(feature = "bitpacking")]
+    fn high_entropy_runs(num_runs: usize, run_length: usize) -> Vec<i32> {
+        let mut values = Vec::with_capacity(num_runs * run_length);
+        let mut state = 7u64;
+        for _ in 0..num_runs {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            values.extend(std::iter::repeat_n((state >> 32) as i32, run_length));
+        }
+        values
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7329.

RLE miniblock compression currently stores run values and run lengths as raw `Flat` child buffers, so repeated or low-entropy child buffers can dominate the encoded page even after RLE chooses a better shape than raw fixed-width data.

This change lets RLE child buffers choose the smallest valid representation among `Flat`, `OutOfLineBitpacking(Flat)`, and `General(Flat)` when a general compression scheme is configured. The decoder validates the supported nested child encodings and preserves the existing flat path, while rejecting combinations where both children require the run count.

The strategy automatically enables RLE child bitpacking and reuses explicit field compression settings for LZ4/Zstd child candidates, so configured general compression can reduce the values and run-length payload without adding a new public compression knob.

Performance data from a local release microbenchmark is below. Payload bytes exclude metadata; `shape` is `values/run_lengths`.

| Scenario | Plain RLE | Auto child bitpack | LZ4 configured | Zstd configured |
|---|---:|---:|---:|---:|
| Long constant runs | 384 B | 384 B (`flat/flat`) | 384 B (`flat/flat`) | 384 B (`flat/flat`) |
| Short runs, small values | 327,680 B | 90,112 B (`bitpack/flat`) | 5,120 B (`general/general`) | 5,440 B (`general/general`) |
| Short runs, monotonic values | 327,680 B | 196,608 B (`bitpack/flat`) | 132,224 B (`bitpack/general`) | 132,800 B (`bitpack/general`) |
| Short runs, random values | 327,680 B | 286,720 B (`flat/bitpack`) | 263,296 B (`flat/general`) | 263,872 B (`flat/general`) |
| Variable U16 run lengths | 26,226 B | 26,226 B (`flat/flat`) | 26,226 B (`flat/flat`) | 26,226 B (`flat/flat`) |

The encoder falls back to `Flat` when a child encoding does not shrink the payload. In the high-benefit cases, child bitpacking keeps encode/decode time in the same order of magnitude as plain RLE, while LZ4/Zstd trade more CPU for substantially smaller payloads. For example, short runs with small values measured about 512/237 us encode/decode for plain RLE, 517/248 us with child bitpacking, 585/265 us with LZ4, and 633/294 us with Zstd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for newer file versions with more flexible compression choices for encoded data.
  * Added smarter selection between compact encoding options to reduce stored size when possible.

* **Bug Fixes**
  * Fixed decoding issues for data using newer compression layouts.
  * Improved compatibility across older and newer encoded files, including mixed compression settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->