### PR TITLE
fix(lance-core): avoid aliasing &mut Runtime in global_cpu_runtime

### DIFF
--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -66,11 +66,15 @@ static RUNTIME_INSTALLED: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 static ATFORK_INSTALLED: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
-fn global_cpu_runtime() -> &'static mut Runtime {
+fn global_cpu_runtime() -> &'static Runtime {
     loop {
         let ptr = CPU_RUNTIME.load(Ordering::SeqCst);
         if !ptr.is_null() {
-            return unsafe { &mut *ptr };
+            // SAFETY: `ptr` was produced by `Box::into_raw` below and is only ever
+            // reset to null by `atfork_tokio_child` in the forked child (single-
+            // threaded, async-signal context). The `Box` is never reclaimed, so the
+            // `Runtime` lives for the rest of the process.
+            return unsafe { &*ptr };
         }
         if !RUNTIME_INSTALLED.fetch_or(true, Ordering::SeqCst) {
             break;
@@ -82,7 +86,9 @@ fn global_cpu_runtime() -> &'static mut Runtime {
     }
     let new_ptr = Box::into_raw(Box::new(create_runtime()));
     CPU_RUNTIME.store(new_ptr, Ordering::SeqCst);
-    unsafe { &mut *new_ptr }
+    // SAFETY: `new_ptr` was just obtained from `Box::into_raw`, so it is non-null,
+    // aligned, and points to a live `Runtime` that is never reclaimed.
+    unsafe { &*new_ptr }
 }
 
 /// After a fork() operation, force re-creation of the BackgroundExecutor. Note: this function


### PR DESCRIPTION
## What & why

`lance-core` keeps a process-global CPU thread-pool runtime behind `CPU_RUNTIME: AtomicPtr<Runtime>`. `global_cpu_runtime()` dereferenced that raw pointer into `&'static mut Runtime`. Its only caller, `spawn_cpu`, runs concurrently on many worker threads, so multiple `&'static mut` references to the same `Runtime` could be live at once — a violation of `&mut` uniqueness, which is undefined behavior on the Rust abstract machine even though every `Runtime` method actually used takes `&self` and never mutates. It is latent UB the compiler is permitted to miscompile under noalias assumptions (Miri flags it), not an observed crash today.

## How & why it is correct

Return `&'static Runtime` and dereference with `&*ptr` instead. Three facts make this sound:

- The only method called is `Runtime::spawn_blocking`, which takes `&self` — the `&mut` was never needed.
- `Runtime: Sync`, so many threads may hold `&'static Runtime` concurrently without UB, which is exactly the aliasing the old code got wrong.
- The runtime is created via `Box::into_raw` and never reclaimed, so the `&'static` lifetime is genuine (no use-after-free); `atfork_tokio_child` only nulls the pointer, it does not free.

Both `unsafe` derefs now carry `// SAFETY:` comments documenting these invariants.

## Compatibility

Fully backward compatible, zero behavior change. `global_cpu_runtime` is private, so the return-type change is internal-only; `spawn_cpu`'s public signature is unchanged. `&mut Runtime` already auto-reborrowed to `&self` for `spawn_blocking`, so narrowing to `&Runtime` is byte-for-byte identical at runtime — purely tightening a gratuitous, unsound `&mut` into a shared `&`.

## Test plan

- `cargo test -p lance-core`
- `cargo clippy -p lance-core --tests -- -D warnings`
- `cargo fmt --all -- --check`
