### PR TITLE
fix(index): batch IVF streaming partition search off the CPU pool

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -122,6 +122,22 @@ pub(crate) struct IvfIndexState<Q: Quantization> {
     pub(crate) rq_search_cache: RabitSearchCacheCell,
 }
 
+/// Number of prepared partitions handed to a single `spawn_cpu` dispatch on the
+/// streaming search path.
+///
+/// The streaming path deliberately avoids per-partition CPU-task fan-out (a measured
+/// 14-30% latency win, see #6475). Searching a batch of partitions per `spawn_cpu`
+/// keeps most of that benefit — the per-dispatch overhead is paid once per
+/// `STREAMING_SEARCH_BATCH_SIZE` partitions instead of once per partition — while
+/// keeping the channel `recv`/`send` in async code so no CPU-pool thread ever parks on
+/// a channel (which can deadlock the pool on small hosts, see #7642). `should_stop` is
+/// still checked per partition, so early-stop granularity is unchanged.
+///
+/// This is a tunable knob: larger batches amortize dispatch overhead further and keep
+/// more work on a single CPU thread, at the cost of a higher time-to-first-result and
+/// more prepared partitions held in memory at once.
+pub(crate) const STREAMING_SEARCH_BATCH_SIZE: usize = 16;
+
 struct PreparedPartitionSearch<S: IvfSubIndex, Q: Quantization> {
     query: Query,
     pre_filter: Arc<dyn PreFilter>,
@@ -1665,61 +1681,112 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         let use_query_residual = self.use_query_residual;
         let use_residual_scratch = self.use_residual_scratch;
         let search_metrics = metrics.clone();
-        let batch_tx_for_search = batch_tx.clone();
         let search_control = control.clone();
         let scratch_pool = self.scratch_pool.clone();
+        // Search prepared partitions in batches. Each batch is searched in a single
+        // `spawn_cpu` dispatch (amortizing the per-dispatch overhead the single-worker
+        // design in #6475 avoided), but the channel `recv`/`send` stay in async code so
+        // no CPU-pool thread ever parks on a channel — parking one can deadlock the pool
+        // on small hosts (#7642). `should_stop` is checked per partition, so early-stop
+        // granularity is unchanged.
         tokio::spawn(async move {
-            let search_result = spawn_cpu(move || -> DataFusionResult<()> {
-                scratch_pool.with_scratch(|scratch| {
-                    while let Some(prepared) = prepared_rx.blocking_recv() {
-                        let prepared = match prepared {
-                            Ok(prepared) => prepared,
-                            Err(err) => {
-                                let _ = batch_tx_for_search
-                                    .blocking_send(Err(DataFusionError::from(err)));
-                                return Ok(());
-                            }
-                        };
-
-                        if search_control
-                            .as_ref()
-                            .is_some_and(|control| control.should_stop())
-                        {
-                            return Ok(());
+            loop {
+                let mut prepared_batch = Vec::with_capacity(STREAMING_SEARCH_BATCH_SIZE);
+                let mut prepare_error = None;
+                let mut producer_done = false;
+                while prepared_batch.len() < STREAMING_SEARCH_BATCH_SIZE {
+                    // Stop pulling as soon as the search is done so the producer stops
+                    // preparing partitions we would never search.
+                    if search_control
+                        .as_ref()
+                        .is_some_and(|control| control.should_stop())
+                    {
+                        return;
+                    }
+                    match prepared_rx.recv().await {
+                        Some(Ok(prepared)) => prepared_batch.push(prepared),
+                        Some(Err(err)) => {
+                            prepare_error = Some(DataFusionError::from(err));
+                            break;
                         }
-
-                        let batch = {
-                            Self::run_prepared_partition_search(
-                                use_query_residual,
-                                use_residual_scratch,
-                                prepared,
-                                search_metrics.as_ref(),
-                                scratch,
-                            )
-                        }
-                        .map_err(DataFusionError::from);
-                        match batch {
-                            Ok(batch) => {
-                                if let Some(control) = search_control.as_ref() {
-                                    control.record_batch(&batch);
-                                }
-                                if batch_tx_for_search.blocking_send(Ok(batch)).is_err() {
-                                    return Ok(());
-                                }
-                            }
-                            Err(err) => {
-                                let _ = batch_tx_for_search.blocking_send(Err(err));
-                                return Ok(());
-                            }
+                        None => {
+                            producer_done = true;
+                            break;
                         }
                     }
-                    Ok(())
-                })
-            })
-            .await;
+                }
 
-            if let Err(err) = search_result {
-                let _ = batch_tx.send(Err(err)).await;
+                if !prepared_batch.is_empty() {
+                    let scratch_pool = scratch_pool.clone();
+                    let search_metrics = search_metrics.clone();
+                    let search_control = search_control.clone();
+                    let search_output = spawn_cpu(move || {
+                        let mut outputs: Vec<DataFusionResult<RecordBatch>> =
+                            Vec::with_capacity(prepared_batch.len());
+                        // `stopped` means the whole search should end (an error, or an
+                        // early-stop signal), not just this batch.
+                        let mut stopped = false;
+                        scratch_pool.with_scratch(|scratch| {
+                            for prepared in prepared_batch {
+                                if search_control
+                                    .as_ref()
+                                    .is_some_and(|control| control.should_stop())
+                                {
+                                    stopped = true;
+                                    break;
+                                }
+                                match Self::run_prepared_partition_search(
+                                    use_query_residual,
+                                    use_residual_scratch,
+                                    prepared,
+                                    search_metrics.as_ref(),
+                                    scratch,
+                                )
+                                .map_err(DataFusionError::from)
+                                {
+                                    Ok(batch) => {
+                                        if let Some(control) = search_control.as_ref() {
+                                            control.record_batch(&batch);
+                                        }
+                                        outputs.push(Ok(batch));
+                                    }
+                                    Err(err) => {
+                                        outputs.push(Err(err));
+                                        stopped = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        });
+                        Ok::<_, DataFusionError>((outputs, stopped))
+                    })
+                    .await;
+
+                    let (outputs, stopped) = match search_output {
+                        Ok(output) => output,
+                        // `spawn_cpu` only fails if the closure panics; forward and stop.
+                        Err(err) => {
+                            let _ = batch_tx.send(Err(err)).await;
+                            return;
+                        }
+                    };
+                    for output in outputs {
+                        if batch_tx.send(output).await.is_err() {
+                            return;
+                        }
+                    }
+                    if stopped {
+                        return;
+                    }
+                }
+
+                if let Some(err) = prepare_error {
+                    let _ = batch_tx.send(Err(err)).await;
+                    return;
+                }
+                if producer_done {
+                    return;
+                }
             }
         });
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -2321,6 +2321,7 @@ mod tests {
 
     use crate::dataset::{WriteMode, WriteParams};
     use crate::index::vector::VectorIndexParams;
+    use crate::index::vector::ivf::v2::STREAMING_SEARCH_BATCH_SIZE;
     use crate::io::exec::testing::TestingExec;
 
     fn base_query() -> Query {
@@ -2634,7 +2635,6 @@ mod tests {
             _metrics: Arc<dyn lance_index::metrics::MetricsCollector>,
         ) -> Result<SendableRecordBatchStream> {
             let (batch_tx, batch_rx) = mpsc::channel(1);
-            let batch_tx_for_search = batch_tx.clone();
             let prepared_partition_ids = (start_idx..end_idx)
                 .map(|idx| partitions.value(idx) as usize)
                 .collect::<Vec<_>>();
@@ -2642,42 +2642,71 @@ mod tests {
                 .lock()
                 .unwrap()
                 .extend(prepared_partition_ids.iter().copied());
+            // Mirror the production streaming path (v2.rs): search prepared partitions
+            // in batches of STREAMING_SEARCH_BATCH_SIZE, one `spawn_cpu` per batch, with
+            // the channel send in async code so no CPU-pool thread parks (#7642).
             tokio::spawn(async move {
-                let search_result = spawn_cpu(move || -> DataFusionResult<()> {
-                    for partition_id in prepared_partition_ids {
-                        if control
-                            .as_ref()
-                            .is_some_and(|control| control.should_stop())
-                        {
-                            return Ok(());
+                for chunk in prepared_partition_ids.chunks(STREAMING_SEARCH_BATCH_SIZE) {
+                    if control
+                        .as_ref()
+                        .is_some_and(|control| control.should_stop())
+                    {
+                        return;
+                    }
+                    let chunk = chunk.to_vec();
+                    let index = self.clone();
+                    let control_for_search = control.clone();
+                    let search_output = spawn_cpu(move || {
+                        let mut outputs: Vec<DataFusionResult<RecordBatch>> =
+                            Vec::with_capacity(chunk.len());
+                        let mut stopped = false;
+                        for partition_id in chunk {
+                            if control_for_search
+                                .as_ref()
+                                .is_some_and(|control| control.should_stop())
+                            {
+                                stopped = true;
+                                break;
+                            }
+                            match index
+                                .search_prepared_partition(
+                                    Box::new(partition_id),
+                                    &lance_index::metrics::NoOpMetricsCollector,
+                                )
+                                .map_err(datafusion::error::DataFusionError::from)
+                            {
+                                Ok(batch) => {
+                                    if let Some(control) = control_for_search.as_ref() {
+                                        control.record_batch(&batch);
+                                    }
+                                    outputs.push(Ok(batch));
+                                }
+                                Err(err) => {
+                                    outputs.push(Err(err));
+                                    stopped = true;
+                                    break;
+                                }
+                            }
                         }
-                        let batch = self
-                            .search_prepared_partition(
-                                Box::new(partition_id),
-                                &lance_index::metrics::NoOpMetricsCollector,
-                            )
-                            .map_err(datafusion::error::DataFusionError::from);
-                        match batch {
-                            Ok(batch) => {
-                                if let Some(control) = control.as_ref() {
-                                    control.record_batch(&batch);
-                                }
-                                if batch_tx_for_search.blocking_send(Ok(batch)).is_err() {
-                                    return Ok(());
-                                }
-                            }
-                            Err(err) => {
-                                let _ = batch_tx_for_search.blocking_send(Err(err));
-                                return Ok(());
-                            }
+                        Ok::<_, datafusion::error::DataFusionError>((outputs, stopped))
+                    })
+                    .await;
+
+                    let (outputs, stopped) = match search_output {
+                        Ok(output) => output,
+                        Err(err) => {
+                            let _ = batch_tx.send(Err(err)).await;
+                            return;
+                        }
+                    };
+                    for output in outputs {
+                        if batch_tx.send(output).await.is_err() {
+                            return;
                         }
                     }
-                    Ok(())
-                })
-                .await;
-
-                if let Err(err) = search_result {
-                    let _ = batch_tx.send(Err(err)).await;
+                    if stopped {
+                        return;
+                    }
                 }
             });
 
@@ -2871,8 +2900,16 @@ mod tests {
         );
     }
 
+    // The three partitions fit in a single search batch (3 <= STREAMING_SEARCH_BATCH_SIZE),
+    // so they are searched in one `spawn_cpu` dispatch and therefore share one cpu thread.
     #[tokio::test]
     async fn test_sequential_initial_search_prepares_all_then_searches_on_one_cpu_thread() {
+        const {
+            assert!(
+                3 <= STREAMING_SEARCH_BATCH_SIZE,
+                "test assumes all partitions fit in one search batch",
+            )
+        };
         let (index, prepared_partitions, searched_partitions, search_threads) =
             prepared_index(vec![10, 11, 12]);
         let mut query = base_query();
@@ -2905,6 +2942,52 @@ mod tests {
         assert!(
             search_threads.iter().all(|name| name == &search_threads[0]),
             "expected all prepared searches to reuse one cpu thread, got threads {search_threads:?}",
+        );
+    }
+
+    // Regression guard for the batched streaming search (#7642): with more partitions
+    // than a single batch, the search spans multiple `spawn_cpu` dispatches. Verify that
+    // every partition is still prepared and searched in order across the batch boundary,
+    // and that all search work stays on the cpu runtime.
+    //
+    // Note: this does not reproduce the single-thread-pool deadlock the async recv/send
+    // fixes -- that requires a 1-thread CPU pool, which is a process-global singleton and
+    // impractical to force in a unit test (same limitation noted for the #7423 fix).
+    #[tokio::test]
+    async fn test_sequential_search_spans_multiple_cpu_batches() {
+        let num_partitions = STREAMING_SEARCH_BATCH_SIZE + 3;
+        let row_ids = (0..num_partitions).map(|i| i as u64 * 10).collect();
+        let (index, prepared_partitions, searched_partitions, search_threads) =
+            prepared_index(row_ids);
+        let mut query = base_query();
+        query.minimum_nprobes = num_partitions;
+        let state = Arc::new(ANNIvfEarlySearchResults::new(1, query.k));
+
+        let partition_idx = (0..num_partitions as u32).collect::<Vec<_>>();
+        let q_c_dists = (0..num_partitions).map(|i| i as f32).collect::<Vec<_>>();
+        let batches = ANNIvfSubIndexExec::initial_search(
+            index,
+            query,
+            Arc::new(UInt32Array::from(partition_idx.clone())),
+            Arc::new(Float32Array::from(q_c_dists)),
+            empty_prefilter().await,
+            prepared_metrics(),
+            state,
+            usize::MAX,
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+        let expected: Vec<usize> = (0..num_partitions).collect();
+        assert_eq!(batches.len(), num_partitions);
+        assert_eq!(*prepared_partitions.lock().unwrap(), expected);
+        assert_eq!(*searched_partitions.lock().unwrap(), expected);
+        let search_threads = search_threads.lock().unwrap().clone();
+        assert_eq!(search_threads.len(), num_partitions);
+        assert!(
+            search_threads.iter().all(|name| name.contains("lance-cpu")),
+            "expected prepared searches to run on the cpu runtime, got threads {search_threads:?}",
         );
     }
 


### PR DESCRIPTION
The streaming/sequential partition search (`IVFIndex::search_partitions`, streaming branch) ran its entire `recv` → search → `send` loop inside a single `spawn_cpu` closure, pumping `blocking_recv` on the prepared-partitions channel and `blocking_send` on a capacity-1 output channel. Both park the CPU-pool thread. The producer feeding the input channel does object-store I/O, and its partition decode can itself need the CPU pool, so on hosts whose CPU pool collapses to a single thread (`<= 3` CPUs) — or under enough concurrent queries — the parked search thread and the work that would unblock it can starve each other and deadlock the pool with a silent 0% hang. This is the same deadlock class as #7423.

### Fix

Implements the batched-K approach from the issue discussion (thanks @a-agmon, @BubbleCal). The channel `recv`/`send` move back into the async task; only the pure-CPU search runs in `spawn_cpu`, over a batch of `STREAMING_SEARCH_BATCH_SIZE` prepared partitions at a time:

- **No CPU-pool thread ever parks on a channel** → the deadlock is structurally gone.
- **CPU work stays on the CPU pool** (unlike moving to `spawn_blocking`, which would oversubscribe cores / spawn unbounded threads).
- **Keeps most of the #6475 win**: batching amortizes the per-dispatch overhead the single-worker design was avoiding — the fan-out cost is paid `N/K` times instead of `N`, rather than reintroducing per-partition fan-out.
- **Early-stop unchanged**: `should_stop` is still checked per partition (both before pulling the next batch and before each search within a batch), so granularity is preserved. `record_batch` stays interleaved with the search.

`STREAMING_SEARCH_BATCH_SIZE` is a tunable knob (currently 16): larger batches amortize dispatch further and keep more work on one CPU thread, at the cost of higher time-to-first-result and more prepared partitions held in memory. **The value still needs benchmarking** — @a-agmon offered to characterize `K` against the current single-worker baseline, which is the remaining acceptance item.

### Tests

- Updated the `PreparedThreadCapturingIndex` mock in `knn.rs` to mirror the new non-blocking batched structure (it previously modeled the same blocking-in-`spawn_cpu` anti-pattern).
- Existing sequential tests (`..._searches_on_one_cpu_thread`, `..._stops_search_early`) still pass — 3 partitions fit in one batch.
- New `test_sequential_search_spans_multiple_cpu_batches`: with more partitions than one batch, verifies every partition is still prepared and searched in order across the batch boundary and all search work stays on the cpu runtime.
- `cargo test -p lance` IVF build+search recall suite (36 tests) passes, exercising the real batched path.

As with #7423, this does not add a test that literally reproduces the single-thread-pool deadlock: the CPU pool is a process-global singleton, impractical to force to one thread in a unit test.

Closes #7642

🤖 Generated with [Claude Code](https://claude.com/claude-code)
