### PR TITLE
fix(python): ignore PyTorch 3.14 script_method warning

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -147,6 +147,8 @@ filterwarnings = [
     'ignore:.*the load_module\(\) method is deprecated.*:DeprecationWarning',
     # Pytorch uses deprecated jit.script_method internally (torch/utils/mkldnn.py)
     'ignore:.*torch\.jit\.script_method.*is deprecated.*:DeprecationWarning',
+    # Pytorch uses the same API internally on Python 3.14+ with a different warning message.
+    'ignore:.*torch\.jit\.script_method.*is not supported in Python 3\.14\+.*:DeprecationWarning',
     # huggingface_hub still calls the deprecated hf_xet.download_files() during Xet downloads
     'ignore:.*hf_xet\.download_files\(\) is deprecated.*:DeprecationWarning',
 ]


### PR DESCRIPTION
Part of #7349.

PyTorch 2.12.1 emits a new `torch.jit.script_method` deprecation warning on Python 3.14+ from its internal `torch.utils.mkldnn` import path. Lance already treats deprecation warnings as errors in pytest and already ignores the older PyTorch warning wording, but the Python 3.14+ message did not match that rule.

This adds a narrow pytest warning filter for the new PyTorch 3.14+ message while keeping Lance's broader `DeprecationWarning` policy intact.

Validation:

- `uv run --frozen --python 3.14 --extra torch pytest -q python/tests/torch_tests/test_distance.py python/tests/torch_tests/test_torch_kmeans.py python/tests/torch_tests/test_bench_utils.py`
- `git diff --check`
