### PR TITLE
feat(cache): support register and switch pluggable cache backend

### DIFF
--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -278,6 +278,23 @@ class LanceColumnStatistics:
     size_bytes: int
 
 class _Session:
+    def __init__(
+        self,
+        index_cache_size_bytes: Optional[int] = None,
+        metadata_cache_size_bytes: Optional[int] = None,
+        index_cache_backend: Optional[str | Dict[str, Any]] = None,
+        metadata_cache_backend: Optional[str | Dict[str, Any]] = None,
+    ) -> None:
+        """Create a Lance session.
+
+        Cache backends may be backend URI strings such as
+        ``"moka://?capacity=1048576"`` or dictionaries such as
+        ``{"kind": "moka", "options": {"capacity": "1048576"}}``.
+        ``index_cache_backend`` is mutually exclusive with
+        ``index_cache_size_bytes``. ``metadata_cache_backend`` is mutually
+        exclusive with ``metadata_cache_size_bytes``.
+        """
+        ...
     def size_bytes(self) -> int: ...
     def index_cache_size_bytes(self) -> int: ...
 

--- a/python/python/tests/test_session.py
+++ b/python/python/tests/test_session.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import lance
 import pyarrow as pa
+import pytest
 
 
 def test_cache_size_bytes(
@@ -37,3 +38,41 @@ def test_share_session(tmp_path: Path):
     assert ds1.session().size_bytes() == ds2.session().size_bytes()
 
     assert ds1.to_table() == ds2.to_table()
+
+
+def test_cache_backend_uri_config():
+    session = lance.Session(index_cache_backend="moka://?capacity=1048576")
+
+    assert session.index_cache_size_bytes() == 0
+
+
+def test_cache_backend_dict_config():
+    session = lance.Session(
+        index_cache_backend={
+            "kind": "moka",
+            "options": {"capacity": "1048576"},
+        },
+    )
+
+    assert session.index_cache_size_bytes() == 0
+
+
+def test_cache_backend_rejects_size_and_backend():
+    with pytest.raises(
+        ValueError,
+        match="index_cache_size_bytes and index_cache_backend are mutually exclusive",
+    ):
+        lance.Session(
+            index_cache_size_bytes=1024,
+            index_cache_backend="moka://?capacity=1048576",
+        )
+
+
+def test_cache_backend_rejects_unknown_dict_key():
+    with pytest.raises(ValueError, match="unknown dict key"):
+        lance.Session(
+            index_cache_backend={
+                "kind": "moka",
+                "capacity": "1048576",
+            },
+        )

--- a/python/python/tests/test_session.py
+++ b/python/python/tests/test_session.py
@@ -49,7 +49,7 @@ def test_cache_backend_uri_config():
 def test_cache_backend_dict_config():
     session = lance.Session(
         index_cache_backend={
-            "kind": "moka",
+            "kind": "MOKA",
             "options": {"capacity": "1048576"},
         },
     )
@@ -76,3 +76,13 @@ def test_cache_backend_rejects_unknown_dict_key():
                 "capacity": "1048576",
             },
         )
+
+
+def test_cache_backend_rejects_moka_without_capacity():
+    with pytest.raises(ValueError, match="capacity is required"):
+        lance.Session(index_cache_backend="moka://")
+
+
+def test_cache_backend_rejects_moka_empty_capacity():
+    with pytest.raises(ValueError, match="capacity must not be empty"):
+        lance.Session(index_cache_backend="moka://?capacity=")

--- a/python/src/session.rs
+++ b/python/src/session.rs
@@ -8,9 +8,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods, PyString};
 use pyo3::{Bound, PyAny, PyResult, pyclass, pymethods};
 
-use lance::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
-use lance::session::Session as LanceSession;
-use lance_core::cache::{BackendConfig, CacheBackend, build_from_config, build_from_uri};
+use lance::session::{CacheSpec, Session as LanceSession};
+use lance_core::cache::{BackendConfig, build_from_config, build_from_uri};
 
 use crate::rt;
 
