### PR TITLE
fix: evict version-scoped cache entries when cleanup deletes their files

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -116,6 +116,26 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// Remove all entries whose prefix starts with the given string.
     async fn invalidate_prefix(&self, prefix: &str);
 
+    /// Remove all entries within `prefix` whose `key` equals `key_prefix` or
+    /// starts with `key_prefix` followed by `/`.
+    ///
+    /// Unlike [`invalidate_prefix`](Self::invalidate_prefix), which matches
+    /// against an entry's namespace [`prefix`](InternalCacheKey::prefix)
+    /// (e.g. a dataset URI), this matches against the per-entry
+    /// [`key`](InternalCacheKey::key) (e.g. a version number or fragment id).
+    /// This lets callers evict every cached entry associated with one
+    /// version/fragment (a manifest, its transaction, its row address mask,
+    /// etc.) without needing to know every optional suffix (e-tag, filter
+    /// hash) a given key type may carry.
+    ///
+    /// The `/` boundary check prevents `key_prefix = "5"` from also matching
+    /// `"50"` or `"500"`.
+    ///
+    /// Backends that cannot support this cheaply may leave it as a no-op;
+    /// doing so only means those entries are evicted later by the normal
+    /// capacity-based eviction policy instead of immediately.
+    async fn invalidate_key_prefix(&self, _prefix: &str, _key_prefix: &str) {}
+
     /// Remove all entries.
     async fn clear(&self);
 

--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -134,7 +134,29 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// Backends that cannot support this cheaply may leave it as a no-op;
     /// doing so only means those entries are evicted later by the normal
     /// capacity-based eviction policy instead of immediately.
-    async fn invalidate_key_prefix(&self, _prefix: &str, _key_prefix: &str) {}
+    ///
+    /// Defaults to a single-element call to
+    /// [`invalidate_key_prefixes`](Self::invalidate_key_prefixes); backends
+    /// only need to implement one of the two.
+    async fn invalidate_key_prefix(&self, prefix: &str, key_prefix: &str) {
+        self.invalidate_key_prefixes(prefix, std::slice::from_ref(&key_prefix.to_owned()))
+            .await;
+    }
+
+    /// Like [`invalidate_key_prefix`](Self::invalidate_key_prefix), but
+    /// removes entries matching *any* of `key_prefixes` in a single pass
+    /// over the cache, instead of one pass per prefix.
+    ///
+    /// Prefer this over calling [`invalidate_key_prefix`](Self::invalidate_key_prefix)
+    /// in a loop when invalidating many keys at once (e.g. several dataset
+    /// versions' worth of cache entries after a cleanup run) — each call to
+    /// either method registers its own scan over the backend's entries, so
+    /// batching avoids `O(prefixes)` scans.
+    ///
+    /// Backends that cannot support this cheaply may leave it as a no-op;
+    /// doing so only means those entries are evicted later by the normal
+    /// capacity-based eviction policy instead of immediately.
+    async fn invalidate_key_prefixes(&self, _prefix: &str, _key_prefixes: &[String]) {}
 
     /// Remove all entries.
     async fn clear(&self);

--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -136,8 +136,14 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// capacity-based eviction policy instead of immediately.
     ///
     /// Defaults to a single-element call to
