### PR TITLE
fix: train IVF indexes on fragment subsets

### DIFF
--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -154,6 +154,39 @@ fn fixed_size_list_almost_equal(a: &FixedSizeListArray, b: &FixedSizeListArray, 
     }
 }
 
+fn ensure_fixed_size_list_compatible(
+    what: &str,
+    reference: &FixedSizeListArray,
+    candidate: &FixedSizeListArray,
+) -> Result<()> {
+    if !fixed_size_list_equal(reference, candidate) {
+        const TOL: f32 = 1e-5;
+        if !fixed_size_list_almost_equal(reference, candidate, TOL) {
+            return Err(Error::index(format!("{what} mismatch across shards")));
+        }
+        log::warn!("{what} differs within tolerance; proceeding with first shard value");
+    }
+    Ok(())
+}
+
+async fn try_read_ivf_proto(reader: &V2Reader) -> Result<Option<pb::Ivf>> {
+    let Some(ivf_idx) = reader.metadata().file_schema.metadata.get(IVF_METADATA_KEY) else {
+        return Ok(None);
+    };
+    let ivf_idx = ivf_idx
+        .parse()
+        .map_err(|_| Error::index("IVF index parse error".to_string()))?;
+    let bytes = reader.read_global_buffer(ivf_idx).await?;
+    Ok(Some(pb::Ivf::decode(bytes)?))
+}
+
+fn ivf_centroids_from_proto(ivf: &pb::Ivf) -> Result<Option<FixedSizeListArray>> {
+    ivf.centroids_tensor
+        .as_ref()
+        .map(FixedSizeListArray::try_from)
+        .transpose()
+}
+
 /// Initialize schema-level metadata on a writer for a given storage.
 ///
 /// It writes the distance type and the storage metadata (as a vector payload),
@@ -771,6 +804,27 @@ pub async fn merge_partial_vector_auxiliary_files(
         )
         .await?;
         let meta = reader.metadata();
