### PR TITLE
feat(credentials): vend AWS credentials via AssumeRoleWithWebIdentity to avoid role chaining

### DIFF
--- a/rust/lance-namespace-impls/src/credentials.rs
+++ b/rust/lance-namespace-impls/src/credentials.rs
@@ -515,18 +515,35 @@ async fn create_aws_vendor(
     // explicit token-file path wins; otherwise, if opted in, resolve the
     // EKS-injected `AWS_WEB_IDENTITY_TOKEN_FILE`. Falling back to the chained
     // AssumeRole path when neither is present keeps existing behavior.
+    let assume_via_pod = properties
+        .get(aws_props::ASSUME_VIA_POD_WEB_IDENTITY)
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     let pod_token_file = properties
         .get(aws_props::POD_WEB_IDENTITY_TOKEN_FILE)
         .cloned()
         .or_else(|| {
-            let enabled = properties
-                .get(aws_props::ASSUME_VIA_POD_WEB_IDENTITY)
-                .map(|v| v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-            enabled
+            assume_via_pod
                 .then(|| std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE").ok())
                 .flatten()
         });
+    // Log the resolved assume path once at vendor init so a deployment can
+    // confirm at runtime which branch `assume_scoped` will take.
+    match &pod_token_file {
+        Some(path) => log::info!(
+            "AWS credential vendor (role {role_arn}): direct AssumeRoleWithWebIdentity \
+             via pod token file '{path}'"
+        ),
+        None if assume_via_pod => log::warn!(
+            "AWS credential vendor (role {role_arn}): aws_assume_via_pod_web_identity=true \
+             but no token file resolved (aws_pod_web_identity_token_file unset and \
+             AWS_WEB_IDENTITY_TOKEN_FILE not in env); falling back to chained AssumeRole"
+        ),
+        None => log::info!(
+            "AWS credential vendor (role {role_arn}): chained AssumeRole \
+             (pod web-identity not enabled)"
+        ),
+    }
     if let Some(path) = pod_token_file {
         config = config.with_pod_web_identity_token_file(path);
     }

--- a/rust/lance-namespace-impls/src/credentials.rs
+++ b/rust/lance-namespace-impls/src/credentials.rs
@@ -223,6 +223,14 @@ pub mod aws_props {
     /// AWS credential duration in milliseconds.
     /// Default: 3600000 (1 hour). Range: 900000 (15 min) to 43200000 (12 hours).
     pub const DURATION_MILLIS: &str = "aws_duration_millis";
+
+    /// When "true", the scoped assume is performed via `AssumeRoleWithWebIdentity`
+    /// using the pod's projected service-account OIDC token
+    pub const ASSUME_VIA_POD_WEB_IDENTITY: &str = "aws_assume_via_pod_web_identity";
+
+    /// Explicit path to the pod's projected SA OIDC token file. Overrides
+    /// `AWS_WEB_IDENTITY_TOKEN_FILE` when set.
+    pub const POD_WEB_IDENTITY_TOKEN_FILE: &str = "aws_pod_web_identity_token_file";
 }
 
 /// GCP-specific property keys (short form, without prefix)
@@ -501,6 +509,26 @@ async fn create_aws_vendor(
     }
     if let Some(session_name) = properties.get(aws_props::ROLE_SESSION_NAME) {
         config = config.with_role_session_name(session_name);
+    }
+
+    // Direct (non-chained) web-identity assume for the pod, when enabled. An
+    // explicit token-file path wins; otherwise, if opted in, resolve the
+    // EKS-injected `AWS_WEB_IDENTITY_TOKEN_FILE`. Falling back to the chained
+    // AssumeRole path when neither is present keeps existing behavior.
+    let pod_token_file = properties
+        .get(aws_props::POD_WEB_IDENTITY_TOKEN_FILE)
+        .cloned()
+        .or_else(|| {
+            let enabled = properties
+                .get(aws_props::ASSUME_VIA_POD_WEB_IDENTITY)
+                .map(|v| v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+            enabled
+                .then(|| std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE").ok())
+                .flatten()
+        });
+    if let Some(path) = pod_token_file {
+        config = config.with_pod_web_identity_token_file(path);
     }
 
     let vendor = AwsCredentialVendor::new(config).await?;

--- a/rust/lance-namespace-impls/src/credentials/aws.rs
+++ b/rust/lance-namespace-impls/src/credentials/aws.rs
@@ -60,6 +60,17 @@ pub struct AwsCredentialVendorConfig {
     /// When an API key is provided, its hash is looked up in this map.
     /// If found, the mapped permission is used instead of the default permission.
     pub api_key_hash_permissions: HashMap<String, VendedPermission>,
+
+    /// Optional path to the pod's projected service-account OIDC token file (typically the
+    /// EKS-injected `AWS_WEB_IDENTITY_TOKEN_FILE`).
+    /// This is the recommended method when running in Kubernetes.
+    /// When set, the scoped assume is performed with `AssumeRoleWithWebIdentity`
+    /// using this token instead of a role-chained `AssumeRole` from the process's
+    /// ambient credentials. A web-identity assumption is *not* role chaining, so
+    /// STS honors the role's `MaxSessionDuration` (up to 12h) and the returned
+    /// expiration is accurate. When `None`, the `AssumeRole` path
+    /// is used and `duration_millis` is subject to the source role duration and may be invalid
+    pub pod_web_identity_token_file: Option<String>,
 }
 
 impl AwsCredentialVendorConfig {
@@ -74,6 +85,7 @@ impl AwsCredentialVendorConfig {
             permission: VendedPermission::default(),
             api_key_salt: None,
             api_key_hash_permissions: HashMap::new(),
+            pod_web_identity_token_file: None,
         }
     }
 
@@ -98,6 +110,14 @@ impl AwsCredentialVendorConfig {
     /// Set the AWS region for the STS client.
     pub fn with_region(mut self, region: impl Into<String>) -> Self {
         self.region = Some(region.into());
+        self
+    }
+
+    /// Set the pod web-identity token file, enabling direct (non-chained)
+    /// `AssumeRoleWithWebIdentity` for the scoped assume. See
+    /// [`AwsCredentialVendorConfig::pod_web_identity_token_file`].
+    pub fn with_pod_web_identity_token_file(mut self, path: impl Into<String>) -> Self {
+        self.pod_web_identity_token_file = Some(path.into());
         self
     }
 
@@ -421,6 +441,93 @@ impl AwsCredentialVendor {
     }
 
     /// Vend credentials using AssumeRole with API key validation.
+    /// Perform the scoped assume for `(bucket, prefix, permission)`, attaching the
+    /// per-table session policy.
+    ///
+    /// When [`AwsCredentialVendorConfig::pod_web_identity_token_file`] is set this
+    /// uses `AssumeRoleWithWebIdentity` with the pod's projected SA OIDC token -- a
+    /// *direct*, non-chained assumption that honors the role's `MaxSessionDuration`
+    /// (so `expires_at_millis` is accurate). Otherwise it falls back to the legacy
+    /// role-chained `AssumeRole` from ambient credentials (STS-capped at 1h).
+    ///
+    /// `external_id` is only applied on the chained `AssumeRole` path;
+    /// `AssumeRoleWithWebIdentity` has no external-id parameter (the OIDC
+    /// `sub`/`aud` trust condition is the binding instead).
+    async fn assume_scoped(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        permission: VendedPermission,
+        session_name: &str,
+        external_id: Option<&str>,
+    ) -> Result<VendedCredentials> {
+        let policy = Self::build_policy(bucket, prefix, permission);
+        let duration_secs = self.config.duration_millis.div_ceil(1000).clamp(900, 43200) as i32;
+
+        let credentials = if let Some(token_file) = &self.config.pod_web_identity_token_file {
+            // DIRECT (non-chained): AssumeRoleWithWebIdentity with the pod's SA
+            // OIDC token. Re-read the file every vend -- kubelet rotates it.
+            let token = tokio::fs::read_to_string(token_file).await.map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "failed to read pod web identity token '{}': {}",
+                        token_file, e
+                    ),
+                })
+            })?;
+            debug!(
+                "AWS AssumeRoleWithWebIdentity (pod): role={}, session={}, permission={}",
+                self.config.role_arn, session_name, permission
+            );
+            let response = self
+                .sts_client
+                .assume_role_with_web_identity()
+                .role_arn(&self.config.role_arn)
+                .web_identity_token(token.trim())
+                .role_session_name(session_name)
+                .policy(&policy)
+                .duration_seconds(duration_secs)
+                .send()
+                .await
+                .map_err(|e| {
+                    lance_core::Error::from(NamespaceError::Internal {
+                        message: format!(
+                            "AssumeRoleWithWebIdentity (pod) failed for role '{}': {}",
+                            self.config.role_arn, e
+                        ),
+                    })
+                })?;
+            response.credentials().cloned()
+        } else {
+            // LEGACY chained path: AssumeRole from ambient credentials (1h cap).
+            debug!(
+                "AWS AssumeRole (chained): role={}, session={}, permission={}",
+                self.config.role_arn, session_name, permission
+            );
+            let mut request = self
+                .sts_client
+                .assume_role()
+                .role_arn(&self.config.role_arn)
+                .role_session_name(session_name)
+                .policy(&policy)
+                .duration_seconds(duration_secs);
+            if let Some(external_id) = external_id {
+                request = request.external_id(external_id);
+            }
+            let response = request.send().await.map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "AssumeRole failed for role '{}': {}",
+                        self.config.role_arn, e
+                    ),
+                })
+            })?;
+            response.credentials().cloned()
+        };
+
+        self.extract_credentials(credentials.as_ref(), bucket, prefix, permission)
+    }
+
     async fn vend_with_api_key(
         &self,
         bucket: &str,
@@ -452,42 +559,19 @@ impl AwsCredentialVendor {
                 })
             })?;
 
