### PR TITLE
fix: assign fragment and row ids to new fragments in Merge commits

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -1139,9 +1139,10 @@ def write_fragments(
     enable_stable_row_ids: bool
         Has no effect. Row ids are not assigned by this function; they are
         assigned when the fragments are committed to a dataset (e.g. via
-        :class:`lance.LanceOperation.Append` and
-        :meth:`lance.LanceDataset.commit`), based on whether the target
-        dataset uses stable row ids.
+        :class:`lance.LanceOperation.Append`, or
+        :class:`lance.LanceOperation.Merge` when merging staged fragments
+        with existing ones, together with :meth:`lance.LanceDataset.commit`),
+        based on whether the target dataset uses stable row ids.
     target_bases : list of str, optional
         References to base paths where data should be written. Can be
         specified in all modes.

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -1137,10 +1137,11 @@ def write_fragments(
         Extra options that make sense for a particular storage connection. This is
         used to store connection parameters like credentials, endpoint, etc.
     enable_stable_row_ids: bool
-        Experimental: if set to true, the writer will use stable row ids.
-        These row ids are stable after compaction operations, but not after updates.
-        This makes compaction more efficient, since with stable row ids no
-        secondary indices need to be updated to point to new row ids.
+        Has no effect. Row ids are not assigned by this function; they are
+        assigned when the fragments are committed to a dataset (e.g. via
+        :class:`lance.LanceOperation.Append` and
+        :meth:`lance.LanceDataset.commit`), based on whether the target
+        dataset uses stable row ids.
     target_bases : list of str, optional
         References to base paths where data should be written. Can be
         specified in all modes.

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -981,6 +981,10 @@ def test_merge_commits_staged_new_fragments(
     new_frags = write_fragments(pa.table({"id": [5, 6], "v": [50, 60]}), tmp_path)
     assert all(f.id == 0 for f in new_frags)
 
+    if enable_stable_row_ids:
+        pre = ds.to_table(with_row_id=True)
+        pre_row_ids = dict(zip(pre["id"].to_pylist(), pre["_rowid"].to_pylist()))
+
     all_frags = [f.metadata for f in ds.get_fragments()] + list(new_frags)
     merge = lance.LanceOperation.Merge(all_frags, ds.lance_schema)
     ds = lance.LanceDataset.commit(tmp_path, merge, read_version=ds.version)
@@ -994,3 +998,6 @@ def test_merge_commits_staged_new_fragments(
     if enable_stable_row_ids:
         assert sorted(row_ids) == list(range(6))
         assert all(f.metadata.row_id_meta is not None for f in ds.get_fragments())
+        # Pre-existing rows keep their exact row ids through the merge.
+        post_row_ids = dict(zip(table["id"].to_pylist(), row_ids))
+        assert {i: post_row_ids[i] for i in pre_row_ids} == pre_row_ids

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -962,3 +962,35 @@ def test_fragment_update_columns_with_json_column(tmp_path):
             assert "x" in meta_val or "x" in str(meta), (
                 f"id={id_val} should have original value, got {meta_val}"
             )
+
+
+@pytest.mark.parametrize("enable_stable_row_ids", [False, True])
+def test_merge_commits_staged_new_fragments(
+    tmp_path: Path, enable_stable_row_ids: bool
+):
+    # Regression test for https://github.com/lance-format/lance/issues/7702: a
+    # Merge that introduces staged fragments must assign fresh fragment ids
+    # and, on stable row id datasets, row ids at commit time.
+    tab = pa.table({"id": [1, 2, 3, 4], "v": [10, 20, 30, 40]})
+    ds = write_dataset(
+        tab,
+        tmp_path,
+        max_rows_per_file=2,
+        enable_stable_row_ids=enable_stable_row_ids,
+    )
+    new_frags = write_fragments(pa.table({"id": [5, 6], "v": [50, 60]}), tmp_path)
+    assert all(f.id == 0 for f in new_frags)
+
+    all_frags = [f.metadata for f in ds.get_fragments()] + list(new_frags)
+    merge = lance.LanceOperation.Merge(all_frags, ds.lance_schema)
+    ds = lance.LanceDataset.commit(tmp_path, merge, read_version=ds.version)
+
+    frag_ids = [f.fragment_id for f in ds.get_fragments()]
+    assert frag_ids == [0, 1, 2]
+    table = ds.to_table(with_row_id=True)
+    assert sorted(table["id"].to_pylist()) == [1, 2, 3, 4, 5, 6]
+    row_ids = table["_rowid"].to_pylist()
+    assert len(set(row_ids)) == 6
+    if enable_stable_row_ids:
+        assert sorted(row_ids) == list(range(6))
+        assert all(f.metadata.row_id_meta is not None for f in ds.get_fragments())

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -4294,3 +4294,200 @@ async fn test_merge_insert_target_all_bases() {
         assert!(all_rows.contains(&row), "missing row {:?}", row);
     }
 }
+
+/// A Merge commit may introduce staged fragments (write_fragments output:
+/// placeholder id 0, no row id metadata) alongside the existing fragments.
+/// They must receive fresh fragment ids and, on stable row id datasets, row
+/// ids -- the same treatment Append gives them. Regression test for
+/// https://github.com/lance-format/lance/issues/7702.
+#[rstest]
+#[tokio::test]
+async fn test_merge_commits_staged_new_fragments(#[values(false, true)] use_stable_row_id: bool) {
+    use arrow::datatypes::UInt64Type;
+
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+    )
+    .unwrap();
+    let test_uri = TempStrDir::default();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            enable_stable_row_ids: use_stable_row_id,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.fragments().len(), 2);
+    let read_version = dataset.version().version;
+    let existing: Vec<Fragment> = dataset.fragments().as_ref().clone();
+
+    // Stage new fragments without committing, like Python's write_fragments.
+    let batch2 =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![5, 6]))]).unwrap();
+    let transaction = InsertBuilder::new(WriteDestination::Dataset(Arc::new(dataset.clone())))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute_uncommitted(vec![batch2])
+        .await
+        .unwrap();
+    let Operation::Append { fragments: staged } = transaction.operation else {
+        panic!("expected an Append transaction from execute_uncommitted");
+    };
+    assert!(
+        staged.iter().all(|f| f.id == 0 && f.row_id_meta.is_none()),
+        "staged fragments arrive with placeholder id 0 and no row ids"
+    );
+
+    let mut merge_list = existing.clone();
+    merge_list.extend(staged);
+    let merge_schema = dataset.schema().clone();
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::Merge {
+            fragments: merge_list,
+            schema: merge_schema,
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+    dataset.validate().await.unwrap();
+
+    // The staged fragment received a fresh, non-duplicate id.
+    let ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+    assert_eq!(ids, vec![0, 1, 2]);
+
+    // Existing fragments keep their row id metadata byte-identical.
+    for prev in &existing {
+        let frag = dataset
+            .fragments()
+            .iter()
+            .find(|f| f.id == prev.id)
+            .unwrap();
+        assert_eq!(frag.row_id_meta, prev.row_id_meta);
+    }
+
+    let batch = dataset.scan().try_into_batch().await.unwrap();
+    let mut values: Vec<i32> = batch["i"].as_primitive::<Int32Type>().values().to_vec();
+    values.sort_unstable();
+    assert_eq!(values, vec![1, 2, 3, 4, 5, 6]);
+
+    if use_stable_row_id {
+        let new_frag = dataset.fragments().iter().find(|f| f.id == 2).unwrap();
+        assert!(
+            new_frag.row_id_meta.is_some(),
+            "staged fragment must be assigned row ids at commit time"
+        );
+        assert_eq!(dataset.manifest.next_row_id, 6);
+
+        // Row ids are unique and the staged rows got the next allocation block.
+        let batch = dataset.scan().with_row_id().try_into_batch().await.unwrap();
+        let row_ids: HashSet<u64> = batch[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(row_ids, (0..6).collect::<HashSet<u64>>());
+    } else {
+        assert!(dataset.fragments().iter().all(|f| f.row_id_meta.is_none()));
+    }
+}
+
+/// A concurrent Append between the Merge's read version and its commit must
+/// fail the Merge with a retryable conflict instead of committing overlapping
+/// fragment or row ids.
+#[tokio::test]
+async fn test_merge_staged_new_fragments_concurrent_append_conflicts() {
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+    )
+    .unwrap();
+    let test_uri = TempStrDir::default();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            enable_stable_row_ids: true,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    let read_version = dataset.version().version;
+    let existing: Vec<Fragment> = dataset.fragments().as_ref().clone();
+
+    // The merging writer holds a handle at the read version.
+    let merge_handle = dataset.clone();
+
+    let batch2 =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![5, 6]))]).unwrap();
+    let transaction = InsertBuilder::new(WriteDestination::Dataset(Arc::new(dataset.clone())))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute_uncommitted(vec![batch2])
+        .await
+        .unwrap();
+    let Operation::Append { fragments: staged } = transaction.operation else {
+        panic!("expected an Append transaction from execute_uncommitted");
+    };
+
+    // Concurrent Append lands between the Merge's read version and its commit.
+    let batch3 =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![7, 8]))]).unwrap();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![Ok(batch3)], schema.clone()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut merge_list = existing;
+    merge_list.extend(staged);
+    let merge_schema = merge_handle.schema().clone();
+    let err = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(merge_handle)),
+        Operation::Merge {
+            fragments: merge_list,
+            schema: merge_schema,
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::RetryableCommitConflict { .. }),
+        "unexpected error: {}",
+        err
+    );
+}

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -24,6 +24,7 @@ use mock_instant::thread_local::MockClock;
 use crate::dataset::write::{InsertBuilder, WriteMode, WriteParams};
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
+use arrow::datatypes::UInt64Type;
 use arrow_array::RecordBatch;
 use arrow_array::{Array, LargeBinaryArray, StructArray};
 use arrow_array::{
@@ -4301,10 +4302,10 @@ async fn test_merge_insert_target_all_bases() {
 /// ids -- the same treatment Append gives them. Regression test for
 /// https://github.com/lance-format/lance/issues/7702.
 #[rstest]
+#[case::no_stable_row_ids(false)]
+#[case::stable_row_ids(true)]
 #[tokio::test]
-async fn test_merge_commits_staged_new_fragments(#[values(false, true)] use_stable_row_id: bool) {
-    use arrow::datatypes::UInt64Type;
-
+async fn test_merge_commits_staged_new_fragments(#[case] use_stable_row_id: bool) {
     let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
         "i",
         DataType::Int32,
@@ -4488,6 +4489,12 @@ async fn test_merge_staged_new_fragments_concurrent_append_conflicts() {
     assert!(
         matches!(err, Error::RetryableCommitConflict { .. }),
         "unexpected error: {}",
+        err
+    );
+    assert!(
+        err.to_string()
+            .contains("preempted by concurrent transaction"),
+        "unexpected message: {}",
         err
     );
 }

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -25,12 +25,12 @@ use crate::dataset::write::{InsertBuilder, WriteMode, WriteParams};
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
 use arrow::datatypes::UInt64Type;
-use arrow_array::RecordBatch;
 use arrow_array::{Array, LargeBinaryArray, StructArray};
 use arrow_array::{
     ArrayRef, Float32Array, Int32Array, ListArray, RecordBatchIterator, StringArray,
     types::Int32Type,
 };
+use arrow_array::{RecordBatch, record_batch};
 use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
 use lance_arrow::BLOB_META_KEY;
 use lance_core::utils::tempfile::{TempDir, TempStrDir};
@@ -4306,16 +4306,8 @@ async fn test_merge_insert_target_all_bases() {
 #[case::stable_row_ids(true)]
 #[tokio::test]
 async fn test_merge_commits_staged_new_fragments(#[case] use_stable_row_id: bool) {
-    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-        "i",
-        DataType::Int32,
-        false,
-    )]));
-    let batch = RecordBatch::try_new(
-        schema.clone(),
-        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
-    )
-    .unwrap();
+    let batch = record_batch!(("i", Int32, [1, 2, 3, 4])).unwrap();
+    let schema = batch.schema();
     let test_uri = TempStrDir::default();
     let dataset = Dataset::write(
         RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
@@ -4333,8 +4325,7 @@ async fn test_merge_commits_staged_new_fragments(#[case] use_stable_row_id: bool
     let existing: Vec<Fragment> = dataset.fragments().as_ref().clone();
 
     // Stage new fragments without committing, like Python's write_fragments.
-    let batch2 =
-        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![5, 6]))]).unwrap();
+    let batch2 = record_batch!(("i", Int32, [5, 6])).unwrap();
     let transaction = InsertBuilder::new(WriteDestination::Dataset(Arc::new(dataset.clone())))
         .with_params(&WriteParams {
             mode: WriteMode::Append,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -370,8 +370,9 @@ pub enum Operation {
     /// Merge a new column in
     /// 'fragments' is the final fragment list: the merged version of every existing
     /// fragment (aligned with the old one at rows) and, optionally, brand-new fragments
-    /// listed after them. New fragments use id 0 (a fresh id and, on stable row id
-    /// datasets, row ids are assigned at commit time, like Append) or a pre-reserved id.
+    /// listed after them. New fragments use id 0 (assigned a fresh id at commit time) or
+    /// a pre-reserved id; either way, on stable row id datasets they are also assigned
+    /// row ids at commit time, like Append.
     /// 'schema' is not forced to include existed columns, which means we could use Merge to drop column data
     Merge {
         fragments: Vec<Fragment>,
@@ -5666,57 +5667,49 @@ mod tests {
         Ok(out)
     }
 
-    #[test]
-    fn merge_build_manifest_assigns_ids_and_row_ids_to_staged_fragments() {
+    #[rstest::rstest]
+    #[case::placeholder_id_0(0, vec![0, 1, 2], 2)]
+    #[case::pre_reserved_id_7(7, vec![0, 1, 7], 7)]
+    fn merge_build_manifest_assigns_ids_and_row_ids_to_staged_fragments(
+        #[case] staged_id: u64,
+        #[case] expected_ids: Vec<u64>,
+        #[case] new_id: u64,
+    ) {
         // A placeholder id 0 gets a fresh fragment id; a pre-reserved id is
         // kept. Either way the staged fragment's row ids come from
         // next_row_id at commit time.
-        let cases = [
-            ("placeholder id 0", 0, vec![0, 1, 2], 2u64),
-            ("pre-reserved id 7", 7, vec![0, 1, 7], 7u64),
+        let existing = vec![
+            frag_with_row_ids(0, "frag0.lance", &[0, 1, 2]),
+            frag_with_row_ids(1, "frag1.lance", &[3, 4]),
         ];
-        for (name, staged_id, expected_ids, new_id) in cases {
-            let existing = vec![
-                frag_with_row_ids(0, "frag0.lance", &[0, 1, 2]),
-                frag_with_row_ids(1, "frag1.lance", &[3, 4]),
-            ];
-            let (manifest, schema) = merge_test_manifest(existing.clone(), true);
+        let (manifest, schema) = merge_test_manifest(existing.clone(), true);
 
-            let mut merge_list = existing.clone();
-            merge_list.push(frag_without_row_ids(staged_id, "staged.lance", 4));
-            let out = build_merge(&manifest, schema, merge_list).unwrap();
+        let mut merge_list = existing.clone();
+        merge_list.push(frag_without_row_ids(staged_id, "staged.lance", 4));
+        let out = build_merge(&manifest, schema, merge_list).unwrap();
 
-            let ids: Vec<u64> = out.fragments.iter().map(|f| f.id).collect();
-            assert_eq!(ids, expected_ids, "{name}");
-            assert_eq!(out.max_fragment_id, Some(new_id.max(1) as u32), "{name}");
+        let ids: Vec<u64> = out.fragments.iter().map(|f| f.id).collect();
+        assert_eq!(ids, expected_ids);
+        assert_eq!(out.max_fragment_id, Some(new_id.max(1) as u32));
 
-            // Existing fragments keep their row id sequences byte-identical.
-            for prev in &existing {
-                let frag = out.fragments.iter().find(|f| f.id == prev.id).unwrap();
-                assert_eq!(frag.row_id_meta, prev.row_id_meta, "{name}");
-            }
-
-            // The staged fragment was allocated row ids from next_row_id.
-            let new_frag = out.fragments.iter().find(|f| f.id == new_id).unwrap();
-            let Some(RowIdMeta::Inline(data)) = &new_frag.row_id_meta else {
-                panic!("{name}: staged fragment must have inline row id metadata");
-            };
-            let row_ids: Vec<u64> = read_row_ids(data).unwrap().iter().collect();
-            assert_eq!(row_ids, vec![100, 101, 102, 103], "{name}");
-            assert_eq!(out.next_row_id, 104, "{name}");
-
-            // Version metadata is stamped like Append.
-            assert_eq!(
-                created_at_versions(&out, new_id),
-                vec![2, 2, 2, 2],
-                "{name}"
-            );
-            assert_eq!(
-                last_updated_at_versions(&out, new_id),
-                vec![2, 2, 2, 2],
-                "{name}"
-            );
+        // Existing fragments keep their row id sequences byte-identical.
+        for prev in &existing {
+            let frag = out.fragments.iter().find(|f| f.id == prev.id).unwrap();
+            assert_eq!(frag.row_id_meta, prev.row_id_meta);
         }
+
+        // The staged fragment was allocated row ids from next_row_id.
+        let new_frag = out.fragments.iter().find(|f| f.id == new_id).unwrap();
+        let Some(RowIdMeta::Inline(data)) = &new_frag.row_id_meta else {
+            panic!("staged fragment must have inline row id metadata");
+        };
+        let row_ids: Vec<u64> = read_row_ids(data).unwrap().iter().collect();
+        assert_eq!(row_ids, vec![100, 101, 102, 103]);
+        assert_eq!(out.next_row_id, 104);
+
+        // Version metadata is stamped like Append.
+        assert_eq!(created_at_versions(&out, new_id), vec![2, 2, 2, 2]);
+        assert_eq!(last_updated_at_versions(&out, new_id), vec![2, 2, 2, 2]);
     }
 
     #[test]
@@ -5746,6 +5739,11 @@ mod tests {
         let mut merge_list = existing;
         merge_list.push(frag_without_row_ids(1, "other.lance", 2));
         let err = build_merge(&manifest, schema, merge_list).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "unexpected error variant: {}",
+            err
+        );
         assert!(
             err.to_string().contains("duplicate fragment id 1"),
             "unexpected error: {}",
@@ -5789,6 +5787,11 @@ mod tests {
 
         let staged = frag_without_row_ids(0, "staged.lance", 2);
         let err = build_merge(&manifest, schema, vec![staged, existing]).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "unexpected error variant: {}",
+            err
+        );
         assert!(
             err.to_string()
                 .contains("dropped row id metadata for existing fragment 0"),

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -368,7 +368,10 @@ pub enum Operation {
         replacements: Vec<DataReplacementGroup>,
     },
     /// Merge a new column in
-    /// 'fragments' is the final fragments include all data files, the new fragments must align with old ones at rows.
+    /// 'fragments' is the final fragment list: the merged version of every existing
+    /// fragment (aligned with the old one at rows) and, optionally, brand-new fragments
+    /// listed after them. New fragments use id 0 (a fresh id and, on stable row id
+    /// datasets, row ids are assigned at commit time, like Append) or a pre-reserved id.
     /// 'schema' is not forced to include existed columns, which means we could use Merge to drop column data
     Merge {
         fragments: Vec<Fragment>,
@@ -2111,43 +2114,61 @@ impl Transaction {
             Operation::Merge { fragments, .. } => {
                 let existing_fragments = maybe_existing_fragments?;
                 let mut merged_fragments = fragments.clone();
-                if next_row_id.is_some() {
-                    let prev_by_id: HashMap<u64, &Fragment> =
-                        existing_fragments.iter().map(|f| (f.id, f)).collect();
-                    for fragment in merged_fragments.iter_mut() {
-                        match prev_by_id.get(&fragment.id) {
-                            Some(prev) => {
-                                if merge_fragment_physically_rewritten(prev, fragment) {
-                                    lance_table::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
-                                        fragment,
-                                        new_version,
-                                    )?;
-                                }
-                            }
-                            None => {
-                                // Brand-new fragment ID not present in the previous manifest.
-                                // Set both last_updated and created version meta, consistent
-                                // with Append/Overwrite for genuinely new fragments.
-                                lance_table::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
-                                    fragment,
-                                    new_version,
-                                )?;
-                                fragment.created_at_version_meta =
-                                    fragment.last_updated_at_version_meta.clone();
-                            }
+
+                // For each previous id, the first occurrence in the list is the
+                // merged existing fragment; everything else is new (staged
+                // write_fragments output arrives with placeholder id 0, colliding
+                // with real fragment 0). merge_fragments_valid enforces this rule.
+                let prev_by_id: HashMap<u64, &Fragment> =
+                    existing_fragments.iter().map(|f| (f.id, f)).collect();
+                let mut seen_prev_ids = HashSet::new();
+                let is_new = merged_fragments
+                    .iter()
+                    .map(|f| !prev_by_id.contains_key(&f.id) || !seen_prev_ids.insert(f.id))
+                    .collect::<Vec<_>>();
+
+                // New fragments get Append's treatment: id assignment (0 means
+                // unassigned, non-zero pre-reserved) and, with stable row ids,
+                // row ids plus fresh version metadata.
+                for (fragment, is_new) in merged_fragments.iter_mut().zip(is_new.iter()) {
+                    if *is_new && fragment.id == 0 {
+                        fragment.id = fragment_id;
+                        fragment_id += 1;
+                    }
+                }
+
+                if let Some(next_row_id) = &mut next_row_id {
+                    for (fragment, is_new) in merged_fragments.iter_mut().zip(is_new.iter()) {
+                        if *is_new {
+                            // Fragments that already carry a complete row id sequence
+                            // are left untouched by assign_row_ids.
+                            Self::assign_row_ids(next_row_id, std::slice::from_mut(fragment))?;
+                            let version_meta = build_version_meta(fragment, new_version);
+                            fragment.last_updated_at_version_meta = version_meta.clone();
+                            fragment.created_at_version_meta = version_meta;
+                        } else if let Some(prev) = prev_by_id.get(&fragment.id)
+                            && merge_fragment_physically_rewritten(prev, fragment)
+                        {
+                            lance_table::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
+                                fragment,
+                                new_version,
+                            )?;
                         }
                     }
                 }
-                final_fragments.extend(merged_fragments);
 
                 // A Merge can rewrite a column's data file in place; the field stays
                 // in the schema, so the index is retained -- prune its now-stale
-                // entries for the rewritten fragments.
+                // entries for the rewritten fragments. Compare with the assigned ids
+                // so brand-new fragments are not mistaken for rewrites of the
+                // fragment whose id they arrived with.
                 Self::prune_merge_rewritten_fields_from_indices(
                     &mut final_indices,
                     existing_fragments,
-                    fragments,
+                    &merged_fragments,
                 );
+
+                final_fragments.extend(merged_fragments);
 
                 // Some fields that have indices may have been removed, so we should
                 // remove those indices as well.
@@ -3839,9 +3860,21 @@ fn merge_fragments_valid(manifest: &Manifest, new_fragments: &[Fragment]) -> Res
         )));
     }
 
-    // Collect new fragment IDs
-    let new_fragment_map: HashMap<u64, &Fragment> =
-        new_fragments.iter().map(|f| (f.id, f)).collect();
+    // Id 0 means unassigned (assigned at commit, like Append); a non-zero id
+    // unknown to the manifest was pre-reserved. The first occurrence of each
+    // previous id is the existing fragment (mirrors build_manifest), so staged
+    // id-0 fragments must follow the existing ones.
+    let mut new_fragment_map: HashMap<u64, &Fragment> = HashMap::new();
+    for fragment in new_fragments {
+        if fragment.id != 0 && new_fragment_map.contains_key(&fragment.id) {
+            return Err(Error::invalid_input(format!(
+                "Merge operation contains duplicate fragment id {}. \
+                 New fragments must use id 0 (assigned at commit time) or a unique reserved id.",
+                fragment.id
+            )));
+        }
+        new_fragment_map.entry(fragment.id).or_insert(fragment);
+    }
 
     // Check that all original fragments are preserved in the new fragments list
     // Validate that each original fragment's metadata is preserved
@@ -3857,6 +3890,16 @@ fn merge_fragments_valid(manifest: &Manifest, new_fragments: &[Fragment]) -> Res
                     original_fragment.id,
                     original_fragment.physical_rows,
                     new_fragment.physical_rows
+                )));
+            }
+            // A previous-id fragment without row id metadata on a stable
+            // dataset is most likely a staged fragment listed too early.
+            if manifest.uses_stable_row_ids() && new_fragment.row_id_meta.is_none() {
+                return Err(Error::invalid_input(format!(
+                    "Merge operation dropped row id metadata for existing fragment {}. \
+                     New fragments (id 0) must be listed after the existing fragments; \
+                     they are assigned row ids at commit time.",
+                    original_fragment.id
                 )));
             }
         } else {
@@ -5525,6 +5568,184 @@ mod tests {
             .unwrap();
         assert_eq!(created_seq.version_at(0).unwrap(), 2);
         assert_eq!(created_seq.version_at(3).unwrap(), 2);
+    }
+
+    fn merge_test_file(path: &str) -> DataFile {
+        use lance_file::version::LanceFileVersion;
+        let (major, minor) = LanceFileVersion::Stable.to_numbers();
+        DataFile::new(path, vec![0], vec![0], major, minor, None, None)
+    }
+
+    /// Committed fragment carrying `row_ids`.
+    fn frag_with_row_ids(id: u64, path: &str, row_ids: &[u64]) -> Fragment {
+        Fragment {
+            id,
+            files: vec![merge_test_file(path)],
+            deletion_file: None,
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&RowIdSequence::from(
+                row_ids,
+            )))),
+            physical_rows: Some(row_ids.len()),
+            last_updated_at_version_meta: None,
+            created_at_version_meta: None,
+        }
+    }
+
+    /// Fragment without row id metadata: staged write_fragments output, or a
+    /// committed fragment of a non-stable dataset.
+    fn frag_without_row_ids(id: u64, path: &str, physical_rows: usize) -> Fragment {
+        Fragment {
+            id,
+            files: vec![merge_test_file(path)],
+            deletion_file: None,
+            row_id_meta: None,
+            physical_rows: Some(physical_rows),
+            last_updated_at_version_meta: None,
+            created_at_version_meta: None,
+        }
+    }
+
+    /// Single-column manifest over `existing`; stable datasets get row id
+    /// flags and `next_row_id` = 100.
+    fn merge_test_manifest(existing: Vec<Fragment>, stable: bool) -> (Manifest, LanceSchema) {
+        use lance_file::version::LanceFileVersion;
+        use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, false)]);
+        let lance_schema = LanceSchema::try_from(&arrow_schema).unwrap();
+        let mut manifest = Manifest::new(
+            lance_schema.clone(),
+            Arc::new(existing),
+            DataStorageFormat::new(LanceFileVersion::V2_0),
+            HashMap::new(),
+        );
+        if stable {
+            manifest.reader_feature_flags |= FLAG_STABLE_ROW_IDS;
+            manifest.next_row_id = 100;
+        }
+        (manifest, lance_schema)
+    }
+
+    /// Validate and build a Merge of `fragments` against `manifest`.
+    fn build_merge(
+        manifest: &Manifest,
+        schema: LanceSchema,
+        fragments: Vec<Fragment>,
+    ) -> Result<Manifest> {
+        let operation = Operation::Merge { fragments, schema };
+        validate_operation(Some(manifest), &operation)?;
+        let tx = Transaction::new(manifest.version, operation, None);
+        let (out, _) = tx.build_manifest(
+            Some(manifest),
+            vec![],
+            "txn",
+            &ManifestWriteConfig::default(),
+        )?;
+        Ok(out)
+    }
+
+    #[test]
+    fn merge_build_manifest_assigns_ids_and_row_ids_to_staged_fragments() {
+        // A placeholder id 0 gets a fresh fragment id; a pre-reserved id is
+        // kept. Either way the staged fragment's row ids come from
+        // next_row_id at commit time.
+        let cases = [
+            ("placeholder id 0", 0, vec![0, 1, 2], 2u64),
+            ("pre-reserved id 7", 7, vec![0, 1, 7], 7u64),
+        ];
+        for (name, staged_id, expected_ids, new_id) in cases {
+            let existing = vec![
+                frag_with_row_ids(0, "frag0.lance", &[0, 1, 2]),
+                frag_with_row_ids(1, "frag1.lance", &[3, 4]),
+            ];
+            let (manifest, schema) = merge_test_manifest(existing.clone(), true);
+
+            let mut merge_list = existing.clone();
+            merge_list.push(frag_without_row_ids(staged_id, "staged.lance", 4));
+            let out = build_merge(&manifest, schema, merge_list).unwrap();
+
+            let ids: Vec<u64> = out.fragments.iter().map(|f| f.id).collect();
+            assert_eq!(ids, expected_ids, "{name}");
+            assert_eq!(out.max_fragment_id, Some(new_id.max(1) as u32), "{name}");
+
+            // Existing fragments keep their row id sequences byte-identical.
+            for prev in &existing {
+                let frag = out.fragments.iter().find(|f| f.id == prev.id).unwrap();
+                assert_eq!(frag.row_id_meta, prev.row_id_meta, "{name}");
+            }
+
+            // The staged fragment was allocated row ids from next_row_id.
+            let new_frag = out.fragments.iter().find(|f| f.id == new_id).unwrap();
+            let Some(RowIdMeta::Inline(data)) = &new_frag.row_id_meta else {
+                panic!("{name}: staged fragment must have inline row id metadata");
+            };
+            let row_ids: Vec<u64> = read_row_ids(data).unwrap().iter().collect();
+            assert_eq!(row_ids, vec![100, 101, 102, 103], "{name}");
+            assert_eq!(out.next_row_id, 104, "{name}");
+
+            // Version metadata is stamped like Append.
+            assert_eq!(
+                created_at_versions(&out, new_id),
+                vec![2, 2, 2, 2],
+                "{name}"
+            );
+            assert_eq!(
+                last_updated_at_versions(&out, new_id),
+                vec![2, 2, 2, 2],
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_build_manifest_assigns_unique_ids_to_staged_fragments_non_stable() {
+        // Regression for the duplicate fragment id corruption: a staged
+        // fragment with placeholder id 0 must not be committed as-is.
+        let existing = vec![
+            frag_without_row_ids(0, "frag0.lance", 2),
+            frag_without_row_ids(1, "frag1.lance", 2),
+        ];
+        let (manifest, schema) = merge_test_manifest(existing.clone(), false);
+
+        let mut merge_list = existing;
+        merge_list.push(frag_without_row_ids(0, "staged.lance", 2));
+        let out = build_merge(&manifest, schema, merge_list).unwrap();
+
+        let ids: Vec<u64> = out.fragments.iter().map(|f| f.id).collect();
+        assert_eq!(ids, vec![0, 1, 2]);
+        assert!(out.fragments.iter().all(|f| f.row_id_meta.is_none()));
+    }
+
+    #[test]
+    fn merge_validate_rejects_duplicate_nonzero_fragment_ids() {
+        let existing = vec![frag_without_row_ids(1, "frag1.lance", 2)];
+        let (manifest, schema) = merge_test_manifest(existing.clone(), false);
+
+        let mut merge_list = existing;
+        merge_list.push(frag_without_row_ids(1, "other.lance", 2));
+        let err = build_merge(&manifest, schema, merge_list).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate fragment id 1"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn merge_validate_rejects_staged_fragment_listed_before_existing_stable() {
+        // A staged id-0 fragment listed before the real fragment 0 would be
+        // taken as the existing one; validation must reject the swap.
+        let existing = frag_with_row_ids(0, "frag0.lance", &[0, 1]);
+        let (manifest, schema) = merge_test_manifest(vec![existing.clone()], true);
+
+        let staged = frag_without_row_ids(0, "staged.lance", 2);
+        let err = build_merge(&manifest, schema, vec![staged, existing]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("dropped row id metadata for existing fragment 0"),
+            "unexpected error: {}",
+            err
+        );
     }
 
     #[test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3876,6 +3876,28 @@ fn merge_fragments_valid(manifest: &Manifest, new_fragments: &[Fragment]) -> Res
         new_fragment_map.entry(fragment.id).or_insert(fragment);
     }
 
+    // build_manifest treats the FIRST occurrence of each previous id as the
+    // merged existing fragment, so a staged id-0 fragment listed before the
+    // fragment it collides with would silently take that fragment's place.
+    // The row-count and row-id-metadata checks below only catch that swap
+    // when the two fragments differ; enforce the order structurally instead:
+    // every fragment classified as existing must precede every new one.
+    let previous_ids: HashSet<u64> = original_fragments.iter().map(|f| f.id).collect();
+    let mut seen_previous: HashSet<u64> = HashSet::new();
+    let mut first_new_id: Option<u64> = None;
+    for fragment in new_fragments {
+        let is_existing = previous_ids.contains(&fragment.id) && seen_previous.insert(fragment.id);
+        if !is_existing {
+            first_new_id.get_or_insert(fragment.id);
+        } else if let Some(new_id) = first_new_id {
+            return Err(Error::invalid_input(format!(
+                "Merge operation lists existing fragment {} after a new fragment \
+                 (id {}). New fragments must be listed after every existing fragment.",
+                fragment.id, new_id
+            )));
+        }
+    }
+
     // Check that all original fragments are preserved in the new fragments list
     // Validate that each original fragment's metadata is preserved
     let mut missing_fragments: Vec<u64> = Vec::new();
@@ -5726,6 +5748,33 @@ mod tests {
         let err = build_merge(&manifest, schema, merge_list).unwrap_err();
         assert!(
             err.to_string().contains("duplicate fragment id 1"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn merge_validate_rejects_staged_fragment_listed_before_existing_non_stable() {
+        // With equal row counts and no row id metadata, a misordered staged
+        // fragment is indistinguishable by content from the fragment whose id
+        // it collides with; the order check must reject it on non-stable
+        // datasets too.
+        let existing = vec![
+            frag_without_row_ids(0, "frag0.lance", 2),
+            frag_without_row_ids(1, "frag1.lance", 2),
+        ];
+        let (manifest, schema) = merge_test_manifest(existing.clone(), false);
+
+        let mut merge_list = vec![frag_without_row_ids(0, "staged.lance", 2)];
+        merge_list.extend(existing);
+        let err = build_merge(&manifest, schema, merge_list).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "unexpected error variant: {}",
+            err
+        );
+        assert!(
+            err.to_string().contains("after a new fragment"),
             "unexpected error: {}",
             err
         );


### PR DESCRIPTION
The Merge arm of build_manifest skipped both fragment id and row id assignment, so committing staged write_fragments output via Merge was rejected on stable-row-id datasets ("All fragments must have row ids") and silently committed duplicate fragment ids on non-stable datasets.

Run new fragments through the same machinery Append uses: fragment id assignment (id 0 means unassigned; a non-zero id was pre-reserved) and, on stable-row-id datasets, row id assignment plus fresh version metadata. For each previous id, the first occurrence in the fragment list is the merged existing fragment -- a staged fragment's placeholder id 0 collides with the real fragment 0 -- and everything else is new; merge_fragments_valid enforces the rule and rejects duplicate non-zero ids and staged fragments listed before the existing ones. Also fix index pruning to compare post-assignment ids so a staged id-0 fragment does not prune fragment 0's index entries, and document in write_fragments that enable_stable_row_ids has no effect there (row ids are assigned at commit time).

Fixes #7702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge commits that include staged-but-uncommitted fragments: staged fragments now get fresh fragment IDs at commit time.
  * Improved stable row ID behavior: row IDs are allocated during commit, preserving existing `_rowid` metadata through merges.
  * Stricter merge validation: rejects duplicate or incorrectly ordered fragment inputs and prevents loss of stable row ID metadata.
* **Documentation**
  * Clarified that enabling stable row IDs does not affect fragment writing; row IDs are assigned when fragments are committed.
* **Tests**
  * Added regression coverage for merge commits with staged fragments, including concurrent commit conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->