### PR TITLE
chore: upgrade Rust toolchain to 1.97.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # We keep this pinned to keep clippy and rustfmt in sync between local and CI.
 # Feel free to upgrade to bring in new lints.
 [toolchain]
-channel = "1.94.0"
+channel = "1.97.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -1022,13 +1022,7 @@ fn merge_list_struct(left: &dyn Array, right: &dyn Array) -> Arc<dyn Array> {
 fn normalize_validity(
     validity: Option<&arrow_buffer::NullBuffer>,
 ) -> Option<&arrow_buffer::NullBuffer> {
-    validity.and_then(|v| {
-        if v.null_count() == v.len() {
-            None
-        } else {
-            Some(v)
-        }
-    })
+    validity.filter(|v| v.null_count() != v.len())
 }
 
 /// Helper function to merge validity buffers from two struct arrays

--- a/rust/lance-datafusion/src/logical_expr.rs
+++ b/rust/lance-datafusion/src/logical_expr.rs
@@ -51,14 +51,10 @@ pub fn resolve_column_type(expr: &Expr, schema: &Schema) -> Option<DataType> {
                 field_path.push(c.name.as_str());
                 break;
             }
-            Expr::ScalarFunction(udf) => {
-                if udf.name() == GetFieldFunc::default().name() {
-                    let name = get_as_string_scalar_opt(&udf.args[1])?;
-                    field_path.push(name);
-                    current_expr = &udf.args[0];
-                } else {
-                    return None;
-                }
+            Expr::ScalarFunction(udf) if udf.name() == GetFieldFunc::default().name() => {
+                let name = get_as_string_scalar_opt(&udf.args[1])?;
+                field_path.push(name);
+                current_expr = &udf.args[0];
             }
             _ => return None,
         }

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -503,7 +503,7 @@ impl Planner {
             }
             _ => Err(Error::invalid_input(format!(
                 "Unsupported function args: {:?}",
-                &func.args
+                func.args
             ))),
         }
     }
@@ -1062,13 +1062,9 @@ impl TreeNodeVisitor<'_> for ColumnCapturingVisitor {
                 self.columns.insert(path);
                 self.current_path.clear();
             }
