### PR TITLE
fix: reconstruct protobuf schema fields in linear time

### DIFF
--- a/python/python/tests/test_schema.py
+++ b/python/python/tests/test_schema.py
@@ -64,6 +64,8 @@ def test_lance_schema(tmp_path: Path):
 
 
 def test_lance_schema_from_protos_rejects_missing_parent():
+    # name (field 2): child; id (field 3): 7; parent_id (field 4): 42;
+    # logical_type (field 5): int32.
     field_proto = b"\x12\x05child\x18\x07\x20\x2a\x2a\x05int32"
 
     with pytest.raises(

--- a/python/python/tests/test_schema.py
+++ b/python/python/tests/test_schema.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import lance
 import pyarrow as pa
+import pytest
 from lance.schema import LanceSchema
 
 
@@ -60,3 +61,13 @@ def test_lance_schema(tmp_path: Path):
     s_fields = fields[1].children()
     assert s_fields[0].name() == "new_name"
     assert s_fields[0].id() == 2
+
+
+def test_lance_schema_from_protos_rejects_missing_parent():
+    field_proto = b"\x12\x05child\x18\x07\x20\x2a\x2a\x05int32"
+
+    with pytest.raises(
+        ValueError,
+        match="Field 'child' \\(id=7\\) references parent id 42",
+    ):
+        LanceSchema._from_protos("{}", field_proto)

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -179,8 +179,7 @@ impl LanceSchema {
             fields: Fields(fields),
             metadata,
         };
-        let schema = fields_with_meta
-            .try_into_schema()
+        let schema = Schema::try_from(fields_with_meta)
             .map_err(|err| PyValueError::new_err(format!("Failed to reconstruct schema: {err}")))?;
         Ok(Self(schema))
     }

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -179,7 +179,9 @@ impl LanceSchema {
             fields: Fields(fields),
             metadata,
         };
-        let schema = Schema::from(fields_with_meta);
+        let schema = fields_with_meta
+            .try_into_schema()
+            .map_err(|err| PyValueError::new_err(format!("Failed to reconstruct schema: {err}")))?;
         Ok(Self(schema))
     }
 

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -61,5 +61,9 @@ features = ["protoc"]
 name = "reader"
 harness = false
 
+[[bench]]
+name = "schema"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance-file/benches/schema.rs
+++ b/rust/lance-file/benches/schema.rs
@@ -17,6 +17,10 @@ fn proto_field(id: i32, parent_id: i32, name: String, logical_type: &str) -> pb:
     }
 }
 
+/// Builds a pre-order flat schema with `num_physical_columns` physical leaves.
+///
+/// Each struct contributes one parent and two `int32` leaves. Root fields use
+/// `-1` as `parent_id`, and each struct consumes a three-ID block.
 fn wide_two_leaf_structs(num_physical_columns: usize) -> Fields {
     assert_eq!(num_physical_columns % 2, 0);
     let num_structs = num_physical_columns / 2;
@@ -57,7 +61,7 @@ fn bench_schema_reconstruction(c: &mut Criterion) {
             BenchmarkId::new("physical_columns", num_physical_columns),
             &fields,
             |bencher, fields| {
-                bencher.iter(|| Schema::from(black_box(fields)));
+                bencher.iter(|| Schema::try_from(black_box(fields)).unwrap());
             },
         );
     }

