### PR TITLE
ci: pin Rust nightly around test attribute ICE

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,8 +96,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup rust toolchain
         run: |
-          rustup toolchain install nightly
-          rustup default nightly
+          # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
+          rustup toolchain install nightly-2026-07-13
+          rustup default nightly-2026-07-13
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Install dependencies
@@ -111,7 +112,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
-          cargo +nightly llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo +nightly-2026-07-13 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:


### PR DESCRIPTION
Fixes #7786.

Rust `nightly-2026-07-14` introduced rust-lang/rust#159261, which makes `linux-build` deterministically ICE while expanding a `#[test]` followed by an attribute macro. Lance hits this in the `lance-encoding` test binary before any tests execute, and the same failure is present on `main`.

Pin the job's toolchain installation and `cargo llvm-cov` invocation to the last known-good `nightly-2026-07-13`. This is a temporary CI mitigation; restore the floating nightly after a dated release containing rust-lang/rust#159277 passes the reproduction and the full job.
