### PR TITLE
feat(transaction): experimental action-based transaction format skeleton

### DIFF
--- a/protos/transaction_experimental.proto
+++ b/protos/transaction_experimental.proto
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+syntax = "proto3";
+
+import "table.proto";
+
+package lance.table;
+
+// EXPERIMENTAL — Action-based transactions (milestone "Action-based
+// Transactions (UserOperation)"; design discussion #5960).
+//
+// This file defines the *unstable* wire format for compound, action-based
+// transactions. It is doubly gated and MUST NOT be treated as a stable format:
+//
+//   1. Rust: only compiled under the non-default `unstable-action-transactions`
+//      Cargo feature, so it is absent from released artifacts.
+//   2. On disk: any dataset that writes one of these transactions sets the
+//      FLAG_ACTION_TRANSACTIONS writer feature flag, so libraries that do not
+//      understand it refuse to commit.
+//
+// The messages here carry NO backwards- or forwards-compatibility guarantee
+// and may change or be removed in any release. Once the format is finalized
+// and ratified by PMC vote, these messages will be promoted into
+// transaction.proto and the guarantee will attach then.
+
+// A user-facing, composable transaction: an ordered list of user actions that
+// commit atomically as a single manifest change.
+//
+// When promoted, this becomes a variant of the top-level `Transaction` in
+// transaction.proto (replacing the single-`Operation` model):
+//
+//   Transaction {
+//     oneof operation {
+//       ...existing operations...
+//       UserOperation user_operation = N;  // <-- actions land here
+//     }
+//   }
+message UserOperation {
+  // Human-readable description, e.g. "INSERT INTO t VALUES (1)".
+  string description = 1;
+  // Unique identifier for this operation, matching Transaction.uuid semantics.
+  string uuid = 2;
+  // The dataset version this operation was planned against.
+  uint64 read_version = 3;
+  // The ordered list of user actions applied by this operation.
+  repeated UserAction actions = 4;
+}
+
+// A single user-recognizable step within a UserOperation (e.g. "append batch",
+// "rebuild index"), carrying a description and the granular actions it expands
+// to. Action lists are flattened when applied to the manifest.
+message UserAction {
+  // Human-readable description of this step.
+  string description = 1;
+  // The granular manifest changes this step expands to.
+  repeated Action actions = 2;
+}
+
+// A granular change to the manifest. Traditional operations decompose into an
+// ordered list of these.
+//
+// EXPERIMENTAL: only `AddFragments` is defined so far, as a proof of shape.
+// The remaining actions (RemoveFragments, UpdateDeletionVector, AddIndex, ...)
+// land in follow-up vertical slices.
+message Action {
+  oneof action {
+    AddFragments add_fragments = 1;
+  }
+}
+
+// Append new fragments to the table.
+//
+// Covers: Append, the "add new rows" part of Overwrite, and new fragments
+// produced by compaction.
+message AddFragments {
+  // The new fragments to append. Fragment IDs are not carried here; they are
+  // assigned at apply time from the manifest's counters (late binding).
+  repeated DataFragment fragments = 1;
+}

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -60,6 +60,10 @@ protobuf-src = { version = "2.1", optional = true }
 
 [features]
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]
+# EXPERIMENTAL: action-based (UserOperation) transactions. Unstable wire format
+# with no compatibility guarantee; not compiled into default builds. See
+# protos/transaction_experimental.proto.
+unstable-action-transactions = []
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance-table/build.rs
+++ b/rust/lance-table/build.rs
@@ -12,18 +12,23 @@ fn main() -> Result<()> {
         std::env::set_var("PROTOC", protobuf_src::protoc());
     }
 
