### PR TITLE
perf(index): pack prewarmed FTS posting groups

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use super::encoding::encode_group_starts;
 use super::{InvertedIndexParams, index::*};
 use crate::scalar::inverted::document_tokenizer::DocType;
 use crate::scalar::inverted::json::JsonTextStream;
@@ -15,7 +14,6 @@ use arrow::array::AsArray;
 use arrow::datatypes;
 use arrow_array::{Array, BinaryArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use bytes::Bytes;
 use datafusion::execution::SendableRecordBatchStream;
 use fst::Streamer;
 use futures::{StreamExt, TryStreamExt};
@@ -73,91 +71,7 @@ static LANCE_FTS_POSTING_BATCH_ROWS: LazyLock<usize> = LazyLock::new(|| {
         .parse()
         .expect("failed to parse LANCE_FTS_POSTING_BATCH_ROWS")
 });
-// Target serialized byte size of a posting-list cache group. Consecutive
-// posting lists are grouped into a single cache entry until their combined
-// serialized size reaches this target, amortizing per-entry overhead across
-// small (Zipfian-rare) terms. See issue #7040.
-static LANCE_FTS_POSTING_GROUP_TARGET_BYTES: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("LANCE_FTS_POSTING_GROUP_TARGET_BYTES")
-        .unwrap_or_else(|_| "4096".to_string())
-        .parse()
-        .expect("failed to parse LANCE_FTS_POSTING_GROUP_TARGET_BYTES")
-});
-// Maximum number of posting lists in a single cache group, regardless of byte
-// size. Caps the work and memory of a single group read for corpora with many
-// tiny terms.
-static LANCE_FTS_POSTING_GROUP_MAX_TOKENS: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
-        .unwrap_or_else(|_| "256".to_string())
-        .parse()
-        .expect("failed to parse LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
-});
 const MAX_RETAINED_TOKEN_IDS: usize = 8 * 1024;
