### PR TITLE
fix: avoid panic when filtering on a nested Blob v2 extension field

### DIFF
--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -304,6 +304,7 @@ impl Field {
             !children.is_empty() // Some children were projected
                 || !projection.contains_field_id(self.id) // Caller is not asking for this field
                 || self.children.is_empty() // This isn't a nested field
+                || self.is_blob() // This is a blob field
         );
 
         if children.is_empty() && !projection.contains_field_id(self.id) {
@@ -311,7 +312,11 @@ impl Field {
         } else {
             let mut new_field = self.clone();
             new_field.children = children;
-            Some(projection.blob_handling.unload_if_needed(new_field))
+            let mut new_field = projection.blob_handling.unload_if_needed(new_field);
+            if new_field.is_blob() && new_field.children.is_empty() {
+                new_field.unloaded_mut();
+            }
+            Some(new_field)
         }
     }
 

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -1636,6 +1636,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn repro_nested_blob_v2_projection_panic() {
+        use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+        use lance_arrow::{ARROW_EXT_NAME_KEY, BLOB_V2_EXT_NAME};
+
+        // image: struct<image_bytes: extension<lance.blob.v2>, error: utf8>
+        let blob_meta: HashMap<String, String> =
+            [(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string())]
+                .into_iter()
+                .collect();
+        let image_bytes = ArrowField::new(
+            "image_bytes",
+            ArrowDataType::Struct(ArrowFields::from(vec![
+                ArrowField::new("data", ArrowDataType::LargeBinary, true),
+                ArrowField::new("uri", ArrowDataType::Utf8, true),
+            ])),
+            true,
+        )
+        .with_metadata(blob_meta);
+        let error = ArrowField::new("error", ArrowDataType::Utf8, true);
+        let image = ArrowField::new(
+            "image",
+            ArrowDataType::Struct(ArrowFields::from(vec![image_bytes, error])),
+            true,
+        );
+
+        let mut schema = Schema::try_from(&ArrowSchema::new(vec![image])).unwrap();
+        schema.set_field_id(None);
+        let base = Arc::new(schema);
+
+        // Mirrors Scanner::filtered_projection for `image.image_bytes IS NOT NULL`
+        let filter_schema = Projection::empty(base.clone())
+            .union_column("image.image_bytes", OnMissing::Error)
+            .unwrap()
+            .into_schema();
+        let scan_projection = Projection::empty(base.clone()).union_schema(&filter_schema);
+        let _read_schema = scan_projection.into_schema(); // panics in Field::apply_projection
+    }
+
+    #[test]
     fn test_resolve_with_quoted_fields() {
         // Create a schema with fields containing dots
         let field_with_dots = Field::try_from(&ArrowField::new(


### PR DESCRIPTION
### Summary
Fixes a Rust assertion panic in `Field::apply_projection` when a filter is applied on a nested Blob v2 extension field (e.g., `image.image_bytes IS NOT NULL`), resolving issue #7707.

### Root Cause
When a filter is applied to a Blob v2 field, the query filter is parsed and evaluated. The filter schema unloads the blob to read its metadata/description, replacing its physical child fields (e.g., `data`, `uri`) with descriptor children that have a field ID of `-1`. 

When this filter schema is unioned into the scan projection:
1. The physical child IDs of the blob are missing from the projection's selected `field_ids` set.
2. During the subsequent `Field::apply_projection` call on the base schema, the physical children are filtered out, leaving the projected children list empty.
3. This triggers a panic in the assertion `!children.is_empty() || !projection.contains_field_id(self.id) || self.children.is_empty()`.

### Changes
* **Bypass Assertion for Blobs**: Modified `Field::apply_projection` in `rust/lance-core/src/datatypes/field.rs` to allow blob fields to bypass the empty-children assertion since they can be dynamically unloaded.
* **Force Unloading to Descriptor View**: If a blob field's children list becomes empty during projection, we force-unload it using `unloaded_mut()`. This guarantees the field correctly holds descriptor children instead of an empty struct list.
* **Added Unit Test**: Added the unit test `repro_nested_blob_v2_projection_panic` in `rust/lance-core/src/datatypes/schema.rs` to prevent regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema projections involving nested blob fields that could previously trigger a panic.
  * Improved handling of projected blob fields when their contents are unloaded.

* **Tests**
  * Added regression coverage for nested blob field projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->