+    // `mut` is used only when the experimental feature adds to the list below.
+    #[allow(unused_mut)]
+    let mut protos = vec![
+        "./protos/table.proto",
+        "./protos/transaction.proto",
+        "./protos/rowids.proto",
+    ];
+    // EXPERIMENTAL: only compile the action-based transaction messages when the
+    // unstable feature is enabled, so they are absent from default builds.
+    #[cfg(feature = "unstable-action-transactions")]
+    protos.push("./protos/transaction_experimental.proto");
+
     let mut prost_build = prost_build::Config::new();
     prost_build.extern_path(".lance.file", "::lance_file::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
-    prost_build.compile_protos(
-        &[
-            "./protos/table.proto",
-            "./protos/transaction.proto",
-            "./protos/rowids.proto",
-        ],
-        &["./protos"],
-    )?;
+    prost_build.compile_protos(&protos, &["./protos"])?;
 
     Ok(())
 }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -46,8 +46,9 @@ const _: () = assert!(FLAG_EXPERIMENTAL < FLAG_UNKNOWN);
 /// its name moves out of this list and onto a dedicated feature-flag bit.
 pub fn known_experimental_features() -> &'static [&'static str] {
     &[
-        // Register experimental feature names here, gated by their Cargo feature:
-        //   #[cfg(feature = "unstable-action-transactions")] "action-transactions",
+        // Register experimental feature names here, gated by their Cargo feature.
+        #[cfg(feature = "unstable-action-transactions")]
+        crate::transaction::FEATURE_NAME,
     ]
 }
 
@@ -246,6 +247,28 @@ mod tests {
 
         assert_ne!(manifest.writer_feature_flags & FLAG_EXPERIMENTAL, 0);
         assert_eq!(manifest.reader_feature_flags & FLAG_EXPERIMENTAL, 0);
+    }
+
+    // Without the Cargo feature, the action-transactions experiment is not
+    // registered, so a dataset declaring it is rejected — this is what makes a
+    // default build refuse action-based transactions.
+    #[cfg(not(feature = "unstable-action-transactions"))]
+    #[test]
+    fn test_action_transactions_rejected_by_default() {
+        let declared = vec!["action-transactions".to_string()];
+        assert!(!can_read_dataset(FLAG_EXPERIMENTAL, &declared));
+        assert!(!can_write_dataset(FLAG_EXPERIMENTAL, &declared));
+    }
+
+    // With the Cargo feature, the experiment is registered and admitted.
+    #[cfg(feature = "unstable-action-transactions")]
+    #[test]
+    fn test_action_transactions_recognized() {
+        let name = crate::transaction::FEATURE_NAME;
+        assert!(known_experimental_features().contains(&name));
+        let declared = vec![name.to_string()];
+        assert!(can_read_dataset(FLAG_EXPERIMENTAL, &declared));
+        assert!(can_write_dataset(FLAG_EXPERIMENTAL, &declared));
     }
 
     #[test]

--- a/rust/lance-table/src/lib.rs
+++ b/rust/lance-table/src/lib.rs
@@ -6,4 +6,8 @@ pub mod format;
 pub mod io;
 pub mod rowids;
 pub mod system_index;
+/// EXPERIMENTAL: action-based (`UserOperation`) transactions. Gated behind the
+/// non-default `unstable-action-transactions` feature; unstable wire format.
+#[cfg(feature = "unstable-action-transactions")]
+pub mod transaction;
 pub mod utils;

