### PR TITLE
feat: support wider hamming hashes

### DIFF
--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -856,7 +856,8 @@ def hamming_clustering_for_sample(
     dataset : LanceDataset
         The Lance dataset containing the hash column.
     column : str
-        Name of the hash column (must be FixedSizeList<UInt8, 8>)
+        Name of the hash column (must be FixedSizeList<UInt8, N> where N is a
+        positive multiple of 8 bytes)
     sample_size : int, optional
         Number of rows to sample. If None, uses all rows.
     hamming_threshold : int, default 10
@@ -898,7 +899,8 @@ def hamming_clustering_for_range(
     dataset : LanceDataset
         The Lance dataset containing the hash column.
     column : str
-        Name of the hash column (must be FixedSizeList<UInt8, 8>)
+        Name of the hash column (must be FixedSizeList<UInt8, N> where N is a
+        positive multiple of 8 bytes)
     fragment_id : int
         The fragment ID to read from
     start_row : int

--- a/python/python/tests/test_vector.py
+++ b/python/python/tests/test_vector.py
@@ -155,21 +155,26 @@ def test_binary_vectors_invalid_metric(tmp_path):
 
 
 def _hash_table(hashes):
-    """Build a table with a ``hash`` column of FixedSizeList<UInt8, 8>.
+    """Build a table with a ``hash`` column of FixedSizeList<UInt8, N>.
 
-    ``hashes`` is a list of 8-byte sequences, one per row.
+    ``hashes`` is a list of byte sequences, one per row. The byte width must
+    be a positive multiple of 8.
     """
+    byte_width = len(hashes[0])
+    assert byte_width > 0 and byte_width % 8 == 0
+    assert all(len(row) == byte_width for row in hashes)
     flat = [byte for row in hashes for byte in row]
     values = pa.FixedSizeListArray.from_arrays(
-        pa.array(flat, type=pa.uint8()), list_size=8
+        pa.array(flat, type=pa.uint8()), list_size=byte_width
     )
     return pa.Table.from_arrays([values], names=["hash"])
 
 
-def test_hamming_clustering_for_sample(tmp_path):
-    hash_a = [0, 0, 0, 0, 0, 0, 0, 0]
-    hash_b = [255, 0, 0, 0, 0, 0, 0, 0]  # 8 bits from hash_a
-    hash_c = [1, 2, 3, 4, 5, 6, 7, 8]  # far from both
+@pytest.mark.parametrize("byte_width", [8, 16])
+def test_hamming_clustering_for_sample(tmp_path, byte_width):
+    hash_a = [0] * byte_width
+    hash_b = [255] + [0] * (byte_width - 1)  # 8 bits from hash_a
+    hash_c = list(range(1, byte_width + 1))  # far from both
     # Rows 0,1,2 share hash_a; rows 3,4 share hash_b; row 5 is unique.
     table = _hash_table([hash_a, hash_a, hash_a, hash_b, hash_b, hash_c])
     dataset = lance.write_dataset(table, tmp_path / "hashes")
@@ -189,11 +194,21 @@ def test_hamming_clustering_for_sample(tmp_path):
     assert clusters == {0: [1, 2], 3: [4]}
 
 
-def test_hamming_clustering_multi_segment(tmp_path):
+@pytest.mark.parametrize("byte_width", [8, 16])
+def test_hamming_clustering_multi_segment(tmp_path, byte_width):
+    mask = (1 << 64) - 1
+
+    def hash_bytes(value):
+        row = []
+        for lane in range(byte_width // 8):
+            lane_value = (value ^ ((lane * 0xA5A5A5A5A5A5A5A5) & mask)) & mask
+            row.extend(lane_value.to_bytes(8, "little"))
+        return row
+
     # 25 distinct hash values, two copies each; the same table is written to
     # fragment 0 and appended as fragment 1.
     values = [((i // 2) * 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF for i in range(50)]
-    table = _hash_table([list(value.to_bytes(8, "little")) for value in values])
+    table = _hash_table([hash_bytes(value) for value in values])
     dataset = lance.write_dataset(table, tmp_path / "hashes")
     dataset.create_index(
         "hash", index_type="IVF_FLAT", num_partitions=4, metric="hamming"

--- a/python/python/tests/test_vector.py
+++ b/python/python/tests/test_vector.py
@@ -173,7 +173,7 @@ def _hash_table(hashes):
 @pytest.mark.parametrize("byte_width", [8, 16])
 def test_hamming_clustering_for_sample(tmp_path, byte_width):
     hash_a = [0] * byte_width
-    hash_b = [255] + [0] * (byte_width - 1)  # 8 bits from hash_a
+    hash_b = [0] * (byte_width - 8) + [255] + [0] * 7  # 8 bits from hash_a
     hash_c = list(range(1, byte_width + 1))  # far from both
     # Rows 0,1,2 share hash_a; rows 3,4 share hash_b; row 5 is unique.
     table = _hash_table([hash_a, hash_a, hash_a, hash_b, hash_b, hash_c])
@@ -199,15 +199,22 @@ def test_hamming_clustering_multi_segment(tmp_path, byte_width):
     mask = (1 << 64) - 1
 
     def hash_bytes(value):
-        row = []
-        for lane in range(byte_width // 8):
-            lane_value = (value ^ ((lane * 0xA5A5A5A5A5A5A5A5) & mask)) & mask
-            row.extend(lane_value.to_bytes(8, "little"))
-        return row
+        if byte_width == 8:
+            lanes = [(value * 0x9E3779B97F4A7C15) & mask]
+        else:
+            # Adjacent logical values share the first 64-bit lane and differ in
+            # later lanes, so threshold-0 clustering must compare every lane.
+            lanes = [
+                ((value // 2) * 0x9E3779B97F4A7C15) & mask,
+                ((value * 0xD6E8FEB86659FD93) ^ 0xA5A5A5A5A5A5A5A5) & mask,
+            ]
+        return [
+            byte for lane_value in lanes for byte in lane_value.to_bytes(8, "little")
+        ]
 
     # 25 distinct hash values, two copies each; the same table is written to
     # fragment 0 and appended as fragment 1.
-    values = [((i // 2) * 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF for i in range(50)]
+    values = [i // 2 for i in range(50)]
     table = _hash_table([hash_bytes(value) for value in values])
     dataset = lance.write_dataset(table, tmp_path / "hashes")
     dataset.create_index(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3768,7 +3768,8 @@ impl Dataset {
     /// Parameters
     /// ----------
     /// column : str
-    ///     Name of the hash column (must be FixedSizeList<UInt8, 8>)
+    ///     Name of the hash column (must be FixedSizeList<UInt8, N> where N is
+    ///     a positive multiple of 8 bytes)
     /// sample_size : int, optional
     ///     Number of rows to sample (if None or >= total rows, uses all rows)
     /// hamming_threshold : int
@@ -3811,7 +3812,8 @@ impl Dataset {
     /// Parameters
     /// ----------
     /// column : str
-    ///     Name of the hash column (must be FixedSizeList<UInt8, 8>)
+    ///     Name of the hash column (must be FixedSizeList<UInt8, N> where N is
+    ///     a positive multiple of 8 bytes)
     /// fragment_id : int
     ///     The fragment ID to read from
     /// start_row : int

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -28,9 +28,11 @@ pub mod norm_l2;
 pub use cosine::*;
 pub use dot::*;
 pub use hamming::{
-    Cluster, ClusteringResult, PairwiseResult, UnionFind, cluster_edges, cluster_pairwise_result,
-    extract_hashes_from_fixed_list, hamming_distance_arrow_batch, hamming_u64,
-    pairwise_hamming_distance, pairwise_hamming_distance_parallel,
+    BinaryHashValues, Cluster, ClusteringResult, PairwiseResult, UnionFind, cluster_edges,
+    cluster_pairwise_result, extract_binary_hashes_from_fixed_list, extract_hashes_from_fixed_list,
+    hamming_distance_arrow_batch, hamming_u64, pairwise_hamming_distance,
+    pairwise_hamming_distance_binary, pairwise_hamming_distance_binary_parallel,
+    pairwise_hamming_distance_parallel,
 };
 pub use l2::*;
 use lance_core::deepsize::DeepSizeOf;

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -4,7 +4,7 @@
 //! Hamming distance.
 //!
 //! This module provides hamming distance computation for binary vectors,
-//! including SIMD-accelerated pairwise hamming distance for 64-bit hashes.
+//! including SIMD-accelerated pairwise hamming distance for binary hashes.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -100,6 +100,196 @@ pub fn hamming_distance_arrow_batch(
 #[inline(always)]
 pub fn hamming_u64(a: u64, b: u64) -> u32 {
     (a ^ b).count_ones()
+}
+
+/// Binary hash values stored as 64-bit lanes in lane-major order.
+///
+/// For a hash width of `N` bytes, `N` must be a positive multiple of 8 and the
+/// number of lanes is `N / 8`. Lane-major layout keeps each lane contiguous for
+/// all rows, which allows the pairwise path to reuse the SIMD `u64` batch
+/// implementation for wider hashes.
+#[derive(Debug, Clone)]
+pub struct BinaryHashValues {
+    lane_values: Vec<u64>,
+    num_rows: usize,
+    byte_width: usize,
+}
+
+impl BinaryHashValues {
+    /// Create hash values from lane-major `u64` values.
+    pub fn try_new(lane_values: Vec<u64>, num_rows: usize, byte_width: usize) -> Result<Self> {
+        let num_lanes = validate_hash_byte_width(byte_width)?;
+        let expected_values = checked_lane_value_count(num_rows, num_lanes)?;
+        if lane_values.len() != expected_values {
+            return Err(Error::InvalidArgumentError(format!(
+                "Expected {} lane values for {} rows and {} byte hashes, got {}",
+                expected_values,
+                num_rows,
+                byte_width,
+                lane_values.len()
+            )));
+        }
+        Ok(Self {
+            lane_values,
+            num_rows,
+            byte_width,
+        })
+    }
+
+    /// Extract binary hash values from a `FixedSizeList<UInt8, N>` Arrow array.
+    pub fn from_fixed_size_list(array: &FixedSizeListArray) -> Result<Self> {
+        let byte_width = usize::try_from(array.value_length()).map_err(|_| {
+            Error::InvalidArgumentError(format!(
+                "Expected FixedSizeList with a positive size that is a multiple of 8 bytes, got size {}",
+                array.value_length()
+            ))
+        })?;
+        let num_lanes = validate_hash_byte_width(byte_width)?;
+
+        let values = array
+            .values()
+            .as_any()
+            .downcast_ref::<arrow_array::UInt8Array>()
+            .ok_or_else(|| {
+                Error::InvalidArgumentError(
+                    "Expected UInt8Array values in FixedSizeList".to_string(),
+                )
+            })?;
+
+        let num_rows = array.len();
+        let value_count = checked_lane_value_count(num_rows, num_lanes)?;
+        let expected_bytes = checked_hash_byte_count(num_rows, byte_width)?;
+        let bytes = values.values();
+        if bytes.len() != expected_bytes {
+            return Err(Error::InvalidArgumentError(format!(
+                "Expected {} bytes for {} rows and {} byte hashes, got {}",
+                expected_bytes,
+                num_rows,
+                byte_width,
+                bytes.len()
+            )));
+        }
+
+        let mut lane_values = vec![0u64; value_count];
+        for row in 0..num_rows {
+            let row_start = row * byte_width;
+            for lane in 0..num_lanes {
+                let start = row_start + lane * 8;
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(&bytes[start..start + 8]);
+                lane_values[lane * num_rows + row] = u64::from_le_bytes(arr);
+            }
+        }
+
+        Ok(Self {
+            lane_values,
+            num_rows,
+            byte_width,
+        })
+    }
+
+    /// Concatenate chunks with the same hash width into a single lane-major set.
+    pub fn concat(chunks: &[Self]) -> Result<Self> {
+        let Some(first) = chunks.first() else {
+            return Err(Error::InvalidArgumentError(
+                "Cannot concatenate zero binary hash chunks".to_string(),
+            ));
+        };
+
+        let byte_width = first.byte_width;
+        let num_lanes = first.num_lanes();
+        let mut num_rows = 0usize;
+        for chunk in chunks {
+            if chunk.byte_width != byte_width {
+                return Err(Error::InvalidArgumentError(format!(
+                    "Cannot concatenate binary hash chunks with different widths: {} and {} bytes",
+                    byte_width, chunk.byte_width
+                )));
+            }
+            num_rows = num_rows.checked_add(chunk.num_rows).ok_or_else(|| {
+                Error::InvalidArgumentError(
+                    "Binary hash row count overflowed while concatenating chunks".to_string(),
+                )
+            })?;
+        }
+
+        let value_count = checked_lane_value_count(num_rows, num_lanes)?;
+        let mut lane_values = vec![0u64; value_count];
+        let mut row_offset = 0;
+        for chunk in chunks {
+            for lane in 0..num_lanes {
+                let dest_start = lane * num_rows + row_offset;
+                let dest_end = dest_start + chunk.num_rows;
+                lane_values[dest_start..dest_end].copy_from_slice(chunk.lane(lane));
+            }
+            row_offset += chunk.num_rows;
+        }
+
+        Ok(Self {
+            lane_values,
+            num_rows,
+            byte_width,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.num_rows
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_rows == 0
+    }
+
+    pub fn byte_width(&self) -> usize {
+        self.byte_width
+    }
+
+    pub fn num_lanes(&self) -> usize {
+        self.byte_width / 8
+    }
+
+    pub fn lane(&self, lane: usize) -> &[u64] {
+        let start = lane * self.num_rows;
+        &self.lane_values[start..start + self.num_rows]
+    }
+
+    pub fn into_u64_values(self) -> Result<Vec<u64>> {
+        if self.num_lanes() != 1 {
+            return Err(Error::InvalidArgumentError(format!(
+                "Expected 8-byte binary hashes, got {} byte hashes",
+                self.byte_width
+            )));
+        }
+        Ok(self.lane_values)
+    }
+}
+
+fn checked_lane_value_count(num_rows: usize, num_lanes: usize) -> Result<usize> {
+    num_rows.checked_mul(num_lanes).ok_or_else(|| {
+        Error::InvalidArgumentError(format!(
+            "Binary hash lane value count overflowed for {} rows and {} lanes",
+            num_rows, num_lanes
+        ))
+    })
+}
+
+fn checked_hash_byte_count(num_rows: usize, byte_width: usize) -> Result<usize> {
+    num_rows.checked_mul(byte_width).ok_or_else(|| {
+        Error::InvalidArgumentError(format!(
+            "Binary hash byte count overflowed for {} rows and {} byte hashes",
+            num_rows, byte_width
+        ))
+    })
+}
+
+fn validate_hash_byte_width(byte_width: usize) -> Result<usize> {
+    if byte_width == 0 || !byte_width.is_multiple_of(8) {
+        return Err(Error::InvalidArgumentError(format!(
+            "Expected FixedSizeList with a positive size that is a multiple of 8 bytes, got size {}",
+            byte_width
+        )));
+    }
+    Ok(byte_width / 8)
 }
 
 /// Result of pairwise hamming distance computation.
@@ -386,6 +576,88 @@ pub fn pairwise_hamming_distance_parallel(
     combined
 }
 
+/// Compute pairwise hamming distances for all pairs of fixed-width binary hashes.
+///
+/// This supports any hash width that is a positive multiple of 8 bytes. For
+/// 8-byte hashes this delegates to the existing `u64` implementation.
+pub fn pairwise_hamming_distance_binary(
+    hashes: &BinaryHashValues,
+    row_ids: Option<&[u64]>,
+    threshold: Option<u32>,
+) -> PairwiseResult {
+    let n = hashes.len();
+    if n < 2 {
+        return PairwiseResult::new();
+    }
+
+    if hashes.num_lanes() == 1 {
+        return pairwise_hamming_distance(hashes.lane(0), row_ids, threshold);
+    }
+
+    let threshold = threshold.unwrap_or(u32::MAX);
+    let num_pairs = n * (n - 1) / 2;
+    let mut result = PairwiseResult::with_capacity(num_pairs.min(1_000_000));
+
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let mut dist = 0;
+            for lane in 0..hashes.num_lanes() {
+                let lane_values = hashes.lane(lane);
+                dist += hamming_u64(lane_values[i], lane_values[j]);
+            }
+            if dist <= threshold {
+                let id_a = row_ids.map_or(i as u64, |ids| ids[i]);
+                let id_b = row_ids.map_or(j as u64, |ids| ids[j]);
+                result.push(id_a, id_b, dist);
+            }
+        }
+    }
+
+    result
+}
+
+/// Compute pairwise hamming distances in parallel for fixed-width binary hashes.
+///
+/// Wider hashes reuse the SIMD `u64` batch implementation lane-by-lane.
+pub fn pairwise_hamming_distance_binary_parallel(
+    hashes: &BinaryHashValues,
+    row_ids: Option<&[u64]>,
+    threshold: Option<u32>,
+) -> PairwiseResult {
+    let n = hashes.len();
+    if n < 2 {
+        return PairwiseResult::new();
+    }
+
+    if hashes.num_lanes() == 1 {
+        return pairwise_hamming_distance_parallel(hashes.lane(0), row_ids, threshold);
+    }
+
+    let threshold = threshold.unwrap_or(u32::MAX);
+    let total_pairs = n * (n - 1) / 2;
+
+    if total_pairs < 10_000 {
+        return pairwise_hamming_distance_binary(hashes, row_ids, Some(threshold));
+    }
+
+    let threads = rayon::current_num_threads();
+    let pairs_per_chunk = total_pairs.div_ceil(threads);
+    let chunks = compute_balanced_chunks(n, pairs_per_chunk);
+
+    let results: Vec<PairwiseResult> = chunks
+        .into_par_iter()
+        .map(|(start_row, end_row)| {
+            process_row_range_binary(hashes, row_ids, threshold, start_row, end_row)
+        })
+        .collect();
+
+    let mut combined = PairwiseResult::new();
+    for r in results {
+        combined.extend(r);
+    }
+    combined
+}
+
 /// Compute balanced chunks for parallel processing.
 fn compute_balanced_chunks(n: usize, target_pairs_per_chunk: usize) -> Vec<(usize, usize)> {
     let mut chunks = Vec::new();
@@ -439,36 +711,80 @@ fn process_row_range(
     result
 }
 
+/// Process a range of rows for pairwise comparison of wider binary hashes.
+fn process_row_range_binary(
+    hashes: &BinaryHashValues,
+    row_ids: Option<&[u64]>,
+    threshold: u32,
+    start_row: usize,
+    end_row: usize,
+) -> PairwiseResult {
+    let n = hashes.len();
+    let mut result = PairwiseResult::new();
+    let mut distances = Vec::new();
+    let mut lane_distances = Vec::new();
+
+    for i in start_row..end_row {
+        let remaining = n - i - 1;
+        if remaining == 0 {
+            continue;
+        }
+
+        distances.clear();
+        distances.resize(remaining, 0);
+
+        let first_lane = hashes.lane(0);
+        hamming_batch_u64(
+            first_lane[i],
+            &first_lane[i + 1..],
+            distances.as_mut_slice(),
+        );
+
+        for lane in 1..hashes.num_lanes() {
+            lane_distances.clear();
+            lane_distances.resize(remaining, 0);
+            let lane_values = hashes.lane(lane);
+            hamming_batch_u64(
+                lane_values[i],
+                &lane_values[i + 1..],
+                lane_distances.as_mut_slice(),
+            );
+            for (distance, lane_distance) in distances.iter_mut().zip(&lane_distances) {
+                *distance += *lane_distance;
+            }
+        }
+
+        let id_a = row_ids.map_or(i as u64, |ids| ids[i]);
+        for (j_offset, &dist) in distances.iter().enumerate() {
+            if dist <= threshold {
+                let j = i + 1 + j_offset;
+                let id_b = row_ids.map_or(j as u64, |ids| ids[j]);
+                result.push(id_a, id_b, dist);
+            }
+        }
+    }
+
+    result
+}
+
 /// Extract u64 hashes from a FixedSizeList<UInt8, 8> Arrow array.
 pub fn extract_hashes_from_fixed_list(array: &FixedSizeListArray) -> Result<Vec<u64>> {
-    let list_size = array.value_length();
-    if list_size != 8 {
+    let hashes = extract_binary_hashes_from_fixed_list(array)?;
+    if hashes.byte_width() != 8 {
         return Err(Error::InvalidArgumentError(format!(
             "Expected FixedSizeList with size 8, got size {}",
-            list_size
+            hashes.byte_width()
         )));
     }
+    hashes.into_u64_values()
+}
 
-    let values = array
-        .values()
-        .as_any()
-        .downcast_ref::<arrow_array::UInt8Array>()
-        .ok_or_else(|| {
-            Error::InvalidArgumentError("Expected UInt8Array values in FixedSizeList".to_string())
-        })?;
-
-    let n = array.len();
-    let mut hashes = Vec::with_capacity(n);
-
-    for i in 0..n {
-        let start = i * 8;
-        let bytes = &values.values()[start..start + 8];
-        let mut arr = [0u8; 8];
-        arr.copy_from_slice(bytes);
-        hashes.push(u64::from_le_bytes(arr));
-    }
-
-    Ok(hashes)
+/// Extract binary hashes from a `FixedSizeList<UInt8, N>` Arrow array where
+/// `N` is a positive multiple of 8 bytes.
+pub fn extract_binary_hashes_from_fixed_list(
+    array: &FixedSizeListArray,
+) -> Result<BinaryHashValues> {
+    BinaryHashValues::from_fixed_size_list(array)
 }
 
 /// Union-Find data structure with path compression for clustering.
@@ -733,6 +1049,7 @@ pub fn cluster_pairwise_result(result: &PairwiseResult) -> ClusteringResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lance_arrow::FixedSizeListArrayExt;
 
     #[test]
     fn test_hamming() {
@@ -910,6 +1227,121 @@ mod tests {
             .collect();
         v.sort();
         v
+    }
+
+    #[test]
+    fn test_extract_binary_hashes_from_fixed_list_128() {
+        use arrow_array::UInt8Array;
+
+        let rows = [
+            (0x0102_0304_0506_0708u64, 0x1112_1314_1516_1718u64),
+            (0x2122_2324_2526_2728u64, 0x3132_3334_3536_3738u64),
+        ];
+        let bytes: Vec<u8> = rows
+            .iter()
+            .flat_map(|(lo, hi)| lo.to_le_bytes().into_iter().chain(hi.to_le_bytes()))
+            .collect();
+        let array = FixedSizeListArray::try_new_from_values(UInt8Array::from(bytes), 16).unwrap();
+
+        let hashes = extract_binary_hashes_from_fixed_list(&array).unwrap();
+        assert_eq!(hashes.len(), 2);
+        assert_eq!(hashes.byte_width(), 16);
+        assert_eq!(hashes.num_lanes(), 2);
+        assert_eq!(hashes.lane(0), &[rows[0].0, rows[1].0]);
+        assert_eq!(hashes.lane(1), &[rows[0].1, rows[1].1]);
+    }
+
+    #[test]
+    fn test_extract_binary_hashes_rejects_non_u64_multiple() {
+        use arrow_array::UInt8Array;
+
+        let array =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0u8; 24]), 12).unwrap();
+        let err = extract_binary_hashes_from_fixed_list(&array).unwrap_err();
+        assert!(err.to_string().contains("multiple of 8 bytes"), "{}", err);
+    }
+
+    #[test]
+    fn test_binary_hash_values_rejects_width_not_divisible_by_8() {
+        let err = BinaryHashValues::try_new(Vec::new(), 0, 12).unwrap_err();
+        assert!(err.to_string().contains("multiple of 8 bytes"), "{}", err);
+    }
+
+    #[test]
+    fn test_pairwise_binary_hashes_128() {
+        let hashes = BinaryHashValues::try_new(
+            vec![
+                0,
+                0,
+                1,
+                u64::MAX, // lane 0
+                0,
+                1,
+                1,
+                u64::MAX, // lane 1
+            ],
+            4,
+            16,
+        )
+        .unwrap();
+
+        let seq = pairwise_hamming_distance_binary(&hashes, None, Some(1));
+        let par = pairwise_hamming_distance_binary_parallel(&hashes, None, Some(1));
+        let expected = vec![(0, 1, 1), (1, 2, 1)];
+        assert_eq!(result_to_sorted_vec(&seq), expected);
+        assert_eq!(result_to_sorted_vec(&par), expected);
+    }
+
+    #[test]
+    fn test_pairwise_binary_hashes_parallel_128_matches_sequential() {
+        let rows: Vec<(u64, u64)> = (0..80)
+            .flat_map(|i| {
+                let lo = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+                let hi = !lo.rotate_left(17);
+                [(lo, hi), (lo ^ 1, hi)]
+            })
+            .collect();
+        let mut lane_values = Vec::with_capacity(rows.len() * 2);
+        lane_values.extend(rows.iter().map(|(lo, _)| *lo));
+        lane_values.extend(rows.iter().map(|(_, hi)| *hi));
+        let hashes = BinaryHashValues::try_new(lane_values, rows.len(), 16).unwrap();
+        let row_ids: Vec<u64> = (0..rows.len()).map(|i| 10_000 + i as u64).collect();
+
+        let seq = pairwise_hamming_distance_binary(&hashes, Some(&row_ids), Some(1));
+        let par = pairwise_hamming_distance_binary_parallel(&hashes, Some(&row_ids), Some(1));
+
+        assert_eq!(result_to_sorted_vec(&par), result_to_sorted_vec(&seq));
+        assert!(par.len() >= 80);
+    }
+
+    #[test]
+    fn test_pairwise_binary_hashes_32_with_row_ids() {
+        let hashes = BinaryHashValues::try_new(
+            vec![
+                0,
+                0,
+                1, // lane 0
+                0,
+                1,
+                1, // lane 1
+                7,
+                7,
+                7, // lane 2
+                u64::MAX,
+                u64::MAX,
+                u64::MAX - 1, // lane 3
+            ],
+            3,
+            32,
+        )
+        .unwrap();
+        let row_ids = [10, 20, 30];
+
+        let result = pairwise_hamming_distance_binary_parallel(&hashes, Some(&row_ids), Some(2));
+        assert_eq!(
+            result_to_sorted_vec(&result),
+            vec![(10, 20, 1), (20, 30, 2)]
+        );
     }
 
     #[test]

--- a/rust/lance/src/index/vector/hamming.rs
+++ b/rust/lance/src/index/vector/hamming.rs
@@ -711,53 +711,6 @@ pub fn hamming_clustering_from_hashes(
     clustering.into_reader(None)
 }
 
-/// Perform pairwise hamming distance clustering on provided fixed-width binary
-/// hashes (no I/O).
-pub fn hamming_clustering_from_binary_hashes(
-    hashes: &BinaryHashValues,
-    row_ids: Option<&[u64]>,
-    hamming_threshold: u32,
-) -> Box<dyn RecordBatchReader + Send> {
-    let num_rows = hashes.len();
-    if num_rows < 2 {
-        let empty = ClusteringResult {
-            clusters: Vec::new(),
-        };
-        return empty.into_reader(None);
-    }
-
-    let total_pairs = (num_rows as u64) * (num_rows as u64 - 1) / 2;
-
-    let t_compute_start = Instant::now();
-    let pairwise =
-        pairwise_hamming_distance_binary_parallel(hashes, row_ids, Some(hamming_threshold));
-    let compute_time = t_compute_start.elapsed();
-
-    let t_cluster_start = Instant::now();
-    let clustering = cluster_pairwise_result(&pairwise);
-    let cluster_time = t_cluster_start.elapsed();
-
-    let pairs_per_sec = if compute_time.as_secs_f64() > 0.0 {
-        total_pairs as f64 / compute_time.as_secs_f64()
-    } else {
-        0.0
-    };
-    tracing::info!(
-        num_rows,
-        hash_width_bytes = hashes.byte_width(),
-        total_pairs,
-        edges = pairwise.len(),
-        compute_time_ms = compute_time.as_millis(),
-        cluster_time_ms = cluster_time.as_millis(),
-        pairs_per_sec_millions = pairs_per_sec / 1_000_000.0,
-        num_clusters = clustering.num_clusters(),
-        num_duplicates = clustering.num_duplicates(),
-        "Hamming clustering completed"
-    );
-
-    clustering.into_reader(None)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -864,32 +817,6 @@ mod tests {
         assert_eq!(clusters.len(), 1);
         assert_eq!(clusters[0].0, 100); // representative
         assert_eq!(clusters[0].1, vec![200]); // duplicates
-    }
-
-    #[test]
-    fn test_hamming_clustering_from_binary_hashes_128() {
-        let hashes = BinaryHashValues::try_new(
-            vec![
-                0,
-                0,
-                1,
-                u64::MAX, // lane 0
-                0,
-                1,
-                1,
-                u64::MAX, // lane 1
-            ],
-            4,
-            16,
-        )
-        .unwrap();
-
-        let reader = hamming_clustering_from_binary_hashes(&hashes, None, 1);
-        let clusters = collect_clusters(reader);
-
-        assert_eq!(clusters.len(), 1);
-        assert_eq!(clusters[0].0, 0);
-        assert_eq!(clusters[0].1, vec![1, 2]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/hamming.rs
+++ b/rust/lance/src/index/vector/hamming.rs
@@ -28,7 +28,8 @@ use lance_index::vector::flat::storage::FLAT_COLUMN;
 use lance_index::vector::ivf::storage::IvfModel;
 use lance_index::vector::storage::VectorStore;
 use lance_linalg::distance::{
-    ClusteringResult, cluster_pairwise_result, extract_hashes_from_fixed_list,
+    BinaryHashValues, ClusteringResult, cluster_pairwise_result,
+    extract_binary_hashes_from_fixed_list, pairwise_hamming_distance_binary_parallel,
     pairwise_hamming_distance_parallel,
 };
 use lance_table::format::IndexMetadata;
@@ -56,17 +57,30 @@ impl HashIndexSegment {
     }
 }
 
-/// Validate that a column stores 64-bit hashes as `FixedSizeList<UInt8, 8>`.
-fn validate_hash_column(column: &str, data_type: &DataType) -> Result<()> {
+/// Validate that a column stores fixed-width binary hashes as
+/// `FixedSizeList<UInt8, N>`, where `N` is a positive multiple of 8 bytes.
+fn validate_hash_column(column: &str, data_type: &DataType) -> Result<usize> {
     match data_type {
-        DataType::FixedSizeList(inner, 8) if *inner.data_type() == DataType::UInt8 => Ok(()),
-        DataType::FixedSizeList(inner, 8) => Err(Error::invalid_input(format!(
-            "Column '{}' must be FixedSizeList<UInt8, 8>, got FixedSizeList<{:?}, 8>",
+        DataType::FixedSizeList(inner, size) if *inner.data_type() == DataType::UInt8 => {
+            if *size <= 0 || !(*size as usize).is_multiple_of(8) {
+                return Err(Error::invalid_input(format!(
+                    "Column '{}' must be FixedSizeList<UInt8, N> where N is a positive \
+                     multiple of 8 bytes, got FixedSizeList<UInt8, {}>",
+                    column, size
+                )));
+            }
+            Ok(*size as usize)
+        }
+        DataType::FixedSizeList(inner, size) => Err(Error::invalid_input(format!(
+            "Column '{}' must be FixedSizeList<UInt8, N> where N is a positive \
+             multiple of 8 bytes, got FixedSizeList<{:?}, {}>",
             column,
-            inner.data_type()
+            inner.data_type(),
+            size
         ))),
         _ => Err(Error::invalid_input(format!(
-            "Column '{}' must be FixedSizeList<UInt8, 8>, got {:?}",
+            "Column '{}' must be FixedSizeList<UInt8, N> where N is a positive \
+             multiple of 8 bytes, got {:?}",
             column, data_type
         ))),
     }
@@ -125,7 +139,7 @@ fn validate_shared_centroids<'a>(
 ///
 /// When `segment_ids` is `None` all segments are opened; otherwise only the
 /// requested segments are opened and every requested id must exist. Validates
-/// that all selected segments index the same `FixedSizeList<UInt8, 8>` column,
+/// that all selected segments index the same fixed-width binary hash column,
 /// are IVF_FLAT indices for binary data, and share the same global centroids.
 async fn open_hash_index_segments(
     dataset: &Dataset,
@@ -225,7 +239,8 @@ async fn hamming_clustering_for_ivf_partition_impl(
     // hashes land in the same partition of every segment, so one pairwise pass
     // over the union finds cross-segment duplicates.
     let mut all_row_ids: Vec<u64> = Vec::new();
-    let mut all_hashes: Vec<u64> = Vec::new();
+    let mut hash_chunks = Vec::new();
+    let mut num_hashes = 0;
     for segment in &segments {
         let storage = segment
             .ivf_flat_bin()
@@ -239,16 +254,18 @@ async fn hamming_clustering_for_ivf_partition_impl(
                     Error::invalid_input(format!("Column '{}' not found in storage", FLAT_COLUMN))
                 })?
                 .as_fixed_size_list();
-            all_hashes.extend(extract_hashes_from_fixed_list(vectors)?);
+            let hashes = extract_binary_hashes_from_fixed_list(vectors)?;
+            num_hashes += hashes.len();
+            hash_chunks.push(hashes);
         }
-        if all_row_ids.len() != all_hashes.len() {
+        if all_row_ids.len() != num_hashes {
             return Err(Error::internal(format!(
                 "Index '{}' segment {} partition {}: row id count {} does not match hash count {}",
                 index_name,
                 segment.metadata.uuid,
                 partition_id,
                 all_row_ids.len(),
-                all_hashes.len()
+                num_hashes
             )));
         }
     }
@@ -259,9 +276,10 @@ async fn hamming_clustering_for_ivf_partition_impl(
         };
         return Ok(empty.into_reader(None));
     }
+    let all_hashes = BinaryHashValues::concat(&hash_chunks)?;
 
     // Compute pairwise hamming distances with threshold filtering
-    let pairwise_result = pairwise_hamming_distance_parallel(
+    let pairwise_result = pairwise_hamming_distance_binary_parallel(
         &all_hashes,
         Some(&all_row_ids),
         Some(hamming_threshold),
@@ -298,7 +316,8 @@ async fn hamming_clustering_for_ivf_partition_impl(
 ///
 /// Returns an error if:
 /// - The index doesn't exist or is not an IVF_FLAT index
-/// - The indexed column has wrong type (must be `FixedSizeList<UInt8, 8>`)
+/// - The indexed column has wrong type (must be `FixedSizeList<UInt8, N>` where
+///   `N` is a positive multiple of 8 bytes)
 /// - The index segments do not share the same global IVF centroids
 /// - The partition ID is out of range
 pub async fn hamming_clustering_for_ivf_partition(
@@ -407,7 +426,8 @@ pub struct PartitionInfo {
 /// # Arguments
 ///
 /// * `dataset` - The Lance dataset
-/// * `column` - Name of the hash column (must be `FixedSizeList<UInt8, 8>`)
+/// * `column` - Name of the hash column (must be `FixedSizeList<UInt8, N>`
+///   where `N` is a positive multiple of 8 bytes)
 /// * `sample_size` - Number of rows to sample (if None or >= total rows, uses all rows)
 /// * `hamming_threshold` - Maximum hamming distance to consider as similar
 ///
@@ -467,7 +487,7 @@ pub async fn hamming_clustering_for_sample(
             Error::invalid_input(format!("Column '{}' not found in result", column))
         })?;
         let hashes_arr = hash_col.as_fixed_size_list();
-        let hashes = extract_hashes_from_fixed_list(hashes_arr)?;
+        let hashes = extract_binary_hashes_from_fixed_list(hashes_arr)?;
 
         (hashes, row_id_vec)
     } else {
@@ -489,7 +509,7 @@ pub async fn hamming_clustering_for_sample(
             Error::invalid_input(format!("Column '{}' not found in result", column))
         })?;
         let hashes_arr = hash_col.as_fixed_size_list();
-        let hashes = extract_hashes_from_fixed_list(hashes_arr)?;
+        let hashes = extract_binary_hashes_from_fixed_list(hashes_arr)?;
 
         (hashes, row_id_vec)
     };
@@ -503,7 +523,7 @@ pub async fn hamming_clustering_for_sample(
 
     // Compute pairwise hamming distances
     let pairwise =
-        pairwise_hamming_distance_parallel(&hashes, Some(&row_ids), Some(hamming_threshold));
+        pairwise_hamming_distance_binary_parallel(&hashes, Some(&row_ids), Some(hamming_threshold));
 
     // Cluster edges
     let clustering = cluster_pairwise_result(&pairwise);
@@ -521,7 +541,8 @@ pub async fn hamming_clustering_for_sample(
 /// # Arguments
 ///
 /// * `dataset` - The Lance dataset
-/// * `column` - Name of the hash column (must be `FixedSizeList<UInt8, 8>`)
+/// * `column` - Name of the hash column (must be `FixedSizeList<UInt8, N>`
+///   where `N` is a positive multiple of 8 bytes)
 /// * `fragment_id` - The fragment ID to read from
 /// * `start_row` - The starting row offset within the fragment
 /// * `num_rows` - Number of rows to read from the start position
@@ -537,7 +558,8 @@ pub async fn hamming_clustering_for_sample(
 ///
 /// Returns an error if:
 /// - The fragment doesn't exist
-/// - The column has wrong type (must be `FixedSizeList<UInt8, 8>`)
+/// - The column has wrong type (must be `FixedSizeList<UInt8, N>` where `N`
+///   is a positive multiple of 8 bytes)
 /// - The row range is out of bounds
 pub async fn hamming_clustering_for_range(
     dataset: &Dataset,
@@ -605,7 +627,7 @@ pub async fn hamming_clustering_for_range(
         .column_by_name(column)
         .ok_or_else(|| Error::invalid_input(format!("Column '{}' not found in result", column)))?;
     let hashes_arr = hash_col.as_fixed_size_list();
-    let hashes = extract_hashes_from_fixed_list(hashes_arr)?;
+    let hashes = extract_binary_hashes_from_fixed_list(hashes_arr)?;
 
     if hashes.len() < 2 {
         let empty = ClusteringResult {
@@ -615,8 +637,11 @@ pub async fn hamming_clustering_for_range(
     }
 
     // Compute pairwise hamming distances
-    let pairwise =
-        pairwise_hamming_distance_parallel(&hashes, Some(&row_id_vec), Some(hamming_threshold));
+    let pairwise = pairwise_hamming_distance_binary_parallel(
+        &hashes,
+        Some(&row_id_vec),
+        Some(hamming_threshold),
+    );
 
     // Cluster edges
     let clustering = cluster_pairwise_result(&pairwise);
@@ -686,6 +711,53 @@ pub fn hamming_clustering_from_hashes(
     clustering.into_reader(None)
 }
 
+/// Perform pairwise hamming distance clustering on provided fixed-width binary
+/// hashes (no I/O).
+pub fn hamming_clustering_from_binary_hashes(
+    hashes: &BinaryHashValues,
+    row_ids: Option<&[u64]>,
+    hamming_threshold: u32,
+) -> Box<dyn RecordBatchReader + Send> {
+    let num_rows = hashes.len();
+    if num_rows < 2 {
+        let empty = ClusteringResult {
+            clusters: Vec::new(),
+        };
+        return empty.into_reader(None);
+    }
+
+    let total_pairs = (num_rows as u64) * (num_rows as u64 - 1) / 2;
+
+    let t_compute_start = Instant::now();
+    let pairwise =
+        pairwise_hamming_distance_binary_parallel(hashes, row_ids, Some(hamming_threshold));
+    let compute_time = t_compute_start.elapsed();
+
+    let t_cluster_start = Instant::now();
+    let clustering = cluster_pairwise_result(&pairwise);
+    let cluster_time = t_cluster_start.elapsed();
+
+    let pairs_per_sec = if compute_time.as_secs_f64() > 0.0 {
+        total_pairs as f64 / compute_time.as_secs_f64()
+    } else {
+        0.0
+    };
+    tracing::info!(
+        num_rows,
+        hash_width_bytes = hashes.byte_width(),
+        total_pairs,
+        edges = pairwise.len(),
+        compute_time_ms = compute_time.as_millis(),
+        cluster_time_ms = cluster_time.as_millis(),
+        pairs_per_sec_millions = pairs_per_sec / 1_000_000.0,
+        num_clusters = clustering.num_clusters(),
+        num_duplicates = clustering.num_duplicates(),
+        "Hamming clustering completed"
+    );
+
+    clustering.into_reader(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -719,6 +791,31 @@ mod tests {
             }
         }
         clusters
+    }
+
+    #[test]
+    fn test_validate_hash_column_generic_widths() {
+        use arrow_schema::{DataType, Field};
+        use std::sync::Arc;
+
+        fn hash_type(size: i32) -> DataType {
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt8, true)), size)
+        }
+
+        assert_eq!(validate_hash_column("hash", &hash_type(8)).unwrap(), 8);
+        assert_eq!(validate_hash_column("hash", &hash_type(16)).unwrap(), 16);
+        assert_eq!(validate_hash_column("hash", &hash_type(32)).unwrap(), 32);
+
+        let err = validate_hash_column("hash", &hash_type(12)).unwrap_err();
+        assert!(err.to_string().contains("12"), "{}", err);
+        assert!(err.to_string().contains("multiple of 8 bytes"), "{}", err);
+
+        let err = validate_hash_column("hash", &hash_type(4)).unwrap_err();
+        assert!(err.to_string().contains("4"), "{}", err);
+        assert!(err.to_string().contains("multiple of 8 bytes"), "{}", err);
+
+        let err = validate_hash_column("hash", &hash_type(-8)).unwrap_err();
+        assert!(err.to_string().contains("-8"), "{}", err);
     }
 
     #[test]
@@ -767,6 +864,32 @@ mod tests {
         assert_eq!(clusters.len(), 1);
         assert_eq!(clusters[0].0, 100); // representative
         assert_eq!(clusters[0].1, vec![200]); // duplicates
+    }
+
+    #[test]
+    fn test_hamming_clustering_from_binary_hashes_128() {
+        let hashes = BinaryHashValues::try_new(
+            vec![
+                0,
+                0,
+                1,
+                u64::MAX, // lane 0
+                0,
+                1,
+                1,
+                u64::MAX, // lane 1
+            ],
+            4,
+            16,
+        )
+        .unwrap();
+
+        let reader = hamming_clustering_from_binary_hashes(&hashes, None, 1);
+        let clusters = collect_clusters(reader);
+
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].0, 0);
+        assert_eq!(clusters[0].1, vec![1, 2]);
     }
 
     #[tokio::test]
@@ -928,7 +1051,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hamming_clustering_for_ivf_partition_multi_segment() {
+    async fn test_hamming_clustering_for_ivf_partition_multi_segment_128_bit() {
         use arrow_array::{FixedSizeListArray, RecordBatchIterator, UInt8Array};
         use arrow_schema::{Field, Schema};
         use lance_arrow::FixedSizeListArrayExt;
@@ -937,13 +1060,18 @@ mod tests {
         use std::sync::Arc;
         use tempfile::tempdir;
 
+        const HASH_BYTES: i32 = 16;
+
         fn hash_batch(schema: Arc<Schema>, values: &[u64]) -> arrow_array::RecordBatch {
-            let mut bytes = Vec::with_capacity(values.len() * 8);
+            let mut bytes = Vec::with_capacity(values.len() * HASH_BYTES as usize);
             for value in values {
                 bytes.extend_from_slice(&value.to_le_bytes());
+                let high = value.rotate_left(17) ^ 0xA5A5_A5A5_A5A5_A5A5;
+                bytes.extend_from_slice(&high.to_le_bytes());
             }
             let array =
-                FixedSizeListArray::try_new_from_values(UInt8Array::from(bytes), 8).unwrap();
+                FixedSizeListArray::try_new_from_values(UInt8Array::from(bytes), HASH_BYTES)
+                    .unwrap();
             arrow_array::RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
         }
 
@@ -951,7 +1079,7 @@ mod tests {
             "hash",
             arrow_schema::DataType::FixedSizeList(
                 Arc::new(Field::new("item", arrow_schema::DataType::UInt8, true)),
-                8,
+                HASH_BYTES,
             ),
             false,
         )]));


### PR DESCRIPTION
## Summary
- Support `FixedSizeList<UInt8, N>` hamming hashes where `N` is a positive multiple of 8 bytes.
- Reuse the SIMD `u64` pairwise path lane-by-lane for wider hashes.
- Add Rust and Python coverage for 16-byte and wider hash clustering, including invalid-width rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Hamming-distance clustering to support binary hashes of any positive, 8-byte-aligned width (`FixedSizeList<UInt8, N>`), including 16-byte hashes.
  * Added sequential and parallel pairwise Hamming-distance APIs for multi-lane binary hashes, with support for extracting fixed-list hash values.
* **Bug Fixes**
  * Improved validation and error handling for malformed or inconsistent fixed-list hash inputs and byte widths.
* **Tests**
  * Broadened and parameterized clustering and distance test coverage for 8- and 16-byte hashes, multi-segment behavior, and sequential-vs-parallel consistency.
* **Documentation**
  * Updated API docs and parameter descriptions to reflect the generalized hash column shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->