### PR TITLE
perf: increase default memory pool to 150MB with 40MB sort spill reservation

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -311,7 +311,6 @@ impl std::fmt::Debug for LanceExecutionOptions {
 }
 
 const DEFAULT_LANCE_MEM_POOL_SIZE_PER_PARTITION: u64 = 150 * 1024 * 1024;
-const DEFAULT_LANCE_SORT_SPILL_RESERVATION_BYTES: usize = 50 * 1024 * 1024;
 const DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE: u64 = 100 * 1024 * 1024 * 1024; // 100GB
 
 impl LanceExecutionOptions {
@@ -361,8 +360,9 @@ impl LanceExecutionOptions {
 }
 
 pub fn new_session_context(options: &LanceExecutionOptions) -> SessionContext {
+    let sort_spill_reservation_bytes = (options.mem_pool_size() / 3) as usize;
     let mut session_config = SessionConfig::new()
-        .with_sort_spill_reservation_bytes(DEFAULT_LANCE_SORT_SPILL_RESERVATION_BYTES);
+        .with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);
     let mut runtime_env_builder = RuntimeEnvBuilder::new();
     if let Some(target_partition) = options.target_partition {
         session_config = session_config.with_target_partitions(target_partition);

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -6,6 +6,7 @@
 use std::{
     collections::HashMap,
     fmt::{self, Formatter},
+    num::NonZero,
     sync::{Arc, Mutex, OnceLock},
     time::Duration,
 };
@@ -14,7 +15,6 @@ use chrono::{DateTime, Utc};
 
 use arrow_array::RecordBatch;
 use arrow_schema::Schema as ArrowSchema;
-use datafusion::physical_plan::metrics::MetricType;
 use datafusion::{
     catalog::streaming::StreamingTable,
     dataframe::DataFrame,
@@ -36,6 +36,7 @@ use datafusion::{
         streaming::PartitionStream,
     },
 };
+use datafusion::{execution::memory_pool::TrackConsumersPool, physical_plan::metrics::MetricType};
 use datafusion_common::{DataFusionError, Statistics};
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 
@@ -360,20 +361,27 @@ impl LanceExecutionOptions {
 }
 
 pub fn new_session_context(options: &LanceExecutionOptions) -> SessionContext {
-    let sort_spill_reservation_bytes = (options.mem_pool_size() / 3) as usize;
-    let mut session_config =
-        SessionConfig::new().with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);
+    let mut session_config = SessionConfig::new();
     let mut runtime_env_builder = RuntimeEnvBuilder::new();
     if let Some(target_partition) = options.target_partition {
         session_config = session_config.with_target_partitions(target_partition);
     }
     if options.use_spilling() {
+        // The default 10MB sort spill reservation seems to be too small for many common cases.
+        //
+        // There currently is no reasonable guidance provided by DataFusion for setting this value.
+        // We bump this to 40MB but try a smaller value if the mem pool is small.
+        let sort_spill_reservation_bytes =
+            (options.mem_pool_size() / 3).min(40 * 1024 * 1024) as usize;
+        session_config =
+            session_config.with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);
         let disk_manager_builder = DiskManagerBuilder::default()
             .with_max_temp_directory_size(options.max_temp_directory_size());
         runtime_env_builder = runtime_env_builder
             .with_disk_manager_builder(disk_manager_builder)
-            .with_memory_pool(Arc::new(FairSpillPool::new(
-                options.mem_pool_size() as usize
+            .with_memory_pool(Arc::new(TrackConsumersPool::new(
+                FairSpillPool::new(options.mem_pool_size() as usize),
+                NonZero::try_from(16).unwrap(),
             )));
     }
     let runtime_env = runtime_env_builder.build_arc().unwrap();

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -310,7 +310,8 @@ impl std::fmt::Debug for LanceExecutionOptions {
     }
 }
 
-const DEFAULT_LANCE_MEM_POOL_SIZE_PER_PARTITION: u64 = 100 * 1024 * 1024;
+const DEFAULT_LANCE_MEM_POOL_SIZE_PER_PARTITION: u64 = 150 * 1024 * 1024;
+const DEFAULT_LANCE_SORT_SPILL_RESERVATION_BYTES: usize = 50 * 1024 * 1024;
 const DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE: u64 = 100 * 1024 * 1024 * 1024; // 100GB
 
 impl LanceExecutionOptions {
@@ -360,7 +361,8 @@ impl LanceExecutionOptions {
 }
 
 pub fn new_session_context(options: &LanceExecutionOptions) -> SessionContext {
-    let mut session_config = SessionConfig::new();
+    let mut session_config = SessionConfig::new()
+        .with_sort_spill_reservation_bytes(DEFAULT_LANCE_SORT_SPILL_RESERVATION_BYTES);
     let mut runtime_env_builder = RuntimeEnvBuilder::new();
     if let Some(target_partition) = options.target_partition {
         session_config = session_config.with_target_partitions(target_partition);

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -361,8 +361,8 @@ impl LanceExecutionOptions {
 
 pub fn new_session_context(options: &LanceExecutionOptions) -> SessionContext {
     let sort_spill_reservation_bytes = (options.mem_pool_size() / 3) as usize;
-    let mut session_config = SessionConfig::new()
-        .with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);
+    let mut session_config =
+        SessionConfig::new().with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);
     let mut runtime_env_builder = RuntimeEnvBuilder::new();
     if let Some(target_partition) = options.target_partition {
         session_config = session_config.with_target_partitions(target_partition);


### PR DESCRIPTION
Raises the per-partition memory pool from 100MB to 150MB and sets the sort spill reservation to 40MB (up from the DataFusion default of 10MB) to give sort operations more headroom while spilling to disk (we should still spill at roughly the same rate).

The previous defaults were 100MB / 10MB.  This _usually_ worked but certain patterns would lead to false memory exhaustion errors:

```
OSError: LanceError(IO): Resources exhausted: Additional allocation failed for ExternalSorterMerge[0] with top memory consumers (across reservations) as:
  ExternalSorterMerge[0]#1(can spill: false) consumed 58.5 MB, peak 58.5 MB,
  ExternalSorter[0]#0(can spill: true) consumed 41.4 MB, peak 89.9 MB.
Error: Failed to allocate additional 345.9 KB for ExternalSorterMerge[0] with 27.6 MB already allocated for this reservation - 92.2 KB remain available for the total pool, /home/pace/lance/rust/lance-datafusion/src/chunker.rs:49:46
```

The problem happens as follows:

1. The sort node accumulates batches of data without modifying them until it determines a spill is needed.  During this phase each batch counts double against the pool reservation.  This is meant to provide overhead for the later steps.  In our above example we can see spilling was triggered at 41.4MB which is about half of the 90MB pool (half, because each batch is counted double)
2. The sort node determines that spilling is needed.  First, it must sort the data that has accumulated in memory.  Each batch is sorted by itself.  This batch sort is in-place and doesn't affect reservations much.
3. A cursor is created for each in-memory batch.  The in-memory batches are then fed into a merge sort.
4. The merge sort accumulates batches of data to send to the spill.  Once a batch is accumulated it is written to the spill file.

Both the cursors and the accumulation require additional space.  This is the `ExternalSorterMerge[0]` mentioned above.  It is given the overcounting described in step 1.  In other words, once this starts, we have half the reservation in `ExternalSorter[0]` and half the reservation in `ExternalSorterMerge[0]`.  This "additional space" _should_ be about the same size as the input.  This is why we count each batch twice.

In practice, the `ExternalSorterMerge[0]` reservation ends up being slightly higher (for various reasons).  This is what the `sort_spill_reservation_bytes` is supposed to account for.  Datafusion defaults this to 10MB.  There is no guidance (and I can't get Claude to come up with any good guidance) as to what this value should be set to.  However, 10MB seems like too little.  This PR updates it to about 1/3 of the memory pool size.  In theory it shouldn't grow proportionally to the memory pool but in practice it seems to.  I also really don't want to expose it as yet another knob that users have to tune so I'm hoping 1/3 is slightly conservative but good enough.