### PR TITLE
perf(encoding): avoid inline bitpacking input copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,6 +4692,7 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
+ "object_store",
  "proptest",
  "prost",
  "prost-build",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3907,6 +3907,7 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
+ "object_store",
  "prost",
  "prost-build",
  "rand 0.9.4",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
+ "object_store",
  "prost",
  "prost-build",
  "rand 0.9.4",

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -29,6 +29,7 @@ hex = "0.4.3"
 itertools.workspace = true
 log.workspace = true
 num-traits.workspace = true
+object_store.workspace = true
 prost.workspace = true
 hyperloglogplus.workspace = true
 rand.workspace = true

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -1,14 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, hint::black_box, sync::Arc};
 
 use arrow_array::{RecordBatch, UInt32Array};
+#[cfg(feature = "bitpacking")]
+use arrow_buffer::ArrowNativeType;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use arrow_select::take::take;
+#[cfg(feature = "bitpacking")]
+use bytemuck::Pod;
 use criterion::{Criterion, criterion_group, criterion_main};
 use futures::StreamExt;
+#[cfg(feature = "bitpacking")]
+use lance_bitpacking::BitPacking;
 use lance_core::cache::LanceCache;
 use lance_datagen::ArrayGeneratorExt;
+#[cfg(feature = "bitpacking")]
+use lance_encoding::buffer::LanceBuffer;
+#[cfg(feature = "bitpacking")]
+use lance_encoding::compression::BlockDecompressor;
+#[cfg(feature = "bitpacking")]
+use lance_encoding::data::{BlockInfo, DataBlock, FixedWidthDataBlock};
+#[cfg(feature = "bitpacking")]
+use lance_encoding::encodings::physical::bitpacking::InlineBitpacking;
 use lance_encoding::{
     decoder::{
         DecodeBatchScheduler, DecoderConfig, DecoderPlugins, FilterExpression, create_decode_stream,
@@ -48,6 +62,9 @@ const PRIMITIVE_TYPES: &[DataType] = &[
 // Some types are supported by the encoder/decoder but Lance
 // schema doesn't yet parse them in the context of a fixed size list.
 const PRIMITIVE_TYPES_FOR_FSL: &[DataType] = &[DataType::Int8, DataType::Float32];
+
+#[cfg(feature = "bitpacking")]
+const BITPACKING_ELEMS_PER_CHUNK: usize = 1024;
 
 fn bench_decode(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -563,6 +580,142 @@ fn bench_decode_compressed_parallel(c: &mut Criterion) {
     }
 }
 
+#[cfg(feature = "bitpacking")]
+fn make_inline_bitpacking_chunk<T>(bit_width: usize) -> LanceBuffer
+where
+    T: ArrowNativeType + BitPacking + Pod,
+{
+    let value_range = 1_usize << bit_width;
+    let values: Vec<T> = (0..BITPACKING_ELEMS_PER_CHUNK)
+        .map(|i| T::from_usize((i * 31 + 7) % value_range).unwrap())
+        .collect();
+    let packed_words = BITPACKING_ELEMS_PER_CHUNK * bit_width / (std::mem::size_of::<T>() * 8);
+
+    let mut chunk = Vec::with_capacity(1 + packed_words);
+    chunk.push(T::from_usize(bit_width).unwrap());
+    let payload_start = chunk.len();
+    chunk.resize(payload_start + packed_words, T::from_usize(0).unwrap());
+    unsafe {
+        BitPacking::unchecked_pack(bit_width, &values, &mut chunk[payload_start..]);
+    }
+
+    LanceBuffer::reinterpret_vec(chunk)
+}
+
+#[cfg(feature = "bitpacking")]
+fn read_little_endian_header<T>(bytes: &[u8]) -> usize {
+    bytes[..std::mem::size_of::<T>()]
+        .iter()
+        .enumerate()
+        .fold(0_u64, |value, (idx, byte)| {
+            value | ((*byte as u64) << (idx * 8))
+        }) as usize
+}
+
+#[cfg(feature = "bitpacking")]
+fn legacy_copy_unchunk<T>(data: LanceBuffer, num_values: u64) -> DataBlock
+where
+    T: ArrowNativeType + BitPacking + Pod,
+{
+    assert!(data.len() >= std::mem::size_of::<T>());
+    assert!(num_values <= BITPACKING_ELEMS_PER_CHUNK as u64);
+
+    let chunk_in_u8 = data.to_vec();
+    let bit_width_value = read_little_endian_header::<T>(&chunk_in_u8);
+    let chunk = bytemuck::cast_slice(&chunk_in_u8[std::mem::size_of::<T>()..]);
+    assert!(std::mem::size_of_val(chunk) == bit_width_value * BITPACKING_ELEMS_PER_CHUNK / 8);
+
+    let mut decompressed = vec![T::from_usize(0).unwrap(); BITPACKING_ELEMS_PER_CHUNK];
+    unsafe {
+        BitPacking::unchecked_unpack(bit_width_value, chunk, &mut decompressed);
+    }
+
+    decompressed.truncate(num_values as usize);
+    DataBlock::FixedWidth(FixedWidthDataBlock {
+        data: LanceBuffer::reinterpret_vec(decompressed),
+        bits_per_value: (std::mem::size_of::<T>() * 8) as u64,
+        num_values,
+        block_info: BlockInfo::new(),
+    })
+}
+
+#[cfg(feature = "bitpacking")]
+fn typed_view_unchunk(buffer: LanceBuffer, uncompressed_bits: u64, num_values: u64) -> DataBlock {
+    InlineBitpacking::new(uncompressed_bits)
+        .decompress(buffer, num_values)
+        .unwrap()
+}
+
+#[cfg(feature = "bitpacking")]
+fn assert_same_fixed_width_payloads(legacy: &DataBlock, typed_view: &DataBlock) {
+    let legacy = legacy.as_fixed_width_ref().unwrap();
+    let typed_view = typed_view.as_fixed_width_ref().unwrap();
+
+    assert_eq!(legacy.num_values, typed_view.num_values);
+    assert_eq!(legacy.bits_per_value, typed_view.bits_per_value);
+    assert_eq!(legacy.data.as_ref(), typed_view.data.as_ref());
+}
+
+#[cfg(feature = "bitpacking")]
+fn bench_inline_bitpacking_case<T>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    name: &str,
+    bit_width: usize,
+) where
+    T: ArrowNativeType + BitPacking + Pod,
+{
+    let buffer = make_inline_bitpacking_chunk::<T>(bit_width);
+    let compressed_bytes = buffer.len() as u64;
+    let uncompressed_bits = (std::mem::size_of::<T>() * 8) as u64;
+    group.throughput(criterion::Throughput::Bytes(compressed_bytes));
+
+    let legacy = legacy_copy_unchunk::<T>(buffer.clone(), BITPACKING_ELEMS_PER_CHUNK as u64);
+    let typed_view = typed_view_unchunk(
+        buffer.clone(),
+        uncompressed_bits,
+        BITPACKING_ELEMS_PER_CHUNK as u64,
+    );
+    assert_same_fixed_width_payloads(&legacy, &typed_view);
+
+    group.bench_function(format!("{name}/legacy_copy/compressed_bytes"), |b| {
+        b.iter(|| {
+            let decoded = legacy_copy_unchunk::<T>(
+                black_box(buffer.clone()),
+                black_box(BITPACKING_ELEMS_PER_CHUNK as u64),
+            );
+            let fixed = decoded.as_fixed_width().unwrap();
+            black_box(fixed.data.as_ref());
+        })
+    });
+
+    group.bench_function(format!("{name}/typed_view/compressed_bytes"), |b| {
+        b.iter(|| {
+            let decoded = typed_view_unchunk(
+                black_box(buffer.clone()),
+                black_box(uncompressed_bits),
+                black_box(BITPACKING_ELEMS_PER_CHUNK as u64),
+            );
+            let fixed = decoded.as_fixed_width().unwrap();
+            black_box(fixed.data.as_ref());
+        })
+    });
+}
+
+#[cfg(feature = "bitpacking")]
+fn bench_decode_inline_bitpacking_unchunk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_inline_bitpacking_unchunk");
+    bench_inline_bitpacking_case::<u32>(&mut group, "u32_bw12_1024", 12);
+    bench_inline_bitpacking_case::<u64>(&mut group, "u64_bw23_1024", 23);
+    group.finish();
+}
+
+#[cfg(not(feature = "bitpacking"))]
+fn bench_decode_inline_bitpacking_unchunk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_inline_bitpacking_unchunk");
+    group.bench_function("bitpacking_feature_disabled", |b| b.iter(|| black_box(())));
+    group.finish();
+}
+
 #[cfg(target_os = "linux")]
 criterion_group!(
     name=benches;
@@ -570,7 +723,7 @@ criterion_group!(
         .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_decode, bench_decode_fsl, bench_decode_str_with_dict_encoding, bench_decode_packed_struct,
                 bench_decode_str_with_fixed_size_binary_encoding, bench_decode_compressed,
-                bench_decode_compressed_parallel);
+                bench_decode_compressed_parallel, bench_decode_inline_bitpacking_unchunk);
 
 // Non-linux version does not support pprof.
 #[cfg(not(target_os = "linux"))]
