### PR TITLE
fix(dataset): reject all system column names on write

### DIFF
--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -8,8 +8,8 @@ use arrow_array::{RecordBatch, RecordBatchIterator};
 use datafusion::execution::SendableRecordBatchStream;
 use humantime::format_duration;
 use lance_core::datatypes::{NullabilityComparison, Schema, SchemaCompareOptions};
+use lance_core::is_system_column;
 use lance_core::utils::tracing::{DATASET_WRITING_EVENT, TRACE_DATASET_EVENTS};
-use lance_core::{ROW_ADDR, ROW_ID, ROW_OFFSET};
 use lance_datafusion::utils::StreamingWriteSource;
 use lance_file::version::LanceFileVersion;
 use lance_io::object_store::ObjectStore;
@@ -328,9 +328,12 @@ impl<'a> InsertBuilder<'a> {
             normalized_data_schema.check_compatible(dataset.schema(), &schema_cmp_opts)?;
         }
 
-        // Make sure we aren't using any reserved column names
+        // The system columns (`_rowid`, `_rowaddr`, `_rowoffset`, and the row-version
+        // columns) are virtual: they're injected into scan results at read time and
+        // never stored. A stored column sharing one of these names would collide with
+        // the system column on read, so reject it at write time.
         for field in data_schema.fields.iter() {
-            if field.name == ROW_ID || field.name == ROW_ADDR || field.name == ROW_OFFSET {
+            if is_system_column(&field.name) {
                 return Err(Error::invalid_input_source(
                     format!(
                         "The column {} is a reserved name and cannot be used in a Lance dataset",
@@ -503,6 +506,38 @@ mod test {
                 .await
                 .unwrap(),
             1
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::row_id("_rowid")]
+    #[case::row_addr("_rowaddr")]
+    #[case::row_offset("_rowoffset")]
+    #[case::row_created_at_version("_row_created_at_version")]
+    #[case::row_last_updated_at_version("_row_last_updated_at_version")]
+    #[tokio::test]
+    async fn rejects_reserved_system_column_names(#[case] reserved_name: &str) {
+        // Every system column name must be rejected on write. The row-version
+        // columns (`_row_created_at_version`, `_row_last_updated_at_version`) are
+        // computed at read time and appended by `Projection::to_schema`; a user
+        // data column sharing one of those names would otherwise pass ingest and
+        // later collide with the appended field.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            reserved_name,
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
+            .unwrap();
+
+        let result = InsertBuilder::new("memory://")
+            .execute_stream(RecordBatchIterator::new(vec![Ok(batch)], schema.clone()))
+            .await;
+
+        let err = result.expect_err("writing a reserved system column name should fail");
+        assert!(
+            err.to_string().contains("reserved name"),
+            "unexpected error for {reserved_name}: {err}"
         );
     }
 


### PR DESCRIPTION
## What & why

The write-path reserved-column-name guard only rejected three of the five system column names (`_rowid`, `_rowaddr`, `_rowoffset`), missing `_row_created_at_version` and `_row_last_updated_at_version`. Those two were introduced by the row-tracking feature and the guard was never extended.

System columns are virtual — they are injected into scan results at read time and never stored in the physical data. `Projection::to_schema` appends `_rowid`, `_rowaddr`, and the two row-version columns to a projection, and the scanner's `filterable_schema` sets all of those flags on every filtered scan. So a user data column literally named `_row_created_at_version` passed ingest, then collided with the appended system field the next time the dataset was scanned with a filter, hitting `to_schema`'s `extend(...).unwrap()` and panicking. Rare (the column name has to match exactly) but reachable on well-formed, in-memory data — not a corrupt-file case.

## How & why it is correct

Replace the hardcoded three-name check with `is_system_column`, which covers all five names. This rejects the collision at the write boundary with a clear error instead of letting it surface as a later panic, so `to_schema`'s existing contract genuinely holds. `is_system_column` is a strict superset of the old three names, so the previously-rejected names still error exactly as before.

## Compatibility

No behavior change for legitimate writes. The row-version columns are virtual and never part of a stored schema, so no valid write payload contains them; the only schema that reaches this guard is the user-provided data schema in `InsertBuilder`. Internal writers (merge-insert, update) build their schemas from `dataset.schema()` and bypass this guard entirely. The only newly-rejected input is a user explicitly naming a physical column after a system column — which is precisely the case that used to panic on read.

## Test plan

- New parameterized test `rejects_reserved_system_column_names` covering all five system column names; the two version-column cases fail against the old three-name guard and pass with the fix.
- `cargo test -p lance --lib`, `cargo clippy -p lance --tests -- -D warnings`, `cargo fmt --all -- --check` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset ingestion now rejects user-provided field names that conflict with reserved system columns.
  * Validation covers the complete set of system column names, including row-version fields.
  * Added coverage to ensure conflicting field names consistently fail ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->