### PR TITLE
feat: support multi-segment indices in hamming clustering

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -75,7 +75,11 @@ from .types import _coerce_reader
 from .udf import BatchUDF, normalize_transform
 from .udf import BatchUDFCheckpoint as BatchUDFCheckpoint
 from .udf import batch_udf as batch_udf
-from .util import _target_partition_size_to_num_partitions, td_to_micros
+from .util import (
+    _normalize_index_segment_ids,
+    _target_partition_size_to_num_partitions,
+    td_to_micros,
+)
 
 if TYPE_CHECKING:
     from pyarrow._compute import Expression
@@ -4324,20 +4328,10 @@ class LanceDataset(pa.dataset.Dataset):
             named logical index. Use :meth:`describe_indices` to inspect logical
             indices and obtain segment UUIDs from ``IndexDescription.segments``.
         """
-        if index_segments is not None:
-            segment_ids = []
-            for segment_id in index_segments:
-                if isinstance(segment_id, (str, uuid.UUID)):
-                    segment_ids.append(str(segment_id))
-                else:
-                    raise TypeError(
-                        "index_segments must be an iterable of str or uuid.UUID. "
-                        f"Got {type(segment_id)} instead."
-                    )
-            index_segments = segment_ids
-
         return self._ds.prewarm_index(
-            name, with_position=with_position, index_segments=index_segments
+            name,
+            with_position=with_position,
+            index_segments=_normalize_index_segment_ids(index_segments),
         )
 
     def merge_index_metadata(
@@ -6423,19 +6417,7 @@ class ScannerBuilder:
     def with_index_segments(
         self, index_segments: Optional[Iterable[Union[str, uuid.UUID]]]
     ) -> ScannerBuilder:
-        if index_segments is not None:
-            segment_ids = []
-            for segment_id in index_segments:
-                if isinstance(segment_id, (str, uuid.UUID)):
-                    segment_ids.append(str(segment_id))
-                else:
-                    raise TypeError(
-                        "index_segments must be an iterable of str or uuid.UUID. "
-                        f"Got {type(segment_id)} instead."
-                    )
-            index_segments = segment_ids
-
-        self._index_segments = index_segments
+        self._index_segments = _normalize_index_segment_ids(index_segments)
         return self
 
     def nearest(

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -568,8 +568,13 @@ class _Dataset:
         index_name: str,
         partition_id: int,
         hamming_threshold: int,
+        index_segments: Optional[List[str]] = None,
     ) -> pa.RecordBatchReader: ...
-    def get_ivf_partition_info(self, index_name: str) -> List[dict]: ...
+    def get_ivf_partition_info(
+        self,
+        index_name: str,
+        index_segments: Optional[List[str]] = None,
+    ) -> List[dict]: ...
     def hamming_clustering_for_sample(
         self,
         column: str,

--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -3,8 +3,18 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Iterator, Literal, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Union,
+    cast,
+)
 
 import pyarrow as pa
 
@@ -49,6 +59,29 @@ def sanitize_ts(ts: ts_types) -> datetime:
 def td_to_micros(td: timedelta) -> int:
     """Returns the number of microseconds in a timedelta object."""
     return round(td / timedelta(microseconds=1))
+
+
+def _normalize_index_segment_ids(
+    index_segments: Optional[Iterable[Union[str, uuid.UUID]]],
+) -> Optional[List[str]]:
+    """Normalize a physical index segment selection to a list of UUID strings."""
+    if index_segments is None:
+        return None
+    if isinstance(index_segments, (str, uuid.UUID)):
+        raise TypeError(
+            "index_segments must be an iterable of str or uuid.UUID, "
+            f"not a single {type(index_segments)}."
+        )
+    segment_ids = []
+    for segment_id in index_segments:
+        if isinstance(segment_id, (str, uuid.UUID)):
+            segment_ids.append(str(segment_id))
+        else:
+            raise TypeError(
+                "index_segments must be an iterable of str or uuid.UUID. "
+                f"Got {type(segment_id)} instead."
+            )
+    return segment_ids
 
 
 class KMeans:

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import re
 import tempfile
-import uuid
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
 import pyarrow as pa
@@ -20,9 +19,10 @@ from .dependencies import (
 )
 from .dependencies import numpy as np
 from .log import LOGGER
-from .util import MetricType, _normalize_metric_type
+from .util import MetricType, _normalize_index_segment_ids, _normalize_metric_type
 
 if TYPE_CHECKING:
+    import uuid
     from pathlib import Path
 
     from . import LanceDataset
@@ -757,23 +757,6 @@ def one_pass_assign_ivf_pq_on_accelerator(
 # =============================================================================
 
 
-def _normalize_index_segments(
-    index_segments: Optional[Iterable[Union[str, uuid.UUID]]],
-) -> Optional[List[str]]:
-    if index_segments is None:
-        return None
-    segment_ids = []
-    for segment_id in index_segments:
-        if isinstance(segment_id, (str, uuid.UUID)):
-            segment_ids.append(str(segment_id))
-        else:
-            raise TypeError(
-                "index_segments must be an iterable of str or uuid.UUID. "
-                f"Got {type(segment_id)} instead."
-            )
-    return segment_ids
-
-
 def hamming_clustering_for_ivf_partition(
     dataset: "LanceDataset",
     index_name: str,
@@ -819,7 +802,7 @@ def hamming_clustering_for_ivf_partition(
         index_name,
         partition_id,
         hamming_threshold,
-        _normalize_index_segments(index_segments),
+        _normalize_index_segment_ids(index_segments),
     )
 
 
@@ -851,7 +834,7 @@ def get_ivf_partition_info(
         List of partition info dicts with 'partition_id' and 'size'
     """
     return dataset._ds.get_ivf_partition_info(
-        index_name, _normalize_index_segments(index_segments)
+        index_name, _normalize_index_segment_ids(index_segments)
     )
 
 

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import tempfile
+import uuid
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
 import pyarrow as pa
