### PR TITLE
feat(mem_wal): thread store_params + session through WAL write/read paths

### DIFF
--- a/rust/lance/benches/mem_wal/write/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal/write/mem_wal_write.rs
@@ -656,6 +656,8 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                                     enable_memtable,
                                     hnsw_params: default_config.hnsw_params,
                                     warmer: None,
+                                    store_params: default_config.store_params,
+                                    session: default_config.session,
                                 };
 
                                 // Get writer through Dataset API (index configs loaded automatically)

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2309,13 +2309,9 @@ impl Dataset {
         }
     }
 
-    /// The `ObjectStoreParams` this dataset was opened with (endpoint / region /
-    /// credential accessor), or `None` when opened without explicit params.
-    ///
-    /// Lets a caller re-open a derived path — e.g. a MemWAL flushed generation
-    /// under the same authority — with the identical store, including the
-    /// refreshing credential accessor of a namespace-backed dataset, rather than
-    /// re-resolving an ambient one.
+    /// The `ObjectStoreParams` this dataset was opened with, or `None` when
+    /// opened without explicit params. Lets a caller re-open a derived path
+    /// (e.g. a MemWAL flushed generation) with the same store this dataset used.
     pub fn store_params(&self) -> Option<&ObjectStoreParams> {
         self.store_params.as_deref()
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2309,6 +2309,17 @@ impl Dataset {
         }
     }
 
