### PR TITLE
fix: round-trip empty blob values in the 2.1+ structural encoding

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -536,6 +536,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_blob_round_trip_empty_values() {
+        // Empty values share size == 0 with nulls in the descriptor layout
+        // and schedule no read; each must decode to zero-length bytes without
+        // consuming the read result of a following non-empty blob. Empties
+        // are placed before payloads so a misassignment corrupts the output
+        // instead of only exhausting the read iterator.
+        let blob_metadata =
+            HashMap::from([(lance_arrow::BLOB_META_KEY.to_string(), "true".to_string())]);
+
+        let val1: &[u8] = &vec![1u8; 1024];
+        let val2: &[u8] = &vec![2u8; 10240];
+        let empty: &[u8] = &[];
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(empty),
+            Some(val1),
+            None,
+            Some(empty),
+            Some(val2),
+            None,
+            Some(empty),
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default().with_max_file_version(LanceFileVersion::V2_1),
+            blob_metadata,
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_blob_v2_external_round_trip() {
         let blob_metadata = HashMap::from([(
             lance_arrow::ARROW_EXT_NAME_KEY.to_string(),

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -558,12 +558,7 @@ mod tests {
             Some(empty),
         ]));
 
-        check_round_trip_encoding_of_data(
-            vec![array],
-            &TestCases::default().with_max_file_version(LanceFileVersion::V2_1),
-            blob_metadata,
-        )
-        .await;
+        check_round_trip_encoding_of_data(vec![array], &TestCases::default(), blob_metadata).await;
     }
 
     #[tokio::test]

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -258,7 +258,9 @@ impl BlobPageScheduler {
             let bytes = read_fut.await?;
             let mut bytes_iter = bytes.into_iter();
             for blob in loaded_blobs.iter_mut() {
-                if blob.def == 0 {
+                // Empty values have def == 0 too but scheduled no read; their
+                // bytes were set at scheduling time.
+                if blob.def == 0 && blob.bytes.is_none() {
                     blob.set_bytes(bytes_iter.next().expect_ok()?);
                 }
             }
@@ -364,7 +366,17 @@ impl StructuralPageScheduler for BlobPageScheduler {
                 if size == 0 {
                     let rep = (position & 0xFFFF) as u16;
                     let def = ((position >> 16) & 0xFFFF) as u16;
-                    loaded_blobs.push(LoadedBlob::new(rep, def));
+                    let mut blob = LoadedBlob::new(rep, def);
+                    if def == 0 {
+                        // A size-0 descriptor with definition level 0 is a
+                        // valid, empty value (nulls carry their non-zero
+                        // packed rep/def levels in `position`). No read is
+                        // scheduled for it, so it gets its zero-length bytes
+                        // here rather than consuming another blob's read
+                        // result in the load task.
+                        blob.set_bytes(Bytes::new());
+                    }
+                    loaded_blobs.push(blob);
                 } else {
                     loaded_blobs.push(LoadedBlob::new(0, 0));
                     ranges_to_read.push(position..(position + size));


### PR DESCRIPTION
A valid empty value is stored as {position: 0, size: 0} while nulls pack their non-zero rep/def levels into position. The page scheduler skips size-0 rows when scheduling reads, but the load task assigned read results to every def == 0 blob, so an empty value consumed the next blob's payload and the last consumer crashed on an exhausted iterator ("Expected option to have value"). Give empty values their zero-length bytes at scheduling time and only assign read results to blobs that scheduled a read.

Fixes #7716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding/round-trip handling for empty blob (`LargeBinary`) values so they’re preserved and remain correctly aligned when mixed with non-empty payloads and nulls.
  * Prevented empty blob byte data from being overwritten during page loading and ensured empty values are treated as present during decoding.
* **Tests**
  * Added an async round-trip test covering empty (`LargeBinary`) values interleaved with nulls when blob metadata is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->