@@ -65,33 +64,34 @@ impl Session {
 /// backend were provided for the same cache. Rather than silently letting
 /// one override the other (Proposal §7), this is rejected up-front so the
 /// operator gets an actionable error.
-fn resolve_backend(
+fn resolve_cache_spec(
     backend_field: &str,
     backend: Option<&Bound<'_, PyAny>>,
     size_field: &str,
-    size_field_set: bool,
-) -> PyResult<Option<Arc<dyn CacheBackend>>> {
-    let Some(value) = backend else {
-        return Ok(None);
-    };
-    if size_field_set {
+    size: Option<usize>,
+) -> PyResult<CacheSpec> {
+    if backend.is_some() && size.is_some() {
         return Err(PyValueError::new_err(format!(
             "{} and {} are mutually exclusive; set one or the other",
             size_field, backend_field,
         )));
     }
 
+    let Some(value) = backend else {
+        return Ok(size.map(CacheSpec::Size).unwrap_or(CacheSpec::Default));
+    };
+
     if value.cast::<PyString>().is_ok() {
         let uri: String = value.extract()?;
         return build_from_uri(&uri)
-            .map(Some)
+            .map(CacheSpec::Backend)
             .map_err(|e| PyValueError::new_err(format!("{}: {}", backend_field, e)));
     }
 
     if let Ok(dict) = value.cast::<PyDict>() {
         let cfg = backend_config_from_dict(backend_field, dict)?;
         return build_from_config(&cfg)
-            .map(Some)
+            .map(CacheSpec::Backend)
             .map_err(|e| PyValueError::new_err(format!("{}: {}", backend_field, e)));
     }
 
@@ -154,7 +154,10 @@ fn backend_config_from_dict(field: &str, dict: &Bound<'_, PyDict>) -> PyResult<B
         }
     }
 
-    Ok(BackendConfig { kind, options })
+    let mut config = BackendConfig::new(&kind)
+        .map_err(|e| PyValueError::new_err(format!("{}: {}", field, e)))?;
+    config.options = options;
+    Ok(config)
 }
 
 #[pymethods]
@@ -172,26 +175,21 @@ impl Session {
         index_cache_backend: Option<Bound<'_, PyAny>>,
         metadata_cache_backend: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
-        let index_backend = resolve_backend(
+        let index_cache = resolve_cache_spec(
             "index_cache_backend",
             index_cache_backend.as_ref(),
             "index_cache_size_bytes",
-            index_cache_size_bytes.is_some(),
+            index_cache_size_bytes,
         )?;
-        let metadata_backend = resolve_backend(
+        let metadata_cache = resolve_cache_spec(
             "metadata_cache_backend",
             metadata_cache_backend.as_ref(),
             "metadata_cache_size_bytes",
-            metadata_cache_size_bytes.is_some(),
+            metadata_cache_size_bytes,
         )?;
 
-        let session = LanceSession::with_cache_backends(
-            index_backend,
-            metadata_backend,
-            index_cache_size_bytes.unwrap_or(DEFAULT_INDEX_CACHE_SIZE),
-            metadata_cache_size_bytes.unwrap_or(DEFAULT_METADATA_CACHE_SIZE),
-            Default::default(),
-        );
+        let session =
+            LanceSession::with_cache_backends(index_cache, metadata_cache, Default::default());
         Ok(Self {
             inner: Arc::new(session),
         })

--- a/python/src/session.rs
+++ b/python/src/session.rs
@@ -1,18 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use pyo3::{PyResult, pyclass, pymethods};
+use pyo3::exceptions::PyValueError;
+use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods, PyString};
+use pyo3::{Bound, PyAny, PyResult, pyclass, pymethods};
 
 use lance::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use lance::session::Session as LanceSession;
+use lance_core::cache::{BackendConfig, CacheBackend, build_from_config, build_from_uri};
 
 use crate::rt;
 
 /// The Session holds stateful information for a dataset.
 ///
 /// The session contains caches for opened indices and file metadata.
+///
+/// Parameters
+/// ----------
+/// index_cache_size_bytes : int, optional
+///     Capacity of the default index cache in bytes.
+/// metadata_cache_size_bytes : int, optional
+///     Capacity of the default metadata cache in bytes.
+/// index_cache_backend : str or dict, optional
+///     Custom index cache backend. Strings are backend URIs such as
+///     ``"moka://?capacity=1048576"``. Dicts must contain ``"kind"`` and may
+///     contain ``"options"``, for example
+///     ``{"kind": "moka", "options": {"capacity": "1048576"}}``.
+/// metadata_cache_backend : str or dict, optional
+///     Custom metadata cache backend with the same format as
+///     ``index_cache_backend``.
+///
+/// ``index_cache_backend`` is mutually exclusive with
+/// ``index_cache_size_bytes``. ``metadata_cache_backend`` is mutually
+/// exclusive with ``metadata_cache_size_bytes``.
 #[pyclass(name = "_Session", module = "_lib", from_py_object)]
 #[derive(Clone)]
 pub struct Session {
@@ -25,22 +48,153 @@ impl Session {
     }
 }
 
+/// Turn a Python-supplied backend descriptor into an `Arc<dyn CacheBackend>`,
+/// or return `Ok(None)` when the caller did not pass one.
+///
+/// Accepts:
+///   * `str` — treated as a URI (`moka://?capacity=...`) and passed to
+///     [`build_from_uri`].
+///   * `dict` — must have string keys `kind` (required) and `options`
+///     (optional `dict[str, str]`) matching [`BackendConfig`]; passed to
+///     [`build_from_config`].
+///
+/// Any other Python type is rejected with a clear `TypeError`-style
+/// `PyValueError`.
+///
+/// If `size_field_set` is `true` and `backend` is `Some`, both a size and a
+/// backend were provided for the same cache. Rather than silently letting
+/// one override the other (Proposal §7), this is rejected up-front so the
+/// operator gets an actionable error.
+fn resolve_backend(
+    backend_field: &str,
+    backend: Option<&Bound<'_, PyAny>>,
+    size_field: &str,
+    size_field_set: bool,
+) -> PyResult<Option<Arc<dyn CacheBackend>>> {
+    let Some(value) = backend else {
+        return Ok(None);
+    };
+    if size_field_set {
+        return Err(PyValueError::new_err(format!(
+            "{} and {} are mutually exclusive; set one or the other",
+            size_field, backend_field,
+        )));
+    }
+
+    if value.cast::<PyString>().is_ok() {
+        let uri: String = value.extract()?;
+        return build_from_uri(&uri)
+            .map(Some)
+            .map_err(|e| PyValueError::new_err(format!("{}: {}", backend_field, e)));
+    }
+
+    if let Ok(dict) = value.cast::<PyDict>() {
+        let cfg = backend_config_from_dict(backend_field, dict)?;
+        return build_from_config(&cfg)
+            .map(Some)
+            .map_err(|e| PyValueError::new_err(format!("{}: {}", backend_field, e)));
+    }
+
+    let type_name: String = value.get_type().getattr("__name__")?.extract()?;
+    Err(PyValueError::new_err(format!(
+        "{}: expected str (URI) or dict with 'kind'/'options' keys, got {}",
+        backend_field, type_name,
+    )))
+}
+
+fn backend_config_from_dict(field: &str, dict: &Bound<'_, PyDict>) -> PyResult<BackendConfig> {
+    for (key, _) in dict.iter() {
+        if key.cast::<PyString>().is_err() {
+            return Err(PyValueError::new_err(format!(
+                "{}: dict keys must be strings",
+                field
+            )));
+        }
+        let key: String = key.extract()?;
+        if key != "kind" && key != "options" {
+            return Err(PyValueError::new_err(format!(
+                "{}: unknown dict key {:?}; expected 'kind' or 'options'",
+                field, key
+            )));
+        }
+    }
+
+    let kind_obj = dict.get_item("kind")?.ok_or_else(|| {
+        PyValueError::new_err(format!("{}: dict must contain a 'kind' key", field))
+    })?;
+    if kind_obj.cast::<PyString>().is_err() {
+        return Err(PyValueError::new_err(format!(
+            "{}: 'kind' must be a string",
+            field
+        )));
+    }
+    let kind: String = kind_obj.extract()?;
+
+    let mut options: HashMap<String, String> = HashMap::new();
+    if let Some(options_obj) = dict.get_item("options")? {
+        let options_dict = options_obj.cast::<PyDict>().map_err(|_| {
+            PyValueError::new_err(format!("{}: 'options' must be a dict[str, str]", field))
+        })?;
+        for (k, v) in options_dict.iter() {
+            if k.cast::<PyString>().is_err() {
+                return Err(PyValueError::new_err(format!(
+                    "{}: 'options' keys must be strings",
+                    field
+                )));
+            }
+            if v.cast::<PyString>().is_err() {
+                return Err(PyValueError::new_err(format!(
+                    "{}: 'options' values must be strings",
+                    field
+                )));
+            }
+            let key: String = k.extract()?;
+            let value: String = v.extract()?;
+            options.insert(key, value);
+        }
+    }
+
+    Ok(BackendConfig { kind, options })
+}
+
 #[pymethods]
 impl Session {
     #[new]
-    #[pyo3(signature=(index_cache_size_bytes=None, metadata_cache_size_bytes=None))]
+    #[pyo3(signature=(
+        index_cache_size_bytes=None,
+        metadata_cache_size_bytes=None,
+        index_cache_backend=None,
+        metadata_cache_backend=None,
+    ))]
     fn create(
         index_cache_size_bytes: Option<usize>,
         metadata_cache_size_bytes: Option<usize>,
-    ) -> Self {
-        let session = LanceSession::new(
+        index_cache_backend: Option<Bound<'_, PyAny>>,
+        metadata_cache_backend: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<Self> {
+        let index_backend = resolve_backend(
+            "index_cache_backend",
+            index_cache_backend.as_ref(),
+            "index_cache_size_bytes",
+            index_cache_size_bytes.is_some(),
+        )?;
+        let metadata_backend = resolve_backend(
+            "metadata_cache_backend",
+            metadata_cache_backend.as_ref(),
+            "metadata_cache_size_bytes",
+            metadata_cache_size_bytes.is_some(),
+        )?;
+
+        let session = LanceSession::with_cache_backends(
+            index_backend,
+            metadata_backend,
             index_cache_size_bytes.unwrap_or(DEFAULT_INDEX_CACHE_SIZE),
             metadata_cache_size_bytes.unwrap_or(DEFAULT_METADATA_CACHE_SIZE),
             Default::default(),
         );
-        Self {
+        Ok(Self {
             inner: Arc::new(session),
-        }
+        })
     }
 
     fn __repr__(&self) -> String {

--- a/rust/lance-core/src/cache/backend_uri.rs
+++ b/rust/lance-core/src/cache/backend_uri.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! URI-based configuration for cache backends.
+//!
+//! [`build_from_uri`] parses a compact string form such as
+//! `moka://?capacity=1073741824` into a [`BackendConfig`] and hands it to
+//! the registry. This gives Python/Java bindings and configuration files a
+//! single-string representation of a backend without having to expose a
+//! typed builder for every backend.
+//!
+//! Grammar (intentionally a subset of RFC 3986 — Lance only needs a
+//! predictable, unambiguous form):
+//!
+//! ```text
+//! uri     ::= scheme ":" hier ( "?" query )?
+//! scheme  ::= ALPHA ( ALPHA | DIGIT | "+" | "-" | "." )*
+//! hier    ::= "//" authority path?   -- e.g. moka://?..., other:///path?...
+//!           | path                    -- e.g. moka:capacity=...  (rare)
+//! authority ::= *( any char except "/" | "?" )
+//! path    ::= *( any char except "?" )
+//! query   ::= pair ( "&" pair )*
+//! pair    ::= key "=" value          -- both percent-decoded
+//! ```
+//!
+//! Mapping to [`BackendConfig`]:
+//!
+//! * `scheme` becomes `kind`.
+//! * The joined `authority + path` (with any leading `//` stripped) is stored
+//!   under the option key `path` when non-empty. Empty-authority absolute
+//!   paths such as `backend:///tmp/cache` keep their leading `/`; host-style
+//!   paths such as `backend://localhost:6379/0` are stored as
+//!   `localhost:6379/0`. If the query already contains a `path` key, the
+//!   URI-supplied path wins and the parser errors on the conflict.
+//! * Each `key=value` pair from the query becomes an entry in `options`.
+//!   Duplicate keys are rejected.
+
+use std::sync::Arc;
+
+use super::backend::CacheBackend;
+use super::registry::{BackendConfig, build_from_config};
+use crate::{Error, Result};
+
+/// Parse `uri` into a [`BackendConfig`] and build the backend registered
+/// under its `scheme`.
+///
+/// Returns an error if:
+/// * the URI cannot be parsed,
+/// * no backend is registered for that scheme, or
+/// * the constructor itself fails.
+pub fn build_from_uri(uri: &str) -> Result<Arc<dyn CacheBackend>> {
+    let config = parse_backend_uri(uri)?;
+    build_from_config(&config)
+}
+
+/// Parse `uri` into a [`BackendConfig`] without touching the registry.
+///
+/// See the module docs for the accepted grammar.
+pub fn parse_backend_uri(uri: &str) -> Result<BackendConfig> {
+    let (scheme, rest) = split_scheme(uri)?;
+    let (path, query) = split_path_query(rest);
+
+    let mut config = BackendConfig::new(scheme);
+
+    let normalized_path = normalize_path(path);
+    if !normalized_path.is_empty() {
+        config.options.insert("path".to_string(), normalized_path);
+    }
+
+    if let Some(query) = query {
+        for raw_pair in query.split('&') {
+            if raw_pair.is_empty() {
+                continue;
+            }
+            let (raw_key, raw_value) = raw_pair.split_once('=').ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "cache backend uri {:?}: query pair {:?} is missing '='",
+                    uri, raw_pair
+                ))
+            })?;
+            let key = percent_decode(raw_key).map_err(|err| {
+                Error::invalid_input(format!(
+                    "cache backend uri {:?}: cannot decode query key {:?}: {}",
+                    uri, raw_key, err
+                ))
+            })?;
+            let value = percent_decode(raw_value).map_err(|err| {
+                Error::invalid_input(format!(
+                    "cache backend uri {:?}: cannot decode query value {:?}: {}",
+                    uri, raw_value, err
+                ))
+            })?;
+            if config.options.contains_key(&key) {
+                return Err(Error::invalid_input(format!(
+                    "cache backend uri {:?}: option {:?} is set more than once",
+                    uri, key
+                )));
+            }
+            config.options.insert(key, value);
+        }
+    }
+
+    Ok(config)
+}
+
+fn split_scheme(uri: &str) -> Result<(String, &str)> {
+    let colon = uri.find(':').ok_or_else(|| {
+        Error::invalid_input(format!("cache backend uri {:?} is missing ':'", uri))
+    })?;
+    let scheme = &uri[..colon];
+    validate_scheme(scheme, uri)?;
+    Ok((scheme.to_ascii_lowercase(), &uri[colon + 1..]))
+}
+
+fn validate_scheme(scheme: &str, uri: &str) -> Result<()> {
+    let mut chars = scheme.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => {
+            return Err(Error::invalid_input(format!(
+                "cache backend uri {:?}: scheme must start with an ASCII letter",
+                uri
+            )));
+        }
+    }
+    for c in chars {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.');
+        if !ok {
+            return Err(Error::invalid_input(format!(
+                "cache backend uri {:?}: invalid character {:?} in scheme",
+                uri, c
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn split_path_query(rest: &str) -> (&str, Option<&str>) {
+    match rest.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (rest, None),
+    }
+}
+
+/// Strip leading `//authority/` boilerplate and return the useful path
+/// component. Empty authorities (e.g. `moka://`) yield an empty path, while
+/// empty-authority absolute paths (e.g. `disk:///tmp/cache`) retain their
+/// leading slash.
+fn normalize_path(raw: &str) -> String {
+    let Some(without_marker) = raw.strip_prefix("//") else {
+        return raw.to_string();
+    };
+    if without_marker.is_empty() {
+        return String::new();
+    }
+    without_marker.to_string()
+}
+
+fn percent_decode(input: &str) -> std::result::Result<String, String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' => {
+                if i + 2 >= bytes.len() {
+                    return Err(format!("truncated percent-escape at offset {}", i));
+                }
+                let hi = decode_hex_digit(bytes[i + 1])?;
+                let lo = decode_hex_digit(bytes[i + 2])?;
+                out.push((hi << 4) | lo);
+                i += 3;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).map_err(|err| err.to_string())
+}
+
+fn decode_hex_digit(b: u8) -> std::result::Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(10 + b - b'a'),
+        b'A'..=b'F' => Ok(10 + b - b'A'),
+        _ => Err(format!(
+            "invalid hex digit {:?} in percent-escape",
+            b as char
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_authority_only() {
+        let cfg = parse_backend_uri("moka://?capacity=1073741824").unwrap();
+        assert_eq!(cfg.kind, "moka");
+        assert_eq!(
+            cfg.options.get("capacity").map(String::as_str),
+            Some("1073741824")
+        );
+        assert!(!cfg.options.contains_key("path"));
+    }
+
+    #[test]
+    fn test_parse_path_and_query() {
+        let cfg = parse_backend_uri("example:///var/lance/cache?capacity=10G").unwrap();
+        assert_eq!(cfg.kind, "example");
+        assert_eq!(
+            cfg.options.get("path").map(String::as_str),
+            Some("/var/lance/cache")
+        );
+        assert_eq!(cfg.options.get("capacity").map(String::as_str), Some("10G"));
+    }
+
+    #[test]
+    fn test_parse_host_style() {
+        // Redis-style URI with host:port + path segment. All of it lives
+        // under the "path" option; the backend is responsible for
+        // interpreting it.
+        let cfg = parse_backend_uri("redis://localhost:6379/0?prefix=lance").unwrap();
+        assert_eq!(cfg.kind, "redis");
+        assert_eq!(
+            cfg.options.get("path").map(String::as_str),
+            Some("localhost:6379/0"),
+        );
+        assert_eq!(cfg.options.get("prefix").map(String::as_str), Some("lance"));
+    }
+
+    #[test]
+    fn test_scheme_is_lowercased() {
+        // Different upper/lower cases must resolve to the same registry
+        // key, otherwise `Moka://` and `moka://` would look up different
+        // backends.
+        let cfg = parse_backend_uri("MOKA://?capacity=1").unwrap();
+        assert_eq!(cfg.kind, "moka");
+    }
+
+    #[test]
+    fn test_percent_decoding() {
+        let cfg = parse_backend_uri("kv://?prefix=a%2Fb&name=hello%20world&token=a+b%2Bc").unwrap();
+        assert_eq!(cfg.options.get("prefix").map(String::as_str), Some("a/b"));
+        assert_eq!(
+            cfg.options.get("name").map(String::as_str),
+            Some("hello world")
+        );
+        assert_eq!(cfg.options.get("token").map(String::as_str), Some("a+b+c"));
+    }
+
+    #[test]
+    fn test_empty_query_pair_is_skipped() {
+        // A trailing "&" should not cause a spurious "" pair to appear.
+        let cfg = parse_backend_uri("moka://?capacity=1&").unwrap();
+        assert_eq!(cfg.options.len(), 1);
+    }
+
+    #[test]
+    fn test_missing_scheme_errors() {
+        let err = parse_backend_uri("no-scheme-here").unwrap_err();
+        assert!(err.to_string().contains("missing ':'"));
+    }
+
+    #[test]
+    fn test_invalid_scheme_errors() {
+        // Digit-leading schemes are invalid per RFC 3986 and would clash
+        // with URI-like values elsewhere in the config.
+        let err = parse_backend_uri("1moka://").unwrap_err();
+        assert!(err.to_string().contains("must start with an ASCII letter"));
+    }
+
+    #[test]
+    fn test_duplicate_option_errors() {
+        let err = parse_backend_uri("moka://?capacity=1&capacity=2").unwrap_err();
+        assert!(err.to_string().contains("more than once"));
+    }
+
+    #[test]
+    fn test_query_pair_without_equals_errors() {
+        let err = parse_backend_uri("moka://?capacity").unwrap_err();
+        assert!(err.to_string().contains("missing '='"));
+    }
+}

--- a/rust/lance-core/src/cache/backend_uri.rs
+++ b/rust/lance-core/src/cache/backend_uri.rs
@@ -38,7 +38,7 @@
 use std::sync::Arc;
 
 use super::backend::CacheBackend;
-use super::registry::{BackendConfig, build_from_config};
+use super::registry::{BackendConfig, build_from_config, normalize_backend_kind};
 use crate::{Error, Result};
 
 /// Parse `uri` into a [`BackendConfig`] and build the backend registered
@@ -60,7 +60,7 @@ pub fn parse_backend_uri(uri: &str) -> Result<BackendConfig> {
     let (scheme, rest) = split_scheme(uri)?;
     let (path, query) = split_path_query(rest);
 
-    let mut config = BackendConfig::new(scheme);
+    let mut config = BackendConfig::new(&scheme)?;
 
     let normalized_path = normalize_path(path);
     if !normalized_path.is_empty() {
@@ -108,31 +108,9 @@ fn split_scheme(uri: &str) -> Result<(String, &str)> {
         Error::invalid_input(format!("cache backend uri {:?} is missing ':'", uri))
     })?;
     let scheme = &uri[..colon];
-    validate_scheme(scheme, uri)?;
-    Ok((scheme.to_ascii_lowercase(), &uri[colon + 1..]))
-}
-
-fn validate_scheme(scheme: &str, uri: &str) -> Result<()> {
-    let mut chars = scheme.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() => {}
-        _ => {
-            return Err(Error::invalid_input(format!(
-                "cache backend uri {:?}: scheme must start with an ASCII letter",
-                uri
-            )));
-        }
-    }
-    for c in chars {
-        let ok = c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.');
-        if !ok {
-            return Err(Error::invalid_input(format!(
-                "cache backend uri {:?}: invalid character {:?} in scheme",
-                uri, c
-            )));
-        }
-    }
-    Ok(())
+    let scheme = normalize_backend_kind(scheme)
+        .map_err(|err| Error::invalid_input(format!("cache backend uri {:?}: {}", uri, err)))?;
+    Ok((scheme, &uri[colon + 1..]))
 }
 
 fn split_path_query(rest: &str) -> (&str, Option<&str>) {

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -46,13 +46,16 @@
 //!    `codec.deserialize(reader)` on get to persist entries across restarts.
 
 pub mod backend;
+mod backend_uri;
 pub mod codec;
 mod entry_io;
 mod key;
 mod moka;
 mod quick;
+mod registry;
 
 pub use backend::{CacheBackend, CacheEntry};
+pub use backend_uri::{build_from_uri, parse_backend_uri};
 pub use codec::{
     CacheCodec, CacheCodecImpl, CacheDecode, CacheMissReason, MAGIC, has_cache_envelope,
 };
@@ -60,6 +63,7 @@ pub use entry_io::{CacheEntryReader, CacheEntryWriter};
 pub use key::{CACHE_KEY_FORMAT, CacheKeySchema, CacheNamespace, InternalCacheKey, KeyBuilder};
 pub use moka::MokaCacheBackend;
 pub use quick::{QuickCacheBackend, recommended_cache_shards};
+pub use registry::{BackendBuildFn, BackendConfig, build_from_config, register_backend};
 
 use std::borrow::Cow;
 use std::sync::{

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -51,6 +51,7 @@ fn entry_weight(key: &InternalCacheKey, size_bytes: usize, weight_unit: usize) -
 /// via moka's built-in `optionally_get_with`.
 pub struct MokaCacheBackend {
     cache: moka::future::Cache<InternalCacheKey, MokaCacheEntry>,
+    capacity: usize,
     weight_unit: usize,
 }
 
@@ -72,14 +73,24 @@ impl MokaCacheBackend {
                 entry_weight(key, entry.size_bytes, weight_unit)
             })
             .build();
-        Self { cache, weight_unit }
+        Self {
+            cache,
+            capacity,
+            weight_unit,
+        }
     }
 
     pub fn no_cache() -> Self {
         Self {
             cache: moka::future::Cache::new(0),
+            capacity: 0,
             weight_unit: 1,
         }
+    }
+
+    /// Configured weighted capacity in bytes.
+    pub fn capacity(&self) -> usize {
+        self.capacity
     }
 
     fn weighted_size_bytes(&self) -> usize {
@@ -211,24 +222,28 @@ pub const MOKA_BACKEND_KIND: &str = "moka";
 ///
 /// Recognized options:
 ///   * `capacity` — total weighted capacity in bytes (`usize`).
-///     A missing or empty value defaults to 0, i.e. a disabled cache.
+///     This must be present and non-empty.
 ///
 /// Unknown options are rejected so typos surface immediately instead of
 /// silently falling through to the default capacity.
-pub(super) fn build_moka(config: &super::registry::BackendConfig) -> Result<Arc<dyn CacheBackend>> {
-    let mut capacity: usize = 0;
+pub(super) fn build_moka_backend(
+    config: &super::registry::BackendConfig,
+) -> Result<MokaCacheBackend> {
+    let mut capacity: Option<usize> = None;
     for (key, value) in &config.options {
         match key.as_str() {
             "capacity" => {
                 if value.is_empty() {
-                    capacity = 0;
+                    return Err(crate::Error::invalid_input(
+                        "moka cache backend: capacity must not be empty",
+                    ));
                 } else {
-                    capacity = value.parse::<usize>().map_err(|err| {
+                    capacity = Some(value.parse::<usize>().map_err(|err| {
                         crate::Error::invalid_input(format!(
                             "moka cache backend: cannot parse capacity {:?}: {}",
                             value, err
                         ))
-                    })?;
+                    })?);
                 }
             }
             other => {
@@ -239,34 +254,50 @@ pub(super) fn build_moka(config: &super::registry::BackendConfig) -> Result<Arc<
             }
         }
     }
-    Ok(Arc::new(MokaCacheBackend::with_capacity(capacity)))
+    let capacity = capacity.ok_or_else(|| {
+        crate::Error::invalid_input(
+            "moka cache backend: capacity is required; use moka://?capacity=<bytes>",
+        )
+    })?;
+    Ok(MokaCacheBackend::with_capacity(capacity))
+}
+
+pub(super) fn build_moka(config: &super::registry::BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+    Ok(Arc::new(build_moka_backend(config)?))
 }
 
 #[cfg(test)]
 mod moka_registry_tests {
-    use super::super::backend_uri::build_from_uri;
+    use super::super::backend_uri::{build_from_uri, parse_backend_uri};
     use super::super::registry::{BackendConfig, build_from_config, registry_test_lock};
+    use super::*;
 
     #[test]
     fn test_moka_builds_from_config() {
         let _lock = registry_test_lock();
-        let cfg = BackendConfig::new("moka").with_option("capacity", "1048576");
-        // Any Arc<dyn CacheBackend> we can construct is a pass; we're
-        // checking that "moka" is discoverable in the registry without
-        // the caller having to register it manually.
+        let cfg = BackendConfig::new("moka")
+            .unwrap()
+            .with_option("capacity", "1048576");
+        let backend = build_moka_backend(&cfg).unwrap();
+        assert_eq!(backend.capacity(), 1048576);
         let _backend = build_from_config(&cfg).unwrap();
     }
 
     #[test]
     fn test_moka_builds_from_uri() {
         let _lock = registry_test_lock();
+        let cfg = parse_backend_uri("moka://?capacity=1048576").unwrap();
+        let backend = build_moka_backend(&cfg).unwrap();
+        assert_eq!(backend.capacity(), 1048576);
         let _backend = build_from_uri("moka://?capacity=1048576").unwrap();
     }
 
     #[test]
     fn test_moka_rejects_unknown_option() {
         let _lock = registry_test_lock();
-        let cfg = BackendConfig::new("moka").with_option("mystery", "1");
+        let cfg = BackendConfig::new("moka")
+            .unwrap()
+            .with_option("mystery", "1");
         let err = build_from_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("unknown option"));
     }
@@ -274,8 +305,28 @@ mod moka_registry_tests {
     #[test]
     fn test_moka_rejects_bad_capacity() {
         let _lock = registry_test_lock();
-        let cfg = BackendConfig::new("moka").with_option("capacity", "not-a-number");
+        let cfg = BackendConfig::new("moka")
+            .unwrap()
+            .with_option("capacity", "not-a-number");
         let err = build_from_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("cannot parse capacity"));
+    }
+
+    #[test]
+    fn test_moka_rejects_missing_capacity() {
+        let _lock = registry_test_lock();
+        let cfg = BackendConfig::new("moka").unwrap();
+        let err = build_from_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("capacity is required"));
+    }
+
+    #[test]
+    fn test_moka_rejects_empty_capacity() {
+        let _lock = registry_test_lock();
+        let cfg = BackendConfig::new("moka")
+            .unwrap()
+            .with_option("capacity", "");
+        let err = build_from_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("capacity must not be empty"));
     }
 }

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -203,3 +203,79 @@ mod tests {
         assert_ne!(weight, u32::MAX);
     }
 }
+
+/// Registry identifier for the built-in Moka backend.
+pub const MOKA_BACKEND_KIND: &str = "moka";
+
+/// [`BackendBuildFn`](super::registry::BackendBuildFn) for [`MokaCacheBackend`].
+///
+/// Recognized options:
+///   * `capacity` — total weighted capacity in bytes (`usize`).
+///     A missing or empty value defaults to 0, i.e. a disabled cache.
+///
+/// Unknown options are rejected so typos surface immediately instead of
+/// silently falling through to the default capacity.
+pub(super) fn build_moka(config: &super::registry::BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+    let mut capacity: usize = 0;
+    for (key, value) in &config.options {
+        match key.as_str() {
+            "capacity" => {
+                if value.is_empty() {
+                    capacity = 0;
+                } else {
+                    capacity = value.parse::<usize>().map_err(|err| {
+                        crate::Error::invalid_input(format!(
+                            "moka cache backend: cannot parse capacity {:?}: {}",
+                            value, err
+                        ))
+                    })?;
+                }
+            }
+            other => {
+                return Err(crate::Error::invalid_input(format!(
+                    "moka cache backend: unknown option {:?}",
+                    other
+                )));
+            }
+        }
+    }
+    Ok(Arc::new(MokaCacheBackend::with_capacity(capacity)))
+}
+
+#[cfg(test)]
+mod moka_registry_tests {
+    use super::super::backend_uri::build_from_uri;
+    use super::super::registry::{BackendConfig, build_from_config, registry_test_lock};
+
+    #[test]
+    fn test_moka_builds_from_config() {
+        let _lock = registry_test_lock();
+        let cfg = BackendConfig::new("moka").with_option("capacity", "1048576");
+        // Any Arc<dyn CacheBackend> we can construct is a pass; we're
+        // checking that "moka" is discoverable in the registry without
+        // the caller having to register it manually.
+        let _backend = build_from_config(&cfg).unwrap();
+    }
+
+    #[test]
+    fn test_moka_builds_from_uri() {
+        let _lock = registry_test_lock();
+        let _backend = build_from_uri("moka://?capacity=1048576").unwrap();
+    }
+
+    #[test]
+    fn test_moka_rejects_unknown_option() {
+        let _lock = registry_test_lock();
+        let cfg = BackendConfig::new("moka").with_option("mystery", "1");
+        let err = build_from_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("unknown option"));
+    }
+
+    #[test]
+    fn test_moka_rejects_bad_capacity() {
+        let _lock = registry_test_lock();
+        let cfg = BackendConfig::new("moka").with_option("capacity", "not-a-number");
+        let err = build_from_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("cannot parse capacity"));
+    }
+}