--- a/rust/lance-file/benches/schema.rs
+++ b/rust/lance-file/benches/schema.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use lance_core::datatypes::Schema;
+use lance_file::{datatypes::Fields, format::pb};
+
+fn proto_field(id: i32, parent_id: i32, name: String, logical_type: &str) -> pb::Field {
+    pb::Field {
+        id,
+        parent_id,
+        name,
+        logical_type: logical_type.to_owned(),
+        ..Default::default()
+    }
+}
+
+fn wide_two_leaf_structs(num_physical_columns: usize) -> Fields {
+    assert_eq!(num_physical_columns % 2, 0);
+    let num_structs = num_physical_columns / 2;
+    let mut fields = Vec::with_capacity(num_structs + num_physical_columns);
+
+    for struct_index in 0..num_structs {
+        let parent_id = (struct_index * 3) as i32;
+        fields.push(proto_field(
+            parent_id,
+            -1,
+            format!("struct_{struct_index}"),
+            "struct",
+        ));
+        fields.push(proto_field(
+            parent_id + 1,
+            parent_id,
+            format!("left_{struct_index}"),
+            "int32",
+        ));
+        fields.push(proto_field(
+            parent_id + 2,
+            parent_id,
+            format!("right_{struct_index}"),
+            "int32",
+        ));
+    }
+
+    Fields(fields)
+}
+
+fn bench_schema_reconstruction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("schema_from_flat_fields");
+
+    for num_physical_columns in [1024, 4096, 16_384, 65_536] {
+        let fields = wide_two_leaf_structs(num_physical_columns);
+        group.throughput(Throughput::Elements(fields.0.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("physical_columns", num_physical_columns),
+            &fields,
+            |bencher, fields| {
+                bencher.iter(|| Schema::from(black_box(fields)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_schema_reconstruction);
+criterion_main!(benches);

--- a/rust/lance-file/src/datatypes.rs
+++ b/rust/lance-file/src/datatypes.rs
@@ -99,6 +99,30 @@ impl From<&Field> for pb::Field {
 
 pub struct Fields(pub Vec<pb::Field>);
 
+struct FieldNode {
+    field: Field,
+    child_indices: Vec<usize>,
+}
+
+fn first_field_index_by_id(
+    nodes: &[FieldNode],
+    root_indices: &[usize],
+    field_id: i32,
+) -> Option<usize> {
+    let mut to_visit = Vec::with_capacity(nodes.len());
+    to_visit.extend(root_indices.iter().rev().copied());
+
+    while let Some(node_index) = to_visit.pop() {
+        let node = &nodes[node_index];
+        if node.field.id == field_id {
+            return Some(node_index);
+        }
+        to_visit.extend(node.child_indices.iter().rev().copied());
+    }
+
+    None
+}
+
 impl From<&Field> for Fields {
     fn from(field: &Field) -> Self {
         let mut protos = vec![pb::Field::from(field)];
@@ -107,24 +131,127 @@ impl From<&Field> for Fields {
     }
 }
 
-/// Convert list of protobuf `Field` to a Schema.
+impl Fields {
+    /// Reconstruct a schema from a flat, pre-order protobuf field list.
+    ///
+    /// Parent fields must appear before their children. Duplicate field IDs are
+    /// retained for backwards compatibility, and parent references use the
+    /// legacy first depth-first match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lance_file::{datatypes::Fields, format::pb};
+    ///
+    /// let field = pb::Field {
+    ///     id: 0,
+    ///     parent_id: -1,
+    ///     name: "value".to_owned(),
+    ///     logical_type: "int32".to_owned(),
+    ///     ..Default::default()
+    /// };
+    /// let schema = Fields(vec![field]).try_to_schema()?;
+    /// assert_eq!(schema.fields[0].name, "value");
+    /// # Ok::<(), lance_core::Error>(())
+    /// ```
+    pub fn try_to_schema(&self) -> Result<Schema> {
+        let mut nodes: Vec<FieldNode> = Vec::with_capacity(self.0.len());
+        let mut root_indices = Vec::with_capacity(self.0.len());
+        let mut field_indices: HashMap<i32, Option<usize>> = HashMap::with_capacity(self.0.len());
+
+        for proto_field in &self.0 {
+            let parent_index = if proto_field.parent_id == -1 {
+                None
+            } else {
+                let parent_index = match field_indices.get(&proto_field.parent_id) {
+                    Some(Some(parent_index)) => *parent_index,
+                    Some(None) => {
+                        // Duplicate IDs are invalid but occur in historical
+                        // manifests. Match the legacy tree traversal only for
+                        // these ambiguous parent references so valid schemas
+                        // retain the linear fast path.
+                        first_field_index_by_id(&nodes, &root_indices, proto_field.parent_id)
+                            .ok_or_else(|| {
+                                Error::internal(format!(
+                                    "Duplicate field id {} has no existing arena node",
+                                    proto_field.parent_id
+                                ))
+                            })?
+                    }
+                    None => {
+                        return Err(Error::schema(format!(
+                            "Field '{}' (id={}) references parent id {}, which must appear earlier in the protobuf field list",
+                            proto_field.name, proto_field.id, proto_field.parent_id
+                        )));
+                    }
+                };
+                Some(parent_index)
+            };
+
+            let node_index = nodes.len();
+            if let Some(parent_index) = parent_index {
+                nodes[parent_index].child_indices.push(node_index);
+            } else {
+                root_indices.push(node_index);
+            }
+            nodes.push(FieldNode {
+                field: Field::from(proto_field),
+                child_indices: Vec::new(),
+            });
+
+            field_indices
+                .entry(proto_field.id)
+                .and_modify(|field_index| *field_index = None)
+                .or_insert(Some(node_index));
+        }
+
+        let mut fields_by_node = Vec::with_capacity(nodes.len());
+        fields_by_node.resize_with(nodes.len(), || None);
+        for (node_index, mut node) in nodes.into_iter().enumerate().rev() {
+            node.field.children.reserve(node.child_indices.len());
+            for child_index in node.child_indices {
+                let child = fields_by_node
+                    .get_mut(child_index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "Schema field arena node {child_index} was not materialized before its parent"
+                        ))
+                    })?;
+                node.field.children.push(child);
+            }
+            fields_by_node[node_index] = Some(node.field);
+        }
+
+        let fields = root_indices
+            .into_iter()
+            .map(|root_index| {
+                fields_by_node[root_index].take().ok_or_else(|| {
+                    Error::internal(format!(
+                        "Schema field arena root node {root_index} was not materialized"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Schema {
+            fields,
+            metadata: HashMap::default(),
+        })
+    }
+}
+
+/// Convert a list of protobuf fields to a schema.
+///
+/// This preserves the legacy infallible conversion contract and panics when a
+/// child references a missing or later parent. Use [`Fields::try_to_schema`]
+/// when decoding untrusted protobuf data.
+#[allow(clippy::fallible_impl_from)]
 impl From<&Fields> for Schema {
     fn from(fields: &Fields) -> Self {
-        let mut schema = Self {
-            fields: vec![],
-            metadata: HashMap::default(),
-        };
-
-        fields.0.iter().for_each(|f| {
-            if f.parent_id == -1 {
-                schema.fields.push(Field::from(f));
-            } else {
-                let parent = schema.mut_field_by_id(f.parent_id).unwrap();
-                parent.children.push(Field::from(f));
-            }
-        });
-
-        schema
+        fields
+            .try_to_schema()
+            .unwrap_or_else(|error| panic!("Failed to reconstruct schema: {error}"))
     }
 }
 
@@ -133,10 +260,26 @@ pub struct FieldsWithMeta {
     pub metadata: HashMap<String, Vec<u8>>,
 }
 
-/// Convert list of protobuf `Field` and Metadata to a Schema.
-impl From<FieldsWithMeta> for Schema {
-    fn from(fields_with_meta: FieldsWithMeta) -> Self {
-        let lance_metadata = fields_with_meta
+impl FieldsWithMeta {
+    /// Reconstruct a schema from flat protobuf fields and schema metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    ///
+    /// use lance_file::datatypes::{Fields, FieldsWithMeta};
+    ///
+    /// let schema = FieldsWithMeta {
+    ///     fields: Fields(Vec::new()),
+    ///     metadata: HashMap::from([("owner".to_owned(), b"lance".to_vec())]),
+    /// }
+    /// .try_into_schema()?;
+    /// assert_eq!(schema.metadata["owner"], "lance");
+    /// # Ok::<(), lance_core::Error>(())
+    /// ```
+    pub fn try_into_schema(self) -> Result<Schema> {
+        let lance_metadata = self
             .metadata
             .into_iter()
             .map(|(key, value)| {
@@ -145,11 +288,25 @@ impl From<FieldsWithMeta> for Schema {
             })
             .collect();
 
-        let schema_with_fields = Self::from(&fields_with_meta.fields);
-        Self {
+        let schema_with_fields = self.fields.try_to_schema()?;
+        Ok(Schema {
             fields: schema_with_fields.fields,
             metadata: lance_metadata,
-        }
+        })
+    }
+}
+
+/// Convert protobuf fields and metadata to a schema.
+///
+/// This preserves the legacy infallible conversion contract and panics when a
+/// child references a missing or later parent. Use
+/// [`FieldsWithMeta::try_into_schema`] when decoding untrusted protobuf data.
+#[allow(clippy::fallible_impl_from)]
+impl From<FieldsWithMeta> for Schema {
+    fn from(fields_with_meta: FieldsWithMeta) -> Self {
+        fields_with_meta
+            .try_into_schema()
+            .unwrap_or_else(|error| panic!("Failed to reconstruct schema: {error}"))
     }
 }
 
@@ -270,14 +427,27 @@ pub async fn populate_schema_dictionary(schema: &mut Schema, reader: &dyn Reader
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, panic::AssertUnwindSafe};
+
     use arrow_schema::DataType;
     use arrow_schema::Field as ArrowField;
     use arrow_schema::Fields as ArrowFields;
     use arrow_schema::Schema as ArrowSchema;
+    use lance_core::Error;
     use lance_core::datatypes::Schema;
-    use std::collections::HashMap;
 
     use super::{Fields, FieldsWithMeta};
+    use crate::format::pb;
+
+    fn proto_field(id: i32, parent_id: i32, name: String, logical_type: &str) -> pb::Field {
+        pb::Field {
+            id,
+            parent_id,
+            name,
+            logical_type: logical_type.to_owned(),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn test_schema_set_ids() {
@@ -319,6 +489,117 @@ mod tests {
 
         let schema = Schema::from(fields_with_meta);
         assert_eq!(expected_schema, schema);
+    }
+
+    #[test]
+    fn test_reconstruct_wide_nested_schema() {
+        const NUM_STRUCTS: usize = 4096;
+
+        let mut proto_fields = Vec::with_capacity(NUM_STRUCTS * 3);
+        for struct_index in 0..NUM_STRUCTS {
+            let parent_id = (struct_index * 3) as i32;
+            proto_fields.push(proto_field(
+                parent_id,
+                -1,
+                format!("struct_{struct_index}"),
+                "struct",
+            ));
+            proto_fields.push(proto_field(
+                parent_id + 1,
+                parent_id,
+                format!("left_{struct_index}"),
+                "int32",
+            ));
+            proto_fields.push(proto_field(
+                parent_id + 2,
+                parent_id,
+                format!("right_{struct_index}"),
+                "int32",
+            ));
+        }
+
+        let schema = Fields(proto_fields).try_to_schema().unwrap();
+        assert_eq!(schema.fields.len(), NUM_STRUCTS);
+        for (struct_index, field) in schema.fields.iter().enumerate() {
+            let parent_id = (struct_index * 3) as i32;
+            assert_eq!(field.id, parent_id);
+            assert_eq!(field.name, format!("struct_{struct_index}"));
+            assert_eq!(field.children.len(), 2);
+            assert_eq!(field.children[0].id, parent_id + 1);
+            assert_eq!(field.children[0].name, format!("left_{struct_index}"));
+            assert_eq!(field.children[1].id, parent_id + 2);
+            assert_eq!(field.children[1].name, format!("right_{struct_index}"));
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_deep_nested_schema() {
+        const DEPTH: usize = 1024;
+
+        let proto_fields = (0..DEPTH)
+            .map(|depth| {
+                proto_field(
+                    depth as i32,
+                    if depth == 0 { -1 } else { depth as i32 - 1 },
+                    format!("level_{depth}"),
+                    if depth + 1 == DEPTH {
+                        "int32"
+                    } else {
+                        "struct"
+                    },
+                )
+            })
+            .collect();
+
+        let schema = Fields(proto_fields).try_to_schema().unwrap();
+        assert_eq!(schema.fields.len(), 1);
+        let mut field = &schema.fields[0];
+        for depth in 0..DEPTH {
+            assert_eq!(field.id, depth as i32);
+            assert_eq!(field.name, format!("level_{depth}"));
+            if depth + 1 == DEPTH {
+                assert!(field.children.is_empty());
+            } else {
+                assert_eq!(field.children.len(), 1);
+                field = &field.children[0];
+            }
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_schema_reports_missing_parent() {
+        let fields = Fields(vec![proto_field(7, 42, "child".to_owned(), "int32")]);
+
+        let error = fields.try_to_schema().unwrap_err();
+        assert!(matches!(&error, Error::Schema { .. }));
+        assert!(
+            error.to_string().contains(
+                "Field 'child' (id=7) references parent id 42, which must appear earlier"
+            )
+        );
+
+        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| Schema::from(&fields)));
+        assert!(panic.is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_schema_preserves_legacy_duplicate_id_match() {
+        let fields = Fields(vec![
+            proto_field(1, -1, "root_a".to_owned(), "struct"),
+            proto_field(2, -1, "root_b".to_owned(), "struct"),
+            proto_field(2, 1, "nested_duplicate".to_owned(), "struct"),
+            proto_field(3, 2, "child".to_owned(), "int32"),
+        ]);
+
+        let schema = fields.try_to_schema().unwrap();
+        assert_eq!(schema.fields.len(), 2);
+        assert_eq!(schema.fields[0].name, "root_a");
+        assert_eq!(schema.fields[0].children.len(), 1);
+        assert_eq!(schema.fields[0].children[0].name, "nested_duplicate");
+        assert_eq!(schema.fields[0].children[0].children.len(), 1);
+        assert_eq!(schema.fields[0].children[0].children[0].name, "child");
+        assert_eq!(schema.fields[1].name, "root_b");
+        assert!(schema.fields[1].children.is_empty());
     }
 
     #[test]

--- a/rust/lance-file/src/datatypes.rs
+++ b/rust/lance-file/src/datatypes.rs
@@ -104,6 +104,8 @@ struct FieldNode {
     child_indices: Vec<usize>,
 }
 
+/// Searches in pre-order depth-first order and returns the first matching node,
+/// preserving the legacy parent tie-break for duplicate field IDs.
 fn first_field_index_by_id(
     nodes: &[FieldNode],
     root_indices: &[usize],
@@ -131,35 +133,41 @@ impl From<&Field> for Fields {
     }
 }
 
-impl Fields {
-    /// Reconstruct a schema from a flat, pre-order protobuf field list.
-    ///
-    /// Parent fields must appear before their children. Duplicate field IDs are
-    /// retained for backwards compatibility, and parent references use the
-    /// legacy first depth-first match.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use lance_file::{datatypes::Fields, format::pb};
-    ///
-    /// let field = pb::Field {
-    ///     id: 0,
-    ///     parent_id: -1,
-    ///     name: "value".to_owned(),
-    ///     logical_type: "int32".to_owned(),
-    ///     ..Default::default()
-    /// };
-    /// let schema = Fields(vec![field]).try_to_schema()?;
-    /// assert_eq!(schema.fields[0].name, "value");
-    /// # Ok::<(), lance_core::Error>(())
-    /// ```
-    pub fn try_to_schema(&self) -> Result<Schema> {
-        let mut nodes: Vec<FieldNode> = Vec::with_capacity(self.0.len());
-        let mut root_indices = Vec::with_capacity(self.0.len());
-        let mut field_indices: HashMap<i32, Option<usize>> = HashMap::with_capacity(self.0.len());
+/// Reconstruct a schema from a flat, pre-order protobuf field list.
+///
+/// Parent fields must appear before their children. Historical manifests may
+/// contain duplicate field IDs, so an ID may not identify a unique parent. For
+/// those references, reconstruction preserves the legacy
+/// [`Schema::mut_field_by_id`] tie-break by selecting the first matching field
+/// in pre-order depth-first traversal.
+///
+/// # Examples
+///
+/// ```
+/// use lance_core::datatypes::Schema;
+/// use lance_file::{datatypes::Fields, format::pb};
+///
+/// let field = pb::Field {
+///     id: 0,
+///     parent_id: -1,
+///     name: "value".to_owned(),
+///     logical_type: "int32".to_owned(),
+///     ..Default::default()
+/// };
+/// let fields = Fields(vec![field]);
+/// let schema = Schema::try_from(&fields)?;
+/// assert_eq!(schema.fields[0].name, "value");
+/// # Ok::<(), lance_core::Error>(())
+/// ```
+impl TryFrom<&Fields> for Schema {
+    type Error = Error;
 
-        for proto_field in &self.0 {
+    fn try_from(fields: &Fields) -> Result<Self> {
+        let mut nodes: Vec<FieldNode> = Vec::with_capacity(fields.0.len());
+        let mut root_indices = Vec::with_capacity(fields.0.len());
+        let mut field_indices: HashMap<i32, Option<usize>> = HashMap::with_capacity(fields.0.len());
+
+        for proto_field in &fields.0 {
             let parent_index = if proto_field.parent_id == -1 {
                 None
             } else {
@@ -234,24 +242,10 @@ impl Fields {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(Schema {
+        Ok(Self {
             fields,
             metadata: HashMap::default(),
         })
-    }
-}
-
-/// Convert a list of protobuf fields to a schema.
-///
-/// This preserves the legacy infallible conversion contract and panics when a
-/// child references a missing or later parent. Use [`Fields::try_to_schema`]
-/// when decoding untrusted protobuf data.
-#[allow(clippy::fallible_impl_from)]
-impl From<&Fields> for Schema {
-    fn from(fields: &Fields) -> Self {
-        fields
-            .try_to_schema()
-            .unwrap_or_else(|error| panic!("Failed to reconstruct schema: {error}"))
     }
 }
 
@@ -260,26 +254,29 @@ pub struct FieldsWithMeta {
     pub metadata: HashMap<String, Vec<u8>>,
 }
 
-impl FieldsWithMeta {
-    /// Reconstruct a schema from flat protobuf fields and schema metadata.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::collections::HashMap;
-    ///
-    /// use lance_file::datatypes::{Fields, FieldsWithMeta};
-    ///
-    /// let schema = FieldsWithMeta {
-    ///     fields: Fields(Vec::new()),
-    ///     metadata: HashMap::from([("owner".to_owned(), b"lance".to_vec())]),
-    /// }
-    /// .try_into_schema()?;
-    /// assert_eq!(schema.metadata["owner"], "lance");
-    /// # Ok::<(), lance_core::Error>(())
-    /// ```
-    pub fn try_into_schema(self) -> Result<Schema> {
-        let lance_metadata = self
+/// Reconstruct a schema from flat protobuf fields and schema metadata.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use lance_core::datatypes::Schema;
+/// use lance_file::datatypes::{Fields, FieldsWithMeta};
+///
+/// let fields = FieldsWithMeta {
+///     fields: Fields(Vec::new()),
+///     metadata: HashMap::from([("owner".to_owned(), b"lance".to_vec())]),
+/// };
+/// let schema = Schema::try_from(fields)?;
+/// assert_eq!(schema.metadata["owner"], "lance");
+/// # Ok::<(), lance_core::Error>(())
+/// ```
+impl TryFrom<FieldsWithMeta> for Schema {
+    type Error = Error;
+
+    fn try_from(fields_with_meta: FieldsWithMeta) -> Result<Self> {
+        let lance_metadata = fields_with_meta
             .metadata
             .into_iter()
             .map(|(key, value)| {
@@ -288,25 +285,11 @@ impl FieldsWithMeta {
             })
             .collect();
 
-        let schema_with_fields = self.fields.try_to_schema()?;
-        Ok(Schema {
+        let schema_with_fields = Self::try_from(&fields_with_meta.fields)?;
+        Ok(Self {
             fields: schema_with_fields.fields,
             metadata: lance_metadata,
         })
-    }
-}
-
-/// Convert protobuf fields and metadata to a schema.
-///
-/// This preserves the legacy infallible conversion contract and panics when a
-/// child references a missing or later parent. Use
-/// [`FieldsWithMeta::try_into_schema`] when decoding untrusted protobuf data.
-#[allow(clippy::fallible_impl_from)]
-impl From<FieldsWithMeta> for Schema {
-    fn from(fields_with_meta: FieldsWithMeta) -> Self {
-        fields_with_meta
-            .try_into_schema()
-            .unwrap_or_else(|error| panic!("Failed to reconstruct schema: {error}"))
     }
 }
 
@@ -427,7 +410,7 @@ pub async fn populate_schema_dictionary(schema: &mut Schema, reader: &dyn Reader
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, panic::AssertUnwindSafe};
+    use std::collections::HashMap;
 
     use arrow_schema::DataType;
     use arrow_schema::Field as ArrowField;
@@ -487,7 +470,7 @@ mod tests {
         let expected_schema = Schema::try_from(&arrow_schema).unwrap();
         let fields_with_meta: FieldsWithMeta = (&expected_schema).into();
 
-        let schema = Schema::from(fields_with_meta);
+        let schema = Schema::try_from(fields_with_meta).unwrap();
         assert_eq!(expected_schema, schema);
     }
 
@@ -518,7 +501,8 @@ mod tests {
             ));
         }
 
-        let schema = Fields(proto_fields).try_to_schema().unwrap();
+        let fields = Fields(proto_fields);
+        let schema = Schema::try_from(&fields).unwrap();
         assert_eq!(schema.fields.len(), NUM_STRUCTS);
         for (struct_index, field) in schema.fields.iter().enumerate() {
             let parent_id = (struct_index * 3) as i32;
@@ -551,7 +535,8 @@ mod tests {
             })
             .collect();
 
-        let schema = Fields(proto_fields).try_to_schema().unwrap();
+        let fields = Fields(proto_fields);
+        let schema = Schema::try_from(&fields).unwrap();
         assert_eq!(schema.fields.len(), 1);
         let mut field = &schema.fields[0];
         for depth in 0..DEPTH {
@@ -570,16 +555,13 @@ mod tests {
     fn test_reconstruct_schema_reports_missing_parent() {
         let fields = Fields(vec![proto_field(7, 42, "child".to_owned(), "int32")]);
 
-        let error = fields.try_to_schema().unwrap_err();
+        let error = Schema::try_from(&fields).unwrap_err();
         assert!(matches!(&error, Error::Schema { .. }));
         assert!(
             error.to_string().contains(
                 "Field 'child' (id=7) references parent id 42, which must appear earlier"
             )
         );
-
-        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| Schema::from(&fields)));
-        assert!(panic.is_err());
     }
 
     #[test]
@@ -591,7 +573,7 @@ mod tests {
             proto_field(3, 2, "child".to_owned(), "int32"),
         ]);
 
-        let schema = fields.try_to_schema().unwrap();
+        let schema = Schema::try_from(&fields).unwrap();
         assert_eq!(schema.fields.len(), 2);
         assert_eq!(schema.fields[0].name, "root_a");
         assert_eq!(schema.fields[0].children.len(), 1);
@@ -632,7 +614,7 @@ mod tests {
 
         // Round-trip through protobuf
         let fields_with_meta: FieldsWithMeta = (&schema).into();
-        let restored = Schema::from(fields_with_meta);
+        let restored = Schema::try_from(fields_with_meta).unwrap();
 
         let ck2 = restored.unenforced_clustering_key();
         assert_eq!(ck2.len(), 2);

--- a/rust/lance-file/src/previous/format/metadata.rs
+++ b/rust/lance-file/src/previous/format/metadata.rs
@@ -62,10 +62,11 @@ impl TryFrom<pb::Metadata> for Metadata {
             manifest_position: Some(m.manifest_position as usize),
             stats_metadata: if let Some(stats_meta) = m.statistics {
                 Some(StatisticsMetadata {
-                    schema: Schema::from(FieldsWithMeta {
+                    schema: FieldsWithMeta {
                         fields: Fields(stats_meta.schema),
                         metadata: Default::default(),
-                    }),
+                    }
+                    .try_into_schema()?,
                     leaf_field_ids: stats_meta.fields,
                     page_table_position: stats_meta.page_table_position as usize,
                 })

--- a/rust/lance-file/src/previous/format/metadata.rs
+++ b/rust/lance-file/src/previous/format/metadata.rs
@@ -62,11 +62,10 @@ impl TryFrom<pb::Metadata> for Metadata {
             manifest_position: Some(m.manifest_position as usize),
             stats_metadata: if let Some(stats_meta) = m.statistics {
                 Some(StatisticsMetadata {
-                    schema: FieldsWithMeta {
+                    schema: Schema::try_from(FieldsWithMeta {
                         fields: Fields(stats_meta.schema),
                         metadata: Default::default(),
-                    }
-                    .try_into_schema()?,
+                    })?,
                     leaf_field_ids: stats_meta.fields,
                     page_table_position: stats_meta.page_table_position as usize,
                 })

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -961,7 +961,7 @@ impl FileReader {
             fields: Fields(pb_schema.fields),
             metadata: pb_schema.metadata,
         };
-        let schema = fields_with_meta.try_into_schema()?;
+        let schema = Schema::try_from(fields_with_meta)?;
         Ok((num_rows, schema))
     }
 

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -961,7 +961,7 @@ impl FileReader {
             fields: Fields(pb_schema.fields),
             metadata: pb_schema.metadata,
         };
-        let schema = lance_core::datatypes::Schema::from(fields_with_meta);
+        let schema = fields_with_meta.try_into_schema()?;
         Ok((num_rows, schema))
     }
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -900,7 +900,7 @@ impl TryFrom<pb::Manifest> for Manifest {
             Some(format) => DataStorageFormat::from(format),
         };
 
-        let schema = fields_with_meta.try_into_schema()?;
+        let schema = Schema::try_from(fields_with_meta)?;
 
         Ok(Self {
             schema,

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -900,7 +900,7 @@ impl TryFrom<pb::Manifest> for Manifest {
             Some(format) => DataStorageFormat::from(format),
         };
 
-        let schema = Schema::from(fields_with_meta);
+        let schema = fields_with_meta.try_into_schema()?;
 
         Ok(Self {
             schema,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3246,7 +3246,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                         .into_iter()
                         .map(Fragment::try_from)
                         .collect::<Result<Vec<_>>>()?,
-                    schema: Schema::from(&Fields(schema)),
+                    schema: Fields(schema).try_to_schema()?,
                     config_upsert_values: config_upsert_option,
                     initial_bases: if initial_bases.is_empty() {
                         None
@@ -3314,7 +3314,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                     .into_iter()
                     .map(Fragment::try_from)
                     .collect::<Result<Vec<_>>>()?,
-                schema: Schema::from(&Fields(schema)),
+                schema: Fields(schema).try_to_schema()?,
             },
             Some(pb::transaction::Operation::Restore(pb::transaction::Restore { version })) => {
                 Operation::Restore { version }
@@ -3368,7 +3368,7 @@ impl TryFrom<pb::Transaction> for Transaction {
             },
             Some(pb::transaction::Operation::Project(pb::transaction::Project { schema })) => {
                 Operation::Project {
-                    schema: Schema::from(&Fields(schema)),
+                    schema: Fields(schema).try_to_schema()?,
                 }
             }
             Some(pb::transaction::Operation::UpdateConfig(update_config)) => {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3246,7 +3246,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                         .into_iter()
                         .map(Fragment::try_from)
                         .collect::<Result<Vec<_>>>()?,
-                    schema: Fields(schema).try_to_schema()?,
+                    schema: Schema::try_from(&Fields(schema))?,
                     config_upsert_values: config_upsert_option,
                     initial_bases: if initial_bases.is_empty() {
                         None
@@ -3314,7 +3314,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                     .into_iter()
                     .map(Fragment::try_from)
                     .collect::<Result<Vec<_>>>()?,
-                schema: Fields(schema).try_to_schema()?,
+                schema: Schema::try_from(&Fields(schema))?,
             },
             Some(pb::transaction::Operation::Restore(pb::transaction::Restore { version })) => {
                 Operation::Restore { version }
@@ -3368,7 +3368,7 @@ impl TryFrom<pb::Transaction> for Transaction {
             },
             Some(pb::transaction::Operation::Project(pb::transaction::Project { schema })) => {
                 Operation::Project {
-                    schema: Fields(schema).try_to_schema()?,
+                    schema: Schema::try_from(&Fields(schema))?,
                 }
             }
             Some(pb::transaction::Operation::UpdateConfig(update_config)) => {


### PR DESCRIPTION
## Why

Schema decoding currently rebuilds a tree from flat protobuf fields by calling `mut_field_by_id` for every child. Each lookup traverses the partially built tree, making wide schemas O(N²). The same conversion is used by raw file schema decoding and dataset manifest decoding; on the 65,536-physical-column fixture the lookup dominated profiles.

## Solution

Build fields into an input-ordered arena, resolve unique parent IDs through an ID-to-node map, then materialize children in reverse arena order. Valid schemas preserve root and child order with O(total fields) time and memory. Malformed duplicate IDs retain the legacy first depth-first parent match; missing or forward parents now return errors through `TryFrom<&Fields>` and `TryFrom<FieldsWithMeta>`.

The reader, manifest, transaction, and Python protobuf boundaries now propagate this error (`ValueError` in Python). Wide/deep correctness coverage and a Criterion scaling benchmark cover 1,024 through 65,536 physical columns.

## Read-path impact

Raw/self-describing opens still fetch and decode file schema but reconstruct it linearly. Dataset manifest opens pay the same linear conversion once. Known-schema metadata-index fragment reads continue to skip the file schema buffer entirely; only their full-metadata fallback decodes and benefits from this change.

## Performance

Measured on the same `m7i.4xlarge` EC2 host in `us-east-2` with Rust 1.97.0 and the repository's `release-with-debug` profile. The fixture contains 32,768 two-leaf structs: 65,536 physical columns and 98,304 protobuf schema nodes. The valid-schema baseline restores the previous per-child `mut_field_by_id` lookup; the benchmark variants otherwise use identical code and fixture shapes.

Pure reconstruction uses three measured samples for each variant:

| Physical columns | Schema nodes | Before | After | Speedup |
|---:|---:|---:|---:|---:|
| 1,024 | 1,536 | 2.080 ms | 0.202 ms | 10.30x |
| 4,096 | 6,144 | 31.943 ms | 0.960 ms | 33.27x |
| 16,384 | 24,576 | 845.834 ms | 3.972 ms | 212.95x |
| 65,536 | 98,304 | 17,312.360 ms | 16.769 ms | **1,032.40x** |

Across the endpoints, the empirical scaling exponent drops from 2.17 to 1.06, discriminating quadratic-like from linear growth on this fixture.

End-to-end values are medians of three baseline samples and ten fixed samples. Read bytes, I/O counts, and observed result counts match before and after for every row.

| Path | Backend / cache | Before | After | Speedup |
|---|---|---:|---:|---:|
| Raw file open + query | local cold | 18,120.450 ms | 199.642 ms | **90.77x** |
| Raw file open + query | local hot | 18,089.921 ms | 162.132 ms | **111.58x** |
| Raw file open + query | S3 | 17,511.494 ms | 367.527 ms | **47.65x** |
| Self-describing metadata open | local cold | 17,908.873 ms | 78.325 ms | **228.65x** |
| Self-describing metadata open | local hot | 17,988.429 ms | 63.903 ms | **281.50x** |
| Self-describing metadata open | S3 | 17,262.306 ms | 153.614 ms | **112.38x** |
| Read all file metadata | local cold | 17,974.323 ms | 181.297 ms | **99.14x** |
| Read all file metadata | local hot | 18,064.959 ms | 147.584 ms | **122.41x** |
| Read all file metadata | S3 | 17,404.097 ms | 297.587 ms | **58.48x** |
| Dataset manifest open | local cold | 17,172.622 ms | 55.073 ms | **311.82x** |
| Dataset manifest open | local hot | 17,160.633 ms | 44.528 ms | **385.39x** |
| Dataset manifest open | S3 | 16,908.815 ms | 115.787 ms | **146.03x** |

Known-schema metadata opens bypass reconstruction and serve as an unaffected control:

| Backend / cache | Before | After |
|---|---:|---:|
| local cold | 7.635 ms | 7.697 ms |
| local hot | 0.868 ms | 1.317 ms |
| S3 | 61.781 ms | 64.014 ms |

The control ranges overlap, and their absolute median differences are 0.062–2.233 ms. Affected end-to-end paths save 16.79–17.93 seconds per open on this fixture.

This is independent of indexed metadata structural projection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema reconstruction validation now rejects missing or invalid parent references and enforces correct parent ordering.
  - Schema decoding during metadata, manifest, transaction, and reader operations now uses fallible reconstruction and returns clearer errors when schema data is invalid.
- **Tests**
  - Added regression coverage for missing parent references with a specific error message, plus coverage for wide/deep nested schemas and legacy duplicate field ID behavior.
- **Performance / Benchmarks**
  - Added Criterion benchmark for schema reconstruction on wide, large-nesting inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