--- a/rust/lance-table/src/transaction.rs
+++ b/rust/lance-table/src/transaction.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! EXPERIMENTAL: action-based (`UserOperation`) transactions.
+//!
+//! This module is a skeleton for the "Action-based Transactions" milestone
+//! (design discussion #5960). It models a transaction as an ordered list of
+//! granular [`Action`]s that commit atomically, which is what enables compound
+//! commits such as *append data + create index* in a single manifest change.
+//!
+//! # Stability
+//!
+//! Everything here is **unstable and gated** — it compiles only under the
+//! non-default `unstable-action-transactions` Cargo feature, so it is absent
+//! from released artifacts. It is the first consumer of the general
+//! experimental-feature mechanism: a dataset that persists one of these
+//! transactions declares the [`FEATURE_NAME`] experimental feature, which sets
+//! the `FLAG_EXPERIMENTAL` bit so that libraries which do not understand the
+//! format refuse to commit. The wire format
+//! (`protos/transaction_experimental.proto`) carries no compatibility guarantee
+//! and may change or be removed in any release until it is finalized and
+//! ratified by PMC vote, at which point it graduates to its own feature-flag
+//! bit. See `rust/lance-table/design/experimental_feature_flags.md`.
+//!
+//! # Scope
+//!
+//! Only [`AddFragments`] is implemented, as a proof of shape. The remaining
+//! actions and the translation/conflict-resolution machinery land in follow-up
+//! vertical slices.
+
+use lance_core::deepsize::DeepSizeOf;
+use lance_core::{Error, Result};
+
+use crate::format::{Fragment, pb};
+
+/// The experimental-feature name a dataset declares when its transaction log
+/// uses action-based transactions. Registered in
+/// [`crate::feature_flags::known_experimental_features`] under this crate's
+/// `unstable-action-transactions` feature.
+pub const FEATURE_NAME: &str = "action-transactions";
+
+/// A user-facing, composable transaction: an ordered list of [`UserAction`]s
+/// that commit atomically as a single manifest change.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct UserOperation {
+    /// Human-readable description, e.g. `"INSERT INTO t VALUES (1)"`.
+    pub description: String,
+    /// Unique identifier for this operation.
+    pub uuid: String,
+    /// The dataset version this operation was planned against.
+    pub read_version: u64,
+    /// The ordered list of user actions applied by this operation.
+    pub actions: Vec<UserAction>,
+}
+
+/// A single user-recognizable step within a [`UserOperation`] (e.g. "append
+/// batch", "rebuild index"), carrying a description and the granular actions it
+/// expands to. Action lists are flattened when applied to the manifest.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct UserAction {
+    /// Human-readable description of this step.
+    pub description: String,
+    /// The granular manifest changes this step expands to.
+    pub actions: Vec<Action>,
+}
+
+/// A granular change to the manifest. Traditional operations decompose into an
+/// ordered list of these.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+#[non_exhaustive]
+pub enum Action {
+    /// Append new fragments to the table.
+    AddFragments(AddFragments),
+}
+
+/// Append new fragments to the table.
+///
+/// Covers Append, the "add new rows" part of Overwrite, and new fragments
+/// produced by compaction.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct AddFragments {
+    /// The new fragments to append. Fragment IDs are assigned at apply time
+    /// from the manifest's counters (late binding), not carried here.
+    pub fragments: Vec<Fragment>,
+}
+
+impl From<&AddFragments> for pb::AddFragments {
+    fn from(action: &AddFragments) -> Self {
+        Self {
+            fragments: action
+                .fragments
+                .iter()
+                .map(pb::DataFragment::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::AddFragments> for AddFragments {
+    type Error = Error;
+
+    fn try_from(proto: pb::AddFragments) -> Result<Self> {
+        Ok(Self {
+            fragments: proto
+                .fragments
+                .into_iter()
+                .map(Fragment::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+impl From<&Action> for pb::Action {
+    fn from(action: &Action) -> Self {
+        let action = match action {
+            Action::AddFragments(add) => pb::action::Action::AddFragments(add.into()),
+        };
+        Self {
+            action: Some(action),
+        }
+    }
+}
+
+impl TryFrom<pb::Action> for Action {
+    type Error = Error;
+
+    fn try_from(proto: pb::Action) -> Result<Self> {
+        match proto.action {
+            Some(pb::action::Action::AddFragments(add)) => Ok(Self::AddFragments(add.try_into()?)),
+            None => Err(Error::invalid_input(
+                "Action protobuf has no variant set".to_string(),
+            )),
+        }
+    }
+}
+
+impl From<&UserAction> for pb::UserAction {
+    fn from(user_action: &UserAction) -> Self {
+        Self {
+            description: user_action.description.clone(),
+            actions: user_action.actions.iter().map(pb::Action::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::UserAction> for UserAction {
+    type Error = Error;
+
+    fn try_from(proto: pb::UserAction) -> Result<Self> {
+        Ok(Self {
+            description: proto.description,
+            actions: proto
+                .actions
+                .into_iter()
+                .map(Action::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+impl From<&UserOperation> for pb::UserOperation {
+    fn from(op: &UserOperation) -> Self {
+        Self {
+            description: op.description.clone(),
+            uuid: op.uuid.clone(),
+            read_version: op.read_version,
+            actions: op.actions.iter().map(pb::UserAction::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::UserOperation> for UserOperation {
+    type Error = Error;
+
+    fn try_from(proto: pb::UserOperation) -> Result<Self> {
+        Ok(Self {
+            description: proto.description,
+            uuid: proto.uuid,
+            read_version: proto.read_version,
+            actions: proto
+                .actions
+                .into_iter()
+                .map(UserAction::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_operation_roundtrips_through_protobuf() {
+        let op = UserOperation {
+            description: "INSERT INTO t VALUES (1)".to_string(),
+            uuid: "test-uuid".to_string(),
+            read_version: 7,
+            actions: vec![UserAction {
+                description: "append batch".to_string(),
+                actions: vec![Action::AddFragments(AddFragments {
+                    fragments: vec![Fragment::new(0), Fragment::new(1)],
+                })],
+            }],
+        };
+
+        let proto = pb::UserOperation::from(&op);
+        let roundtripped = UserOperation::try_from(proto).unwrap();
+
+        assert_eq!(op, roundtripped);
+    }
+}

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -163,6 +163,9 @@ huggingface = ["lance-io/huggingface"]
 geo = ["lance-datafusion/geo", "lance-index/geo"]
 # Enable slow integration tests (disabled by default in CI)
 slow_tests = []
+# EXPERIMENTAL: action-based (UserOperation) transactions. Unstable wire format
+# with no compatibility guarantee; not compiled into default builds.
+unstable-action-transactions = ["lance-table/unstable-action-transactions"]
 # Compile the RocksDB comparison arm of the (disabled) mem_wal_kv_point_lookup
 # bench. Commented out so it stays out of CI's all-features build.
 # bench-rocksdb = ["dep:rocksdb"]


### PR DESCRIPTION
Skeleton establishing the *shape and safety gating* of action-based
(`UserOperation`) transactions — the first slice of the Action-based
Transactions milestone (discussion #5960).

## Stacked on #7670

This PR is **stacked on #7670** (the general experimental-feature mechanism).
Its first commit belongs to #7670; review that PR first. Action-based
transactions are the first *consumer* of that mechanism rather than claiming a
dedicated feature-flag bit:

- A dataset using action-based transactions declares the `"action-transactions"`
  experimental feature, registered in `known_experimental_features()` only under
  the `unstable-action-transactions` Cargo feature.
- That sets `FLAG_EXPERIMENTAL`, so libraries that don't understand it fail
  closed. On graduation (PMC vote), the name moves onto its own dedicated bit.

## Double gating

1. **Cargo feature** — everything is behind the non-default
   `unstable-action-transactions` feature, so it is not compiled into released
   builds at all.
2. **Experimental feature flag** — via `FLAG_EXPERIMENTAL` + the
   `"action-transactions"` name, as above.

## What's here (the skeleton commit)

- `protos/transaction_experimental.proto` — `UserOperation` / `UserAction` /
  `Action` (with `AddFragments` only, as a proof of shape), in a separate proto
  file so canonical `transaction.proto` stays clean until promotion. Compiled
  only under the feature.
- `lance_table::transaction` — Rust `UserOperation` / `UserAction` / `Action` /
  `AddFragments` types with protobuf conversions, a roundtrip test, and the
  `FEATURE_NAME` constant.
- Registration of `"action-transactions"` in the experimental-feature registry,
  with admission tests for both default-build (rejected) and feature-on
  (recognized).

## What's NOT here (follow-up vertical slices)

- Translation from `Operation`, `apply`, and conflict resolution.
- Wiring into the commit path / public API (nothing yet *populates* the
  experimental feature list).
- The remaining actions beyond `AddFragments`.

Part of #5960. Precedes the proto PMC vote (#6455), which will promote the
finalized messages into `transaction.proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