@@ -578,5 +731,5 @@ criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10);
     targets = bench_decode, bench_decode_fsl, bench_decode_str_with_dict_encoding, bench_decode_packed_struct,
-                bench_decode_compressed, bench_decode_compressed_parallel);
+                bench_decode_compressed, bench_decode_compressed_parallel, bench_decode_inline_bitpacking_unchunk);
 criterion_main!(benches);

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -18,7 +18,6 @@
 use arrow_array::types::UInt64Type;
 use arrow_array::{Array, PrimitiveArray};
 use arrow_buffer::ArrowNativeType;
-use byteorder::{ByteOrder, LittleEndian};
 use lance_bitpacking::BitPacking;
 
 use lance_core::{Error, Result};
@@ -33,7 +32,7 @@ use crate::encodings::logical::primitive::miniblock::{
 use crate::format::pb21::CompressiveEncoding;
 use crate::format::{ProtobufUtils21, pb21};
 use crate::statistics::{GetStat, Stat};
-use bytemuck::{AnyBitPattern, cast_slice};
+use bytemuck::Pod;
 
 const LOG_ELEMS_PER_CHUNK: u8 = 10;
 const ELEMS_PER_CHUNK: u64 = 1 << LOG_ELEMS_PER_CHUNK;
@@ -181,27 +180,64 @@ impl InlineBitpacking {
         )
     }
 