-
-/// Write-time configuration controlling how consecutive posting lists are
-/// grouped into a single read-path cache entry (issue #7040). Defaults come
-/// from the `LANCE_FTS_POSTING_GROUP_*` environment variables.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PostingGroupConfig {
-    pub(crate) target_bytes: usize,
-    pub(crate) max_tokens: usize,
-}
-
-impl Default for PostingGroupConfig {
-    fn default() -> Self {
-        Self {
-            target_bytes: (*LANCE_FTS_POSTING_GROUP_TARGET_BYTES).max(1),
-            max_tokens: (*LANCE_FTS_POSTING_GROUP_MAX_TOKENS).max(1),
-        }
-    }
-}
-
-/// Accumulates posting-list group boundaries at write time. Tokens are pushed
-/// in row order; a group is cut once its serialized bytes reach
-/// `target_bytes` or it holds `max_tokens` posting lists. A posting list
-/// larger than the target that *starts* a group occupies that group alone (the
-/// clamp case); one encountered mid-group is absorbed and closes that group, so
-/// a single term is never split across groups.
-#[derive(Debug)]
-pub(crate) struct PostingGroupAccumulator {
-    config: PostingGroupConfig,
-    starts: Vec<u32>,
-    next_token: u32,
-    current_bytes: usize,
-    current_tokens: usize,
-}
-
-impl PostingGroupAccumulator {
-    pub(crate) fn new(config: PostingGroupConfig) -> Self {
-        Self {
-            config,
-            starts: Vec::new(),
-            next_token: 0,
-            current_bytes: 0,
-            current_tokens: 0,
-        }
-    }
-
-    /// Record the next posting list in row order, given its serialized byte size.
-    pub(crate) fn push(&mut self, posting_bytes: usize) {
-        if self.current_tokens == 0 {
-            self.starts.push(self.next_token);
-        }
-        self.current_bytes += posting_bytes;
-        self.current_tokens += 1;
-        self.next_token += 1;
-        if self.current_bytes >= self.config.target_bytes
-            || self.current_tokens >= self.config.max_tokens
-        {
-            self.current_bytes = 0;
-            self.current_tokens = 0;
-        }
-    }
-
-    pub(crate) fn into_starts(self) -> Vec<u32> {
-        self.starts
-    }
-}
 
 fn default_num_workers() -> usize {
     let total_cpus = get_num_compute_intensive_cpus() + *IO_CORE_RESERVATION;
@@ -828,7 +742,6 @@ pub struct InnerBuilder {
     pub(crate) tokens: TokenSet,
     pub(crate) posting_lists: Vec<PostingListBuilder>,
     pub(crate) docs: DocSet,
-    pub(crate) group_config: PostingGroupConfig,
 }
 
 impl InnerBuilder {
@@ -856,7 +769,6 @@ impl InnerBuilder {
             tokens: TokenSet::default(),
             posting_lists: Vec::new(),
             docs: DocSet::default(),
-            group_config: PostingGroupConfig::default(),
         }
     }
 
@@ -956,7 +868,6 @@ impl InnerBuilder {
             tokens,
             posting_lists,
             docs,
-            group_config: _,
         } = other;
 
         if self.with_position != with_position {
@@ -1088,7 +999,6 @@ impl InnerBuilder {
         );
         let with_position = self.with_position;
         let format_version = self.format_version;
-        let group_config = self.group_config;
         let schema = inverted_list_schema_for_version(self.with_position, self.format_version);
         let docs_for_batches = docs.clone();
         let schema_for_batches = schema.clone();
@@ -1109,15 +1019,13 @@ impl InnerBuilder {
                 with_position,
                 format_version,
                 batch_rows,
-                group_config,
             );
             let mut posting_lists = posting_lists.into_iter();
             loop {
                 let docs_for_batches = docs_for_batches.clone();
                 // Build the next batch on the CPU pool. The builder and the
                 // remaining posting lists are moved in and handed back so state
-                // persists across batches -- notably the cache-group accumulator,
-                // which spans every batch this builder produces.
+                // persists across batches.
                 let (next_builder, next_posting_lists, batch) = spawn_cpu(move || {
                     let mut batch_builder = batch_builder;
                     let mut posting_lists = posting_lists;
@@ -1153,7 +1061,7 @@ impl InnerBuilder {
                 }
             }
 
-            Result::Ok(batch_builder.into_group_starts())
+            Result::Ok(())
         });
 
         while let Ok(batch) = rx.recv().await {
@@ -1165,22 +1073,8 @@ impl InnerBuilder {
             }
         }
         drop(rx);
-        let group_starts = producer.await??;
-
-        // Persist the posting-list cache-group boundaries as a global buffer,
-        // recording its 1-indexed id in schema metadata so the reader can group
-        // small posting lists into a single cache entry (issue #7040). Empty
-        // partitions skip this entirely and fall back to the per-token path.
-        let mut extra_metadata = HashMap::new();
-        if !group_starts.is_empty() {
-            let encoded = encode_group_starts(&group_starts);
-            let buffer_id = writer.add_global_buffer(Bytes::from(encoded)).await?;
-            extra_metadata.insert(
-                POSTING_GROUP_OFFSETS_BUF_KEY.to_owned(),
-                buffer_id.to_string(),
-            );
-        }
-        writer.finish_with_metadata(extra_metadata).await
+        producer.await??;
+        writer.finish().await
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -2610,8 +2504,7 @@ mod tests {
         }
 
         async fn add_global_buffer(&mut self, _data: Bytes) -> Result<u32> {
-            // The posting-list writer stores the group offsets as a global
-            // buffer; mirror the real writer's 1-indexed return value.
+            // Mirror the real writer's 1-indexed return value.
             Ok(1)
         }
 
@@ -2694,63 +2587,6 @@ mod tests {
         async fn list_files_with_sizes(&self) -> Result<Vec<IndexFile>> {
             Ok(vec![])
         }
-    }
-
-    fn collect_group_starts(config: PostingGroupConfig, sizes: &[usize]) -> Vec<u32> {
-        let mut acc = PostingGroupAccumulator::new(config);
-        for &size in sizes {
-            acc.push(size);
-        }
-        acc.into_starts()
-    }
-
-    #[test]
-    fn test_group_accumulator_cuts_on_target_bytes() {
-        let config = PostingGroupConfig {
-            target_bytes: 100,
-            max_tokens: 1000,
-        };
-        // 40+40 -> cut at 80? no, 80 < 100; third 40 reaches 120 >= 100 -> cut.
-        // So group 0 = tokens [0,3), then a new group starts at token 3.
-        let starts = collect_group_starts(config, &[40, 40, 40, 10, 10]);
-        assert_eq!(starts, vec![0, 3]);
-    }
-
-    #[test]
-    fn test_group_accumulator_cuts_on_max_tokens() {
-        let config = PostingGroupConfig {
-            target_bytes: 1_000_000,
-            max_tokens: 2,
-        };
-        // Byte target never reached; cap of 2 forces a cut every 2 tokens.
-        let starts = collect_group_starts(config, &[1, 1, 1, 1, 1]);
-        assert_eq!(starts, vec![0, 2, 4]);
-    }
-
-    #[test]
-    fn test_group_accumulator_clamps_oversized_term() {
-        let config = PostingGroupConfig {
-            target_bytes: 100,
-            max_tokens: 64,
-        };
-        // A term larger than the target that *starts* a group occupies that
-        // group alone ([1, 2) here), so a single huge posting list is never
-        // forced to share a cache entry. Token 0 (==100) closes its own group
-        // first; the trailing small terms regroup after the big one.
-        let starts = collect_group_starts(config, &[100, 5000, 10, 10]);
-        assert_eq!(starts, vec![0, 1, 2]);
-
-        // A huge term encountered mid-group is absorbed and closes that group;
-        // we never split one term across groups.
-        let starts = collect_group_starts(config, &[10, 10, 5000, 10, 10]);
-        assert_eq!(starts, vec![0, 3]);
-    }
-
-    #[test]
-    fn test_group_accumulator_empty_and_single() {
-        let config = PostingGroupConfig::default();
-        assert_eq!(collect_group_starts(config, &[]), Vec::<u32>::new());
-        assert_eq!(collect_group_starts(config, &[10]), vec![0]);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/cache_codec.rs
+++ b/rust/lance-index/src/scalar/inverted/cache_codec.rs
@@ -17,6 +17,9 @@
 //!   encoding);
 //! - the plain posting list: an IPC section of `(row_ids, frequencies)`, then
 //!   an optional legacy position IPC section;
+//! - a packed posting-list group: one IPC section containing the original
+//!   `List<LargeBinary>` posting rows; prewarmed groups omit score/length
+//!   metadata and inject it from the posting reader into query-local views;
 //! - the standalone [`Positions`] codec: the position sections alone.
 //!
 //! All sections read back zero-copy via [`lance_arrow::ipc`]. This is the FTS
@@ -41,7 +44,8 @@ use crate::cache_pb::{
 
 use super::index::{
     CompressedPositionStorage, CompressedPostingList, PlainPostingList, PositionStreamCodec,
-    Positions, PostingList, PostingListGroup, PostingTailCodec, SharedPositionStream,
+    Positions, PostingList, PostingListGroup, PostingListGroupStorage, PostingTailCodec,
+    SharedPositionStream,
 };
 
 // ---------------------------------------------------------------------------
@@ -50,6 +54,8 @@ use super::index::{
 
 const POSTING_VARIANT_PLAIN: u8 = 0;
 const POSTING_VARIANT_COMPRESSED: u8 = 1;
+const GROUP_VARIANT_MATERIALIZED: u8 = 0;
+const GROUP_VARIANT_PACKED: u8 = 1;
 
 // ---------------------------------------------------------------------------
 // Codec enum mappings
@@ -69,6 +75,23 @@ fn proto_to_posting_tail_codec(c: PbPostingTailCodec) -> PostingTailCodec {
     match c {
         PbPostingTailCodec::Fixed32 => PostingTailCodec::Fixed32,
         PbPostingTailCodec::VarintDelta => PostingTailCodec::VarintDelta,
+    }
+}
+
+fn posting_tail_codec_to_tag(c: PostingTailCodec) -> u8 {
+    match c {
+        PostingTailCodec::Fixed32 => 0,
+        PostingTailCodec::VarintDelta => 1,
+    }
+}
+
+fn posting_tail_codec_from_tag(tag: u8) -> Result<PostingTailCodec> {
+    match tag {
+        0 => Ok(PostingTailCodec::Fixed32),
+        1 => Ok(PostingTailCodec::VarintDelta),
+        other => Err(Error::io(format!(
+            "unknown packed posting tail codec: {other}"
+        ))),
     }
 }
 
@@ -336,34 +359,75 @@ fn deserialize_compressed(r: &mut CacheEntryReader<'_>) -> Result<CompressedPost
 // PostingListGroup codec
 // ---------------------------------------------------------------------------
 
-/// Serializes a [`PostingListGroup`] as a member-count header followed by each
-/// member posting list written **inline** through the same writer. Reusing the
-/// [`PostingList`] codec inline (rather than into per-member sub-buffers) keeps
-/// each member's Arrow IPC sections 64-byte aligned within the group entry, so
-/// they read back zero-copy. Member bodies are self-delimiting, so they need no
-/// length prefixes to separate them. See issue #7040.
+/// Version 2 distinguishes packed groups from the materialized fallback. A
+/// packed group writes one IPC batch; materialized groups retain the v1 inline
+/// member framing used by legacy and position-bearing prewarm paths.
 impl CacheCodecImpl for PostingListGroup {
     const TYPE_ID: &'static str = "lance.fts.PostingListGroup";
-    const CURRENT_VERSION: u32 = 1;
+    const CURRENT_VERSION: u32 = 2;
 
     fn serialize(&self, w: &mut CacheEntryWriter<'_>) -> Result<()> {
-        let count = u32::try_from(self.posting_lists.len())
+        let count = u32::try_from(self.len())
             .map_err(|_| Error::io("posting list group too large to serialize".to_string()))?;
-        w.write_header(&PostingListGroupHeader { count })?;
-        for posting in &self.posting_lists {
-            posting.serialize(w)?;
+        match &self.storage {
+            PostingListGroupStorage::Materialized(posting_lists) => {
+                w.write_u8(GROUP_VARIANT_MATERIALIZED)?;
+                w.write_header(&PostingListGroupHeader { count })?;
+                for posting in posting_lists {
+                    posting.serialize(w)?;
+                }
+            }
+            PostingListGroupStorage::Packed(group) => {
+                w.write_u8(GROUP_VARIANT_PACKED)?;
+                w.write_header(&PostingListGroupHeader { count })?;
+                w.write_u8(posting_tail_codec_to_tag(group.posting_tail_codec))?;
+                w.write_ipc(&group.batch)?;
+            }
         }
         Ok(())
     }
 
     fn deserialize(r: &mut CacheEntryReader<'_>) -> Result<Self> {
-        let header: PostingListGroupHeader = r.read_header()?;
-        let mut posting_lists = Vec::with_capacity(header.count as usize);
-        for _ in 0..header.count {
-            posting_lists.push(PostingList::deserialize(r)?);
+        match r.version() {
+            1 => return deserialize_materialized_group(r),
+            Self::CURRENT_VERSION => {}
+            other => {
+                return Err(Error::io(format!(
+                    "unsupported PostingListGroup cache version: {other}"
+                )));
+            }
         }
-        Ok(Self::new(posting_lists))
+
+        let variant = r.read_u8()?;
+        match variant {
+            GROUP_VARIANT_MATERIALIZED => deserialize_materialized_group(r),
+            GROUP_VARIANT_PACKED => {
+                let header: PostingListGroupHeader = r.read_header()?;
+                let posting_tail_codec = posting_tail_codec_from_tag(r.read_u8()?)?;
+                let batch = r.read_ipc()?;
+                if batch.num_rows() != header.count as usize {
+                    return Err(Error::io(format!(
+                        "packed posting group row count {} does not match header count {}",
+                        batch.num_rows(),
+                        header.count
+                    )));
+                }
+                Self::new_packed(batch, posting_tail_codec)
+            }
+            other => Err(Error::io(format!(
+                "unknown PostingListGroup variant: {other}"
+            ))),
+        }
     }
+}
+
+fn deserialize_materialized_group(r: &mut CacheEntryReader<'_>) -> Result<PostingListGroup> {
+    let header: PostingListGroupHeader = r.read_header()?;
+    let mut posting_lists = Vec::with_capacity(header.count as usize);
+    for _ in 0..header.count {
+        posting_lists.push(PostingList::deserialize(r)?);
+    }
+    Ok(PostingListGroup::new(posting_lists))
 }
 
 // ---------------------------------------------------------------------------
@@ -409,16 +473,20 @@ impl CacheCodecImpl for Positions {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use arrow::buffer::ScalarBuffer;
-    use arrow_array::LargeBinaryArray;
-    use arrow_array::builder::{Int32Builder, ListBuilder};
+    use arrow_array::builder::{Int32Builder, LargeBinaryBuilder, ListBuilder};
+    use arrow_array::{Array, LargeBinaryArray, RecordBatch};
+    use arrow_schema::{Field, Schema};
     use bytes::Bytes;
     use lance_core::Result;
     use lance_core::cache::{CacheCodecImpl, CacheEntryReader, CacheEntryWriter};
 
     use super::super::index::{
-        CompressedPositionStorage, CompressedPostingList, PlainPostingList, PositionStreamCodec,
-        Positions, PostingList, PostingListGroup, PostingTailCodec, SharedPositionStream,
+        CompressedPositionStorage, CompressedPostingList, POSTING_COL, PlainPostingList,
+        PositionStreamCodec, Positions, PostingList, PostingListGroup, PostingTailCodec,
+        SharedPositionStream,
     };
 
     fn legacy_positions(rows: &[&[i32]]) -> arrow_array::ListArray {
@@ -430,6 +498,27 @@ mod tests {
             builder.append(true);
         }
         builder.finish()
+    }
+
+    fn packed_group(
+        postings: &[Vec<Vec<u8>>],
+        posting_tail_codec: PostingTailCodec,
+    ) -> PostingListGroup {
+        let mut builder = ListBuilder::new(LargeBinaryBuilder::new());
+        for posting in postings {
+            for block in posting {
+                builder.values().append_value(block);
+            }
+            builder.append(true);
+        }
+        let postings = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            POSTING_COL,
+            postings.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(postings)]).unwrap();
+        PostingListGroup::new_packed(batch, posting_tail_codec).unwrap()
     }
 
     fn assert_plain_eq(a: &PlainPostingList, b: &PlainPostingList) {
@@ -661,9 +750,11 @@ mod tests {
         ] {
             let group = PostingListGroup::new(members.clone());
             let restored = from_body::<PostingListGroup>(&body_bytes(&group)).unwrap();
-            assert_eq!(restored.posting_lists.len(), members.len());
-            for (a, b) in members.iter().zip(restored.posting_lists.iter()) {
-                match (a, b) {
+            assert!(!restored.is_packed());
+            assert_eq!(restored.len(), members.len());
+            for (index, a) in members.iter().enumerate() {
+                let b = restored.posting_list(index, None, None).unwrap().unwrap();
+                match (a, &b) {
                     (PostingList::Plain(x), PostingList::Plain(y)) => assert_plain_eq(x, y),
                     (PostingList::Compressed(x), PostingList::Compressed(y)) => {
                         assert_eq!(x.blocks, y.blocks);
@@ -674,6 +765,57 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn packed_posting_list_group_roundtrip_and_v1_fallback() {
+        let group = packed_group(
+            &[vec![vec![1, 2, 3], vec![4, 5]], vec![vec![7; 16 * 1024]]],
+            PostingTailCodec::VarintDelta,
+        );
+        let restored = from_body::<PostingListGroup>(&body_bytes(&group)).unwrap();
+        assert!(restored.is_packed());
+        assert_eq!(restored.len(), 2);
+        for slot in 0..2 {
+            let max_score = [1.5, 3.25][slot];
+            let length = [3, 4096][slot];
+            let expected = group
+                .posting_list(slot, Some(max_score), Some(length))
+                .unwrap()
+                .unwrap();
+            let actual = restored
+                .posting_list(slot, Some(max_score), Some(length))
+                .unwrap()
+                .unwrap();
+            let (PostingList::Compressed(expected), PostingList::Compressed(actual)) =
+                (expected, actual)
+            else {
+                panic!("expected compressed packed posting views");
+            };
+            assert_eq!(actual.blocks, expected.blocks);
+            assert_eq!(actual.max_score, expected.max_score);
+            assert_eq!(actual.length, expected.length);
+            assert_eq!(actual.posting_tail_codec, expected.posting_tail_codec);
+        }
+
+        let legacy_member = PostingList::Compressed(CompressedPostingList::new(
+            LargeBinaryArray::from_opt_vec(vec![Some(&[9u8, 8, 7][..])]),
+            2.0,
+            3,
+            PostingTailCodec::VarintDelta,
+            None,
+        ));
+        let mut legacy_body = Vec::new();
+        let mut writer = CacheEntryWriter::new(&mut legacy_body);
+        writer
+            .write_header(&crate::cache_pb::PostingListGroupHeader { count: 1 })
+            .unwrap();
+        legacy_member.serialize(&mut writer).unwrap();
+        let legacy_body = Bytes::from(legacy_body);
+        let mut reader = CacheEntryReader::new(&legacy_body, 0, 1);
+        let restored = PostingListGroup::deserialize(&mut reader).unwrap();
+        assert!(!restored.is_packed());
+        assert_eq!(restored.len(), 1);
     }
 
     #[test]
@@ -795,25 +937,17 @@ mod tests {
             assert!(points_in(stream.bytes().as_ptr() as usize));
         }
 
-        /// Every member of a `PostingListGroup` must also decode zero-copy. The
-        /// group writes its members inline so each member's IPC sections stay
-        /// 64-byte aligned within the entry; embedding members in per-member
-        /// sub-buffers would land them at arbitrary offsets and force a
-        /// realigning memcpy on load.
+        /// A packed group's single IPC batch and all posting views decoded from
+        /// it must borrow the cache entry's aligned input buffer.
         #[test]
-        fn group_member_sections_are_zero_copy_through_envelope() {
-            let make_member = |fill: u8| {
-                let blocks =
-                    LargeBinaryArray::from_opt_vec(vec![Some(&[fill; 48][..]), Some(&[fill; 48])]);
-                PostingList::Compressed(CompressedPostingList::new(
-                    blocks,
-                    7.0,
-                    3,
-                    PostingTailCodec::VarintDelta,
-                    None,
-                ))
-            };
-            let group = PostingListGroup::new(vec![make_member(9), make_member(1)]);
+        fn packed_group_sections_are_zero_copy_through_envelope() {
+            let group = packed_group(
+                &[
+                    vec![vec![9; 48], vec![9; 48]],
+                    vec![vec![1; 48], vec![1; 48]],
+                ],
+                PostingTailCodec::VarintDelta,
+            );
 
             let group_codec = CacheCodec::from_impl::<PostingListGroup>();
             let any: ArcAny = Arc::new(group);
@@ -828,8 +962,13 @@ mod tests {
             let end = base + serialized.len();
             let points_in = |ptr: usize| ptr >= base && ptr < end;
 
-            assert_eq!(restored.posting_lists.len(), 2);
-            for member in &restored.posting_lists {
+            assert!(restored.is_packed());
+            assert_eq!(restored.len(), 2);
+            for slot in 0..restored.len() {
+                let member = restored
+                    .posting_list(slot, Some(7.0), Some(3))
+                    .unwrap()
+                    .unwrap();
                 let PostingList::Compressed(member) = member else {
                     panic!("expected Compressed member");
                 };

--- a/rust/lance-index/src/scalar/inverted/encoding.rs
+++ b/rust/lance-index/src/scalar/inverted/encoding.rs
@@ -244,39 +244,6 @@ fn encode_varint_u32(dst: &mut Vec<u8>, mut value: u32) {
     dst.push(value as u8);
 }
 
-/// Encode a monotonically increasing sequence of `group_starts` (the first
-/// row of each posting-list cache group) as varint-encoded deltas. The first
-/// value is stored as-is and each subsequent value as its delta from the
-/// previous one; since deltas are group sizes (1..=cap) they fit in ~1 byte,
-/// keeping the buffer tiny even for indexes with millions of tokens. See
-/// issue #7040.
-pub(super) fn encode_group_starts(group_starts: &[u32]) -> Vec<u8> {
-    let mut dst = Vec::with_capacity(group_starts.len());
-    let mut previous = 0u32;
-    for &start in group_starts {
-        debug_assert!(start >= previous, "group_starts must be monotonic");
-        encode_varint_u32(&mut dst, start - previous);
-        previous = start;
-    }
-    dst
-}
-
-/// Decode the buffer produced by [`encode_group_starts`] back into the
-/// absolute `group_starts` values.
-pub(super) fn decode_group_starts(src: &[u8]) -> Result<Vec<u32>> {
-    let mut group_starts = Vec::new();
-    let mut offset = 0;
-    let mut previous = 0u32;
-    while offset < src.len() {
-        let delta = decode_varint_u32(src, &mut offset)?;
-        previous = previous
-            .checked_add(delta)
-            .ok_or_else(|| Error::index("group_starts delta decode overflowed u32".to_owned()))?;
-        group_starts.push(previous);
-    }
-    Ok(group_starts)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PositionBlockBuilder {
     codec: PositionStreamCodec,
@@ -804,31 +771,6 @@ mod tests {
     use arrow::array::Array;
     use itertools::Itertools;
     use rand::Rng;
-
-    #[test]
-    fn test_group_starts_codec_roundtrip() {
-        for case in [
-            vec![],
-            vec![0u32],
-            vec![0, 1, 2, 3],
-            // realistic: monotonic with varied group sizes and a large jump
-            vec![0, 64, 128, 129, 4096, 1_000_000],
-        ] {
-            let encoded = encode_group_starts(&case);
-            let decoded = decode_group_starts(&encoded).unwrap();
-            assert_eq!(decoded, case, "roundtrip mismatch for {case:?}");
-        }
-    }
-
-    #[test]
-    fn test_decode_group_starts_rejects_overflow() {
-        // A crafted buffer whose deltas sum past u32::MAX must error rather
-        // than wrap. Encodes u32::MAX followed by a +1 delta.
-        let mut buf = Vec::new();
-        encode_varint_u32(&mut buf, u32::MAX);
-        encode_varint_u32(&mut buf, 1);
-        assert!(decode_group_starts(&buf).is_err());
-    }
 
     #[test]
     fn test_compress_posting_list() -> Result<()> {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1258,7 +1258,9 @@ fn runtime_posting_group_tokens() -> usize {
 /// persisted grouping metadata or index rebuilds.
 #[derive(Debug, Clone, DeepSizeOf)]
 enum PostingGrouping {
+    /// Leaves legacy or empty partitions ungrouped.
     None,
+    /// Uses a fixed runtime cache group size measured in token rows, not posting bytes.
     SyntheticFixed { group_size: u32 },
 }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -53,14 +53,14 @@ use std::sync::LazyLock;
 use tokio::{sync::OnceCell, task::spawn_blocking};
 use tracing::{info, instrument, warn};
 
-use super::encoding::{PositionBlockBuilder, decode_group_starts};
+use super::encoding::PositionBlockBuilder;
 use super::iter::PostingListIterator;
 use super::lazy_docset::LazyDocSet;
 use super::{InvertedIndexBuilder, InvertedIndexParams, wand::*};
 use super::{
     builder::{
-        BLOCK_SIZE, PostingGroupAccumulator, PostingGroupConfig, ScoredDoc, doc_file_path,
-        inverted_list_schema_for_version, posting_file_path, token_file_path,
+        BLOCK_SIZE, ScoredDoc, doc_file_path, inverted_list_schema_for_version,
+        posting_file_path, token_file_path,
     },
     iter::PlainPostingListIterator,
     query::*,
@@ -112,11 +112,6 @@ pub const TOKEN_SET_FORMAT_KEY: &str = "token_set_format";
 pub const POSTING_TAIL_CODEC_KEY: &str = "posting_tail_codec";
 pub const POSITIONS_LAYOUT_KEY: &str = "positions_layout";
 pub const POSITIONS_CODEC_KEY: &str = "positions_codec";
-/// Schema-metadata key holding the 1-indexed global-buffer id of the
-/// varint-delta-encoded posting-list cache-group boundaries (issue #7040).
-/// Absent on indexes written before grouping was introduced, which fall back
-/// to the per-token cache path.
-pub const POSTING_GROUP_OFFSETS_BUF_KEY: &str = "posting_group_offsets_buf";
 pub const POSTING_TAIL_CODEC_FIXED32_V1: &str = "fixed32_v1";
 pub const POSTING_TAIL_CODEC_VARINT_DELTA_V1: &str = "varint_delta_v1";
 pub const POSITIONS_LAYOUT_SHARED_STREAM_V2: &str = "shared_stream_v2";
@@ -1244,6 +1239,96 @@ const PREWARM_MAX_CHUNK_TOKENS: usize = 256 * 1024;
 /// Floor on token rows per chunk, so a partition always makes progress.
 const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
 
+/// Maximum number of posting lists in a runtime synthetic cache group. This is
+/// deliberately token-count based so grouping works for old v2 indexes without
+/// scanning posting lengths or requiring index rebuilds.
+static LANCE_FTS_POSTING_GROUP_MAX_TOKENS: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
+        .unwrap_or_else(|_| "256".to_string())
+        .parse()
+        .expect("failed to parse LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
+});
+
+fn runtime_posting_group_tokens() -> usize {
+    (*LANCE_FTS_POSTING_GROUP_MAX_TOKENS).max(1)
+}
+
+/// Runtime posting-list cache grouping. Non-empty v2 indexes synthesize fixed
+/// groups at read time so prewarm and queries share group cache entries without
+/// persisted grouping metadata or index rebuilds.
+#[derive(Debug, Clone, DeepSizeOf)]
+enum PostingGrouping {
+    None,
+    SyntheticFixed { group_size: u32 },
+}
+
+impl PostingGrouping {
+    fn for_reader(is_legacy_layout: bool, token_count: usize) -> Self {
+        if is_legacy_layout || token_count == 0 {
+            return Self::None;
+        }
+
+        let group_size = u32::try_from(runtime_posting_group_tokens())
+            .unwrap_or(u32::MAX)
+            .max(1);
+        Self::SyntheticFixed { group_size }
+    }
+
+    fn is_grouped(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    fn range_for_token(&self, token_id: u32, token_count: usize) -> Option<(u32, u32)> {
+        match self {
+            Self::None => None,
+            Self::SyntheticFixed { group_size } => {
+                let token_count = u32::try_from(token_count).unwrap_or(u32::MAX);
+                let start = (token_id / *group_size) * *group_size;
+                let end = start.saturating_add(*group_size).min(token_count);
+                Some((start, end))
+            }
+        }
+    }
+
+    fn aligned_chunk_end(
+        &self,
+        token_count: usize,
+        tok_start: usize,
+        desired_end: usize,
+    ) -> usize {
+        match self {
+            Self::None => desired_end,
+            Self::SyntheticFixed { group_size } => {
+                synthetic_group_aligned_chunk_end(
+                    usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
+                    token_count,
+                    tok_start,
+                    desired_end,
+                )
+            }
+        }
+    }
+
+    fn ranges_for_chunk(
+        &self,
+        tok_start: usize,
+        tok_end: usize,
+        token_count: usize,
+    ) -> Vec<(u32, u32)> {
+        match self {
+            Self::None => Vec::new(),
+            Self::SyntheticFixed { group_size } => {
+                synthetic_group_ranges_for_chunk(
+                    usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
+                    tok_start,
+                    tok_end,
+                    token_count,
+                )
+            }
+        }
+    }
+}
+
 /// Token rows per chunk: byte target / average bytes-per-token, clamped to `[MIN, MAX]`.
 fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     if token_count == 0 {
@@ -1254,11 +1339,8 @@ fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     by_bytes.clamp(PREWARM_MIN_CHUNK_TOKENS, PREWARM_MAX_CHUNK_TOKENS)
 }
 
-/// Snap a chunk's exclusive token end back to a posting-group boundary so no group
-/// straddles chunks. Returns the largest group boundary in `(tok_start, desired_end]`,
-/// or the next boundary past an oversized group so it runs as one solo chunk.
-fn group_aligned_chunk_end(
-    starts: &[u32],
+fn synthetic_group_aligned_chunk_end(
+    group_size: usize,
     token_count: usize,
     tok_start: usize,
     desired_end: usize,
@@ -1267,21 +1349,38 @@ fn group_aligned_chunk_end(
         return token_count;
     }
 
-    let first_after_start = starts.partition_point(|&start| start as usize <= tok_start);
-    let first_after_desired = starts.partition_point(|&start| start as usize <= desired_end);
-    if first_after_desired > first_after_start {
-        return starts[first_after_desired - 1] as usize;
+    let boundary = desired_end - (desired_end % group_size);
+    if boundary > tok_start {
+        boundary
+    } else {
+        tok_start.saturating_add(group_size).min(token_count)
     }
+}
 
-    // Oversized group: extend to its end so it runs as one chunk.
-    starts
-        .get(first_after_start)
-        .map(|&start| start as usize)
-        .unwrap_or(token_count)
+fn synthetic_group_ranges_for_chunk(
+    group_size: usize,
+    tok_start: usize,
+    tok_end: usize,
+    token_count: usize,
+) -> Vec<(u32, u32)> {
+    let mut ranges = Vec::new();
+    let mut start = tok_start - (tok_start % group_size);
+    if start < tok_start {
+        start = start.saturating_add(group_size).min(token_count);
+    }
+    while start < tok_end {
+        let end = start.saturating_add(group_size).min(token_count);
+        ranges.push((
+            u32::try_from(start).unwrap_or(u32::MAX),
+            u32::try_from(end).unwrap_or(u32::MAX),
+        ));
+        start = end;
+    }
+    ranges
 }
 
 fn prewarm_chunk_ranges(
-    group_starts: Option<&[u32]>,
+    grouping: &PostingGrouping,
     token_count: usize,
     chunk_tokens: usize,
 ) -> Vec<(usize, usize)> {
@@ -1290,28 +1389,13 @@ fn prewarm_chunk_ranges(
     while tok_start < token_count {
         let mut tok_end = (tok_start + chunk_tokens).min(token_count);
         // `tok_start` is always a group boundary; snap `tok_end` back to one too.
-        if let Some(starts) = group_starts {
-            tok_end = group_aligned_chunk_end(starts, token_count, tok_start, tok_end);
+        if grouping.is_grouped() {
+            tok_end = grouping.aligned_chunk_end(token_count, tok_start, tok_end);
         }
         ranges.push((tok_start, tok_end));
         tok_start = tok_end;
     }
     ranges
-}
-
-fn group_start_indices_for_chunk(starts: &[u32], tok_start: usize, tok_end: usize) -> Range<usize> {
-    let first = starts.partition_point(|&start| (start as usize) < tok_start);
-    let end = starts.partition_point(|&start| (start as usize) < tok_end);
-    first..end
-}
-
-fn group_range_for_start_index(starts: &[u32], token_count: usize, group_idx: usize) -> (u32, u32) {
-    let start = starts[group_idx];
-    let end = starts
-        .get(group_idx + 1)
-        .copied()
-        .unwrap_or(token_count as u32);
-    (start, end)
 }
 
 impl InvertedIndex {
@@ -2366,11 +2450,10 @@ pub struct PostingListReader {
     posting_tail_codec: PostingTailCodec,
     positions_layout: PositionsLayout,
 
-    /// First row of each posting-list cache group, decoded at open from the
-    /// global buffer named by [`POSTING_GROUP_OFFSETS_BUF_KEY`] (issue #7040).
-    /// `None` for indexes written before grouping; those use the per-token
-    /// cache path. Always present for grouped v2 indexes with `>0` rows.
-    group_starts: Option<Vec<u32>>,
+    /// Runtime posting-list cache grouping. Non-empty v2 indexes use synthetic
+    /// fixed groups so prewarm can improve cache density without rebuilding the
+    /// index or relying on persisted grouping metadata.
+    grouping: PostingGrouping,
 
     index_cache: WeakLanceCache,
 }
@@ -2445,7 +2528,7 @@ impl DeepSizeOf for PostingListReader {
                 })
                 .unwrap_or(0),
         };
-        metadata_size + self.group_starts.deep_size_of_children(context)
+        metadata_size + self.grouping.deep_size_of_children(context)
     }
 }
 
@@ -2475,7 +2558,8 @@ impl PostingListReader {
             }
         };
 
-        let group_starts = Self::load_group_starts(reader.as_ref()).await?;
+        let is_legacy_layout = matches!(&metadata, PostingMetadata::LegacyV1 { .. });
+        let grouping = PostingGrouping::for_reader(is_legacy_layout, reader.num_rows());
 
         Ok(Self {
             reader,
@@ -2483,26 +2567,9 @@ impl PostingListReader {
             has_position,
             posting_tail_codec,
             positions_layout,
-            group_starts,
+            grouping,
             index_cache: WeakLanceCache::from(index_cache),
         })
-    }
-
-    /// Decode the posting-list cache-group boundaries from the global buffer
-    /// recorded in schema metadata, if present (issue #7040). Returns `None`
-    /// for indexes written before grouping was introduced.
-    async fn load_group_starts(reader: &dyn IndexReader) -> Result<Option<Vec<u32>>> {
-        let Some(buf_id) = reader.schema().metadata.get(POSTING_GROUP_OFFSETS_BUF_KEY) else {
-            return Ok(None);
-        };
-        let buf_id: u32 = buf_id.parse().map_err(|e| {
-            Error::index(format!(
-                "invalid {POSTING_GROUP_OFFSETS_BUF_KEY} metadata value {buf_id:?}: {e}"
-            ))
-        })?;
-        let bytes = reader.read_global_buffer(buf_id).await?;
-        let group_starts = decode_group_starts(&bytes)?;
-        Ok(Some(group_starts))
     }
 
     // for legacy format
@@ -2747,8 +2814,8 @@ impl PostingListReader {
                     })?
                     .clone()
             }
-            // Fallback for indexes written before grouping: one cache entry
-            // per token.
+            // Fallback for layouts that cannot use row-based groups: one cache
+            // entry per token.
             None => self
                 .index_cache
                 .get_or_insert_with_key(PostingListKey { token_id }, || async move {
@@ -2779,29 +2846,11 @@ impl PostingListReader {
     }
 
     /// Map a token id to its cache group's row range `[start, end)`, or `None`
-    /// when grouping is not available (pre-grouping indexes) so the caller
-    /// falls back to the per-token path. In v2 the token id is the row offset,
-    /// so the group range is also the physical row range.
+    /// when grouping is not available so the caller falls back to the per-token
+    /// path. In v2 the token id is the row offset, so the group range is also
+    /// the physical row range.
     fn group_range_for_token(&self, token_id: u32) -> Option<(u32, u32)> {
-        let starts = self.group_starts.as_ref()?;
-        // partition_point returns the count of group starts <= token_id, so the
-        // owning group begins at index k - 1 and the next start (if any) is its
-        // exclusive end.
-        let k = starts.partition_point(|&s| s <= token_id);
-        // k == 0 means token_id precedes the first group start, which cannot
-        // happen for a valid token in a grouped index (the first group starts
-        // at row 0); guard anyway and fall back to the per-token path.
-        if k == 0 {
-            return None;
-        }
-        let start = starts[k - 1];
-        // The last group runs to the final posting list. `self.len()` is the
-        // authoritative posting-list count (offsets length for v1, row count for
-        // v2), and prewarm derives the same `end` from it — so warm- and
-        // cold-cache group keys are identical by construction, not by the
-        // incidental v2 `num_rows == token_count` equality.
-        let end = starts.get(k).copied().unwrap_or(self.len() as u32);
-        Some((start, end))
+        self.grouping.range_for_token(token_id, self.len())
     }
 
     /// Read rows `[start, end)` of the posting file and decode them into a
@@ -2957,16 +3006,16 @@ impl PostingListReader {
         self.ensure_metadata_loaded().await?;
 
         let state = self.chunk_build_state();
-        // With grouping the cache stores one entry per group, so a group's posting
-        // lists must all be resident at once: align chunk boundaries to whole
-        // groups. Without grouping, chunks are plain token ranges.
-        let group_starts = self.group_starts.clone();
+        // With grouping the cache stores one entry per group, so a group's
+        // posting lists must all be resident at once: align chunk boundaries to
+        // whole groups. Without grouping, chunks are plain token ranges.
+        let grouping = self.grouping.clone();
         let token_count = self.len();
         let posting_data_size_bytes = self.posting_data_size_bytes();
         let chunk_tokens = chunk_tokens_override
             .unwrap_or_else(|| prewarm_chunk_tokens(token_count, posting_data_size_bytes))
             .max(1);
-        let chunk_ranges = prewarm_chunk_ranges(group_starts.as_deref(), token_count, chunk_tokens);
+        let chunk_ranges = prewarm_chunk_ranges(&grouping, token_count, chunk_tokens);
         let chunk_count = chunk_ranges.len();
         let chunk_concurrency = chunk_concurrency.max(1);
 
@@ -2974,14 +3023,14 @@ impl PostingListReader {
         stream::iter(chunk_ranges)
             .map(|(tok_start, tok_end)| {
                 let state = &state;
-                let group_starts = group_starts.as_deref();
+                let grouping = &grouping;
                 async move {
                     let posting_lists = self
                         .build_chunk_postings(tok_start, tok_end, with_position, state)
                         .await?;
                     self.publish_chunk_postings(
                         posting_lists,
-                        group_starts,
+                        grouping,
                         tok_start,
                         tok_end,
                         token_count,
@@ -3104,14 +3153,23 @@ impl PostingListReader {
     async fn publish_chunk_postings(
         &self,
         posting_lists: Vec<(u32, PostingList)>,
-        group_starts: Option<&[u32]>,
+        grouping: &PostingGrouping,
         tok_start: usize,
         tok_end: usize,
         token_count: usize,
         with_position: bool,
     ) {
-        match group_starts {
-            Some(starts) => {
+        match grouping {
+            PostingGrouping::None => {
+                for (token_id, mut posting_list) in posting_lists {
+                    self.cache_positions(&mut posting_list, token_id, with_position)
+                        .await;
+                    self.index_cache
+                        .insert_with_key(&PostingListKey { token_id }, Arc::new(posting_list))
+                        .await;
+                }
+            }
+            PostingGrouping::SyntheticFixed { .. } => {
                 let mut chunk_postings = Vec::with_capacity(posting_lists.len());
                 for (token_id, mut posting_list) in posting_lists {
                     self.cache_positions(&mut posting_list, token_id, with_position)
@@ -3122,23 +3180,13 @@ impl PostingListReader {
                 // in it; `chunk_postings[i]` is token `tok_start + i`. The last
                 // group's `end` derives from `token_count`, matching the read path
                 // so both produce identical `PostingListGroupKey`s.
-                for group_idx in group_start_indices_for_chunk(starts, tok_start, tok_end) {
-                    let (start, end) = group_range_for_start_index(starts, token_count, group_idx);
+                for (start, end) in grouping.ranges_for_chunk(tok_start, tok_end, token_count) {
                     let start_usize = start as usize;
                     let lo = start_usize - tok_start;
                     let hi = end as usize - tok_start;
                     let group = PostingListGroup::new(chunk_postings[lo..hi].to_vec());
                     self.index_cache
                         .insert_with_key(&PostingListGroupKey { start, end }, Arc::new(group))
-                        .await;
-                }
-            }
-            None => {
-                for (token_id, mut posting_list) in posting_lists {
-                    self.cache_positions(&mut posting_list, token_id, with_position)
-                        .await;
-                    self.index_cache
-                        .insert_with_key(&PostingListKey { token_id }, Arc::new(posting_list))
                         .await;
                 }
             }
@@ -3422,8 +3470,8 @@ impl CacheKey for PostingListKey {
 
 /// Cache key for a group of consecutive posting lists stored as a single
 /// entry, covering rows `[start, end)` (issue #7040). The range, not a token
-/// id, is the key so that a write-time config change that reshapes groups
-/// simply misses old entries instead of serving a differently-shaped group.
+/// id, is the key so a runtime group-size change simply misses old entries
+/// instead of serving a differently-shaped group.
 #[derive(Debug, Clone)]
 pub struct PostingListGroupKey {
     pub start: u32,
@@ -4106,10 +4154,6 @@ pub(super) struct PostingListBatchBuilder {
     lengths: UInt32Builder,
     positions: BatchPositionsBuilder,
     len: usize,
-    /// Tracks posting-list cache-group boundaries in row order across all
-    /// batches this builder produces (issue #7040). Outlives `finish`, which
-    /// only resets the per-batch column builders.
-    group_accumulator: PostingGroupAccumulator,
 }
 
 enum BatchPositionsBuilder {
@@ -4137,7 +4181,6 @@ impl PostingListBatchBuilder {
         with_positions: bool,
         format_version: InvertedListFormatVersion,
         capacity: usize,
-        group_config: PostingGroupConfig,
     ) -> Self {
         let positions = if !with_positions {
             BatchPositionsBuilder::None
@@ -4159,7 +4202,6 @@ impl PostingListBatchBuilder {
             lengths: UInt32Builder::with_capacity(capacity),
             positions,
             len: 0,
-            group_accumulator: PostingGroupAccumulator::new(group_config),
         }
     }
 
@@ -4178,7 +4220,6 @@ impl PostingListBatchBuilder {
         length: u32,
         positions: Option<&CompressedPositionStorage>,
     ) -> Result<()> {
-        let posting_bytes = compressed.value_data().len();
         {
             let values = self.postings.values();
             for index in 0..compressed.len() {
@@ -4186,7 +4227,6 @@ impl PostingListBatchBuilder {
             }
         }
         self.postings.append(true);
-        self.group_accumulator.push(posting_bytes);
         self.max_scores.append_value(max_score);
         self.lengths.append_value(length);
 
@@ -4266,13 +4306,6 @@ impl PostingListBatchBuilder {
         }
         self.len = 0;
         RecordBatch::try_new(self.schema.clone(), columns).map_err(Error::from)
-    }
-
-    /// Consume the builder and return the posting-list cache-group boundaries
-    /// accumulated across all batches (issue #7040). Each entry is the first
-    /// row of a group; the sequence is monotonically increasing.
-    pub fn into_group_starts(self) -> Vec<u32> {
-        self.group_accumulator.into_starts()
     }
 }
 
@@ -6800,76 +6833,42 @@ mod tests {
     }
 
     #[test]
-    fn test_group_aligned_chunk_end_boundary_cases() {
-        let starts = [0, 3, 7, 10];
-        let token_count = 13;
-
-        assert_eq!(
-            group_aligned_chunk_end(&starts, token_count, 0, 5),
-            3,
-            "chunk should snap back to the largest group boundary that fits"
-        );
-        assert_eq!(
-            group_aligned_chunk_end(&starts, token_count, 3, 6),
-            7,
-            "oversized groups should run as one chunk"
-        );
-        assert_eq!(
-            group_aligned_chunk_end(&starts, token_count, 7, 10),
-            10,
-            "an exact next group boundary should be selected"
-        );
-        assert_eq!(
-            group_aligned_chunk_end(&starts, token_count, 10, 12),
-            13,
-            "the last group should extend to token_count"
-        );
-        assert_eq!(
-            group_aligned_chunk_end(&starts, token_count, 7, 13),
-            13,
-            "token_count should act as the final boundary"
-        );
-    }
-
-    #[test]
-    fn test_group_start_indices_for_chunk_boundary_cases() {
-        let starts = [0, 3, 7, 10];
-        let token_count = 13;
-        let ranges_for_chunk = |tok_start, tok_end| {
-            group_start_indices_for_chunk(&starts, tok_start, tok_end)
-                .map(|group_idx| group_range_for_start_index(&starts, token_count, group_idx))
-                .collect::<Vec<_>>()
-        };
-
-        assert_eq!(
-            ranges_for_chunk(0, 7),
-            vec![(0, 3), (3, 7)],
-            "publish should include only groups that start in the chunk"
-        );
-        assert_eq!(
-            ranges_for_chunk(7, 13),
-            vec![(7, 10), (10, 13)],
-            "publish should include the final group ending at token_count"
-        );
-        assert_eq!(
-            ranges_for_chunk(3, 10),
-            vec![(3, 7), (7, 10)],
-            "publish selection should work for an interior chunk"
-        );
-    }
-
-    #[test]
     fn test_prewarm_chunk_ranges_preserve_group_boundaries() {
-        let starts = [0, 3, 7, 10];
+        let grouping = PostingGrouping::SyntheticFixed { group_size: 4 };
         assert_eq!(
-            prewarm_chunk_ranges(Some(&starts), 13, 5),
-            vec![(0, 3), (3, 7), (7, 10), (10, 13)],
+            prewarm_chunk_ranges(&grouping, 13, 5),
+            vec![(0, 4), (4, 8), (8, 12), (12, 13)],
             "grouped chunk ranges must never split a posting cache group"
         );
         assert_eq!(
-            prewarm_chunk_ranges(None, 13, 5),
+            prewarm_chunk_ranges(&PostingGrouping::None, 13, 5),
             vec![(0, 5), (5, 10), (10, 13)],
             "ungrouped chunk ranges should use plain token ranges"
+        );
+    }
+
+    #[test]
+    fn test_synthetic_grouping_preserves_fixed_boundaries() {
+        let grouping = PostingGrouping::SyntheticFixed { group_size: 4 };
+        assert_eq!(
+            grouping.range_for_token(5, 10),
+            Some((4, 8)),
+            "synthetic token groups should be fixed-size ranges"
+        );
+        assert_eq!(
+            grouping.range_for_token(9, 10),
+            Some((8, 10)),
+            "the final synthetic group should end at token_count"
+        );
+        assert_eq!(
+            prewarm_chunk_ranges(&grouping, 10, 6),
+            vec![(0, 4), (4, 8), (8, 10)],
+            "prewarm chunks must not split synthetic groups"
+        );
+        assert_eq!(
+            grouping.ranges_for_chunk(4, 10, 10),
+            vec![(4, 8), (8, 10)],
+            "publish selection should enumerate synthetic groups in a chunk"
         );
     }
 
@@ -6891,9 +6890,9 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // One partition with many tokens (so it spans many chunks) and several
-        // docs per token (so each token is more than one posting row).
-        const NUM_TOKENS: u32 = 20;
+        // One partition with enough tokens to span multiple runtime synthetic
+        // groups and several docs per token.
+        let num_tokens = runtime_posting_group_tokens() as u32 + 4;
         const DOCS_PER_TOKEN: u32 = 3;
         let posting_tail_codec = format_version.posting_tail_codec();
         let mut builder = InnerBuilder::new_with_format_version(
@@ -6902,16 +6901,10 @@ mod tests {
             TokenSetFormat::default(),
             format_version,
         );
-        // Small groups so the partition spans several; chunks snap to whole groups,
-        // so several groups are needed to stream in more than one chunk.
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 4096,
-            max_tokens: 4,
-        };
         // expected[token] = [(doc_id, frequency)] in stored (doc-id) order.
         let mut expected: Vec<Vec<(u32, u32)>> = Vec::new();
         let mut doc_id = 0u64;
-        for t in 0..NUM_TOKENS {
+        for t in 0..num_tokens {
             builder.tokens.add(format!("tok_{t:03}"));
             let mut posting =
                 PostingListBuilder::new_with_posting_tail_codec(false, posting_tail_codec);
@@ -6956,10 +6949,11 @@ mod tests {
             .await
             .unwrap();
         let inverted_list = &index.partitions[0].inverted_list;
-        assert_eq!(inverted_list.len(), NUM_TOKENS as usize);
+        assert_eq!(inverted_list.len(), num_tokens as usize);
 
-        // Force a small chunk so the partition deterministically splits; with
-        // CHUNK_TOKENS < NUM_TOKENS each chunk is bounded below the whole partition.
+        // Force a small target chunk. Since CHUNK_TOKENS is below the runtime
+        // group size, synthetic group alignment should still split only at
+        // group boundaries.
         const CHUNK_TOKENS: usize = 6;
         let chunk_count = inverted_list
             .prewarm_posting_lists_chunked(false, Some(CHUNK_TOKENS), 2)
@@ -6976,7 +6970,7 @@ mod tests {
 
         // (2) Correctness: every token's posting list round-trips with exactly
         // the doc ids and frequencies of the whole-file path.
-        for token_id in 0..NUM_TOKENS {
+        for token_id in 0..num_tokens {
             let actual = inverted_list
                 .posting_list(token_id, false, &NoOpMetricsCollector)
                 .await
@@ -7005,7 +6999,7 @@ mod tests {
 
         let format_version = InvertedListFormatVersion::V2;
         let posting_tail_codec = format_version.posting_tail_codec();
-        const NUM_TOKENS: u32 = 16;
+        let num_tokens = runtime_posting_group_tokens() as u32 + 4;
         const DOCS_PER_TOKEN: u32 = 3;
         let mut builder = InnerBuilder::new_with_format_version(
             0,
@@ -7013,14 +7007,10 @@ mod tests {
             TokenSetFormat::default(),
             format_version,
         );
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 4096,
-            max_tokens: 4,
-        };
         // expected[token] = [(doc_id, frequency, positions)].
         let mut expected: Vec<Vec<(u32, u32, Vec<u32>)>> = Vec::new();
         let mut doc_id = 0u64;
-        for t in 0..NUM_TOKENS {
+        for t in 0..num_tokens {
             builder.tokens.add(format!("tok_{t:03}"));
             let mut posting =
                 PostingListBuilder::new_with_posting_tail_codec(true, posting_tail_codec);
@@ -7088,7 +7078,7 @@ mod tests {
             "partition must be streamed in more than one chunk, got {chunk_count}"
         );
 
-        for token_id in 0..NUM_TOKENS {
+        for token_id in 0..num_tokens {
             // The prewarmed posting cache entry is positions-free.
             let (start, end) = inverted_list.group_range_for_token(token_id).unwrap();
             let group = inverted_list
@@ -7434,8 +7424,13 @@ mod tests {
         // K adjacent cold tokens shares a single group cache entry: one
         // read_range bounded by the group size, independent of the partition's
         // total token count.
-        let num_tokens = 500;
-        let queried_tokens: [u32; 4] = [0, 1, 2, 3];
+        let runtime_group_size = runtime_posting_group_tokens().max(1);
+        let queried_token_count = runtime_group_size.min(4);
+        let queried_tokens = (0..queried_token_count as u32).collect::<Vec<_>>();
+        let num_tokens = runtime_group_size
+            .saturating_mul(2)
+            .max(queried_token_count + 1)
+            .min(1024);
         let (index, counter, _tmpdir) =
             load_counted_v2_index(num_tokens, LanceCache::no_cache()).await;
         let inverted_list = index.partitions[0].inverted_list.clone();
@@ -7444,15 +7439,18 @@ mod tests {
             "this test only proves the lazy path for v2 indexes",
         );
         assert!(
-            inverted_list.group_starts.is_some(),
-            "freshly written v2 index should carry posting group offsets",
+            matches!(
+                &inverted_list.grouping,
+                PostingGrouping::SyntheticFixed { .. }
+            ),
+            "freshly written v2 index should use runtime synthetic groups",
         );
 
         // This fixture uses a no-op cache, so each call re-reads; that isolates
         // the per-query read shape. Each posting_list call reads exactly its
         // own group — bounded by the group size, never the full token table.
         let metrics = Arc::new(NoOpMetricsCollector);
-        for token_id in queried_tokens {
+        for &token_id in &queried_tokens {
             inverted_list
                 .posting_list(token_id, false, metrics.as_ref())
                 .await
@@ -7462,9 +7460,9 @@ mod tests {
         let (start, end) = inverted_list.group_range_for_token(0).unwrap();
         let group_len = (end - start) as usize;
         assert!(
-            (queried_tokens.len()..num_tokens).contains(&group_len),
-            "group [{start}, {end}) should cover the queried neighborhood but be \
-             far smaller than the {num_tokens}-token table",
+            (queried_tokens.len()..=num_tokens).contains(&group_len),
+            "group [{start}, {end}) should cover the queried neighborhood and \
+             stay bounded by the {num_tokens}-token table",
         );
         assert_eq!(
             counter.read_range_calls(),
@@ -7480,8 +7478,8 @@ mod tests {
     }
 
     /// Build a single-partition v2 index where every token's posting list spans
-    /// `docs_per_token` docs. Small `docs_per_token` yields tiny posting lists
-    /// that the writer packs densely into shared cache groups.
+    /// `docs_per_token` docs. Runtime grouping packs consecutive token rows
+    /// into shared cache groups.
     async fn load_v2_index_with_grouped_postings(
         num_tokens: usize,
         docs_per_token: usize,
@@ -7556,7 +7554,10 @@ mod tests {
         let inverted_list = index.partitions[0].inverted_list.clone();
         assert!(!inverted_list.is_legacy_layout(), "expected v2 layout");
         assert!(
-            inverted_list.group_starts.is_some(),
+            matches!(
+                &inverted_list.grouping,
+                PostingGrouping::SyntheticFixed { .. }
+            ),
             "expected grouped posting lists"
         );
 
@@ -9247,58 +9248,14 @@ mod tests {
         assert_eq!(row_ids.values(), &[0]);
     }
 
-    /// An [`IndexReader`] wrapper that hides the posting-group-offsets schema
-    /// metadata key, so a [`PostingListReader`] opened on it takes the
-    /// pre-grouping per-token fallback path (issue #7040).
-    struct GroupKeyStrippingReader {
-        inner: Arc<dyn IndexReader>,
-        schema: lance_core::datatypes::Schema,
-    }
-
-    impl GroupKeyStrippingReader {
-        fn new(inner: Arc<dyn IndexReader>) -> Self {
-            let mut schema = inner.schema().clone();
-            schema.metadata.remove(POSTING_GROUP_OFFSETS_BUF_KEY);
-            Self { inner, schema }
-        }
-    }
-
-    #[async_trait]
-    impl IndexReader for GroupKeyStrippingReader {
-        async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
-            self.inner.read_record_batch(n, batch_size).await
-        }
-        async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
-            self.inner.read_global_buffer(index).await
-        }
-        async fn read_range(
-            &self,
-            range: std::ops::Range<usize>,
-            projection: Option<&[&str]>,
-        ) -> Result<RecordBatch> {
-            self.inner.read_range(range, projection).await
-        }
-        async fn num_batches(&self, batch_size: u64) -> u32 {
-            self.inner.num_batches(batch_size).await
-        }
-        fn num_rows(&self) -> usize {
-            self.inner.num_rows()
-        }
-        fn schema(&self) -> &lance_core::datatypes::Schema {
-            &self.schema
-        }
-    }
-
     fn posting_entries(posting: &PostingList) -> Vec<(u64, u32)> {
         posting.iter().map(|(doc, freq, _)| (doc, freq)).collect()
     }
 
-    /// The grouped read path and the legacy per-token fallback must return
-    /// identical posting lists for every token, including at group
-    /// boundaries. Builds a single v2 partition that spans several groups,
-    /// then reads it both with and without the group offsets present.
+    /// Runtime synthetic grouping must return correct posting lists for every
+    /// token, including across synthetic group boundaries.
     #[tokio::test]
-    async fn test_posting_list_fallback_matches_grouped() {
+    async fn test_posting_list_synthetic_grouping_reads_group_boundaries() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -9306,15 +9263,8 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // A small token cap forces several groups regardless of the default,
-        // so the comparison exercises the partition_point math at group
-        // boundaries.
-        let num_tokens = 150u32;
+        let num_tokens = runtime_posting_group_tokens() as u32 + 4;
         let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 4096,
-            max_tokens: 32,
-        };
         for t in 0..num_tokens {
             builder.tokens.add(format!("t{t}"));
             let mut pl = PostingListBuilder::new(false);
@@ -9326,36 +9276,29 @@ mod tests {
 
         let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
         let cache = LanceCache::no_cache();
-        let grouped = PostingListReader::try_new(reader.clone(), &cache)
+        let posting_reader = PostingListReader::try_new(reader, &cache)
             .await
             .unwrap();
         assert!(
-            grouped.group_starts.as_ref().is_some_and(|s| s.len() > 1),
-            "fixture should span multiple groups",
-        );
-
-        let stripped: Arc<dyn IndexReader> = Arc::new(GroupKeyStrippingReader::new(reader));
-        let fallback = PostingListReader::try_new(stripped, &cache).await.unwrap();
-        assert!(
-            fallback.group_starts.is_none(),
-            "stripped reader must take the per-token fallback path",
+            matches!(
+                &posting_reader.grouping,
+                PostingGrouping::SyntheticFixed { .. }
+            ),
+            "v2 reader must synthesize runtime posting groups",
         );
 
         let metrics = NoOpMetricsCollector;
         for token in 0..num_tokens {
-            let g = grouped.posting_list(token, false, &metrics).await.unwrap();
-            let f = fallback.posting_list(token, false, &metrics).await.unwrap();
+            let posting = posting_reader
+                .posting_list(token, false, &metrics)
+                .await
+                .unwrap();
             assert_eq!(
-                posting_entries(&g),
-                posting_entries(&f),
-                "grouped vs fallback mismatch for token {token}",
+                posting_entries(&posting),
+                vec![(token as u64, 1)],
+                "synthetic grouping mismatch for token {token}",
             );
-            assert_eq!(g.len(), f.len(), "length mismatch for token {token}");
-            assert_eq!(
-                g.max_score(),
-                f.max_score(),
-                "max_score mismatch for token {token}",
-            );
+            assert_eq!(posting.len(), 1, "length mismatch for token {token}");
         }
     }
 
@@ -9373,14 +9316,8 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // Small token cap so the partition spans several groups regardless of
-        // the default, exercising every group boundary including the last.
-        let num_tokens = 150u32;
+        let num_tokens = runtime_posting_group_tokens() as u32 + 4;
         let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 4096,
-            max_tokens: 32,
-        };
         for t in 0..num_tokens {
             builder.tokens.add(format!("t{t}"));
             let mut pl = PostingListBuilder::new(false);
@@ -9396,11 +9333,11 @@ mod tests {
         let cache = LanceCache::with_capacity(1 << 20);
         let posting_reader = PostingListReader::try_new(reader, &cache).await.unwrap();
         assert!(
-            posting_reader
-                .group_starts
-                .as_ref()
-                .is_some_and(|s| s.len() > 1),
-            "fixture should span multiple groups",
+            matches!(
+                &posting_reader.grouping,
+                PostingGrouping::SyntheticFixed { .. }
+            ),
+            "v2 reader should use runtime synthetic groups",
         );
 
         posting_reader
@@ -9430,10 +9367,10 @@ mod tests {
         );
     }
 
-    /// An empty partition writes no group-offsets buffer, so its reader takes
-    /// the per-token fallback path (issue #7040).
+    /// An empty partition has no synthetic groups because there are no token
+    /// rows to cache.
     #[tokio::test]
-    async fn test_empty_partition_has_no_group_offsets() {
+    async fn test_empty_partition_has_no_synthetic_groups() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -9445,28 +9382,20 @@ mod tests {
         builder.write(store.as_ref()).await.unwrap();
 
         let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
-        assert!(
-            !reader
-                .schema()
-                .metadata
-                .contains_key(POSTING_GROUP_OFFSETS_BUF_KEY),
-            "empty partition must not write the group-offsets metadata key",
-        );
-
         let posting_reader = PostingListReader::try_new(reader, &LanceCache::no_cache())
             .await
             .unwrap();
         assert!(
-            posting_reader.group_starts.is_none(),
-            "reader for an empty partition must use the per-token fallback path",
+            matches!(&posting_reader.grouping, PostingGrouping::None),
+            "reader for an empty partition must not create cache groups",
         );
         assert!(posting_reader.is_empty());
     }
 
-    /// A posting list that alone exceeds the group target lands in its own
-    /// `[t, t+1)` group (the clamp case) and reads back intact (issue #7040).
+    /// A large posting list can share a runtime synthetic group with neighbors;
+    /// grouping is token-count based and should still read every member intact.
     #[tokio::test]
-    async fn test_oversized_term_is_own_group_on_read() {
+    async fn test_large_posting_reads_inside_synthetic_group() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -9474,13 +9403,7 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // A tiny byte target so a modest posting trips the clamp without
-        // needing a huge fixture; the surrounding tiny terms regroup after it.
         let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 50,
-            max_tokens: 1000,
-        };
         let big_docs = 30u32;
         builder.tokens.add("big".to_owned());
         let mut big = PostingListBuilder::new(false);
@@ -9503,11 +9426,12 @@ mod tests {
         let posting_reader = PostingListReader::try_new(reader, &LanceCache::no_cache())
             .await
             .unwrap();
+        let expected_end = runtime_posting_group_tokens().min(5) as u32;
 
         assert_eq!(
             posting_reader.group_range_for_token(0),
-            Some((0, 1)),
-            "an oversized term must occupy its own single-row group",
+            Some((0, expected_end)),
+            "runtime synthetic grouping should group by token count, not posting bytes",
         );
         let big = posting_reader
             .posting_list(0, false, &NoOpMetricsCollector)
@@ -9522,11 +9446,11 @@ mod tests {
         assert_eq!(tiny.len(), 1);
     }
 
-    /// When the group offsets are absent, prewarm populates per-token
-    /// `PostingListKey` entries (the fallback path), matching what the read
-    /// path then looks up (issue #7040).
+    /// Non-empty v2 indexes should prewarm synthetic `PostingListGroupKey`
+    /// entries, matching what the read path then looks up without persisted
+    /// grouping metadata.
     #[tokio::test]
-    async fn test_prewarm_fallback_populates_per_token_entries() {
+    async fn test_prewarm_synthetic_grouping_populates_group_entries() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -9546,10 +9470,12 @@ mod tests {
         builder.write(store.as_ref()).await.unwrap();
 
         let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
-        let stripped: Arc<dyn IndexReader> = Arc::new(GroupKeyStrippingReader::new(reader));
         let cache = LanceCache::with_capacity(1 << 20);
-        let posting_reader = PostingListReader::try_new(stripped, &cache).await.unwrap();
-        assert!(posting_reader.group_starts.is_none());
+        let posting_reader = PostingListReader::try_new(reader, &cache).await.unwrap();
+        assert!(matches!(
+            &posting_reader.grouping,
+            PostingGrouping::SyntheticFixed { .. }
+        ));
 
         posting_reader
             .prewarm_posting_lists(false, 2)
@@ -9557,13 +9483,22 @@ mod tests {
             .unwrap();
 
         for token_id in 0..num_tokens {
+            let (start, end) = posting_reader.group_range_for_token(token_id).unwrap();
+            assert!(
+                posting_reader
+                    .index_cache
+                    .get_with_key(&PostingListGroupKey { start, end })
+                    .await
+                    .is_some(),
+                "synthetic prewarm should populate group [{start}, {end}) for token {token_id}",
+            );
             assert!(
                 posting_reader
                     .index_cache
                     .get_with_key(&PostingListKey { token_id })
                     .await
-                    .is_some(),
-                "fallback prewarm should populate per-token entry {token_id}",
+                    .is_none(),
+                "synthetic prewarm should not populate per-token entry {token_id}",
             );
         }
     }
@@ -9580,15 +9515,11 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // 130 rare tokens (one doc each) plus one common token in every doc; a
-        // small token cap spreads them across several groups so scoring must
-        // index into the right group slot.
-        let num_rare = 130u32;
+        // Rare tokens (one doc each) plus one common token in every doc. The
+        // token count exceeds the runtime group size so scoring must index
+        // into the right synthetic group slot.
+        let num_rare = runtime_posting_group_tokens() as u32 + 2;
         let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
-        builder.group_config = PostingGroupConfig {
-            target_bytes: 4096,
-            max_tokens: 32,
-        };
         for t in 0..num_rare {
             builder.tokens.add(format!("t{t}"));
             builder.posting_lists.push(PostingListBuilder::new(false));
@@ -9646,8 +9577,13 @@ mod tests {
             }
         };
 
-        let (rows_70, _) = query("t70").await;
-        assert_eq!(rows_70, vec![1070], "rare token must map to its single doc");
+        let rare_query_id = num_rare / 2;
+        let (rare_rows, _) = query(&format!("t{rare_query_id}")).await;
+        assert_eq!(
+            rare_rows,
+            vec![1000 + rare_query_id as u64],
+            "rare token must map to its single doc",
+        );
 
         // Cold vs warm cache must agree for the common (large) token.
         let (cold_rows, cold_scores) = query("common").await;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -9566,7 +9566,7 @@ mod tests {
                 index
                     .bm25_search(
                         Arc::new(Tokens::new(vec![term], DocType::Text)),
-                        Arc::new(FtsSearchParams::new().with_limit(Some(200))),
+                        Arc::new(FtsSearchParams::new().with_limit(Some(num_rare as usize))),
                         Operator::Or,
                         Arc::new(NoFilter),
                         Arc::new(NoOpMetricsCollector),

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1244,7 +1244,7 @@ const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
 /// scanning posting lengths or requiring index rebuilds.
 static LANCE_FTS_POSTING_GROUP_MAX_TOKENS: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
-        .unwrap_or_else(|_| "256".to_string())
+        .unwrap_or_else(|_| "128".to_string())
         .parse()
         .expect("failed to parse LANCE_FTS_POSTING_GROUP_MAX_TOKENS")
 });

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -59,8 +59,8 @@ use super::lazy_docset::LazyDocSet;
 use super::{InvertedIndexBuilder, InvertedIndexParams, wand::*};
 use super::{
     builder::{
-        BLOCK_SIZE, ScoredDoc, doc_file_path, inverted_list_schema_for_version,
-        posting_file_path, token_file_path,
+        BLOCK_SIZE, ScoredDoc, doc_file_path, inverted_list_schema_for_version, posting_file_path,
+        token_file_path,
     },
     iter::PlainPostingListIterator,
     query::*,
@@ -1290,22 +1290,15 @@ impl PostingGrouping {
         }
     }
 
-    fn aligned_chunk_end(
-        &self,
-        token_count: usize,
-        tok_start: usize,
-        desired_end: usize,
-    ) -> usize {
+    fn aligned_chunk_end(&self, token_count: usize, tok_start: usize, desired_end: usize) -> usize {
         match self {
             Self::None => desired_end,
-            Self::SyntheticFixed { group_size } => {
-                synthetic_group_aligned_chunk_end(
-                    usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
-                    token_count,
-                    tok_start,
-                    desired_end,
-                )
-            }
+            Self::SyntheticFixed { group_size } => synthetic_group_aligned_chunk_end(
+                usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
+                token_count,
+                tok_start,
+                desired_end,
+            ),
         }
     }
 
@@ -1317,14 +1310,12 @@ impl PostingGrouping {
     ) -> Vec<(u32, u32)> {
         match self {
             Self::None => Vec::new(),
-            Self::SyntheticFixed { group_size } => {
-                synthetic_group_ranges_for_chunk(
-                    usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
-                    tok_start,
-                    tok_end,
-                    token_count,
-                )
-            }
+            Self::SyntheticFixed { group_size } => synthetic_group_ranges_for_chunk(
+                usize::try_from(*group_size).unwrap_or(usize::MAX).max(1),
+                tok_start,
+                tok_end,
+                token_count,
+            ),
         }
     }
 }
@@ -2804,15 +2795,19 @@ impl PostingListReader {
                         self.load_posting_list_group(start, end).await
                     })
                     .await?;
+                let (max_score, length) = if group.needs_external_metadata() {
+                    self.posting_metadata_for_token(token_id).await?
+                } else {
+                    (None, None)
+                };
                 let slot = (token_id - start) as usize;
                 group
-                    .get(slot)
+                    .posting_list(slot, max_score, length)?
                     .ok_or_else(|| {
                         Error::index(format!(
                             "token {token_id} maps to slot {slot} outside posting group [{start}, {end})"
                         ))
                     })?
-                    .clone()
             }
             // Fallback for layouts that cannot use row-based groups: one cache
             // entry per token.
@@ -2853,9 +2848,9 @@ impl PostingListReader {
         self.grouping.range_for_token(token_id, self.len())
     }
 
-    /// Read rows `[start, end)` of the posting file and decode them into a
-    /// [`PostingListGroup`] cache value (issue #7040). Positions are excluded;
-    /// phrase queries load them on demand via [`Self::read_positions`].
+    /// Read rows `[start, end)` into one compact Arrow-backed cache value.
+    /// Positions are excluded; phrase queries load them on demand via
+    /// [`Self::read_positions`].
     async fn load_posting_list_group(&self, start: u32, end: u32) -> Result<PostingListGroup> {
         let batch = self
             .reader
@@ -2864,19 +2859,7 @@ impl PostingListReader {
                 Some(&[POSTING_COL, MAX_SCORE_COL, LENGTH_COL]),
             )
             .await?;
-        let max_scores = batch[MAX_SCORE_COL].as_primitive::<Float32Type>();
-        let lengths = batch[LENGTH_COL].as_primitive::<UInt32Type>();
-        let mut posting_lists = Vec::with_capacity(batch.num_rows());
-        for i in 0..batch.num_rows() {
-            let row = batch.slice(i, 1);
-            let posting = self.posting_list_from_batch(
-                &row,
-                Some(max_scores.value(i)),
-                Some(lengths.value(i)),
-            )?;
-            posting_lists.push(posting);
-        }
-        Ok(PostingListGroup::new(posting_lists))
+        PostingListGroup::new_packed(batch.shrink_to_fit()?, self.posting_tail_codec)
     }
 
     fn posting_list_from_batch_parts(
@@ -3000,16 +2983,19 @@ impl PostingListReader {
             ));
         }
 
-        // Make sure max_scores/lengths are populated before we clone them into
-        // the blocking task; otherwise the v2 branch would unwrap empty
-        // OnceCells.
+        // Make max_scores/lengths available for query-local packed views. The
+        // materialized fallback also clones them into its blocking build task.
         self.ensure_metadata_loaded().await?;
 
-        let state = self.chunk_build_state();
         // With grouping the cache stores one entry per group, so a group's
         // posting lists must all be resident at once: align chunk boundaries to
         // whole groups. Without grouping, chunks are plain token ranges.
         let grouping = self.grouping.clone();
+        let use_packed_groups = grouping.is_grouped() && !with_position;
+        // Packed groups reuse the reader's bulk metadata at query time, so they
+        // do not need the temporary full-partition metadata clones used by the
+        // materialized fallback.
+        let state = (!use_packed_groups).then(|| self.chunk_build_state());
         let token_count = self.len();
         let posting_data_size_bytes = self.posting_data_size_bytes();
         let chunk_tokens = chunk_tokens_override
@@ -3022,21 +3008,38 @@ impl PostingListReader {
         let read_build_start = Instant::now();
         stream::iter(chunk_ranges)
             .map(|(tok_start, tok_end)| {
-                let state = &state;
+                let state = state.as_ref();
                 let grouping = &grouping;
                 async move {
-                    let posting_lists = self
-                        .build_chunk_postings(tok_start, tok_end, with_position, state)
-                        .await?;
-                    self.publish_chunk_postings(
-                        posting_lists,
-                        grouping,
-                        tok_start,
-                        tok_end,
-                        token_count,
-                        with_position,
-                    )
-                    .await;
+                    if use_packed_groups {
+                        let groups = self
+                            .build_packed_chunk_groups(tok_start, tok_end, token_count, grouping)
+                            .await?;
+                        for (start, end, group) in groups {
+                            self.index_cache
+                                .insert_with_key(
+                                    &PostingListGroupKey { start, end },
+                                    Arc::new(group),
+                                )
+                                .await;
+                        }
+                    } else {
+                        let state = state.expect(
+                            "materialized prewarm must initialize posting-list build state",
+                        );
+                        let posting_lists = self
+                            .build_chunk_postings(tok_start, tok_end, with_position, state)
+                            .await?;
+                        self.publish_chunk_postings(
+                            posting_lists,
+                            grouping,
+                            tok_start,
+                            tok_end,
+                            token_count,
+                            with_position,
+                        )
+                        .await;
+                    }
                     Result::Ok(())
                 }
             })
@@ -3144,6 +3147,47 @@ impl PostingListReader {
                 .all(|(i, (token_id, _))| *token_id as usize == tok_start + i)
         );
         Ok(posting_lists)
+    }
+
+    /// Build compact v2 groups directly from one posting-row chunk. Each group
+    /// slice is deep-copied once, so it owns only its Arrow buffers without
+    /// materializing a `Vec<PostingList>` or retaining the full chunk.
+    async fn build_packed_chunk_groups(
+        &self,
+        tok_start: usize,
+        tok_end: usize,
+        token_count: usize,
+        grouping: &PostingGrouping,
+    ) -> Result<Vec<(u32, u32, PostingListGroup)>> {
+        debug_assert!(grouping.is_grouped());
+        debug_assert!(!self.is_legacy_layout());
+
+        let chunk_batch = self.read_chunk_batch(tok_start, tok_end, false).await?;
+        let ranges = grouping.ranges_for_chunk(tok_start, tok_end, token_count);
+        let posting_tail_codec = self.posting_tail_codec;
+
+        spawn_blocking(move || {
+            let mut groups = Vec::with_capacity(ranges.len());
+            for (start, end) in ranges {
+                let start_usize = start as usize;
+                let end_usize = end as usize;
+                let local_start = start_usize - tok_start;
+                let group_len = end_usize - start_usize;
+                let group_batch = chunk_batch.slice(local_start, group_len).shrink_to_fit()?;
+                groups.push((
+                    start,
+                    end,
+                    PostingListGroup::new_packed(group_batch, posting_tail_codec)?,
+                ));
+            }
+            Result::Ok(groups)
+        })
+        .await
+        .map_err(|err| {
+            Error::internal(format!(
+                "Failed to build packed prewarm posting groups in blocking task: {err}"
+            ))
+        })?
     }
 
     /// Strip positions into their own per-token cache entries (the posting cache
@@ -3608,22 +3652,194 @@ impl SharedPositionStream {
 }
 
 /// A group of consecutive posting lists held in a single cache entry, in row
-/// order (issue #7040). `posting_lists[i]` corresponds to row `start + i`,
-/// where `start` is the group's first row from [`PostingListGroupKey`].
-#[derive(Debug, Clone, DeepSizeOf)]
+/// order (issue #7040). Prewarmed v2 groups without positions retain only the
+/// compact Arrow posting rows read from `invert.lance`; max-score/length
+/// metadata stays in the reader and is injected when a query creates a
+/// posting-list view. Cold-loaded groups may keep inline metadata to preserve
+/// one-read query loading. Legacy and position-bearing prewarm paths use the
+/// materialized fallback.
+#[derive(Debug, Clone)]
 pub struct PostingListGroup {
-    pub(super) posting_lists: Vec<PostingList>,
+    pub(super) storage: PostingListGroupStorage,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum PostingListGroupStorage {
+    Packed(PackedPostingListGroup),
+    Materialized(Vec<PostingList>),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PackedPostingListGroup {
+    pub(super) batch: RecordBatch,
+    pub(super) posting_tail_codec: PostingTailCodec,
+}
+
+impl DeepSizeOf for PostingListGroup {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        match &self.storage {
+            PostingListGroupStorage::Packed(group) => group
+                .batch
+                .columns()
+                .iter()
+                .map(|column| sliced_cache_bytes(column.as_ref()))
+                .sum(),
+            PostingListGroupStorage::Materialized(posting_lists) => {
+                posting_lists.deep_size_of_children(context)
+            }
+        }
+    }
 }
 
 impl PostingListGroup {
     pub(super) fn new(posting_lists: Vec<PostingList>) -> Self {
-        Self { posting_lists }
+        Self {
+            storage: PostingListGroupStorage::Materialized(posting_lists),
+        }
     }
 
-    /// Borrow the posting list at offset `slot` within the group (i.e.
-    /// `token_id - start`).
-    pub(super) fn get(&self, slot: usize) -> Option<&PostingList> {
-        self.posting_lists.get(slot)
+    pub(super) fn new_packed(
+        batch: RecordBatch,
+        posting_tail_codec: PostingTailCodec,
+    ) -> Result<Self> {
+        let postings = batch
+            .column_by_name(POSTING_COL)
+            .and_then(|column| column.as_list_opt::<i32>())
+            .ok_or_else(|| {
+                Error::index(format!(
+                    "packed posting group column {POSTING_COL} must be List<LargeBinary>"
+                ))
+            })?;
+        if postings.values().data_type() != &DataType::LargeBinary {
+            return Err(Error::index(format!(
+                "packed posting group column {POSTING_COL} must contain LargeBinary values, got {}",
+                postings.values().data_type()
+            )));
+        }
+        if postings.null_count() != 0 {
+            return Err(Error::index(
+                "packed posting group column must not contain nulls".to_string(),
+            ));
+        }
+        match (
+            batch.column_by_name(MAX_SCORE_COL),
+            batch.column_by_name(LENGTH_COL),
+        ) {
+            (None, None) => {}
+            (Some(max_scores), Some(lengths)) => {
+                let max_scores = max_scores
+                    .as_primitive_opt::<Float32Type>()
+                    .ok_or_else(|| {
+                        Error::index(format!(
+                            "packed posting group column {MAX_SCORE_COL} must be Float32"
+                        ))
+                    })?;
+                let lengths = lengths.as_primitive_opt::<UInt32Type>().ok_or_else(|| {
+                    Error::index(format!(
+                        "packed posting group column {LENGTH_COL} must be UInt32"
+                    ))
+                })?;
+                if max_scores.null_count() != 0 || lengths.null_count() != 0 {
+                    return Err(Error::index(
+                        "packed posting group metadata columns must not contain nulls".to_string(),
+                    ));
+                }
+            }
+            _ => {
+                return Err(Error::index(format!(
+                    "packed posting group must contain both {MAX_SCORE_COL} and {LENGTH_COL}, or neither"
+                )));
+            }
+        }
+
+        Ok(Self {
+            storage: PostingListGroupStorage::Packed(PackedPostingListGroup {
+                batch,
+                posting_tail_codec,
+            }),
+        })
+    }
+
+    pub(super) fn len(&self) -> usize {
+        match &self.storage {
+            PostingListGroupStorage::Packed(group) => group.batch.num_rows(),
+            PostingListGroupStorage::Materialized(posting_lists) => posting_lists.len(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_packed(&self) -> bool {
+        matches!(&self.storage, PostingListGroupStorage::Packed(_))
+    }
+
+    fn needs_external_metadata(&self) -> bool {
+        match &self.storage {
+            PostingListGroupStorage::Packed(group) => {
+                group.batch.column_by_name(MAX_SCORE_COL).is_none()
+            }
+            PostingListGroupStorage::Materialized(_) => false,
+        }
+    }
+
+    /// Build an owned posting-list view for `slot`. Packed groups clone only
+    /// Arrow array metadata; the compressed posting bytes remain shared with
+    /// the group's `List<LargeBinary>` child buffers.
+    pub(super) fn posting_list(
+        &self,
+        slot: usize,
+        max_score: Option<f32>,
+        length: Option<u32>,
+    ) -> Result<Option<PostingList>> {
+        match &self.storage {
+            PostingListGroupStorage::Materialized(posting_lists) => {
+                Ok(posting_lists.get(slot).cloned())
+            }
+            PostingListGroupStorage::Packed(group) => {
+                if slot >= group.batch.num_rows() {
+                    return Ok(None);
+                }
+                let postings = group
+                    .batch
+                    .column_by_name(POSTING_COL)
+                    .and_then(|column| column.as_list_opt::<i32>())
+                    .ok_or_else(|| {
+                        Error::index(format!(
+                            "packed posting group column {POSTING_COL} must be List<LargeBinary>"
+                        ))
+                    })?;
+                let blocks = postings.value(slot);
+                let blocks = blocks.as_binary_opt::<i64>().ok_or_else(|| {
+                    Error::index(format!(
+                        "packed posting group slot {slot} is not LargeBinary"
+                    ))
+                })?;
+                let max_score = match group.batch.column_by_name(MAX_SCORE_COL) {
+                    Some(column) => column
+                        .as_primitive_opt::<Float32Type>()
+                        .expect("packed group metadata was validated at construction")
+                        .value(slot),
+                    None => max_score.ok_or_else(|| {
+                        Error::index("packed posting group requires max-score metadata".to_string())
+                    })?,
+                };
+                let length = match group.batch.column_by_name(LENGTH_COL) {
+                    Some(column) => column
+                        .as_primitive_opt::<UInt32Type>()
+                        .expect("packed group metadata was validated at construction")
+                        .value(slot),
+                    None => length.ok_or_else(|| {
+                        Error::index("packed posting group requires length metadata".to_string())
+                    })?,
+                };
+                Ok(Some(PostingList::Compressed(CompressedPostingList::new(
+                    blocks.clone(),
+                    max_score,
+                    length,
+                    group.posting_tail_codec,
+                    None,
+                ))))
+            }
+        }
     }
 }
 
@@ -6754,7 +6970,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_modern_prewarm_shrinks_cached_posting_buffers() {
+    async fn test_modern_prewarm_packs_group_with_shared_posting_buffer() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -6818,17 +7034,115 @@ mod tests {
             .await
             .unwrap();
 
-        let PostingList::Compressed(alpha) = group.get(0).unwrap() else {
+        assert!(
+            group.is_packed(),
+            "no-position prewarm should pack v2 groups"
+        );
+        assert!(
+            group.needs_external_metadata(),
+            "prewarmed packed groups must not duplicate reader score/length metadata"
+        );
+        let (alpha_score, alpha_len) = inverted_list.bulk_metadata_for_token(0);
+        let PostingList::Compressed(alpha) = group
+            .posting_list(0, alpha_score, alpha_len)
+            .unwrap()
+            .unwrap()
+        else {
             panic!("expected compressed posting list for token 0");
         };
-        let PostingList::Compressed(beta) = group.get(1).unwrap() else {
+        let (beta_score, beta_len) = inverted_list.bulk_metadata_for_token(1);
+        let PostingList::Compressed(beta) = group
+            .posting_list(1, beta_score, beta_len)
+            .unwrap()
+            .unwrap()
+        else {
             panic!("expected compressed posting list for token 1");
         };
 
-        assert_ne!(
+        assert_eq!(
             alpha.blocks.values().as_ptr(),
             beta.blocks.values().as_ptr(),
-            "prewarm should not leave cached posting lists sharing the same values buffer"
+            "packed posting views should share the group's values buffer"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_packed_prewarm_groups_do_not_retain_the_full_chunk() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
+        for token_id in 0..4u32 {
+            builder.tokens.add(format!("t{token_id}"));
+            let mut posting = PostingListBuilder::new(false);
+            posting.add(token_id, PositionRecorder::Count(1));
+            builder.posting_lists.push(posting);
+            builder.docs.append(1000 + token_id as u64, 1);
+        }
+        builder.write(store.as_ref()).await.unwrap();
+
+        let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
+        let cache = LanceCache::with_capacity(1 << 20);
+        let mut posting_reader = PostingListReader::try_new(reader, &cache).await.unwrap();
+        posting_reader.grouping = PostingGrouping::SyntheticFixed { group_size: 2 };
+
+        assert_eq!(
+            posting_reader
+                .prewarm_posting_lists_chunked(false, Some(4), 1)
+                .await
+                .unwrap(),
+            1,
+            "the test must read both groups in one prewarm chunk"
+        );
+
+        let first_group = posting_reader
+            .index_cache
+            .get_with_key(&PostingListGroupKey { start: 0, end: 2 })
+            .await
+            .unwrap();
+        let second_group = posting_reader
+            .index_cache
+            .get_with_key(&PostingListGroupKey { start: 2, end: 4 })
+            .await
+            .unwrap();
+        let (first_score, first_len) = posting_reader.bulk_metadata_for_token(0);
+        let PostingList::Compressed(first) = first_group
+            .posting_list(0, first_score, first_len)
+            .unwrap()
+            .unwrap()
+        else {
+            panic!("expected compressed posting list in first group");
+        };
+        let (neighbor_score, neighbor_len) = posting_reader.bulk_metadata_for_token(1);
+        let PostingList::Compressed(first_neighbor) = first_group
+            .posting_list(1, neighbor_score, neighbor_len)
+            .unwrap()
+            .unwrap()
+        else {
+            panic!("expected compressed posting list in first group");
+        };
+        let (second_score, second_len) = posting_reader.bulk_metadata_for_token(2);
+        let PostingList::Compressed(second) = second_group
+            .posting_list(0, second_score, second_len)
+            .unwrap()
+            .unwrap()
+        else {
+            panic!("expected compressed posting list in second group");
+        };
+
+        assert_eq!(
+            first.blocks.values().as_ptr(),
+            first_neighbor.blocks.values().as_ptr(),
+            "postings in one group should share the group's values buffer"
+        );
+        assert_ne!(
+            first.blocks.values().as_ptr(),
+            second.blocks.values().as_ptr(),
+            "each group must own a compact buffer instead of retaining the full chunk"
         );
     }
 
@@ -6837,8 +7151,8 @@ mod tests {
         let grouping = PostingGrouping::SyntheticFixed { group_size: 4 };
         assert_eq!(
             prewarm_chunk_ranges(&grouping, 13, 5),
-            vec![(0, 4), (4, 8), (8, 12), (12, 13)],
-            "grouped chunk ranges must never split a posting cache group"
+            vec![(0, 4), (4, 8), (8, 13)],
+            "grouped chunks may contain multiple groups but must never split one"
         );
         assert_eq!(
             prewarm_chunk_ranges(&PostingGrouping::None, 13, 5),
@@ -6862,8 +7176,8 @@ mod tests {
         );
         assert_eq!(
             prewarm_chunk_ranges(&grouping, 10, 6),
-            vec![(0, 4), (4, 8), (8, 10)],
-            "prewarm chunks must not split synthetic groups"
+            vec![(0, 4), (4, 10)],
+            "prewarm chunks may contain multiple synthetic groups but must not split one"
         );
         assert_eq!(
             grouping.ranges_for_chunk(4, 10, 10),
@@ -7088,7 +7402,15 @@ mod tests {
                 .unwrap();
             let slot = (token_id - start) as usize;
             assert!(
-                !group.get(slot).unwrap().has_position(),
+                !group.is_packed(),
+                "with-position prewarm should retain the materialized fallback"
+            );
+            assert!(
+                !group
+                    .posting_list(slot, None, None)
+                    .unwrap()
+                    .unwrap()
+                    .has_position(),
                 "token {token_id} posting cache entry must be positions-free after prewarm"
             );
 
@@ -7536,21 +7858,11 @@ mod tests {
         (index, cache)
     }
 
-    /// The read path decodes a posting-list group by slicing one buffer read for
-    /// the whole `[start, end)` row range, so every posting list in a cached
-    /// group shares a single `blocks` buffer. `DeepSizeOf` must count each
-    /// posting's slice of that buffer, not the whole buffer once per posting —
-    /// otherwise a group of N postings reports ~N times its real footprint.
-    #[rstest::rstest]
-    #[case::single_doc_terms(512, 1)]
-    #[case::small_terms(512, 4)]
-    #[case::medium_terms(256, 32)]
+    /// Packed groups charge their Arrow buffers and contiguous metadata once,
+    /// avoiding the per-member enum/array object graph of a materialized group.
     #[tokio::test]
-    async fn test_read_path_group_size_counts_slices_not_shared_buffer(
-        #[case] num_tokens: usize,
-        #[case] docs_per_token: usize,
-    ) {
-        let (index, _cache) = load_v2_index_with_grouped_postings(num_tokens, docs_per_token).await;
+    async fn test_packed_group_deep_size_is_smaller_than_materialized_graph() {
+        let (index, _cache) = load_v2_index_with_grouped_postings(512, 1).await;
         let inverted_list = index.partitions[0].inverted_list.clone();
         assert!(!inverted_list.is_legacy_layout(), "expected v2 layout");
         assert!(
@@ -7572,19 +7884,24 @@ mod tests {
             .get_with_key(&PostingListGroupKey { start, end })
             .await
             .unwrap();
+        assert!(group.is_packed(), "cold v2 group should use packed storage");
+        inverted_list.ensure_metadata_loaded().await.unwrap();
 
-        // Sum what counting the full backing buffer once per posting list would
-        // charge, and confirm the postings really do share a single buffer.
         let mut distinct_buffers = std::collections::HashSet::new();
-        let mut charged_if_counted_per_posting = 0usize;
-        for posting in &group.posting_lists {
+        let mut materialized = Vec::with_capacity(group.len());
+        for slot in 0..group.len() {
+            let (max_score, length) = inverted_list.bulk_metadata_for_token(start + slot as u32);
+            let posting = group
+                .posting_list(slot, max_score, length)
+                .unwrap()
+                .unwrap();
             let PostingList::Compressed(compressed) = posting else {
                 panic!("expected compressed posting lists");
             };
-            charged_if_counted_per_posting += compressed.blocks.get_buffer_memory_size();
             distinct_buffers.insert(compressed.blocks.values().as_ptr());
+            materialized.push(PostingList::Compressed(compressed));
         }
-        let posting_count = group.posting_lists.len();
+        let posting_count = materialized.len();
 
         assert!(
             posting_count > 1,
@@ -7595,13 +7912,12 @@ mod tests {
             1,
             "read-path postings in a group should share one backing buffer"
         );
-        // With slice-aware accounting the shared buffer is counted ~once, so the
-        // whole group costs far less than counting it once per posting list.
-        let reported = group.deep_size_of();
+        let packed_size = group.deep_size_of();
+        let materialized_size = PostingListGroup::new(materialized).deep_size_of();
         assert!(
-            reported < charged_if_counted_per_posting / 2,
-            "group deep_size_of {reported}B should not scale with the {posting_count}x-counted \
-             shared buffer ({charged_if_counted_per_posting}B)"
+            packed_size * 2 < materialized_size,
+            "packed group deep_size_of {packed_size}B should be less than half of the \
+             {materialized_size}B materialized graph for {posting_count} postings"
         );
     }
 
@@ -7807,7 +8123,15 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !group.get(0).unwrap().has_position(),
+            !group.is_packed(),
+            "with-position prewarm should retain the materialized fallback"
+        );
+        assert!(
+            !group
+                .posting_list(0, None, None)
+                .unwrap()
+                .unwrap()
+                .has_position(),
             "posting cache should remain positions-free after prewarm"
         );
 
@@ -9276,9 +9600,7 @@ mod tests {
 
         let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
         let cache = LanceCache::no_cache();
-        let posting_reader = PostingListReader::try_new(reader, &cache)
-            .await
-            .unwrap();
+        let posting_reader = PostingListReader::try_new(reader, &cache).await.unwrap();
         assert!(
             matches!(
                 &posting_reader.grouping,
@@ -9404,7 +9726,7 @@ mod tests {
         ));
 
         let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
-        let big_docs = 30u32;
+        let big_docs = (BLOCK_SIZE * 3 + 5) as u32;
         builder.tokens.add("big".to_owned());
         let mut big = PostingListBuilder::new(false);
         for d in 0..big_docs {
@@ -9484,13 +9806,18 @@ mod tests {
 
         for token_id in 0..num_tokens {
             let (start, end) = posting_reader.group_range_for_token(token_id).unwrap();
+            let group = posting_reader
+                .index_cache
+                .get_with_key(&PostingListGroupKey { start, end })
+                .await
+                .unwrap_or_else(|| {
+                    panic!(
+                        "synthetic prewarm should populate group [{start}, {end}) for token {token_id}"
+                    )
+                });
             assert!(
-                posting_reader
-                    .index_cache
-                    .get_with_key(&PostingListGroupKey { start, end })
-                    .await
-                    .is_some(),
-                "synthetic prewarm should populate group [{start}, {end}) for token {token_id}",
+                group.is_packed(),
+                "no-position synthetic prewarm should insert a packed group"
             );
             assert!(
                 posting_reader


### PR DESCRIPTION
## Performance issue

No-position FTS prewarm currently decodes posting rows into a `Vec<PostingList>` object graph. This substantially amplifies the index cache for workloads dominated by singleton and small posting lists.

Measured before this change:

- 10M globally unique terms: 2.76 GB cache for a 239.6 MB index (11.53x)

## How this improves performance

This PR:

- replaces index-time posting-group metadata with runtime synthetic groups, so existing indexes benefit without rebuilding;
- stores no-position prewarmed groups as compact Arrow-backed posting rows instead of materializing every posting list;
- creates a lightweight posting-list view only for the term used by a query, sharing the cached posting buffers;
- keeps score and length metadata in the posting reader for prewarmed groups;
- retains the materialized fallback for legacy and position-bearing paths;
- versions the cache codec while continuing to read the previous materialized group representation.

The persistent FTS index format and public API do not change. `prewarm_index` still populates the posting cache for subsequent queries.

## Benchmark

Fresh `c4-standard-16` VM, no-position format-v2 indexes created once by baseline Lance `5dbd1400d`, then reused unchanged by the target. The target uses the default runtime group size of 128. Each prewarm result is the mean of five runs.

| Dataset | Main cache | Target cache | Change | Cold prewarm |
|---|---:|---:|---:|---:|
| 10M unique terms | 2.762 GB | 250.3 MB | -90.94% | 6.440s -> 0.895s |
| Wikipedia-40M | 8.423 GB | 3.724 GB | -55.79% | 15.697s -> 6.860s |

A 64/128/256 sweep selected 128: compared with 256 it halves cache-group granularity for a 2.36% cache increase on 10M unique terms and 0.29% on Wikipedia-40M. Size 64 increased the 10M cache by 7.07% and cold prewarm time by 30.8%.

Three repeated, prewarmed query runs at group size 128 showed no materialization regression. Mean QPS changed by -0.7% to +0.6% across the 10M unique-term and Wikipedia k=10/k=100 workloads, within run-to-run variance.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lance-index scalar::inverted --lib --profile release-with-debug` (197 passed)
- `cargo clippy --all --tests --benches -- -D warnings`
- same-index benchmark validation: every query run reported `index_action=reused` and `prewarm_with_position=false`

Addresses OSS-1409.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime synthetic posting-list grouping for non-legacy v2 indexes.
  * Introduced a more compact packed posting-list cache format and packed-group prewarming.
* **Bug Fixes**
  * Preserved backward-compatible decoding by falling back to the legacy layout.
  * Added consistency validation for packed cache contents and ensured BM25 correctness.
* **Refactor**
  * Removed persisted posting-group boundary bookkeeping; grouping is now computed at runtime.
* **Tests**
  * Updated and extended tests for packed vs materialized groups, including roundtrip and zero-copy coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->