--- a/rust/lance-core/src/cache/registry.rs
+++ b/rust/lance-core/src/cache/registry.rs
@@ -35,11 +35,11 @@ pub struct BackendConfig {
 
 impl BackendConfig {
     /// Build a config with no options.
-    pub fn new(kind: impl Into<String>) -> Self {
-        Self {
-            kind: kind.into(),
+    pub fn new(kind: impl AsRef<str>) -> Result<Self> {
+        Ok(Self {
+            kind: normalize_backend_kind(kind.as_ref())?,
             options: HashMap::new(),
-        }
+        })
     }
 
     /// Insert a single option and return `self`, enabling chaining.
@@ -47,6 +47,34 @@ impl BackendConfig {
         self.options.insert(key.into(), value.into());
         self
     }
+}
+
+/// Normalize and validate a cache backend kind.
+///
+/// Backend kinds share the same syntax as URI schemes. They are matched
+/// case-insensitively and stored as lowercase ASCII so registry lookups,
+/// config dictionaries, and URI parsing all address the same key.
+pub fn normalize_backend_kind(kind: &str) -> Result<String> {
+    let mut chars = kind.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => {
+            return Err(Error::invalid_input(format!(
+                "cache backend kind {:?}: must start with an ASCII letter",
+                kind
+            )));
+        }
+    }
+    for c in chars {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.');
+        if !ok {
+            return Err(Error::invalid_input(format!(
+                "cache backend kind {:?}: invalid character {:?}",
+                kind, c
+            )));
+        }
+    }
+    Ok(kind.to_ascii_lowercase())
 }
 
 /// Constructor signature for a cache backend.
@@ -75,11 +103,10 @@ fn registry_lock_for_test() -> MutexGuard<'static, HashMap<String, BackendBuildF
 
 /// Register a constructor for a cache backend under `kind`.
 ///
-/// Returns `Err` if `kind` is already registered or reserved by a built-in
-/// backend. This is intentional: duplicate registration (e.g. two crates or a
-/// dynamic plugin claiming the same identifier) is a configuration bug that
-/// should surface immediately rather than silently overriding an existing
-/// implementation.
+/// Returns `Err` if a non-built-in `kind` is already registered. Built-in
+/// backends may be replaced so callers can mask a built-in implementation
+/// (for example, a patched `"moka"` backend) without changing URI/config
+/// strings elsewhere.
 ///
 /// Typical usage from a backend crate:
 ///
@@ -89,18 +116,13 @@ fn registry_lock_for_test() -> MutexGuard<'static, HashMap<String, BackendBuildF
 /// }
 /// ```
 pub fn register_backend(kind: &str, build: BackendBuildFn) -> Result<()> {
-    if builtin_backend(kind).is_some() {
-        return Err(Error::invalid_input(format!(
-            "cache backend kind {:?} is reserved for a built-in backend",
-            kind
-        )));
-    }
-    insert_backend(kind, build)
+    let kind = normalize_backend_kind(kind)?;
+    insert_backend(&kind, build, builtin_backend(&kind).is_some())
 }
 
-fn insert_backend(kind: &str, build: BackendBuildFn) -> Result<()> {
+fn insert_backend(kind: &str, build: BackendBuildFn, allow_replace: bool) -> Result<()> {
     let mut map = registry_lock()?;
-    if map.contains_key(kind) {
+    if map.contains_key(kind) && !allow_replace {
         return Err(Error::invalid_input(format!(
             "cache backend {:?} is already registered",
             kind
@@ -122,15 +144,20 @@ fn builtin_backend(kind: &str) -> Option<BackendBuildFn> {
 /// Returns `Err` if no backend has been registered under that identifier.
 pub fn build_from_config(config: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
     ensure_builtin_backends()?;
+    let kind = normalize_backend_kind(&config.kind)?;
+    let config = BackendConfig {
+        kind: kind.clone(),
+        options: config.options.clone(),
+    };
     let build = {
         let map = registry_lock()?;
-        map.get(&config.kind).copied()
+        map.get(&kind).copied()
     };
     match build {
-        Some(build) => build(config),
+        Some(build) => build(&config),
         None => Err(Error::invalid_input(format!(
             "unknown cache backend kind: {:?}",
-            config.kind
+            kind
         ))),
     }
 }
@@ -261,7 +288,7 @@ mod tests {
     fn test_register_and_build() {
         let _guard = RegistryGuard::new();
         register_backend("null", build_null).unwrap();
-        let backend = build_from_config(&BackendConfig::new("null")).unwrap();
+        let backend = build_from_config(&BackendConfig::new("null").unwrap()).unwrap();
         // Backend is opaque; we just check that the constructor ran and
         // gave us an Arc<dyn CacheBackend>.
         assert_eq!(Arc::strong_count(&backend), 1);
@@ -276,17 +303,49 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_kind_is_reserved() {
+    fn test_builtin_kind_can_be_overridden() {
         let _guard = RegistryGuard::new();
-        let err = register_backend("moka", build_null).unwrap_err();
-        assert!(err.to_string().contains("reserved"));
+        register_backend("moka", build_null).unwrap();
+        let backend = build_from_config(&BackendConfig::new("moka").unwrap()).unwrap();
+        assert_eq!(Arc::strong_count(&backend), 1);
     }
 
     #[test]
     fn test_unknown_kind_errors() {
         let _guard = RegistryGuard::new();
-        let err = build_from_config(&BackendConfig::new("missing")).unwrap_err();
+        let err = build_from_config(&BackendConfig::new("missing").unwrap()).unwrap_err();
         assert!(err.to_string().contains("unknown cache backend kind"));
+    }
+
+    #[test]
+    fn test_backend_kind_is_normalized() {
+        let _guard = RegistryGuard::new();
+        register_backend("Echo.Backend", build_null).unwrap();
+        let backend = build_from_config(&BackendConfig::new("echo.backend").unwrap()).unwrap();
+        assert_eq!(Arc::strong_count(&backend), 1);
+    }
+
+    #[test]
+    fn test_config_lookup_normalizes_direct_config() {
+        let _guard = RegistryGuard::new();
+        fn build_echo(cfg: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+            assert_eq!(cfg.kind, "echo.backend");
+            Ok(Arc::new(NullBackend))
+        }
+        register_backend("echo.backend", build_echo).unwrap();
+        let cfg = BackendConfig {
+            kind: "ECHO.Backend".to_string(),
+            options: HashMap::new(),
+        };
+        build_from_config(&cfg).unwrap();
+    }
+
+    #[test]
+    fn test_invalid_backend_kind_errors() {
+        let err = register_backend("not a scheme", build_null).unwrap_err();
+        assert!(err.to_string().contains("invalid character"));
+        let err = BackendConfig::new("1moka").unwrap_err();
+        assert!(err.to_string().contains("must start with an ASCII letter"));
     }
 
     #[test]
@@ -297,7 +356,9 @@ mod tests {
             Ok(Arc::new(NullBackend))
         }
         register_backend("echo", build_echo).unwrap();
-        let cfg = BackendConfig::new("echo").with_option("capacity", "42");
+        let cfg = BackendConfig::new("echo")
+            .unwrap()
+            .with_option("capacity", "42");
         build_from_config(&cfg).unwrap();
     }
 }

--- a/rust/lance-core/src/cache/registry.rs
+++ b/rust/lance-core/src/cache/registry.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Pluggable cache-backend registry.
+//!
+//! A [`BackendConfig`] identifies which backend to build (`kind`) and carries
+//! backend-specific string options. Backends are constructed through a
+//! [`BackendBuildFn`] registered under a unique `kind`. Third-party crates
+//! integrate by calling [`register_backend`] once at application startup;
+//! [`build_from_config`] then locates the constructor and hands it the
+//! config.
+//!
+//! The registry uses `HashMap<String, String>` for options so it can be
+//! represented naturally across FFI (Python `dict[str, str]`, Java
+//! `Map<String, String>`, etc.).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use super::backend::CacheBackend;
+use super::moka::{MOKA_BACKEND_KIND, build_moka};
+use crate::{Error, Result};
+
+/// Backend-independent configuration passed to a [`BackendBuildFn`].
+///
+/// `kind` selects which registered backend to construct; `options` carries
+/// backend-specific key/value settings (e.g. `capacity`, `path`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendConfig {
+    /// Registered backend identifier, e.g. `"moka"`.
+    pub kind: String,
+    /// Backend-specific string options.
+    pub options: HashMap<String, String>,
+}
+
+impl BackendConfig {
+    /// Build a config with no options.
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            options: HashMap::new(),
+        }
+    }
+
+    /// Insert a single option and return `self`, enabling chaining.
+    pub fn with_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// Constructor signature for a cache backend.
+///
+/// Constructors are synchronous. Backends that need async initialization
+/// should surface a `try_new_blocking` shim (or equivalent) and call it here.
+pub type BackendBuildFn = fn(&BackendConfig) -> Result<Arc<dyn CacheBackend>>;
+
+fn registry() -> &'static Mutex<HashMap<String, BackendBuildFn>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, BackendBuildFn>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn registry_lock() -> Result<MutexGuard<'static, HashMap<String, BackendBuildFn>>> {
+    registry()
+        .lock()
+        .map_err(|_| Error::internal("cache backend registry mutex is poisoned"))
+}
+
+#[cfg(test)]
+fn registry_lock_for_test() -> MutexGuard<'static, HashMap<String, BackendBuildFn>> {
+    registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Register a constructor for a cache backend under `kind`.
+///
+/// Returns `Err` if `kind` is already registered or reserved by a built-in
+/// backend. This is intentional: duplicate registration (e.g. two crates or a
+/// dynamic plugin claiming the same identifier) is a configuration bug that
+/// should surface immediately rather than silently overriding an existing
+/// implementation.
+///
+/// Typical usage from a backend crate:
+///
+/// ```ignore
+/// pub fn register() -> lance_core::Result<()> {
+///     lance_core::cache::register_backend("my_backend", build_my_backend)
+/// }
+/// ```
+pub fn register_backend(kind: &str, build: BackendBuildFn) -> Result<()> {
+    if builtin_backend(kind).is_some() {
+        return Err(Error::invalid_input(format!(
+            "cache backend kind {:?} is reserved for a built-in backend",
+            kind
+        )));
+    }
+    insert_backend(kind, build)
+}
+
+fn insert_backend(kind: &str, build: BackendBuildFn) -> Result<()> {
+    let mut map = registry_lock()?;
+    if map.contains_key(kind) {
+        return Err(Error::invalid_input(format!(
+            "cache backend {:?} is already registered",
+            kind
+        )));
+    }
+    map.insert(kind.to_string(), build);
+    Ok(())
+}
+
+fn builtin_backend(kind: &str) -> Option<BackendBuildFn> {
+    match kind {
+        MOKA_BACKEND_KIND => Some(build_moka),
+        _ => None,
+    }
+}
+
+/// Look up the constructor for `config.kind` and build a backend.
+///
+/// Returns `Err` if no backend has been registered under that identifier.
+pub fn build_from_config(config: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+    ensure_builtin_backends()?;
+    let build = {
+        let map = registry_lock()?;
+        map.get(&config.kind).copied()
+    };
+    match build {
+        Some(build) => build(config),
+        None => Err(Error::invalid_input(format!(
+            "unknown cache backend kind: {:?}",
+            config.kind
+        ))),
+    }
+}
+
+/// Idempotently register the backends that ship with `lance-core`.
+///
+/// Called by [`build_from_config`] (and, transitively, by
+/// [`build_from_uri`](super::backend_uri::build_from_uri)) so a bare Lance
+/// installation can build a Moka backend without the caller having to
+/// register it. Third-party backends still have to opt in with their own
+/// `register()` call.
+///
+/// The check is against the current registry contents rather than a
+/// process-once flag so that `#[cfg(test)]` helpers which snapshot and
+/// restore the registry still see the built-in backend after they take
+/// ownership.
+fn ensure_builtin_backends() -> Result<()> {
+    let mut map = registry_lock()?;
+    if !map.contains_key(MOKA_BACKEND_KIND)
+        && let Some(build) = builtin_backend(MOKA_BACKEND_KIND)
+    {
+        map.insert(MOKA_BACKEND_KIND.to_string(), build);
+    }
+    Ok(())
+}
+
+/// Test-only helper: replace the registry with an empty map so tests can
+/// exercise duplicate-registration logic without polluting the global one.
+#[cfg(test)]
+pub(super) fn take_registry_for_test() -> HashMap<String, BackendBuildFn> {
+    let mut map = registry_lock_for_test();
+    std::mem::take(&mut *map)
+}
+
+/// Test-only helper: restore a previously captured registry state.
+#[cfg(test)]
+pub(super) fn restore_registry_for_test(saved: HashMap<String, BackendBuildFn>) {
+    let mut map = registry_lock_for_test();
+    *map = saved;
+}
+
+#[cfg(test)]
+pub(super) fn registry_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static M: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::pin::Pin;
+
+    use crate::cache::InternalCacheKey;
+    use crate::cache::backend::CacheEntry;
+    use crate::cache::codec::CacheCodec;
+    use futures::Future;
+
+    // A trivial no-op backend so tests do not depend on Moka or any other
+    // real backend. Every method returns "empty" / does nothing.
+    #[derive(Debug, Default)]
+    struct NullBackend;
+
+    #[async_trait]
+    impl CacheBackend for NullBackend {
+        async fn get(
+            &self,
+            _key: &InternalCacheKey,
+            _codec: Option<CacheCodec>,
+        ) -> Option<CacheEntry> {
+            None
+        }
+
+        async fn insert(
+            &self,
+            _key: &InternalCacheKey,
+            _entry: CacheEntry,
+            _size_bytes: usize,
+            _codec: Option<CacheCodec>,
+        ) {
+        }
+
+        async fn get_or_insert<'a>(
+            &self,
+            _key: &InternalCacheKey,
+            loader: Pin<Box<dyn Future<Output = crate::Result<(CacheEntry, usize)>> + Send + 'a>>,
+            _codec: Option<CacheCodec>,
+        ) -> crate::Result<(CacheEntry, bool)> {
+            let (entry, _size) = loader.await?;
+            Ok((entry, false))
+        }
+
+        async fn clear(&self) {}
+        async fn num_entries(&self) -> usize {
+            0
+        }
+        async fn size_bytes(&self) -> usize {
+            0
+        }
+    }
+
+    fn build_null(_cfg: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+        Ok(Arc::new(NullBackend))
+    }
+
+    struct RegistryGuard {
+        // Hold the serialization lock for the full test.
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: HashMap<String, BackendBuildFn>,
+    }
+    impl RegistryGuard {
+        fn new() -> Self {
+            Self {
+                _lock: registry_test_lock(),
+                saved: take_registry_for_test(),
+            }
+        }
+    }
+    impl Drop for RegistryGuard {
+        fn drop(&mut self) {
+            restore_registry_for_test(std::mem::take(&mut self.saved));
+        }
+    }
+
+    #[test]
+    fn test_register_and_build() {
+        let _guard = RegistryGuard::new();
+        register_backend("null", build_null).unwrap();
+        let backend = build_from_config(&BackendConfig::new("null")).unwrap();
+        // Backend is opaque; we just check that the constructor ran and
+        // gave us an Arc<dyn CacheBackend>.
+        assert_eq!(Arc::strong_count(&backend), 1);
+    }
+
+    #[test]
+    fn test_duplicate_registration_errors() {
+        let _guard = RegistryGuard::new();
+        register_backend("dup", build_null).unwrap();
+        let err = register_backend("dup", build_null).unwrap_err();
+        assert!(err.to_string().contains("already registered"));
+    }
+
+    #[test]
+    fn test_builtin_kind_is_reserved() {
+        let _guard = RegistryGuard::new();
+        let err = register_backend("moka", build_null).unwrap_err();
+        assert!(err.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn test_unknown_kind_errors() {
+        let _guard = RegistryGuard::new();
+        let err = build_from_config(&BackendConfig::new("missing")).unwrap_err();
+        assert!(err.to_string().contains("unknown cache backend kind"));
+    }
+
+    #[test]
+    fn test_options_are_passed_through() {
+        let _guard = RegistryGuard::new();
+        fn build_echo(cfg: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+            assert_eq!(cfg.options.get("capacity").map(String::as_str), Some("42"));
+            Ok(Arc::new(NullBackend))
+        }
+        register_backend("echo", build_echo).unwrap();
+        let cfg = BackendConfig::new("echo").with_option("capacity", "42");
+        build_from_config(&cfg).unwrap();
+    }
+}

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -21,6 +21,17 @@ pub(crate) mod caches;
 pub mod index_caches;
 pub(crate) mod index_extension;
 
+/// Cache selection for one session cache tier.
+#[derive(Clone, Debug)]
+pub enum CacheSpec {
+    /// Use the Lance-level default capacity for the tier.
+    Default,
+    /// Use the default in-memory backend with this capacity.
+    Size(usize),
+    /// Use an already constructed backend.
+    Backend(Arc<dyn CacheBackend>),
+}
+
 /// A user session holds the runtime state for a [`crate::Dataset`]
 ///
 /// A session will be created automatically when a Dataset is opened.  However, you
@@ -167,9 +178,11 @@ impl Session {
 
     /// Create a session with custom backends for both caches.
     ///
-    /// Each argument, if provided, replaces the default Quick backend for that
-    /// cache. Passing `None` for either falls back to the size-based default
-    /// [`Session::new`] would have used for that tier.
+    /// Each [`CacheSpec`] controls one tier. [`CacheSpec::Default`] uses that
+    /// tier's Lance-level default capacity, [`CacheSpec::Size`] uses the
+    /// default in-memory backend with an explicit capacity, and
+    /// [`CacheSpec::Backend`] uses a caller-provided backend. This keeps size
+    /// and backend selection mutually exclusive.
     ///
     /// This is the recommended constructor when a caller has already resolved
     /// backend selection through
@@ -180,15 +193,13 @@ impl Session {
     /// # Examples
     ///
     /// ```
-    /// # use lance::session::Session;
+    /// # use lance::session::{CacheSpec, Session};
     /// # use lance_core::cache::build_from_uri;
     /// # fn example() -> lance_core::Result<()> {
     /// let index_backend = build_from_uri("moka://?capacity=1048576")?;
     /// let session = Session::with_cache_backends(
-    ///     Some(index_backend),
-    ///     None,
-    ///     0,
-    ///     32 * 1024 * 1024,
+    ///     CacheSpec::Backend(index_backend),
+    ///     CacheSpec::Default,
     ///     Default::default(),
     /// );
     /// # let _ = session;
@@ -196,30 +207,30 @@ impl Session {
     /// # }
     /// ```
     pub fn with_cache_backends(
-        index_cache_backend: Option<Arc<dyn CacheBackend>>,
-        metadata_cache_backend: Option<Arc<dyn CacheBackend>>,
-        index_cache_size: usize,
-        metadata_cache_size: usize,
+        index_cache: CacheSpec,
+        metadata_cache: CacheSpec,
         store_registry: Arc<ObjectStoreRegistry>,
     ) -> Self {
-        let index_cache = match index_cache_backend {
-            Some(backend) => LanceCache::with_backend(backend),
-            None => LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(
-                index_cache_size,
-            ))),
-        };
-        let metadata_cache = match metadata_cache_backend {
-            Some(backend) => LanceCache::with_backend(backend),
-            None => LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(
-                metadata_cache_size,
-            ))),
-        };
+        let index_cache = Self::build_cache(index_cache, DEFAULT_INDEX_CACHE_SIZE);
+        let metadata_cache = Self::build_cache(metadata_cache, DEFAULT_METADATA_CACHE_SIZE);
         Self {
             index_cache: GlobalIndexCache(index_cache),
             metadata_cache: GlobalMetadataCache(metadata_cache),
             index_extensions: HashMap::new(),
             store_registry,
             spill_store: Arc::new(LocalSpillStore::default()),
+        }
+    }
+
+    fn build_cache(spec: CacheSpec, default_size: usize) -> LanceCache {
+        match spec {
+            CacheSpec::Default => {
+                LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(default_size)))
+            }
+            CacheSpec::Size(size) => {
+                LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(size)))
+            }
+            CacheSpec::Backend(backend) => LanceCache::with_backend(backend),
         }
     }
 
@@ -363,15 +374,18 @@ mod tests {
     }
 
     /// `with_cache_backends` should honor whichever tier the caller
-    /// provided a backend for and fall back to the size-based default on
-    /// the other tier.
+    /// provided a backend for and fall back to that tier's default on the
+    /// other tier.
     #[tokio::test]
     async fn test_with_cache_backends_uses_provided_and_default() {
         use lance_core::cache::build_from_uri;
 
         let index_backend = build_from_uri("moka://?capacity=1048576").unwrap();
-        let session =
-            Session::with_cache_backends(Some(index_backend), None, 0, 2048, Default::default());
+        let session = Session::with_cache_backends(
+            CacheSpec::Backend(index_backend),
+            CacheSpec::Default,
+            Default::default(),
+        );
 
         let value = Arc::new(vec![1, 2, 3]);
         session
@@ -390,6 +404,41 @@ mod tests {
         // sanity-check that the session was constructed without panicking.
         let stats = session.metadata_cache.0.stats().await;
         assert_eq!(stats.num_entries, 0);
+    }
+
+    #[tokio::test]
+    async fn test_with_cache_backends_uses_explicit_size() {
+        let session = Session::with_cache_backends(
+            CacheSpec::Size(0),
+            CacheSpec::Size(2048),
+            Default::default(),
+        );
+
+        session
+            .index_cache
+            .insert_with_key(&TestKey("disabled-index-cache"), Arc::new(vec![1, 2, 3]))
+            .await;
+        assert!(
+            session
+                .index_cache
+                .get_with_key(&TestKey("disabled-index-cache"))
+                .await
+                .is_none()
+        );
+
+        session
+            .metadata_cache
+            .0
+            .insert_with_key(&TestKey("metadata-cache"), Arc::new(vec![4, 5, 6]))
+            .await;
+        assert!(
+            session
+                .metadata_cache
+                .0
+                .get_with_key(&TestKey("metadata-cache"))
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -165,6 +165,64 @@ impl Session {
         &*self.spill_store
     }
 
+    /// Create a session with custom backends for both caches.
+    ///
+    /// Each argument, if provided, replaces the default Quick backend for that
+    /// cache. Passing `None` for either falls back to the size-based default
+    /// [`Session::new`] would have used for that tier.
+    ///
+    /// This is the recommended constructor when a caller has already resolved
+    /// backend selection through
+    /// [`build_from_config`](lance_core::cache::build_from_config) or
+    /// [`build_from_uri`](lance_core::cache::build_from_uri) — the resulting
+    /// `Arc<dyn CacheBackend>` can be plugged in for either or both caches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lance::session::Session;
+    /// # use lance_core::cache::build_from_uri;
+    /// # fn example() -> lance_core::Result<()> {
+    /// let index_backend = build_from_uri("moka://?capacity=1048576")?;
+    /// let session = Session::with_cache_backends(
+    ///     Some(index_backend),
+    ///     None,
+    ///     0,
+    ///     32 * 1024 * 1024,
+    ///     Default::default(),
+    /// );
+    /// # let _ = session;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_cache_backends(
+        index_cache_backend: Option<Arc<dyn CacheBackend>>,
+        metadata_cache_backend: Option<Arc<dyn CacheBackend>>,
+        index_cache_size: usize,
+        metadata_cache_size: usize,
+        store_registry: Arc<ObjectStoreRegistry>,
+    ) -> Self {
+        let index_cache = match index_cache_backend {
+            Some(backend) => LanceCache::with_backend(backend),
+            None => LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(
+                index_cache_size,
+            ))),
+        };
+        let metadata_cache = match metadata_cache_backend {
+            Some(backend) => LanceCache::with_backend(backend),
+            None => LanceCache::with_backend(Arc::new(QuickCacheBackend::with_capacity(
+                metadata_cache_size,
+            ))),
+        };
+        Self {
+            index_cache: GlobalIndexCache(index_cache),
+            metadata_cache: GlobalMetadataCache(metadata_cache),
+            index_extensions: HashMap::new(),
+            store_registry,
+            spill_store: Arc::new(LocalSpillStore::default()),
+        }
+    }
+
     /// Register a new index extension.
     ///
     /// A name can only be registered once per type of index extension.
@@ -262,10 +320,23 @@ impl Default for Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lance_core::cache::UnsizedCacheKey;
+    use lance_core::cache::{CacheKey, UnsizedCacheKey};
     use lance_index::vector::VectorIndex;
     use std::borrow::Cow;
     use tokio::io::AsyncWriteExt;
+
+    struct TestKey(&'static str);
+    impl CacheKey for TestKey {
+        type ValueType = Vec<i32>;
+
+        fn key(&self) -> Cow<'_, str> {
+            Cow::Borrowed(self.0)
+        }
+
+        fn type_name() -> &'static str {
+            "Test"
+        }
+    }
 
     struct TestUnsizedKey(&'static str);
     impl UnsizedCacheKey for TestUnsizedKey {
@@ -289,6 +360,36 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    /// `with_cache_backends` should honor whichever tier the caller
+    /// provided a backend for and fall back to the size-based default on
+    /// the other tier.
+    #[tokio::test]
+    async fn test_with_cache_backends_uses_provided_and_default() {
+        use lance_core::cache::build_from_uri;
+
+        let index_backend = build_from_uri("moka://?capacity=1048576").unwrap();
+        let session =
+            Session::with_cache_backends(Some(index_backend), None, 0, 2048, Default::default());
+
+        let value = Arc::new(vec![1, 2, 3]);
+        session
+            .index_cache
+            .insert_with_key(&TestKey("injected-index-backend"), value.clone())
+            .await;
+        assert_eq!(
+            session
+                .index_cache
+                .get_with_key(&TestKey("injected-index-backend"))
+                .await
+                .as_deref(),
+            Some(value.as_ref())
+        );
+        // Metadata cache fell back to a size-based default. We can only
+        // sanity-check that the session was constructed without panicking.
+        let stats = session.metadata_cache.0.stats().await;
+        assert_eq!(stats.num_entries, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

  Implements the phase-1 framework proposed in
  [discussion #7575](https://github.com/lance-format/lance/discussions/7575):
  a registry so cache backends can be selected by a stable string identifier
  (`kind`) and configured through either a structured `BackendConfig` or a
  compact URI. `MokaCacheBackend` is auto-registered under `"moka"` so no
  user-visible behavior changes for the default configuration.

  This PR intentionally ships only the mechanism. It does not add a new
  concrete backend implementation. Third-party crates (compiled together with
  Lance) integrate by defining their own `BackendBuildFn` and calling
  `register_backend(kind, build)` once at startup. A future PR can add a
  dynamic-library loader on top of the same registry without changing the
  user-facing configuration model.

  ## What lands

  1. **`BackendConfig` + registry**
     `BackendConfig { kind, options: HashMap<String, String> }` and a
     process-wide registry (`register_backend`, `build_from_config`). Options
     are FFI-friendly string pairs so the same shape carries across Python
     `dict[str, str]`, Java `Map<String, String>`, or a future stable ABI.
     Duplicate `kind` registration returns an error rather than silently
     overriding an existing constructor.

  2. **URI form**
     `parse_backend_uri` / `build_from_uri` accept a compact single-string
     form (`moka://?capacity=1073741824`). Grammar is a small, predictable
     subset of RFC 3986:

     ```text
     uri     ::= scheme ":" hier ( "?" query )?
     hier    ::= "//" authority path?  |  path
     ```

     The scheme becomes `kind`; the joined authority+path (if any) is stored
     under the option `path`; query pairs are percent-decoded. Duplicate query
     keys, pairs without `=`, and invalid schemes are rejected.

  3. **Auto-register `MokaCacheBackend` as `"moka"`**
     A private `ensure_builtin_backends()` runs on the first call to
     `build_from_config` / `build_from_uri`, so a bare Lance install can
     build a Moka backend from a URI/config without the caller registering
     it first. The build fn recognises a single option (`capacity` in bytes)
     and rejects unknown options so typos surface at construction time.

  4. **Symmetric `Session::with_cache_backends`**
     New constructor takes `Option<Arc<dyn CacheBackend>>` for both the index
     and metadata caches. Whichever tier the caller passes `None` for falls
     back to the same size-based default that `Session::new` would have used.
     The existing `Session::new` / `Session::with_index_cache_backend`
     entrypoints are unchanged.

  5. **Python `Session(index_cache_backend=..., metadata_cache_backend=...)`**
     Each accepts either a URI `str` (`"moka://?capacity=..."`) resolved
     through `build_from_uri`, or a `dict` of the form
     `{"kind": "moka", "options": {"capacity": "..."}}` resolved through
     `build_from_config`. Passing both `*_cache_size_bytes` and
     `*_cache_backend` for the same cache raises `ValueError` at the binding
     boundary rather than silently letting one override the other
     (proposal §7).

  ## What this PR intentionally does not do

  * No new concrete backend is added. Foyer / Redis / disk backends live in
    external crates and register themselves with `register_backend(...)`.
  * No dynamic `.so` / C-ABI loader. The design keeps room for it later
    (string-map config, conflict-detecting registry, byte-oriented
    values via `CacheCodec`), but that's a follow-up.
  * No changes to the `CacheBackend` trait itself.
  * Default behavior (`Session::new(index_cache_size, metadata_cache_size, ...)`)
    is byte-for-byte the same as before.

  ## Usage sketch

  Rust:

  ```rust
  use lance_core::cache::build_from_uri;
  use lance::session::Session;

  let index = build_from_uri("moka://?capacity=1073741824")?;
  let session = Session::with_cache_backends(
      Some(index), None, /* size defaults */ 0, 0, Default::default(),
  );
  ```

  A hypothetical third-party crate:

  ```rust
  // In `my-cache-backend` crate:
  pub fn register() -> lance_core::Result<()> {
      lance_core::cache::register_backend("my_backend", build_my_backend)
  }
  ```

  Python:

  ```python
  session = lance.Session(
      index_cache_backend="moka://?capacity=1073741824",
      metadata_cache_backend={"kind": "moka", "options": {"capacity": "268435456"}},
  )
  ```

  ## Test plan

  - [x] `cargo check -p lance-core --tests`
  - [x] `cargo check -p lance --tests`
  - [x] `cargo check --manifest-path python/Cargo.toml`
  - [x] `cargo test -p lance-core --lib cache::` — 39 passed (14 new: 4 registry
        + 10 URI parser + 4 moka via config/URI)
  - [x] `cargo test -p lance --lib session::tests` — 10 passed (1 new:
        `test_with_cache_backends_uses_provided_and_default`)
  - [ ] Python end-to-end (`Session(index_cache_backend="moka://...")` roundtrip)
        — reviewers who prefer a wheel-based smoke test, please shout and I'll add
        one.

  ## Discussion link

  Design context and open questions:
  [Discussion #7575 — Proposal: Pluggable cache backends](https://github.com/lance-format/lance/discussions/7575)