### PR TITLE
feat(python): add target_partition_size to IndicesBuilder.train_ivf()

### DIFF
--- a/python/python/lance/indices/builder.py
+++ b/python/python/lance/indices/builder.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-import math
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
@@ -11,6 +10,7 @@ import pyarrow as pa
 
 from lance.indices.ivf import IvfModel
 from lance.indices.pq import PqModel
+from lance.util import _target_partition_size_to_num_partitions
 
 if TYPE_CHECKING:
     import torch
@@ -69,6 +69,7 @@ class IndicesBuilder:
         sample_rate: int = 256,
         max_iters: int = 50,
         fragment_ids: Optional[list[int]] = None,
+        target_partition_size: Optional[int] = None,
     ) -> IvfModel:
         """
         Train IVF centroids for the given vector column.
@@ -87,12 +88,14 @@ class IndicesBuilder:
         Parameters
         ----------
 
-        num_partitions: int
+        num_partitions: int, optional
+            Deprecated.  Use ``target_partition_size`` instead.
+
             The number of partitions to train.  Large values are more expensive to
             train and can lead to longer search times.  Smaller values could lead to
-            overtraining, reduced recall, and require large nprobes values.  If not
-            specified the default will be the integer nearest the square root of the
-            number of rows.
+            overtraining, reduced recall, and require large nprobes values.  If both
+            ``num_partitions`` and ``target_partition_size`` are specified,
+            ``num_partitions`` takes precedence.
         distance_type: "l2" | "dot" | "cosine" | "hamming"
             The distance type to used.  This is defined in more detail in the LanceDB
             documentation on creating indices.
@@ -111,9 +114,25 @@ class IndicesBuilder:
             max_iters parameter defines a cutoff at which we terminate training.
         fragment_ids: list[int], optional
             If provided, train using only the specified fragments from the dataset.
+        target_partition_size: int, optional
+            The target number of rows per partition.  The number of partitions is
+            computed as ``num_rows // target_partition_size``, clamped to [1, 4096].
+            If neither ``num_partitions`` nor ``target_partition_size`` is specified,
+            a default target partition size of 8192 is used.
         """
         num_rows = self._count_rows(fragment_ids)
-        num_partitions = self._determine_num_partitions(num_partitions, num_rows)
+        if num_partitions is None:
+            num_partitions = _target_partition_size_to_num_partitions(
+                num_rows, target_partition_size
+            )
+        elif target_partition_size is not None:
+            warnings.warn(
+                "Both num_partitions and target_partition_size are specified; "
+                "num_partitions takes precedence and target_partition_size is "
+                "ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._verify_ivf_sample_rate(sample_rate, num_partitions, num_rows)
         distance_type = self._normalize_distance_type(distance_type)
         self._verify_ivf_params(num_partitions)
@@ -474,11 +493,6 @@ class IndicesBuilder:
             )
         else:
             raise ValueError("filenames must be a list of strings")
-
-    def _determine_num_partitions(self, num_partitions: Optional[int], num_rows: int):
-        if num_partitions is None:
-            return round(math.sqrt(num_rows))
-        return num_partitions
 
     def _count_rows(self, fragment_ids: Optional[list[int]] = None) -> int:
         if fragment_ids is None:

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
-import math
 import os
 import pathlib
 
@@ -92,7 +91,9 @@ def make_multivector_dataset(tmpdir):
 
 
 def test_ivf_centroids(tmpdir, rand_dataset):
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(sample_rate=16)
+    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+        num_partitions=NUM_PARTITIONS, sample_rate=16
+    )
 
     assert ivf.distance_type == "l2"
     assert len(ivf.centroids) == NUM_PARTITIONS
@@ -115,12 +116,11 @@ def test_ivf_centroids_hamming(tmpdir):
     ds = lance.write_dataset(table, uri, max_rows_per_file=NUM_ROWS_PER_FRAGMENT)
 
     ivf = IndicesBuilder(ds, "vectors").train_ivf(
-        sample_rate=16, distance_type="hamming"
+        num_partitions=NUM_PARTITIONS, sample_rate=16, distance_type="hamming"
     )
 
     assert ivf.distance_type == "hamming"