-        let policy = Self::build_policy(bucket, prefix, permission);
+        // The api_key authorizes the client and picks the permission; the AWS
+        // assume itself goes through `assume_scoped` (pod web-identity when
+        // configured, else chained AssumeRole with the key hash as external_id).
         let session_name = Self::cap_session_name(&format!("lance-api-{}", &key_hash[..16]));
-        let duration_secs = self.config.duration_millis.div_ceil(1000).clamp(900, 43200) as i32;
-
-        debug!(
-            "AWS AssumeRole with API key: role={}, session={}, permission={}",
-            self.config.role_arn, session_name, permission
-        );
-
-        let request = self
-            .sts_client
-            .assume_role()
-            .role_arn(&self.config.role_arn)
-            .role_session_name(&session_name)
-            .policy(&policy)
-            .duration_seconds(duration_secs)
-            .external_id(&key_hash); // Use hash as external_id
-
-        let response = request.send().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!(
-                    "AssumeRole with API key failed for role '{}': {}",
-                    self.config.role_arn, e
-                ),
-            })
-        })?;
-
-        self.extract_credentials(response.credentials(), bucket, prefix, permission)
+        self.assume_scoped(bucket, prefix, permission, &session_name, Some(&key_hash))
+            .await
     }
 
-    /// Vend credentials using AssumeRole with static configuration.
+    /// Vend credentials using the vendor's static (default) permission.
     async fn vend_with_static_config(
         &self,
         bucket: &str,
         prefix: &str,
-        policy: &str,
     ) -> Result<VendedCredentials> {
         let role_session_name = self
             .config
@@ -496,40 +580,14 @@ impl AwsCredentialVendor {
             .unwrap_or_else(|| "lance-credential-vending".to_string());
         let role_session_name = Self::cap_session_name(&role_session_name);
 
-        let duration_secs = self.config.duration_millis.div_ceil(1000).clamp(900, 43200) as i32;
-
-        debug!(
-            "AWS AssumeRole (static): role={}, session={}, permission={}",
-            self.config.role_arn, role_session_name, self.config.permission
-        );
-
-        let mut request = self
-            .sts_client
-            .assume_role()
-            .role_arn(&self.config.role_arn)
-            .role_session_name(&role_session_name)
-            .policy(policy)
-            .duration_seconds(duration_secs);
-
-        if let Some(ref external_id) = self.config.external_id {
-            request = request.external_id(external_id);
-        }
-
-        let response = request.send().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!(
-                    "AssumeRole failed for role '{}': {}",
-                    self.config.role_arn, e
-                ),
-            })
-        })?;
-
-        self.extract_credentials(
-            response.credentials(),
+        self.assume_scoped(
             bucket,
             prefix,
             self.config.permission,
+            &role_session_name,
+            self.config.external_id.as_deref(),
         )
+        .await
     }
 }
 