-    fn unchunk<T: ArrowNativeType + BitPacking + AnyBitPattern>(
+    fn unchunk<T: ArrowNativeType + BitPacking + Pod>(
         data: LanceBuffer,
         num_values: u64,
     ) -> Result<DataBlock> {
-        // Ensure at least the header is present
-        assert!(data.len() >= std::mem::size_of::<T>());
-        assert!(num_values <= ELEMS_PER_CHUNK);
-
         // This macro decompresses a chunk(1024 values) of bitpacked values.
         let uncompressed_bit_width = std::mem::size_of::<T>() * 8;
-        let mut decompressed = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
+        let word_size = std::mem::size_of::<T>();
 
-        // Copy for memory alignment
-        let chunk_in_u8: Vec<u8> = data.to_vec();
-        let bit_width_bytes = &chunk_in_u8[..std::mem::size_of::<T>()];
-        let bit_width_value = LittleEndian::read_uint(bit_width_bytes, std::mem::size_of::<T>());
-        let chunk = cast_slice(&chunk_in_u8[std::mem::size_of::<T>()..]);
-        // The bit-packed chunk should have number of bytes (bit_width_value * ELEMS_PER_CHUNK / 8)
-        assert!(std::mem::size_of_val(chunk) == (bit_width_value * ELEMS_PER_CHUNK) as usize / 8);
+        if data.len() < word_size {
+            return Err(Self::corrupt_inline_bitpacking(format!(
+                "Inline bitpacking chunk is too small for {}-byte header: {} bytes",
+                word_size,
+                data.len()
+            )));
+        }
+        if !data.len().is_multiple_of(word_size) {
+            return Err(Self::corrupt_inline_bitpacking(format!(
+                "Inline bitpacking chunk size must be a multiple of {} bytes, got {} bytes",
+                word_size,
+                data.len()
+            )));
+        }
+        if num_values > ELEMS_PER_CHUNK {
+            return Err(Self::corrupt_inline_bitpacking(format!(
+                "Inline bitpacking chunk has {} values, expected at most {}",
+                num_values, ELEMS_PER_CHUNK
+            )));
+        }
+
+        let chunk_words = data.borrow_to_typed_view::<T>();
+        let bit_width_value = chunk_words[0].as_usize();
+        if bit_width_value > uncompressed_bit_width {
+            return Err(Self::corrupt_inline_bitpacking(format!(
+                "Inline bitpacking width {} exceeds {}-bit values",
+                bit_width_value, uncompressed_bit_width
+            )));
+        }
+        let chunk = &chunk_words[1..];
+        let expected_num_bits = bit_width_value
+            .checked_mul(ELEMS_PER_CHUNK as usize)
+            .ok_or_else(|| {
+                Self::corrupt_inline_bitpacking(format!(
+                    "Inline bitpacking width {} overflows chunk bit count",
+                    bit_width_value
+                ))
+            })?;
+        let expected_num_bytes = expected_num_bits / 8;
+        let actual_num_bytes = std::mem::size_of_val(chunk);
+        if actual_num_bytes != expected_num_bytes {
+            return Err(Self::corrupt_inline_bitpacking(format!(
+                "Inline bitpacking payload has {} bytes, expected {} bytes for bit width {}",
+                actual_num_bytes, expected_num_bytes, bit_width_value
+            )));
+        }
+
+        let mut decompressed = vec![T::default(); ELEMS_PER_CHUNK as usize];
         unsafe {
-            BitPacking::unchecked_unpack(bit_width_value as usize, chunk, &mut decompressed);
+            BitPacking::unchecked_unpack(bit_width_value, chunk, &mut decompressed);
         }
 
         decompressed.truncate(num_values as usize);
@@ -211,6 +247,10 @@ impl InlineBitpacking {
             num_values,
             block_info: BlockInfo::new(),
         }))