@@ -756,18 +757,39 @@ def one_pass_assign_ivf_pq_on_accelerator(
 # =============================================================================
 
 
+def _normalize_index_segments(
+    index_segments: Optional[Iterable[Union[str, uuid.UUID]]],
+) -> Optional[List[str]]:
+    if index_segments is None:
+        return None
+    segment_ids = []
+    for segment_id in index_segments:
+        if isinstance(segment_id, (str, uuid.UUID)):
+            segment_ids.append(str(segment_id))
+        else:
+            raise TypeError(
+                "index_segments must be an iterable of str or uuid.UUID. "
+                f"Got {type(segment_id)} instead."
+            )
+    return segment_ids
+
+
 def hamming_clustering_for_ivf_partition(
     dataset: "LanceDataset",
     index_name: str,
     partition_id: int,
     hamming_threshold: int,
+    *,
+    index_segments: Optional[Iterable[Union[str, uuid.UUID]]] = None,
 ) -> pa.RecordBatchReader:
     """
     Perform hamming clustering on a partition of an IVF_FLAT index.
 
-    Loads a partition from an IVF_FLAT index on a hash column, computes
-    pairwise hamming distances between all hashes in the partition,
-    filters by threshold, and clusters the results using union-find.
+    Loads a partition from every segment of an IVF_FLAT index on a hash
+    column, computes pairwise hamming distances between all hashes in the
+    combined partition, filters by threshold, and clusters the results using
+    union-find. All segments of the logical index must share the same global
+    IVF centroids; an error is raised if they do not.
 
     Parameters
     ----------
@@ -779,6 +801,11 @@ def hamming_clustering_for_ivf_partition(
         The partition ID within the IVF_FLAT index
     hamming_threshold : int
         Maximum hamming distance to consider as similar
+    index_segments : iterable of str or uuid.UUID, optional
+        If specified, only these physical index segment UUIDs of the named
+        logical index contribute rows. Use
+        :meth:`LanceDataset.describe_indices` to obtain segment UUIDs from
+        ``IndexDescription.segments``. Defaults to all segments.
 
     Returns
     -------
@@ -789,16 +816,24 @@ def hamming_clustering_for_ivf_partition(
         - 'duplicates': list<uint64> - List of duplicate row IDs in each cluster
     """
     return dataset._ds.hamming_clustering_for_ivf_partition(
-        index_name, partition_id, hamming_threshold
+        index_name,
+        partition_id,
+        hamming_threshold,
+        _normalize_index_segments(index_segments),
     )
 
 
 def get_ivf_partition_info(
     dataset: "LanceDataset",
     index_name: str,
+    *,
+    index_segments: Optional[Iterable[Union[str, uuid.UUID]]] = None,
 ) -> List[dict]:
     """
     Get partition information for an IVF_FLAT index.
+
+    Partition sizes are aggregated across all segments of the logical index
+    unless a subset is selected via ``index_segments``.
 
     Parameters
     ----------
@@ -806,13 +841,18 @@ def get_ivf_partition_info(
         The Lance dataset containing the hash column with an IVF_FLAT index.
     index_name : str
         Name of the IVF_FLAT index
+    index_segments : iterable of str or uuid.UUID, optional
+        If specified, only these physical index segment UUIDs of the named
+        logical index contribute to the sizes. Defaults to all segments.
 
     Returns
     -------
     list[dict]
         List of partition info dicts with 'partition_id' and 'size'
     """
-    return dataset._ds.get_ivf_partition_info(index_name)
+    return dataset._ds.get_ivf_partition_info(
+        index_name, _normalize_index_segments(index_segments)
+    )
 
 
 def hamming_clustering_for_sample(

--- a/python/python/tests/test_vector.py
+++ b/python/python/tests/test_vector.py
@@ -5,7 +5,12 @@ import lance
 import numpy as np
 import pyarrow as pa
 import pytest
-from lance.vector import hamming_clustering_for_sample, vec_to_table
+from lance.vector import (
+    get_ivf_partition_info,
+    hamming_clustering_for_ivf_partition,
+    hamming_clustering_for_sample,
+    vec_to_table,
+)
 
 
 def test_dict():
@@ -182,3 +187,70 @@ def test_hamming_clustering_for_sample(tmp_path):
     }
     # Singleton row 5 is not emitted as a cluster.
     assert clusters == {0: [1, 2], 3: [4]}
+
+
+def test_hamming_clustering_multi_segment(tmp_path):
+    # 25 distinct hash values, two copies each; the same table is written to
+    # fragment 0 and appended as fragment 1.
+    values = [((i // 2) * 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF for i in range(50)]
+    table = _hash_table([list(value.to_bytes(8, "little")) for value in values])
+    dataset = lance.write_dataset(table, tmp_path / "hashes")
+    dataset.create_index(
+        "hash", index_type="IVF_FLAT", num_partitions=4, metric="hamming"
+    )
+    dataset = lance.write_dataset(table, tmp_path / "hashes", mode="append")
+    # Optimizing with merge disabled creates a delta segment for fragment 1.
+    dataset.optimize.optimize_indices(num_indices_to_merge=0)
+
+    index = dataset.describe_indices()[0]
+    assert len(index.segments) == 2
+
+    infos = get_ivf_partition_info(dataset, index.name)
+    assert sum(info["size"] for info in infos) == 100
+
+    # All four copies of each value cluster together across both fragments.
+    frag1_start = 1 << 32
+    clusters = []
+    for info in infos:
+        result = hamming_clustering_for_ivf_partition(
+            dataset, index.name, info["partition_id"], 0
+        ).read_all()
+        clusters.extend(
+            zip(
+                result["representative"].to_pylist(),
+                result["duplicates"].to_pylist(),
+            )
+        )
+    assert len(clusters) == 25
+    for representative, duplicates in clusters:
+        assert representative < frag1_start
+        assert len(duplicates) == 3
+        assert any(dup >= frag1_start for dup in duplicates)
+
+    # Selecting the fragment-0 segment reproduces the single-segment scope.
+    first_segment = next(
+        segment for segment in index.segments if segment.fragment_ids == {0}
+    )
+    infos = get_ivf_partition_info(
+        dataset, index.name, index_segments=[first_segment.uuid]
+    )
+    assert sum(info["size"] for info in infos) == 50
+    num_selected_clusters = 0
+    for info in infos:
+        result = hamming_clustering_for_ivf_partition(
+            dataset,
+            index.name,
+            info["partition_id"],
+            0,
+            index_segments=[first_segment.uuid],
+        ).read_all()
+        for duplicates in result["duplicates"].to_pylist():
+            num_selected_clusters += 1
+            assert duplicates == [dup for dup in duplicates if dup < frag1_start]
+            assert len(duplicates) == 1
+    assert num_selected_clusters == 25
+
+    with pytest.raises(ValueError, match="invalid index segment uuid"):
+        get_ivf_partition_info(dataset, index.name, index_segments=["not-a-uuid"])
+    with pytest.raises(TypeError, match="str or uuid.UUID"):
+        get_ivf_partition_info(dataset, index.name, index_segments=[123])

--- a/python/python/tests/test_vector.py
+++ b/python/python/tests/test_vector.py
@@ -254,3 +254,5 @@ def test_hamming_clustering_multi_segment(tmp_path):
         get_ivf_partition_info(dataset, index.name, index_segments=["not-a-uuid"])
     with pytest.raises(TypeError, match="str or uuid.UUID"):
         get_ivf_partition_info(dataset, index.name, index_segments=[123])
+    with pytest.raises(TypeError, match="not a single"):
+        get_ivf_partition_info(dataset, index.name, index_segments=first_segment.uuid)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -549,6 +549,23 @@ fn extract_index_segments(segments: &Bound<'_, PyAny>) -> PyResult<Vec<IndexSegm
     Ok(extracted)
 }
 
+fn parse_index_segment_ids(index_segments: Option<Vec<String>>) -> PyResult<Option<Vec<Uuid>>> {
+    index_segments
+        .map(|segments| {
+            segments
+                .into_iter()
+                .map(|segment| {
+                    Uuid::parse_str(&segment).map_err(|err| {
+                        PyValueError::new_err(format!(
+                            "invalid index segment uuid '{segment}': {err}"
+                        ))
+                    })
+                })
+                .collect::<PyResult<Vec<_>>>()
+        })
+        .transpose()
+}
+
 impl MergeInsertBuilder {
     fn build_stats<'a>(stats: &MergeStats, py: Python<'a>) -> PyResult<Bound<'a, PyDict>> {
         let dict = PyDict::new(py);
@@ -2607,20 +2624,7 @@ impl Dataset {
         with_position: bool,
         index_segments: Option<Vec<String>>,
     ) -> PyResult<()> {
-        let index_segments = index_segments
-            .map(|segments| {
-                segments
-                    .into_iter()
-                    .map(|segment| {
-                        Uuid::parse_str(&segment).map_err(|err| {
-                            PyValueError::new_err(format!(
-                                "invalid index segment uuid '{segment}': {err}"
-                            ))
-                        })
-                    })
-                    .collect::<PyResult<Vec<_>>>()
-            })
-            .transpose()?;
+        let index_segments = parse_index_segment_ids(index_segments)?;
 
         rt().block_on(None, async {
             if with_position {
@@ -3629,9 +3633,10 @@ impl Dataset {
 
     /// Perform pairwise hamming distance clustering on a partition of an IVF_FLAT index.
     ///
-    /// This function loads a specific partition from an IVF_FLAT index on a hash column,
-    /// computes pairwise hamming distances between all hashes in the partition,
-    /// filters by threshold, and clusters the results using union-find.
+    /// This function loads a specific partition from every segment of an IVF_FLAT
+    /// index on a hash column, computes pairwise hamming distances between all
+    /// hashes in the combined partition, filters by threshold, and clusters the
+    /// results using union-find.
     ///
     /// Parameters
     /// ----------
@@ -3641,6 +3646,9 @@ impl Dataset {
     ///     The partition ID within the IVF_FLAT index
     /// hamming_threshold : int
     ///     Maximum hamming distance to consider as similar
+    /// index_segments : list of str, optional
+    ///     If specified, only these physical index segment UUIDs of the named
+    ///     logical index contribute rows. Defaults to all segments.
     ///
     /// Returns
     /// -------
@@ -3648,27 +3656,45 @@ impl Dataset {
     ///     A reader yielding batches with columns:
     ///     - 'representative': uint64 - The representative row ID for each cluster
     ///     - 'duplicates': list<uint64> - List of duplicate row IDs in each cluster
-    #[pyo3(signature = (index_name, partition_id, hamming_threshold))]
+    #[pyo3(signature = (index_name, partition_id, hamming_threshold, index_segments=None))]
     fn hamming_clustering_for_ivf_partition(
         &self,
         py: Python<'_>,
         index_name: &str,
         partition_id: usize,
         hamming_threshold: u32,
+        index_segments: Option<Vec<String>>,
     ) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
-        use lance::index::vector::hamming::hamming_clustering_for_ivf_partition;
+        use lance::index::vector::hamming::{
+            hamming_clustering_for_ivf_partition, hamming_clustering_for_ivf_partition_segments,
+        };
 
+        let segment_ids = parse_index_segment_ids(index_segments)?;
         let ds = self.ds.as_ref();
         let reader = rt()
-            .block_on(
-                Some(py),
-                hamming_clustering_for_ivf_partition(
-                    ds,
-                    index_name,
-                    partition_id,
-                    hamming_threshold,
-                ),
-            )?
+            .block_on(Some(py), async {
+                match segment_ids.as_deref() {
+                    Some(segment_ids) => {
+                        hamming_clustering_for_ivf_partition_segments(
+                            ds,
+                            index_name,
+                            segment_ids,
+                            partition_id,
+                            hamming_threshold,
+                        )
+                        .await
+                    }
+                    None => {
+                        hamming_clustering_for_ivf_partition(
+                            ds,
+                            index_name,
+                            partition_id,
+                            hamming_threshold,
+                        )
+                        .await
+                    }
+                }
+            })?
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         Ok(PyArrowType(reader))
@@ -3676,26 +3702,43 @@ impl Dataset {
 
     /// Get partition information for an IVF_FLAT index.
     ///
+    /// Partition sizes are aggregated across all segments of the logical index
+    /// unless a subset is selected via ``index_segments``.
+    ///
     /// Parameters
     /// ----------
     /// index_name : str
     ///     Name of the IVF_FLAT index
+    /// index_segments : list of str, optional
+    ///     If specified, only these physical index segment UUIDs of the named
+    ///     logical index contribute to the sizes. Defaults to all segments.
     ///
     /// Returns
     /// -------
     /// List[dict]
     ///     List of partition info dicts with 'partition_id' and 'size'
-    #[pyo3(signature = (index_name))]
+    #[pyo3(signature = (index_name, index_segments=None))]
     fn get_ivf_partition_info(
         &self,
         py: Python<'_>,
         index_name: &str,
+        index_segments: Option<Vec<String>>,
     ) -> PyResult<Vec<Py<PyDict>>> {
-        use lance::index::vector::hamming::get_ivf_partition_info;
+        use lance::index::vector::hamming::{
+            get_ivf_partition_info, get_ivf_partition_info_segments,
+        };
 
+        let segment_ids = parse_index_segment_ids(index_segments)?;
         let ds = self.ds.as_ref();
         let result = rt()
-            .block_on(Some(py), get_ivf_partition_info(ds, index_name))?
+            .block_on(Some(py), async {
+                match segment_ids.as_deref() {
+                    Some(segment_ids) => {
+                        get_ivf_partition_info_segments(ds, index_name, segment_ids).await
+                    }
+                    None => get_ivf_partition_info(ds, index_name).await,
+                }
+            })?
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         let partitions: PyResult<Vec<_>> = result

--- a/rust/lance/src/index/vector/hamming.rs
+++ b/rust/lance/src/index/vector/hamming.rs
@@ -5,36 +5,281 @@
 //!
 //! This module provides functionality to perform pairwise hamming distance
 //! computation and clustering on specific partitions of IVF_FLAT indices.
+//!
+//! A logical IVF_FLAT index may consist of multiple physical segments (e.g.
+//! delta segments created by `optimize_indices` in append mode, or segments
+//! committed by distributed index builds). All segments of one logical index
+//! are assumed to share the same global IVF centroids, so one partition id
+//! refers to the same centroid region in every segment; this is validated and
+//! an error is returned if the centroids differ.
 
+use std::sync::Arc;
 use std::time::Instant;
 
-use arrow_array::RecordBatchReader;
 use arrow_array::cast::AsArray;
 use arrow_array::types::UInt64Type;
+use arrow_array::{Array, FixedSizeListArray, RecordBatchReader};
 use arrow_schema::DataType;
 use lance_core::{Error, Result};
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::vector::VectorIndex;
 use lance_index::vector::flat::index::{FlatBinQuantizer, FlatIndex};
 use lance_index::vector::flat::storage::FLAT_COLUMN;
+use lance_index::vector::ivf::storage::IvfModel;
 use lance_index::vector::storage::VectorStore;
 use lance_linalg::distance::{
     ClusteringResult, cluster_pairwise_result, extract_hashes_from_fixed_list,
     pairwise_hamming_distance_parallel,
 };
+use lance_table::format::IndexMetadata;
 use rand::rng;
 use rand::seq::index::sample;
+use uuid::Uuid;
 
 use crate::dataset::Dataset;
-use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt, filter_index_segments_by_ids};
 
 use super::ivf::v2::IVFIndex;
 
+/// One opened physical segment of a logical IVF_FLAT binary index.
+struct HashIndexSegment {
+    metadata: IndexMetadata,
+    index: Arc<dyn VectorIndex>,
+}
+
+impl HashIndexSegment {
+    fn ivf_flat_bin(&self) -> &IVFIndex<FlatIndex, FlatBinQuantizer> {
+        self.index
+            .as_any()
+            .downcast_ref::<IVFIndex<FlatIndex, FlatBinQuantizer>>()
+            .expect("segment type validated in open_hash_index_segments")
+    }
+}
+
+/// Validate that a column stores 64-bit hashes as `FixedSizeList<UInt8, 8>`.
+fn validate_hash_column(column: &str, data_type: &DataType) -> Result<()> {
+    match data_type {
+        DataType::FixedSizeList(inner, 8) if *inner.data_type() == DataType::UInt8 => Ok(()),
+        DataType::FixedSizeList(inner, 8) => Err(Error::invalid_input(format!(
+            "Column '{}' must be FixedSizeList<UInt8, 8>, got FixedSizeList<{:?}, 8>",
+            column,
+            inner.data_type()
+        ))),
+        _ => Err(Error::invalid_input(format!(
+            "Column '{}' must be FixedSizeList<UInt8, 8>, got {:?}",
+            column, data_type
+        ))),
+    }
+}
+
+/// Validate that every segment of a logical IVF index shares the same global
+/// centroids, so one partition id refers to the same centroid region in each
+/// segment. Fails if any segment has no centroids or diverging centroids.
+fn validate_shared_centroids<'a>(
+    index_name: &str,
+    models: impl IntoIterator<Item = (Uuid, &'a IvfModel)>,
+) -> Result<()> {
+    struct Reference<'a> {
+        uuid: Uuid,
+        num_partitions: usize,
+        centroids: &'a FixedSizeListArray,
+    }
+
+    let mut reference: Option<Reference<'a>> = None;
+    for (uuid, model) in models {
+        let centroids = model.centroids_array().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Index '{}' segment {} has no IVF centroids; hamming clustering requires \
+                 segments built from a shared global IVF model",
+                index_name, uuid
+            ))
+        })?;
+        match &reference {
+            None => {
+                reference = Some(Reference {
+                    uuid,
+                    num_partitions: model.num_partitions(),
+                    centroids,
+                });
+            }
+            Some(reference) => {
+                if centroids.to_data() != reference.centroids.to_data() {
+                    return Err(Error::invalid_input(format!(
+                        "Index '{}' segments do not share the same global IVF centroids: \
+                         segment {} ({} partitions) differs from segment {} ({} partitions); \
+                         retrain the index to merge segments before hamming clustering",
+                        index_name,
+                        uuid,
+                        model.num_partitions(),
+                        reference.uuid,
+                        reference.num_partitions
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Open the physical segments of a logical IVF_FLAT binary index.
+///
+/// When `segment_ids` is `None` all segments are opened; otherwise only the
+/// requested segments are opened and every requested id must exist. Validates
+/// that all selected segments index the same `FixedSizeList<UInt8, 8>` column,
+/// are IVF_FLAT indices for binary data, and share the same global centroids.
+async fn open_hash_index_segments(
+    dataset: &Dataset,
+    index_name: &str,
+    segment_ids: Option<&[Uuid]>,
+) -> Result<Vec<HashIndexSegment>> {
+    let metadatas = dataset.load_indices_by_name(index_name).await?;
+    if metadatas.is_empty() {
+        return Err(Error::invalid_input(format!(
+            "Index '{}' not found on dataset",
+            index_name
+        )));
+    }
+
+    let metadatas = match segment_ids {
+        None => metadatas,
+        Some(segment_ids) => {
+            if segment_ids.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "Segment selection for index '{}' must not be empty; \
+                     omit index_segments to use all segments",
+                    index_name
+                )));
+            }
+            filter_index_segments_by_ids(index_name, metadatas, segment_ids)?
+        }
+    };
+
+    let fields = metadatas[0].fields.clone();
+    if let Some(mismatched) = metadatas.iter().find(|meta| meta.fields != fields) {
+        return Err(Error::invalid_input(format!(
+            "Index '{}' segments cover different fields: segment {} covers {:?} \
+             while segment {} covers {:?}",
+            index_name, metadatas[0].uuid, fields, mismatched.uuid, mismatched.fields
+        )));
+    }
+
+    let field_id = fields
+        .first()
+        .ok_or_else(|| Error::invalid_input(format!("Index '{}' has no fields", index_name)))?;
+    let schema = dataset.schema();
+    let field = schema.field_by_id(*field_id).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "Field with id {} not found in schema for index '{}'",
+            field_id, index_name
+        ))
+    })?;
+    validate_hash_column(&field.name, &field.data_type())?;
+
+    let mut segments = Vec::with_capacity(metadatas.len());
+    for metadata in metadatas {
+        let index = dataset
+            .open_vector_index(&field.name, &metadata.uuid, &NoOpMetricsCollector)
+            .await?;
+        if index
+            .as_any()
+            .downcast_ref::<IVFIndex<FlatIndex, FlatBinQuantizer>>()
+            .is_none()
+        {
+            return Err(Error::invalid_input(format!(
+                "Index '{}' segment {} is not an IVF_FLAT index for binary data",
+                index_name, metadata.uuid
+            )));
+        }
+        segments.push(HashIndexSegment { metadata, index });
+    }
+
+    validate_shared_centroids(
+        index_name,
+        segments
+            .iter()
+            .map(|segment| (segment.metadata.uuid, segment.ivf_flat_bin().ivf_model())),
+    )?;
+
+    Ok(segments)
+}
+
+async fn hamming_clustering_for_ivf_partition_impl(
+    dataset: &Dataset,
+    index_name: &str,
+    segment_ids: Option<&[Uuid]>,
+    partition_id: usize,
+    hamming_threshold: u32,
+) -> Result<Box<dyn RecordBatchReader + Send>> {
+    let segments = open_hash_index_segments(dataset, index_name, segment_ids).await?;
+
+    // All segments share centroids, so the partition count is uniform.
+    let num_partitions = segments[0].ivf_flat_bin().ivf_model().num_partitions();
+    if partition_id >= num_partitions {
+        return Err(Error::invalid_input(format!(
+            "Partition ID {} is out of range (0..{})",
+            partition_id, num_partitions
+        )));
+    }
+
+    // Concatenate the partition's row ids and hashes across segments; identical
+    // hashes land in the same partition of every segment, so one pairwise pass
+    // over the union finds cross-segment duplicates.
+    let mut all_row_ids: Vec<u64> = Vec::new();
+    let mut all_hashes: Vec<u64> = Vec::new();
+    for segment in &segments {
+        let storage = segment
+            .ivf_flat_bin()
+            .load_partition_storage(partition_id, None)
+            .await?;
+        all_row_ids.extend(storage.row_ids().copied());
+        for batch in storage.to_batches()? {
+            let vectors = batch
+                .column_by_name(FLAT_COLUMN)
+                .ok_or_else(|| {
+                    Error::invalid_input(format!("Column '{}' not found in storage", FLAT_COLUMN))
+                })?
+                .as_fixed_size_list();
+            all_hashes.extend(extract_hashes_from_fixed_list(vectors)?);
+        }
+        if all_row_ids.len() != all_hashes.len() {
+            return Err(Error::internal(format!(
+                "Index '{}' segment {} partition {}: row id count {} does not match hash count {}",
+                index_name,
+                segment.metadata.uuid,
+                partition_id,
+                all_row_ids.len(),
+                all_hashes.len()
+            )));
+        }
+    }
+
+    if all_row_ids.is_empty() {
+        let empty = ClusteringResult {
+            clusters: Vec::new(),
+        };
+        return Ok(empty.into_reader(None));
+    }
+
+    // Compute pairwise hamming distances with threshold filtering
+    let pairwise_result = pairwise_hamming_distance_parallel(
+        &all_hashes,
+        Some(&all_row_ids),
+        Some(hamming_threshold),
+    );
+
+    // Cluster the results
+    let clustering = cluster_pairwise_result(&pairwise_result);
+
+    Ok(clustering.into_reader(None))
+}
+
 /// Perform pairwise hamming distance clustering on a partition of an IVF_FLAT index.
 ///
-/// This function loads a specific partition from an IVF_FLAT index on a hash column,
-/// computes pairwise hamming distances between all hashes in the partition,
-/// filters by threshold, and clusters the results using union-find.
+/// This function loads a specific partition from every segment of an IVF_FLAT
+/// index on a hash column, computes pairwise hamming distances between all
+/// hashes in the combined partition, filters by threshold, and clusters the
+/// results using union-find. See [`hamming_clustering_for_ivf_partition_segments`]
+/// to restrict the computation to selected segments.
 ///
 /// # Arguments
 ///
@@ -54,6 +299,7 @@ use super::ivf::v2::IVFIndex;
 /// Returns an error if:
 /// - The index doesn't exist or is not an IVF_FLAT index
 /// - The indexed column has wrong type (must be `FixedSizeList<UInt8, 8>`)
+/// - The index segments do not share the same global IVF centroids
 /// - The partition ID is out of range
 pub async fn hamming_clustering_for_ivf_partition(
     dataset: &Dataset,
@@ -61,174 +307,88 @@ pub async fn hamming_clustering_for_ivf_partition(
     partition_id: usize,
     hamming_threshold: u32,
 ) -> Result<Box<dyn RecordBatchReader + Send>> {
-    // Load indices and find the IVF_FLAT index
-    let indices = dataset.load_indices().await?;
-    let index_meta = indices
-        .iter()
-        .find(|idx| idx.name == index_name)
-        .ok_or_else(|| {
-            Error::invalid_input(format!("Index '{}' not found on dataset", index_name))
-        })?;
+    hamming_clustering_for_ivf_partition_impl(
+        dataset,
+        index_name,
+        None,
+        partition_id,
+        hamming_threshold,
+    )
+    .await
+}
 
-    // Get the column name from the index metadata
-    let schema = dataset.schema();
-    let field_id = index_meta
-        .fields
-        .first()
-        .ok_or_else(|| Error::invalid_input(format!("Index '{}' has no fields", index_name)))?;
-    let field = schema.field_by_id(*field_id).ok_or_else(|| {
-        Error::invalid_input(format!(
-            "Field with id {} not found in schema for index '{}'",
-            field_id, index_name
-        ))
-    })?;
-    let column = &field.name;
+/// Perform pairwise hamming distance clustering on a partition of selected
+/// segments of an IVF_FLAT index.
+///
+/// Same as [`hamming_clustering_for_ivf_partition`] but only the requested
+/// physical segments contribute rows. Segment ids are the index UUIDs reported
+/// by index descriptions; every requested id must belong to the named index and
+/// the selection must not be empty.
+pub async fn hamming_clustering_for_ivf_partition_segments(
+    dataset: &Dataset,
+    index_name: &str,
+    segment_ids: &[Uuid],
+    partition_id: usize,
+    hamming_threshold: u32,
+) -> Result<Box<dyn RecordBatchReader + Send>> {
+    hamming_clustering_for_ivf_partition_impl(
+        dataset,
+        index_name,
+        Some(segment_ids),
+        partition_id,
+        hamming_threshold,
+    )
+    .await
+}
 
-    // Check column is FixedSizeList<UInt8, 8>
-    let data_type = field.data_type();
-    match data_type {
-        DataType::FixedSizeList(inner, 8) => {
-            if *inner.data_type() != DataType::UInt8 {
-                return Err(Error::invalid_input(format!(
-                    "Column '{}' must be FixedSizeList<UInt8, 8>, got FixedSizeList<{:?}, 8>",
-                    column,
-                    inner.data_type()
-                )));
-            }
+async fn get_ivf_partition_info_impl(
+    dataset: &Dataset,
+    index_name: &str,
+    segment_ids: Option<&[Uuid]>,
+) -> Result<Vec<PartitionInfo>> {
+    let segments = open_hash_index_segments(dataset, index_name, segment_ids).await?;
+
+    let num_partitions = segments[0].ivf_flat_bin().ivf_model().num_partitions();
+    let mut partition_infos: Vec<PartitionInfo> = (0..num_partitions)
+        .map(|partition_id| PartitionInfo {
+            partition_id,
+            size: 0,
+        })
+        .collect();
+    for segment in &segments {
+        // Sizes come from the partition storage; the IVF model of a v3 index
+        // file does not carry partition lengths.
+        let index = segment.ivf_flat_bin();
+        for info in partition_infos.iter_mut() {
+            info.size += index.partition_size(info.partition_id);
         }
-        _ => {
-            return Err(Error::invalid_input(format!(
-                "Column '{}' must be FixedSizeList<UInt8, 8>, got {:?}",
-                column, data_type
-            )));
-        }
     }
 
-    // Open the vector index
-    let index = dataset
-        .open_vector_index(column, &index_meta.uuid, &NoOpMetricsCollector)
-        .await?;
-
-    // Try to downcast to IVFIndex<FlatIndex, FlatBinQuantizer> (IVF_FLAT for binary data)
-    let ivf_index = index
-        .as_any()
-        .downcast_ref::<IVFIndex<FlatIndex, FlatBinQuantizer>>()
-        .ok_or_else(|| {
-            Error::invalid_input(format!(
-                "Index '{}' is not an IVF_FLAT index for binary data",
-                index_name
-            ))
-        })?;
-
-    // Check partition ID is valid
-    let num_partitions = ivf_index.ivf_model().num_partitions();
-    if partition_id >= num_partitions {
-        return Err(Error::invalid_input(format!(
-            "Partition ID {} is out of range (0..{})",
-            partition_id, num_partitions
-        )));
-    }
-
-    // Load the partition storage
-    let storage = ivf_index.load_partition_storage(partition_id, None).await?;
-
-    // Get row IDs
-    let row_id_slice: Vec<u64> = storage.row_ids().copied().collect();
-
-    if row_id_slice.is_empty() {
-        let empty = ClusteringResult {
-            clusters: Vec::new(),
-        };
-        return Ok(empty.into_reader(None));
-    }
-
-    // Get vectors from the storage batches
-    let batches: Vec<_> = storage.to_batches()?.collect();
-    if batches.is_empty() {
-        let empty = ClusteringResult {
-            clusters: Vec::new(),
-        };
-        return Ok(empty.into_reader(None));
-    }
-
-    // Extract the hash vectors from the FLAT_COLUMN
-    let mut all_hashes = Vec::new();
-    for batch in &batches {
-        let vectors = batch
-            .column_by_name(FLAT_COLUMN)
-            .ok_or_else(|| {
-                Error::invalid_input(format!("Column '{}' not found in storage", FLAT_COLUMN))
-            })?
-            .as_fixed_size_list();
-        let hashes = extract_hashes_from_fixed_list(vectors)?;
-        all_hashes.extend(hashes);
-    }
-
-    // Compute pairwise hamming distances with threshold filtering
-    let pairwise_result = pairwise_hamming_distance_parallel(
-        &all_hashes,
-        Some(&row_id_slice),
-        Some(hamming_threshold),
-    );
-
-    // Cluster the results
-    let clustering = cluster_pairwise_result(&pairwise_result);
-
-    Ok(clustering.into_reader(None))
+    Ok(partition_infos)
 }
 
 /// Get partition statistics for an IVF_FLAT index.
+///
+/// Partition sizes are aggregated across all segments of the logical index.
+/// See [`get_ivf_partition_info_segments`] to restrict the statistics to
+/// selected segments.
 pub async fn get_ivf_partition_info(
     dataset: &Dataset,
     index_name: &str,
 ) -> Result<Vec<PartitionInfo>> {
-    let indices = dataset.load_indices().await?;
-    let index_meta = indices
-        .iter()
-        .find(|idx| idx.name == index_name)
-        .ok_or_else(|| {
-            Error::invalid_input(format!("Index '{}' not found on dataset", index_name))
-        })?;
+    get_ivf_partition_info_impl(dataset, index_name, None).await
+}
 
-    // Get the column name from the index metadata
-    let schema = dataset.schema();
-    let field_id = index_meta
-        .fields
-        .first()
-        .ok_or_else(|| Error::invalid_input(format!("Index '{}' has no fields", index_name)))?;
-    let field = schema.field_by_id(*field_id).ok_or_else(|| {
-        Error::invalid_input(format!(
-            "Field with id {} not found in schema for index '{}'",
-            field_id, index_name
-        ))
-    })?;
-    let column = &field.name;
-
-    let index = dataset
-        .open_vector_index(column, &index_meta.uuid, &NoOpMetricsCollector)
-        .await?;
-
-    let ivf_index = index
-        .as_any()
-        .downcast_ref::<IVFIndex<FlatIndex, FlatBinQuantizer>>()
-        .ok_or_else(|| {
-            Error::invalid_input(format!(
-                "Index '{}' is not an IVF_FLAT index for binary data",
-                index_name
-            ))
-        })?;
-
-    let num_partitions = ivf_index.ivf_model().num_partitions();
-    let mut partition_infos = Vec::with_capacity(num_partitions);
-
-    for i in 0..num_partitions {
-        partition_infos.push(PartitionInfo {
-            partition_id: i,
-            size: ivf_index.ivf_model().partition_size(i),
-        });
-    }
-
-    Ok(partition_infos)
+/// Get partition statistics for selected segments of an IVF_FLAT index.
+///
+/// Same as [`get_ivf_partition_info`] but only the requested physical segments
+/// contribute to the partition sizes.
+pub async fn get_ivf_partition_info_segments(
+    dataset: &Dataset,
+    index_name: &str,
+    segment_ids: &[Uuid],
+) -> Result<Vec<PartitionInfo>> {
+    get_ivf_partition_info_impl(dataset, index_name, Some(segment_ids)).await
 }
 
 /// Information about an IVF partition.
@@ -267,26 +427,7 @@ pub async fn hamming_clustering_for_sample(
     let field = schema.field(column).ok_or_else(|| {
         Error::invalid_input(format!("Column '{}' not found in dataset schema", column))
     })?;
-
-    // Check column is FixedSizeList<UInt8, 8>
-    let data_type = field.data_type();
-    match data_type {
-        DataType::FixedSizeList(inner, 8) => {
-            if *inner.data_type() != DataType::UInt8 {
-                return Err(Error::invalid_input(format!(
-                    "Column '{}' must be FixedSizeList<UInt8, 8>, got FixedSizeList<{:?}, 8>",
-                    column,
-                    inner.data_type()
-                )));
-            }
-        }
-        _ => {
-            return Err(Error::invalid_input(format!(
-                "Column '{}' must be FixedSizeList<UInt8, 8>, got {:?}",
-                column, data_type
-            )));
-        }
-    }
+    validate_hash_column(column, &field.data_type())?;
 
     // Get total row count
     let total_rows: usize = dataset
@@ -411,26 +552,7 @@ pub async fn hamming_clustering_for_range(
     let field = schema.field(column).ok_or_else(|| {
         Error::invalid_input(format!("Column '{}' not found in dataset schema", column))
     })?;
-
-    // Check column is FixedSizeList<UInt8, 8>
-    let data_type = field.data_type();
-    match data_type {
-        DataType::FixedSizeList(inner, 8) => {
-            if *inner.data_type() != DataType::UInt8 {
-                return Err(Error::invalid_input(format!(
-                    "Column '{}' must be FixedSizeList<UInt8, 8>, got FixedSizeList<{:?}, 8>",
-                    column,
-                    inner.data_type()
-                )));
-            }
-        }
-        _ => {
-            return Err(Error::invalid_input(format!(
-                "Column '{}' must be FixedSizeList<UInt8, 8>, got {:?}",
-                column, data_type
-            )));
-        }
-    }
+    validate_hash_column(column, &field.data_type())?;
 
     // Get the fragment
     let fragment = dataset.get_fragment(fragment_id).ok_or_else(|| {
@@ -762,6 +884,195 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(err.to_string().contains("not found"), "Error: {}", err);
+    }
+
+    #[test]
+    fn test_validate_shared_centroids() {
+        use arrow_array::UInt8Array;
+        use lance_arrow::FixedSizeListArrayExt;
+
+        fn model_from_bytes(bytes: Vec<u8>) -> IvfModel {
+            let centroids =
+                FixedSizeListArray::try_new_from_values(UInt8Array::from(bytes), 8).unwrap();
+            IvfModel::new(centroids, None)
+        }
+
+        let uuid_a = Uuid::new_v4();
+        let uuid_b = Uuid::new_v4();
+
+        let model_a = model_from_bytes(vec![0u8; 16]);
+        let model_b = model_from_bytes(vec![0u8; 16]);
+        validate_shared_centroids("idx", [(uuid_a, &model_a), (uuid_b, &model_b)]).unwrap();
+
+        let mut diverged = vec![0u8; 16];
+        diverged[0] = 1;
+        let model_c = model_from_bytes(diverged);
+        let err =
+            validate_shared_centroids("idx", [(uuid_a, &model_a), (uuid_b, &model_c)]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("do not share the same global IVF centroids"),
+            "{}",
+            err
+        );
+        assert!(err.to_string().contains(&uuid_b.to_string()), "{}", err);
+
+        let model_d = model_from_bytes(vec![0u8; 24]);
+        let err =
+            validate_shared_centroids("idx", [(uuid_a, &model_a), (uuid_b, &model_d)]).unwrap_err();
+        assert!(err.to_string().contains("2 partitions"), "{}", err);
+        assert!(err.to_string().contains("3 partitions"), "{}", err);
+
+        let err = validate_shared_centroids("idx", [(uuid_a, &IvfModel::empty())]).unwrap_err();
+        assert!(err.to_string().contains("has no IVF centroids"), "{}", err);
+    }
+
+    #[tokio::test]
+    async fn test_hamming_clustering_for_ivf_partition_multi_segment() {
+        use arrow_array::{FixedSizeListArray, RecordBatchIterator, UInt8Array};
+        use arrow_schema::{Field, Schema};
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_index::vector::ivf::IvfBuildParams;
+        use std::sync::Arc;
+        use tempfile::tempdir;
+
+        fn hash_batch(schema: Arc<Schema>, values: &[u64]) -> arrow_array::RecordBatch {
+            let mut bytes = Vec::with_capacity(values.len() * 8);
+            for value in values {
+                bytes.extend_from_slice(&value.to_le_bytes());
+            }
+            let array =
+                FixedSizeListArray::try_new_from_values(UInt8Array::from(bytes), 8).unwrap();
+            arrow_array::RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+        }
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "hash",
+            arrow_schema::DataType::FixedSizeList(
+                Arc::new(Field::new("item", arrow_schema::DataType::UInt8, true)),
+                8,
+            ),
+            false,
+        )]));
+
+        // 25 distinct hash values, two copies each; the same batch is written to
+        // fragment 0 and appended as fragment 1, so every value has duplicates
+        // in both fragments.
+        let values: Vec<u64> = (0..50)
+            .map(|i| ((i / 2) as u64).wrapping_mul(0x9E3779B97F4A7C15))
+            .collect();
+        let num_values = 25;
+
+        let temp_dir = tempdir().unwrap();
+        let uri = temp_dir.path().to_str().unwrap();
+        let reader = RecordBatchIterator::new(
+            vec![Ok(hash_batch(schema.clone(), &values))],
+            schema.clone(),
+        );
+        let mut dataset = crate::Dataset::write(reader, uri, None).await.unwrap();
+
+        let params = crate::index::vector::VectorIndexParams::with_ivf_flat_params(
+            lance_linalg::distance::MetricType::Hamming,
+            IvfBuildParams::new(4),
+        );
+        dataset
+            .create_index(
+                &["hash"],
+                crate::index::IndexType::Vector,
+                Some("hash_idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let reader = RecordBatchIterator::new(
+            vec![Ok(hash_batch(schema.clone(), &values))],
+            schema.clone(),
+        );
+        dataset.append(reader, None).await.unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        let segments = dataset.load_indices_by_name("hash_idx").await.unwrap();
+        assert_eq!(
+            segments.len(),
+            2,
+            "expected a delta segment after optimize append"
+        );
+
+        // Partition sizes aggregate across both segments.
+        let infos = get_ivf_partition_info(&dataset, "hash_idx").await.unwrap();
+        assert_eq!(infos.len(), 4);
+        assert_eq!(infos.iter().map(|info| info.size).sum::<usize>(), 100);
+
+        // Clustering each partition with threshold 0 must group all four copies
+        // of every value, including the copies in the appended fragment.
+        const FRAG1_START: u64 = 1 << 32;
+        let mut clusters = Vec::new();
+        for partition_id in 0..4 {
+            let reader =
+                hamming_clustering_for_ivf_partition(&dataset, "hash_idx", partition_id, 0)
+                    .await
+                    .unwrap();
+            clusters.extend(collect_clusters(reader));
+        }
+        assert_eq!(clusters.len(), num_values);
+        for (representative, duplicates) in &clusters {
+            assert_eq!(duplicates.len(), 3);
+            assert!(*representative < FRAG1_START);
+            assert!(
+                duplicates.iter().any(|row_id| *row_id >= FRAG1_START),
+                "cluster {} should contain rows from the appended fragment",
+                representative
+            );
+        }
+
+        // Selecting only the original segment reproduces the single-segment scope.
+        let first_segment = segments
+            .iter()
+            .find(|meta| meta.fragment_bitmap.as_ref().unwrap().contains(0))
+            .unwrap();
+        let mut old_clusters = Vec::new();
+        for partition_id in 0..4 {
+            let reader = hamming_clustering_for_ivf_partition_segments(
+                &dataset,
+                "hash_idx",
+                &[first_segment.uuid],
+                partition_id,
+                0,
+            )
+            .await
+            .unwrap();
+            old_clusters.extend(collect_clusters(reader));
+        }
+        assert_eq!(old_clusters.len(), num_values);
+        for (representative, duplicates) in &old_clusters {
+            assert_eq!(duplicates.len(), 1);
+            assert!(*representative < FRAG1_START);
+            assert!(duplicates.iter().all(|row_id| *row_id < FRAG1_START));
+        }
+        let infos = get_ivf_partition_info_segments(&dataset, "hash_idx", &[first_segment.uuid])
+            .await
+            .unwrap();
+        assert_eq!(infos.iter().map(|info| info.size).sum::<usize>(), 50);
+
+        // Invalid segment selections are rejected.
+        let err = hamming_clustering_for_ivf_partition_segments(&dataset, "hash_idx", &[], 0, 0)
+            .await
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("must not be empty"), "{}", err);
+        let missing = Uuid::new_v4();
+        let err =
+            hamming_clustering_for_ivf_partition_segments(&dataset, "hash_idx", &[missing], 0, 0)
+                .await
+                .err()
+                .unwrap();
+        assert!(err.to_string().contains(&missing.to_string()), "{}", err);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`hamming_clustering_for_ivf_partition` and `get_ivf_partition_info` resolved the target index with `find(name)` — the first physical segment only. On a logical IVF_FLAT index made of multiple segments (delta segments from append-mode `optimize_indices`, or distributed builds committed via `commit_existing_index_segments`), this silently processed only the oldest segment: appended rows were excluded and cross-segment duplicate pairs were never compared, with no error raised.

Both functions now cover **all** segments of the logical index. Delta segments of one IVF index share centroids, so partition `p` denotes the same centroid region in every segment; the correct clustering unit is the union of partition `p`'s rows across all segments in a single pairwise pass (representative = min row id, so results are order-independent).

## Changes

- **Rust** (`lance-index::vector::hamming`): all-segments behavior for both functions. Every selected segment is validated to share byte-identical global IVF centroids; a mismatch (or missing centroids) raises a descriptive error naming the diverging segment UUIDs and partition counts, advising a retrain. New `hamming_clustering_for_ivf_partition_segments` / `get_ivf_partition_info_segments` accept explicit segment UUIDs, following the `prewarm_index_segments` precedent (#7677).
- **Python**: keyword-only `index_segments` argument on `hamming_clustering_for_ivf_partition` and `get_ivf_partition_info` (`None` = all segments, the default). Segment-id normalization used in three places (these wrappers, `prewarm_index`, `ScannerBuilder.with_index_segments`) is consolidated into `lance.util._normalize_index_segment_ids`.

## Notes

- Fixes a latent bug: `get_ivf_partition_info` returned `size: 0` for every partition on v3 index files because the loaded IVF model carries no partition lengths. Sizes now come from partition storage via `VectorIndex::partition_size`.
- Behavior tightening: `get_ivf_partition_info` now validates the indexed column is `FixedSizeList<UInt8, 8>`, a check it previously skipped. This is consistent with the clustering function, which always required 8-byte hashes.
- An empty explicit segment selection is rejected rather than silently returning "no duplicates", to avoid a silent data-quality hazard in dedup pipelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running IVF_FLAT Hamming clustering and partition analysis across multiple index segments.
  * Added optional segment selection to limit clustering and partition statistics to specific physical segments.
  * Segment identifiers now accept UUID strings or UUID objects with validation for invalid selections.

* **Bug Fixes**
  * Improved handling and validation of index segment identifiers across dataset and scanner operations.
  * Added validation to ensure selected segments are compatible before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->