### PR TITLE
fix(fts): do not count empty documents in num_docs

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1254,7 +1254,7 @@ impl IndexWorker {
                     .filter_map(|(doc, row_id)| doc.map(|doc| (doc, *row_id)));
 
                 for (doc, row_id) in docs {
-                    self.process_document(row_id, DocumentSource::Text(doc), false)
+                    self.process_document(row_id, DocumentSource::Text(doc))
                         .await?;
                 }
             }
@@ -1298,7 +1298,7 @@ impl IndexWorker {
                 continue;
             };
 
-            self.process_document(*row_id, DocumentSource::StringList(doc.as_ref()), true)
+            self.process_document(*row_id, DocumentSource::StringList(doc.as_ref()))
                 .await?;
         }
 
@@ -1324,12 +1324,7 @@ impl IndexWorker {
         doc
     }
 
-    async fn process_document(
-        &mut self,
-        row_id: u64,
-        document: DocumentSource<'_>,
-        skip_empty_document: bool,
-    ) -> Result<()> {
+    async fn process_document(&mut self, row_id: u64, document: DocumentSource<'_>) -> Result<()> {
         let with_position = self.has_position();
         let builder_was_empty = self.builder.docs.is_empty();
         let old_temporary_memory_size = self.temporary_memory_size();
@@ -1435,7 +1430,11 @@ impl IndexWorker {
             self.builder.tokens.memory_size() as u64,
         );
 
-        if skip_empty_document && token_num == 0 {
+        // A document that produces no tokens (e.g. an empty or whitespace-only
+        // string, or a list whose elements tokenize to nothing) is not indexed:
+        // it carries no searchable content, so counting it would only inflate
+        // `num_docs` and skew document-count-based statistics such as BM25.
+        if token_num == 0 {
             self.last_token_count = 0;
             self.trim_temporary_buffers();
             self.adjust_tracked_memory_size(

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -402,10 +402,18 @@ async fn test_create_fts_index_with_empty_strings() {
         false,
     )]));
 
+    // Mix documents that produce tokens with ones that tokenize to nothing
+    // (empty and whitespace-only strings). The latter carry no searchable
+    // content and must not be counted in `num_docs`.
     let batches: Vec<RecordBatch> = vec![
         RecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(StringArray::from(vec!["", "", ""]))],
+            vec![Arc::new(StringArray::from(vec![
+                "lance",
+                "",
+                "lance database",
+                "   ",
+            ]))],
         )
         .unwrap(),
     ];
@@ -420,9 +428,29 @@ async fn test_create_fts_index_with_empty_strings() {
         .await
         .unwrap();
 
+    // Only the two token-producing rows are indexed; the empty and
+    // whitespace-only rows are skipped so they do not inflate BM25 statistics.
+    let stats: serde_json::Value =
+        serde_json::from_str(&dataset.index_statistics("text_idx").await.unwrap()).unwrap();
+    assert_eq!(
+        stats["indices"][0]["num_docs"], 2,
+        "empty documents must not count: {stats}"
+    );
+
+    // The token-producing rows remain searchable.
     let batch = dataset
         .scan()
         .full_text_search(FullTextSearchQuery::new("lance".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(batch.num_rows(), 2);
+
+    // A term present in no document returns nothing.
+    let batch = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("missing".to_owned()))
         .unwrap()
         .try_into_batch()
         .await


### PR DESCRIPTION
Closes #7660

Follow-up to #7656. Empty and whitespace-only string documents tokenize to nothing but were still appended to the inverted index, inflating `num_docs` and skewing BM25 document-count statistics. #7656 introduced skip-empty behavior for list-string documents via a `skip_empty_document` flag; the plain-string path still passed `false`.

Since both call sites should now skip zero-token documents, this removes the flag and makes `IndexWorker::process_document` unconditionally skip when a document produces no tokens, unifying string and list behavior.

Verified locally: `test_create_fts_index_with_empty_strings` (strengthened to assert `num_docs`), `cargo fmt`, and `cargo clippy --features protoc --tests -- -D warnings` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty and whitespace-only text is no longer counted as searchable content.
  * Full-text search results now exclude documents that produce no searchable tokens.
  * Index statistics accurately reflect only documents containing searchable text.
* **Tests**
  * Added coverage for mixed datasets containing searchable, empty, and whitespace-only values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->