+        let idx_path = aux
+            .parent()
+            .unwrap_or_default()
+            .join(crate::INDEX_FILE_NAME);
+        let idx_reader = if object_store.exists(&idx_path).await.unwrap_or(false) {
+            let fh = sched
+                .open_file(&idx_path, &CachedFileSize::unknown())
+                .await?;
+            Some(
+                V2Reader::try_open(
+                    fh,
+                    None,
+                    Arc::default(),
+                    &lance_core::cache::LanceCache::no_cache(),
+                    V2ReaderOptions::default(),
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
 
         // Inherit format version from the first shard file
         if format_version.is_none() {
@@ -795,45 +849,29 @@ pub async fn merge_partial_vector_auxiliary_files(
         // Detect index type (first iteration only)
         if detected_index_type.is_none() {
             // Try to derive precise type from sibling partial index.idx metadata if available
-            let idx_path = aux
-                .parent()
-                .unwrap_or_default()
-                .join(crate::INDEX_FILE_NAME);
-            if object_store.exists(&idx_path).await.unwrap_or(false) {
-                let fh2 = sched
-                    .open_file(&idx_path, &CachedFileSize::unknown())
-                    .await?;
-                let idx_reader = V2Reader::try_open(
-                    fh2,
-                    None,
-                    Arc::default(),
-                    &lance_core::cache::LanceCache::no_cache(),
-                    V2ReaderOptions::default(),
-                )
-                .await?;
-                if let Some(idx_meta_json) = idx_reader
+            if let Some(idx_reader) = idx_reader.as_ref()
+                && let Some(idx_meta_json) = idx_reader
                     .metadata()
                     .file_schema
                     .metadata
                     .get(INDEX_METADATA_SCHEMA_KEY)
-                {
-                    let idx_meta: IndexMetaSchema = serde_json::from_str(idx_meta_json)?;
-                    detected_index_type = Some(match idx_meta.index_type.as_str() {
-                        "IVF_FLAT" => SupportedIvfIndexType::IvfFlat,
-                        "IVF_PQ" => SupportedIvfIndexType::IvfPq,
-                        "IVF_SQ" => SupportedIvfIndexType::IvfSq,
-                        "IVF_RQ" => SupportedIvfIndexType::IvfRq,
-                        "IVF_HNSW_FLAT" => SupportedIvfIndexType::IvfHnswFlat,
-                        "IVF_HNSW_PQ" => SupportedIvfIndexType::IvfHnswPq,
-                        "IVF_HNSW_SQ" => SupportedIvfIndexType::IvfHnswSq,
-                        other => {
-                            return Err(Error::index(format!(
-                                "Unsupported index type in shard index.idx: {}",
-                                other
-                            )));
-                        }
-                    });
-                }
+            {
+                let idx_meta: IndexMetaSchema = serde_json::from_str(idx_meta_json)?;
+                detected_index_type = Some(match idx_meta.index_type.as_str() {
+                    "IVF_FLAT" => SupportedIvfIndexType::IvfFlat,
+                    "IVF_PQ" => SupportedIvfIndexType::IvfPq,
+                    "IVF_SQ" => SupportedIvfIndexType::IvfSq,
+                    "IVF_RQ" => SupportedIvfIndexType::IvfRq,
+                    "IVF_HNSW_FLAT" => SupportedIvfIndexType::IvfHnswFlat,
+                    "IVF_HNSW_PQ" => SupportedIvfIndexType::IvfHnswPq,
+                    "IVF_HNSW_SQ" => SupportedIvfIndexType::IvfHnswSq,
+                    other => {
+                        return Err(Error::index(format!(
+                            "Unsupported index type in shard index.idx: {}",
+                            other
+                        )));
+                    }
+                });
             }
             // Fallback: infer from auxiliary schema
             if detected_index_type.is_none() {
@@ -843,35 +881,48 @@ pub async fn merge_partial_vector_auxiliary_files(
         }
 
         // Read IVF lengths from global buffer
-        let ivf_idx: u32 = reader
-            .metadata()
-            .file_schema
-            .metadata
-            .get(IVF_METADATA_KEY)
-            .ok_or_else(|| Error::index("IVF meta missing".to_string()))?
-            .parse()
-            .map_err(|_| Error::index("IVF index parse error".to_string()))?;
-        let bytes = reader.read_global_buffer(ivf_idx).await?;
-        let pb_ivf: pb::Ivf = prost::Message::decode(bytes)?;
+        let pb_ivf = try_read_ivf_proto(&reader)
+            .await?
+            .ok_or_else(|| Error::index("IVF meta missing".to_string()))?;
         let lengths = pb_ivf.lengths.clone();
         let nlist = lengths.len();
 
+        let mut current_centroids = ivf_centroids_from_proto(&pb_ivf)?;
+        if current_centroids.is_none()
+            && let Some(idx_reader) = idx_reader.as_ref()
+            && let Some(index_ivf) = try_read_ivf_proto(idx_reader).await?
+        {
+            current_centroids = ivf_centroids_from_proto(&index_ivf)?;
+        }
         if nlist_opt.is_none() {
             nlist_opt = Some(nlist);
             accumulated_lengths = vec![0; nlist];
-            // Try load centroids tensor if present
-            if let Some(tensor) = pb_ivf.centroids_tensor.as_ref() {
-                let arr = FixedSizeListArray::try_from(tensor)?;
-                first_centroids = Some(arr.clone());
+            if let Some(arr) = current_centroids {
                 let d0 = arr.value_length() as usize;
                 if dim.is_none() {
                     dim = Some(d0);
                 }
+                first_centroids = Some(arr);
             }
         } else if nlist_opt.as_ref().map(|v| *v != nlist).unwrap_or(false) {
             return Err(Error::index(
                 "IVF partition count mismatch across shards".to_string(),
             ));
+        } else {
+            match (&first_centroids, &current_centroids) {
+                (Some(reference), Some(candidate)) => {
+                    ensure_fixed_size_list_compatible("IVF centroids", reference, candidate)?;
+                }
+                (Some(_), None) => {
+                    return Err(Error::index("IVF centroids missing from shard".to_string()));
+                }
+                (None, Some(_)) => {
+                    return Err(Error::index(
+                        "IVF centroids missing from first shard".to_string(),
+                    ));
+                }
+                (None, None) => {}
+            }
         }
 
         // Handle logic based on detected index type
@@ -921,6 +972,13 @@ pub async fn merge_partial_vector_auxiliary_files(
 
                 let sq_meta_parsed: ScalarQuantizationMetadata = serde_json::from_str(&sq_json)
                     .map_err(|e| Error::index(format!("SQ metadata parse error: {}", e)))?;
+                if let Some(existing_sq) = sq_meta.as_ref()
+                    && existing_sq != &sq_meta_parsed
+                {
+                    return Err(Error::index(
+                        "SQ metadata mismatch across shards".to_string(),
+                    ));
+                }
 
                 let d0 = sq_meta_parsed.dim;
                 dim.get_or_insert(d0);
@@ -985,6 +1043,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                     rq_meta_parsed.parse_buffer(rotate_mat_bytes)?;
                 }
                 validate_rq_num_bits(rq_meta_parsed.num_bits)?;
+                if rq_meta_parsed.packed {
+                    return Err(Error::index(
+                        "Distributed RQ merge: source shard stores packed RQ codes; expected row-major distributed shard".to_string(),
+                    ));
+                }
 
                 let d0 = rq_meta_parsed.rotated_dim();
                 if d0 == 0 {
@@ -1001,7 +1064,9 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if let Some(existing_rq) = rq_meta.as_ref()
                     && (existing_rq.code_dim != rq_meta_parsed.code_dim
                         || existing_rq.num_bits != rq_meta_parsed.num_bits
-                        || existing_rq.rotation_type != rq_meta_parsed.rotation_type)
+                        || existing_rq.rotation_type != rq_meta_parsed.rotation_type
+                        || existing_rq.query_estimator != rq_meta_parsed.query_estimator
+                        || existing_rq.fast_rotation_signs != rq_meta_parsed.fast_rotation_signs)
                 {
                     return Err(Error::index(format!(
                         "Distributed RQ merge: structural mismatch across shards; first(code_dim={}, num_bits={}, rotation_type={:?}), current(code_dim={}, num_bits={}, rotation_type={:?})",
@@ -1012,6 +1077,24 @@ pub async fn merge_partial_vector_auxiliary_files(
                         rq_meta_parsed.num_bits,
                         rq_meta_parsed.rotation_type
                     )));
+                }
+                if let Some(existing_rq) = rq_meta.as_ref() {
+                    match (&existing_rq.rotate_mat, &rq_meta_parsed.rotate_mat) {
+                        (Some(reference), Some(candidate)) => {
+                            ensure_fixed_size_list_compatible(
+                                "RQ rotation matrix",
+                                reference,
+                                candidate,
+                            )?;
+                        }
+                        (Some(_), None) | (None, Some(_)) => {
+                            return Err(Error::index(
+                                "Distributed RQ merge: rotation matrix mismatch across shards"
+                                    .to_string(),
+                            ));
+                        }
+                        (None, None) => {}
+                    }
                 }
                 if rq_meta.is_none() {
                     rq_meta = Some(rq_meta_parsed.clone());
@@ -1061,6 +1144,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                 };
                 let mut pm: ProductQuantizationMetadata = serde_json::from_str(&pm_json)
                     .map_err(|e| Error::index(format!("PQ metadata parse error: {}", e)))?;
+                if pm.transposed {
+                    return Err(Error::index(
+                        "Distributed PQ merge: source shard stores transposed PQ codes; expected row-major distributed shard".to_string(),
+                    ));
+                }
                 // Load codebook from global buffer if not present
                 if pm.codebook.is_none() {
                     let tensor_bytes = reader
@@ -1100,18 +1188,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                         .codebook
                         .as_ref()
                         .ok_or_else(|| Error::index("PQ codebook missing in shard".to_string()))?;
-                    if !fixed_size_list_equal(existing_cb, current_cb) {
-                        const TOL: f32 = 1e-5;
-                        if !fixed_size_list_almost_equal(existing_cb, current_cb, TOL) {
-                            return Err(Error::index(
-                                "PQ codebook content mismatch across shards".to_string(),
-                            ));
-                        } else {
-                            log::warn!(
-                                "PQ codebook differs within tolerance; proceeding with first shard codebook"
-                            );
-                        }
-                    }
+                    ensure_fixed_size_list_compatible(
+                        "PQ codebook content",
+                        existing_cb,
+                        current_cb,
+                    )?;
                 }
                 if pq_meta.is_none() {
                     pq_meta = Some(pm.clone());
@@ -1222,6 +1303,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                 };
                 let mut pm: ProductQuantizationMetadata = serde_json::from_str(&pm_json)
                     .map_err(|e| Error::index(format!("PQ metadata parse error: {}", e)))?;
+                if pm.transposed {
+                    return Err(Error::index(
+                        "Distributed PQ merge: source shard stores transposed PQ codes; expected row-major distributed shard".to_string(),
+                    ));
+                }
                 if pm.codebook.is_none() {
                     let tensor_bytes = reader
                         .read_global_buffer(pm.codebook_position as u32)
@@ -1260,18 +1346,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                         .codebook
                         .as_ref()
                         .ok_or_else(|| Error::index("PQ codebook missing in shard".to_string()))?;
-                    if !fixed_size_list_equal(existing_cb, current_cb) {
-                        const TOL: f32 = 1e-5;
-                        if !fixed_size_list_almost_equal(existing_cb, current_cb, TOL) {
-                            return Err(Error::index(
-                                "PQ codebook content mismatch across shards".to_string(),
-                            ));
-                        } else {
-                            log::warn!(
-                                "PQ codebook differs within tolerance; proceeding with first shard codebook"
-                            );
-                        }
-                    }
+                    ensure_fixed_size_list_compatible(
+                        "PQ codebook content",
+                        existing_cb,
+                        current_cb,
+                    )?;
                 }
                 if pq_meta.is_none() {
                     pq_meta = Some(pm.clone());
@@ -1320,6 +1399,13 @@ pub async fn merge_partial_vector_auxiliary_files(
                 };
                 let sq_meta_parsed: ScalarQuantizationMetadata = serde_json::from_str(&sq_json)
                     .map_err(|e| Error::index(format!("SQ metadata parse error: {}", e)))?;
+                if let Some(existing_sq) = sq_meta.as_ref()
+                    && existing_sq != &sq_meta_parsed
+                {
+                    return Err(Error::index(
+                        "SQ metadata mismatch across shards".to_string(),
+                    ));
+                }
                 let d0 = sq_meta_parsed.dim;
                 dim.get_or_insert(d0);
                 if let Some(dprev) = dim
@@ -2014,7 +2100,7 @@ mod tests {
             dimension,
             codebook: Some(codebook.clone()),
             codebook_tensor: Vec::new(),
-            transposed: true,
+            transposed: false,
         };
 
         let codebook_tensor: pb::Tensor = pb::Tensor::try_from(codebook)?;

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -998,19 +998,6 @@ pub async fn merge_partial_vector_auxiliary_files(
 
                 let sq_meta_parsed: ScalarQuantizationMetadata = serde_json::from_str(&sq_json)
                     .map_err(|e| Error::index(format!("SQ metadata parse error: {}", e)))?;
-                if let Some(existing_sq) = sq_meta.as_ref()
-                    && existing_sq != &sq_meta_parsed
-                {
-                    return Err(Error::index(format!(
-                        "Distributed SQ merge: metadata mismatch across shards; first(dim={}, nbits={}, bounds={:?}), current(dim={}, nbits={}, bounds={:?})",
-                        existing_sq.dim,
-                        existing_sq.num_bits,
-                        existing_sq.bounds,
-                        sq_meta_parsed.dim,
-                        sq_meta_parsed.num_bits,
-                        sq_meta_parsed.bounds
-                    )));
-                }
 
                 let d0 = sq_meta_parsed.dim;
                 dim.get_or_insert(d0);
@@ -1076,9 +1063,9 @@ pub async fn merge_partial_vector_auxiliary_files(
                 }
                 validate_rq_num_bits(rq_meta_parsed.num_bits)?;
                 if rq_meta_parsed.packed {
-                    return Err(Error::index(
-                        "Distributed RQ merge: source shard stores packed RQ codes; expected row-major distributed shard".to_string(),
-                    ));
+                    return Err(Error::index(format!(
+                        "Distributed RQ merge: source shard {idx} stores packed RQ codes; expected row-major distributed shard"
+                    )));
                 }
 
                 let d0 = rq_meta_parsed.rotated_dim();
@@ -1177,9 +1164,9 @@ pub async fn merge_partial_vector_auxiliary_files(
                 let mut pm: ProductQuantizationMetadata = serde_json::from_str(&pm_json)
                     .map_err(|e| Error::index(format!("PQ metadata parse error: {}", e)))?;
                 if pm.transposed {
-                    return Err(Error::index(
-                        "Distributed PQ merge: source shard stores transposed PQ codes; expected row-major distributed shard".to_string(),
-                    ));
+                    return Err(Error::index(format!(
+                        "Distributed PQ merge: source shard {idx} stores transposed PQ codes; expected row-major distributed shard"
+                    )));
                 }
                 // Load codebook from global buffer if not present
                 if pm.codebook.is_none() {
@@ -1336,9 +1323,9 @@ pub async fn merge_partial_vector_auxiliary_files(
                 let mut pm: ProductQuantizationMetadata = serde_json::from_str(&pm_json)
                     .map_err(|e| Error::index(format!("PQ metadata parse error: {}", e)))?;
                 if pm.transposed {
-                    return Err(Error::index(
-                        "Distributed PQ merge: source shard stores transposed PQ codes; expected row-major distributed shard".to_string(),
-                    ));
+                    return Err(Error::index(format!(
+                        "Distributed PQ merge: source shard {idx} stores transposed PQ codes; expected row-major distributed shard"
+                    )));
                 }
                 if pm.codebook.is_none() {
                     let tensor_bytes = reader
@@ -1431,19 +1418,6 @@ pub async fn merge_partial_vector_auxiliary_files(
                 };
                 let sq_meta_parsed: ScalarQuantizationMetadata = serde_json::from_str(&sq_json)
                     .map_err(|e| Error::index(format!("SQ metadata parse error: {}", e)))?;
-                if let Some(existing_sq) = sq_meta.as_ref()
-                    && existing_sq != &sq_meta_parsed
-                {
-                    return Err(Error::index(format!(
-                        "Distributed SQ merge (HNSW_SQ): metadata mismatch across shards; first(dim={}, nbits={}, bounds={:?}), current(dim={}, nbits={}, bounds={:?})",
-                        existing_sq.dim,
-                        existing_sq.num_bits,
-                        existing_sq.bounds,
-                        sq_meta_parsed.dim,
-                        sq_meta_parsed.num_bits,
-                        sq_meta_parsed.bounds
-                    )));
-                }
                 let d0 = sq_meta_parsed.dim;
                 dim.get_or_insert(d0);
                 if let Some(dprev) = dim
@@ -2100,6 +2074,7 @@ mod tests {
         base_row_id: u64,
         distance_type: DistanceType,
         codebook: &FixedSizeListArray,
+        transposed: bool,
     ) -> Result<usize> {
         let num_bytes = if nbits == 4 {
             // Two 4-bit codes per byte.
@@ -2138,7 +2113,7 @@ mod tests {
             dimension,
             codebook: Some(codebook.clone()),
             codebook_tensor: Vec::new(),
-            transposed: false,
+            transposed,
         };
 
         let codebook_tensor: pb::Tensor = pb::Tensor::try_from(codebook)?;
@@ -2349,6 +2324,7 @@ mod tests {
             0,
             DistanceType::L2,
             &codebook,
+            false,
         )
         .await
         .unwrap();
@@ -2363,6 +2339,7 @@ mod tests {
             1_000,
             DistanceType::L2,
             &codebook,
+            false,
         )
         .await
         .unwrap();
@@ -2441,6 +2418,66 @@ mod tests {
         let merged_codebook = FixedSizeListArray::try_from(&cb_tensor).unwrap();
 
         assert!(fixed_size_list_equal(&codebook, &merged_codebook));
+    }
+
+    #[tokio::test]
+    async fn test_merge_ivf_pq_rejects_transposed_source_shard() {
+        let object_store = ObjectStore::memory();
+        let index_dir = Path::from("index/uuid_pq_transposed");
+
+        let partial0 = index_dir.clone().join("partial_0");
+        let aux0 = partial0.clone().join(INDEX_AUXILIARY_FILE_NAME);
+        let lengths = vec![2_u32, 1_u32];
+
+        let nbits = 4_u32;
+        let num_sub_vectors = 2_usize;
+        let dimension = 8_usize;
+        let num_centroids = 1_usize << nbits;
+        let num_codebook_vectors = num_centroids * num_sub_vectors;
+        let total_values = num_codebook_vectors * dimension;
+        let values = Float32Array::from_iter((0..total_values).map(|v| v as f32));
+        let codebook = FixedSizeListArray::try_new_from_values(values, dimension as i32).unwrap();
+
+        write_pq_partial_aux(
+            &object_store,
+            &aux0,
+            nbits,
+            num_sub_vectors,
+            dimension,
+            &lengths,
+            0,
+            DistanceType::L2,
+            &codebook,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let res = merge_partial_vector_auxiliary_files(
+            &object_store,
+            std::slice::from_ref(&aux0),
+            &index_dir,
+            crate::progress::noop_progress(),
+        )
+        .await;
+        match res {
+            Err(Error::Index { message, .. }) => {
+                assert!(
+                    message.contains("source shard 0"),
+                    "unexpected message: {}",
+                    message
+                );
+                assert!(
+                    message.contains("transposed PQ codes"),
+                    "unexpected message: {}",
+                    message
+                );
+            }
+            other => panic!(
+                "expected Error::Index for transposed PQ source shard, got {:?}",
+                other
+            ),
+        }
     }
 
     #[tokio::test]
@@ -2577,6 +2614,64 @@ mod tests {
         assert!(checked_code_width);
         let expected_total: usize = expected_lengths.iter().map(|v| *v as usize).sum();
         assert_eq!(total_rows, expected_total);
+    }
+
+    #[tokio::test]
+    async fn test_merge_ivf_rq_rejects_packed_source_shard() {
+        let object_store = ObjectStore::memory();
+        let index_dir = Path::from("index/uuid_rq_packed");
+
+        let partial0 = index_dir.clone().join("partial_0");
+        let aux0 = partial0.clone().join(INDEX_AUXILIARY_FILE_NAME);
+        let lengths = vec![2_u32, 1_u32];
+
+        let rq_meta = RabitQuantizationMetadata {
+            rotate_mat: None,
+            rotate_mat_position: None,
+            fast_rotation_signs: Some(vec![0xAA; 2]),
+            rotation_type: RQRotationType::Fast,
+            code_dim: 16,
+            num_bits: 1,
+            packed: true,
+            query_estimator: RabitQueryEstimator::RawQuery,
+        };
+
+        write_rq_partial_aux(
+            &object_store,
+            &aux0,
+            &rq_meta,
+            &lengths,
+            0,
+            DistanceType::L2,
+        )
+        .await
+        .unwrap();
+
+        let res = merge_partial_vector_auxiliary_files(
+            &object_store,
+            std::slice::from_ref(&aux0),
+            &index_dir,
+            crate::progress::noop_progress(),
+        )
+        .await;
+        match res {
+            Err(Error::Index { message, .. }) => {
+                assert!(
+                    message.contains("source shard 0"),
+                    "unexpected message: {}",
+                    message
+                );
+                assert!(
+                    message.contains("packed RQ codes"),
+                    "unexpected message: {}",
+                    message
+                );
+            }
+            other => panic!(
+                "expected Error::Index for packed RQ source shard, got {:?}",
+                other
+            ),
+        }
     }
 
     #[tokio::test]
@@ -2736,6 +2831,7 @@ mod tests {
             0,
             DistanceType::L2,
             &codebook0,
+            false,
         )
         .await
         .unwrap();
@@ -2750,6 +2846,7 @@ mod tests {
             1_000,
             DistanceType::L2,
             &codebook1,
+            false,
         )
         .await
         .unwrap();
@@ -2815,6 +2912,7 @@ mod tests {
             0,
             DistanceType::L2,
             &codebook,
+            false,
         )
         .await
         .unwrap();
@@ -2830,6 +2928,7 @@ mod tests {
             1_000,
             DistanceType::L2,
             &codebook,
+            false,
         )
         .await
         .unwrap();

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -112,6 +112,9 @@ fn fixed_size_list_almost_equal(a: &FixedSizeListArray, b: &FixedSizeListArray, 
                 return false;
             }
             for i in 0..av.len() {
+                if av[i].is_nan() || bv[i].is_nan() {
+                    return false;
+                }
                 if (av[i] - bv[i]).abs() > tol {
                     return false;
                 }
@@ -127,6 +130,9 @@ fn fixed_size_list_almost_equal(a: &FixedSizeListArray, b: &FixedSizeListArray, 
                 return false;
             }
             for i in 0..av.len() {
+                if av[i].is_nan() || bv[i].is_nan() {
+                    return false;
+                }
                 if (av[i] - bv[i]).abs() > tol as f64 {
                     return false;
                 }
@@ -144,6 +150,9 @@ fn fixed_size_list_almost_equal(a: &FixedSizeListArray, b: &FixedSizeListArray, 
             for i in 0..av.len() {
                 let da = av[i].to_f32();
                 let db = bv[i].to_f32();
+                if da.is_nan() || db.is_nan() {
+                    return false;
+                }
                 if (da - db).abs() > tol {
                     return false;
                 }
@@ -185,6 +194,30 @@ fn ivf_centroids_from_proto(ivf: &pb::Ivf) -> Result<Option<FixedSizeListArray>>
         .as_ref()
         .map(FixedSizeListArray::try_from)
         .transpose()
+}
+
+async fn open_sibling_index_reader(
+    object_store: &lance_io::object_store::ObjectStore,
+    sched: &Arc<ScanScheduler>,
+    idx_path: &object_store::path::Path,
+) -> Result<Option<V2Reader>> {
+    if !object_store.exists(idx_path).await? {
+        return Ok(None);
+    }
+
+    let fh = sched
+        .open_file(idx_path, &CachedFileSize::unknown())
+        .await?;
+    Ok(Some(
+        V2Reader::try_open(
+            fh,
+            None,
+            Arc::default(),
+            &lance_core::cache::LanceCache::no_cache(),
+            V2ReaderOptions::default(),
+        )
+        .await?,
+    ))
 }
 
 /// Initialize schema-level metadata on a writer for a given storage.
@@ -808,23 +841,8 @@ pub async fn merge_partial_vector_auxiliary_files(
             .parent()
             .unwrap_or_default()
             .join(crate::INDEX_FILE_NAME);
-        let idx_reader = if object_store.exists(&idx_path).await.unwrap_or(false) {
-            let fh = sched
-                .open_file(&idx_path, &CachedFileSize::unknown())
-                .await?;
-            Some(
-                V2Reader::try_open(
-                    fh,
-                    None,
-                    Arc::default(),
-                    &lance_core::cache::LanceCache::no_cache(),
-                    V2ReaderOptions::default(),
-                )
-                .await?,
-            )
-        } else {
-            None
-        };
+        let mut idx_reader: Option<V2Reader> = None;
+        let mut idx_reader_checked = false;
 
         // Inherit format version from the first shard file
         if format_version.is_none() {
@@ -849,6 +867,10 @@ pub async fn merge_partial_vector_auxiliary_files(
         // Detect index type (first iteration only)
         if detected_index_type.is_none() {
             // Try to derive precise type from sibling partial index.idx metadata if available
+            if !idx_reader_checked {
+                idx_reader = open_sibling_index_reader(object_store, &sched, &idx_path).await?;
+                idx_reader_checked = true;
+            }
             if let Some(idx_reader) = idx_reader.as_ref()
                 && let Some(idx_meta_json) = idx_reader
                     .metadata()
@@ -888,11 +910,15 @@ pub async fn merge_partial_vector_auxiliary_files(
         let nlist = lengths.len();
 
         let mut current_centroids = ivf_centroids_from_proto(&pb_ivf)?;
-        if current_centroids.is_none()
-            && let Some(idx_reader) = idx_reader.as_ref()
-            && let Some(index_ivf) = try_read_ivf_proto(idx_reader).await?
-        {
-            current_centroids = ivf_centroids_from_proto(&index_ivf)?;
+        if current_centroids.is_none() {
+            if !idx_reader_checked {
+                idx_reader = open_sibling_index_reader(object_store, &sched, &idx_path).await?;
+            }
+            if let Some(idx_reader) = idx_reader.as_ref()
+                && let Some(index_ivf) = try_read_ivf_proto(idx_reader).await?
+            {
+                current_centroids = ivf_centroids_from_proto(&index_ivf)?;
+            }
         }
         if nlist_opt.is_none() {
             nlist_opt = Some(nlist);
@@ -975,9 +1001,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if let Some(existing_sq) = sq_meta.as_ref()
                     && existing_sq != &sq_meta_parsed
                 {
-                    return Err(Error::index(
-                        "SQ metadata mismatch across shards".to_string(),
-                    ));
+                    return Err(Error::index(format!(
+                        "Distributed SQ merge: metadata mismatch across shards; first(dim={}, nbits={}, bounds={:?}), current(dim={}, nbits={}, bounds={:?})",
+                        existing_sq.dim,
+                        existing_sq.num_bits,
+                        existing_sq.bounds,
+                        sq_meta_parsed.dim,
+                        sq_meta_parsed.num_bits,
+                        sq_meta_parsed.bounds
+                    )));
                 }
 
                 let d0 = sq_meta_parsed.dim;
@@ -1402,9 +1434,15 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if let Some(existing_sq) = sq_meta.as_ref()
                     && existing_sq != &sq_meta_parsed
                 {
-                    return Err(Error::index(
-                        "SQ metadata mismatch across shards".to_string(),
-                    ));
+                    return Err(Error::index(format!(
+                        "Distributed SQ merge (HNSW_SQ): metadata mismatch across shards; first(dim={}, nbits={}, bounds={:?}), current(dim={}, nbits={}, bounds={:?})",
+                        existing_sq.dim,
+                        existing_sq.num_bits,
+                        existing_sq.bounds,
+                        sq_meta_parsed.dim,
+                        sq_meta_parsed.num_bits,
+                        sq_meta_parsed.bounds
+                    )));
                 }
                 let d0 = sq_meta_parsed.dim;
                 dim.get_or_insert(d0);

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -60,7 +60,7 @@ use roaring::RoaringBitmap;
 use rowids::get_row_id_index;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::num::NonZero;
 use std::ops::Range;
@@ -1716,26 +1716,7 @@ impl Dataset {
                     ));
                 }
 
-                let selected_fragment_ids = fragment_ids.iter().copied().collect::<BTreeSet<_>>();
-                let selected_fragments = self
-                    .get_fragments()
-                    .into_iter()
-                    .filter(|fragment| selected_fragment_ids.contains(&(fragment.id() as u32)))
-                    .collect::<Vec<_>>();
-
-                if selected_fragments.len() != selected_fragment_ids.len() {
-                    let present_fragment_ids = selected_fragments
-                        .iter()
-                        .map(|fragment| fragment.id() as u32)
-                        .collect::<HashSet<_>>();
-                    let missing_fragment_ids = selected_fragment_ids
-                        .into_iter()
-                        .filter(|fragment_id| !present_fragment_ids.contains(fragment_id))
-                        .collect::<Vec<_>>();
-                    return Err(Error::invalid_input(format!(
-                        "Dataset::sample received fragment ids that are not part of the current dataset version: {missing_fragment_ids:?}",
-                    )));
-                }
+                let selected_fragments = self.get_fragments_from_ids(fragment_ids)?;
 
                 let num_rows = stream::iter(selected_fragments.iter().cloned())
                     .map(|fragment| async move { fragment.count_rows(None).await })
@@ -2545,37 +2526,109 @@ impl Dataset {
         &self.manifest.fragments
     }
 
-    // Gets a filtered list of fragments from ids in O(N) time instead of using
-    // `get_fragment` which would require O(N^2) time.
+    pub(crate) fn normalize_fragment_ids(fragment_ids: &[u32]) -> Vec<u32> {
+        let mut ids = fragment_ids.to_vec();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
+    pub(crate) fn get_fragments_from_ids(&self, fragment_ids: &[u32]) -> Result<Vec<FileFragment>> {
+        let ordered_ids = Self::normalize_fragment_ids(fragment_ids);
+        let fragments = self.get_frags_from_ordered_ids(&ordered_ids);
+        if let Some(missing_id) = fragments
+            .iter()
+            .zip(ordered_ids.iter())
+            .find_map(|(fragment, fragment_id)| fragment.is_none().then_some(*fragment_id))
+        {
+            return Err(Error::invalid_input(format!(
+                "Unknown fragment id {missing_id} in fragment filter; not part of the current dataset version"
+            )));
+        }
+
+        Ok(fragments.into_iter().flatten().collect())
+    }
+
+    pub(crate) fn get_existing_fragments_from_ids(
+        &self,
+        fragment_ids: &[u32],
+    ) -> Vec<FileFragment> {
+        let ordered_ids = Self::normalize_fragment_ids(fragment_ids);
+        self.get_frags_from_ordered_ids(&ordered_ids)
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+
+    pub(crate) fn get_fragment_metadata_from_ids(
+        &self,
+        fragment_ids: &[u32],
+    ) -> Result<Vec<Fragment>> {
+        Ok(self
+            .get_fragments_from_ids(fragment_ids)?
+            .into_iter()
+            .map(|fragment| fragment.metadata().clone())
+            .collect())
+    }
+
+    pub(crate) fn get_existing_fragment_metadata_from_ids(
+        &self,
+        fragment_ids: &[u32],
+    ) -> Vec<Fragment> {
+        self.get_existing_fragments_from_ids(fragment_ids)
+            .into_iter()
+            .map(|fragment| fragment.metadata().clone())
+            .collect()
+    }
+
+    pub(crate) async fn count_rows_in_fragments(&self, fragment_ids: &[u32]) -> Result<usize> {
+        let fragments = self.get_fragments_from_ids(fragment_ids)?;
+        self.count_rows_in_resolved_fragments(fragments).await
+    }
+
+    pub(crate) async fn count_rows_in_existing_fragments(
+        &self,
+        fragment_ids: &[u32],
+    ) -> Result<usize> {
+        let fragments = self.get_existing_fragments_from_ids(fragment_ids);
+        self.count_rows_in_resolved_fragments(fragments).await
+    }
+
+    async fn count_rows_in_resolved_fragments(
+        &self,
+        fragments: Vec<FileFragment>,
+    ) -> Result<usize> {
+        let counts = stream::iter(fragments)
+            .map(|fragment| async move { fragment.count_rows(None).await })
+            .buffer_unordered(16)
+            .try_collect::<Vec<_>>()
+            .await?;
+        Ok(counts.iter().sum())
+    }
+
+    // Gets a filtered list of fragments from ids without scanning the manifest.
     pub fn get_frags_from_ordered_ids(&self, ordered_ids: &[u32]) -> Vec<Option<FileFragment>> {
-        let mut fragments = Vec::with_capacity(ordered_ids.len());
-        let mut id_iter = ordered_ids.iter();
-        let mut id = id_iter.next();
+        let dataset = Arc::new(self.clone());
         // This field is just used to assert the ids are in order
         let mut last_id: i64 = -1;
-        for frag in self.manifest.fragments.iter() {
-            let mut the_id = if let Some(id) = id { *id } else { break };
-            // Assert the given ids are, in fact, in order
-            assert!(the_id as i64 > last_id);
-            // For any IDs we've passed we can assume that no fragment exists any longer
-            // with that ID.
-            while the_id < frag.id as u32 {
-                fragments.push(None);
-                last_id = the_id as i64;
-                id = id_iter.next();
-                the_id = if let Some(id) = id { *id } else { break };
-            }
+        ordered_ids
+            .iter()
+            .map(|id| {
+                // Assert the given ids are, in fact, in order
+                assert!(*id as i64 > last_id);
+                last_id = *id as i64;
 
-            if the_id == frag.id as u32 {
-                fragments.push(Some(FileFragment::new(
-                    Arc::new(self.clone()),
-                    frag.clone(),
-                )));
-                last_id = the_id as i64;
-                id = id_iter.next();
-            }
-        }
-        fragments
+                if !self.fragment_bitmap.contains(*id) {
+                    return None;
+                }
+                let fragment_index = self.fragment_bitmap.rank(*id) as usize - 1;
+                let fragment = self.manifest.fragments.get(fragment_index)?;
+                if fragment.id != *id as u64 {
+                    return None;
+                }
+                Some(FileFragment::new(dataset.clone(), fragment.clone()))
+            })
+            .collect()
     }
 
     // This method filters deleted items from `addr_or_ids` using `addrs` as a reference

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2620,9 +2620,11 @@ impl Dataset {
                 }
                 let fragment_index = self.fragment_bitmap.rank(*id) as usize - 1;
                 let fragment = self.manifest.fragments.get(fragment_index)?;
-                if fragment.id != *id as u64 {
-                    return None;
-                }
+                debug_assert_eq!(
+                    fragment.id, *id as u64,
+                    "fragment_bitmap rank({id}) resolved to fragment {}, but fragment_bitmap and manifest.fragments are expected to stay in sync",
+                    fragment.id
+                );
                 Some(FileFragment::new(dataset.clone(), fragment.clone()))
             })
             .collect()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2606,18 +2606,15 @@ impl Dataset {
         Ok(counts.iter().sum())
     }
 
-    // Gets a filtered list of fragments from ids without scanning the manifest.
+    /// Resolves fragments for the given ids without scanning the manifest.
+    ///
+    /// The ids do not need to be sorted or deduplicated. Each id is resolved
+    /// independently via the fragment bitmap.
     pub fn get_frags_from_ordered_ids(&self, ordered_ids: &[u32]) -> Vec<Option<FileFragment>> {
         let dataset = Arc::new(self.clone());
-        // This field is just used to assert the ids are in order
-        let mut last_id: i64 = -1;
         ordered_ids
             .iter()
             .map(|id| {
-                // Assert the given ids are, in fact, in order
-                assert!(*id as i64 > last_id);
-                last_id = *id as i64;
-
                 if !self.fragment_bitmap.contains(*id) {
                     return None;
                 }

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1247,6 +1247,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_frags_from_ordered_ids_accepts_unsorted_duplicates() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+        let first = fragments[0].id() as u32;
+        let second = fragments[1].id() as u32;
+
+        let resolved = dataset.get_frags_from_ordered_ids(&[second, first, second, u32::MAX]);
+
+        assert_eq!(resolved.len(), 4);
+        assert_eq!(resolved[0].as_ref().unwrap().id() as u32, second);
+        assert_eq!(resolved[1].as_ref().unwrap().id() as u32, first);
+        assert_eq!(resolved[2].as_ref().unwrap().id() as u32, second);
+        assert!(resolved[3].is_none());
+    }
+
+    #[tokio::test]
     async fn test_execute_uncommitted() {
         // Test the complete workflow that covers the user's specified code pattern:
         // 1. Create dataset with multiple fragments
@@ -1929,6 +1949,58 @@ mod tests {
         assert_eq!(
             segment.fragment_bitmap.as_ref().unwrap(),
             dataset.fragment_bitmap.as_ref()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_vector_precomputed_ivf_num_partitions_mismatch_errors() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let mut ivf_params = prepare_vector_ivf(&dataset, "vector").await;
+        let centroid_count = ivf_params.centroids.as_ref().unwrap().len();
+        ivf_params.num_partitions = Some(centroid_count + 1);
+        let params = VectorIndexParams::with_ivf_flat_params(DistanceType::L2, ivf_params);
+
+        let err = CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .execute_uncommitted()
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains(&format!(
+                "num_partitions {} does not match precomputed IVF centroids length {}",
+                centroid_count + 1,
+                centroid_count
+            )),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_vector_subset_legacy_ivf_pq_rejects_filtered_build() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+        let mut params = VectorIndexParams::ivf_pq(2, 8, 1, MetricType::L2, 10);
+        params.version(crate::index::vector::IndexFileVersion::Legacy);
+
+        let err = CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .fragments(vec![fragments[0].id() as u32])
+            .execute_uncommitted()
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("filtered IVF_PQ builds do not support legacy format"),
+            "unexpected error: {err}"
         );
     }
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -12,8 +12,8 @@ use crate::{
         build_index_metadata_from_segments,
         scalar::{build_bitmap_index_segment, build_scalar_index},
         vector::{
-            LANCE_VECTOR_INDEX, VectorIndexParams, build_distributed_vector_index,
-            build_empty_vector_index, build_vector_index,
+            LANCE_VECTOR_INDEX, StageParams, VectorIndexParams, build_distributed_vector_index,
+            build_empty_vector_index, build_filtered_vector_index, build_vector_index,
         },
         vector_index_details, vector_index_details_default,
     },
@@ -158,12 +158,16 @@ impl<'a> CreateIndexBuilder<'a> {
         let quoted_column: String = format_field_path(&names);
         let column = quoted_column.as_str();
 
-        // If train is true but dataset is empty, automatically set train to false
-        let train = if self.train {
-            self.dataset.count_rows(None).await? > 0
-        } else {
-            false
-        };
+        let vector_fragments_for_validation =
+            is_builtin_vector_index(self.index_type, self.params)
+                .then_some(self.fragments.as_deref())
+                .flatten();
+        let train = should_train_index(
+            self.dataset,
+            self.train,
+            vector_fragments_for_validation,
+        )
+        .await?;
 
         // Load indices from the disk.
         let indices = self.dataset.load_indices().await?;
@@ -367,24 +371,40 @@ impl<'a> CreateIndexBuilder<'a> {
                     })?;
                 let index_version = vec_params.index_type().version() as u32;
 
+                let effective_fragments =
+                    effective_vector_fragments(self.dataset, self.fragments.as_deref());
                 let files = if train {
                     // Check if this is distributed indexing (fragment-level)
-                    if let Some(fragments) = &self.fragments {
-                        // For distributed indexing, build only on specified fragments
-                        // This creates temporary index metadata without committing
-                        let (segment_uuid, files) = Box::pin(build_distributed_vector_index(
-                            self.dataset,
-                            column,
-                            &index_name,
-                            index_id,
-                            vec_params,
-                            fri,
-                            fragments,
-                            self.progress.clone(),
-                        ))
-                        .await?;
-                        output_index_uuid = segment_uuid;
-                        files
+                    if let Some(fragments) = effective_fragments.as_deref() {
+                        if vector_params_have_precomputed_ivf(vec_params) {
+                            // For distributed indexing, build only on specified fragments
+                            // This creates temporary index metadata without committing
+                            let (segment_uuid, files) = Box::pin(build_distributed_vector_index(
+                                self.dataset,
+                                column,
+                                &index_name,
+                                index_id,
+                                vec_params,
+                                fri,
+                                fragments,
+                                self.progress.clone(),
+                            ))
+                            .await?;
+                            output_index_uuid = segment_uuid;
+                            files
+                        } else {
+                            Box::pin(build_filtered_vector_index(
+                                self.dataset,
+                                column,
+                                &index_name,
+                                index_id,
+                                vec_params,
+                                fri,
+                                fragments,
+                                self.progress.clone(),
+                            ))
+                            .await?
+                        }
                     } else {
                         // Standard full dataset indexing
                         Box::pin(build_vector_index(
@@ -775,6 +795,56 @@ fn is_btree_scalar_params(params: &dyn IndexParams) -> bool {
         .is_some_and(|p| p.index_type.eq_ignore_ascii_case("btree"))
 }
 
+fn is_builtin_vector_index(index_type: IndexType, params: &dyn IndexParams) -> bool {
+    params.index_name() == LANCE_VECTOR_INDEX
+        && matches!(
+            index_type,
+            IndexType::Vector
+                | IndexType::IvfPq
+                | IndexType::IvfSq
+                | IndexType::IvfFlat
+                | IndexType::IvfRq
+                | IndexType::IvfHnswFlat
+                | IndexType::IvfHnswPq
+                | IndexType::IvfHnswSq
+        )
+        && params.as_any().is::<VectorIndexParams>()
+}
+
+async fn should_train_index(
+    dataset: &Dataset,
+    train: bool,
+    vector_fragments: Option<&[u32]>,
+) -> Result<bool> {
+    if !train {
+        return Ok(false);
+    }
+
+    if dataset.fragment_bitmap.is_empty() {
+        return Ok(false);
+    }
+
+    if let Some(fragment_ids) = vector_fragments {
+        dataset.get_fragments_from_ids(fragment_ids)?;
+        return Ok(true);
+    }
+
+    Ok(dataset.count_rows(None).await? > 0)
+}
+
+fn vector_params_have_precomputed_ivf(params: &VectorIndexParams) -> bool {
+    matches!(
+        params.stages.first(),
+        Some(StageParams::Ivf(ivf_params)) if ivf_params.centroids.is_some()
+    )
+}
+
+fn effective_vector_fragments(dataset: &Dataset, fragments: Option<&[u32]>) -> Option<Vec<u32>> {
+    let fragments = Dataset::normalize_fragment_ids(fragments?);
+    let fragment_bitmap: roaring::RoaringBitmap = fragments.iter().copied().collect();
+    (fragment_bitmap != *dataset.fragment_bitmap).then_some(fragments)
+}
+
 /// Validate that a user-supplied `index_uuid` is permitted for this build.
 fn ensure_index_uuid_allowed(
     index_type: IndexType,
@@ -1150,6 +1220,30 @@ mod tests {
             .unwrap(),
         );
         IvfBuildParams::try_with_centroids(4, centroids).unwrap()
+    }
+
+    async fn write_vector_fragment_dataset(uri: &str) -> Dataset {
+        let reader = gen_batch()
+            .col("id", lance_datagen::array::step::<Int32Type>())
+            .col(
+                "vector",
+                lance_datagen::array::rand_vec::<Float32Type>(lance_datagen::Dimension::from(16)),
+            )
+            .into_reader_rows(
+                lance_datagen::RowCount::from(256),
+                lance_datagen::BatchCount::from(4),
+            );
+        Dataset::write(
+            reader,
+            uri,
+            Some(WriteParams {
+                max_rows_per_file: 64,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
     }
 
     #[tokio::test]
@@ -1807,6 +1901,166 @@ mod tests {
             .await
             .unwrap();
         assert!(result.num_rows() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_vector_explicit_all_fragments_uses_full_build_without_precomputed_ivf() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragment_ids = dataset
+            .get_fragments()
+            .iter()
+            .map(|fragment| fragment.id() as u32)
+            .collect::<Vec<_>>();
+        assert!(fragment_ids.len() >= 2);
+
+        let mut params = VectorIndexParams::ivf_pq(2, 8, 1, MetricType::L2, 10);
+        params.version(crate::index::vector::IndexFileVersion::Legacy);
+        let segment =
+            CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+                .name("vector_idx".to_string())
+                .fragments(fragment_ids)
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        assert_eq!(
+            segment.fragment_bitmap.as_ref().unwrap(),
+            dataset.fragment_bitmap.as_ref()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_vector_subset_fragments_train_without_precomputed_ivf() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 3);
+        let selected = vec![
+            fragments[1].id() as u32,
+            fragments[0].id() as u32,
+            fragments[1].id() as u32,
+        ];
+        let expected_bitmap = selected.iter().copied().collect::<roaring::RoaringBitmap>();
+
+        let params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        let segment =
+            CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+                .name("vector_idx".to_string())
+                .fragments(selected)
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        assert_eq!(segment.fragment_bitmap.as_ref().unwrap(), &expected_bitmap);
+    }
+
+    #[tokio::test]
+    async fn test_vector_merge_rejects_independently_trained_fragment_segments() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+
+        let params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        let mut segments = Vec::new();
+        for fragment in fragments.iter().take(2) {
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+                    .name("vector_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            segments.push(segment);
+        }
+
+        let err = dataset
+            .merge_existing_index_segments(segments)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("IVF centroids mismatch across shards"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_vector_optimize_rejects_independently_trained_fragment_segments() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() >= 2);
+
+        let params = VectorIndexParams::ivf_flat(2, DistanceType::L2);
+        let mut segments = Vec::new();
+        for fragment in fragments.iter().take(2) {
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+                    .name("vector_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            segments.push(segment);
+        }
+        dataset
+            .commit_existing_index_segments("vector_idx", "vector", segments)
+            .await
+            .unwrap();
+
+        let err = dataset
+            .optimize_indices(&OptimizeOptions::merge(2))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("vector index segments do not share IVF centroids"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_vector_empty_fragments_with_precomputed_ivf_builds_empty_segment() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let mut dataset = write_vector_fragment_dataset(&dataset_uri).await;
+
+        let mut ivf_params = prepare_vector_ivf(&dataset, "vector").await;
+        let expected_partitions = ivf_params.centroids.as_ref().unwrap().len();
+        ivf_params.num_partitions = None;
+        let params = VectorIndexParams::with_ivf_flat_params(DistanceType::L2, ivf_params);
+        let segment =
+            CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+                .name("vector_idx".to_string())
+                .fragments(vec![])
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        assert!(segment.fragment_bitmap.as_ref().unwrap().is_empty());
+        dataset
+            .commit_existing_index_segments("vector_idx", "vector", vec![segment])
+            .await
+            .unwrap();
+        let logical_index = dataset
+            .open_logical_vector_index("vector", "vector_idx")
+            .await
+            .unwrap();
+        let metadata = logical_index.metadatas().next().unwrap();
+        assert_eq!(
+            logical_index.as_ivf().unwrap().num_partitions_per_segment(),
+            vec![(metadata.uuid, expected_partitions)]
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -19,6 +19,7 @@ pub mod utils;
 mod fixture_test;
 
 use self::{ivf::*, pq::PQIndex};
+use arrow_array::Array;
 use arrow_schema::{DataType, Schema};
 use builder::{IvfIndexBuilder, VectorIndexBuildSummary};
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -516,6 +517,7 @@ async fn prepare_vector_segment_build(
     progress: Arc<dyn IndexBuildProgress>,
     mode: &str,
     require_precomputed_ivf: bool,
+    fragment_ids: Option<&[u32]>,
 ) -> Result<(DataType, IndexType, IvfBuildParams, Box<dyn Shuffler>)> {
     let stages = &params.stages;
 
@@ -557,15 +559,29 @@ async fn prepare_vector_segment_build(
         validate_supported_rq_num_bits(rq_params.num_bits)?;
     }
 
-    let num_rows = dataset.count_rows(None).await?;
-    let num_partitions = ivf_params0.num_partitions.unwrap_or_else(|| {
-        recommended_num_partitions(
-            num_rows,
-            ivf_params0
-                .target_partition_size
-                .unwrap_or(index_type.target_partition_size()),
-        )
-    });
+    let num_partitions = match (ivf_params0.num_partitions, ivf_params0.centroids.as_ref()) {
+        (Some(num_partitions), Some(centroids)) if num_partitions != centroids.len() => {
+            return Err(Error::index(format!(
+                "{mode}: num_partitions {} does not match precomputed IVF centroids length {}",
+                num_partitions,
+                centroids.len()
+            )));
+        }
+        (Some(num_partitions), _) => num_partitions,
+        (None, Some(centroids)) => centroids.len(),
+        (None, None) => {
+            let num_rows = match fragment_ids {
+                Some(fragment_ids) => dataset.count_rows_in_fragments(fragment_ids).await?,
+                None => dataset.count_rows(None).await?,
+            };
+            recommended_num_partitions(
+                num_rows,
+                ivf_params0
+                    .target_partition_size
+                    .unwrap_or(index_type.target_partition_size()),
+            )
+        }
+    };
     let mut ivf_params = ivf_params0.clone();
     ivf_params.num_partitions = Some(num_partitions);
 
@@ -602,6 +618,7 @@ pub(crate) async fn build_distributed_vector_index(
         progress.clone(),
         "Build Distributed Vector Index",
         true,
+        Some(fragment_ids),
     )
     .await?;
     let stages = &params.stages;
@@ -946,6 +963,55 @@ pub(crate) async fn build_vector_index(
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<Vec<IndexFile>> {
+    build_vector_index_impl(
+        dataset,
+        column,
+        name,
+        uuid,
+        params,
+        frag_reuse_index,
+        progress,
+        None,
+    )
+    .await
+}
+
+/// Build a standalone vector index segment over a subset of fragments.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn build_filtered_vector_index(
+    dataset: &Dataset,
+    column: &str,
+    name: &str,
+    uuid: Uuid,
+    params: &VectorIndexParams,
+    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    fragment_ids: &[u32],
+    progress: Arc<dyn IndexBuildProgress>,
+) -> Result<Vec<IndexFile>> {
+    build_vector_index_impl(
+        dataset,
+        column,
+        name,
+        uuid,
+        params,
+        frag_reuse_index,
+        progress,
+        Some(fragment_ids),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_vector_index_impl(
+    dataset: &Dataset,
+    column: &str,
+    name: &str,
+    uuid: Uuid,
+    params: &VectorIndexParams,
+    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    progress: Arc<dyn IndexBuildProgress>,
+    fragment_ids: Option<&[u32]>,
+) -> Result<Vec<IndexFile>> {
     let (element_type, index_type, ivf_params, shuffler) = prepare_vector_segment_build(
         dataset,
         column,
@@ -953,6 +1019,7 @@ pub(crate) async fn build_vector_index(
         progress.clone(),
         "Build Vector Index",
         false,
+        fragment_ids,
     )
     .await?;
     let stages = &params.stages;
@@ -971,10 +1038,11 @@ pub(crate) async fn build_vector_index(
                     (),
                     frag_reuse_index,
                 )?
+                .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
                 .build()
                 .await?;
-                return Ok(summary.files);
+                Ok(summary.files)
             }
             DataType::UInt8 => {
                 let summary = IvfIndexBuilder::<FlatIndex, FlatBinQuantizer>::new(
@@ -988,17 +1056,16 @@ pub(crate) async fn build_vector_index(
                     (),
                     frag_reuse_index,
                 )?
+                .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
                 .build()
                 .await?;
-                return Ok(summary.files);
+                Ok(summary.files)
             }
-            _ => {
-                return Err(Error::index(format!(
-                    "Build Vector Index: invalid data type: {:?}",
-                    element_type
-                )));
-            }
+            _ => Err(Error::index(format!(
+                "Build Vector Index: invalid data type: {:?}",
+                element_type
+            ))),
         },
         IndexType::IvfPq => {
             let len = stages.len();
@@ -1011,6 +1078,12 @@ pub(crate) async fn build_vector_index(
 
             match params.version {
                 IndexFileVersion::Legacy => {
+                    if fragment_ids.is_some() {
+                        return Err(Error::index(
+                            "Build Vector Index: filtered IVF_PQ builds do not support legacy format"
+                                .to_string(),
+                        ));
+                    }
                     let files = build_ivf_pq_index(
                         dataset,
                         column,
@@ -1022,7 +1095,7 @@ pub(crate) async fn build_vector_index(
                         progress.clone(),
                     )
                     .await?;
-                    return Ok(files);
+                    Ok(files)
                 }
                 IndexFileVersion::V3 => {
                     let mut builder = IvfIndexBuilder::<FlatIndex, ProductQuantizer>::new(
@@ -1039,10 +1112,11 @@ pub(crate) async fn build_vector_index(
 
                     let summary = builder
                         .with_transpose(!params.skip_transpose)
+                        .with_optional_fragment_filter(fragment_ids)
                         .with_progress(progress.clone())
                         .build()
                         .await?;
-                    return Ok(summary.files);
+                    Ok(summary.files)
                 }
             }
         }
@@ -1065,10 +1139,11 @@ pub(crate) async fn build_vector_index(
                 (),
                 frag_reuse_index,
             )?
+            .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
             .await?;
-            return Ok(summary.files);
+            Ok(summary.files)
         }
         IndexType::IvfRq => {
             let StageParams::RQ(rq_params) = &stages[1] else {
@@ -1092,10 +1167,11 @@ pub(crate) async fn build_vector_index(
 
             let summary = builder
                 .with_transpose(!params.skip_transpose)
+                .with_optional_fragment_filter(fragment_ids)
                 .with_progress(progress.clone())
                 .build()
                 .await?;
-            return Ok(summary.files);
+            Ok(summary.files)
         }
         IndexType::IvfHnswFlat => {
             let StageParams::Hnsw(hnsw_params) = &stages[1] else {
@@ -1117,10 +1193,11 @@ pub(crate) async fn build_vector_index(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_optional_fragment_filter(fragment_ids)
                     .with_progress(progress.clone())
                     .build()
                     .await?;
-                    return Ok(summary.files);
+                    Ok(summary.files)
                 }
                 _ => {
                     let summary = IvfIndexBuilder::<HNSW, FlatQuantizer>::new(
@@ -1134,10 +1211,11 @@ pub(crate) async fn build_vector_index(
                         hnsw_params.clone(),
                         frag_reuse_index,
                     )?
+                    .with_optional_fragment_filter(fragment_ids)
                     .with_progress(progress.clone())
                     .build()
                     .await?;
-                    return Ok(summary.files);
+                    Ok(summary.files)
                 }
             }
         }
@@ -1165,10 +1243,11 @@ pub(crate) async fn build_vector_index(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
             .await?;
-            return Ok(summary.files);
+            Ok(summary.files)
         }
         IndexType::IvfHnswSq => {
             let StageParams::Hnsw(hnsw_params) = &stages[1] else {
@@ -1194,17 +1273,16 @@ pub(crate) async fn build_vector_index(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_optional_fragment_filter(fragment_ids)
             .with_progress(progress.clone())
             .build()
             .await?;
-            return Ok(summary.files);
+            Ok(summary.files)
         }
-        _ => {
-            return Err(Error::index(format!(
-                "Build Vector Index: invalid index type: {:?}",
-                index_type
-            )));
-        }
+        _ => Err(Error::index(format!(
+            "Build Vector Index: invalid index type: {:?}",
+            index_type
+        ))),
     }
 }
 

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -395,7 +395,14 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
     /// Set fragment filter for distributed indexing
     pub fn with_fragment_filter(&mut self, fragment_ids: Vec<u32>) -> &mut Self {
-        self.fragment_filter = Some(fragment_ids);
+        self.fragment_filter = Some(Dataset::normalize_fragment_ids(&fragment_ids));
+        self
+    }
+
+    pub fn with_optional_fragment_filter(&mut self, fragment_ids: Option<&[u32]>) -> &mut Self {
+        if let Some(fragment_ids) = fragment_ids {
+            self.fragment_filter = Some(Dataset::normalize_fragment_ids(fragment_ids));
+        }
         self
     }
 
@@ -553,19 +560,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             return Ok(None);
         };
         match &self.fragment_filter {
-            Some(fragment_ids) => {
-                let fragments: Vec<_> = dataset
-                    .get_fragments()
-                    .into_iter()
-                    .filter(|f| fragment_ids.contains(&(f.id() as u32)))
-                    .collect();
-                let counts = futures::stream::iter(fragments)
-                    .map(|f| async move { f.count_rows(None).await })
-                    .buffer_unordered(16) // ref: Dataset::count_all_rows()
-                    .try_collect::<Vec<_>>()
-                    .await?;
-                Ok(Some(counts.iter().sum::<usize>() as u64))
-            }
+            Some(fragment_ids) => Ok(Some(
+                dataset
+                    .count_rows_in_existing_fragments(fragment_ids)
+                    .await? as u64,
+            )),
             None => Ok(Some(dataset.count_rows(None).await? as u64)),
         }
     }
@@ -603,14 +602,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         "applying fragment filter for distributed indexing: {:?}",
                         fragment_ids
                     );
-                    // Filter fragments by converting fragment_ids to Fragment objects
-                    let all_fragments = dataset.fragments();
-                    let filtered_fragments: Vec<_> = all_fragments
-                        .iter()
-                        .filter(|fragment| fragment_ids.contains(&(fragment.id as u32)))
-                        .cloned()
-                        .collect();
-                    builder.with_fragments(filtered_fragments);
+                    builder.with_fragments(
+                        dataset.get_existing_fragment_metadata_from_ids(fragment_ids),
+                    );
                 }
 
                 let (vector_type, _) = get_vector_type(dataset.schema(), &self.column)?;

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -386,6 +386,106 @@ pub(crate) fn select_segment_for_single_rebalance(
     Ok(selected.map(|candidate| candidate.segment_id))
 }
 
+fn validate_shared_vector_model(indices: &[Arc<dyn VectorIndex>], operation: &str) -> Result<()> {
+    let Some(first) = indices.first() else {
+        return Ok(());
+    };
+    if indices.len() == 1 {
+        return Ok(());
+    }
+
+    let first_metric = first.metric_type();
+    let first_index_type = first.sub_index_type();
+    let first_centroids = first.ivf_model().centroids_array();
+    let first_quantizer = first.quantizer();
+    let first_quantizer_type = first_quantizer.quantization_type();
+
+    for (idx, index) in indices.iter().enumerate().skip(1) {
+        if index.metric_type() != first_metric {
+            return Err(Error::index(format!(
+                "{operation}: vector index segment {idx} has metric {:?}, expected {:?}",
+                index.metric_type(),
+                first_metric
+            )));
+        }
+        let index_type = index.sub_index_type();
+        if std::mem::discriminant(&index_type.0) != std::mem::discriminant(&first_index_type.0)
+            || index_type.1 != first_index_type.1
+        {
+            return Err(Error::index(format!(
+                "{operation}: vector index segment {idx} has type {:?}, expected {:?}",
+                index_type, first_index_type
+            )));
+        }
+        match (first_centroids, index.ivf_model().centroids_array()) {
+            (Some(expected), Some(actual)) if expected.to_data() != actual.to_data() => {
+                return Err(Error::index(format!(
+                    "{operation}: vector index segments do not share IVF centroids"
+                )));
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(Error::index(format!(
+                    "{operation}: vector index segments do not share IVF centroids"
+                )));
+            }
+            _ => {}
+        }
+
+        let quantizer = index.quantizer();
+        if quantizer.quantization_type() != first_quantizer_type {
+            return Err(Error::index(format!(
+                "{operation}: vector index segment {idx} has quantizer {:?}, expected {:?}",
+                quantizer.quantization_type(),
+                first_quantizer_type
+            )));
+        }
+        if !shared_quantizer_model(&first_quantizer, &quantizer) {
+            return Err(Error::index(format!(
+                "{operation}: vector index segments do not share quantizer metadata"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn shared_quantizer_model(left: &Quantizer, right: &Quantizer) -> bool {
+    match (left, right) {
+        (Quantizer::Flat(left), Quantizer::Flat(right)) => {
+            left.metadata(None).dim == right.metadata(None).dim
+        }
+        (Quantizer::FlatBin(left), Quantizer::FlatBin(right)) => {
+            left.metadata(None).dim == right.metadata(None).dim
+        }
+        (Quantizer::Product(left), Quantizer::Product(right)) => {
+            left.num_sub_vectors == right.num_sub_vectors
+                && left.num_bits == right.num_bits
+                && left.dimension == right.dimension
+                && left.distance_type == right.distance_type
+                && left.codebook.to_data() == right.codebook.to_data()
+        }
+        (Quantizer::Scalar(left), Quantizer::Scalar(right)) => {
+            left.metadata(None) == right.metadata(None)
+        }
+        (Quantizer::Rabit(left), Quantizer::Rabit(right)) => {
+            let left = left.metadata(None);
+            let right = right.metadata(None);
+            left.rotation_type == right.rotation_type
+                && left.code_dim == right.code_dim
+                && left.num_bits == right.num_bits
+                && left.packed == right.packed
+                && left.query_estimator == right.query_estimator
+                && left.fast_rotation_signs == right.fast_rotation_signs
+                && match (&left.rotate_mat, &right.rotate_mat) {
+                    (Some(left), Some(right)) => left.to_data() == right.to_data(),
+                    (None, None) => true,
+                    _ => false,
+                }
+        }
+        _ => false,
+    }
+}
+
 // TODO: move to `lance-index` crate.
 ///
 /// Returns (new_uuid, num_indices_merged, files)
@@ -407,6 +507,7 @@ pub(crate) async fn optimize_vector_indices(
     // try cast to v1 IVFIndex,
     // fallback to v2 IVFIndex if it's not v1 IVFIndex
     if !existing_indices[0].as_any().is::<IVFIndex>() {
+        validate_shared_vector_model(&existing_indices, "optimizing vector index")?;
         return optimize_vector_indices_v2(
             &dataset,
             unindexed,
@@ -4583,6 +4684,41 @@ mod tests {
     use crate::utils::test::copy_test_data_to_tmp;
 
     const DIM: usize = 32;
+
+    #[test]
+    fn test_shared_quantizer_model_compares_skipped_payloads() {
+        let codebook = |offset| {
+            let values = Float32Array::from_iter_values((0..32).map(|v| v as f32 + offset));
+            FixedSizeListArray::try_new_from_values(values, 2).unwrap()
+        };
+        let pq1 = Quantizer::Product(ProductQuantizer::new(
+            1,
+            4,
+            2,
+            codebook(0.0),
+            DistanceType::L2,
+        ));
+        let pq2 = Quantizer::Product(ProductQuantizer::new(
+            1,
+            4,
+            2,
+            codebook(100.0),
+            DistanceType::L2,
+        ));
+        assert!(!shared_quantizer_model(&pq1, &pq2));
+
+        let rq1 = Quantizer::Rabit(RabitQuantizer::new_with_rotation::<Float32Type>(
+            1,
+            8,
+            lance_index::vector::bq::RQRotationType::Matrix,
+        ));
+        let rq2 = Quantizer::Rabit(RabitQuantizer::new_with_rotation::<Float32Type>(
+            1,
+            8,
+            lance_index::vector::bq::RQRotationType::Matrix,
+        ));
+        assert!(!shared_quantizer_model(&rq1, &rq2));
+    }
 
     async fn compute_test_ivf_loss(dataset: &Dataset, column: &str, ivf: &IvfModel) -> f64 {
         let centroids = ivf

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -10,7 +10,7 @@ use arrow::datatypes::DataType;
 use arrow_array::new_empty_array;
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, RecordBatch, cast::AsArray};
 use arrow_buffer::{Buffer, MutableBuffer};
-use futures::{Stream, StreamExt, TryStreamExt, stream};
+use futures::{Stream, StreamExt, stream};
 use lance_arrow::DataTypeExt;
 use lance_core::datatypes::Schema;
 use lance_linalg::distance::DistanceType;
@@ -265,38 +265,7 @@ fn infer_vector_element_type_impl(
 async fn count_rows(dataset: &Dataset, fragment_ids: Option<&[u32]>) -> Result<usize> {
     match fragment_ids {
         None => dataset.count_rows(None).await,
-        Some(fragment_ids) => {
-            let sorted_ids: Vec<u32>;
-            let sorted_fragment_ids = if fragment_ids.windows(2).all(|w| w[0] <= w[1]) {
-                fragment_ids
-            } else {
-                sorted_ids = {
-                    let mut v = fragment_ids.to_vec();
-                    v.sort_unstable();
-                    v
-                };
-                &sorted_ids
-            };
-            let fragments = dataset.get_frags_from_ordered_ids(sorted_fragment_ids);
-            let valid_fragments = fragments
-                .into_iter()
-                .enumerate()
-                .map(|(i, frag)| {
-                    frag.ok_or_else(|| {
-                        Error::index(format!(
-                            "Unexpectedly missing fragment {}",
-                            sorted_fragment_ids[i]
-                        ))
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
-            let cnts = stream::iter(valid_fragments)
-                .map(|f| async move { f.count_rows(None).await })
-                .buffer_unordered(16)
-                .try_collect::<Vec<usize>>()
-                .await?;
-            Ok(cnts.iter().sum::<usize>())
-        }
+        Some(fragment_ids) => dataset.count_rows_in_fragments(fragment_ids).await,
     }
 }
 
@@ -310,8 +279,6 @@ pub async fn maybe_sample_training_data(
     sample_size_hint: usize,
     fragment_ids: Option<&[u32]>,
 ) -> Result<FixedSizeListArray> {
-    let num_rows = count_rows(dataset, fragment_ids).await?;
-
     let vector_field = dataset.schema().field(column).ok_or(Error::index(format!(
         "Sample training data: column {} does not exist in schema",
         column
@@ -328,6 +295,8 @@ pub async fn maybe_sample_training_data(
         );
         return Ok(new_empty_array(&fsl_type).as_fixed_size_list().clone());
     }
+
+    let num_rows = count_rows(dataset, fragment_ids).await?;
 
     let is_nullable = vector_field.nullable;
 
@@ -600,21 +569,7 @@ fn sample_training_data_scan_from_fragments(
         ));
     }
 
-    let mut ordered_ids = fragment_ids.to_vec();
-    ordered_ids.sort_unstable();
-    ordered_ids.dedup();
-    let selected_fragments = dataset
-        .get_frags_from_ordered_ids(&ordered_ids)
-        .into_iter()
-        .zip(ordered_ids.iter())
-        .map(|(fragment, fragment_id)| {
-            fragment.ok_or_else(|| {
-                Error::invalid_input(format!(
-                    "Unknown fragment id {fragment_id} in training fragment filter"
-                ))
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let selected_fragments = dataset.get_fragments_from_ids(fragment_ids)?;
     let dataset = Arc::new(dataset.clone());
     let projection = Arc::new(
         ProjectionRequest::from(dataset.schema().project(&[column])?)
@@ -707,22 +662,7 @@ fn resolve_scan_fragments(
     dataset: &Dataset,
     fragment_ids: &[u32],
 ) -> Result<Vec<lance_table::format::Fragment>> {
-    let mut ordered_ids = fragment_ids.to_vec();
-    ordered_ids.sort_unstable();
-    let fragments = dataset.get_frags_from_ordered_ids(&ordered_ids);
-    if let Some(missing_id) = fragments
-        .iter()
-        .zip(ordered_ids.iter())
-        .find_map(|(fragment, fragment_id)| fragment.is_none().then_some(*fragment_id))
-    {
-        return Err(Error::invalid_input(format!(
-            "Unknown fragment id {missing_id} in training fragment filter"
-        )));
-    }
-    Ok(fragments
-        .into_iter()
-        .map(|fragment| fragment.unwrap().metadata().clone())
-        .collect())
+    dataset.get_fragment_metadata_from_ids(fragment_ids)
 }
 
 /// Build a FixedSizeListArray from raw flat value bytes.


### PR DESCRIPTION
## Summary

- Resolve explicit vector fragment filters by fragment id in O(k), so fragment-scoped IVF training no longer scans the whole manifest to find selected fragments.
- Treat an explicit vector fragment filter that covers every current dataset fragment as an unfiltered full build in `CreateIndexBuilder`.
- Add a filtered vector build path for genuine subset fragment builds without precomputed IVF, covering standalone segmented index creation.
- Preserve distributed builds with shared precomputed IVF/PQ/RQ state, and reject unsafe merge/optimize of independently trained vector segments that do not share the same model.
- Harden distributed vector auxiliary merge validation for IVF centroids and quantizer metadata, including codebook/rotation payload checks.
- Add regression coverage for all-fragment filters, subset training, empty precomputed-IVF segments, unsafe merge/optimize rejection, legacy filtered IVF_PQ rejection, and precomputed centroid partition mismatches.

The important semantic distinction is that subset training/build is valid and now uses fragment-scoped work, but independently trained subset IVF segments are not merge-compatible unless they share the same precomputed vector model.

Validated locally with `cargo fmt --all`, `cargo clippy --all --tests --benches -- -D warnings`, targeted `lance` vector index tests, and `cargo test -p lance-index index_merger`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for building vector indexes over a selected subset of dataset fragments, including correct behavior for empty subsets and precomputed-IVF centroids.
  - Improved index-build routing to better respect fragment selection when training.

- **Bug Fixes**
  - Strengthened cross-shard merge/optimize validation for shared vector models (metrics, centroids, quantizers, rotation details) with NaN-aware comparisons.
  - Rejected unsupported or incompatible metadata during merges (including legacy IVF_PQ filtered builds, transposed/packed PQ/RQ cases).

- **Tests**
  - Expanded and added coverage for fragment-selection behavior and shared-model comparison and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->