+    }
+
+    fn corrupt_inline_bitpacking(message: impl Into<String>) -> Error {
+        Error::corrupt_file(object_store::path::Path::from("inline_bitpacking"), message)
     }
 }
 
@@ -527,15 +567,90 @@ mod test {
     use std::{collections::HashMap, sync::Arc};
 
     use arrow_array::{Array, Int8Array, Int64Array};
+    use arrow_buffer::ArrowNativeType;
     use arrow_schema::DataType;
+    use bytemuck::Pod;
+    use lance_bitpacking::BitPacking;
+    use rstest::rstest;
 
-    use super::{ELEMS_PER_CHUNK, bitpack_out_of_line, unpack_out_of_line};
+    use super::{ELEMS_PER_CHUNK, InlineBitpacking, bitpack_out_of_line, unpack_out_of_line};
     use crate::{
         buffer::LanceBuffer,
-        data::{BlockInfo, FixedWidthDataBlock},
+        data::{BlockInfo, DataBlock, FixedWidthDataBlock},
         testing::{TestCases, check_round_trip_encoding_of_data},
         version::LanceFileVersion,
     };
+
+    fn roundtrip_unchunk<T>(values: &[T], bit_width: usize)
+    where
+        T: ArrowNativeType + BitPacking + Pod,
+    {
+        assert!(values.len() <= ELEMS_PER_CHUNK as usize);
+        let num_values = values.len() as u64;
+
+        let mut padded = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
+        padded[..values.len()].copy_from_slice(values);
+
+        let packed_words = ELEMS_PER_CHUNK as usize * bit_width / (std::mem::size_of::<T>() * 8);
+        let mut chunk: Vec<T> = Vec::with_capacity(1 + packed_words);
+        chunk.push(T::from_usize(bit_width).unwrap());
+        let out_len = chunk.len();
+        chunk.resize(out_len + packed_words, T::from_usize(0).unwrap());
+        unsafe {
+            BitPacking::unchecked_pack(bit_width, &padded, &mut chunk[out_len..]);
+        }
+
+        let data = LanceBuffer::reinterpret_vec(chunk);
+        let decoded = InlineBitpacking::unchunk::<T>(data, num_values).unwrap();
+        let DataBlock::FixedWidth(fixed) = decoded else {
+            panic!("expected FixedWidth DataBlock");
+        };
+        let decoded_values = fixed.data.borrow_to_typed_view::<T>();
+        assert_eq!(decoded_values.as_ref(), values);
+    }
+
+    fn assert_corrupt_unchunk<T>(data: LanceBuffer, num_values: u64, expected_message: &str)
+    where
+        T: ArrowNativeType + BitPacking + Pod,
+    {
+        let err = InlineBitpacking::unchunk::<T>(data, num_values).unwrap_err();
+        assert!(matches!(err, lance_core::Error::CorruptFile { .. }));
+        let err = err.to_string();
+        assert!(
+            err.contains(expected_message),
+            "expected error containing {expected_message:?}, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unchunk_u32_bw12_tail() {
+        let values: Vec<u32> = (0..500).map(|i| ((i * 7) % (1 << 12)) as u32).collect();
+        roundtrip_unchunk(&values, 12);
+    }
+
+    #[test]
+    fn unchunk_u64_bw23_full() {
+        let values: Vec<u64> = (0..1024).map(|i| ((i * 3) % (1 << 23)) as u64).collect();
+        roundtrip_unchunk(&values, 23);
+    }
+
+    #[rstest]
+    #[case::too_small_header(LanceBuffer::from(vec![1, 2, 3]), 1, "too small")]
+    #[case::misaligned_chunk_size(LanceBuffer::from(vec![0, 0, 0, 0, 0]), 1, "multiple")]
+    #[case::too_many_values(
+        LanceBuffer::reinterpret_vec(vec![0_u32]),
+        ELEMS_PER_CHUNK + 1,
+        "expected at most"
+    )]
+    #[case::payload_size_mismatch(LanceBuffer::reinterpret_vec(vec![12_u32]), 1, "payload")]
+    #[case::invalid_bit_width(LanceBuffer::reinterpret_vec(vec![33_u32]), 1, "exceeds")]
+    fn unchunk_rejects(
+        #[case] data: LanceBuffer,
+        #[case] num_values: u64,
+        #[case] expected_message: &str,
+    ) {
+        assert_corrupt_unchunk::<u32>(data, num_values, expected_message);
+    }
 
     #[test_log::test(tokio::test)]
     async fn test_miniblock_bitpack() {


### PR DESCRIPTION
Supersedes #7696. This PR contains the same changes as #7696, but squashed into a single commit with a consolidated commit message.

## Summary

- Avoid the unconditional input copy in `InlineBitpacking::unchunk` by borrowing a typed view over the inline bitpacking chunk words.
- Keep output zero-initialization unchanged; this PR only changes compressed input handling.
- Add focused `unchunk` roundtrip coverage and a Criterion benchmark comparing the old copy path with the new typed-view path.
- Harden validation by rejecting malformed inline bitpacking chunks up front with clear errors.

## Benchmark

Local machine: WSL2 on Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz, 12 logical CPUs.

Command:

```bash
cargo bench -p lance-encoding --bench decoder decode_inline_bitpacking_unchunk --features bitpacking -- --noplot
```

Results:

| Case | Path | Criterion time estimate | Throughput |
| --- | --- | ---: | ---: |
| `u32_bw12_1024` | `legacy_copy` | 285.46 ns | 5.0244 GiB/s |
| `u32_bw12_1024` | `typed_view` | 247.35 ns | 5.7985 GiB/s |
| `u64_bw23_1024` | `legacy_copy` | 434.11 ns | 6.3331 GiB/s |
| `u64_bw23_1024` | `typed_view` | 340.27 ns | 8.0797 GiB/s |

Path-to-path deltas:

- `u32_bw12_1024`: `typed_view` was 13.4% faster than `legacy_copy`
- `u64_bw23_1024`: `typed_view` was 21.6% faster than `legacy_copy`

The benchmark uses aligned chunks built with `LanceBuffer::reinterpret_vec`, so it measures the aligned `borrow_to_typed_view` fast path. Misaligned buffers can still fall back to a copy.

## Test Plan

- `cargo fmt --all`
- `cargo test -p lance-encoding --features bitpacking`
- `cargo clippy -p lance-encoding --all-features --tests --benches -- -D warnings`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo bench -p lance-encoding --bench decoder decode_inline_bitpacking_unchunk --features bitpacking -- --noplot`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline bitpacked data decoding with stronger validation for malformed buffers, invalid value counts, unsupported bit widths, alignment issues, and inconsistent payload sizes.
  - Added clearer corruption errors to help identify invalid encoded data.

- **Performance**
  - Improved the inline bitpacking decoding path by using typed views, reducing unnecessary data copying.

- **Tests**
  - Expanded coverage for valid round trips, corruption handling, and decoding performance across multiple data types and bit widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->