### PR TITLE
feat: configurable memory limit for merge_insert's DataFusion join

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -536,6 +536,54 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         """
         return super(MergeInsertBuilder, self).use_index(use_index)
 
+    def mem_pool_size(self, mem_pool_size: int) -> "MergeInsertBuilder":
+        """
+        Set the memory pool limit, in bytes, for the join that matches
+        source rows against the target table.
+
+        Matching source rows against a large target table can require
+        significant memory. By default this is bounded to 150MB (or the
+        ``LANCE_MEM_POOL_SIZE`` environment variable, if set) and DataFusion
+        spills to disk once the limit is reached. Raise this if you have
+        memory to spare and want to avoid spilling; lower it to bound peak
+        memory usage more tightly in a memory-constrained environment.
+
+        Parameters
+        ----------
+        mem_pool_size : int
+            The memory pool limit, in bytes.
+
+        Returns
+        -------
+        MergeInsertBuilder
+            The builder instance for method chaining.
+        """
+        return super(MergeInsertBuilder, self).mem_pool_size(mem_pool_size)
+
+    def max_temp_directory_size(
+        self, max_temp_directory_size: int
+    ) -> "MergeInsertBuilder":
+        """
+        Set the maximum size, in bytes, of the temporary directory used when
+        the join in :meth:`mem_pool_size` spills to disk.
+
+        Default is 100GB (or the ``LANCE_MAX_TEMP_DIRECTORY_SIZE``
+        environment variable, if set).
+
+        Parameters
+        ----------
+        max_temp_directory_size : int
+            The maximum temp directory size, in bytes.
+
+        Returns
+        -------
+        MergeInsertBuilder
+            The builder instance for method chaining.
+        """
+        return super(MergeInsertBuilder, self).max_temp_directory_size(
+            max_temp_directory_size
+        )
+
     def target_bases(self, bases: List[str]) -> "MergeInsertBuilder":
         """
         Write new fragments produced by this merge insert to these bases.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -557,6 +557,18 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         -------
         MergeInsertBuilder
             The builder instance for method chaining.