@@ -575,10 +633,8 @@ impl CredentialVendor for AwsCredentialVendor {
                 .into())
             }
             None => {
-                // Use AssumeRole with static configuration
-                let policy = Self::build_policy(&bucket, &prefix, self.config.permission);
-                self.vend_with_static_config(&bucket, &prefix, &policy)
-                    .await
+                // Use the vendor's static (default) permission
+                self.vend_with_static_config(&bucket, &prefix).await
             }
         }
     }
@@ -743,6 +799,41 @@ mod tests {
         assert_eq!(config.duration_millis, 7200000);
         assert_eq!(config.role_session_name, Some("my-session".to_string()));
         assert_eq!(config.region, Some("us-west-2".to_string()));
+        // Defaults to the legacy chained AssumeRole path.
+        assert_eq!(config.pod_web_identity_token_file, None);
+
+        let pod_config = AwsCredentialVendorConfig::new("arn:aws:iam::123456789012:role/MyRole")
+            .with_pod_web_identity_token_file("/var/run/secrets/.../token");
+        assert_eq!(
+            pod_config.pod_web_identity_token_file,
+            Some("/var/run/secrets/.../token".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pod_web_identity_path_reads_token_file() {
+        // When pod_web_identity_token_file is set, the scoped assume takes the
+        // AssumeRoleWithWebIdentity branch and reads the token file first. Point
+        // it at a missing file so we deterministically hit the read error without
+        // needing a live STS -- this proves the branch selection + file read.
+        let sdk_config = aws_config::SdkConfig::builder()
+            .behavior_version(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new("us-east-2"))
+            .build();
+        let sts_client = StsClient::new(&sdk_config);
+        let config = AwsCredentialVendorConfig::new("arn:aws:iam::123456789012:role/MyRole")
+            .with_pod_web_identity_token_file("/nonexistent/pod/web-identity-token");
+        let vendor = AwsCredentialVendor::with_sts_client(config, sts_client);
+
+        let err = vendor
+            .vend_credentials("s3://bucket/prefix", None)
+            .await
+            .expect_err("missing token file must fail before any STS call");
+        assert!(
+            err.to_string()
+                .contains("failed to read pod web identity token"),
+            "unexpected error: {err}"
+        );
     }
 
     // ============================================================================

--- a/rust/lance-namespace-impls/src/credentials/aws.rs
+++ b/rust/lance-namespace-impls/src/credentials/aws.rs
@@ -24,6 +24,18 @@ use super::{
     redact_credential,
 };
 
+/// Render an error together with its full `source()` chain.
+fn full_error_chain(err: &dyn std::error::Error) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        out.push_str(": ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
+}
+
 /// Configuration for AWS credential vending.
 #[derive(Debug, Clone)]
 pub struct AwsCredentialVendorConfig {
@@ -427,7 +439,8 @@ impl AwsCredentialVendor {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!(
                         "AssumeRoleWithWebIdentity failed for role '{}': {}",
-                        self.config.role_arn, e
+                        self.config.role_arn,
+                        full_error_chain(&e)
                     ),
                 })
             })?;
@@ -493,7 +506,8 @@ impl AwsCredentialVendor {
                     lance_core::Error::from(NamespaceError::Internal {
                         message: format!(
                             "AssumeRoleWithWebIdentity (pod) failed for role '{}': {}",
-                            self.config.role_arn, e
+                            self.config.role_arn,
+                            full_error_chain(&e)
                         ),
                     })
                 })?;