-    /// [`invalidate_key_prefixes`](Self::invalidate_key_prefixes); backends
-    /// only need to implement one of the two.
+    /// [`invalidate_key_prefixes`](Self::invalidate_key_prefixes). Overriding
+    /// [`invalidate_key_prefixes`](Self::invalidate_key_prefixes) is
+    /// therefore the one to implement: it gives you both methods for free.
+    /// Overriding only this method does *not* work the other way around --
+    /// [`invalidate_key_prefixes`](Self::invalidate_key_prefixes)'s own
+    /// default (a no-op) is unaffected, so any caller that invokes it
+    /// directly (as [`LanceCache::invalidate_key_prefixes`](super::LanceCache::invalidate_key_prefixes)
+    /// does) would silently evict nothing.
     async fn invalidate_key_prefix(&self, prefix: &str, key_prefix: &str) {
         self.invalidate_key_prefixes(prefix, std::slice::from_ref(&key_prefix.to_owned()))
             .await;

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -247,9 +247,42 @@ impl LanceCache {
     /// `invalidate_key_prefix("manifest/5")` removes both a `"manifest/5"`
     /// entry and a `"manifest/5/{e_tag}"` entry, but leaves `"manifest/50"`
     /// untouched.
+    ///
+    /// To invalidate many keys at once (e.g. several dataset versions after
+    /// a cleanup run), prefer [`Self::invalidate_key_prefixes`], which does
+    /// so in a single pass over the cache instead of one pass per key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::{borrow::Cow, sync::Arc};
+    /// # use lance_core::cache::{CacheKey, LanceCache};
+    /// # struct ManifestKey(u64);
+    /// # impl CacheKey for ManifestKey {
+    /// #     type ValueType = Vec<i32>;
+    /// #     fn key(&self) -> Cow<'_, str> { format!("manifest/{}", self.0).into() }
+    /// #     fn type_name() -> &'static str { "Manifest" }
+    /// # }
+    /// # async fn example() {
+    /// let cache = LanceCache::with_capacity(1024);
+    /// cache.insert_with_key(&ManifestKey(5), Arc::new(vec![1])).await;
+    /// cache.invalidate_key_prefix("manifest/5").await;
+    /// assert!(cache.get_with_key(&ManifestKey(5)).await.is_none());
+    /// # }
+    /// ```
     pub async fn invalidate_key_prefix(&self, key_prefix: &str) {
         self.cache
             .invalidate_key_prefix(&self.prefix, key_prefix)
+            .await;
+    }
+
+    /// Like [`Self::invalidate_key_prefix`], but removes entries matching
+    /// *any* of `key_prefixes` in a single pass over the cache, instead of
+    /// one pass per prefix. Prefer this when invalidating many keys at
+    /// once.
+    pub async fn invalidate_key_prefixes(&self, key_prefixes: &[String]) {
+        self.cache
+            .invalidate_key_prefixes(&self.prefix, key_prefixes)
             .await;
     }
 
@@ -949,6 +982,56 @@ mod tests {
         assert_eq!(
             remaining,
             BTreeSet::from(["manifest/50".to_string(), "txn/5".to_string()])
+        );
+    }
+
+    /// `invalidate_key_prefixes` removes entries matching any of several
+    /// prefixes in one call -- the batched form `invalidate_stale_version_caches`
+    /// (in `dataset/cleanup.rs`) uses so a cleanup run touching many
+    /// versions issues a handful of cache scans instead of one per
+    /// version per key type.
+    #[tokio::test]
+    async fn test_cache_invalidate_key_prefixes() {
+        let cache = LanceCache::with_capacity(1000);
+
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/5"), Arc::new(vec![1]))
+            .await;
+        cache
+            .insert_with_key(
+                &TestKey::<Vec<i32>>::new("txn/5/etag-abc"),
+                Arc::new(vec![2]),
+            )
+            .await;
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/7"), Arc::new(vec![3]))
+            .await;
+        // Must not be removed: neither prefix nor a "/"-suffixed extension of one.
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/50"), Arc::new(vec![4]))
+            .await;
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/8"), Arc::new(vec![5]))
+            .await;
+        assert_eq!(cache.keys().await.unwrap().count(), 5);
+
+        cache
+            .invalidate_key_prefixes(&[
+                "manifest/5".to_string(),
+                "txn/5".to_string(),
+                "manifest/7".to_string(),
+            ])
+            .await;
+
+        let remaining: BTreeSet<String> = cache
+            .keys()
+            .await
+            .unwrap()
+            .map(|k| k.key().to_string())
+            .collect();
+        assert_eq!(
+            remaining,
+            BTreeSet::from(["manifest/50".to_string(), "manifest/8".to_string()])
         );
     }
 

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -237,6 +237,22 @@ impl LanceCache {
         self.cache.invalidate_prefix(&full_prefix).await;
     }
 
+    /// Invalidate all entries under this cache's namespace whose `key`
+    /// (as produced by a [`CacheKey::key`]) equals `key_prefix` or starts
+    /// with `key_prefix` followed by `/`.
+    ///
+    /// Use this to evict every cached entry associated with a single
+    /// version or fragment id, regardless of any optional suffix (e.g. an
+    /// e-tag or filter hash) individual entries may carry. For example,
+    /// `invalidate_key_prefix("manifest/5")` removes both a `"manifest/5"`
+    /// entry and a `"manifest/5/{e_tag}"` entry, but leaves `"manifest/50"`
+    /// untouched.
+    pub async fn invalidate_key_prefix(&self, key_prefix: &str) {
+        self.cache
+            .invalidate_key_prefix(&self.prefix, key_prefix)
+            .await;
+    }
+
     pub async fn size(&self) -> usize {
         self.cache.num_entries().await
     }
@@ -892,6 +908,48 @@ mod tests {
 
         base.clear().await;
         assert_eq!(base.keys().await.unwrap().count(), 0);
+    }
+
+    /// `invalidate_key_prefix` matches on an entry's `key` (e.g. a version
+    /// number), not its namespace `prefix`, and must remove every key that
+    /// is exactly `key_prefix` or `key_prefix` followed by `/` -- covering
+    /// keys with optional suffixes like an e-tag -- while leaving unrelated
+    /// keys that merely share a numeric prefix (e.g. "50" vs "5") alone.
+    #[tokio::test]
+    async fn test_cache_invalidate_key_prefix() {
+        let cache = LanceCache::with_capacity(1000);
+
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/5"), Arc::new(vec![1]))
+            .await;
+        cache
+            .insert_with_key(
+                &TestKey::<Vec<i32>>::new("manifest/5/etag-abc"),
+                Arc::new(vec![2]),
+            )
+            .await;
+        // Must not be removed: shares the "5" prefix but is a different version.
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("manifest/50"), Arc::new(vec![3]))
+            .await;
+        // Must not be removed: unrelated key entirely.
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("txn/5"), Arc::new(vec![4]))
+            .await;
+        assert_eq!(cache.keys().await.unwrap().count(), 4);
+
+        cache.invalidate_key_prefix("manifest/5").await;
+
+        let remaining: BTreeSet<String> = cache
+            .keys()
+            .await
+            .unwrap()
+            .map(|k| k.key().to_string())
+            .collect();
+        assert_eq!(
+            remaining,
+            BTreeSet::from(["manifest/50".to_string(), "txn/5".to_string()])
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -129,6 +129,17 @@ impl CacheBackend for MokaCacheBackend {
             .expect("Cache configured correctly");
     }
 
+    async fn invalidate_key_prefix(&self, prefix: &str, key_prefix: &str) {
+        let prefix = prefix.to_owned();
+        let key_prefix = key_prefix.to_owned();
+        self.cache
+            .invalidate_entries_if(move |key, _value| {
+                key.prefix() == prefix
+                    && (key.key() == key_prefix || key.key().starts_with(&format!("{key_prefix}/")))
+            })
+            .expect("Cache configured correctly");
+    }
+
     async fn clear(&self) {
         self.cache.invalidate_all();
         self.cache.run_pending_tasks().await;

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -129,13 +130,19 @@ impl CacheBackend for MokaCacheBackend {
             .expect("Cache configured correctly");
     }
 
-    async fn invalidate_key_prefix(&self, prefix: &str, key_prefix: &str) {
+    async fn invalidate_key_prefixes(&self, prefix: &str, key_prefixes: &[String]) {
         let prefix = prefix.to_owned();
-        let key_prefix = key_prefix.to_owned();
+        // Exact matches (e.g. a manifest with no e-tag) check this set
+        // directly; matches with a suffix (e.g. "manifest/5/{e_tag}") check
+        // against the `/`-suffixed forms below. Both are precomputed once
+        // here rather than per entry.
+        let exact: HashSet<String> = key_prefixes.iter().cloned().collect();
+        let with_slash: Vec<String> = key_prefixes.iter().map(|kp| format!("{kp}/")).collect();
         self.cache
             .invalidate_entries_if(move |key, _value| {
                 key.prefix() == prefix
-                    && (key.key() == key_prefix || key.key().starts_with(&format!("{key_prefix}/")))
+                    && (exact.contains(key.key())
+                        || with_slash.iter().any(|p| key.key().starts_with(p)))
             })
             .expect("Cache configured correctly");
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -520,28 +520,37 @@ impl<'a> CleanupTask<'a> {
     /// capacity-based policy. See
     /// https://github.com/lance-format/lance/issues/1983 for follow-up.
     async fn invalidate_stale_version_caches(&self, stale_versions: &[u64]) {
-        for version in stale_versions {
-            self.dataset
-                .metadata_cache
-                .invalidate_key_prefix(&format!("manifest/{version}"))
-                .await;
-            self.dataset
-                .metadata_cache
-                .invalidate_key_prefix(&format!("txn/{version}"))
-                .await;
-            self.dataset
-                .metadata_cache
-                .invalidate_key_prefix(&format!("row_addr_mask/{version}"))
-                .await;
-            self.dataset
-                .metadata_cache
-                .invalidate_key_prefix(&format!("row_id_index/{version}"))
-                .await;
-            self.dataset
-                .index_cache
-                .invalidate_key_prefix(&version.to_string())
-                .await;
+        if stale_versions.is_empty() {
+            return;
         }
+        // Batched into two cache-wide passes (one per cache) rather than
+        // one pass per version per key type, so this stays cheap even when
+        // a cleanup run clears out many versions at once (e.g. the first
+        // cleanup after a long gap).
+        let metadata_key_prefixes: Vec<String> = stale_versions
+            .iter()
+            .flat_map(|version| {
+                [
+                    format!("manifest/{version}"),
+                    format!("txn/{version}"),
+                    format!("row_addr_mask/{version}"),
+                    format!("row_id_index/{version}"),
+                ]
+            })
+            .collect();
+        self.dataset
+            .metadata_cache
+            .invalidate_key_prefixes(&metadata_key_prefixes)
+            .await;
+
+        let index_key_prefixes: Vec<String> = stale_versions
+            .iter()
+            .map(|version| version.to_string())
+            .collect();
+        self.dataset
+            .index_cache
+            .invalidate_key_prefixes(&index_key_prefixes)
+            .await;
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1611,6 +1611,7 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_core::utils::testing::{ProxyObjectStore, ProxyObjectStorePolicy};
     use lance_index::IndexType;
+    use lance_index::optimize::OptimizeOptions;
     use lance_io::object_store::{
         ObjectStore, ObjectStoreParams, ObjectStoreRegistry, WrappingObjectStore,
     };
@@ -4406,10 +4407,15 @@ mod tests {
     /// leak from the outside, even though every individual entry was a
     /// legitimately "live" (referenced) cache object.
     ///
-    /// This test writes many versions under one shared `Session`, runs
-    /// cleanup to retain only the latest version, and asserts that (a) the
-    /// cache actually shrinks and (b) no cached key still references a
-    /// version whose files cleanup just deleted.
+    /// This test writes many versions under one shared `Session` -- including
+    /// a real vector index build and a later `optimize_indices()` call, so
+    /// the index cache (not just the metadata cache) actually accumulates
+    /// version-keyed entries the same way production code populates them,
+    /// rather than only exercising a code path that happens to have nothing
+    /// to invalidate -- runs cleanup to retain only the latest version, and
+    /// asserts that (a) both caches actually shrink and (b) no cached key in
+    /// either one still references a version whose files cleanup just
+    /// deleted.
     #[tokio::test]
     async fn cleanup_evicts_stale_version_caches() {
         let tmpdir = TempStrDir::default();
@@ -4419,6 +4425,7 @@ mod tests {
         // cleanup's explicit invalidation, not incidental LRU eviction.
         let session = Arc::new(Session::new(1 << 30, 1 << 30, Default::default()));
 
+        // v1: create the dataset.
         Dataset::write(
             some_batch(),
             &dataset_path,
@@ -4431,8 +4438,31 @@ mod tests {
         .await
         .unwrap();
 
-        const NUM_APPENDS: usize = 10;
-        for _ in 0..NUM_APPENDS {
+        // v2: build a vector index -- this is a real, separate commit whose
+        // transaction carries non-empty index metadata, so it inserts a
+        // genuine `IndexMetadataKey` entry into the index cache (see
+        // `commit_transaction` in `rust/lance/src/io/commit.rs`).
+        let mut dataset = DatasetBuilder::from_uri(&dataset_path)
+            .with_session(session.clone())
+            .load()
+            .await
+            .unwrap();
+        let index_params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 5);
+        dataset
+            .create_index(
+                &["indexable"],
+                IndexType::Vector,
+                Some("some_index".to_owned()),
+                &index_params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // v3-v5: appends. These don't touch the index, so they only add
+        // metadata-cache entries (matching most of production traffic).
+        const NUM_APPENDS_BEFORE_OPTIMIZE: usize = 3;
+        for _ in 0..NUM_APPENDS_BEFORE_OPTIMIZE {
             Dataset::write(
                 some_batch(),
                 &dataset_path,
@@ -4446,7 +4476,38 @@ mod tests {
             .unwrap();
         }
 
-        let before = session.metadata_cache_stats().await;
+        // v6: fold the newly-appended, unindexed fragments into the index.
+        // Another real commit with non-empty index metadata -- a second,
+        // distinct `IndexMetadataKey` entry, at a version that will itself
+        // become stale once more commits follow.
+        let mut dataset = DatasetBuilder::from_uri(&dataset_path)
+            .with_session(session.clone())
+            .load()
+            .await
+            .unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        // v7-v11: more appends, so v1-v6 are all old by the time cleanup runs.
+        const NUM_APPENDS_AFTER_OPTIMIZE: usize = 5;
+        for _ in 0..NUM_APPENDS_AFTER_OPTIMIZE {
+            Dataset::write(
+                some_batch(),
+                &dataset_path,
+                Some(WriteParams {
+                    session: Some(session.clone()),
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+        }
+
+        let metadata_before = session.metadata_cache_stats().await;
+        let index_before = session.index_cache_stats().await;
 
         let dataset = DatasetBuilder::from_uri(&dataset_path)
             .with_session(session.clone())
@@ -4454,6 +4515,12 @@ mod tests {
             .await
             .unwrap();
         let latest_version = dataset.version().version;
+        let total_versions = 1 // create
+            + 1 // create_index
+            + NUM_APPENDS_BEFORE_OPTIMIZE as u64
+            + 1 // optimize_indices
+            + NUM_APPENDS_AFTER_OPTIMIZE as u64;
+        assert_eq!(latest_version, total_versions);
 
         // Retain only the latest version (the default policy has no
         // before_timestamp/before_version restriction, and process_manifest_file
@@ -4465,14 +4532,20 @@ mod tests {
         };
         let removed = cleanup_old_versions(&dataset, policy).await.unwrap();
         assert_eq!(
-            removed.old_versions, NUM_APPENDS as u64,
+            removed.old_versions,
+            total_versions - 1,
             "expected every version except the latest to be cleaned up"
         );
 
-        let after = session.metadata_cache_stats().await;
+        let metadata_after = session.metadata_cache_stats().await;
         assert!(
-            after.num_entries < before.num_entries,
-            "expected cleanup to evict stale version cache entries: before={before:?} after={after:?}"
+            metadata_after.num_entries < metadata_before.num_entries,
+            "expected cleanup to evict stale version cache entries: before={metadata_before:?} after={metadata_after:?}"
+        );
+        let index_after = session.index_cache_stats().await;
+        assert!(
+            index_after.num_entries < index_before.num_entries,
+            "expected cleanup to evict stale index cache entries: before={index_before:?} after={index_after:?}"
         );
 
         // No cached manifest/txn/row_addr_mask/row_id_index entry should
@@ -4480,7 +4553,7 @@ mod tests {
         // those versions' files are gone from disk, so their cache entries
         // are unreachable dead weight that would otherwise sit in the cache
         // until it hit its configured byte-capacity ceiling.
-        let stale_entries: Vec<String> = session
+        let stale_metadata_entries: Vec<String> = session
             .metadata_cache_keys()
             .await
             .expect("moka backend supports key inventory")
@@ -4498,8 +4571,27 @@ mod tests {
             })
             .collect();
         assert!(
-            stale_entries.is_empty(),
-            "cache still holds entries for cleaned-up versions: {stale_entries:?}"
+            stale_metadata_entries.is_empty(),
+            "cache still holds entries for cleaned-up versions: {stale_metadata_entries:?}"
+        );
+
+        // Same check for the index cache's `IndexMetadataKey` entries (whose
+        // key is the bare version number, with no other index-cache entry
+        // format sharing that shape -- see `IndexMetadataKey::key` in
+        // `rust/lance/src/session/index_caches.rs`).
+        let stale_index_entries: Vec<String> = session
+            .index_cache_keys()
+            .await
+            .expect("moka backend supports key inventory")
+            .filter_map(|k| {
+                let key = k.key().to_string();
+                let version: u64 = key.parse().ok()?;
+                (version < latest_version).then_some(key)
+            })
+            .collect();
+        assert!(
+            stale_index_entries.is_empty(),
+            "index cache still holds entries for cleaned-up versions: {stale_index_entries:?}"
         );
     }
 }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -487,11 +487,61 @@ impl<'a> CleanupTask<'a> {
                 .await?
         };
 
-        final_result.merge(
-            self.delete_unreferenced_files(inspection).await?,
-            candidate_file_limit,
-        );
+        // Capture which versions cleanup is about to make unreachable before
+        // `inspection` is consumed below, so we can evict their cache
+        // entries once deletion actually succeeds.
+        let stale_versions: Vec<u64> = inspection.old_manifests.values().copied().collect();
+
+        let removal_stats = self.delete_unreferenced_files(inspection).await?;
+        if self.action.deletes_files() {
+            // Only evict once files are actually deleted (not on `explain`,
+            // which must not have side effects). Nothing else in the write,
+            // commit, or cleanup paths ever invalidates these version-keyed
+            // cache entries, so without this the metadata/index caches keep
+            // every version's entries forever, growing RSS roughly linearly
+            // with commit count until DEFAULT_METADATA_CACHE_SIZE /
+            // DEFAULT_INDEX_CACHE_SIZE (1 GiB each) is hit. See
+            // https://github.com/lance-format/lance/issues/1983.
+            self.invalidate_stale_version_caches(&stale_versions).await;
+        }
+        final_result.merge(removal_stats, candidate_file_limit);
         Ok(final_result)
+    }
+
+    /// Evict cached metadata/index entries for versions that are no longer
+    /// reachable on disk (their manifest files were just deleted by this
+    /// cleanup run). Covers every cache key that is scoped to a dataset
+    /// version: manifests, transactions, row address masks, row id
+    /// indexes, and index metadata.
+    ///
+    /// This does not yet cover per-fragment cache entries (deletion vectors,
+    /// row id sequences) for fragments rewritten or removed by this cleanup
+    /// run; those remain cached until evicted by the caches' normal
+    /// capacity-based policy. See
+    /// https://github.com/lance-format/lance/issues/1983 for follow-up.
+    async fn invalidate_stale_version_caches(&self, stale_versions: &[u64]) {
+        for version in stale_versions {
+            self.dataset
+                .metadata_cache
+                .invalidate_key_prefix(&format!("manifest/{version}"))
+                .await;
+            self.dataset
+                .metadata_cache
+                .invalidate_key_prefix(&format!("txn/{version}"))
+                .await;
+            self.dataset
+                .metadata_cache
+                .invalidate_key_prefix(&format!("row_addr_mask/{version}"))
+                .await;
+            self.dataset
+                .metadata_cache
+                .invalidate_key_prefix(&format!("row_id_index/{version}"))
+                .await;
+            self.dataset
+                .index_cache
+                .invalidate_key_prefix(&version.to_string())
+                .await;
+        }
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1536,6 +1586,7 @@ mod tests {
     use super::*;
     use crate::blob::{BlobArrayBuilder, blob_field};
     use crate::index::DatasetIndexExt;
+    use crate::session::Session;
     use crate::{
         dataset::transaction::{Operation, Transaction},
         dataset::{AutoCleanupParams, ReadParams, WriteMode, WriteParams, builder::DatasetBuilder},
@@ -4331,6 +4382,115 @@ mod tests {
             elapsed.as_millis() >= 2000,
             "expected cleanup to be rate-limited (elapsed: {:?})",
             elapsed
+        );
+    }
+
+    /// Regression test for https://github.com/lance-format/lance/issues/1983.
+    ///
+    /// Every commit inserts new version-keyed entries into the session's
+    /// metadata/index caches (`manifest/{version}`, `txn/{version}`,
+    /// `row_addr_mask/{version}`, `row_id_index/{version}`, and index
+    /// metadata keyed by version). Nothing evicted them for versions cleanup
+    /// had already made unreachable on disk, so a long-running writer that
+    /// shares one `Session` across many commits saw these caches grow
+    /// roughly linearly with commit count -- looking exactly like a memory
+    /// leak from the outside, even though every individual entry was a
+    /// legitimately "live" (referenced) cache object.
+    ///
+    /// This test writes many versions under one shared `Session`, runs
+    /// cleanup to retain only the latest version, and asserts that (a) the
+    /// cache actually shrinks and (b) no cached key still references a
+    /// version whose files cleanup just deleted.
+    #[tokio::test]
+    async fn cleanup_evicts_stale_version_caches() {
+        let tmpdir = TempStrDir::default();
+        let dataset_path = format!("{}/my_db", tmpdir.as_str());
+        // Large capacity so nothing is evicted by the normal capacity-based
+        // policy during this test -- any shrinkage we observe must come from
+        // cleanup's explicit invalidation, not incidental LRU eviction.
+        let session = Arc::new(Session::new(1 << 30, 1 << 30, Default::default()));
+
+        Dataset::write(
+            some_batch(),
+            &dataset_path,
+            Some(WriteParams {
+                session: Some(session.clone()),
+                mode: WriteMode::Create,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        const NUM_APPENDS: usize = 10;
+        for _ in 0..NUM_APPENDS {
+            Dataset::write(
+                some_batch(),
+                &dataset_path,
+                Some(WriteParams {
+                    session: Some(session.clone()),
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+        }
+
+        let before = session.metadata_cache_stats().await;
+
+        let dataset = DatasetBuilder::from_uri(&dataset_path)
+            .with_session(session.clone())
+            .load()
+            .await
+            .unwrap();
+        let latest_version = dataset.version().version;
+
+        // Retain only the latest version (the default policy has no
+        // before_timestamp/before_version restriction, and process_manifest_file
+        // never cleans the latest version regardless of policy).
+        let policy = CleanupPolicy {
+            delete_unverified: true,
+            error_if_tagged_old_versions: false,
+            ..Default::default()
+        };
+        let removed = cleanup_old_versions(&dataset, policy).await.unwrap();
+        assert_eq!(
+            removed.old_versions, NUM_APPENDS as u64,
+            "expected every version except the latest to be cleaned up"
+        );
+
+        let after = session.metadata_cache_stats().await;
+        assert!(
+            after.num_entries < before.num_entries,
+            "expected cleanup to evict stale version cache entries: before={before:?} after={after:?}"
+        );
+
+        // No cached manifest/txn/row_addr_mask/row_id_index entry should
+        // reference a version older than the one that survived cleanup --
+        // those versions' files are gone from disk, so their cache entries
+        // are unreachable dead weight that would otherwise sit in the cache
+        // until it hit its configured byte-capacity ceiling.
+        let stale_entries: Vec<String> = session
+            .metadata_cache_keys()
+            .await
+            .expect("moka backend supports key inventory")
+            .filter_map(|k| {
+                let key = k.key().to_string();
+                let rest = key
+                    .strip_prefix("manifest/")
+                    .or_else(|| key.strip_prefix("txn/"))
+                    .or_else(|| key.strip_prefix("row_addr_mask/"))
+                    .or_else(|| key.strip_prefix("row_id_index/"))?;
+                // Some of these keys carry a trailing "/{e_tag}" or
+                // "/{hash}" suffix; the version is always the first segment.
+                let version: u64 = rest.split('/').next().unwrap().parse().ok()?;
+                (version < latest_version).then_some(key)
+            })
+            .collect();
+        assert!(
+            stale_entries.is_empty(),
+            "cache still holds entries for cleaned-up versions: {stale_entries:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

#1983 was originally about `merge_insert`'s DataFusion join having no configured RAM limit. In [investigating it](https://github.com/lance-format/lance/issues/1983#issuecomment-latest) I found that the join's RAM usage is only part of the story — there's a separate, more fundamental issue that also affects plain `add()`, not just `merge_insert()`.

A jemalloc-instrumented reproduction (table held at a **constant** row count, `cleanup_older_than=0` on every `optimize()`, forced allocator `arena.purge()`) showed:

- `stats.allocated` (jemalloc live heap, not just RSS) grows on every commit, even with disk usage and fragment/version counts provably bounded.
- Forced allocator purge recovers **0.0 MB**, every time — ruling out allocator retention.
- **Plain `table.add()` alone leaks** (+77.8 MB live heap over 1,500 calls), not just `merge_insert()` (+117.8 MB) — ruling out the join as the sole cause.

## Root cause

Every commit inserts new entries into the session's metadata/index caches (`rust/lance/src/session/caches.rs`, `rust/lance/src/session/index_caches.rs`), keyed by dataset version:

```rust
ManifestKey { version }        // "manifest/{version}[/{e_tag}]"
TransactionKey { version }     // "txn/{version}"
RowAddrMaskKey { version, .. } // "row_addr_mask/{version}[/{hash}]"
RowIdIndexKey { version }      // "row_id_index/{version}"
IndexMetadataKey { version }   // bare version number, in the index cache
```

Nothing in the write, commit, or cleanup paths ever evicts these. A repo-wide search confirms the only call sites for the existing `invalidate_prefix` are the trait definition, its Moka implementation, and two **test-only** mock backends — never in `commit.rs`, `cleanup.rs`, or `optimize.rs`. So a long-running writer sharing one `Session` across many commits sees these caches grow roughly linearly with commit count — indistinguishable from a leak from the outside — bounded only by `DEFAULT_METADATA_CACHE_SIZE`/`DEFAULT_INDEX_CACHE_SIZE` (1 GiB each), a ceiling that's often above a container's actual memory limit.

Cleanup (`cleanup_old_versions`, and `optimize()`'s auto-cleanup hook — exactly the maintenance cadence the docs recommend for long-running upsert workloads) already knows precisely which versions become unreachable when it deletes their files. It just never told the cache.

## Fix

`CleanupTask::run()` (`rust/lance/src/dataset/cleanup.rs`) now invalidates the metadata/index cache entries for every manifest version it physically deletes, gated on `self.action.deletes_files()` so a side-effect-free `explain()` stays side-effect-free.

The existing `invalidate_prefix` couldn't be reused for this: it matches an entry's namespace `prefix` field (a dataset URI), never its per-entry `key` field where version numbers actually live (see `InternalCacheKey::starts_with`). So I added `invalidate_key_prefix` (backend trait method + Moka implementation + `LanceCache` wrapper) that matches on `key` with a `/`-boundary check — evicting version `5` doesn't also evict version `50`, and it covers every optional suffix a key type may carry (e.g. a manifest's e-tag) without needing to know it in advance.

## Scope

This PR covers version-scoped cache entries, which the jemalloc evidence points to as the dominant driver. Per-fragment entries (`DeletionFileKey`, `RowIdSequenceKey`) aren't covered yet — documented as a follow-up in the code. The original ask in #1983 (a configurable RAM limit for `merge_insert`'s DataFusion join) is a separate, complementary fix I'll follow up with in another PR — it bounds the join's own transient memory, not this cache-retention gap, and doesn't address the fact that plain `add()` leaks too.

## Testing

- New unit test `test_cache_invalidate_key_prefix` (`rust/lance-core/src/cache/mod.rs`) verifies the new primitive's boundary-safety (evicting `"manifest/5"` doesn't touch `"manifest/50"`) and that it covers suffixed variants (`"manifest/5/etag-abc"`).
- New integration test `cleanup_evicts_stale_version_caches` (`rust/lance/src/dataset/cleanup.rs`) writes 11 versions under one shared `Session`, runs cleanup to retain only the latest, and asserts both that the cache shrinks and that no cached key still references a version whose files were just deleted.
- **Verified the integration test actually catches the regression**: temporarily commented out the new invalidation call and confirmed the test fails with a clear diff (`num_entries` unchanged before/after cleanup); restored the fix and confirmed it passes again.
- All existing tests in `dataset::cleanup::`, `session::`, and `lance-core`'s `cache::` modules pass unmodified (34 + 11 + 22 tests respectively).
- `cargo check`, `cargo fmt --check`, and `cargo clippy -- -D warnings` are clean on `lance` and `lance-core`, run under the toolchain pinned in `rust-toolchain.toml` (1.94.0) to match CI exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache invalidation by key prefix, evicting exact matches and `key_prefix/`-prefixed variants while avoiding unrelated shorter numeric-overlap prefixes.
* **Bug Fixes**
  * Dataset cleanup now evicts stale session metadata and index cache entries only after successful file deletion (not during explain), preventing leftover cached data.
* **Tests**
  * Added coverage for key-prefix eviction semantics and stale-version cleanup cache reduction.
* **Refactor**
  * Extended cache backends with a multi-prefix invalidation capability (with safe no-op defaults where not supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->