### PR TITLE
refactor(java): rename WriteDatasetBuilder.tableProperties to properties

### DIFF
--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -70,7 +70,7 @@ public class WriteDatasetBuilder {
   private WriteParams.WriteMode mode = WriteParams.WriteMode.CREATE;
   private Schema schema;
   private Map<String, String> storageOptions = new HashMap<>();
-  private Map<String, String> tableProperties = new HashMap<>();
+  private Map<String, String> properties = new HashMap<>();
   private Map<String, Map<String, String>> baseStoreParams = new HashMap<>();
   private boolean ignoreNamespaceStorageOptions = false;
   private Optional<Integer> maxRowsPerFile = Optional.empty();
@@ -209,17 +209,23 @@ public class WriteDatasetBuilder {
   }
 
   /**
-   * Sets user table properties to forward to the namespace on table creation.
+   * Sets the table properties to forward to the namespace on table creation.
+   *
+   * <p>These are Lance-namespace <b>properties</b>: catalog-level key-value metadata stored by the
+   * namespace outside the Lance table (available even if the table manifest does not exist), as
+   * distinct from the manifest-stored {@code config} (read/write behavior) and {@code metadata}
+   * (business metadata), and from non-persisted {@code storageOptions}. They are attached to the
+   * underlying declareTable request via its {@code properties} field.
    *
    * <p>Only used when a namespace client is configured via namespaceClient()+tableId() and the
-   * write creates the table (CREATE mode): the properties are attached to the underlying
-   * declareTable request. Ignored for direct-URI writes and for APPEND/OVERWRITE modes.
+   * write creates the table (CREATE mode). Ignored for direct-URI writes and for APPEND/OVERWRITE
+   * modes.
    *
-   * @param tableProperties Table properties to forward on declareTable
+   * @param properties Table properties to forward on declareTable
    * @return this builder instance
    */
-  public WriteDatasetBuilder tableProperties(Map<String, String> tableProperties) {
-    this.tableProperties = new HashMap<>(tableProperties);
+  public WriteDatasetBuilder properties(Map<String, String> properties) {
+    this.properties = new HashMap<>(properties);
     return this;
   }
 
@@ -426,8 +432,8 @@ public class WriteDatasetBuilder {
     if (mode == WriteParams.WriteMode.CREATE) {
       DeclareTableRequest declareRequest = new DeclareTableRequest();
       declareRequest.setId(tableId);
-      if (tableProperties != null && !tableProperties.isEmpty()) {
-        declareRequest.setProperties(tableProperties);
+      if (properties != null && !properties.isEmpty()) {
+        declareRequest.setProperties(properties);
       }
       DeclareTableResponse declareResponse = namespaceClient.declareTable(declareRequest);
 


### PR DESCRIPTION
## Summary

Follow-up to #7711. Renames `WriteDatasetBuilder.tableProperties(...)` (and its backing field) to `properties(...)`, with no behavior change.

## Why

#7711 added a builder method to forward user table properties to the namespace's `declareTable` request. Per feedback on the Lance-namespace table-level map taxonomy, the method should be named `properties` to be unambiguous among the four table-level maps:

- **`properties`** *(this method)* — catalog-level key-value metadata stored by the namespace **outside** the table; available even if the Lance manifest does not exist. Forwarded to `DeclareTableRequest.properties`.
- **`config`** — stored in the Lance **manifest**; controls table read/write behavior.
- **`metadata`** — stored in the Lance **manifest**; business-layer metadata.
- **`storageOptions`** — runtime, **not persisted** (e.g. storage credentials).

`tableProperties` was ambiguous vs. `config`/`metadata`; `properties` matches the concept it actually maps to.

## Tests

`./mvnw -pl . compile` and `spotless:check` pass (JNI/native build skipped locally; relying on CI).

## Note

Marked as a breaking change (`!`) since it renames a public builder method added in the same release train as #7711; no released version exposed `tableProperties` yet, so downstream impact is limited to unreleased consumers (lance-spark#685, which will call `.properties(...)`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the dataset builder’s table metadata setter from `tableProperties(...)` to `properties(...)`.

* **New Features**
  * Table creation now forwards the provided properties map when creating a dataset in namespace mode.

* **Documentation**
  * Updated the builder’s guidance to reflect the new `properties(...)` API and its forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->