### PR TITLE
test(index): stabilize simple index nearest centroid test

### DIFF
--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -277,6 +277,7 @@ mod tests {
     use half::f16;
     use lance_arrow::FixedSizeListArrayExt;
     use num_traits::identities::Zero;
+    use rayon::ThreadPoolBuilder;
 
     use arrow::compute::cast;
     use rstest::rstest;
@@ -307,7 +308,8 @@ mod tests {
         (0..100).flat_map(|i| std::iter::repeat_n(i as f32, 16)).collect::<Vec<_>>(),
     )) as ArrayRef, 42.0f32)]
     fn test_simple_index_nearest_centroid(#[case] centroids: ArrayRef, #[case] query_val: f32) {
-        let index = build_index(centroids, 16);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let index = thread_pool.install(|| build_index(centroids, 16));
         let query: ArrayRef = Arc::new(Float32Array::from(vec![query_val; 16]));
         let (id, dist) = index.search(query).unwrap();
         assert_eq!(id, 42);


### PR DESCRIPTION
## Bug Fix

### What is the bug?

`test_simple_index_nearest_centroid` builds a small HNSW index in parallel and then requires an exact nearest-centroid result. HNSW node insertion mutates the shared graph concurrently, so Rayon scheduling can produce different graph topologies even though node-level RNG is seeded.

### What incorrect behavior does the bug cause?

The approximate search occasionally fails the strict `id == 42` assertion and returns a nearby centroid such as 43 or 44. This makes the test flaky, especially under CPU contention, without indicating a production regression.

### How does this PR fix the problem?

Build the test's 100-point HNSW index inside a dedicated single-thread Rayon pool. This preserves the exact assertions while making graph construction deterministic. Production index construction and the binary nearest-centroid test are unchanged.

## Validation

- `cargo test -p lance-index test_simple_index_nearest_centroid -- --nocapture`
- 3,000 concurrent stress-test runs with 16 processes and `RAYON_NUM_THREADS=8`: 0 failures
- `cargo fmt --all -- --check`
- `cargo clippy -p lance-index --tests -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vector index testing to run index construction within a controlled single-threaded environment.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->