### PR TITLE
fix: keep ids and addresses aligned in filter_deleted_ids under stabl…

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2702,16 +2702,17 @@ impl Dataset {
     pub(crate) async fn filter_deleted_ids(&self, ids: &[u64]) -> Result<Vec<u64>> {
         let (ids, addresses) = if let Some(row_id_index) = get_row_id_index(self).await? {
             // Ids absent from the deletion-aware index are deleted; drop
-            // them from both lists to keep the zip aligned.
-            let (ids, addresses): (Vec<u64>, Vec<u64>) = ids
-                .iter()
-                .filter_map(|id| {
-                    row_id_index
-                        .get(*id)
-                        .map(|address| (*id, u64::from(address)))
-                })
-                .unzip();
-            (Cow::Owned(ids), Cow::Owned(addresses))
+            // them from both lists to keep the zip aligned. ids.len() is an
+            // upper bound on the output size, so allocate once up front.
+            let mut live_ids = Vec::with_capacity(ids.len());
+            let mut addresses = Vec::with_capacity(ids.len());
+            for id in ids {
+                if let Some(address) = row_id_index.get(*id) {
+                    live_ids.push(*id);
+                    addresses.push(u64::from(address));
+                }
+            }
+            (Cow::Owned(live_ids), Cow::Owned(addresses))
         } else {
             (Cow::Borrowed(ids), Cow::Borrowed(ids))
         };

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2580,6 +2580,15 @@ impl Dataset {
 
     // This method filters deleted items from `addr_or_ids` using `addrs` as a reference
     async fn filter_addr_or_ids(&self, addr_or_ids: &[u64], addrs: &[u64]) -> Result<Vec<u64>> {
+        // The final zip pairs these positionally; misalignment must fail
+        // loud rather than truncate.
+        if addr_or_ids.len() != addrs.len() {
+            return Err(Error::internal(format!(
+                "filter_addr_or_ids: addr_or_ids has {} entries but addrs has {}",
+                addr_or_ids.len(),
+                addrs.len()
+            )));
+        }
         if addrs.is_empty() {
             return Ok(Vec::new());
         }
@@ -2691,17 +2700,23 @@ impl Dataset {
     }
 
     pub(crate) async fn filter_deleted_ids(&self, ids: &[u64]) -> Result<Vec<u64>> {
-        let addresses = if let Some(row_id_index) = get_row_id_index(self).await? {
-            let addresses = ids
+        let (ids, addresses) = if let Some(row_id_index) = get_row_id_index(self).await? {
+            // Ids absent from the deletion-aware index are deleted; drop
+            // them from both lists to keep the zip aligned.
+            let (ids, addresses): (Vec<u64>, Vec<u64>) = ids
                 .iter()
-                .filter_map(|id| row_id_index.get(*id).map(|address| address.into()))
-                .collect::<Vec<_>>();
-            Cow::Owned(addresses)
+                .filter_map(|id| {
+                    row_id_index
+                        .get(*id)
+                        .map(|address| (*id, u64::from(address)))
+                })
+                .unzip();
+            (Cow::Owned(ids), Cow::Owned(addresses))
         } else {
-            Cow::Borrowed(ids)
+            (Cow::Borrowed(ids), Cow::Borrowed(ids))
         };
 
-        self.filter_addr_or_ids(ids, &addresses).await
+        self.filter_addr_or_ids(&ids, &addresses).await
     }
 
     /// Gets the number of files that are so small they don't even have a full

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -467,6 +467,61 @@ mod test {
         assert_eq!(index.get(5), None);
     }
 
+    /// 100 sequential rows across 4 fragments with every third row deleted.
+    async fn deleted_thirds_dataset(enable_stable_row_ids: bool) -> Dataset {
+        let batch = sequence_batch(0..100);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let write_params = WriteParams {
+            enable_stable_row_ids,
+            max_rows_per_file: 25,
+            ..Default::default()
+        };
+        let mut dataset = Dataset::write(reader, "memory://", Some(write_params))
+            .await
+            .unwrap();
+        dataset.delete("id % 3 = 0").await.unwrap();
+        dataset
+    }
+
+    #[tokio::test]
+    async fn test_filter_deleted_ids_with_stable_row_ids() {
+        // Regression test for https://github.com/lance-format/lance/issues/7701:
+        // filter_deleted_ids must return exactly the live ids, in order.
+        // Sequential inserts, so stable row id == id column value, and the
+        // deleted ids sit at the front of each sorted query.
+        let dataset = deleted_thirds_dataset(true).await;
+
+        let all: Vec<u64> = (0..100).collect();
+        let live: Vec<u64> = (0..100).filter(|id| id % 3 != 0).collect();
+        let cases: [(&str, &[u64], &[u64]); 3] = [
+            ("interleaved", &all, &live),
+            ("all deleted", &[0, 3, 9], &[]),
+            ("all live", &[1, 2, 50, 98], &[1, 2, 50, 98]),
+        ];
+        for (name, ids, expected) in cases {
+            assert_eq!(
+                dataset.filter_deleted_ids(ids).await.unwrap(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_filter_deleted_ids_without_stable_row_ids() {
+        // Non-stable: ids are row addresses; only deleted rows drop out.
+        let dataset = deleted_thirds_dataset(false).await;
+
+        // Row addresses: fragment (id / 25) << 32 | offset (id % 25).
+        let addr = |id: u64| (id / 25) << 32 | (id % 25);
+        let ids = (0..100).map(addr).collect::<Vec<u64>>();
+        let expected = (0..100)
+            .filter(|id| id % 3 != 0)
+            .map(addr)
+            .collect::<Vec<u64>>();
+        assert_eq!(dataset.filter_deleted_ids(&ids).await.unwrap(), expected);
+    }
+
     fn build_rowid_to_i_map(row_ids: &UInt64Array, i_array: &Int32Array) -> HashMap<u64, i32> {
         row_ids
             .values()

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -483,28 +483,20 @@ mod test {
         dataset
     }
 
+    #[rstest::rstest]
+    #[case::interleaved((0..100).collect(), (0..100).filter(|id| id % 3 != 0).collect())]
+    #[case::all_deleted(vec![0, 3, 9], vec![])]
+    #[case::all_live(vec![1, 2, 50, 98], vec![1, 2, 50, 98])]
     #[tokio::test]
-    async fn test_filter_deleted_ids_with_stable_row_ids() {
+    async fn test_filter_deleted_ids_with_stable_row_ids(
+        #[case] ids: Vec<u64>,
+        #[case] expected: Vec<u64>,
+    ) {
         // Regression test for https://github.com/lance-format/lance/issues/7701:
         // filter_deleted_ids must return exactly the live ids, in order.
-        // Sequential inserts, so stable row id == id column value, and the
-        // deleted ids sit at the front of each sorted query.
+        // Sequential inserts, so stable row id == id column value.
         let dataset = deleted_thirds_dataset(true).await;
-
-        let all: Vec<u64> = (0..100).collect();
-        let live: Vec<u64> = (0..100).filter(|id| id % 3 != 0).collect();
-        let cases: [(&str, &[u64], &[u64]); 3] = [
-            ("interleaved", &all, &live),
-            ("all deleted", &[0, 3, 9], &[]),
-            ("all live", &[1, 2, 50, 98], &[1, 2, 50, 98]),
-        ];
-        for (name, ids, expected) in cases {
-            assert_eq!(
-                dataset.filter_deleted_ids(ids).await.unwrap(),
-                expected,
-                "{name}"
-            );
-        }
+        assert_eq!(dataset.filter_deleted_ids(&ids).await.unwrap(), expected);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2055,7 +2055,7 @@ mod tests {
     use crate::dataset::{InsertBuilder, UpdateBuilder, WriteMode, WriteParams};
     use crate::index::DatasetIndexExt;
     use crate::index::DatasetIndexInternalExt;
-    use crate::index::vector::ivf::v2::IvfPq;
+    use crate::index::vector::ivf::v2::{IvfFlatIndex, IvfPq};
     use crate::utils::test::copy_test_data_to_tmp;
     use crate::{
         Dataset,
@@ -2863,6 +2863,17 @@ mod tests {
     }
 
     async fn load_partition_row_ids(index: &IvfPq, partition_idx: usize) -> Vec<u64> {
+        index
+            .storage
+            .load_partition(partition_idx, None)
+            .await
+            .unwrap()
+            .row_ids()
+            .copied()
+            .collect()
+    }
+
+    async fn load_flat_partition_row_ids(index: &IvfFlatIndex, partition_idx: usize) -> Vec<u64> {
         index
             .storage
             .load_partition(partition_idx, None)
@@ -6138,6 +6149,187 @@ mod tests {
             assert!(
                 search_result.num_rows() > 0,
                 "Multivector search should return results with remaining data"
+            );
+        }
+    }
+
+    async fn row_ids_matching(dataset: &Dataset, predicate: &str) -> HashSet<u64> {
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        scan.filter(predicate).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        batch[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    struct OptimizeAfterDelete {
+        deleted_row_ids: HashSet<u64>,
+        partition_row_ids_before: Vec<Vec<u64>>,
+        index_row_ids: HashSet<u64>,
+        num_partitions_after: usize,
+        stats_json: String,
+    }
+
+    /// Shared scenario for the issue-7701 regressions: stable-row-id dataset,
+    /// IVF_FLAT index, scattered delete, optimize. Asserts the invariants both
+    /// partition adjustments must hold -- no live row lost, no id that never
+    /// existed -- and returns the state for the mode-specific assertions.
+    async fn optimize_after_delete(
+        total_rows: usize,
+        nlist: usize,
+        delete_predicate: &str,
+        keep_predicate: &str,
+    ) -> OptimizeAfterDelete {
+        const INDEX_NAME: &str = "vector_idx";
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let (batch, schema) = generate_batch::<Float32Type>(total_rows, None, 0.0..1.0, false);
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+        let mut dataset = Dataset::write(
+            batches,
+            test_uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params = VectorIndexParams::ivf_flat(nlist, DistanceType::L2);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let index_ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let flat = index_ctx
+            .index
+            .as_any()
+            .downcast_ref::<IvfFlatIndex>()
+            .expect("expected IvfFlat index");
+        let mut partition_row_ids_before = Vec::with_capacity(nlist);
+        for part in 0..flat.ivf.num_partitions() {
+            partition_row_ids_before.push(load_flat_partition_row_ids(flat, part).await);
+        }
+
+        let deleted_row_ids = row_ids_matching(&dataset, delete_predicate).await;
+        let live_row_ids = row_ids_matching(&dataset, keep_predicate).await;
+        dataset.delete(delete_predicate).await.unwrap();
+
+        dataset
+            .optimize_indices(&OptimizeOptions::new())
+            .await
+            .unwrap();
+
+        let final_ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
+        let num_partitions_after = final_ctx.num_partitions();
+        let stats_json = final_ctx.stats_json().to_string();
+        let flat = final_ctx
+            .index
+            .as_any()
+            .downcast_ref::<IvfFlatIndex>()
+            .expect("expected IvfFlat index");
+        let mut index_row_ids = HashSet::new();
+        for part in 0..flat.ivf.num_partitions() {
+            index_row_ids.extend(load_flat_partition_row_ids(flat, part).await);
+        }
+
+        for row_id in &live_row_ids {
+            assert!(
+                index_row_ids.contains(row_id),
+                "live row id {} missing from index after optimize",
+                row_id
+            );
+        }
+        for row_id in &index_row_ids {
+            assert!(
+                live_row_ids.contains(row_id) || deleted_row_ids.contains(row_id),
+                "unexpected row id {} in index after optimize",
+                row_id
+            );
+        }
+
+        OptimizeAfterDelete {
+            deleted_row_ids,
+            partition_row_ids_before,
+            index_row_ids,
+            num_partitions_after,
+            stats_json,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_optimize_join_after_delete_with_stable_row_ids() {
+        // Regression test for https://github.com/lance-format/lance/issues/7701:
+        // every partition (400 rows / 4) is under the IVF_FLAT join threshold,
+        // so optimize joins the smallest after a scattered delete.
+        let run = optimize_after_delete(400, 4, "id % 3 = 0", "id % 3 != 0").await;
+
+        assert_eq!(
+            run.num_partitions_after, 3,
+            "optimize should have joined the smallest partition, got stats: {}",
+            run.stats_json
+        );
+
+        // Only the joined partition is rebuilt from live rows; untouched
+        // partitions keep their deleted ids (filtered at query time).
+        let missing = run
+            .deleted_row_ids
+            .difference(&run.index_row_ids)
+            .copied()
+            .collect::<HashSet<_>>();
+        assert!(
+            !missing.is_empty(),
+            "joined partition should have contained deleted row ids"
+        );
+        let matches_one_partition = run.partition_row_ids_before.iter().any(|part_ids| {
+            let part_deleted = part_ids
+                .iter()
+                .copied()
+                .filter(|id| run.deleted_row_ids.contains(id))
+                .collect::<HashSet<_>>();
+            part_deleted == missing
+        });
+        assert!(
+            matches_one_partition,
+            "row ids dropped from the index should be exactly the joined partition's deleted ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimize_split_after_delete_with_stable_row_ids() {
+        // Regression test for https://github.com/lance-format/lance/issues/7701:
+        // one partition holds more than 4x the IVF_FLAT target, so optimize
+        // splits it after a scattered delete. This path reaches
+        // filter_deleted_ids through reshuffle_partitions, unlike the join
+        // path's take_vectors.
+        let run = optimize_after_delete(20_000, 1, "id % 5 = 0", "id % 5 != 0").await;
+
+        assert!(
+            run.num_partitions_after > 1,
+            "optimize should have split the oversized partition, got stats: {}",
+            run.stats_json
+        );
+
+        // The split rebuilds the whole partition from live rows: no deleted
+        // ids remain.
+        for row_id in &run.deleted_row_ids {
+            assert!(
+                !run.index_row_ids.contains(row_id),
+                "deleted row id {} still in index after split",
+                row_id
             );
         }
     }


### PR DESCRIPTION
…e row ids

The deletion-aware row id index drops deleted ids when mapping row ids to addresses, so on stable-row-id datasets filter_deleted_ids produced an address list shorter than its id list. filter_addr_or_ids then zipped the two lists and silently truncated at the shorter one, returning the first N sorted input ids verbatim: deleted ids were kept and trailing live ids were dropped.

This broke optimize_indices whenever a partition fell under the join threshold after a delete, failing with
"batch.num_rows() != chunk.len()" while taking the joined partition's vectors; the partition split path reaches filter_deleted_ids the same way.

Filter ids and addresses together so an id absent from the index is dropped from both lists, and make filter_addr_or_ids return an internal error on mismatched input lengths instead of silently truncating.

Fixes #7701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete filtering to keep row IDs and row addresses correctly aligned, preventing incorrect matches after deletions.
  * Added a safeguard to fail fast on mismatched input lengths instead of returning potentially wrong results.
  * Fixed post-delete index optimization so deleted rows are properly removed and stable row IDs remain consistent.

* **Tests**
  * Added regression coverage for stable vs non-stable row ID deletion filtering.
  * Expanded IVF v2 regression tests to verify correct behavior after scattered deletes, including join/split scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->