-    expected_partitions = round(math.sqrt(num_rows))
-    assert len(ivf.centroids) == expected_partitions
+    assert len(ivf.centroids) == NUM_PARTITIONS
 
     ivf.save(str(tmpdir / "ivf_hamming"))
     reloaded = IvfModel.load(str(tmpdir / "ivf_hamming"))
@@ -131,7 +131,7 @@ def test_ivf_centroids_hamming(tmpdir):
 @pytest.mark.parametrize("distance_type", ["l2", "cosine", "dot"])
 def test_ivf_centroids_mostly_null(mostly_null_dataset, distance_type):
     ivf = IndicesBuilder(mostly_null_dataset, "vectors").train_ivf(
-        sample_rate=16, distance_type=distance_type
+        num_partitions=NUM_PARTITIONS, sample_rate=16, distance_type=distance_type
     )
 
     assert ivf.distance_type == distance_type
@@ -141,20 +141,21 @@ def test_ivf_centroids_mostly_null(mostly_null_dataset, distance_type):
 @pytest.mark.cuda
 def test_ivf_centroids_cuda(rand_dataset):
     ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
-        sample_rate=16, accelerator="cuda"
+        num_partitions=NUM_PARTITIONS, sample_rate=16, accelerator="cuda"
     )
 
     assert ivf.distance_type == "l2"
-    # Can't use NUM_PARTITIONS here because
-    # CUDA uses math.ceil and CPU uses round to calc. num_partitions
-    assert len(ivf.centroids) == math.ceil(np.sqrt(NUM_ROWS))
+    assert len(ivf.centroids) == NUM_PARTITIONS
 
 
 @pytest.mark.cuda
 @pytest.mark.parametrize("distance_type", ["l2", "cosine", "dot"])
 def test_ivf_centroids_mostly_null_cuda(mostly_null_dataset, distance_type):
     ivf = IndicesBuilder(mostly_null_dataset, "vectors").train_ivf(
-        sample_rate=16, accelerator="cuda", distance_type=distance_type
+        num_partitions=NUM_PARTITIONS,
+        sample_rate=16,
+        accelerator="cuda",
+        distance_type=distance_type,
     )
 
     assert ivf.distance_type == distance_type
@@ -181,6 +182,30 @@ def test_num_partitions(rand_dataset):
         sample_rate=16, num_partitions=10
     )
     assert ivf.num_partitions == 10
+
+
+def test_target_partition_size(rand_dataset):
+    # num_partitions is computed as num_rows // target_partition_size,
+    # clamped to [1, 4096].
+    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+        sample_rate=16, target_partition_size=5000
+    )
+    assert ivf.num_partitions == NUM_ROWS // 5000
+
+
+def test_target_partition_size_default(rand_dataset):
+    # When neither num_partitions nor target_partition_size is specified, the
+    # default target partition size of 8192 is used.
+    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(sample_rate=16)
+    assert ivf.num_partitions == NUM_ROWS // 8192
+
+
+def test_num_partitions_overrides_target(rand_dataset):
+    with pytest.warns(DeprecationWarning, match="num_partitions takes precedence"):
+        ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, num_partitions=5, target_partition_size=5000
+        )
+    assert ivf.num_partitions == 5
 
 
 @pytest.fixture


### PR DESCRIPTION
Exposes `target_partition_size` on `IndicesBuilder.train_ivf()`, mirroring `Dataset.create_index()`. Previously this lower-level builder API only accepted the deprecated `num_partitions` and defaulted to `round(sqrt(num_rows))`.

When `num_partitions` is not given, the partition count is derived via the shared `_target_partition_size_to_num_partitions` helper: `clamp(num_rows // target_partition_size, 1, 4096)`, defaulting `target_partition_size` to 8192. `num_partitions` is now deprecated; when both are passed it takes precedence with a `DeprecationWarning`.

This changes the no-argument default from `round(sqrt(num_rows))` to the 8192-based sizing, matching `create_index`. Existing centroid-count tests that relied on the sqrt default now pass `num_partitions` explicitly; the new default is covered by a dedicated test.

Takes over #6468.

Closes #6286

## Tests
- `test_target_partition_size` — explicit `target_partition_size`
- `test_target_partition_size_default` — no-arg default (8192)
- `test_num_partitions_overrides_target` — precedence + `DeprecationWarning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)