### PR TITLE
fix(encoding): decode empty inline-bitpacked blocks

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -241,6 +241,15 @@ impl MiniBlockDecompressor for InlineBitpacking {
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         assert_eq!(data.len(), 1);
         let data = data.into_iter().next().unwrap();
+        if num_values == 0 {
+            // Empty mini-blocks have no inline bit-width header to decode.
+            return Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+                data: LanceBuffer::empty(),
+                bits_per_value: self.uncompressed_bit_width,
+                num_values: 0,
+                block_info: BlockInfo::new(),
+            }));
+        }
         match self.uncompressed_bit_width {
             8 => Self::unchunk::<u8>(data, num_values),
             16 => Self::unchunk::<u16>(data, num_values),
@@ -528,14 +537,35 @@ mod test {
 
     use arrow_array::{Array, Int8Array, Int64Array};
     use arrow_schema::DataType;
+    use rstest::rstest;
 
-    use super::{ELEMS_PER_CHUNK, bitpack_out_of_line, unpack_out_of_line};
+    use super::{ELEMS_PER_CHUNK, InlineBitpacking, bitpack_out_of_line, unpack_out_of_line};
     use crate::{
         buffer::LanceBuffer,
-        data::{BlockInfo, FixedWidthDataBlock},
+        compression::MiniBlockDecompressor,
+        data::{BlockInfo, DataBlock, FixedWidthDataBlock},
         testing::{TestCases, check_round_trip_encoding_of_data},
         version::LanceFileVersion,
     };
+
+    #[rstest]
+    #[case::u8(8)]
+    #[case::u16(16)]
+    #[case::u32(32)]
+    #[case::u64(64)]
+    fn test_inline_bitpacking_decompress_empty_miniblock(#[case] bit_width: u64) {
+        let decompressor = InlineBitpacking::new(bit_width);
+        let decompressed =
+            MiniBlockDecompressor::decompress(&decompressor, vec![LanceBuffer::empty()], 0)
+                .unwrap();
+
+        let DataBlock::FixedWidth(block) = decompressed else {
+            panic!("Expected FixedWidth block");
+        };
+        assert_eq!(block.bits_per_value, bit_width);
+        assert_eq!(block.num_values, 0);
+        assert_eq!(block.data.len(), 0);
+    }
 
     #[test_log::test(tokio::test)]
     async fn test_miniblock_bitpack() {


### PR DESCRIPTION
Part of #7750

Inline bitpacking mini-block decompression currently enters the non-empty unchunk path for zero values, which expects an inline bit-width header and panics on an empty payload. Return an empty `FixedWidthDataBlock` with the configured bit width instead.

This is the generic zero-value codec prerequisite used when sparse pages project to no leaf values. It contains no sparse format or layout behavior.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p lance-encoding encodings::physical::bitpacking::test`
- `cargo test -p lance-encoding`
- `cargo clippy -p lance-encoding --tests --benches -- -D warnings`
- `cargo clippy --all --tests --benches -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decompression for empty bitpacked data blocks.
  * Empty miniblocks now return correctly formatted empty results without attempting to read missing metadata.

* **Tests**
  * Added coverage to verify empty miniblock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->