-            Expr::ScalarFunction(udf) => {
-                if udf.name() == GetFieldFunc::default().name() {
-                    if let Some(name) = get_as_string_scalar_opt(&udf.args[1]) {
-                        self.current_path.push_front(name.to_string())
-                    } else {
-                        self.current_path.clear();
-                    }
+            Expr::ScalarFunction(udf) if udf.name() == GetFieldFunc::default().name() => {
+                if let Some(name) = get_as_string_scalar_opt(&udf.args[1]) {
+                    self.current_path.push_front(name.to_string())
                 } else {
                     self.current_path.clear();
                 }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1949,8 +1949,7 @@ impl StructuralBatchDecodeStream {
                     next_task.into_batch(emitted_batch_size_warning)?
                 };
                 let num_rows = batch.num_rows() as u64;
-                if num_rows > 0 {
-                    let bpr = data_size / num_rows;
+                if let Some(bpr) = data_size.checked_div(num_rows) {
                     let prev = bytes_per_row_feedback.load(Ordering::Relaxed);
                     let next = if prev == 0 || bpr >= prev {
                         // First batch or actual size is larger than estimate:

--- a/rust/lance-encoding/src/encodings/physical/packed.rs
+++ b/rust/lance-encoding/src/encodings/physical/packed.rs
@@ -323,7 +323,7 @@ impl PerValueCompressor for PackedStructVariablePerValueEncoder {
         let mut field_data = Vec::with_capacity(self.fields.len());
         let mut field_metadata = Vec::with_capacity(self.fields.len());
 
-        for (field, child_block) in self.fields.iter().zip(struct_block.children.into_iter()) {
+        for (field, child_block) in self.fields.iter().zip(struct_block.children) {
             let compressor = crate::compression::CompressionStrategy::create_per_value(
                 &self.strategy,
                 field,
@@ -688,7 +688,7 @@ impl VariablePerValueDecompressor for PackedStructVariablePerValueDecompressor {
         }
 
         let mut children = Vec::with_capacity(self.fields.len());
-        for (field, accumulator) in self.fields.iter().zip(accumulators.into_iter()) {
+        for (field, accumulator) in self.fields.iter().zip(accumulators) {
             match (field, accumulator) {
                 (
                     VariablePackedStructFieldDecoder {

--- a/rust/lance-encoding/src/previous/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/blob.rs
@@ -318,7 +318,7 @@ impl BlobFieldEncoder {
             .nulls()
             .cloned()
             .unwrap_or(NullBuffer::new_valid(binarray.len()));
-        for (w, is_valid) in binarray.value_offsets().windows(2).zip(nulls.into_iter()) {
+        for (w, is_valid) in binarray.value_offsets().windows(2).zip(&nulls) {
             if is_valid {
                 let start = w[0] as u64;
                 let end = w[1] as u64;

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -1939,7 +1939,7 @@ impl FileMetadataProvider {
                 .collect::<Vec<_>>();
             let metadata_bytes = io.submit_request(ranges, 0).await?;
             for ((result_index, column_index, _), bytes) in
-                missing_columns.into_iter().zip(metadata_bytes.into_iter())
+                missing_columns.into_iter().zip(metadata_bytes)
             {
                 let column_metadata = pbfile::ColumnMetadata::decode(bytes)?;
                 let column_info = FileReader::meta_to_col_info(

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -891,8 +891,7 @@ impl BitmapBatchWriter {
             return Ok(());
         }
         let keys_array =
-            ScalarValue::iter_to_array(self.keys.drain(..).collect::<Vec<_>>().into_iter())
-                .unwrap();
+            ScalarValue::iter_to_array(self.keys.drain(..).collect::<Vec<_>>()).unwrap();
         let total_size: usize = self.serialized.iter().map(|b| b.len()).sum();
         let mut binary_builder = BinaryBuilder::with_capacity(self.serialized.len(), total_size);
         for b in self.serialized.drain(..) {
@@ -1123,10 +1122,7 @@ async fn drain_same_key_bitmaps(
     let merged_key = OrderableScalarValue(key);
     advance_cursor_and_push(cursors, heap, item.shard_idx).await?;
 
-    loop {
-        let Some(Reverse(next_item)) = heap.peek() else {
-            break;
-        };
+    while let Some(Reverse(next_item)) = heap.peek() {
         if next_item.key != merged_key {
             break;
         }
@@ -1280,7 +1276,7 @@ impl BitmapIndexPlugin {
             let bitmap_size = bytes.len();
 
             if cur_bytes + bitmap_size > MAX_BITMAP_ARRAY_LENGTH {
-                let keys_array = ScalarValue::iter_to_array(cur_keys.clone().into_iter()).unwrap();
+                let keys_array = ScalarValue::iter_to_array(cur_keys.clone()).unwrap();
                 let mut binary_builder = BinaryBuilder::new();
                 for b in &cur_bitmaps {
                     binary_builder.append_value(b);

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -5327,12 +5327,8 @@ mod tests {
             mapping.insert(old_id, None);
         }
 
-        let mut new_id_counter = 100_000;
-
         // Remap all other rows
-        for old_id in (0..1000).chain(10000..15000) {
-            let new_id = new_id_counter;
-            new_id_counter += 1;
+        for (new_id, old_id) in (100_000..).zip((0..1000).chain(10000..15000)) {
             mapping.insert(old_id, Some(new_id));
         }
 

--- a/rust/lance-index/src/scalar/btree/flat.rs
+++ b/rust/lance-index/src/scalar/btree/flat.rs
@@ -218,13 +218,13 @@ impl FlatIndex {
                         ));
                     }
                 }
-                (Bound::Included(lower) | Bound::Excluded(lower), Bound::Unbounded) => {
-                    if lower.is_null() {
-                        return Ok(NullableRowAddrSet::new(
-                            Default::default(),
-                            self.all_addrs_map.clone(),
-                        ));
-                    }
+                (Bound::Included(lower) | Bound::Excluded(lower), Bound::Unbounded)
+                    if lower.is_null() =>
+                {
+                    return Ok(NullableRowAddrSet::new(
+                        Default::default(),
+                        self.all_addrs_map.clone(),
+                    ));
                 }
                 _ => {}
             },

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -1701,7 +1701,7 @@ impl FMIndexScalarIndex {
         }
         pfiles.sort_by_key(|(id, _)| *id);
         let io_parallelism = store.io_parallelism().max(1);
-        let mut parts = futures::stream::iter(pfiles.into_iter())
+        let mut parts = futures::stream::iter(pfiles)
             .map(|(id, name)| {
                 let store = Arc::clone(&store);
                 async move {

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -91,7 +91,7 @@ pub async fn build_global_bm25_scorer(
     let (mut total_tokens, mut num_docs, first_token_docs) =
         first_index.bm25_stats_for_terms(&terms).await?;
     let mut token_docs = HashMap::with_capacity(terms.len());
-    for (term, count) in terms.iter().cloned().zip(first_token_docs.into_iter()) {
+    for (term, count) in terms.iter().cloned().zip(first_token_docs) {
         token_docs.insert(term, count);
     }
 
@@ -100,7 +100,7 @@ pub async fn build_global_bm25_scorer(
             index.bm25_stats_for_terms(&terms).await?;
         total_tokens += segment_total_tokens;
         num_docs += segment_num_docs;
-        for (term, count) in terms.iter().zip(segment_token_docs.into_iter()) {
+        for (term, count) in terms.iter().zip(segment_token_docs) {
             *token_docs
                 .get_mut(term)
                 .expect("global scorer terms should already be initialized") += count;

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -265,10 +265,8 @@ impl ZoneMapIndex {
                                     return Ok(zone.nan_count > 0);
                                 }
                             }
-                            ScalarValue::Float64(Some(f)) => {
-                                if f.is_nan() {
-                                    return Ok(zone.nan_count > 0);
-                                }
+                            ScalarValue::Float64(Some(f)) if f.is_nan() => {
+                                return Ok(zone.nan_count > 0);
                             }
                             _ => {}
                         }
@@ -295,10 +293,8 @@ impl ZoneMapIndex {
                                     return Ok(false); // Nothing is greater than NaN
                                 }
                             }
-                            ScalarValue::Float64(Some(f)) => {
-                                if f.is_nan() {
-                                    return Ok(false); // Nothing is greater than NaN
-                                }
+                            ScalarValue::Float64(Some(f)) if f.is_nan() => {
+                                return Ok(false); // Nothing is greater than NaN
                             }
                             _ => {}
                         }
@@ -322,10 +318,8 @@ impl ZoneMapIndex {
                                     return Ok(zone.nan_count > 0 || zone_min <= e);
                                 }
                             }
-                            ScalarValue::Float64(Some(f)) => {
-                                if f.is_nan() {
-                                    return Ok(zone.nan_count > 0 || zone_min <= e);
-                                }
+                            ScalarValue::Float64(Some(f)) if f.is_nan() => {
+                                return Ok(zone.nan_count > 0 || zone_min <= e);
                             }
                             _ => {}
                         }
@@ -345,10 +339,8 @@ impl ZoneMapIndex {
                                     return Ok(true);
                                 }
                             }
-                            ScalarValue::Float64(Some(f)) => {
-                                if f.is_nan() {
-                                    return Ok(true);
-                                }
+                            ScalarValue::Float64(Some(f)) if f.is_nan() => {
+                                return Ok(true);
                             }
                             _ => {}
                         }

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -3930,7 +3930,7 @@ mod tests {
             .into_iter()
             .map(|(id, dist)| (id as u64, dist))
             .collect::<Vec<_>>();
-        expected.sort_by(|left, right| left.0.cmp(&right.0));
+        expected.sort_by_key(|left| left.0);
 
         let mut heap = BinaryHeap::with_capacity(k);
         let mut distances = Vec::new();
@@ -3952,7 +3952,7 @@ mod tests {
             .into_iter()
             .map(|node| (node.id, node.dist.0))
             .collect::<Vec<_>>();
-        actual.sort_by(|left, right| left.0.cmp(&right.0));
+        actual.sort_by_key(|left| left.0);
 
         assert_eq!(actual.len(), expected.len());
         for ((actual_id, actual_dist), (expected_id, expected_dist)) in

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -570,7 +570,7 @@ mod tests {
             .zip(dists.values().iter())
             .map(|(row_id, dist)| (*row_id, *dist))
             .collect::<Vec<_>>();
-        results.sort_by(|left, right| left.0.cmp(&right.0));
+        results.sort_by_key(|left| left.0);
         results
     }
 
@@ -579,7 +579,7 @@ mod tests {
             .into_iter()
             .map(|node| (node.id, node.dist.0))
             .collect::<Vec<_>>();
-        results.sort_by(|left, right| left.0.cmp(&right.0));
+        results.sort_by_key(|left| left.0);
         results
     }
 

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -134,7 +134,7 @@ impl VectorStore for FlatFloatStorage {
 
     fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
         // TODO: use chunked storage
-        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
+        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch])?;
         let mut storage = self.clone();
         storage.row_ids = Arc::new(
             new_batch
@@ -296,7 +296,7 @@ impl VectorStore for FlatBinStorage {
 
     fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
         // TODO: use chunked storage
-        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
+        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch])?;
         let mut storage = self.clone();
         storage.row_ids = Arc::new(
             new_batch

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -392,25 +392,23 @@ impl AsyncWrite for ObjectWriter {
                     let fut = Box::pin(async move { store.put_multipart(path.as_ref()).await });
                     self.state = UploadState::CreatingUpload(fut);
                 }
+                // TODO: Make max concurrency configurable from storage options.
                 UploadState::InProgress {
                     upload,
                     part_idx,
                     futures,
                     ..
-                } => {
-                    // TODO: Make max concurrency configurable from storage options.
-                    if futures.len() < max_upload_parallelism() {
-                        let data = Self::next_part_buffer(
-                            &mut mut_self.buffer,
-                            *part_idx,
-                            mut_self.use_constant_size_upload_parts,
-                        );
-                        futures.spawn(
-                            Self::put_part(upload.as_mut(), data, *part_idx, None)
-                                .instrument(tracing::Span::current()),
-                        );
-                        *part_idx += 1;
-                    }
+                } if futures.len() < max_upload_parallelism() => {
+                    let data = Self::next_part_buffer(
+                        &mut mut_self.buffer,
+                        *part_idx,
+                        mut_self.use_constant_size_upload_parts,
+                    );
+                    futures.spawn(
+                        Self::put_part(upload.as_mut(), data, *part_idx, None)
+                            .instrument(tracing::Span::current()),
+                    );
+                    *part_idx += 1;
                 }
                 _ => {}
             }

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1669,9 +1669,9 @@ impl DirectoryNamespace {
 
         if needs_sort {
             if descending {
-                table_versions.sort_by(|a, b| b.version.cmp(&a.version));
+                table_versions.sort_by_key(|v| std::cmp::Reverse(v.version));
             } else {
-                table_versions.sort_by(|a, b| a.version.cmp(&b.version));
+                table_versions.sort_by_key(|v| v.version);
             }
         }
 
@@ -2403,7 +2403,7 @@ impl DirectoryNamespace {
     }
 
     fn table_full_uri(&self, table_name: &str) -> String {
-        format!("{}/{}.lance", &self.root, table_name)
+        format!("{}/{}.lance", self.root, table_name)
     }
 
     /// Get the object store path for a table (relative to base_path)

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -355,11 +355,7 @@ impl RowIdSequence {
             while (index - rows_passed) >= cur_seg_len {
                 rows_passed += cur_seg_len;
                 cur_seg = seg_iter.next();
-                if let Some(cur_seg) = cur_seg {
-                    cur_seg_len = cur_seg.len();
-                } else {
-                    return None;
-                }
+                cur_seg_len = cur_seg?.len();
             }
 
             Some(cur_seg.unwrap().get(index - rows_passed).unwrap())

--- a/rust/lance/benches/s3_file_reader_diagnostics.rs
+++ b/rust/lance/benches/s3_file_reader_diagnostics.rs
@@ -2246,21 +2246,15 @@ async fn main() -> Result<()> {
         } else {
             0.0
         };
-        let bytes_per_row = if stats.rows == 0 {
-            0
-        } else {
-            stats.arrow_bytes / stats.rows
-        };
-        let avg_bytes_per_scheduler_request = if scheduler_stats.requests == 0 {
-            0
-        } else {
-            scheduler_stats.bytes_read / scheduler_stats.requests
-        };
-        let avg_bytes_per_scheduler_iop = if scheduler_stats.iops == 0 {
-            0
-        } else {
-            scheduler_stats.bytes_read / scheduler_stats.iops
-        };
+        let bytes_per_row = stats.arrow_bytes.checked_div(stats.rows).unwrap_or(0);
+        let avg_bytes_per_scheduler_request = scheduler_stats
+            .bytes_read
+            .checked_div(scheduler_stats.requests)
+            .unwrap_or(0);
+        let avg_bytes_per_scheduler_iop = scheduler_stats
+            .bytes_read
+            .checked_div(scheduler_stats.iops)
+            .unwrap_or(0);
         let counters = stats.counters.as_ref();
         let record = json!({
             "case": config.case_name,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2779,7 +2779,7 @@ impl Dataset {
                     self.manifest_location.path.clone(),
                     format!(
                         "Duplicate index id {} found in dataset {:?}",
-                        &index.uuid, self.base
+                        index.uuid, self.base
                     ),
                 ));
             }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -691,10 +691,8 @@ impl BlobPreprocessor {
 
         let mut new_columns = Vec::with_capacity(children.len());
         let mut new_fields = Vec::with_capacity(children.len());
-        for ((child_processor, child_array), child_field) in children
-            .iter()
-            .zip(child_columns.into_iter())
-            .zip(child_fields.iter())
+        for ((child_processor, child_array), child_field) in
+            children.iter().zip(child_columns).zip(child_fields.iter())
         {
             let (new_column, new_field) = self
                 .preprocess_field(child_processor, child_array, child_field)

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -2978,10 +2978,8 @@ mod tests {
     async fn cleanup_before_ts_and_retain_n_recent_versions() {
         let fixture = MockDatasetFixture::try_new().unwrap();
         fixture.create_some_data().await.unwrap();
-        let mut time = 1i64;
-        for _ in 0..4 {
+        for time in (1i64..).take(4) {
             MockClock::set_system_time(TimeDelta::try_days(time).unwrap().to_std().unwrap());
-            time += 1i64;
             fixture.overwrite_some_data().await.unwrap();
         }
 

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -422,7 +422,7 @@ mod tests {
             matches!(result.as_ref().unwrap_err(), Error::InvalidInput { source, .. }
             if source.to_string().contains("Cannot write with an empty schema.")),
             "{:?}",
-            &result
+            result
         );
 
         // Writing empty reader produces an error
@@ -436,7 +436,7 @@ mod tests {
             matches!(result.as_ref().unwrap_err(), Error::InvalidInput { source, .. }
             if source.to_string().contains("Input data was empty.")),
             "{:?}",
-            &result
+            result
         );
 
         // Writing with incorrect schema produces an error.
@@ -454,7 +454,7 @@ mod tests {
             matches!(result.as_ref().unwrap_err(), Error::SchemaMismatch { difference, .. }
             if difference.contains("fields did not match")),
             "{:?}",
-            &result
+            result
         );
     }
 
@@ -513,7 +513,7 @@ mod tests {
             matches!(result.as_ref().unwrap_err(), Error::InvalidInput { source, .. }
             if source.to_string().contains("Cannot write with an empty schema.")),
             "{:?}",
-            &result
+            result
         );
 
         // Writing empty reader produces an error
@@ -540,7 +540,7 @@ mod tests {
             matches!(result.as_ref().unwrap_err(), Error::SchemaMismatch { difference, .. }
             if difference.contains("fields did not match")),
             "{:?}",
-            &result
+            result
         );
     }
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -2935,11 +2935,7 @@ impl WriteStatsSnapshot {
 
     /// Get average WAL flush size in bytes.
     pub fn avg_wal_flush_bytes(&self) -> Option<u64> {
-        if self.wal_flush_count > 0 {
-            Some(self.wal_flush_bytes / self.wal_flush_count)
-        } else {
-            None
-        }
+        self.wal_flush_bytes.checked_div(self.wal_flush_count)
     }
 
     /// Get WAL write throughput (bytes per second based on WAL flush time).
@@ -2971,11 +2967,7 @@ impl WriteStatsSnapshot {
 
     /// Get average rows per index update.
     pub fn avg_index_update_rows(&self) -> Option<u64> {
-        if self.index_update_count > 0 {
-            Some(self.index_update_rows / self.index_update_count)
-        } else {
-            None
-        }
+        self.index_update_rows.checked_div(self.index_update_count)
     }
 
     /// Get average MemTable flush latency.
@@ -2989,11 +2981,8 @@ impl WriteStatsSnapshot {
 
     /// Get average MemTable flush size in rows.
     pub fn avg_memtable_flush_rows(&self) -> Option<u64> {
-        if self.memtable_flush_count > 0 {
-            Some(self.memtable_flush_rows / self.memtable_flush_count)
-        } else {
-            None
-        }
+        self.memtable_flush_rows
+            .checked_div(self.memtable_flush_count)
     }
 
     /// Log stats summary using tracing (for structured telemetry).

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -840,7 +840,7 @@ pub async fn compact_files_with_planner(
 
     let dataset_ref = &dataset.clone();
 
-    let result_stream = futures::stream::iter(compaction_plan.tasks.into_iter())
+    let result_stream = futures::stream::iter(compaction_plan.tasks)
         .map(|task| rewrite_files(Cow::Borrowed(dataset_ref), task, &compaction_plan.options))
         .buffer_unordered(
             compaction_plan
@@ -1941,8 +1941,8 @@ async fn recalc_versions_for_rewritten_fragments(
     // Set both version metadata on new fragments
     for ((fragment, last_updated_seq), created_at_seq) in new_fragments
         .iter_mut()
-        .zip(new_last_updated_sequences.into_iter())
-        .zip(new_created_at_sequences.into_iter())
+        .zip(new_last_updated_sequences)
+        .zip(new_created_at_sequences)
     {
         fragment.last_updated_at_version_meta = Some(
             lance_table::format::RowDatasetVersionMeta::from_sequence(&last_updated_seq).unwrap(),

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -475,7 +475,7 @@ impl Branches<'_> {
 
         if !self.object_store().exists(&manifest_file.path).await? {
             return Err(Error::VersionNotFound {
-                message: format!("Manifest file {} does not exist", &manifest_file.path),
+                message: format!("Manifest file {} does not exist", manifest_file.path),
             });
         };
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1742,7 +1742,7 @@ impl Scanner {
                     .field(&column.column_name)
                     .ok_or(Error::invalid_input(format!(
                         "Column {} not found",
-                        &column.column_name
+                        column.column_name
                     )))?;
             }
         }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2021,7 +2021,7 @@ impl MergeInsertJob {
                 } else {
                     removed_row_ids
                 };
-            let removed_row_addrs = RoaringTreemap::from_iter(removed_row_addr_vec.into_iter());
+            let removed_row_addrs = RoaringTreemap::from_iter(removed_row_addr_vec);
 
             let (updated_fragments, removed_fragment_ids) =
                 Self::apply_deletions(&self.dataset, &removed_row_addrs).await?;
@@ -2132,7 +2132,7 @@ impl MergeInsertJob {
                         removed_row_ids
                     };
 
-                Ok(RoaringTreemap::from_iter(removed_row_addr_vec.into_iter()))
+                Ok(RoaringTreemap::from_iter(removed_row_addr_vec))
             }
             .await;
             let removed_row_addrs = match post_write_result {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1892,7 +1892,7 @@ pub(crate) async fn remap_index_file(
 
     let tasks = generate_remap_tasks(&index.ivf.offsets, &index.ivf.lengths)?;
 
-    let mut task_stream = stream::iter(tasks.into_iter())
+    let mut task_stream = stream::iter(tasks)
         .map(|task| task.load_and_remap(reader.clone(), index, mapping))
         .buffered(object_store.io_parallelism());
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -4835,10 +4835,7 @@ mod tests {
             .as_primitive::<Float32Type>()
             .values()
             .to_vec();
-        let results = dists
-            .into_iter()
-            .zip(row_ids.clone().into_iter())
-            .collect::<Vec<_>>();
+        let results = dists.into_iter().zip(row_ids.clone()).collect::<Vec<_>>();
         let row_ids = row_ids.into_iter().collect::<HashSet<_>>();
 
         let gt = multivec_ground_truth(&vectors, &query, k, params.metric_type);
@@ -5231,10 +5228,7 @@ mod tests {
             .as_primitive::<Float32Type>()
             .values()
             .to_vec();
-        let results = dists
-            .into_iter()
-            .zip(row_ids.into_iter())
-            .collect::<Vec<_>>();
+        let results = dists.into_iter().zip(row_ids).collect::<Vec<_>>();
         let row_ids = results.iter().map(|(_, id)| *id).collect::<HashSet<_>>();
         assert!(row_ids.len() == k);
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -489,13 +489,12 @@ fn fix_schema(manifest: &mut Manifest) -> Result<()> {
     }
 
     // Now, we need to remap the field ids to be unique.
-    let mut field_id_seed = manifest.max_field_id() + 1;
     let mut old_field_id_mapping: HashMap<i32, i32> = HashMap::new();
     let mut fields_with_duplicate_ids = fields_with_duplicate_ids.into_iter().collect::<Vec<_>>();
     fields_with_duplicate_ids.sort_unstable();
-    for field_id in fields_with_duplicate_ids {
+    for (field_id_seed, field_id) in (manifest.max_field_id() + 1..).zip(fields_with_duplicate_ids)
+    {
         old_field_id_mapping.insert(field_id, field_id_seed);
-        field_id_seed += 1;
     }
 
     let mut fragments = manifest.fragments.as_ref().clone();

--- a/rust/lance/src/io/exec/count_pushdown.rs
+++ b/rust/lance/src/io/exec/count_pushdown.rs
@@ -380,7 +380,8 @@ fn strip_row_preserving_wrappers(plan: &Arc<dyn ExecutionPlan>) -> Option<&Filte
                 inner.input()
             } else if let Some(inner) = current.as_any().downcast_ref::<CoalescePartitionsExec>() {
                 inner.input()
-            } else if let Some(proj) = current.as_any().downcast_ref::<ProjectionExec>() {
+            } else {
+                let proj = current.as_any().downcast_ref::<ProjectionExec>()?;
                 // Only walk through projections that are row-preserving: every
                 // output expression is a direct column reference back to the
                 // input. (Empty projections trivially qualify — DataFusion uses
@@ -398,8 +399,6 @@ fn strip_row_preserving_wrappers(plan: &Arc<dyn ExecutionPlan>) -> Option<&Filte
                     return None;
                 }
                 proj.input()
-            } else {
-                return None;
             };
         current = next.as_ref();
     }

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -135,7 +135,7 @@ async fn search_segments(
     let mut searches = searches;
 
     while let Some((doc_ids, scores)) = searches.try_next().await? {
-        for (row_id, score) in doc_ids.into_iter().zip(scores.into_iter()) {
+        for (row_id, score) in doc_ids.into_iter().zip(scores) {
             if candidates.len() < limit {
                 candidates.push(std::cmp::Reverse(ScoredDoc::new(row_id, score)));
             } else if candidates.peek().unwrap().0.score.0 < score {

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -44,7 +44,7 @@ pub fn project(input: Arc<dyn ExecutionPlan>, projection: &ArrowSchema) -> Resul
 
     let field_names = projection.fields().iter().map(|f| f.name()).cloned();
 
-    for (name, selection) in field_names.zip(selections.into_iter()) {
+    for (name, selection) in field_names.zip(selections) {
         let expr = selection_as_expr(&selection, input_schema.fields(), None);
         exprs.push((expr, name));
     }


### PR DESCRIPTION
Bumps the pinned toolchain from 1.94.0 to 1.97.0 in `rust-toolchain.toml` (the `python/` and `java/lance-jni/` copies are symlinks to it) and fixes the clippy lints newly reported by 1.97 across the workspace.

New lints fixed:
- `manual_filter`, `manual_checked_ops`, `question_mark`
- `useless_conversion`, `useless_borrows_in_formatting`
- `collapsible_match`, `while_let_loop`, `explicit_counter_loop`, `unnecessary_sort_by`

All fixes are behavior-preserving. `cargo clippy -- -D warnings` is clean across the main workspace (all features, all targets), `python/`, and `java/lance-jni/`; `cargo fmt --check` passes on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of floating-point `NaN` values in range queries for more conservative, reliable results.
  * Prevented potential division-by-zero issues in decoding and statistics calculations.
  * Preserved correct behavior when processing all-null data and missing fields.

* **Maintenance**
  * Updated the Rust toolchain used to build the project.
  * Simplified internal processing across indexing, scanning, encoding, storage, and query-planning components without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->