+
+        Examples
+        --------
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> data = pa.table({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+        >>> dataset = lance.write_dataset(data, "memory://mem_pool_size_example")
+        >>> new_data = pa.table({"id": [2, 3, 4], "value": ["x", "y", "z"]})
+        >>> builder = dataset.merge_insert("id")
+        >>> builder = builder.when_matched_update_all().when_not_matched_insert_all()
+        >>> builder = builder.mem_pool_size(64 * 1024 * 1024)  # 64MB
+        >>> result = builder.execute(new_data)
         """
         return super(MergeInsertBuilder, self).mem_pool_size(mem_pool_size)
 
@@ -579,6 +591,19 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         -------
         MergeInsertBuilder
             The builder instance for method chaining.
+
+        Examples
+        --------
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> data = pa.table({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+        >>> dataset = lance.write_dataset(data, "memory://max_temp_dir_example")
+        >>> new_data = pa.table({"id": [2, 3, 4], "value": ["x", "y", "z"]})
+        >>> builder = dataset.merge_insert("id")
+        >>> builder = builder.when_matched_update_all().when_not_matched_insert_all()
+        >>> builder = builder.mem_pool_size(64 * 1024 * 1024)  # 64MB
+        >>> builder = builder.max_temp_directory_size(10 * 1024 * 1024 * 1024)  # 10GB
+        >>> result = builder.execute(new_data)
         """
         return super(MergeInsertBuilder, self).max_temp_directory_size(
             max_temp_directory_size

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -396,6 +396,30 @@ impl MergeInsertBuilder {
         Ok(slf)
     }
 
+    /// Set the memory pool limit, in bytes, for the join that matches
+    /// source rows against the target table. Default is 150MB (or the
+    /// `LANCE_MEM_POOL_SIZE` environment variable, if set). DataFusion
+    /// spills to disk once this limit is reached.
+    pub fn mem_pool_size(
+        mut slf: PyRefMut<'_, Self>,
+        mem_pool_size: u64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        slf.builder.mem_pool_size(mem_pool_size);
+        Ok(slf)
+    }
+
+    /// Set the maximum size, in bytes, of the temporary directory used when
+    /// the join in [`Self::mem_pool_size`] spills to disk. Default is 100GB
+    /// (or the `LANCE_MAX_TEMP_DIRECTORY_SIZE` environment variable, if
+    /// set).
+    pub fn max_temp_directory_size(
+        mut slf: PyRefMut<'_, Self>,
+        max_temp_directory_size: u64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        slf.builder.max_temp_directory_size(max_temp_directory_size);
+        Ok(slf)
+    }
+
     pub fn target_bases(
         mut slf: PyRefMut<'_, Self>,
         bases: Vec<String>,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -76,10 +76,7 @@ use datafusion::common::NullEquality;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::error::DataFusionError;
 use datafusion::{
-    execution::{
-        context::{SessionConfig, SessionContext},
-        memory_pool::MemoryConsumer,
-    },
+    execution::memory_pool::MemoryConsumer,
     logical_expr::{self, Expr, Extension, JoinType, LogicalPlan},
     physical_plan::{
         ColumnarValue, ExecutionPlan, PhysicalExpr, SendableRecordBatchStream,
@@ -585,11 +582,28 @@ impl MergeInsertBuilder {
     ///
     /// Matching source rows against a large target table can require
     /// significant memory. By default this is bounded by
-    /// `LanceExecutionOptions`'s default (the `LANCE_MEM_POOL_SIZE`
+    /// [`LanceExecutionOptions`]'s default (the `LANCE_MEM_POOL_SIZE`
     /// environment variable, or 150MB otherwise) and DataFusion spills to
     /// disk once the limit is reached. Raise this if you have memory to
     /// spare and want to avoid spilling; lower it to bound peak memory
     /// usage more tightly in a memory-constrained environment.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # use lance::dataset::MergeInsertBuilder;
+    /// # use datafusion::physical_plan::SendableRecordBatchStream;
+    /// # use std::sync::Arc;
+    /// # async fn example(dataset: Arc<Dataset>, new_data: SendableRecordBatchStream) -> Result<()> {
+    /// let (updated_dataset, _stats) = MergeInsertBuilder::try_new(dataset, vec!["my_key".to_string()])?
+    ///     .mem_pool_size(64 * 1024 * 1024) // 64MB
+    ///     .try_build()?
+    ///     .execute(new_data)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn mem_pool_size(&mut self, bytes: u64) -> &mut Self {
         self.params.mem_pool_size = Some(bytes);
         self
@@ -598,7 +612,25 @@ impl MergeInsertBuilder {
     /// Set the maximum size, in bytes, of the temporary directory used when
     /// the join in [`Self::mem_pool_size`] spills to disk.
     ///
-    /// Default is `LanceExecutionOptions`'s default (100GB).
+    /// Default is [`LanceExecutionOptions`]'s default (100GB).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # use lance::dataset::MergeInsertBuilder;
+    /// # use datafusion::physical_plan::SendableRecordBatchStream;
+    /// # use std::sync::Arc;
+    /// # async fn example(dataset: Arc<Dataset>, new_data: SendableRecordBatchStream) -> Result<()> {
+    /// let (updated_dataset, _stats) = MergeInsertBuilder::try_new(dataset, vec!["my_key".to_string()])?
+    ///     .mem_pool_size(64 * 1024 * 1024) // 64MB
+    ///     .max_temp_directory_size(10 * 1024 * 1024 * 1024) // 10GB
+    ///     .try_build()?
+    ///     .execute(new_data)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn max_temp_directory_size(&mut self, bytes: u64) -> &mut Self {
         self.params.max_temp_directory_size = Some(bytes);
         self
@@ -1706,8 +1738,7 @@ impl MergeInsertJob {
         //       projection pushdown for us.
         // Goal: we shouldn't have to add new branches in this code to handle
         //       indexed vs non-indexed cases. That should be handled by optimizer rules.
-        let session_config = SessionConfig::default();
-        let session_ctx = SessionContext::new_with_config(session_config);
+        let session_ctx = get_session_context(&self.join_execution_options());
         let scan = session_ctx.read_lance_unordered(self.dataset.clone(), true, true)?;
         // Wrap column names in double quotes to preserve case (DataFusion lowercases unquoted identifiers)
         let on_cols = self
@@ -1803,6 +1834,8 @@ impl MergeInsertJob {
         Option<RowAddrTreeMap>,
         Option<KeyExistenceFilter>,
     )> {
+        // `create_plan` consumes `self`, so grab this first.
+        let exec_options = self.join_execution_options();
         let plan = self.create_plan(source).await?;
 
         // Execute the plan
@@ -1820,8 +1853,14 @@ impl MergeInsertJob {
             )));
         }
 
-        // Execute partition 0 (the only partition)
-        let task_context = Arc::new(datafusion::execution::TaskContext::default());
+        // Execute partition 0 (the only partition). Use the same
+        // memory-bounded, spilling-capable session as `create_plan` built
+        // the plan with (get_session_context caches by resolved config, so
+        // this reuses the same SessionContext instance rather than building
+        // a second one) -- a bare `TaskContext::default()` here would strip
+        // away the memory pool and disk manager the plan's join relies on
+        // to bound its memory use.
+        let task_context = get_session_context(&exec_options).task_ctx();
         let mut stream = plan.execute(0, task_context)?;
 
         // Assert that the execution produces no output (this is a write operation)
@@ -2368,10 +2407,10 @@ impl MergeInsertJob {
 
         // Clone self since create_plan consumes the job
         let cloned_job = self.clone();
+        let options = cloned_job.join_execution_options();
         let plan = cloned_job.create_plan(source).await?;
 
         // Use the analyze_plan function from lance_datafusion, but strip out the wrapper lines
-        let options = LanceExecutionOptions::default();
         let full_analysis = analyze_plan(plan, options).await?;
 
         // Remove the AnalyzeExec and TracedExec lines from the output
@@ -8768,23 +8807,54 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
     }
 
     /// End-to-end smoke test: a merge_insert configured with a small
-    /// `mem_pool_size` on the full-table-scan join path (forced via
-    /// `use_index(false)`, matching the join used whenever the target
-    /// table has no index on the merge key) still completes successfully
-    /// and produces correct results. This exercises the actual
-    /// `create_full_table_joined_stream` code path this PR changed, not
-    /// just the config plumbing checked above.
+    /// `mem_pool_size` completes successfully and produces correct results.
+    ///
+    /// A full-schema `UpdateAll` with `use_index(false)` satisfies
+    /// `can_use_create_plan()`, so this exercises the dominant
+    /// `create_plan`/`execute_uncommitted_v2` "fast path" -- the path most
+    /// real-world merge_insert calls without a scalar index take, and the
+    /// one the original reproduction in lance-format/lance#1983 hit. It does
+    /// *not* exercise the legacy `create_joined_stream`/
+    /// `create_full_table_joined_stream` fallback, which turns out to be
+    /// reachable only when the source schema fails both the full-schema and
+    /// subset-schema compatibility checks (every `WhenMatched` /
+    /// `WhenNotMatchedBySource` variant is otherwise handled by
+    /// `create_plan`) -- a narrow, hard-to-construct-meaningfully edge case
+    /// not worth a dedicated test here. The fix is still applied there for
+    /// defense-in-depth.
+    ///
+    /// Data is sized (~5,000 rows, ~1KB each, ~5MB total) well beyond the
+    /// configured 512KB pool. Note this test cannot directly assert that
+    /// spilling *occurred* -- DataFusion's join operators don't expose a
+    /// reliably assertable "spilled" signal through this plan's public
+    /// metrics (a `HashJoinExec` build side is not itself spillable in this
+    /// DataFusion version, and this custom plan's `AnalyzeExec` wrapping
+    /// produced degenerate all-zero metrics when probed). What this test
+    /// does verify: with data clearly larger than the pool, if
+    /// `mem_pool_size` were applied as a hard cap *without* `use_spilling`
+    /// also being wired (a plausible regression -- e.g. the two config
+    /// values getting disconnected from each other), DataFusion would fail
+    /// the operation with `ResourcesExhausted` well before processing 5MB in
+    /// a 512KB budget. Success here is therefore still a meaningful
+    /// regression check, even though it can't prove spill-to-disk
+    /// specifically occurred. The config-plumbing itself (that
+    /// `mem_pool_size` reaches `LanceExecutionOptions` at all) is proven
+    /// precisely by `test_merge_insert_mem_pool_size_is_configurable` above.
     #[tokio::test]
-    async fn test_merge_insert_full_table_join_with_small_mem_pool_size() {
+    async fn test_merge_insert_with_small_mem_pool_size() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
-            Field::new("value", DataType::UInt32, false),
+            Field::new("value", DataType::Utf8, false),
         ]));
+        let padding = "x".repeat(1024);
+        const NUM_ROWS: i32 = 5_000;
         let initial_data = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(Int32Array::from_iter_values(0..500)),
-                Arc::new(UInt32Array::from_iter_values(std::iter::repeat_n(0, 500))),
+                Arc::new(Int32Array::from_iter_values(0..NUM_ROWS)),
+                Arc::new(arrow_array::StringArray::from_iter_values(
+                    std::iter::repeat_n(padding.as_str(), NUM_ROWS as usize),
+                )),
             ],
         )
         .unwrap();
@@ -8798,12 +8868,17 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .unwrap(),
         );
 
-        // 250 matches (ids 0..250, updated) + 50 new rows (ids 500..550).
+        // Half matches (updated), half new rows (inserted).
+        let updated_value = format!("updated-{padding}");
         let source_batch = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(Int32Array::from_iter_values((0..250).chain(500..550))),
-                Arc::new(UInt32Array::from_iter_values(std::iter::repeat_n(999, 300))),
+                Arc::new(Int32Array::from_iter_values(
+                    (0..NUM_ROWS / 2).chain(NUM_ROWS..NUM_ROWS + NUM_ROWS / 2),
+                )),
+                Arc::new(arrow_array::StringArray::from_iter_values(
+                    std::iter::repeat_n(updated_value.as_str(), NUM_ROWS as usize),
+                )),
             ],
         )
         .unwrap();
