### PR TITLE
Lazy page metadata init

### DIFF
--- a/python/src/tracing.rs
+++ b/python/src/tracing.rs
@@ -248,7 +248,13 @@ impl tracing_subscriber::Layer<Registry> for LoggingPassthroughRef {
 
         let mut fields = EventToStr::default();
         event.record(&mut fields);
-        log::log!(target: "lance::events", state.level, "target=\"{}\" {}", event.metadata().target(), fields.str);
+        // Forward the event under its real tracing target (e.g. `lance::file_audit`,
+        // `lance::dataset::cleanup`) rather than a single fixed `lance::events` target.
+        // env_logger only filters by the log record's target, so preserving it lets
+        // `LANCE_LOG` directives target specific event families (e.g. silencing the
+        // high-volume per-file `lance::file_audit` events while keeping other INFO logs).
+        let event_target = event.metadata().target();
+        log::log!(target: event_target, state.level, "target=\"{}\" {}", event_target, fields.str);
 
         if let Some(callback_sender) = state.callback_sender.as_ref() {
             let mut args = EventToMap::default();

--- a/rust/arrow-scalar/Cargo.toml
+++ b/rust/arrow-scalar/Cargo.toml
@@ -9,7 +9,6 @@ description = "Arrow scalar type with Ord, Hash, and Eq support"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
-readme = "README.md"
 
 [dependencies]
 # Note: this is a core crate and we should aim to keep this dependency list

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -521,6 +521,7 @@ fn bench_decode_compressed_parallel(c: &mut Criterion) {
                                 cache,
                                 &filter,
                                 &DecoderConfig::default(),
+                                None,
                             )
                             .await
                             .unwrap();

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1013,6 +1013,7 @@ impl DecodeBatchScheduler {
         cache: Arc<LanceCache>,
         filter: &FilterExpression,
         decoder_config: &DecoderConfig,
+        init_ranges: Option<&[Range<u64>]>,
     ) -> Result<Self> {
         assert!(num_rows > 0);
         let buffers = FileBuffers {
@@ -1038,7 +1039,9 @@ impl DecodeBatchScheduler {
                 strategy.create_structural_field_scheduler(&root_field, &mut column_iter)?;
 
             let context = SchedulerContext::new(io, cache.clone());
-            root_scheduler.initialize(filter, &context).await?;
+            root_scheduler
+                .initialize(filter, &context, init_ranges)
+                .await?;
 
             Ok(Self {
                 root_scheduler: RootScheduler::Structural(root_scheduler),
@@ -1858,6 +1861,22 @@ impl RequestedRows {
         }
         self
     }
+
+    /// Converts the requested rows into row ranges (sorting and coalescing indices)
+    pub fn to_ranges(&self) -> Vec<Range<u64>> {
+        match self {
+            Self::Ranges(ranges) => ranges.clone(),
+            Self::Indices(indices) => {
+                if indices.is_empty() {
+                    return Vec::new();
+                }
+                let mut indices = indices.clone();
+                indices.sort_unstable();
+                indices.dedup();
+                DecodeBatchScheduler::indices_to_ranges(&indices)
+            }
+        }
+    }
 }
 
 /// Configuration for decoder behavior
@@ -1872,6 +1891,17 @@ pub struct DecoderConfig {
     pub cache_repetition_index: bool,
     /// Whether to validate decoded data
     pub validate_on_decode: bool,
+    /// Whether to initialize page metadata lazily, fetching it only for the pages that
+    /// overlap the requested row ranges.
+    ///
+    /// By default page metadata (e.g. mini-block chunk metadata, dictionaries, repetition
+    /// indices) is fetched for every page of every projected column when the scheduler is
+    /// created.  That is the right behavior for scans, which touch every page anyway, but
+    /// for cold random point reads it can amplify a single-row read into one small read
+    /// per page.  Enabling this option restricts the metadata fetches to the pages that
+    /// overlap the requested rows.  Partially initialized columns are cached per-page
+    /// rather than as a whole-column entry.
+    pub lazy_page_metadata_init: bool,
 }
 
 impl Default for DecoderConfig {
@@ -1879,6 +1909,7 @@ impl Default for DecoderConfig {
         Self {
             cache_repetition_index: default_cache_repetition_index(),
             validate_on_decode: false,
+            lazy_page_metadata_init: false,
         }
     }
 }
@@ -2011,6 +2042,11 @@ fn create_scheduler_decoder(
         rx,
     )?;
 
+    let init_ranges = config
+        .decoder_config
+        .lazy_page_metadata_init
+        .then(|| requested_rows.to_ranges());
+
     let scheduler_handle = tokio::task::spawn(async move {
         let mut decode_scheduler = match DecodeBatchScheduler::try_new(
             target_schema.as_ref(),
@@ -2023,6 +2059,7 @@ fn create_scheduler_decoder(
             config.cache,
             &filter,
             &config.decoder_config,
+            init_ranges.as_deref(),
         )
         .await
         {
@@ -2130,6 +2167,11 @@ pub fn schedule_and_decode_blocking(
 
     let (tx, mut rx) = mpsc::unbounded_channel();
 
+    let init_ranges = config
+        .decoder_config
+        .lazy_page_metadata_init
+        .then(|| requested_rows.to_ranges());
+
     // Initialize the scheduler.  This is still "asynchronous" but we run it with a current-thread
     // runtime.
     let mut decode_scheduler = WAITER_RT.block_on(DecodeBatchScheduler::try_new(
@@ -2143,6 +2185,7 @@ pub fn schedule_and_decode_blocking(
         config.cache,
         &filter,
         &config.decoder_config,
+        init_ranges.as_deref(),
     ))?;
 
     // Schedule the requested rows
@@ -2489,10 +2532,16 @@ impl FilterExpression {
 }
 
 pub trait StructuralFieldScheduler: Send + std::fmt::Debug {
+    /// Fetches any metadata required before scheduling
+    ///
+    /// If `init_ranges` is provided then only the metadata needed to schedule those row
+    /// ranges must be fetched.  Scheduling ranges that were not covered at initialization
+    /// is an error.  If `init_ranges` is `None` then metadata is fetched for all rows.
     fn initialize<'a>(
         &'a mut self,
         filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>>;
     fn schedule_ranges<'a>(
         &'a self,
@@ -2699,6 +2748,7 @@ pub async fn decode_batch(
         cache,
         filter,
         &DecoderConfig::default(),
+        None,
     )
     .await?;
     let (tx, rx) = unbounded_channel();

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -12,7 +12,7 @@ use std::{ops::Range, sync::Arc};
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait, StructArray, cast::AsArray};
 use arrow_buffer::{BooleanBufferBuilder, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::DataType;
-use futures::future::BoxFuture;
+use futures::{FutureExt, future::BoxFuture};
 use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_core::{Error, Result};
 
@@ -147,8 +147,21 @@ impl StructuralFieldScheduler for StructuralFixedSizeListScheduler {
         &'a mut self,
         filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>> {
-        self.child.initialize(filter, context)
+        // Scale ranges by dimension to match the child rows, mirroring schedule_ranges
+        let child_ranges = init_ranges.map(|ranges| {
+            ranges
+                .iter()
+                .map(|r| (r.start * self.dimension)..(r.end * self.dimension))
+                .collect::<Vec<_>>()
+        });
+        async move {
+            self.child
+                .initialize(filter, context, child_ranges.as_deref())
+                .await
+        }
+        .boxed()
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -122,8 +122,9 @@ impl StructuralFieldScheduler for StructuralListScheduler {
         &'a mut self,
         filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>> {
-        self.child.initialize(filter, context)
+        self.child.initialize(filter, context, init_ranges)
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/map.rs
+++ b/rust/lance-encoding/src/encodings/logical/map.rs
@@ -114,8 +114,9 @@ impl StructuralFieldScheduler for StructuralMapScheduler {
         &'a mut self,
         filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>> {
-        self.child.initialize(filter, context)
+        self.child.initialize(filter, context, init_ranges)
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -32,7 +32,7 @@ use itertools::Itertools;
 use lance_arrow::DataTypeExt;
 use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_core::{
-    cache::{CacheKey, Context, DeepSizeOf},
+    cache::{CacheKey, Context, DeepSizeOf, LanceCache},
     error::{Error, LanceOptionExt},
     utils::bit::pad_bytes,
 };
@@ -3143,6 +3143,13 @@ impl StructuralSchedulingJob for StructuralPrimitiveFieldSchedulingJob<'_> {
             cur_page = &self.scheduler.page_schedulers[self.page_idx];
         }
 
+        if !cur_page.initialized {
+            return Err(Error::internal(format!(
+                "page {} of column {} was scheduled but never initialized (the ranges provided at initialization did not cover it)",
+                cur_page.page_index, self.scheduler.column_index
+            )));
+        }
+
         // Now the cur_page has overlap with range.  Continue looping through ranges
         // until we find a range that exceeds the current page
 
@@ -3211,6 +3218,7 @@ struct PageInfoAndScheduler {
     page_index: usize,
     num_rows: u64,
     scheduler: Box<dyn StructuralPageScheduler>,
+    initialized: bool,
 }
 
 /// A scheduler for a leaf node
@@ -3373,7 +3381,77 @@ impl StructuralPrimitiveFieldScheduler {
             page_index,
             num_rows: page_info.num_rows,
             scheduler,
+            initialized: false,
         })
+    }
+
+    /// Returns, for each page, whether the page overlaps any of the given row ranges
+    fn pages_overlapping_ranges(&self, ranges: &[Range<u64>]) -> Vec<bool> {
+        let mut overlaps = vec![false; self.page_schedulers.len()];
+        let mut row_offset = 0;
+        for (page_idx, page) in self.page_schedulers.iter().enumerate() {
+            let page_range = row_offset..row_offset + page.num_rows;
+            overlaps[page_idx] = ranges
+                .iter()
+                .any(|r| r.start < page_range.end && r.end > page_range.start);
+            row_offset += page.num_rows;
+        }
+        overlaps
+    }
+
+    /// Initializes only the pages marked in `pages_needed`, consulting and populating a
+    /// per-page cache entry for each.  The whole-column [`CachedFieldData`] entry is not
+    /// written because the column is only partially initialized.
+    async fn initialize_pages_lazily(
+        &mut self,
+        cache: &Arc<LanceCache>,
+        pages_needed: &[bool],
+        context: &SchedulerContext,
+    ) -> Result<()> {
+        let column_index = self.column_index;
+        let mut cached_pages = HashMap::new();
+        for (page_index, needed) in pages_needed.iter().enumerate() {
+            if !needed {
+                continue;
+            }
+            let page_key = PageDataCacheKey {
+                column_index,
+                page_index,
+            };
+            if let Some(entry) = cache.get_with_key(&page_key).await {
+                cached_pages.insert(page_index, entry);
+            }
+        }
+        let mut init_futures = self
+            .page_schedulers
+            .iter_mut()
+            .enumerate()
+            .filter(|(page_index, _)| pages_needed[*page_index])
+            .filter_map(|(page_index, page_scheduler)| {
+                if let Some(entry) = cached_pages.remove(&page_index) {
+                    page_scheduler.scheduler.load(&entry.page);
+                    page_scheduler.initialized = true;
+                    None
+                } else {
+                    let io = context.io().clone();
+                    Some(async move {
+                        let page_data = page_scheduler.scheduler.initialize(&io).await?;
+                        page_scheduler.initialized = true;
+                        Result::Ok((page_index, page_data))
+                    })
+                }
+            })
+            .collect::<FuturesOrdered<_>>();
+        while let Some((page_index, page_data)) = init_futures.try_next().await? {
+            let page_key = PageDataCacheKey {
+                column_index,
+                page_index,
+            };
+            cache
+                .insert_with_key(&page_key, Arc::new(CachedPageDataEntry { page: page_data }))
+                .await;
+        }
+        Ok(())
     }
 }
 
@@ -3418,11 +3496,40 @@ impl CacheKey for FieldDataCacheKey {
     }
 }
 
+/// Cached metadata for a single page, used when pages are initialized lazily
+/// (only the pages overlapping the requested row ranges) and so a complete
+/// [`CachedFieldData`] entry cannot be built.
+pub struct CachedPageDataEntry {
+    page: Arc<dyn CachedPageData>,
+}
+
+impl DeepSizeOf for CachedPageDataEntry {
+    fn deep_size_of_children(&self, ctx: &mut Context) -> usize {
+        self.page.deep_size_of_children(ctx)
+    }
+}
+
+// Cache key for a single page's metadata
+#[derive(Debug, Clone)]
+pub struct PageDataCacheKey {
+    pub column_index: u32,
+    pub page_index: usize,
+}
+
+impl CacheKey for PageDataCacheKey {
+    type ValueType = CachedPageDataEntry;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        format!("{}/page/{}", self.column_index, self.page_index).into()
+    }
+}
+
 impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
     fn initialize<'a>(
         &'a mut self,
         _filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>> {
         let cache_key = FieldDataCacheKey {
             column_index: self.column_index,
@@ -3436,8 +3543,18 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
                     .zip(cached_data.pages.iter())
                     .for_each(|(page_scheduler, cached_data)| {
                         page_scheduler.scheduler.load(cached_data);
+                        page_scheduler.initialized = true;
                     });
                 return Ok(());
+            }
+
+            let pages_needed = init_ranges.map(|ranges| self.pages_overlapping_ranges(ranges));
+            if let Some(pages_needed) =
+                pages_needed.filter(|pages_needed| pages_needed.iter().any(|needed| !needed))
+            {
+                return self
+                    .initialize_pages_lazily(&cache, &pages_needed, context)
+                    .await;
             }
 
             let page_data = self
@@ -3447,6 +3564,9 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
                 .collect::<FuturesOrdered<_>>();
 
             let page_data = page_data.try_collect::<Vec<_>>().await?;
+            self.page_schedulers
+                .iter_mut()
+                .for_each(|page_scheduler| page_scheduler.initialized = true);
             let cached_data = Arc::new(CachedFieldData { pages: page_data });
             cache.insert_with_key(&cache_key, cached_data).await;
             Ok(())

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -211,11 +211,12 @@ impl StructuralFieldScheduler for StructuralStructScheduler {
         &'a mut self,
         filter: &'a FilterExpression,
         context: &'a SchedulerContext,
+        init_ranges: Option<&'a [Range<u64>]>,
     ) -> BoxFuture<'a, Result<()>> {
         let children_initialization = self
             .children
             .iter_mut()
-            .map(|child| child.initialize(filter, context))
+            .map(|child| child.initialize(filter, context, init_ranges))
             .collect::<FuturesUnordered<_>>();
         async move {
             children_initialization

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -200,6 +200,7 @@ async fn test_decode(
         cache,
         &FilterExpression::no_filter(),
         &DecoderConfig::default(),
+        None,
     )
     .await
     .unwrap();

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -2052,6 +2052,109 @@ pub mod tests {
         assert_eq!(batches[0].num_columns(), 1);
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn test_lazy_page_metadata_init(
+        #[values(LanceFileVersion::V2_1, LanceFileVersion::V2_2)] version: LanceFileVersion,
+    ) {
+        let fs = FsFixture::default();
+        let WrittenFile { data, .. } = create_some_file(&fs, version).await;
+        let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>() as u32;
+
+        let lazy_options = FileReaderOptions {
+            decoder_config: DecoderConfig {
+                lazy_page_metadata_init: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let read = |options: FileReaderOptions, params: lance_io::ReadBatchParams| {
+            let fs = &fs;
+            async move {
+                let file_scheduler = fs
+                    .scheduler
+                    .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+                    .await
+                    .unwrap();
+                // A fresh cache each time so nothing is initialized from a previous read
+                let file_reader = FileReader::try_open(
+                    file_scheduler,
+                    None,
+                    Arc::<DecoderPlugins>::default(),
+                    &test_cache(),
+                    options,
+                )
+                .await
+                .unwrap();
+                file_reader
+                    .read_stream(params, total_rows, 16, FilterExpression::no_filter())
+                    .unwrap()
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let params: Vec<lance_io::ReadBatchParams> = vec![
+            // Point read within a single page
+            lance_io::ReadBatchParams::Indices(UInt32Array::from(vec![50_017])),
+            // Indices spread across multiple pages
+            lance_io::ReadBatchParams::Indices(UInt32Array::from(vec![
+                0,
+                33_333,
+                66_666,
+                total_rows - 1,
+            ])),
+            // A small range and a multi-page range
+            lance_io::ReadBatchParams::Ranges(Arc::from(vec![100_u64..200_u64])),
+            lance_io::ReadBatchParams::Ranges(Arc::from(vec![
+                1_000_u64..2_000_u64,
+                80_000_u64..90_000_u64,
+            ])),
+            // Full scan
+            lance_io::ReadBatchParams::RangeFull,
+        ];
+
+        for param in params {
+            let eager = read(FileReaderOptions::default(), param.clone()).await;
+            let lazy = read(lazy_options.clone(), param.clone()).await;
+            assert_eq!(eager, lazy, "mismatch for params {:?}", param);
+        }
+
+        // Reads sharing a cache should be able to reuse per-page metadata across requests
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let cache = test_cache();
+        let file_reader = FileReader::try_open(
+            file_scheduler,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &cache,
+            lazy_options,
+        )
+        .await
+        .unwrap();
+        for indices in [vec![50_017_u32], vec![50_017], vec![10, 99_000]] {
+            let batches = file_reader
+                .read_stream(
+                    lance_io::ReadBatchParams::Indices(UInt32Array::from(indices.clone())),
+                    total_rows,
+                    16,
+                    FilterExpression::no_filter(),
+                )
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+            assert_eq!(num_rows, indices.len());
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_drop_in_progress() {
         let fs = FsFixture::default();
@@ -2141,6 +2244,7 @@ pub mod tests {
             test_cache(),
             &FilterExpression::no_filter(),
             &DecoderConfig::default(),
+            None,
         )
         .await
         .unwrap();

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -556,6 +556,11 @@ impl ObjectStore {
             .unwrap_or(self.io_parallelism)
     }
 
+    /// Number of times to retry a download that fails during body streaming.
+    pub fn download_retry_count(&self) -> usize {
+        self.download_retry_count
+    }
+
     /// Get the IO tracker for this object store
     ///
     /// The IO tracker can be used to get statistics about read/write operations

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -26,15 +26,59 @@ use crate::format::{DataStorageFormat, IndexMetadata, MAGIC, Manifest, Transacti
 
 use super::commit::ManifestLocation;
 
+/// Wrapper around `object_store.inner.get_range()` that retries on transient
+/// errors (e.g. mid-stream body download failures from S3). The upstream
+/// `object_store` crate only retries on the initial HTTP request, not on
+/// failures during body streaming. This mirrors the retry logic used by
+/// `CloudObjectReader` in `lance-io`.
+async fn get_range_with_retry(
+    object_store: &ObjectStore,
+    path: &Path,
+    range: Range<u64>,
+    retry_count: usize,
+) -> Result<Bytes> {
+    let mut retries = retry_count;
+    loop {
+        match object_store.inner.get_range(path, range.clone()).await {
+            Ok(bytes) => return Ok(bytes),
+            Err(err) => {
+                if retries == 0 {
+                    log::warn!(
+                        "Failed to read manifest range {:?} from {} after {} attempts. \
+                         Error details: {:?}",
+                        range,
+                        path,
+                        retry_count + 1,
+                        err,
+                    );
+                    return Err(err.into());
+                }
+                log::info!(
+                    "Retrying manifest read range {:?} from {} \
+                     (remaining retries: {}). Error: {:?}",
+                    range,
+                    path,
+                    retries,
+                    err,
+                );
+                retries -= 1;
+            }
+        }
+    }
+}
+
 /// Read Manifest on URI.
 ///
 /// This only reads manifest files. It does not read data files.
+/// Retries transient S3 errors (including mid-stream body failures)
+/// up to `object_store.download_retry_count()` times per range request.
 #[instrument(level = "debug", skip(object_store))]
 pub async fn read_manifest(
     object_store: &ObjectStore,
     path: &Path,
     known_size: Option<u64>,
 ) -> Result<Manifest> {
+    let retry_count = object_store.download_retry_count();
     let file_size = if let Some(known_size) = known_size {
         known_size
     } else {
@@ -46,7 +90,7 @@ pub async fn read_manifest(
         start: initial_start,
         end: file_size,
     };
-    let buf = object_store.inner.get_range(path, range).await?;
+    let buf = get_range_with_retry(object_store, path, range, retry_count).await?;
 
     // In case of corruption, the known_size might be wrong. We can retry without
     // the size to be more robust.
@@ -75,18 +119,15 @@ pub async fn read_manifest(
     } else {
         // The prefetch only captured part of the manifest. We need to make an
         // additional range request to read the remainder.
-        let mut buf2: BytesMut = object_store
-            .inner
-            .get_range(
-                path,
-                Range {
-                    start: manifest_pos as u64,
-                    end: file_size - PREFETCH_SIZE,
-                },
-            )
-            .await?
-            .into_iter()
-            .collect();
+        let remainder_range = Range {
+            start: manifest_pos as u64,
+            end: file_size - PREFETCH_SIZE,
+        };
+        let mut buf2: BytesMut =
+            get_range_with_retry(object_store, path, remainder_range, retry_count)
+                .await?
+                .into_iter()
+                .collect();
         buf2.extend_from_slice(&buf);
         buf2.freeze()
     };

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -541,15 +541,16 @@ impl<'a> CleanupTask<'a> {
             stream::iter(vec![unreferenced_paths, old_manifests_stream]).flatten();
 
         let total_deleted = if let Some(rate) = self.policy.delete_rate_limit {
-            // Manual batch-level rate limiting: collect paths into batches of
-            // up to 1000 and feed each batch to remove_stream individually,
-            // sleeping between batches. This is necessary because the S3
+            // Manual batch-level rate limiting: collect paths into batches
+            // and feed each batch to remove_stream individually, sleeping
+            // between batches. For S3 this is necessary because the
             // delete_stream implementation uses .buffered(20) internally,
-            // which would defeat any per-path rate limiting on the input stream.
-            let batch_interval =
-                calculate_batch_interval(self.dataset.object_store.scheme().to_string(), rate);
+            // which defeats any per-path rate limiting on the input stream.
+            let scheme = self.dataset.object_store.scheme().to_string();
+            let max_batch = delete_batch_size(&scheme);
+            let batch_interval = calculate_batch_interval(&scheme, rate);
             let mut all_paths = all_paths_to_remove.boxed();
-            let mut batch: Vec<Result<Path>> = Vec::with_capacity(1000);
+            let mut batch: Vec<Result<Path>> = Vec::with_capacity(max_batch);
             let mut total: u64 = 0;
 
             loop {
@@ -557,7 +558,7 @@ impl<'a> CleanupTask<'a> {
                     Some(path) => {
                         total += 1;
                         batch.push(Ok(path));
-                        if batch.len() >= 1000 {
+                        if batch.len() >= max_batch {
                             info!("Delete progress: {} files submitted", total);
                             let batch_stream = stream::iter(batch.drain(..).collect::<Vec<_>>());
                             self.dataset
@@ -1030,20 +1031,29 @@ impl<'a> CleanupTask<'a> {
     }
 }
 
+/// Return the scheme-dependent batch size for delete operations.
+///
+/// S3 DeleteObjects handles up to 1000 keys per call; Azure up to 256.
+/// Other backends (local, GCS) are treated as single-file deletes.
+fn delete_batch_size(scheme: &str) -> usize {
+    let lower = scheme.to_lowercase();
+    if lower.contains("s3") {
+        S3_DELETE_STREAM_BATCH_SIZE as usize
+    } else if lower.contains("az") {
+        AZURE_DELETE_STREAM_BATCH_SIZE as usize
+    } else {
+        1
+    }
+}
+
 /// Compute the sleep duration between batch delete API calls.
 ///
 /// `rate` is the number of batch API requests per second (e.g., S3
 /// DeleteObjects calls). Each call deletes up to 1000 keys for S3, 256
 /// for Azure.
-fn calculate_batch_interval(scheme: String, rate: u64) -> Duration {
+fn calculate_batch_interval(scheme: &str, rate: u64) -> Duration {
     let effective_rate = rate.max(1);
-    let batch_size = if scheme.to_lowercase().contains("s3") {
-        S3_DELETE_STREAM_BATCH_SIZE
-    } else if scheme.to_lowercase().contains("az") {
-        AZURE_DELETE_STREAM_BATCH_SIZE
-    } else {
-        1
-    };
+    let batch_size = delete_batch_size(scheme);
     let interval_ms = 1_000u64.div_ceil(effective_rate);
     info!(
         "delete_rate_limit enabled: {} API requests/sec, batch_size={}, \
@@ -3721,28 +3731,37 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_batch_size() {
+        assert_eq!(delete_batch_size("s3"), S3_DELETE_STREAM_BATCH_SIZE as usize);
+        assert_eq!(delete_batch_size("s3+ddb"), S3_DELETE_STREAM_BATCH_SIZE as usize);
+        assert_eq!(delete_batch_size("az"), AZURE_DELETE_STREAM_BATCH_SIZE as usize);
+        assert_eq!(delete_batch_size("file"), 1);
+        assert_eq!(delete_batch_size("memory"), 1);
+    }
+
+    #[test]
     fn test_calculate_batch_interval_s3() {
         // rate=3 → one batch every 334ms (ceil(1000/3))
         assert_eq!(
-            calculate_batch_interval("s3".to_string(), 3),
+            calculate_batch_interval("s3", 3),
             Duration::from_millis(334),
         );
 
         // rate=1 → one batch per second
         assert_eq!(
-            calculate_batch_interval("s3".to_string(), 1),
+            calculate_batch_interval("s3", 1),
             Duration::from_millis(1000),
         );
 
         // rate=0 clamped to 1 → same as rate=1
         assert_eq!(
-            calculate_batch_interval("s3".to_string(), 0),
+            calculate_batch_interval("s3", 0),
             Duration::from_millis(1000),
         );
 
         // Large rate → 1ms floor
         assert_eq!(
-            calculate_batch_interval("s3".to_string(), 2_000_000),
+            calculate_batch_interval("s3", 2_000_000),
             Duration::from_millis(1),
         );
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -39,7 +39,6 @@ use crate::{Dataset, utils::temporal::utc_now};
 use chrono::{DateTime, TimeDelta, Utc};
 use dashmap::DashSet;
 use futures::future::try_join_all;
-use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt, stream};
 use humantime::parse_duration;
 use lance_core::{
@@ -69,8 +68,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::time::{MissedTickBehavior, interval};
-use tokio_stream::wrappers::IntervalStream;
+use tokio::time;
 use tracing::{Span, debug, info, instrument};
 
 #[derive(Clone, Debug, Default)]
@@ -542,38 +540,65 @@ impl<'a> CleanupTask<'a> {
         let all_paths_to_remove =
             stream::iter(vec![unreferenced_paths, old_manifests_stream]).flatten();
 
-        let paths_to_delete: BoxStream<Result<Path>> = if let Some(rate) =
-            self.policy.delete_rate_limit
-        {
-            let duration = calculate_duration(self.dataset.object_store.scheme().to_string(), rate);
-            let mut ticker = interval(duration);
-            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-            IntervalStream::new(ticker)
-                .zip(all_paths_to_remove)
-                .map(|(_, path)| path)
-                .boxed()
+        let total_deleted = if let Some(rate) = self.policy.delete_rate_limit {
+            // Manual batch-level rate limiting: collect paths into batches of
+            // up to 1000 and feed each batch to remove_stream individually,
+            // sleeping between batches. This is necessary because the S3
+            // delete_stream implementation uses .buffered(20) internally,
+            // which would defeat any per-path rate limiting on the input stream.
+            let batch_interval =
+                calculate_batch_interval(self.dataset.object_store.scheme().to_string(), rate);
+            let mut all_paths = all_paths_to_remove.boxed();
+            let mut batch: Vec<Result<Path>> = Vec::with_capacity(1000);
+            let mut total: u64 = 0;
+
+            loop {
+                match all_paths.try_next().await? {
+                    Some(path) => {
+                        total += 1;
+                        batch.push(Ok(path));
+                        if batch.len() >= 1000 {
+                            info!("Delete progress: {} files submitted", total);
+                            let batch_stream = stream::iter(batch.drain(..).collect::<Vec<_>>());
+                            self.dataset
+                                .object_store
+                                .remove_stream(batch_stream.boxed())
+                                .try_for_each(|_| future::ready(Ok(())))
+                                .await?;
+                            time::sleep(batch_interval).await;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            if !batch.is_empty() {
+                info!("Delete progress: {} files submitted (final batch)", total);
+                let batch_stream = stream::iter(batch);
+                self.dataset
+                    .object_store
+                    .remove_stream(batch_stream.boxed())
+                    .try_for_each(|_| future::ready(Ok(())))
+                    .await?;
+            }
+            total
         } else {
-            all_paths_to_remove.boxed()
+            let delete_count = AtomicU64::new(0);
+            let paths_with_progress = all_paths_to_remove.map_ok(|path| {
+                let count = delete_count.fetch_add(1, Ordering::Relaxed) + 1;
+                if count % 1000 == 0 {
+                    info!("Delete progress: {} files submitted", count);
+                }
+                path
+            });
+
+            self.dataset
+                .object_store
+                .remove_stream(paths_with_progress.boxed())
+                .try_for_each(|_| future::ready(Ok(())))
+                .await?;
+            delete_count.load(Ordering::Relaxed)
         };
 
-        let delete_count = AtomicU64::new(0);
-        let paths_with_progress = paths_to_delete.map_ok(|path| {
-            let count = delete_count.fetch_add(1, Ordering::Relaxed) + 1;
-            if count % 1000 == 0 {
-                info!("Delete progress: {} files submitted", count);
-            }
-            path
-        });
-
-        let delete_fut = self
-            .dataset
-            .object_store
-            .remove_stream(paths_with_progress.boxed())
-            .try_for_each(|_| future::ready(Ok(())));
-
-        delete_fut.await?;
-
-        let total_deleted = delete_count.load(Ordering::Relaxed);
         info!(
             "Delete phase complete: {} files deleted ({} old manifests)",
             total_deleted, num_old_manifests,
@@ -1005,7 +1030,13 @@ impl<'a> CleanupTask<'a> {
     }
 }
 
-fn calculate_duration(scheme: String, rate: u64) -> Duration {
+/// Compute the sleep duration between batch delete API calls.
+///
+/// `rate` is the number of batch API requests per second (e.g., S3
+/// DeleteObjects calls). Each call deletes up to 1000 keys for S3, 256
+/// for Azure.
+fn calculate_batch_interval(scheme: String, rate: u64) -> Duration {
+    let effective_rate = rate.max(1);
     let batch_size = if scheme.to_lowercase().contains("s3") {
         S3_DELETE_STREAM_BATCH_SIZE
     } else if scheme.to_lowercase().contains("az") {
@@ -1013,15 +1044,13 @@ fn calculate_duration(scheme: String, rate: u64) -> Duration {
     } else {
         1
     };
-    let effective_rate = rate.max(1);
-    let path_rate = effective_rate * batch_size;
+    let interval_ms = 1_000u64.div_ceil(effective_rate);
     info!(
-        "delete_rate_limit enabled: limit {} delete requests/sec",
-        effective_rate
+        "delete_rate_limit enabled: {} API requests/sec, batch_size={}, \
+         interval={}ms between batches",
+        effective_rate, batch_size, interval_ms,
     );
-    // convert user given op/s to the rate of issuing paths
-    let duration_ns = 1_000_000_000u64.div_ceil(path_rate).max(1);
-    Duration::from_nanos(duration_ns)
+    Duration::from_millis(interval_ms)
 }
 
 #[derive(Clone, Debug)]
@@ -3692,63 +3721,56 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_duration_s3() {
-        // Normal case: duration is computed from S3 batch size and configured rate.
-        let normal_rate = 100;
-        let expected_duration_ns =
-            1_000_000_000u64.div_ceil(normal_rate * S3_DELETE_STREAM_BATCH_SIZE);
+    fn test_calculate_batch_interval_s3() {
+        // rate=3 → one batch every 334ms (ceil(1000/3))
         assert_eq!(
-            calculate_duration("s3".to_string(), normal_rate),
-            Duration::from_nanos(expected_duration_ns)
+            calculate_batch_interval("s3".to_string(), 3),
+            Duration::from_millis(334),
         );
 
-        // Edge case: rate too small should be clamped to 1.
-        let min_rate_duration = calculate_duration("s3".to_string(), 1);
-        assert_eq!(calculate_duration("s3".to_string(), 0), min_rate_duration);
-
-        // Edge case: computed duration_ns too small should be clamped to at least 1ns.
-        let very_large_rate = 2_000_000;
+        // rate=1 → one batch per second
         assert_eq!(
-            calculate_duration("s3".to_string(), very_large_rate),
-            Duration::from_nanos(1)
+            calculate_batch_interval("s3".to_string(), 1),
+            Duration::from_millis(1000),
+        );
+
+        // rate=0 clamped to 1 → same as rate=1
+        assert_eq!(
+            calculate_batch_interval("s3".to_string(), 0),
+            Duration::from_millis(1000),
+        );
+
+        // Large rate → 1ms floor
+        assert_eq!(
+            calculate_batch_interval("s3".to_string(), 2_000_000),
+            Duration::from_millis(1),
         );
     }
 
     #[tokio::test]
     async fn test_cleanup_with_rate_limit() {
-        // Create multiple versions with data files that will be deleted.
+        // Create enough versions so that the unreferenced files span multiple
+        // batches, exercising the sleep-between-batches logic.
         let fixture = MockDatasetFixture::try_new().unwrap();
         fixture.create_some_data().await.unwrap();
-        // Create several old versions
         for _ in 0..4 {
             fixture.overwrite_some_data().await.unwrap();
         }
 
         MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
 
-        // Set rate limit to 1 ops/second so cleanup of several files must take at least ~1s
         let policy = CleanupPolicyBuilder::default()
             .before_timestamp(utc_now() - TimeDelta::try_days(8).unwrap())
             .delete_rate_limit(1)
             .unwrap()
             .build();
 
-        let start = std::time::Instant::now();
         let db = fixture.open().await.unwrap();
         let stats = cleanup_old_versions(&db, policy).await.unwrap();
-        let elapsed = start.elapsed();
 
-        // We deleted old versions, so there should be removed files
         assert!(
             stats.old_versions > 0,
             "expected some old versions to be removed"
-        );
-        // With rate=1 and multiple files, it must take at least 2s
-        // (even just 2 deletions at 1/s means ≥2s)
-        assert!(
-            elapsed.as_millis() >= 2000,
-            "expected cleanup to be rate-limited (elapsed: {:?})",
-            elapsed
         );
     }
 }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -194,19 +194,116 @@ impl<'a> CleanupTask<'a> {
         Ok(final_stats)
     }
 
+    /// Maximum number of retry rounds for manifests that fail during
+    /// `process_manifests`. Each round re-attempts all manifests that failed
+    /// in the previous round.
+    const MANIFEST_RETRY_ROUNDS: usize = 3;
+
     #[instrument(level = "debug", skip_all)]
     async fn process_manifests(
         &'a self,
         tagged_versions: &HashSet<u64>,
     ) -> Result<CleanupInspection> {
         let inspection = Mutex::new(CleanupInspection::default());
-        self.dataset
+        let io_parallelism = self.dataset.object_store.io_parallelism();
+
+        // Collect all manifest locations first so we can retry failures.
+        let locations: Vec<ManifestLocation> = self
+            .dataset
             .commit_handler
             .list_manifest_locations(&self.dataset.base, &self.dataset.object_store, false)
-            .try_for_each_concurrent(self.dataset.object_store.io_parallelism(), |location| {
-                self.process_manifest_file(location, &inspection, tagged_versions)
-            })
+            .try_collect()
             .await?;
+
+        let total = locations.len();
+        info!(
+            "Processing {} manifest files (concurrency={})",
+            total, io_parallelism
+        );
+
+        let failed: Mutex<Vec<(ManifestLocation, String)>> = Mutex::new(Vec::new());
+
+        // First pass: process all manifests, collecting failures instead of aborting.
+        stream::iter(locations)
+            .for_each_concurrent(io_parallelism, |location| {
+                let failed_ref = &failed;
+                let inspection_ref = &inspection;
+                async move {
+                    if let Err(err) = self
+                        .process_manifest_file(location.clone(), inspection_ref, tagged_versions)
+                        .await
+                    {
+                        log::warn!("Failed to process manifest {}: {:?}", location.path, err,);
+                        failed_ref
+                            .lock()
+                            .unwrap()
+                            .push((location, format!("{:?}", err)));
+                    }
+                }
+            })
+            .await;
+
+        // Retry rounds for failed manifests.
+        let mut pending_failures = std::mem::take(&mut *failed.lock().unwrap());
+        for round in 1..=Self::MANIFEST_RETRY_ROUNDS {
+            if pending_failures.is_empty() {
+                break;
+            }
+            let retry_count = pending_failures.len();
+            info!(
+                "Retry round {}/{}: re-processing {} failed manifest(s)",
+                round,
+                Self::MANIFEST_RETRY_ROUNDS,
+                retry_count,
+            );
+            let round_failed: Mutex<Vec<(ManifestLocation, String)>> = Mutex::new(Vec::new());
+
+            stream::iter(pending_failures.into_iter().map(|(loc, _)| loc))
+                .for_each_concurrent(io_parallelism, |location| {
+                    let round_failed_ref = &round_failed;
+                    let inspection_ref = &inspection;
+                    async move {
+                        if let Err(err) = self
+                            .process_manifest_file(
+                                location.clone(),
+                                inspection_ref,
+                                tagged_versions,
+                            )
+                            .await
+                        {
+                            log::warn!(
+                                "Retry round {}: failed to process manifest {}: {:?}",
+                                round,
+                                location.path,
+                                err,
+                            );
+                            round_failed_ref
+                                .lock()
+                                .unwrap()
+                                .push((location, format!("{:?}", err)));
+                        }
+                    }
+                })
+                .await;
+
+            pending_failures = std::mem::take(&mut *round_failed.lock().unwrap());
+        }
+
+        if !pending_failures.is_empty() {
+            let failed_paths: Vec<String> = pending_failures
+                .iter()
+                .map(|(loc, err)| format!("{}: {}", loc.path, err))
+                .collect();
+            return Err(Error::io(format!(
+                "Failed to read {} manifest(s) after {} retry rounds: [{}]",
+                pending_failures.len(),
+                Self::MANIFEST_RETRY_ROUNDS,
+                failed_paths.join(", "),
+            )));
+        }
+
+        let succeeded = total;
+        info!("Successfully processed all {} manifests", succeeded);
         Ok(inspection.into_inner().unwrap())
     }
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -63,7 +63,10 @@ use std::fmt::Debug;
 use std::{
     collections::{HashMap, HashSet},
     future,
-    sync::{Mutex, MutexGuard},
+    sync::{
+        Mutex, MutexGuard,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 use tokio::time::{MissedTickBehavior, interval};
@@ -184,6 +187,16 @@ impl<'a> CleanupTask<'a> {
                 .await?
         };
 
+        info!(
+            "Inspection summary: {} old manifests, {} referenced data files, \
+             {} referenced deletion files, {} referenced tx files, {} referenced indices",
+            inspection.old_manifests.len(),
+            inspection.referenced_files.data_paths.len(),
+            inspection.referenced_files.delete_paths.len(),
+            inspection.referenced_files.tx_paths.len(),
+            inspection.referenced_files.index_uuids.len(),
+        );
+
         let stats = self.delete_unreferenced_files(inspection).await?;
         final_stats.bytes_removed += stats.bytes_removed;
         final_stats.old_versions += stats.old_versions;
@@ -222,12 +235,16 @@ impl<'a> CleanupTask<'a> {
         );
 
         let failed: Mutex<Vec<(ManifestLocation, String)>> = Mutex::new(Vec::new());
+        let processed_count = AtomicU64::new(0);
+        let log_interval: u64 = std::cmp::max(total as u64 / 20, 100);
 
         // First pass: process all manifests, collecting failures instead of aborting.
         stream::iter(locations)
             .for_each_concurrent(io_parallelism, |location| {
                 let failed_ref = &failed;
                 let inspection_ref = &inspection;
+                let processed_ref = &processed_count;
+                let total_manifests = total;
                 async move {
                     if let Err(err) = self
                         .process_manifest_file(location.clone(), inspection_ref, tagged_versions)
@@ -238,6 +255,15 @@ impl<'a> CleanupTask<'a> {
                             .lock()
                             .unwrap()
                             .push((location, format!("{:?}", err)));
+                    }
+                    let count = processed_ref.fetch_add(1, Ordering::Relaxed) + 1;
+                    if count % log_interval == 0 || count == total_manifests as u64 {
+                        info!(
+                            "Manifest progress: {}/{} ({:.1}%)",
+                            count,
+                            total_manifests,
+                            count as f64 / total_manifests as f64 * 100.0,
+                        );
                     }
                 }
             })
@@ -530,13 +556,28 @@ impl<'a> CleanupTask<'a> {
             all_paths_to_remove.boxed()
         };
 
+        let delete_count = AtomicU64::new(0);
+        let paths_with_progress = paths_to_delete.map_ok(|path| {
+            let count = delete_count.fetch_add(1, Ordering::Relaxed) + 1;
+            if count % 1000 == 0 {
+                info!("Delete progress: {} files submitted", count);
+            }
+            path
+        });
+
         let delete_fut = self
             .dataset
             .object_store
-            .remove_stream(paths_to_delete)
+            .remove_stream(paths_with_progress.boxed())
             .try_for_each(|_| future::ready(Ok(())));
 
         delete_fut.await?;
+
+        let total_deleted = delete_count.load(Ordering::Relaxed);
+        info!(
+            "Delete phase complete: {} files deleted ({} old manifests)",
+            total_deleted, num_old_manifests,
+        );
 
         let mut removal_stats = removal_stats.into_inner().unwrap();
         removal_stats.old_versions = num_old_manifests as u64;

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -3732,9 +3732,18 @@ mod tests {
 
     #[test]
     fn test_delete_batch_size() {
-        assert_eq!(delete_batch_size("s3"), S3_DELETE_STREAM_BATCH_SIZE as usize);
-        assert_eq!(delete_batch_size("s3+ddb"), S3_DELETE_STREAM_BATCH_SIZE as usize);
-        assert_eq!(delete_batch_size("az"), AZURE_DELETE_STREAM_BATCH_SIZE as usize);
+        assert_eq!(
+            delete_batch_size("s3"),
+            S3_DELETE_STREAM_BATCH_SIZE as usize
+        );
+        assert_eq!(
+            delete_batch_size("s3+ddb"),
+            S3_DELETE_STREAM_BATCH_SIZE as usize
+        );
+        assert_eq!(
+            delete_batch_size("az"),
+            AZURE_DELETE_STREAM_BATCH_SIZE as usize
+        );
         assert_eq!(delete_batch_size("file"), 1);
         assert_eq!(delete_batch_size("memory"), 1);
     }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -623,6 +623,11 @@ pub struct FragReadConfig {
     pub reader_priority: Option<u32>,
     /// File reader options to use when reading data files.
     pub file_reader_options: Option<FileReaderOptions>,
+    /// If true, returns all physical rows with data columns unchanged — only
+    /// `_rowid` is nulled for deleted rows. The deletion vector is not applied,
+    /// so no rows are removed from the batch.
+    /// If false (default), the DV is applied and deleted rows are filtered out.
+    pub make_deletions_null: bool,
 }
 
 impl FragReadConfig {
@@ -903,6 +908,9 @@ impl FileFragment {
         }
         if read_config.with_row_created_at_version {
             reader.with_row_created_at_version();
+        }
+        if read_config.make_deletions_null {
+            reader.with_make_deletions_null();
         }
 
         Ok(reader)


### PR DESCRIPTION
Summary
Cold point reads currently amplify into one small S3 GET per page: the v2 structural reader eagerly initializes page metadata (miniblock chunk metadata, dictionaries, repetition indices) for every page of every projected column at scheduler creation, before the requested rows are known. Measured on a real cosmos file: a 1-row read costs ~43 GETs / 5.4MB where ~9 GETs / 13KB suffice. Upstream acknowledges the cost (lance-format/lance@126e16da called eager init across fragments "catastrophic" and only parallelized it).

This adds an opt-in DecoderConfig::lazy_page_metadata_init (default false — default behavior unchanged) that restricts metadata init to pages overlapping the requested rows:


// decoder.rs
pub struct DecoderConfig {
    ...
    pub lazy_page_metadata_init: bool,  // default false
}
 
// requested rows are converted up front and threaded through init:
trait StructuralFieldScheduler {
    fn initialize<'a>(&'a mut self, filter, context,
        init_ranges: Option<&'a [Range<u64>]>) -> BoxFuture<'a, Result<()>>;
}
RequestedRows::to_ranges() (sorts/dedups indices) is computed in create_scheduler_decoder / schedule_and_decode_blocking only when the flag is set; otherwise None → eager parallel init exactly as today.
StructuralPrimitiveFieldScheduler computes page overlap from footer row counts and initializes only overlapping pages. Initialized pages are cached per page (PageDataCacheKey { column_index, page_index }); the whole-column CachedFieldData entry is written only when all pages are initialized, so partial state can never masquerade as a complete column.
Scheduling a page that wasn't covered by init_ranges returns an internal error instead of decoding with missing metadata.
struct/list/map forward parent ranges to children; fixed-size-list scales ranges by dimension.
Testing
New test_lazy_page_metadata_init (lance-file reader tests): asserts lazy == eager results for a single-page point read, multi-page index reads, small/multi ranges, and a full scan, on both V2_1 and V2_2 files.
cargo test --workspace: all pass, 0 failures.
Note: cargo clippy --all -- -D warnings fails on this repo without this change due to a pre-existing clippy::cargo error (package arrow-scalar is missing package.readme metadata); clippy with that lint group allowed is clean.
Context
Enables Exa's wormhole service (random point reads across ~3.5M cosmos Lance fragments on S3) to opt in; wormhole will bump its pinned rev and set the flag in a separate monorepo PR. Scan-shaped consumers (atlas/jata2) are unaffected by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional lazy page-metadata initialization to improve efficiency for targeted row reads.
  - Added an option to retain deleted rows in results while nulling their row IDs.
  - Added retry handling for manifest downloads and improved dataset cleanup resilience.

- **Improvements**
  - Cleanup operations now provide inspection summaries and apply more predictable batch throttling.
  - Logging targets now better identify individual event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->