### PR TITLE
fix: scope dataset caches by object store

### DIFF
--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -71,6 +71,13 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
     /// this will be something like 'az$account_name@container'
     ///
     /// Providers should override this if they have special requirements like Azure's.
+    ///
+    /// The prefix must uniquely identify the backing store: it participates in
+    /// store-instance caching and in session dataset-cache keys (joined with the
+    /// dataset URI using `|`, so it should not contain `|`). If two different
+    /// physical stores can be reached through the same URL (for example via a
+    /// storage option selecting an account or endpoint), the distinguishing
+    /// option must be reflected in the prefix.
     fn calculate_object_store_prefix(
         &self,
         url: &Url,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -423,6 +423,10 @@ impl From<Schema> for ProjectionRequest {
 }
 
 impl Dataset {
+    pub(crate) fn cache_dataset_key(object_store: &ObjectStore, uri: &str) -> String {
+        format!("{}|{}", object_store.store_prefix, uri)
+    }
+
     /// Open an existing dataset.
     ///
     /// See also [DatasetBuilder].
@@ -720,7 +724,9 @@ impl Dataset {
                 .map(IndexMetadata::try_from)
                 .collect::<Result<Vec<_>>>()?;
             retain_supported_indices(&mut indices);
-            let ds_index_cache = session.index_cache.for_dataset(uri);
+            let ds_index_cache = session
+                .index_cache
+                .for_dataset(&Self::cache_dataset_key(object_store, uri));
             let metadata_key = crate::session::index_caches::IndexMetadataKey {
                 version: manifest_location.version,
             };
@@ -741,7 +747,9 @@ impl Dataset {
             let transaction: Transaction =
                 lance_table::format::pb::Transaction::decode(message_data)?.try_into()?;
 
-            let metadata_cache = session.metadata_cache.for_dataset(uri);
+            let metadata_cache = session
+                .metadata_cache
+                .for_dataset(&Self::cache_dataset_key(object_store, uri));
             let metadata_key = TransactionKey {
                 version: manifest_location.version,
             };
@@ -770,7 +778,9 @@ impl Dataset {
                 Self::load_manifest(object_store, manifest_location, uri, session).await?,
             ));
         }
-        let metadata_cache = session.metadata_cache.for_dataset(uri);
+        let metadata_cache = session
+            .metadata_cache
+            .for_dataset(&Self::cache_dataset_key(object_store, uri));
         let manifest_key = ManifestKey {
             version: manifest_location.version,
             e_tag: manifest_location.e_tag.as_deref(),
@@ -808,8 +818,16 @@ impl Dataset {
                 branch: manifest.branch.clone(),
             },
         );
-        let metadata_cache = Arc::new(session.metadata_cache.for_dataset(&uri));
-        let index_cache = Arc::new(session.index_cache.for_dataset(&uri));
+        let metadata_cache = Arc::new(
+            session
+                .metadata_cache
+                .for_dataset(&Self::cache_dataset_key(&object_store, &uri)),
+        );
+        let index_cache = Arc::new(
+            session
+                .index_cache
+                .for_dataset(&Self::cache_dataset_key(&object_store, &uri)),
+        );
         let fragment_bitmap = Arc::new(manifest.fragments.iter().map(|f| f.id as u32).collect());
         write::log_unregistered_base_scoped_options(
             store_params.as_ref(),

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -4113,3 +4113,148 @@ async fn test_manifest_read_recovers_from_stale_size() {
     assert_eq!(indices.len(), 1);
     assert_eq!(indices[0].name, "id_idx");
 }
+
+/// Provider that multiplexes multiple "accounts" behind identical URIs, the way
+/// per-tenant storage accounts are served through a shared table URI: the account
+/// comes from a storage option and each account maps to its own local directory
+/// and its own `store_prefix`.
+#[derive(Debug)]
+struct AccountScopedStoreProvider {
+    root: std::path::PathBuf,
+}
+
+const ACCOUNT_OPTION_KEY: &str = "account_name";
+
+impl AccountScopedStoreProvider {
+    fn account(storage_options: Option<&HashMap<String, String>>) -> String {
+        storage_options
+            .and_then(|opts| opts.get(ACCOUNT_OPTION_KEY).cloned())
+            .unwrap_or_else(|| "default".to_string())
+    }
+}
+
+#[async_trait::async_trait]
+impl lance_io::object_store::ObjectStoreProvider for AccountScopedStoreProvider {
+    async fn new_store(
+        &self,
+        base_path: url::Url,
+        params: &lance_io::object_store::ObjectStoreParams,
+    ) -> Result<lance_io::object_store::ObjectStore> {
+        let account_root = self.root.join(Self::account(params.storage_options()));
+        std::fs::create_dir_all(&account_root).unwrap();
+        let mut store = lance_io::object_store::ObjectStore::new(
+            Arc::new(object_store::local::LocalFileSystem::new_with_prefix(&account_root).unwrap()),
+            base_path.clone(),
+            params.block_size,
+            None,
+            false,
+            true,
+            lance_io::object_store::DEFAULT_LOCAL_IO_PARALLELISM,
+            3,
+            params.storage_options(),
+        );
+        store.store_prefix =
+            self.calculate_object_store_prefix(&base_path, params.storage_options())?;
+        Ok(store)
+    }
+
+    fn extract_path(&self, url: &url::Url) -> Result<object_store::path::Path> {
+        object_store::path::Path::from_url_path(url.path())
+            .map_err(|e| Error::invalid_input(format!("invalid path {}: {e}", url.path())))
+    }
+
+    fn calculate_object_store_prefix(
+        &self,
+        url: &url::Url,
+        storage_options: Option<&HashMap<String, String>>,
+    ) -> Result<String> {
+        Ok(format!(
+            "{}${}@{}",
+            url.scheme(),
+            url.host_str().unwrap_or_default(),
+            Self::account(storage_options)
+        ))
+    }
+}
+
+/// Two datasets that share a URI but live in different object stores (distinct
+/// `store_prefix`) must not share session-cache entries. Regression test for
+/// cross-account index-metadata leakage: the per-dataset cache namespace used to
+/// be the URI alone, so the account opened second overwrote the first account's
+/// `IndexMetadataKey{version}` entry and queries planned against a foreign index
+/// UUID that does not exist in their own store.
+#[tokio::test]
+async fn test_session_caches_scoped_by_object_store() {
+    let tmp = TempStrDir::default();
+    let root = std::path::PathBuf::from(tmp.as_str());
+    let uri = "mock-acct://store/tables/tbl";
+
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]));
+
+    // Create one dataset per account through plain file:// paths (writes are not
+    // under test), each with a scalar index so index metadata exists at the same
+    // version in both accounts.
+    let mut truth = HashMap::new();
+    for account in ["acct_a", "acct_b"] {
+        let dir = root.join(account).join("tables").join("tbl");
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new([Ok(batch)], schema.clone());
+        let mut ds = Dataset::write(reader, dir.to_str().unwrap(), None)
+            .await
+            .unwrap();
+        ds.create_index(
+            &["id"],
+            IndexType::Scalar,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let indices = ds.load_indices().await.unwrap();
+        assert_eq!(indices.len(), 1);
+        truth.insert(account, indices[0].uuid);
+    }
+
+    // Shared session with real cache capacities and the multiplexing provider.
+    let registry = Arc::new(lance_io::object_store::ObjectStoreRegistry::default());
+    registry.insert(
+        "mock-acct",
+        Arc::new(AccountScopedStoreProvider { root: root.clone() }),
+    );
+    let session = Arc::new(Session::new(64 * 1024 * 1024, 64 * 1024 * 1024, registry));
+
+    let open = |account: &'static str, session: Arc<Session>| async move {
+        DatasetBuilder::from_uri(uri)
+            .with_storage_options(HashMap::from([(
+                ACCOUNT_OPTION_KEY.to_string(),
+                account.to_string(),
+            )]))
+            .with_session(session)
+            .load()
+            .await
+            .unwrap()
+    };
+
+    // Open A first, then B: B's manifest read populates the index-metadata cache
+    // at the same dataset version as A. With URI-only cache namespaces A then
+    // observes B's index list; store-scoped namespaces must keep them apart.
+    let ds_a = open("acct_a", session.clone()).await;
+    let ds_b = open("acct_b", session.clone()).await;
+
+    let a_indices = ds_a.load_indices().await.unwrap();
+    let b_indices = ds_b.load_indices().await.unwrap();
+    assert_eq!(a_indices.len(), 1);
+    assert_eq!(b_indices.len(), 1);
+    assert_eq!(a_indices[0].uuid, truth["acct_a"]);
+    assert_eq!(b_indices[0].uuid, truth["acct_b"]);
+    assert_ne!(a_indices[0].uuid, b_indices[0].uuid);
+}

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -899,7 +899,12 @@ async fn test_checkout_removed_version_not_served_from_cache() {
 
     let version = dataset.manifest().version;
     let location = dataset.manifest_location().clone();
-    let cache = session.metadata_cache.for_dataset(&dataset.uri);
+    let cache = session
+        .metadata_cache
+        .for_dataset(&Dataset::cache_dataset_key(
+            &dataset.object_store,
+            &dataset.uri,
+        ));
 
     assert!(
         cache

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -327,8 +327,16 @@ impl<'a> CommitBuilder<'a> {
         let (metadata_cache, index_cache) = match &dest {
             WriteDestination::Dataset(ds) => (ds.metadata_cache.clone(), ds.index_cache.clone()),
             WriteDestination::Uri(uri) => (
-                Arc::new(session.metadata_cache.for_dataset(uri)),
-                Arc::new(session.index_cache.for_dataset(uri)),
+                Arc::new(
+                    session
+                        .metadata_cache
+                        .for_dataset(&Dataset::cache_dataset_key(&object_store, uri)),
+                ),
+                Arc::new(
+                    session
+                        .index_cache
+                        .for_dataset(&Dataset::cache_dataset_key(&object_store, uri)),
+                ),
             ),
         };
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -39,16 +39,19 @@ pub struct Session {
     /// Global cache for opened indices.
     ///
     /// Sub-caches are created from this cache for each dataset by adding the
-    /// URI and index UUID as a key prefix. If there is a fragment re-use index,
-    /// that is also in the key prefix. This prevents collisions between different
-    /// datasets and indices.
+    /// dataset key (object store prefix + URI) and index UUID as a key prefix.
+    /// If there is a fragment re-use index, that is also in the key prefix.
+    /// This prevents collisions between different datasets and indices, even
+    /// when datasets share a URI across different object stores.
     pub(crate) index_cache: GlobalIndexCache,
 
     /// Global cache for file metadata.
     ///
     /// Sub-caches are created from this cache for each dataset by adding the
-    /// URI as a key prefix. See the [`LanceDataset::metadata_cache`] field.
-    /// This prevents collisions between different datasets.
+    /// dataset key (object store prefix + URI) as a key prefix. See the
+    /// [`LanceDataset::metadata_cache`] field. This prevents collisions
+    /// between different datasets, even when datasets share a URI across
+    /// different object stores.
     pub(crate) metadata_cache: caches::GlobalMetadataCache,
 
     pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -30,10 +30,13 @@ use crate::dataset::transaction::Transaction;
 pub struct GlobalMetadataCache(pub(super) LanceCache);
 
 impl GlobalMetadataCache {
-    pub fn for_dataset(&self, uri: &str) -> DSMetadataCache {
-        // Create a sub-cache for the dataset by adding the URI as a key prefix.
-        // This prevents collisions between different datasets.
-        DSMetadataCache(self.0.with_key_prefix(uri))
+    pub fn for_dataset(&self, dataset_key: &str) -> DSMetadataCache {
+        // Create a sub-cache for the dataset by adding the dataset key
+        // (object store prefix + URI, see `Dataset::cache_dataset_key`) as a
+        // key prefix. This prevents collisions between different datasets,
+        // including datasets that share a URI but live in different object
+        // stores.
+        DSMetadataCache(self.0.with_key_prefix(dataset_key))
     }
 }
 

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -22,10 +22,13 @@ use uuid::Uuid;
 pub struct GlobalIndexCache(pub(super) LanceCache);
 
 impl GlobalIndexCache {
-    pub fn for_dataset(&self, uri: &str) -> DSIndexCache {
-        // Create a sub-cache for the dataset by adding the URI as a key prefix.
-        // This prevents collisions between different datasets.
-        DSIndexCache(self.0.with_key_prefix(uri))
+    pub fn for_dataset(&self, dataset_key: &str) -> DSIndexCache {
+        // Create a sub-cache for the dataset by adding the dataset key
+        // (object store prefix + URI, see `Dataset::cache_dataset_key`) as a
+        // key prefix. This prevents collisions between different datasets,
+        // including datasets that share a URI but live in different object
+        // stores.
+        DSIndexCache(self.0.with_key_prefix(dataset_key))
     }
 }
 


### PR DESCRIPTION
## Summary

Per-dataset session caches (manifest, transaction, index metadata) were namespaced by dataset URI alone. Deployments that multiplex multiple storage accounts behind identical URIs — e.g. Azure account-per-tenant with the account selected by a storage option — shared cache entries across accounts. The e_tag-less `IndexMetadataKey{version}`/`TransactionKey{version}` entries collide whenever table versions match, so one account's query could plan against another account's index UUID and fail with `Not found .../_indices/<uuid>/...` (or observe foreign metadata).

## Changes

- Add `Dataset::cache_dataset_key` = `{store_prefix}|{uri}` and use it for every per-dataset session cache namespace: `get_manifest`, the opportunistic index/transaction inserts in `load_manifest`, `checkout_manifest`'s cache handles, and `CommitBuilder`.
- Update stale cache-keying docs and rename `for_dataset(uri)` to `for_dataset(dataset_key)`.
- Document the `store_prefix` uniqueness contract on `calculate_object_store_prefix` (it participates in cache keys and must not contain `|`).
- Regression test: two accounts multiplexed behind one URI via a custom provider; each dataset must observe its own index metadata through a shared session. Fails without the fix (dataset A sees B's index UUID), passes with it.

## Notes

- `store_prefix` remains the store identity. Built-in providers that do not reflect every store-distinguishing option in their prefix (e.g. S3 `aws_endpoint` variants sharing `s3$bucket`) still have a residual collision class; fixing those prefixes is a per-provider follow-up, now covered by the documented contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset cache isolation when different object stores use the same dataset URI.
  * Prevented cached metadata and index information from being incorrectly shared across separate storage locations.
  * Added coverage for account-specific storage scenarios to ensure each dataset returns the correct index metadata.

* **Documentation**
  * Clarified cache-key and object-store prefix requirements for reliable dataset identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->