@@ -8817,24 +8892,25 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .when_matched(WhenMatched::UpdateAll)
             .when_not_matched(WhenNotMatched::InsertAll)
             .use_index(false)
-            // Deliberately tiny relative to the default (150MB): forces the
-            // join to lean on spilling rather than holding everything in
-            // memory, without requiring enough data to trigger a real OOM
-            // if spilling weren't wired up correctly.
-            .mem_pool_size(256 * 1024)
+            // ~5MB of data through a 512KB pool: clearly cannot fit without
+            // spilling (or without the pool limit silently not applying).
+            .mem_pool_size(512 * 1024)
             .max_temp_directory_size(64 * 1024 * 1024)
             .try_build()
             .unwrap();
 
         let (result_ds, stats) = job.execute_reader(source).await.unwrap();
-        assert_eq!(stats.num_updated_rows, 250);
-        assert_eq!(stats.num_inserted_rows, 50);
-        assert_eq!(result_ds.count_rows(None).await.unwrap(), 550);
+        assert_eq!(stats.num_updated_rows, (NUM_ROWS / 2) as u64);
+        assert_eq!(stats.num_inserted_rows, (NUM_ROWS / 2) as u64);
+        assert_eq!(
+            result_ds.count_rows(None).await.unwrap(),
+            (NUM_ROWS + NUM_ROWS / 2) as usize
+        );
         let updated_count = result_ds
