### PR TITLE
fix: keep row ids and addresses aligned in filter_deleted_ids

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2743,17 +2743,25 @@ impl Dataset {
     }
 
     pub(crate) async fn filter_deleted_ids(&self, ids: &[u64]) -> Result<Vec<u64>> {
-        let addresses = if let Some(row_id_index) = get_row_id_index(self).await? {
-            let addresses = ids
+        if let Some(row_id_index) = get_row_id_index(self).await? {
+            // Resolve each stable row id to its address. Some ids may no longer
+            // resolve (e.g. their rows were already removed), so we drop those
+            // and keep `ids` and `addresses` positionally aligned via unzip.
+            // `filter_addr_or_ids` relies on that correspondence; passing the
+            // full `ids` alongside a shorter, filter_map'd `addresses` would
+            // misalign the two and mis-filter the results.
+            let (ids, addresses): (Vec<u64>, Vec<u64>) = ids
                 .iter()
-                .filter_map(|id| row_id_index.get(*id).map(|address| address.into()))
-                .collect::<Vec<_>>();
-            Cow::Owned(addresses)
+                .filter_map(|id| {
+                    row_id_index
+                        .get(*id)
+                        .map(|address| (*id, u64::from(address)))
+                })
+                .unzip();
+            self.filter_addr_or_ids(&ids, &addresses).await
         } else {
-            Cow::Borrowed(ids)
-        };
-
-        self.filter_addr_or_ids(ids, &addresses).await
+            self.filter_addr_or_ids(ids, ids).await
+        }
     }
 
     /// Gets the number of files that are so small they don't even have a full

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2434,6 +2434,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn optimize_after_delete_with_stable_row_ids_joins_partitions() {
+        // Regression test for https://github.com/lancedb/lance/issues/7701
+        //
+        // With stable row ids enabled, deleting rows removes them from the
+        // row id index, so those ids no longer resolve to an address. When
+        // `optimize_indices` later joins undersized partitions it re-reads the
+        // stored (stable) row ids for a partition and asks the dataset to drop
+        // the deleted ones. If the surviving ids and their addresses get out of
+        // alignment, some deleted ids leak through and `take_rows` returns
+        // fewer rows than requested, tripping the
+        // `batch.num_rows() != chunk.len()` check. This exercises that path.
+        use crate::dataset::WriteParams;
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::VectorIndexParams;
+        use arrow_array::types::Int64Type;
+        use arrow_array::{Int64Array, RecordBatchIterator};
+        use arrow_schema::Schema as ArrowSchema;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let dim = 32;
+        let num_rows = 5000usize;
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(item_field, dim as i32),
+                false,
+            ),
+        ]));
+
+        let mut values = Vec::with_capacity(num_rows * dim);
+        for i in 0..num_rows {
+            for j in 0..dim {
+                values.push(((i as f32) * 0.1 + (j as f32) * 0.3).sin());
+            }
+        }
+        let fsl = FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim as i32)
+            .unwrap();
+        let ids = Int64Array::from((0..num_rows as i64).collect::<Vec<_>>());
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(fsl)]).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = crate::Dataset::write(
+            reader,
+            uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // 16 partitions over 5000 rows keeps every partition well under the
+        // IVF_FLAT join threshold (1024), so the optimize below takes the join
+        // path for every partition.
+        let params = VectorIndexParams::ivf_flat(16, MetricType::L2);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Delete 1/5 of the rows, spread across every partition, so each
+        // partition carries some now-unresolvable stable row ids.
+        dataset.delete("id % 5 == 0").await.unwrap();
+
+        // Before the fix this panicked with `batch.num_rows() != chunk.len()`.
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        // The delete is intact and the data is untouched.
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 4000);
+
+        // The optimized index is still usable and only returns live rows.
+        let query = dataset
+            .scan()
+            .filter("id = 1")
+            .unwrap()
+            .project(&["vec"] as &[&str])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let q = query["vec"].as_fixed_size_list().value(0);
+        let result = dataset
+            .scan()
+            .project(&["id"] as &[&str])
+            .unwrap()
+            .nearest("vec", q.as_ref(), 10)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert!(
+            result.num_rows() > 0,
+            "search over optimized index returned nothing"
+        );
+        for id in result["id"].as_primitive::<Int64Type>().values() {
+            assert_ne!(id % 5, 0, "search returned a deleted row id {id}");
+        }
+    }
+
+    #[tokio::test]
     async fn take_partition_batches_preserves_partition_order_for_large_fixed_size_list() {
         let value_length = 1_073_741_824i32;
         let num_rows = 5usize;


### PR DESCRIPTION
## Problem

`optimize_indices` fails with `Invalid user input: batch.num_rows() != chunk.len()` after deleting rows from a stable-row-id dataset that has an IVF_FLAT index. Reported in #7701.

Repro (from the issue):

```python
import tempfile, numpy as np, pyarrow as pa, lance
tmp = tempfile.mkdtemp()
n, dim = 5000, 32
ids = np.arange(n)
vecs = np.sin(ids[:, None] * 0.1 + np.arange(dim)[None, :] * 0.3).astype(np.float32)
t = pa.table({
    "id": pa.array(ids, pa.int64()),
    "category": pa.array([["A","B","C","D","E"][i % 5] for i in range(n)]),
    "vec": pa.FixedSizeListArray.from_arrays(pa.array(vecs.ravel(), pa.float32()), dim),
})
ds = lance.write_dataset(t, tmp + "/t.lance", enable_stable_row_ids=True)
ds.create_index("vec", index_type="IVF_FLAT", num_partitions=16)
ds.delete("category = 'A'")
lance.dataset(tmp + "/t.lance").optimize.optimize_indices()  # raises
```

## Root cause

When stable row ids are enabled, deleting rows also removes them from the row id index (`decompose_segment_with_deletions` skips deleted offsets), so those ids no longer resolve to an address.

`filter_deleted_ids` built its address list with a `filter_map`:

```rust
let addresses = ids.iter()
    .filter_map(|id| row_id_index.get(*id).map(|address| address.into()))
    .collect::<Vec<_>>();
self.filter_addr_or_ids(ids, &addresses).await
```

The `filter_map` silently drops the unresolvable ids, so `addresses` ends up shorter than `ids`. `filter_addr_or_ids` then receives the full `ids` slice alongside the shortened `addresses` slice, but it relies on the two being positionally aligned: it sorts the addresses, checks each one against its fragment's deletion vector, un-sorts, and zips the liveness result back against the input ids. Once the lengths diverge the zip pairs ids with the wrong verdict, so some already-deleted ids get reported as live. During an `optimize_indices` partition join, `take_vectors` asks `take_rows` for those ids, gets back fewer rows than the chunk it requested, and hits the `batch.num_rows() != chunk.len()` check.

## Fix

Build `ids` and `addresses` together and `unzip` them, so the two slices stay the same length and positionally correspond. Ids that no longer resolve are dropped from both, which is correct since those rows are already gone.

## Testing

Added `optimize_after_delete_with_stable_row_ids_joins_partitions` in `rust/lance/src/index/vector/builder.rs`, which ports the repro: stable row ids + IVF_FLAT (16 partitions) + delete + `optimize_indices`, then checks the surviving row count and that a search over the optimized index returns only live rows. It reproduces the exact original error (`batch.num_rows() != chunk.len() (188 != 235)`) on the unfixed code and passes with the fix. The existing `builder` (55) and `rowids` (16) test suites still pass; `cargo fmt` and `cargo clippy -p lance --tests -- -D warnings` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed filtering after deletions when stable row IDs are enabled, preventing valid records from being mismatched or incorrectly excluded.
  - Ensured vector indexes remain accurate after optimizing data with deleted rows.

- **Tests**
  - Added coverage for vector search and index optimization scenarios involving deleted records and stable row IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->