+    /// The `ObjectStoreParams` this dataset was opened with (endpoint / region /
+    /// credential accessor), or `None` when opened without explicit params.
+    ///
+    /// Lets a caller re-open a derived path — e.g. a MemWAL flushed generation
+    /// under the same authority — with the identical store, including the
+    /// refreshing credential accessor of a namespace-backed dataset, rather than
+    /// re-resolving an ambient one.
+    pub fn store_params(&self) -> Option<&ObjectStoreParams> {
+        self.store_params.as_deref()
+    }
+
     pub(crate) async fn object_store_for_data_file(
         &self,
         data_file: &DataFile,

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -711,7 +711,7 @@ impl DatasetMemWalExt for Dataset {
 
         // Inject the dataset's store params + session so the flusher opens the
         // base + generations with the same store the base was resolved with.
-        config.store_params = self.store_params.as_deref().cloned();
+        config.store_params = self.store_params().cloned();
         config.session = Some(self.session());
 
         // Reuse the dataset's own object store + base path; `ObjectStore::from_uri`

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -26,6 +26,7 @@ use crate::index::mem_wal::{load_mem_wal_index_details, new_mem_wal_index_meta};
 use super::ShardWriterConfig;
 use super::scanner::flushed_cache::open_flushed_dataset;
 use super::scanner::{DatasetCache, ShardSnapshot};
+use super::util::derived_store_params;
 use super::write::MemIndexConfig;
 use super::write::ShardWriter;
 
@@ -596,7 +597,8 @@ impl DatasetMemWalExt for Dataset {
         cache: Option<&Arc<dyn DatasetCache>>,
     ) -> Result<()> {
         let session = self.session();
-        let store_params = self.store_params().cloned();
+        // Every open below targets a generation URI, never the base's own.
+        let store_params = self.store_params().map(derived_store_params);
         // Resolve flushed paths exactly as the LSM collector does, so the
         // session/cache entries we warm key-match the paths later lookups open.
         let base_path = self.uri().trim_end_matches('/').to_string();

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -610,9 +610,14 @@ impl DatasetMemWalExt for Dataset {
                 snapshot.flushed_generations.iter().map(move |flushed| {
                     let path = format!("{}/_mem_wal/{}/{}", base_path, shard_id, flushed.path);
                     async move {
-                        let dataset =
-                            open_flushed_dataset(&path, Some(session), store_params.as_ref(), cache, None)
-                                .await?;
+                        let dataset = open_flushed_dataset(
+                            &path,
+                            Some(session),
+                            store_params.as_ref(),
+                            cache,
+                            None,
+                        )
+                        .await?;
                         prewarm_all_indexes(&dataset).await
                     }
                 })
@@ -717,7 +722,7 @@ impl DatasetMemWalExt for Dataset {
         // `list_mem_wal_latest_shard_ids`.
         let base_uri = self.uri();
         let store = self.object_store(None).await?;
-        let base_path = self.branch_location().path.clone();
+        let base_path = self.branch_location().path;
 
         // Create ShardWriter
         ShardWriter::open(

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -14,7 +14,6 @@ use async_trait::async_trait;
 use lance_core::{Error, Result};
 use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardingField, ShardingSpec};
 use lance_index::vector::hnsw::builder::HnswBuildParams;
-use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
 
 use crate::Dataset;
@@ -597,6 +596,7 @@ impl DatasetMemWalExt for Dataset {
         cache: Option<&Arc<dyn DatasetCache>>,
     ) -> Result<()> {
         let session = self.session();
+        let store_params = self.store_params().cloned();
         // Resolve flushed paths exactly as the LSM collector does, so the
         // session/cache entries we warm key-match the paths later lookups open.
         let base_path = self.uri().trim_end_matches('/').to_string();
@@ -606,11 +606,13 @@ impl DatasetMemWalExt for Dataset {
                 let shard_id = snapshot.shard_id;
                 let base_path = &base_path;
                 let session = &session;
+                let store_params = &store_params;
                 snapshot.flushed_generations.iter().map(move |flushed| {
                     let path = format!("{}/_mem_wal/{}/{}", base_path, shard_id, flushed.path);
                     async move {
                         let dataset =
-                            open_flushed_dataset(&path, Some(session), cache, None).await?;
+                            open_flushed_dataset(&path, Some(session), store_params.as_ref(), cache, None)
+                                .await?;
                         prewarm_all_indexes(&dataset).await
                     }
                 })
@@ -700,9 +702,22 @@ impl DatasetMemWalExt for Dataset {
         // Set shard_id in config
         config.shard_id = shard_id;
 
-        // Get object store and base path
+        // Inject the dataset's own storage context so the flusher's derived-URI
+        // opens (base + generations) reuse the same store the base was resolved
+        // with (endpoint / region / vended-credential accessor) instead of a
+        // fresh ambient one.
+        config.store_params = self.store_params.as_deref().cloned();
+        config.session = Some(self.session());
+
+        // Reuse the dataset's own object store + base path rather than
+        // re-resolving from the bare URI. `ObjectStore::from_uri` discards the
+        // `ObjectStoreParams` the dataset was opened with (endpoint / region /
+        // vended credentials), so the ShardWriter would sign the WAL log and
+        // manifest CAS with the ambient identity. Mirrors the sibling
+        // `list_mem_wal_latest_shard_ids`.
         let base_uri = self.uri();
-        let (store, base_path) = ObjectStore::from_uri(base_uri).await?;
+        let store = self.object_store(None).await?;
+        let base_path = self.branch_location().path.clone();
 
         // Create ShardWriter
         ShardWriter::open(
@@ -849,7 +864,7 @@ mod tests {
         // The generation is resident in the cache (same session), with its
         // index loadable — a later lookup that opens this path is a pure hit.
         let warmed = cache
-            .get_or_open(&gen_uri, Some(base.session()))
+            .get_or_open(&gen_uri, Some(base.session()), base.store_params().cloned())
             .await
             .unwrap();
         assert_eq!(warmed.load_indices().await.unwrap().len(), 1);

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -707,19 +707,14 @@ impl DatasetMemWalExt for Dataset {
         // Set shard_id in config
         config.shard_id = shard_id;
 
-        // Inject the dataset's own storage context so the flusher's derived-URI
-        // opens (base + generations) reuse the same store the base was resolved
-        // with (endpoint / region / vended-credential accessor) instead of a
-        // fresh ambient one.
+        // Inject the dataset's store params + session so the flusher opens the
+        // base + generations with the same store the base was resolved with.
         config.store_params = self.store_params.as_deref().cloned();
         config.session = Some(self.session());
 
-        // Reuse the dataset's own object store + base path rather than
-        // re-resolving from the bare URI. `ObjectStore::from_uri` discards the
-        // `ObjectStoreParams` the dataset was opened with (endpoint / region /
-        // vended credentials), so the ShardWriter would sign the WAL log and
-        // manifest CAS with the ambient identity. Mirrors the sibling
-        // `list_mem_wal_latest_shard_ids`.
+        // Reuse the dataset's own object store + base path; `ObjectStore::from_uri`
+        // would discard the store params the dataset was opened with, signing WAL
+        // writes with the ambient identity. Mirrors `list_mem_wal_latest_shard_ids`.
         let base_uri = self.uri();
         let store = self.object_store(None).await?;
         let base_path = self.branch_location().path;

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -74,14 +74,11 @@ pub struct MemTableFlusher {
     /// When present, each new generation is warmed before it is committed, so
     /// the first query sees zero cold reads. `None` => no warming.
     warmer: Option<Arc<dyn GenerationWarmer>>,
-    /// `ObjectStoreParams` the base dataset was opened with, injected via
-    /// [`Self::with_storage_context`]. When present, the flusher's derived-URI
-    /// opens (base + generations) reuse the same store — including the
-    /// vended-credential accessor for federated tables — rather than
-    /// re-resolving an ambient one. `None` => bare by-URI open (native default).
+    /// Store params for the flusher's derived-URI opens (base + generations),
+    /// reusing the store the base was opened with. `None` opens by URI alone.
     store_params: Option<ObjectStoreParams>,
-    /// The dataset's shared `Session`, so derived opens hit the same store
-    /// registry the base was resolved in. `None` => a fresh session per open.
+    /// Session for those opens, sharing the base's store registry. `None` opens
+    /// with a fresh session.
     session: Option<Arc<Session>>,
 }
 
@@ -111,9 +108,8 @@ impl MemTableFlusher {
         self
     }
 
-    /// Attach the base dataset's storage context (params + session) so derived
-    /// opens reuse the dataset's store instead of re-resolving from bare URIs.
-    /// Injected by `mem_wal_writer` from the base `Dataset`.
+    /// Set the store params + session used for derived-URI opens. Injected by
+    /// `mem_wal_writer` from the base `Dataset`.
     pub fn with_storage_context(
         mut self,
         store_params: Option<ObjectStoreParams>,
@@ -124,12 +120,9 @@ impl MemTableFlusher {
         self
     }
 
-    /// Open a dataset at a URI derived from this shard's base — the base table
-    /// itself or a flushed generation under `_mem_wal/`. Threads the injected
-    /// store params + session so the open reuses the base's store (and its
-    /// refreshing credential accessor, for federated tables) rather than
-    /// re-resolving an ambient one. Falls back to a bare by-URI open when no
-    /// storage context was injected (native default / tests).
+    /// Open the dataset at a URI derived from this shard's base — the base table
+    /// itself or a flushed generation under `_mem_wal/` — reusing the injected
+    /// store params + session, or opening by URI alone when none were set.
     async fn open_derived(&self, uri: &str) -> Result<Dataset> {
         let mut builder = DatasetBuilder::from_uri(uri);
         if let Some(params) = &self.store_params {
@@ -346,10 +339,8 @@ impl MemTableFlusher {
         let write_params = WriteParams {
             max_rows_per_file: usize::MAX,
             data_storage_version: Some(self.base_storage_version().await?),
-            // Write the generation through the base dataset's store params +
-            // session so it signs with the same identity the base was opened
-            // with (federated: the vended-credential accessor) instead of the
-            // ambient chain.
+            // Write the generation through the base's store params + session so
+            // it uses the same store the base was opened with.
             store_params: self.store_params.clone(),
             session: self.session.clone(),
             ..Default::default()

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -14,7 +14,7 @@ use lance_core::{Error, Result};
 use lance_index::IndexType;
 use lance_index::mem_wal::{FlushedGeneration, ShardManifest};
 use lance_index::scalar::{IndexStore, ScalarIndexParams};
-use lance_io::object_store::ObjectStore;
+use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_table::format::IndexMetadata;
 use lance_table::io::commit::write_manifest_file_to_path;
 use lance_table::io::deletion::write_deletion_file;
@@ -28,10 +28,12 @@ use uuid::Uuid;
 use super::super::index::MemIndexConfig;
 use super::super::memtable::MemTable;
 use crate::Dataset;
+use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::mem_wal::manifest::ShardManifestStore;
 use crate::dataset::mem_wal::scanner::GenerationWarmer;
 use crate::dataset::mem_wal::scanner::exec::{compute_pk_hash, validate_pk_types};
 use crate::dataset::mem_wal::util::{flushed_memtable_path, generate_random_hash};
+use crate::session::Session;
 
 #[derive(Debug, Clone)]
 pub struct FlushResult {
@@ -72,6 +74,15 @@ pub struct MemTableFlusher {
     /// When present, each new generation is warmed before it is committed, so
     /// the first query sees zero cold reads. `None` => no warming.
     warmer: Option<Arc<dyn GenerationWarmer>>,
+    /// `ObjectStoreParams` the base dataset was opened with, injected via
+    /// [`Self::with_storage_context`]. When present, the flusher's derived-URI
+    /// opens (base + generations) reuse the same store — including the
+    /// vended-credential accessor for federated tables — rather than
+    /// re-resolving an ambient one. `None` => bare by-URI open (native default).
+    store_params: Option<ObjectStoreParams>,
+    /// The dataset's shared `Session`, so derived opens hit the same store
+    /// registry the base was resolved in. `None` => a fresh session per open.
+    session: Option<Arc<Session>>,
 }
 
 impl MemTableFlusher {
@@ -89,6 +100,8 @@ impl MemTableFlusher {
             shard_id,
             manifest_store,
             warmer: None,
+            store_params: None,
+            session: None,
         }
     }
 
@@ -96,6 +109,36 @@ impl MemTableFlusher {
     pub fn with_warmer(mut self, warmer: Option<Arc<dyn GenerationWarmer>>) -> Self {
         self.warmer = warmer;
         self
+    }
+
+    /// Attach the base dataset's storage context (params + session) so derived
+    /// opens reuse the dataset's store instead of re-resolving from bare URIs.
+    /// Injected by `mem_wal_writer` from the base `Dataset`.
+    pub fn with_storage_context(
+        mut self,
+        store_params: Option<ObjectStoreParams>,
+        session: Option<Arc<Session>>,
+    ) -> Self {
+        self.store_params = store_params;
+        self.session = session;
+        self
+    }
+
+    /// Open a dataset at a URI derived from this shard's base — the base table
+    /// itself or a flushed generation under `_mem_wal/`. Threads the injected
+    /// store params + session so the open reuses the base's store (and its
+    /// refreshing credential accessor, for federated tables) rather than
+    /// re-resolving an ambient one. Falls back to a bare by-URI open when no
+    /// storage context was injected (native default / tests).
+    async fn open_derived(&self, uri: &str) -> Result<Dataset> {
+        let mut builder = DatasetBuilder::from_uri(uri);
+        if let Some(params) = &self.store_params {
+            builder = builder.with_store_params(params.clone());
+        }
+        if let Some(session) = &self.session {
+            builder = builder.with_session(session.clone());
+        }
+        builder.load().await
     }
 
     /// Warm a just-written generation before it is committed. Best-effort: a
@@ -139,7 +182,7 @@ impl MemTableFlusher {
     /// In production MemWAL is always initialized on a real dataset, so the base
     /// version is inherited; other open errors are propagated.
     async fn base_storage_version(&self) -> Result<lance_file::version::LanceFileVersion> {
-        match Dataset::open(&self.base_uri).await {
+        match self.open_derived(&self.base_uri).await {
             Ok(dataset) => dataset.manifest().data_storage_format.lance_file_version(),
             Err(Error::DatasetNotFound { .. }) => {
                 Ok(lance_file::version::LanceFileVersion::default())
@@ -194,7 +237,7 @@ impl MemTableFlusher {
         // generation exposes newest-per-PK on every read path.
         if !deleted.is_empty() {
             let uri = self.path_to_uri(&gen_path);
-            let dataset = Dataset::open(&uri).await?;
+            let dataset = self.open_derived(&uri).await?;
             self.finalize_generation(&dataset, &deleted, None).await?;
         }
 
@@ -303,6 +346,12 @@ impl MemTableFlusher {
         let write_params = WriteParams {
             max_rows_per_file: usize::MAX,
             data_storage_version: Some(self.base_storage_version().await?),
+            // Write the generation through the base dataset's store params +
+            // session so it signs with the same identity the base was opened
+            // with (federated: the vended-credential accessor) instead of the
+            // ambient chain.
+            store_params: self.store_params.clone(),
+            session: self.session.clone(),
             ..Default::default()
         };
         Dataset::write(reader, &uri, Some(write_params)).await?;
@@ -420,7 +469,7 @@ impl MemTableFlusher {
         // Open the dataset once for all index building. Dataset::write already
         // created a v1 manifest with the fragment data.
         let uri = self.path_to_uri(&gen_path);
-        let mut dataset = Dataset::open(&uri).await?;
+        let mut dataset = self.open_derived(&uri).await?;
 
         // Collect all index metadata without committing individually.
         // We write a single manifest containing both data and all indexes.

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -32,7 +32,9 @@ use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::mem_wal::manifest::ShardManifestStore;
 use crate::dataset::mem_wal::scanner::GenerationWarmer;
 use crate::dataset::mem_wal::scanner::exec::{compute_pk_hash, validate_pk_types};
-use crate::dataset::mem_wal::util::{flushed_memtable_path, generate_random_hash};
+use crate::dataset::mem_wal::util::{
+    derived_store_params, flushed_memtable_path, generate_random_hash,
+};
 use crate::session::Session;
 
 #[derive(Debug, Clone)]
@@ -74,8 +76,9 @@ pub struct MemTableFlusher {
     /// When present, each new generation is warmed before it is committed, so
     /// the first query sees zero cold reads. `None` => no warming.
     warmer: Option<Arc<dyn GenerationWarmer>>,
-    /// Store params for the flusher's derived-URI opens (base + generations),
-    /// reusing the store the base was opened with. `None` opens by URI alone.
+    /// Store params the base dataset was opened with, reused for the flusher's
+    /// own opens + writes. Used verbatim only for the base's own URI; generation
+    /// URIs go through [`derived_store_params`]. `None` opens by URI alone.
     store_params: Option<ObjectStoreParams>,
     /// Session for those opens, sharing the base's store registry. `None` opens
     /// with a fresh session.
@@ -120,13 +123,32 @@ impl MemTableFlusher {
         self
     }
 
-    /// Open the dataset at a URI derived from this shard's base — the base table
-    /// itself or a flushed generation under `_mem_wal/` — reusing the injected
-    /// store params + session, or opening by URI alone when none were set.
-    async fn open_derived(&self, uri: &str) -> Result<Dataset> {
+    /// Open the base table, reusing the injected store params verbatim — they
+    /// were resolved for exactly this URI, so a path-bound `object_store`
+    /// binding still points where it should.
+    async fn open_base(&self) -> Result<Dataset> {
+        self.open_uri(&self.base_uri, self.store_params.clone())
+            .await
+    }
+
+    /// Open a flushed generation under `_mem_wal/`. The params must be adapted
+    /// first: a path-bound store binding would redirect the open at the base
+    /// table (see [`derived_store_params`]).
+    async fn open_generation(&self, uri: &str) -> Result<Dataset> {
+        self.open_uri(uri, self.store_params.as_ref().map(derived_store_params))
+            .await
+    }
+
+    /// Open `uri` with the injected session, or by URI alone when nothing was
+    /// injected.
+    async fn open_uri(
+        &self,
+        uri: &str,
+        store_params: Option<ObjectStoreParams>,
+    ) -> Result<Dataset> {
         let mut builder = DatasetBuilder::from_uri(uri);
-        if let Some(params) = &self.store_params {
-            builder = builder.with_store_params(params.clone());
+        if let Some(params) = store_params {
+            builder = builder.with_store_params(params);
         }
         if let Some(session) = &self.session {
             builder = builder.with_session(session.clone());
@@ -175,7 +197,7 @@ impl MemTableFlusher {
     /// In production MemWAL is always initialized on a real dataset, so the base
     /// version is inherited; other open errors are propagated.
     async fn base_storage_version(&self) -> Result<lance_file::version::LanceFileVersion> {
-        match self.open_derived(&self.base_uri).await {
+        match self.open_base().await {
             Ok(dataset) => dataset.manifest().data_storage_format.lance_file_version(),
             Err(Error::DatasetNotFound { .. }) => {
                 Ok(lance_file::version::LanceFileVersion::default())
@@ -230,7 +252,7 @@ impl MemTableFlusher {
         // generation exposes newest-per-PK on every read path.
         if !deleted.is_empty() {
             let uri = self.path_to_uri(&gen_path);
-            let dataset = self.open_derived(&uri).await?;
+            let dataset = self.open_generation(&uri).await?;
             self.finalize_generation(&dataset, &deleted, None).await?;
         }
 
@@ -339,9 +361,11 @@ impl MemTableFlusher {
         let write_params = WriteParams {
             max_rows_per_file: usize::MAX,
             data_storage_version: Some(self.base_storage_version().await?),
-            // Write the generation through the base's store params + session so
-            // it uses the same store the base was opened with.
-            store_params: self.store_params.clone(),
+            // Write the generation through the base's store params + session so it
+            // uses the same store the base was opened with. Adapted for the
+            // generation URI: a path-bound store binding would send this write at
+            // the base table's own path (see [`derived_store_params`]).
+            store_params: self.store_params.as_ref().map(derived_store_params),
             session: self.session.clone(),
             ..Default::default()
         };
@@ -460,7 +484,7 @@ impl MemTableFlusher {
         // Open the dataset once for all index building. Dataset::write already
         // created a v1 manifest with the fragment data.
         let uri = self.path_to_uri(&gen_path);
-        let mut dataset = self.open_derived(&uri).await?;
+        let mut dataset = self.open_generation(&uri).await?;
 
         // Collect all index metadata without committing individually.
         // We write a single manifest containing both data and all indexes.

--- a/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
@@ -539,7 +539,7 @@ mod tests {
             active_source(shard, 1, &[3]),
         ];
 
-        let memberships = fresh_tier_block_list(&sources, None, None, None,None)
+        let memberships = fresh_tier_block_list(&sources, None, None, None, None)
             .await
             .unwrap();
 
@@ -713,7 +713,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&watermarks))
+        let sets = fresh_tier_block_list(&sources, None, None, None, Some(&watermarks))
             .await
             .unwrap();
         assert!(blocks(&sets, 1).await);
@@ -721,7 +721,7 @@ mod tests {
         assert!(!blocks(&sets, 3).await);
 
         // No watermark → live tier: all three are members.
-        let sets = fresh_tier_block_list(&sources, None, None, None,None)
+        let sets = fresh_tier_block_list(&sources, None, None, None, None)
             .await
             .unwrap();
         for id in [1, 2, 3] {
@@ -755,7 +755,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&watermarks))
+        let sets = fresh_tier_block_list(&sources, None, None, None, Some(&watermarks))
             .await
             .unwrap();
         assert!(blocks(&sets, 1).await); // gen 1, whole
@@ -806,7 +806,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&at))
+        let sets = fresh_tier_block_list(&sources, None, None, None, Some(&at))
             .await
             .unwrap();
         assert!(!blocks(&sets, 5).await);
@@ -821,7 +821,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&above))
+        let sets = fresh_tier_block_list(&sources, None, None, None, Some(&above))
             .await
             .unwrap();
         assert!(blocks(&sets, 5).await);

--- a/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
@@ -37,6 +37,7 @@ use crate::dataset::mem_wal::index::encode_pk_tuple;
 use crate::dataset::mem_wal::util::PK_INDEX_DIR;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// Default-plugin registry, used only to load the standalone PK BTree by its
 /// `BTreeIndexDetails` type. Built once.
@@ -157,6 +158,7 @@ type ShardGenSets = HashMap<Uuid, Vec<(LsmGeneration, GenMembership)>>;
 pub async fn compute_source_block_lists(
     sources: &[LsmDataSource],
     session: Option<&Arc<Session>>,
+    store_params: Option<&ObjectStoreParams>,
     flushed_cache: Option<&Arc<dyn DatasetCache>>,
 ) -> Result<SourceBlockLists> {
     // Membership per non-base source, grouped by shard (generations are
@@ -188,7 +190,7 @@ pub async fn compute_source_block_lists(
                 generation,
                 ..
             } => flushed_loads.push(async move {
-                let index = open_pk_index(path, session, flushed_cache).await?;
+                let index = open_pk_index(path, session, store_params, flushed_cache).await?;
                 Ok::<_, Error>((*shard_id, *generation, GenMembership::OnDisk(index)))
             }),
         }
@@ -238,6 +240,7 @@ pub async fn compute_source_block_lists(
 pub async fn fresh_tier_block_list(
     sources: &[LsmDataSource],
     session: Option<&Arc<Session>>,
+    store_params: Option<&ObjectStoreParams>,
     flushed_cache: Option<&Arc<dyn DatasetCache>>,
     watermarks: Option<&HashMap<Uuid, FreshTierWatermark>>,
 ) -> Result<Vec<GenMembership>> {
@@ -299,7 +302,8 @@ pub async fn fresh_tier_block_list(
                     let slot = slots.len();
                     slots.push(None);
                     flushed_loads.push(async move {
-                        let index = open_pk_index(path, session, flushed_cache).await?;
+                        let index =
+                            open_pk_index(path, session, store_params, flushed_cache).await?;
                         Ok::<_, Error>((slot, GenMembership::OnDisk(index)))
                     });
                 }
@@ -379,9 +383,10 @@ fn path_cache_uuid(path: &str) -> Uuid {
 async fn open_pk_index(
     path: &str,
     session: Option<&Arc<Session>>,
+    store_params: Option<&ObjectStoreParams>,
     flushed_cache: Option<&Arc<dyn DatasetCache>>,
 ) -> Result<Arc<dyn ScalarIndex>> {
-    let dataset = open_flushed_dataset(path, session, flushed_cache, None).await?;
+    let dataset = open_flushed_dataset(path, session, store_params, flushed_cache, None).await?;
     // Namespace the session index cache by the (immutable) flushed path so this
     // sidecar's pages live alongside every other index instead of a bespoke
     // cache. `fri_uuid` is None — flushed generations carry no fragment-reuse.
@@ -534,7 +539,7 @@ mod tests {
             active_source(shard, 1, &[3]),
         ];
 
-        let memberships = fresh_tier_block_list(&sources, None, None, None)
+        let memberships = fresh_tier_block_list(&sources, None, None, None,None)
             .await
             .unwrap();
 
@@ -555,7 +560,7 @@ mod tests {
             active_source(shard, 2, &[1, 2]),
         ];
 
-        let blocked = Box::pin(compute_source_block_lists(&sources, None, None))
+        let blocked = Box::pin(compute_source_block_lists(&sources, None, None, None))
             .await
             .unwrap();
 
@@ -591,7 +596,7 @@ mod tests {
             active_source(Uuid::new_v4(), 1, &[1, 2]),
         ];
 
-        let blocked = Box::pin(compute_source_block_lists(&sources, None, None))
+        let blocked = Box::pin(compute_source_block_lists(&sources, None, None, None))
             .await
             .unwrap();
 
@@ -619,7 +624,7 @@ mod tests {
             active_source(b, 2, &[2]),
         ];
 
-        let blocked = Box::pin(compute_source_block_lists(&sources, None, None))
+        let blocked = Box::pin(compute_source_block_lists(&sources, None, None, None))
             .await
             .unwrap();
 
@@ -670,7 +675,7 @@ mod tests {
             generation: LsmGeneration::memtable(2),
         };
 
-        let blocked = Box::pin(compute_source_block_lists(&[g1, g2], None, None))
+        let blocked = Box::pin(compute_source_block_lists(&[g1, g2], None, None, None))
             .await
             .unwrap();
 
@@ -708,7 +713,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, Some(&watermarks))
+        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&watermarks))
             .await
             .unwrap();
         assert!(blocks(&sets, 1).await);
@@ -716,7 +721,7 @@ mod tests {
         assert!(!blocks(&sets, 3).await);
 
         // No watermark → live tier: all three are members.
-        let sets = fresh_tier_block_list(&sources, None, None, None)
+        let sets = fresh_tier_block_list(&sources, None, None, None,None)
             .await
             .unwrap();
         for id in [1, 2, 3] {
@@ -750,7 +755,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, Some(&watermarks))
+        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&watermarks))
             .await
             .unwrap();
         assert!(blocks(&sets, 1).await); // gen 1, whole
@@ -801,7 +806,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, Some(&at))
+        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&at))
             .await
             .unwrap();
         assert!(!blocks(&sets, 5).await);
@@ -816,7 +821,7 @@ mod tests {
         )]
         .into_iter()
         .collect();
-        let sets = fresh_tier_block_list(&sources, None, None, Some(&above))
+        let sets = fresh_tier_block_list(&sources, None, None, None,Some(&above))
             .await
             .unwrap();
         assert!(blocks(&sets, 5).await);

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -350,8 +350,13 @@ impl LsmScanner {
 
     /// Set the store params used to open flushed generations. Defaults to the
     /// base table's; set explicitly on a fresh-tier-only scanner (no base table).
+    ///
+    /// Pass the params the *base* was opened with. As in [`Self::new`], they are
+    /// adapted for generation URIs: a path-bound `object_store` binding would
+    /// redirect every generation open at the base table itself, so it is dropped
+    /// while storage options, wrapper, and credentials carry over.
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
-        self.store_params = Some(store_params);
+        self.store_params = Some(derived_store_params(&store_params));
         self
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -31,6 +31,7 @@ use super::point_lookup::LsmPointLookupPlanner;
 use super::projection::validate_projection_names;
 use crate::dataset::Dataset;
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// Vector (KNN) search state, set by [`LsmScanner::nearest`] and friends. Mirrors
 /// the subset of `lance::dataset::scanner::Query` the LSM vector planner honors.
@@ -210,6 +211,11 @@ pub struct LsmScanner {
     /// each generation populates the shared index / file-metadata caches.
     /// Defaults to the base table's session when one is present.
     session: Option<Arc<Session>>,
+    /// Store params threaded into flushed-generation opens so they reuse the
+    /// base's store — including the refreshing accessor for a federated
+    /// (namespace-backed) table — rather than resolving an ambient one.
+    /// Defaults to the base table's params when one is present.
+    store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets. When set, repeated
     /// queries against the same generation skip the manifest read entirely.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
@@ -239,6 +245,7 @@ impl LsmScanner {
         // the shared index / metadata caches without extra wiring. An
         // explicit `with_session` still overrides this.
         let session = Some(base_table.session());
+        let store_params = base_table.store_params().cloned();
         Self {
             base: BaseSource::Table(base_table),
             schema: Arc::new(arrow_schema),
@@ -254,6 +261,7 @@ impl LsmScanner {
             with_memtable_gen: false,
             pk_columns,
             session,
+            store_params,
             flushed_cache: None,
             warmer: None,
             overfetch_factor: None,
@@ -296,6 +304,7 @@ impl LsmScanner {
             with_memtable_gen: false,
             pk_columns,
             session: None,
+            store_params: None,
             flushed_cache: None,
             warmer: None,
             overfetch_factor: None,
@@ -340,6 +349,15 @@ impl LsmScanner {
     /// long-lived session).
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
+        self
+    }
+
+    /// Thread the base dataset's store params into flushed-generation opens so
+    /// they reuse the base's store (federated: the refreshing accessor). When a
+    /// base table is configured this defaults to its params; call this on a
+    /// fresh-tier-only scanner (no base table) to inject them explicitly.
+    pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
+        self.store_params = Some(store_params);
         self
     }
 
@@ -564,6 +582,9 @@ impl LsmScanner {
         if let Some(session) = &self.session {
             planner = planner.with_session(session.clone());
         }
+        if let Some(store_params) = &self.store_params {
+            planner = planner.with_store_params(store_params.clone());
+        }
         if let Some(cache) = &self.flushed_cache {
             planner = planner.with_flushed_cache(cache.clone());
         }
@@ -640,6 +661,9 @@ impl LsmScanner {
         if let Some(session) = &self.session {
             planner = planner.with_session(session.clone());
         }
+        if let Some(store_params) = &self.store_params {
+            planner = planner.with_store_params(store_params.clone());
+        }
         if let Some(cache) = &self.flushed_cache {
             planner = planner.with_flushed_cache(cache.clone());
         }
@@ -685,6 +709,9 @@ impl LsmScanner {
             if let Some(session) = &self.session {
                 planner = planner.with_session(session.clone());
             }
+            if let Some(store_params) = &self.store_params {
+                planner = planner.with_store_params(store_params.clone());
+            }
             if let Some(cache) = &self.flushed_cache {
                 planner = planner.with_flushed_cache(cache.clone());
             }
@@ -703,6 +730,9 @@ impl LsmScanner {
         let mut planner = LsmScanPlanner::new(collector, self.pk_columns.clone(), base_schema);
         if let Some(session) = &self.session {
             planner = planner.with_session(session.clone());
+        }
+        if let Some(store_params) = &self.store_params {
+            planner = planner.with_store_params(store_params.clone());
         }
         if let Some(cache) = &self.flushed_cache {
             planner = planner.with_flushed_cache(cache.clone());
@@ -802,6 +832,7 @@ impl LsmScanner {
         let memberships = super::block_list::fresh_tier_block_list(
             &sources,
             self.session.as_ref(),
+            self.store_params.as_ref(),
             self.flushed_cache.as_ref(),
             watermarks,
         )

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -207,14 +207,11 @@ pub struct LsmScanner {
     // Primary key columns (required for deduplication)
     pk_columns: Vec<String>,
 
-    /// Session threaded into flushed-generation opens so the first open of
-    /// each generation populates the shared index / file-metadata caches.
-    /// Defaults to the base table's session when one is present.
+    /// Session for opening flushed generations (shares the base's caches).
+    /// Defaults to the base table's session.
     session: Option<Arc<Session>>,
-    /// Store params threaded into flushed-generation opens so they reuse the
-    /// base's store — including the refreshing accessor for a federated
-    /// (namespace-backed) table — rather than resolving an ambient one.
-    /// Defaults to the base table's params when one is present.
+    /// Store params for opening flushed generations, reusing the base dataset's
+    /// store. Defaults to the base table's params.
     store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets. When set, repeated
     /// queries against the same generation skip the manifest read entirely.
@@ -340,22 +337,15 @@ impl LsmScanner {
         self
     }
 
-    /// Thread an existing session into flushed-generation opens.
-    ///
-    /// The first open of each flushed generation then populates the shared
-    /// index / file-metadata caches, so later queries skip re-decoding them.
-    /// When a base table is configured this defaults to its session; call
-    /// this to override (e.g. on a fresh-tier-only scanner that owns its own
-    /// long-lived session).
+    /// Set the session used to open flushed generations. Defaults to the base
+    /// table's; set explicitly on a fresh-tier-only scanner (no base table).
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
         self
     }
 
-    /// Thread the base dataset's store params into flushed-generation opens so
-    /// they reuse the base's store (federated: the refreshing accessor). When a
-    /// base table is configured this defaults to its params; call this on a
-    /// fresh-tier-only scanner (no base table) to inject them explicitly.
+    /// Set the store params used to open flushed generations. Defaults to the
+    /// base table's; set explicitly on a fresh-tier-only scanner (no base table).
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
         self.store_params = Some(store_params);
         self

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -30,6 +30,7 @@ use super::planner::LsmScanPlanner;
 use super::point_lookup::LsmPointLookupPlanner;
 use super::projection::validate_projection_names;
 use crate::dataset::Dataset;
+use crate::dataset::mem_wal::util::derived_store_params;
 use crate::session::Session;
 use lance_io::object_store::ObjectStoreParams;
 
@@ -242,7 +243,10 @@ impl LsmScanner {
         // the shared index / metadata caches without extra wiring. An
         // explicit `with_session` still overrides this.
         let session = Some(base_table.session());
-        let store_params = base_table.store_params().cloned();
+        // The scanner only ever opens flushed generations with these — the base
+        // table is already open and handed in — so they must not carry a
+        // path-bound store binding.
+        let store_params = base_table.store_params().map(derived_store_params);
         Self {
             base: BaseSource::Table(base_table),
             schema: Arc::new(arrow_schema),

--- a/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
@@ -344,8 +344,12 @@ mod tests {
         let uri = format!("{}/gen_1", temp_dir.path().to_str().unwrap());
         write_dataset(&uri, &[7, 8, 9]).await;
 
-        let a = open_flushed_dataset(&uri, None, None,None, None).await.unwrap();
-        let b = open_flushed_dataset(&uri, None, None,None, None).await.unwrap();
+        let a = open_flushed_dataset(&uri, None, None, None, None)
+            .await
+            .unwrap();
+        let b = open_flushed_dataset(&uri, None, None, None, None)
+            .await
+            .unwrap();
         assert!(
             !Arc::ptr_eq(&a, &b),
             "no-cache path must cold-open each call"
@@ -354,10 +358,10 @@ mod tests {
 
         // With a cache, the second call is a shared clone.
         let cache: Arc<dyn DatasetCache> = Arc::new(FlushedMemTableCache::new(8));
-        let c = open_flushed_dataset(&uri, None, None,Some(&cache), None)
+        let c = open_flushed_dataset(&uri, None, None, Some(&cache), None)
             .await
             .unwrap();
-        let d = open_flushed_dataset(&uri, None, None,Some(&cache), None)
+        let d = open_flushed_dataset(&uri, None, None, Some(&cache), None)
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&c, &d), "cached path must reuse the Arc");
@@ -395,7 +399,7 @@ mod tests {
             notify: notify.clone(),
         });
 
-        let ds = open_flushed_dataset(&uri, None, None,None, Some(&warmer))
+        let ds = open_flushed_dataset(&uri, None, None, None, Some(&warmer))
             .await
             .unwrap();
         assert_eq!(ds.count_rows(None).await.unwrap(), 3);

--- a/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
@@ -67,12 +67,9 @@ impl FlushedMemTableCache {
     }
 
     /// Get the dataset for `path`, opening it (exactly once) on a miss.
-    ///
-    /// `session` is threaded into the open so the first open populates the
-    /// shared index / file-metadata caches; subsequent hits are a pure
-    /// `Arc::clone` with zero object-store I/O. Concurrent callers for the
-    /// same path share a single open via `moka`'s single-flight
-    /// `try_get_with`.
+    /// Concurrent callers share a single open via `moka`'s single-flight
+    /// `try_get_with`; hits are a pure `Arc::clone`. `session` / `store_params`
+    /// configure the open.
     pub async fn get_or_open(
         &self,
         path: &str,

--- a/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
@@ -40,6 +40,15 @@ use crate::session::Session;
 /// The key is the resolved absolute flushed path
 /// (`{base}/_mem_wal/{shard}/{folder}`), which is globally unique, so a single
 /// cache can safely span multiple tables.
+///
+/// `store_params` is deliberately *not* part of the key: the first caller to
+/// open a path binds the store that every later hit reuses. Credential rotation
+/// still works — a vended-credential store holds the live
+/// `StorageOptionsAccessor` and re-resolves per request, so a cached handle
+/// never carries expired credentials. What this does assume is that a given
+/// path is only ever served under one store configuration. Serving one table
+/// through a single cache under two different `ObjectStoreParams` would hand
+/// every caller the store the first one opened with.
 pub struct FlushedMemTableCache {
     // `moka`'s async cache gives a bounded size plus single-flight
     // `try_get_with`, so concurrent first-queries on a just-flushed

--- a/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/flushed_cache.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use lance_core::{Error, Result};
+use lance_io::object_store::ObjectStoreParams;
 
 use crate::dataset::{Dataset, DatasetBuilder};
 use crate::session::Session;
@@ -76,12 +77,16 @@ impl FlushedMemTableCache {
         &self,
         path: &str,
         session: Option<Arc<Session>>,
+        store_params: Option<ObjectStoreParams>,
     ) -> Result<Arc<Dataset>> {
         self.inner
             .try_get_with(path.to_string(), async move {
                 let mut builder = DatasetBuilder::from_uri(path);
                 if let Some(session) = session {
                     builder = builder.with_session(session);
+                }
+                if let Some(store_params) = store_params {
+                    builder = builder.with_store_params(store_params);
                 }
                 builder.load().await.map(Arc::new)
             })
@@ -125,7 +130,12 @@ impl std::fmt::Debug for FlushedMemTableCache {
 /// supply its own implementation.
 #[async_trait]
 pub trait DatasetCache: Send + Sync + std::fmt::Debug {
-    async fn get_or_open(&self, path: &str, session: Option<Arc<Session>>) -> Result<Arc<Dataset>>;
+    async fn get_or_open(
+        &self,
+        path: &str,
+        session: Option<Arc<Session>>,
+        store_params: Option<ObjectStoreParams>,
+    ) -> Result<Arc<Dataset>>;
 
     /// Drop cached entries whose path is not in `live_paths`. Async so an
     /// implementation can evict retired generations' index objects (e.g.
@@ -136,8 +146,13 @@ pub trait DatasetCache: Send + Sync + std::fmt::Debug {
 
 #[async_trait]
 impl DatasetCache for FlushedMemTableCache {
-    async fn get_or_open(&self, path: &str, session: Option<Arc<Session>>) -> Result<Arc<Dataset>> {
-        Self::get_or_open(self, path, session).await
+    async fn get_or_open(
+        &self,
+        path: &str,
+        session: Option<Arc<Session>>,
+        store_params: Option<ObjectStoreParams>,
+    ) -> Result<Arc<Dataset>> {
+        Self::get_or_open(self, path, session, store_params).await
     }
 
     async fn retain_paths(&self, live_paths: &HashSet<String>) {
@@ -179,15 +194,23 @@ pub trait GenerationWarmer: Send + Sync + std::fmt::Debug {
 pub async fn open_flushed_dataset(
     path: &str,
     session: Option<&Arc<Session>>,
+    store_params: Option<&ObjectStoreParams>,
     cache: Option<&Arc<dyn DatasetCache>>,
     warmer: Option<&Arc<dyn GenerationWarmer>>,
 ) -> Result<Arc<Dataset>> {
     let dataset = match cache {
-        Some(cache) => cache.get_or_open(path, session.cloned()).await?,
+        Some(cache) => {
+            cache
+                .get_or_open(path, session.cloned(), store_params.cloned())
+                .await?
+        }
         None => {
             let mut builder = DatasetBuilder::from_uri(path);
             if let Some(session) = session {
                 builder = builder.with_session(session.clone());
+            }
+            if let Some(store_params) = store_params {
+                builder = builder.with_store_params(store_params.clone());
             }
             Arc::new(builder.load().await?)
         }
@@ -239,8 +262,8 @@ mod tests {
         write_dataset(&uri, &[1, 2, 3]).await;
 
         let cache = FlushedMemTableCache::new(8);
-        let first = cache.get_or_open(&uri, None).await.unwrap();
-        let second = cache.get_or_open(&uri, None).await.unwrap();
+        let first = cache.get_or_open(&uri, None, None).await.unwrap();
+        let second = cache.get_or_open(&uri, None, None).await.unwrap();
 
         assert!(
             Arc::ptr_eq(&first, &second),
@@ -271,7 +294,7 @@ mod tests {
             let calls = calls.clone();
             handles.push(tokio::spawn(async move {
                 calls.fetch_add(1, Ordering::SeqCst);
-                cache.get_or_open(&uri, None).await.unwrap()
+                cache.get_or_open(&uri, None, None).await.unwrap()
             }));
         }
 
@@ -299,8 +322,8 @@ mod tests {
         write_dataset(&drop_uri, &[2]).await;
 
         let cache = FlushedMemTableCache::new(8);
-        cache.get_or_open(&keep_uri, None).await.unwrap();
-        cache.get_or_open(&drop_uri, None).await.unwrap();
+        cache.get_or_open(&keep_uri, None, None).await.unwrap();
+        cache.get_or_open(&drop_uri, None, None).await.unwrap();
         cache.inner.run_pending_tasks().await;
         assert_eq!(cache.inner.entry_count(), 2);
 
@@ -321,8 +344,8 @@ mod tests {
         let uri = format!("{}/gen_1", temp_dir.path().to_str().unwrap());
         write_dataset(&uri, &[7, 8, 9]).await;
 
-        let a = open_flushed_dataset(&uri, None, None, None).await.unwrap();
-        let b = open_flushed_dataset(&uri, None, None, None).await.unwrap();
+        let a = open_flushed_dataset(&uri, None, None,None, None).await.unwrap();
+        let b = open_flushed_dataset(&uri, None, None,None, None).await.unwrap();
         assert!(
             !Arc::ptr_eq(&a, &b),
             "no-cache path must cold-open each call"
@@ -331,10 +354,10 @@ mod tests {
 
         // With a cache, the second call is a shared clone.
         let cache: Arc<dyn DatasetCache> = Arc::new(FlushedMemTableCache::new(8));
-        let c = open_flushed_dataset(&uri, None, Some(&cache), None)
+        let c = open_flushed_dataset(&uri, None, None,Some(&cache), None)
             .await
             .unwrap();
-        let d = open_flushed_dataset(&uri, None, Some(&cache), None)
+        let d = open_flushed_dataset(&uri, None, None,Some(&cache), None)
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&c, &d), "cached path must reuse the Arc");
@@ -372,7 +395,7 @@ mod tests {
             notify: notify.clone(),
         });
 
-        let ds = open_flushed_dataset(&uri, None, None, Some(&warmer))
+        let ds = open_flushed_dataset(&uri, None, None,None, Some(&warmer))
             .await
             .unwrap();
         assert_eq!(ds.count_rows(None).await.unwrap(), 3);

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -58,6 +58,7 @@ use super::flushed_cache::{DatasetCache, GenerationWarmer, open_flushed_dataset}
 use super::projection::{project_to_canonical, validate_projection_names};
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// `_score` column name in FTS results — kept aligned with
 /// `lance_index::scalar::inverted::SCORE_COL` so this module doesn't
@@ -111,6 +112,9 @@ pub struct LsmFtsSearchPlanner {
     base_schema: SchemaRef,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
+    /// Store params threaded into flushed-generation opens (federated: the
+    /// refreshing accessor) so they reuse the base's store.
+    store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
@@ -135,6 +139,7 @@ impl LsmFtsSearchPlanner {
             pk_columns,
             base_schema,
             session: None,
+            store_params: None,
             flushed_cache: None,
             warmer: None,
             overfetch_factor: DEFAULT_OVERFETCH_FACTOR,
@@ -162,6 +167,13 @@ impl LsmFtsSearchPlanner {
     /// populates the shared index / file-metadata caches.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
+        self
+    }
+
+    /// Thread the base dataset's store params into flushed-generation opens
+    /// (federated: the refreshing accessor) so they reuse the base's store.
+    pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
+        self.store_params = Some(store_params);
         self
     }
 
@@ -228,6 +240,7 @@ impl LsmFtsSearchPlanner {
         let block_lists = Box::pin(compute_source_block_lists(
             &sources,
             self.session.as_ref(),
+            self.store_params.as_ref(),
             self.flushed_cache.as_ref(),
         ))
         .await?;
@@ -374,6 +387,7 @@ impl LsmFtsSearchPlanner {
                 let dataset = open_flushed_dataset(
                     path,
                     self.session.as_ref(),
+                    self.store_params.as_ref(),
                     self.flushed_cache.as_ref(),
                     self.warmer.as_ref(),
                 )

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -112,8 +112,7 @@ pub struct LsmFtsSearchPlanner {
     base_schema: SchemaRef,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
-    /// Store params threaded into flushed-generation opens (federated: the
-    /// refreshing accessor) so they reuse the base's store.
+    /// Store params for opening flushed generations, reusing the base dataset's store.
     store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
@@ -163,15 +162,13 @@ impl LsmFtsSearchPlanner {
         self
     }
 
-    /// Thread a session into flushed-generation opens so the first open
-    /// populates the shared index / file-metadata caches.
+    /// Set the session used to open flushed generations.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
         self
     }
 
-    /// Thread the base dataset's store params into flushed-generation opens
-    /// (federated: the refreshing accessor) so they reuse the base's store.
+    /// Set the store params used to open flushed generations.
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
         self.store_params = Some(store_params);
         self

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -47,9 +47,7 @@ pub struct LsmScanPlanner {
     base_schema: SchemaRef,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
-    /// Store params threaded into flushed-generation opens so they reuse the
-    /// base's store — including the refreshing credential accessor for a
-    /// federated (namespace-backed) table — instead of resolving an ambient one.
+    /// Store params for opening flushed generations, reusing the base dataset's store.
     store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
@@ -89,16 +87,13 @@ impl LsmScanPlanner {
         }
     }
 
-    /// Thread a session into flushed-generation opens so the first open
-    /// populates the shared index / file-metadata caches.
+    /// Set the session used to open flushed generations.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
         self
     }
 
-    /// Thread the base dataset's store params into flushed-generation opens so
-    /// they reuse the base's store (federated: the refreshing accessor) rather
-    /// than resolving an ambient one.
+    /// Set the store params used to open flushed generations.
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
         self.store_params = Some(store_params);
         self

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -24,6 +24,7 @@ use super::projection::{
     validate_projection_names,
 };
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// Combine the user filter (if any) with `NOT _tombstone` so tombstone rows are
 /// dropped from a WAL-arm scan. Used only for sources whose schema carries the
@@ -46,6 +47,10 @@ pub struct LsmScanPlanner {
     base_schema: SchemaRef,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
+    /// Store params threaded into flushed-generation opens so they reuse the
+    /// base's store — including the refreshing credential accessor for a
+    /// federated (namespace-backed) table — instead of resolving an ambient one.
+    store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
@@ -77,6 +82,7 @@ impl LsmScanPlanner {
             pk_columns,
             base_schema,
             session: None,
+            store_params: None,
             flushed_cache: None,
             warmer: None,
             overfetch_factor: 1.0,
@@ -87,6 +93,14 @@ impl LsmScanPlanner {
     /// populates the shared index / file-metadata caches.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
+        self
+    }
+
+    /// Thread the base dataset's store params into flushed-generation opens so
+    /// they reuse the base's store (federated: the refreshing accessor) rather
+    /// than resolving an ambient one.
+    pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
+        self.store_params = Some(store_params);
         self
     }
 
@@ -167,6 +181,7 @@ impl LsmScanPlanner {
         let block_lists = Box::pin(super::block_list::compute_source_block_lists(
             &sources,
             self.session.as_ref(),
+            self.store_params.as_ref(),
             self.flushed_cache.as_ref(),
         ))
         .await?;
@@ -342,6 +357,7 @@ impl LsmScanPlanner {
                 let dataset = open_flushed_dataset(
                     path,
                     self.session.as_ref(),
+                    self.store_params.as_ref(),
                     self.flushed_cache.as_ref(),
                     self.warmer.as_ref(),
                 )

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -90,8 +90,7 @@ pub struct LsmPointLookupPlanner {
     bloom_filters: std::collections::HashMap<u64, Arc<Sbbf>>,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
-    /// Store params threaded into flushed-generation opens (federated: the
-    /// refreshing accessor) so they reuse the base's store.
+    /// Store params for opening flushed generations, reusing the base dataset's store.
     store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
@@ -136,15 +135,13 @@ impl LsmPointLookupPlanner {
         }
     }
 
-    /// Thread a session into flushed-generation opens so the first open
-    /// populates the shared index / file-metadata caches.
+    /// Set the session used to open flushed generations.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
         self
     }
 
-    /// Thread the base dataset's store params into flushed-generation opens
-    /// (federated: the refreshing accessor) so they reuse the base's store.
+    /// Set the store params used to open flushed generations.
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
         self.store_params = Some(store_params);
         self

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -40,6 +40,7 @@ use super::projection::{
     project_to_canonical, validate_projection_names, wants_row_address, wants_row_id,
 };
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// Plans point lookup queries over LSM data.
 ///
@@ -89,6 +90,9 @@ pub struct LsmPointLookupPlanner {
     bloom_filters: std::collections::HashMap<u64, Arc<Sbbf>>,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
+    /// Store params threaded into flushed-generation opens (federated: the
+    /// refreshing accessor) so they reuse the base's store.
+    store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
@@ -124,6 +128,7 @@ impl LsmPointLookupPlanner {
             base_schema,
             bloom_filters: std::collections::HashMap::new(),
             session: None,
+            store_params: None,
             flushed_cache: None,
             warmer: None,
             none_target,
@@ -135,6 +140,13 @@ impl LsmPointLookupPlanner {
     /// populates the shared index / file-metadata caches.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
+        self
+    }
+
+    /// Thread the base dataset's store params into flushed-generation opens
+    /// (federated: the refreshing accessor) so they reuse the base's store.
+    pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
+        self.store_params = Some(store_params);
         self
     }
 
@@ -651,6 +663,7 @@ impl LsmPointLookupPlanner {
                 let dataset = open_flushed_dataset(
                     path,
                     self.session.as_ref(),
+                    self.store_params.as_ref(),
                     self.flushed_cache.as_ref(),
                     self.warmer.as_ref(),
                 )

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -34,6 +34,7 @@ use super::projection::{
     project_to_canonical, validate_projection_names, wants_row_id,
 };
 use crate::session::Session;
+use lance_io::object_store::ObjectStoreParams;
 
 /// Plans vector search queries over LSM data.
 ///
@@ -91,6 +92,9 @@ pub struct LsmVectorSearchPlanner {
     dataset: Option<Arc<Dataset>>,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
+    /// Store params threaded into flushed-generation opens (federated: the
+    /// refreshing accessor) so they reuse the base's store.
+    store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
@@ -127,6 +131,7 @@ impl LsmVectorSearchPlanner {
             distance_type,
             dataset: None,
             session: None,
+            store_params: None,
             flushed_cache: None,
             warmer: None,
             filter: None,
@@ -145,6 +150,13 @@ impl LsmVectorSearchPlanner {
     /// populates the shared index / file-metadata caches.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
+        self
+    }
+
+    /// Thread the base dataset's store params into flushed-generation opens
+    /// (federated: the refreshing accessor) so they reuse the base's store.
+    pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
+        self.store_params = Some(store_params);
         self
     }
 
@@ -235,6 +247,7 @@ impl LsmVectorSearchPlanner {
         let block_lists = Box::pin(super::block_list::compute_source_block_lists(
             &sources,
             self.session.as_ref(),
+            self.store_params.as_ref(),
             self.flushed_cache.as_ref(),
         ))
         .await?;
@@ -446,6 +459,7 @@ impl LsmVectorSearchPlanner {
                 let dataset = open_flushed_dataset(
                     path,
                     self.session.as_ref(),
+                    self.store_params.as_ref(),
                     self.flushed_cache.as_ref(),
                     self.warmer.as_ref(),
                 )

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -92,8 +92,7 @@ pub struct LsmVectorSearchPlanner {
     dataset: Option<Arc<Dataset>>,
     /// Session threaded into flushed-generation opens (shared caches).
     session: Option<Arc<Session>>,
-    /// Store params threaded into flushed-generation opens (federated: the
-    /// refreshing accessor) so they reuse the base's store.
+    /// Store params for opening flushed generations, reusing the base dataset's store.
     store_params: Option<ObjectStoreParams>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<dyn DatasetCache>>,
@@ -146,15 +145,13 @@ impl LsmVectorSearchPlanner {
         self
     }
 
-    /// Thread a session into flushed-generation opens so the first open
-    /// populates the shared index / file-metadata caches.
+    /// Set the session used to open flushed generations.
     pub fn with_session(mut self, session: Arc<Session>) -> Self {
         self.session = Some(session);
         self
     }
 
-    /// Thread the base dataset's store params into flushed-generation opens
-    /// (federated: the refreshing accessor) so they reuse the base's store.
+    /// Set the store params used to open flushed generations.
     pub fn with_store_params(mut self, store_params: ObjectStoreParams) -> Self {
         self.store_params = Some(store_params);
         self

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Test-only object store that injects WAL-write failures, for exercising the
-//! WAL persistence-failure fencing path.
+//! Test-only object store that injects WAL-write failures (for the WAL
+//! persistence-failure fencing path) and records the paths it serves (for
+//! asserting which opens actually resolved through a given `ObjectStoreParams`).
 
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use bytes::Bytes;
@@ -33,6 +35,10 @@ pub struct FailControls {
     simulate_lost_ack: AtomicBool,
     /// WAL-entry `put_opts` attempts observed, for assertions.
     wal_put_attempts: AtomicUsize,
+    /// Every location written through this store.
+    put_paths: StdMutex<Vec<String>>,
+    /// Every location read through this store.
+    get_paths: StdMutex<Vec<String>>,
 }
 
 impl FailControls {
@@ -47,6 +53,26 @@ impl FailControls {
     }
     pub fn attempts(&self) -> usize {
         self.wal_put_attempts.load(Ordering::SeqCst)
+    }
+
+    /// Did any write land on a path containing `needle`? An open that resolved
+    /// its store from other params never reaches this store, so a `false` here
+    /// means the params under test did not reach that open.
+    pub fn wrote_under(&self, needle: &str) -> bool {
+        self.put_paths
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|p| p.contains(needle))
+    }
+
+    /// Did any read land on a path containing `needle`? See [`Self::wrote_under`].
+    pub fn read_under(&self, needle: &str) -> bool {
+        self.get_paths
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|p| p.contains(needle))
     }
 }
 
@@ -101,6 +127,11 @@ impl OSObjectStore for FailingObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> OSResult<PutResult> {
+        self.controls
+            .put_paths
+            .lock()
+            .unwrap()
+            .push(location.to_string());
         if Self::is_wal_entry(location) {
             self.controls
                 .wal_put_attempts
@@ -124,14 +155,30 @@ impl OSObjectStore for FailingObjectStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> OSResult<Box<dyn MultipartUpload>> {
+        // Data files (`*.lance`) are written multipart, not via `put_opts`.
+        self.controls
+            .put_paths
+            .lock()
+            .unwrap()
+            .push(location.to_string());
         self.inner.put_multipart_opts(location, opts).await
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        self.controls
+            .get_paths
+            .lock()
+            .unwrap()
+            .push(location.to_string());
         self.inner.get_opts(location, options).await
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+        self.controls
+            .get_paths
+            .lock()
+            .unwrap()
+            .push(location.to_string());
         self.inner.get_ranges(location, ranges).await
     }
 
@@ -167,9 +214,11 @@ impl OSObjectStore for FailingObjectStore {
     }
 }
 
-/// Build an in-memory `ObjectStore` whose WAL-entry writes can be failed on
-/// demand. Returns the store, its base path, and the shared controls.
-pub async fn failing_memory_store() -> (Arc<ObjectStore>, Path, Arc<FailControls>) {
+/// `ObjectStoreParams` carrying the observable store wrapper, plus the controls
+/// to drive and inspect it. Open a dataset with these and every store resolved
+/// *from these params* — the base and any derived URI they are threaded to —
+/// reports its traffic back through the controls.
+pub fn observable_store_params() -> (ObjectStoreParams, Arc<FailControls>) {
     let controls = Arc::new(FailControls::default());
     let params = ObjectStoreParams {
         object_store_wrapper: Some(Arc::new(FailingWrapper {
@@ -177,6 +226,13 @@ pub async fn failing_memory_store() -> (Arc<ObjectStore>, Path, Arc<FailControls
         })),
         ..Default::default()
     };
+    (params, controls)
+}
+
+/// Build an in-memory `ObjectStore` whose WAL-entry writes can be failed on
+/// demand. Returns the store, its base path, and the shared controls.
+pub async fn failing_memory_store() -> (Arc<ObjectStore>, Path, Arc<FailControls>) {
+    let (params, controls) = observable_store_params();
     let (store, base) = ObjectStore::from_uri_and_params(
         Arc::new(ObjectStoreRegistry::default()),
         "memory:///",

--- a/rust/lance/src/dataset/mem_wal/util.rs
+++ b/rust/lance/src/dataset/mem_wal/util.rs
@@ -142,7 +142,7 @@ pub fn parse_bit_reversed_filename(filename: &str) -> Option<u64> {
 /// else (storage options, wrapper, credentials, block size) still carries over.
 ///
 /// Only the base's *own* URI may reuse the params verbatim.
-pub fn derived_store_params(params: &ObjectStoreParams) -> ObjectStoreParams {
+pub(crate) fn derived_store_params(params: &ObjectStoreParams) -> ObjectStoreParams {
     #[allow(deprecated)]
     ObjectStoreParams {
         object_store: None,

--- a/rust/lance/src/dataset/mem_wal/util.rs
+++ b/rust/lance/src/dataset/mem_wal/util.rs
@@ -3,6 +3,7 @@
 
 //! Utility functions for MemWAL operations.
 
+use lance_io::object_store::ObjectStoreParams;
 use object_store::path::Path;
 use uuid::Uuid;
 
@@ -127,6 +128,26 @@ pub fn parse_bit_reversed_filename(filename: &str) -> Option<u64> {
     }
     let reversed = u64::from_str_radix(stem, 2).ok()?;
     Some(bit_reverse_u64(reversed))
+}
+
+/// Adapt the store params a base dataset was opened with for use on a URI
+/// *derived* from it (a flushed generation under `_mem_wal/`).
+///
+/// The deprecated `object_store` binding pins a store to one location: given
+/// `Some((store, url))`, both `ObjectStore::from_uri_and_params` and
+/// `DatasetBuilder::build_object_store` take the path from `url` and ignore the
+/// URI they were asked to open. Carried onto a generation URI it would silently
+/// redirect the open — and, on the flush path, the write — at the base table
+/// itself. Drop it so the generation URI resolves its own store; everything
+/// else (storage options, wrapper, credentials, block size) still carries over.
+///
+/// Only the base's *own* URI may reuse the params verbatim.
+pub fn derived_store_params(params: &ObjectStoreParams) -> ObjectStoreParams {
+    #[allow(deprecated)]
+    ObjectStoreParams {
+        object_store: None,
+        ..params.clone()
+    }
 }
 
 /// Path to the MemWAL root directory.
@@ -371,5 +392,41 @@ mod tests {
         let handle = tokio::spawn(async move { reader.await_value().await });
         drop(cell);
         assert_eq!(handle.await.unwrap(), None);
+    }
+
+    /// The path-bound store binding is the only thing dropped — credentials and
+    /// storage options must still reach the generation's store.
+    #[test]
+    fn test_derived_store_params_drops_only_the_path_bound_store() {
+        let accessor = lance_io::object_store::StorageOptionsAccessor::with_static_options(
+            std::collections::HashMap::from([("access_key_id".to_string(), "key".to_string())]),
+        );
+        #[allow(deprecated)]
+        let params = ObjectStoreParams {
+            object_store: Some((
+                std::sync::Arc::new(object_store::memory::InMemory::new()),
+                url::Url::parse("memory:///base").unwrap(),
+            )),
+            block_size: Some(1234),
+            storage_options_accessor: Some(std::sync::Arc::new(accessor)),
+            ..Default::default()
+        };
+
+        let derived = derived_store_params(&params);
+
+        #[allow(deprecated)]
+        {
+            assert!(
+                derived.object_store.is_none(),
+                "a store pinned to the base path must not be reused for a generation URI"
+            );
+        }
+        assert_eq!(derived.block_size, Some(1234));
+        assert_eq!(
+            derived
+                .storage_options()
+                .and_then(|o| o.get("access_key_id")),
+            Some(&"key".to_string()),
+        );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -251,8 +251,10 @@ pub struct ShardWriterConfig {
     /// WAL pod). Default: `None`.
     pub warmer: Option<Arc<dyn GenerationWarmer>>,
 
-    /// Store params for the flusher's derived-URI opens (base + generations),
-    /// reusing the base dataset's store. Injected by `mem_wal_writer`.
+    /// Store params the base dataset was opened with, reused for the flusher's
+    /// opens + writes (base + generations). Injected by `mem_wal_writer`; set
+    /// these to the params of the dataset at `base_uri`, not to params bound to
+    /// some other path — generation URIs are derived from them.
     /// Default: `None` (open by URI alone).
     pub store_params: Option<ObjectStoreParams>,
 
@@ -6755,5 +6757,103 @@ mod shard_writer_tests {
             .close()
             .await
             .expect("Failed to close new writer");
+    }
+
+    /// Regression: a base opened with a *path-bound* store binding (the
+    /// deprecated `ObjectStoreParams::object_store`) must still flush and read
+    /// generations at their own paths.
+    ///
+    /// The binding pins a store to one location, and both
+    /// `ObjectStore::from_uri_and_params` and `DatasetBuilder::build_object_store`
+    /// take the path from it while ignoring the URI they were handed. Reusing the
+    /// base's params verbatim therefore aimed every generation write and open at
+    /// the base table itself: the flush failed ("dataset already exists") and any
+    /// derived open returned base rows as generation rows.
+    #[tokio::test]
+    async fn test_flush_and_read_with_path_bound_object_store() {
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use futures::TryStreamExt;
+        use lance_io::object_store::ObjectStoreParams;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        let initial = create_test_batch(&schema, 0, 16, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+        dataset
+            .initialize_mem_wal()
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        // Re-bind the base to a store pinned at the base's own path — what
+        // `DatasetBuilder::with_object_store` leaves on an opened dataset.
+        #[allow(deprecated)]
+        let store_params = ObjectStoreParams {
+            object_store: Some((
+                Arc::new(object_store::local::LocalFileSystem::new()),
+                url::Url::parse(&uri).unwrap(),
+            )),
+            ..Default::default()
+        };
+        let dataset = dataset.with_object_store(dataset.object_store.clone(), Some(store_params));
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(shard_id, ShardWriterConfig::new(shard_id))
+            .await
+            .expect("Failed to create writer");
+        writer
+            .put(vec![create_test_batch(&schema, 1_000, 8, vector_dim)])
+            .await
+            .expect("Failed to write");
+        writer.force_seal_active().await.unwrap();
+        writer
+            .wait_for_flush_drain()
+            .await
+            .expect("flush must not be redirected at the base table");
+
+        let manifest = writer.manifest().await.unwrap().expect("manifest exists");
+        assert_eq!(manifest.flushed_generations.len(), 1);
+        let flushed = manifest.flushed_generations[0].clone();
+
+        // The generation landed under `_mem_wal/`, and the base table is untouched.
+        let gen_uri = format!("{}/_mem_wal/{}/{}", uri, shard_id, flushed.path);
+        let generation = Dataset::open(&gen_uri)
+            .await
+            .expect("generation must exist at its own path");
+        assert_eq!(generation.count_rows(None).await.unwrap(), 8);
+        let base = Dataset::open(&uri).await.unwrap();
+        assert_eq!(
+            base.count_rows(None).await.unwrap(),
+            16,
+            "the generation write must not land in the base table"
+        );
+
+        // The read path resolves the generation, not the base: 16 base + 8 flushed.
+        // Opening the base instead would dedup back down to 16 rows.
+        let snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(manifest.current_generation)
+            .with_flushed_generation(flushed.generation, flushed.path.clone());
+        let scanner = LsmScanner::new(Arc::new(dataset), vec![snapshot], vec!["id".to_string()]);
+        let rows: usize = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("scan must open the generation, not the base")
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum();
+        assert_eq!(rows, 24);
+
+        writer.close().await.unwrap();
     }
 }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -48,12 +48,12 @@ pub use super::wal::{WalEntry, WalEntryData, WalFlushFailure, WalFlushResult, Wa
 
 use super::memtable::flush::TriggerMemTableFlush;
 use super::scanner::GenerationWarmer;
-use crate::session::Session;
 use super::wal::{
     BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState,
     WalRetryConfig, WalTailer, empty_flush_result,
 };
 use super::{TOMBSTONE, schema_with_tombstone};
+use crate::session::Session;
 
 use super::manifest::ShardManifestStore;
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -251,15 +251,12 @@ pub struct ShardWriterConfig {
     /// WAL pod). Default: `None`.
     pub warmer: Option<Arc<dyn GenerationWarmer>>,
 
-    /// `ObjectStoreParams` the base dataset was opened with (endpoint / region /
-    /// vended-credential accessor). Injected by `mem_wal_writer` from the
-    /// dataset so the flusher's derived-URI opens (base + generations) reuse the
-    /// same store — instead of re-resolving an ambient one — matching the
-    /// ShardWriter's own store. Default: `None` (bare by-URI open).
+    /// Store params for the flusher's derived-URI opens (base + generations),
+    /// reusing the base dataset's store. Injected by `mem_wal_writer`.
+    /// Default: `None` (open by URI alone).
     pub store_params: Option<ObjectStoreParams>,
 
-    /// The dataset's shared `Session`, injected alongside `store_params` so the
-    /// flusher's opens hit the same store registry the base was resolved in.
+    /// Session for those opens, injected alongside `store_params`.
     /// Default: `None`.
     pub session: Option<Arc<Session>>,
 }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -6856,4 +6856,211 @@ mod shard_writer_tests {
 
         writer.close().await.unwrap();
     }
+
+    /// The store params a base was opened with must reach every *derived* open:
+    /// the flush that writes a generation and the scan that reads it back.
+    ///
+    /// This is the point of threading them at all. A namespace-vended store
+    /// exists only on the params (credentials, endpoint, wrapper), so a
+    /// generation resolved by URI alone would silently sign with the ambient
+    /// identity instead — succeeding against a local store and failing against
+    /// the vended one. Asserting on the *generation folder* rather than
+    /// `_mem_wal/` is what makes this bite: WAL entries are written through the
+    /// base dataset's own store, so they would show up here either way.
+    #[tokio::test]
+    async fn test_store_params_reach_generation_write_and_read() {
+        use crate::dataset::builder::DatasetBuilder;
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use crate::dataset::mem_wal::test_util::observable_store_params;
+        use futures::TryStreamExt;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        let initial = create_test_batch(&schema, 0, 16, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
+        Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        // Open the base through an observable store, exactly as a namespace
+        // client would hand in a vended-credential store.
+        let (store_params, controls) = observable_store_params();
+        let mut dataset = DatasetBuilder::from_uri(&uri)
+            .with_store_params(store_params)
+            .load()
+            .await
+            .expect("Failed to open dataset");
+        dataset
+            .initialize_mem_wal()
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(shard_id, ShardWriterConfig::new(shard_id))
+            .await
+            .expect("Failed to create writer");
+        writer
+            .put(vec![create_test_batch(&schema, 1_000, 8, vector_dim)])
+            .await
+            .expect("Failed to write");
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.expect("flush failed");
+
+        let manifest = writer.manifest().await.unwrap().expect("manifest exists");
+        assert_eq!(manifest.flushed_generations.len(), 1);
+        let flushed = manifest.flushed_generations[0].clone();
+
+        // The generation's own Lance manifest is the signal to key on. Keying on
+        // the generation folder alone would pass vacuously: sidecars like
+        // `{gen}/bloom_filter.bin` are written through the *base* dataset's
+        // store, which is observable no matter what the params do. And the
+        // fragments can't be used either — `ObjectStore::create` writes local
+        // files through `tokio::fs`, bypassing the object store entirely, so
+        // `{gen}/data/` never reaches a wrapper under `file://`. The manifest
+        // goes through `put_opts`, and only the flusher's `Dataset::write` /
+        // `open_generation` writes it — both of which must carry the params.
+        let gen_manifest = format!("{}/_versions", flushed.path);
+
+        assert!(
+            controls.wrote_under(&gen_manifest),
+            "the flush must write the generation through the base's store params, \
+             not a store resolved from the generation URI alone"
+        );
+
+        // And the read path must resolve the generation through them too.
+        let snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(manifest.current_generation)
+            .with_flushed_generation(flushed.generation, flushed.path.clone());
+        let scanner = LsmScanner::new(Arc::new(dataset), vec![snapshot], vec!["id".to_string()]);
+        let rows: usize = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("scan failed")
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum();
+        assert_eq!(rows, 24);
+
+        // Reads key on the data files, not the manifest: the flusher already
+        // pulled the generation's manifest into the shared session cache, so the
+        // scan's open serves it from memory and never touches the store. The
+        // fragments are read through it (reads have no local bypass), as is the
+        // generation's standalone PK index.
+        assert!(
+            controls.read_under(&format!("{}/data/", flushed.path)),
+            "the scan must read the generation through the base's store params"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// A fresh-tier-only scanner reaches its store params through
+    /// `with_store_params`, not `new()`, so the setter must strip the path-bound
+    /// store binding too. Left raw, it redirects the generation open at the base
+    /// table and the scan silently returns base rows as WAL rows.
+    #[tokio::test]
+    async fn test_fresh_tier_scan_with_path_bound_object_store() {
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use futures::TryStreamExt;
+        use lance_io::object_store::ObjectStoreParams;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        // 16 base rows with ids 0..16; the WAL gets 8 rows with ids 1000..1008,
+        // so a redirected generation open is unambiguous in the output.
+        let initial = create_test_batch(&schema, 0, 16, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+        dataset
+            .initialize_mem_wal()
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(shard_id, ShardWriterConfig::new(shard_id))
+            .await
+            .expect("Failed to create writer");
+        writer
+            .put(vec![create_test_batch(&schema, 1_000, 8, vector_dim)])
+            .await
+            .expect("Failed to write");
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.expect("flush failed");
+
+        let manifest = writer.manifest().await.unwrap().expect("manifest exists");
+        let flushed = manifest.flushed_generations[0].clone();
+        let snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(manifest.current_generation)
+            .with_flushed_generation(flushed.generation, flushed.path.clone());
+
+        // What `DatasetBuilder::with_object_store` leaves on an opened dataset:
+        // a store pinned at the base's own path.
+        #[allow(deprecated)]
+        let store_params = ObjectStoreParams {
+            object_store: Some((
+                Arc::new(object_store::local::LocalFileSystem::new()),
+                url::Url::parse(&uri).unwrap(),
+            )),
+            ..Default::default()
+        };
+
+        let arrow_schema: Arc<ArrowSchema> = schema.clone();
+        let batches = LsmScanner::without_base_table(
+            arrow_schema,
+            uri.clone(),
+            vec![snapshot],
+            vec!["id".to_string()],
+        )
+        .with_session(dataset.session())
+        .with_store_params(store_params)
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("scan must open the generation, not the base");
+
+        let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+        assert_eq!(
+            rows, 8,
+            "fresh tier holds only the 8 WAL rows; 16 means the generation open \
+             was redirected at the base table"
+        );
+        let ids: Vec<i64> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert!(
+            ids.iter().all(|id| (1_000..1_008).contains(id)),
+            "expected the WAL's own rows, got {ids:?}"
+        );
+
+        writer.close().await.unwrap();
+    }
 }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -25,7 +25,7 @@ use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
 use lance_index::mem_wal::ShardManifest;
 use lance_index::vector::hnsw::builder::HnswBuildParams;
-use lance_io::object_store::ObjectStore;
+use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use log::{debug, error, info, warn};
 use object_store::path::Path;
 use tokio::sync::{RwLock, mpsc};
@@ -48,6 +48,7 @@ pub use super::wal::{WalEntry, WalEntryData, WalFlushFailure, WalFlushResult, Wa
 
 use super::memtable::flush::TriggerMemTableFlush;
 use super::scanner::GenerationWarmer;
+use crate::session::Session;
 use super::wal::{
     BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState,
     WalRetryConfig, WalTailer, empty_flush_result,
@@ -249,6 +250,18 @@ pub struct ShardWriterConfig {
     /// on first query). Wired to the flusher; supplied by the consumer (e.g. the
     /// WAL pod). Default: `None`.
     pub warmer: Option<Arc<dyn GenerationWarmer>>,
+
+    /// `ObjectStoreParams` the base dataset was opened with (endpoint / region /
+    /// vended-credential accessor). Injected by `mem_wal_writer` from the
+    /// dataset so the flusher's derived-URI opens (base + generations) reuse the
+    /// same store — instead of re-resolving an ambient one — matching the
+    /// ShardWriter's own store. Default: `None` (bare by-URI open).
+    pub store_params: Option<ObjectStoreParams>,
+
+    /// The dataset's shared `Session`, injected alongside `store_params` so the
+    /// flusher's opens hit the same store registry the base was resolved in.
+    /// Default: `None`.
+    pub session: Option<Arc<Session>>,
 }
 
 impl Default for ShardWriterConfig {
@@ -275,6 +288,8 @@ impl Default for ShardWriterConfig {
             enable_memtable: true,
             hnsw_params: HashMap::new(),
             warmer: None,
+            store_params: None,
+            session: None,
         }
     }
 }
@@ -1533,7 +1548,8 @@ impl ShardWriter {
 
         let flusher = Arc::new(
             MemTableFlusher::new(object_store, base_path, base_uri, shard_id, manifest_store)
-                .with_warmer(config.warmer.clone()),
+                .with_warmer(config.warmer.clone())
+                .with_storage_context(config.store_params.clone(), config.session.clone()),
         );
 
         let backpressure = BackpressureController::new(config.clone());


### PR DESCRIPTION
## Summary

Threads `store_params` + `session` through the mem_wal write and fresh-tier read paths so WAL tables opened via a namespace client (with a refreshing credential accessor) resolve **every derived-URI open** to the same vended-credential store instead of ambient identity.

`Dataset` already stashes the options it was opened with — including the credential accessor — in its `store_params` field; this exposes that and reuses it everywhere mem_wal opens a derived URI (WAL log, generations, flushed datasets).

## What changed

- `Dataset::store_params()` accessor.
- `ShardWriterConfig` + `MemTableFlusher` carry `store_params` + `session`; the flusher's generation opens/writes use them (`open_derived`, `WriteParams`).
- `LsmScanner` + the four planners (scan / vector / fts / point-lookup) + `flushed_cache` + `block_list` thread `store_params` into flushed-generation opens.

All new fields default to `None`, so existing (ambient) callers and the ~dozen test sites are unaffected in behavior.

## Context

Enables federated (namespace-managed) WAL tables with **vended credentials** in the downstream sophon consumer (companion PR there). Without this, WAL writes/reads of derived URIs sign with ambient credentials and fail against per-table vended stores (e.g. MinIO / S3-compatible endpoints supplied per-request).

## Validation

503 mem_wal tests green; clippy clean. Exercised end-to-end against MinIO downstream (dir-namespace, vended creds, write → flush → compact → read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MemWAL flush/reopen behavior so scans, point lookups, vector search, full-text search, and index/cache warming consistently use the correct custom object-store configuration.
  * Fixed correctness issues where data and derived MemWAL generation datasets could be opened/written with an unintended storage binding.

* **Enhancements**
  * Added a public way to retrieve a dataset’s configured object-store parameters, enabling consistent reuse for derived paths and downstream operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->