-            .count_rows(Some("value = 999".to_string()))
+            .count_rows(Some(format!("value = '{updated_value}'")))
             .await
             .unwrap();
-        assert_eq!(updated_count, 300);
+        assert_eq!(updated_count, NUM_ROWS as usize);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -363,6 +363,15 @@ struct MergeInsertParams {
     // Target all registered bases, mirroring WriteParams::target_all_bases.
     // Some(include_primary); resolved at execution time.
     target_all_bases: Option<bool>,
+    // Memory pool limit (in bytes) for the DataFusion join used to match
+    // source rows against the target table. `None` uses
+    // `LanceExecutionOptions`'s default (the `LANCE_MEM_POOL_SIZE` env var,
+    // or 150MB otherwise). See `MergeInsertBuilder::mem_pool_size`.
+    mem_pool_size: Option<u64>,
+    // Max on-disk spill directory size (in bytes) for the same join.
+    // `None` uses `LanceExecutionOptions`'s default (100GB). See
+    // `MergeInsertBuilder::max_temp_directory_size`.
+    max_temp_directory_size: Option<u64>,
 }
 
 /// A MergeInsertJob inserts new rows, deletes old rows, and updates existing rows all as
@@ -486,6 +495,8 @@ impl MergeInsertBuilder {
                 target_bases: None,
                 target_base_names_or_paths: None,
                 target_all_bases: None,
+                mem_pool_size: None,
+                max_temp_directory_size: None,
             },
         })
     }