@@ -518,7 +532,8 @@ impl AwsCredentialVendor {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!(
                         "AssumeRole failed for role '{}': {}",
-                        self.config.role_arn, e
+                        self.config.role_arn,
+                        full_error_chain(&e)
                     ),
                 })
             })?;


### PR DESCRIPTION
## Problem

The credential vendor's `api_key` and static flows assume the target role with `AssumeRole`, signed by the process's **ambient** credentials. When the vendor runs with temporary credentials — e.g. an IRSA / EKS pod role — that is **role chaining**, which STS **hard-caps to 1 hour** regardless of the role's `MaxSessionDuration`.

In that setup the returned `Expiration` can also exceed the token's *real* validity, so downstream credential caches (`StorageOptionsAccessor`, `CachingCredentialVendor`) keep serving a token S3 already rejects with `ExpiredToken` and never refresh — their expiry checks trust the inflated `expires_at_millis`.

## Change

Add an optional **pod web-identity** path. When `pod_web_identity_token_file` is configured — via property `credential_vendor.aws_assume_via_pod_web_identity=true` (resolving the EKS-injected `AWS_WEB_IDENTITY_TOKEN_FILE`), or an explicit `credential_vendor.aws_pod_web_identity_token_file` — the scoped assume uses `AssumeRoleWithWebIdentity` with the pod's projected service-account OIDC token.

`AssumeRoleWithWebIdentity` is a **direct** (non-chained) assumption, so STS honors the role's `MaxSessionDuration` (up to 12h) and reports an accurate expiration.

- Per-table scoped session policy, permission handling, and the default chained `AssumeRole` behavior are **unchanged**.
- The token file is re-read on every vend (kubelet rotates it).
- Requires the target role's trust policy to federate the cluster OIDC provider for the service account.

This change also improves error handling to propagate the object store error message in namespace error messages.

## Tests

- `test_config_builder` extended for the new field.
- `test_pod_web_identity_path_reads_token_file` — verifies the web-identity branch is selected and reads the token file.

🤖 Co-authored with Claude Opus 4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS pod-based web identity authentication for credential vending.
  * New configuration option to set the projected service-account token file path (with optional opt-in fallback to the standard AWS env var).
  * When configured, scoped role vending uses web identity instead of the legacy chained assume-role flow.
* **Bug Fixes**
  * Preserves existing ambient-credential behavior when web identity is not configured.
* **Tests**
  * Added coverage to ensure vending fails with a clear token-file read error when the configured token file path is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->