### PR TITLE
fix(ci): pin goosefs-sdk to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,6 +4885,7 @@ dependencies = [
  "chrono",
  "criterion",
  "futures",
+ "goosefs-sdk",
  "http 1.4.2",
  "io-uring",
  "lance-arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ geoarrow-schema = "0.8"
 geodatafusion = "0.4.0"
 geo-traits = "0.3.0"
 geo-types = "0.7.16"
+goosefs-sdk = "=0.1.5"
 http = "1.1.0"
 humantime = "2.2.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "goosefs-sdk",
  "http 1.4.2",
  "io-uring",
  "lance-arrow",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4459,6 +4459,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "goosefs-sdk",
  "http 1.4.2",
  "io-uring",
  "lance-arrow",

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -35,6 +35,7 @@ byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 futures.workspace = true
+goosefs-sdk = { workspace = true, optional = true }
 http.workspace = true
 log.workspace = true
 metrics = { workspace = true, optional = true }
@@ -76,7 +77,8 @@ gcp = ["object_store/gcp", "dep:opendal", "opendal/services-gcs", "dep:object_st
 aws = ["object_store/aws", "dep:aws-config", "dep:aws-credential-types", "dep:opendal", "opendal/services-s3", "dep:object_store_opendal"]
 azure = ["object_store/azure", "dep:opendal", "opendal/services-azblob", "opendal/services-azdls", "dep:object_store_opendal"]
 oss = ["dep:opendal", "opendal/services-oss", "dep:object_store_opendal"]
-goosefs = ["dep:opendal", "opendal/services-goosefs", "dep:object_store_opendal"]
+# Pin goosefs-sdk until a release fixes the missing CString import in 0.1.6's Linux backend.
+goosefs = ["dep:goosefs-sdk", "dep:opendal", "opendal/services-goosefs", "dep:object_store_opendal"]
 tencent = ["dep:opendal", "opendal/services-cos", "dep:object_store_opendal"]
 huggingface = ["dep:opendal", "opendal/services-huggingface", "dep:object_store_opendal"]
 tos = ["dep:opendal", "opendal/services-tos", "dep:object_store_opendal"]


### PR DESCRIPTION
Pins goosefs-sdk to 0.1.5 because 0.1.6 fails to compile on Linux due to a missing std::ffi::CString import. This pin can be removed once upstream publishes a fixed release.

```
error[E0433]: cannot find type `CString` in this scope
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/goosefs-sdk-0.1.6/src/cache/store/uring/store.rs:314:23
    |
314 |         let cstring = CString::new(path)
    |                       ^^^^^^^ use of undeclared type `CString`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GooseFS integration to use a compatible SDK version, improving reliability for supported storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->