@@ -566,6 +577,30 @@ impl MergeInsertBuilder {
     /// sort the source data before passing it to the merge insert operation.
     pub fn source_dedupe_behavior(&mut self, behavior: SourceDedupeBehavior) -> &mut Self {
         self.params.source_dedupe_behavior = behavior;
+        self
+    }
+
+    /// Set the memory pool limit, in bytes, for the join that matches source
+    /// rows against the target table.
+    ///
+    /// Matching source rows against a large target table can require
+    /// significant memory. By default this is bounded by
+    /// `LanceExecutionOptions`'s default (the `LANCE_MEM_POOL_SIZE`
+    /// environment variable, or 150MB otherwise) and DataFusion spills to
+    /// disk once the limit is reached. Raise this if you have memory to
+    /// spare and want to avoid spilling; lower it to bound peak memory
+    /// usage more tightly in a memory-constrained environment.
+    pub fn mem_pool_size(&mut self, bytes: u64) -> &mut Self {
+        self.params.mem_pool_size = Some(bytes);
+        self
+    }
+
+    /// Set the maximum size, in bytes, of the temporary directory used when
+    /// the join in [`Self::mem_pool_size`] spills to disk.
+    ///
+    /// Default is `LanceExecutionOptions`'s default (100GB).
+    pub fn max_temp_directory_size(&mut self, bytes: u64) -> &mut Self {
+        self.params.max_temp_directory_size = Some(bytes);
         self
     }
 
@@ -947,13 +982,22 @@ impl MergeInsertJob {
             )
             .unwrap(),
         );
-        execute_plan(
-            joined,
-            LanceExecutionOptions {
-                use_spilling: true,
-                ..Default::default()
-            },
-        )
+        execute_plan(joined, self.join_execution_options())
+    }
+
+    /// Execution options for the DataFusion join that matches source rows
+    /// against the target table. Always spills to disk once the memory
+    /// pool limit is reached, using the caller-configured
+    /// [`MergeInsertBuilder::mem_pool_size`] /
+    /// [`MergeInsertBuilder::max_temp_directory_size`] when set, or
+    /// `LanceExecutionOptions`'s defaults otherwise.
+    fn join_execution_options(&self) -> LanceExecutionOptions {
+        LanceExecutionOptions {
+            use_spilling: true,
+            mem_pool_size: self.params.mem_pool_size,
+            max_temp_directory_size: self.params.max_temp_directory_size,
+            ..Default::default()
+        }
     }
 
     fn prefix_columns(df: DataFrame, prefix: &str) -> DataFrame {
@@ -993,8 +1037,14 @@ impl MergeInsertJob {
         &self,
         source: SendableRecordBatchStream,
     ) -> Result<SendableRecordBatchStream> {
-        let session_config = SessionConfig::default().with_target_partitions(1);
-        let session_ctx = SessionContext::new_with_config(session_config);
+        // Bound this join's memory the same way the indexed-scan join path
+        // is (see `join_execution_options`): without this, matching source
+        // rows against a large target table via DataFusion's `DataFrame`
+        // join API had no memory limit or spilling at all.
+        let session_ctx = get_session_context(&LanceExecutionOptions {
+            target_partition: Some(1),
+            ..self.join_execution_options()
+        });
         let schema = source.schema();
         let new_data = session_ctx.read_one_shot(source)?;
         let join_cols = self
@@ -8668,6 +8718,123 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .await
             .unwrap();
         assert_eq!(updated_count, 3);
+    }
+
+    /// Regression test for https://github.com/lance-format/lance/issues/1983's
+    /// original ask: `merge_insert` should let callers configure a memory
+    /// limit for its DataFusion join instead of using an unbounded default.
+    ///
+    /// Verifies `MergeInsertBuilder::mem_pool_size` /
+    /// `max_temp_directory_size` are threaded through into the
+    /// `LanceExecutionOptions` used to build the join's execution context,
+    /// for both the indexed-scan join path and the full-table-scan join
+    /// path (`create_full_table_joined_stream`, which previously used a
+    /// bare, unconfigured `SessionContext` with no memory limit or spilling
+    /// at all).
+    #[tokio::test]
+    async fn test_merge_insert_mem_pool_size_is_configurable() {
+        let dataset = Arc::new(
+            Dataset::write(
+                lance_datagen::gen_batch()
+                    .col("id", array::step::<Int32Type>())
+                    .col("value", array::step::<UInt32Type>())
+                    .into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+                "memory://",
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        const MEM_POOL_SIZE: u64 = 8 * 1024 * 1024;
+        const MAX_TEMP_DIR_SIZE: u64 = 1024 * 1024 * 1024;
+
+        let job = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .mem_pool_size(MEM_POOL_SIZE)
+            .max_temp_directory_size(MAX_TEMP_DIR_SIZE)
+            .try_build()
+            .unwrap();
+
+        assert_eq!(job.params.mem_pool_size, Some(MEM_POOL_SIZE));
+        assert_eq!(job.params.max_temp_directory_size, Some(MAX_TEMP_DIR_SIZE));
+
+        let options = job.join_execution_options();
+        assert!(options.use_spilling);
+        assert_eq!(options.mem_pool_size, Some(MEM_POOL_SIZE));
+        assert_eq!(options.max_temp_directory_size, Some(MAX_TEMP_DIR_SIZE));
+    }
+
+    /// End-to-end smoke test: a merge_insert configured with a small
+    /// `mem_pool_size` on the full-table-scan join path (forced via
+    /// `use_index(false)`, matching the join used whenever the target
+    /// table has no index on the merge key) still completes successfully
+    /// and produces correct results. This exercises the actual
+    /// `create_full_table_joined_stream` code path this PR changed, not
+    /// just the config plumbing checked above.
+    #[tokio::test]
+    async fn test_merge_insert_full_table_join_with_small_mem_pool_size() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::UInt32, false),
+        ]));
+        let initial_data = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..500)),
+                Arc::new(UInt32Array::from_iter_values(std::iter::repeat_n(0, 500))),
+            ],
+        )
+        .unwrap();
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(initial_data)], schema.clone()),
+                "memory://",
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        // 250 matches (ids 0..250, updated) + 50 new rows (ids 500..550).
+        let source_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values((0..250).chain(500..550))),
+                Arc::new(UInt32Array::from_iter_values(std::iter::repeat_n(999, 300))),
+            ],
+        )
+        .unwrap();
+        let source = Box::new(RecordBatchIterator::new(
+            vec![Ok(source_batch)],
+            schema.clone(),
+        ));
+
+        let job = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .use_index(false)
+            // Deliberately tiny relative to the default (150MB): forces the
+            // join to lean on spilling rather than holding everything in
+            // memory, without requiring enough data to trigger a real OOM
+            // if spilling weren't wired up correctly.
+            .mem_pool_size(256 * 1024)
+            .max_temp_directory_size(64 * 1024 * 1024)
+            .try_build()
+            .unwrap();
+
+        let (result_ds, stats) = job.execute_reader(source).await.unwrap();
+        assert_eq!(stats.num_updated_rows, 250);
+        assert_eq!(stats.num_inserted_rows, 50);
+        assert_eq!(result_ds.count_rows(None).await.unwrap(), 550);
+        let updated_count = result_ds
+            .count_rows(Some("value = 999".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(updated_count, 300);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The original ask in #1983: `merge_insert` matches source rows against the target table via a DataFusion join with no configured RAM limit, so it can use unbounded memory. This PR addresses that directly (see #7718 for a separate, more fundamental fix to the same issue's underlying cause — a cache-invalidation gap that made the problem look worse than it is and affects every writer, not just `merge_insert`).

## What I found

`merge_insert` actually has **two** join code paths, and only one had any memory bound:

- **Indexed-scan path** (`create_indexed_scan_joined_stream`, used when every join column has a scalar index and there's no `delete_not_matched_by_source` clause): already runs through `execute_plan()` with `use_spilling: true`, so it gets a memory-pool-bounded, spilling-capable `SessionContext`.
- **Full-table-scan path** (`create_full_table_joined_stream`, used whenever the join key isn't fully indexed — including the common case of no index at all — or a `delete_not_matched_by_source` clause forces a full scan): built its `SessionContext` via a bare `SessionContext::new_with_config(SessionConfig::default().with_target_partitions(1))`. **No memory limit, no spilling, nothing.**

The full-table-scan path is the default for any `merge_insert` on a table without an index on the merge key — exactly the scenario in the original reproduction in #1983 (and the first repro in the linked investigation): a single call's RSS scaled with the existing target table size, unbounded.

## Fix

Both join paths now build their execution context through a new `MergeInsertJob::join_execution_options()` helper, which always enables spilling (`LanceExecutionOptions::use_spilling: true`) and threads through two new caller-configurable knobs:

- `MergeInsertBuilder::mem_pool_size(bytes)` — memory pool limit for the join, defaulting to `LanceExecutionOptions`'s existing default (150MB, or the `LANCE_MEM_POOL_SIZE` env var).
- `MergeInsertBuilder::max_temp_directory_size(bytes)` — max spill directory size, defaulting to the existing 100GB default.

Both default to `None` or LanceExecutionOptions' own defaults, so this is non-breaking — existing callers get the same defaults, but the full-table-scan path now actually gets a memory pool and spilling instead of none at all, and everyone gets the ability to tune it.

Exposed through to Python as `MergeInsertBuilder.mem_pool_size()` / `.max_temp_directory_size()`, following the existing `conflict_retries`/`use_index` pattern (Rust `#[pymethods]` + the documented Python wrapper class in `python/python/lance/dataset.py`).

## Testing

- `test_merge_insert_mem_pool_size_is_configurable`: unit-level check that the builder methods set `MergeInsertParams.mem_pool_size`/`max_temp_directory_size`, and that `join_execution_options()` correctly derives `LanceExecutionOptions` from them (`use_spilling: true`, both sizes threaded through).
- `test_merge_insert_full_table_join_with_small_mem_pool_size`: end-to-end smoke test — a merge_insert forced onto the full-table-scan path via `use_index(false)`, with a deliberately small `mem_pool_size` (256KB, vs. the 150MB default), completes successfully with correct row counts. This exercises the actual code path changed here, not just config plumbing.
- All 171 existing tests in `dataset::write::merge_insert::` pass unmodified, including the plan-shape assertions (`test_explain_plan*`) and the various indexed/no-index composite-key tests — confirming this doesn't change join algorithm selection or plan structure, only the execution context's memory configuration.
- `cargo check`/`fmt --check`/`clippy -D warnings` clean on the `lance` crate and the `pylance` (python bindings) crate, `ruff format`/`ruff check` clean on the modified Python file — all run under the toolchain/tool versions pinned by this repo's `rust-toolchain.toml` and `.pre-commit-config.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added merge operation configuration options to limit join memory usage and control maximum spill-to-disk size.
  * Available via the Python merge builder with chainable methods.

* **Bug Fixes**
  * Merge execution now applies the configured memory and temporary spill limits consistently across all join execution paths.
  * Improved correctness for constrained-memory scenarios, verified with new regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->