### PR TITLE
feat: add IVF_HNSW_RQ vector index

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1025,7 +1025,8 @@ fn inner_create_index<'local>(
         | IndexType::IvfRq
         | IndexType::IvfHnswSq
         | IndexType::IvfHnswPq
-        | IndexType::IvfHnswFlat => {
+        | IndexType::IvfHnswFlat
+        | IndexType::IvfHnswRq => {
             // For vector indices, use the existing parameter handling
             get_vector_index_params(env, params_jobj)
         }

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -180,6 +180,8 @@ fn determine_index_type<'local>(
                 Some("IVF_HNSW_SQ")
             } else if lower.contains("pq") {
                 Some("IVF_HNSW_PQ")
+            } else if lower.contains("rq") {
+                Some("IVF_HNSW_RQ")
             } else {
                 Some("IVF_HNSW_FLAT")
             }
@@ -188,6 +190,8 @@ fn determine_index_type<'local>(
                 Some("IVF_SQ")
             } else if lower.contains("pq") {
                 Some("IVF_PQ")
+            } else if lower.contains("rq") {
+                Some("IVF_RQ")
             } else {
                 Some("IVF_FLAT")
             }

--- a/java/src/main/java/org/lance/index/IndexType.java
+++ b/java/src/main/java/org/lance/index/IndexType.java
@@ -32,7 +32,8 @@ public enum IndexType {
   IVF_HNSW_SQ(104),
   IVF_HNSW_PQ(105),
   IVF_HNSW_FLAT(106),
-  IVF_RQ(107);
+  IVF_RQ(107),
+  IVF_HNSW_RQ(108);
 
   private final int value;
 

--- a/java/src/main/java/org/lance/index/vector/VectorIndexParams.java
+++ b/java/src/main/java/org/lance/index/vector/VectorIndexParams.java
@@ -45,8 +45,11 @@ public class VectorIndexParams {
         > 1) {
       throw new IllegalArgumentException("Only one of PQ, SQ, or RQ can be specified at a time.");
     }
-    if (hnswParams.isPresent() && !pqParams.isPresent() && !sqParams.isPresent()) {
-      throw new IllegalArgumentException("HNSW must be combined with either PQ or SQ");
+    if (hnswParams.isPresent()
+        && !pqParams.isPresent()
+        && !sqParams.isPresent()
+        && !rqParams.isPresent()) {
+      throw new IllegalArgumentException("HNSW must be combined with PQ, SQ, or RQ");
     }
   }
 
@@ -169,6 +172,27 @@ public class VectorIndexParams {
         .setDistanceType(distanceType)
         .setHnswParams(hnsw)
         .setSqParams(sq)
+        .build();
+  }
+
+  /**
+   * Create a new IVF HNSW index with RQ quantizer. The dataset is partitioned into IVF partitions,
+   * and each partition builds an HNSW graph.
+   *
+   * <p>IVF_HNSW_RQ currently supports only L2 distance.
+   *
+   * @param distanceType the distance type for calculating the distance between vectors
+   * @param ivf the IVF build parameters
+   * @param hnsw the HNSW build parameters
+   * @param rq the RQ build parameters
+   * @return the VectorIndexParams
+   */
+  public static VectorIndexParams withIvfHnswRqParams(
+      DistanceType distanceType, IvfBuildParams ivf, HnswBuildParams hnsw, RQBuildParams rq) {
+    return new Builder(ivf)
+        .setDistanceType(distanceType)
+        .setHnswParams(hnsw)
+        .setRqParams(rq)
         .build();
   }
 

--- a/java/src/test/java/org/lance/JNITest.java
+++ b/java/src/test/java/org/lance/JNITest.java
@@ -18,6 +18,7 @@ import org.lance.index.IndexParams;
 import org.lance.index.vector.HnswBuildParams;
 import org.lance.index.vector.IvfBuildParams;
 import org.lance.index.vector.PQBuildParams;
+import org.lance.index.vector.RQBuildParams;
 import org.lance.index.vector.SQBuildParams;
 import org.lance.index.vector.VectorIndexParams;
 import org.lance.ipc.ApproxMode;
@@ -144,6 +145,24 @@ public class JNITest {
         IndexParams.builder()
             .setVectorIndexParams(
                 VectorIndexParams.withIvfHnswSqParams(DistanceType.Dot, ivf, hnsw, sq))
+            .build());
+  }
+
+  @Test
+  public void testIvfHnswRqIndexParams() {
+    IvfBuildParams ivf = new IvfBuildParams.Builder().setNumPartitions(25).build();
+    HnswBuildParams hnsw =
+        new HnswBuildParams.Builder()
+            .setMaxLevel((short) 8)
+            .setM(25)
+            .setEfConstruction(175)
+            .build();
+    RQBuildParams rq = new RQBuildParams.Builder().setNumBits((byte) 5).build();
+
+    JniTestHelper.parseIndexParams(
+        IndexParams.builder()
+            .setVectorIndexParams(
+                VectorIndexParams.withIvfHnswRqParams(DistanceType.L2, ivf, hnsw, rq))
             .build());
   }
 

--- a/java/src/test/java/org/lance/index/VectorIndexTest.java
+++ b/java/src/test/java/org/lance/index/VectorIndexTest.java
@@ -16,6 +16,7 @@ package org.lance.index;
 import org.lance.Dataset;
 import org.lance.Fragment;
 import org.lance.TestVectorDataset;
+import org.lance.index.vector.HnswBuildParams;
 import org.lance.index.vector.IvfBuildParams;
 import org.lance.index.vector.PQBuildParams;
 import org.lance.index.vector.RQBuildParams;
@@ -309,6 +310,41 @@ public class VectorIndexTest {
         assertTrue(
             indexType == IndexType.VECTOR || indexType == IndexType.IVF_RQ,
             "IndexType for IVF_RQ index should be VECTOR or IVF_RQ but was " + indexType);
+      }
+    }
+  }
+
+  @Test
+  public void testCreateIvfHnswRqIndex(@TempDir Path tempDir) throws Exception {
+    Path datasetPath = tempDir.resolve("ivf_hnsw_rq_index");
+
+    try (TestVectorDataset testVectorDataset = new TestVectorDataset(datasetPath)) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        IvfBuildParams ivf = new IvfBuildParams.Builder().setNumPartitions(2).build();
+        HnswBuildParams hnsw = new HnswBuildParams.Builder().build();
+        RQBuildParams rq = new RQBuildParams.Builder().setNumBits((byte) 5).build();
+        VectorIndexParams vectorIndexParams =
+            VectorIndexParams.withIvfHnswRqParams(DistanceType.L2, ivf, hnsw, rq);
+        IndexParams indexParams =
+            IndexParams.builder().setVectorIndexParams(vectorIndexParams).build();
+
+        dataset.createIndex(
+            IndexOptions.builder(
+                    Collections.singletonList(TestVectorDataset.vectorColumnName),
+                    IndexType.IVF_HNSW_RQ,
+                    indexParams)
+                .withIndexName(TestVectorDataset.indexName)
+                .build());
+
+        Index index =
+            dataset.getIndexes().stream()
+                .filter(candidate -> TestVectorDataset.indexName.equals(candidate.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(index, "Expected IVF_HNSW_RQ index to be present");
+        assertTrue(
+            index.indexType() == IndexType.VECTOR || index.indexType() == IndexType.IVF_HNSW_RQ,
+            "IndexType should be VECTOR or IVF_HNSW_RQ but was " + index.indexType());
       }
     }
   }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3601,6 +3601,7 @@ class LanceDataset(pa.dataset.Dataset):
             "IVF_HNSW_PQ",
             "IVF_HNSW_SQ",
             "IVF_RQ",
+            "IVF_HNSW_RQ",
         ]
         if index_type not in valid_index_types:
             raise NotImplementedError(
@@ -3926,7 +3927,8 @@ class LanceDataset(pa.dataset.Dataset):
             The column to be indexed.
         index_type : str
             The type of the index.
-            ``"IVF_PQ, IVF_HNSW_PQ and IVF_HNSW_SQ"`` are supported now.
+            ``"IVF_PQ"``, ``"IVF_RQ"``, ``"IVF_HNSW_PQ"``,
+            ``"IVF_HNSW_SQ"``, and ``"IVF_HNSW_RQ"`` are supported now.
         name : str, optional
             The index name. If not provided, it will be generated from the
             column name.
@@ -4049,7 +4051,9 @@ class LanceDataset(pa.dataset.Dataset):
             - index_file_version
                 The version of the index file. Default is "V3".
 
-        Optional parameters for `IVF_RQ`:
+        Optional parameters for `IVF_RQ` and `IVF_HNSW_RQ`:
+
+            ``IVF_HNSW_RQ`` currently supports only the ``l2`` metric.
 
             - num_bits
                 The number of bits for RQ (Rabit Quantization). Default is 1.

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1117,6 +1117,34 @@ def test_create_ivf_rq_skip_transpose():
     assert stats["indices"][0]["sub_index"]["packed"] is False
 
 
+def test_create_reopen_and_query_ivf_hnsw_rq_index(tmp_path):
+    rng = np.random.default_rng(42)
+    mat = rng.standard_normal((1000, 128)).astype(np.float32)
+    table = vec_to_table(data=mat).append_column("id", pa.array(range(len(mat))))
+    ds = lance.write_dataset(table, tmp_path)
+    query = mat[0]
+    nearest = {"column": "vector", "q": query, "k": 10, "nprobes": 4}
+    ground_truth = set(
+        ds.to_table(nearest={**nearest, "use_index": False}, columns=["id"])[
+            "id"
+        ].to_pylist()
+    )
+
+    ds = ds.create_index(
+        "vector",
+        index_type="IVF_HNSW_RQ",
+        num_partitions=4,
+        num_bits=5,
+        metric="l2",
+    )
+    assert ds.stats.index_stats("vector_idx")["index_type"] == "IVF_HNSW_RQ"
+
+    reopened = lance.dataset(tmp_path)
+    result = reopened.to_table(nearest=nearest, columns=["id"])["id"].to_pylist()
+    assert len(result) == 10
+    assert len(ground_truth.intersection(result)) / 10 >= 0.5
+
+
 def _assert_recall_at_least(ds, query, metric=None, k=10, recall_requirement=0.5):
     nearest = {"column": "vector", "q": query, "k": k}
     if metric is not None:

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2342,7 +2342,7 @@ impl Dataset {
             "INVERTED" | "FTS" => IndexType::Inverted,
             "FM" => IndexType::Fm,
             "IVF_FLAT" | "IVF_PQ" | "IVF_SQ" | "IVF_RQ" | "IVF_HNSW_FLAT" | "IVF_HNSW_PQ"
-            | "IVF_HNSW_SQ" => IndexType::Vector,
+            | "IVF_HNSW_SQ" | "IVF_HNSW_RQ" => IndexType::Vector,
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "Index type '{index_type}' is not supported."
@@ -4903,6 +4903,13 @@ fn prepare_vector_index_params(
             ivf_params,
             hnsw_params,
             sq_params,
+        ))),
+
+        "IVF_HNSW_RQ" => Ok(Box::new(VectorIndexParams::with_ivf_hnsw_rq_params(
+            m_type,
+            ivf_params,
+            hnsw_params,
+            rq_params,
         ))),
 
         _ => Err(PyValueError::new_err(format!(

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -37,7 +37,7 @@ pub const INDEX_FILE_NAME: &str = "index.idx";
 /// The name of the auxiliary index file.
 ///
 /// This file is used to store additional information about the index, to improve performance.
-/// - For 'IVF_HNSW' index, it stores the partitioned PQ Storage.
+/// - For `IVF_HNSW_*` indices, it stores partitioned vector storage and HNSW graphs.
 pub const INDEX_AUXILIARY_FILE_NAME: &str = "auxiliary.idx";
 pub const INDEX_METADATA_SCHEMA_KEY: &str = "lance:index";
 
@@ -46,7 +46,7 @@ pub const INDEX_METADATA_SCHEMA_KEY: &str = "lance:index";
 /// Most vector indices should use this version unless they need to bump for a
 /// format change.
 pub const VECTOR_INDEX_VERSION: u32 = 1;
-/// Version for IVF_RQ indices.
+/// Version for IVF_RQ and IVF_HNSW_RQ indices.
 pub const IVF_RQ_INDEX_VERSION: u32 = 2;
 
 /// The factor of threshold to trigger split / join for vector index.
@@ -141,6 +141,7 @@ pub enum IndexType {
     IvfHnswPq = 105,
     IvfHnswFlat = 106,
     IvfRq = 107,
+    IvfHnswRq = 108,
 }
 
 impl std::fmt::Display for IndexType {
@@ -164,6 +165,7 @@ impl std::fmt::Display for IndexType {
             Self::IvfHnswPq => write!(f, "IVF_HNSW_PQ"),
             Self::IvfHnswFlat => write!(f, "IVF_HNSW_FLAT"),
             Self::IvfRq => write!(f, "IVF_RQ"),
+            Self::IvfHnswRq => write!(f, "IVF_HNSW_RQ"),
         }
     }
 }
@@ -193,6 +195,7 @@ impl TryFrom<i32> for IndexType {
             v if v == Self::IvfHnswPq as i32 => Ok(Self::IvfHnswPq),
             v if v == Self::IvfHnswFlat as i32 => Ok(Self::IvfHnswFlat),
             v if v == Self::IvfRq as i32 => Ok(Self::IvfRq),
+            v if v == Self::IvfHnswRq as i32 => Ok(Self::IvfHnswRq),
             _ => Err(Error::invalid_input_source(
                 format!("the input value {} is not a valid IndexType", value).into(),
             )),
@@ -222,6 +225,7 @@ impl TryFrom<&str> for IndexType {
             "IVF_HNSW_FLAT" => Ok(Self::IvfHnswFlat),
             "IVF_HNSW_SQ" => Ok(Self::IvfHnswSq),
             "IVF_HNSW_PQ" => Ok(Self::IvfHnswPq),
+            "IVF_HNSW_RQ" => Ok(Self::IvfHnswRq),
             "FragmentReuse" => Ok(Self::FragmentReuse),
             "MemWal" => Ok(Self::MemWal),
             _ => Err(Error::invalid_input(format!(
@@ -257,6 +261,7 @@ impl IndexType {
                 | Self::IvfHnswSq
                 | Self::IvfHnswPq
                 | Self::IvfHnswFlat
+                | Self::IvfHnswRq
                 | Self::IvfFlat
                 | Self::IvfSq
                 | Self::IvfRq
@@ -300,7 +305,7 @@ impl IndexType {
             | Self::IvfHnswSq
             | Self::IvfHnswPq
             | Self::IvfHnswFlat => VECTOR_INDEX_VERSION as i32,
-            Self::IvfRq => IVF_RQ_INDEX_VERSION as i32,
+            Self::IvfRq | Self::IvfHnswRq => IVF_RQ_INDEX_VERSION as i32,
         }
     }
 
@@ -320,6 +325,7 @@ impl IndexType {
             Self::IvfHnswFlat => 1 << 20,
             Self::IvfHnswSq => 1 << 20,
             Self::IvfHnswPq => 1 << 20,
+            Self::IvfHnswRq => 1 << 20,
             _ => 8192,
         }
     }
@@ -335,6 +341,7 @@ impl IndexType {
             Self::IvfHnswPq,
             Self::IvfHnswFlat,
             Self::IvfRq,
+            Self::IvfHnswRq,
         ]
         .into_iter()
         .map(|index_type| index_type.version() as u32)
@@ -377,9 +384,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ivf_rq_has_dedicated_index_version() {
+    fn test_ivf_rq_indices_have_dedicated_index_version() {
         assert!(IndexType::IvfRq.version() > IndexType::IvfPq.version());
         assert_eq!(IndexType::IvfRq.version() as u32, IVF_RQ_INDEX_VERSION);
+        assert_eq!(IndexType::IvfHnswRq.version() as u32, IVF_RQ_INDEX_VERSION);
     }
 
     #[test]
@@ -388,8 +396,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ivf_rq_target_partition_size() {
+    fn test_ivf_rq_target_partition_sizes() {
         assert_eq!(IndexType::IvfRq.target_partition_size(), 4096);
+        assert_eq!(IndexType::IvfHnswRq.target_partition_size(), 1 << 20);
     }
 
     #[test]
@@ -415,6 +424,7 @@ mod tests {
             IndexType::IvfHnswPq,
             IndexType::IvfHnswFlat,
             IndexType::IvfRq,
+            IndexType::IvfHnswRq,
         ];
 
         for index_type in all {
@@ -459,6 +469,7 @@ mod tests {
             ("IVF_HNSW_FLAT", IndexType::IvfHnswFlat),
             ("IVF_HNSW_SQ", IndexType::IvfHnswSq),
             ("IVF_HNSW_PQ", IndexType::IvfHnswPq),
+            ("IVF_HNSW_RQ", IndexType::IvfHnswRq),
             ("FragmentReuse", IndexType::FragmentReuse),
             ("MemWal", IndexType::MemWal),
         ];

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -68,6 +68,11 @@ use crate::vector::storage::{
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
 pub const RABIT_CODE_COLUMN: &str = "_rabit_codes";
+/// Exact rotated residuals used only while constructing an HNSW graph.
+///
+/// This column is removed when [`RabitQuantizationStorage`] is created and is
+/// never persisted in the index auxiliary file.
+pub const RABIT_HNSW_BUILD_VECTOR_COLUMN: &str = "__rabit_hnsw_build_vector";
 /// Legacy ex-code column: sequential LSB-first bit stream per row. Read-only;
 /// rows are repacked into the blocked layout at load time.
 pub const RABIT_EX_CODE_COLUMN: &str = "__ex_codes";
@@ -498,6 +503,7 @@ pub struct RabitQuantizationStorage {
     packed_ex_codes: Option<FixedSizeListArray>,
     ex_add_factors: Option<Float32Array>,
     ex_scale_factors: Option<Float32Array>,
+    hnsw_build_vectors: Option<FixedSizeListArray>,
 }
 
 impl DeepSizeOf for RabitQuantizationStorage {
@@ -508,6 +514,11 @@ impl DeepSizeOf for RabitQuantizationStorage {
                 .packed_ex_codes
                 .as_ref()
                 .map(|codes| (codes as &dyn Array).deep_size_of_children(context))
+                .unwrap_or_default()
+            + self
+                .hnsw_build_vectors
+                .as_ref()
+                .map(|vectors| (vectors as &dyn Array).deep_size_of_children(context))
                 .unwrap_or_default()
     }
 }
@@ -867,6 +878,8 @@ pub struct RabitDistCalculator<'a> {
 
     sum_q: f32,
     sqrt_d: f32,
+    exact_query: Option<&'a [f32]>,
+    exact_vectors: Option<&'a [f32]>,
 }
 
 impl<'a> RabitDistCalculator<'a> {
@@ -913,6 +926,37 @@ impl<'a> RabitDistCalculator<'a> {
             approx_mode,
             sqrt_d: (dim as f32 * num_bits as f32).sqrt(),
             sum_q,
+            exact_query: None,
+            exact_vectors: None,
+        }
+    }
+
+    fn for_hnsw_build(dim: usize, query: &'a [f32], vectors: &'a [f32]) -> Self {
+        debug_assert_eq!(query.len(), dim);
+        debug_assert!(vectors.len().is_multiple_of(dim));
+        Self {
+            dim,
+            num_bits: 1,
+            query_estimator: RabitQueryEstimator::ResidualQuery,
+            codes: &[],
+            ex_codes: None,
+            ex_code_len: 0,
+            dist_table: Cow::Borrowed(&[]),
+            ex_query: Cow::Borrowed(&[]),
+            ex_dot: None,
+            add_factors: &[],
+            scale_factors: &[],
+            error_factors: None,
+            ex_add_factors: None,
+            ex_scale_factors: None,
+            packed_ex_codes: None,
+            query_factor: 0.0,
+            query_error: 0.0,
+            approx_mode: ApproxMode::Accurate,
+            sum_q: 0.0,
+            sqrt_d: (dim as f32).sqrt(),
+            exact_query: Some(query),
+            exact_vectors: Some(vectors),
         }
     }
 
@@ -1771,6 +1815,11 @@ pub(crate) fn load_blocked_ex_codes(
 impl DistCalculator for RabitDistCalculator<'_> {
     #[inline(always)]
     fn distance(&self, id: u32) -> f32 {
+        if let (Some(query), Some(vectors)) = (self.exact_query, self.exact_vectors) {
+            let start = id as usize * self.dim;
+            return l2(query, &vectors[start..start + self.dim]);
+        }
+
         let id = id as usize;
         let code_len = rabit_binary_code_bytes(self.dim);
         let num_vectors = self.codes.len() / code_len;
@@ -1836,6 +1885,19 @@ impl DistCalculator for RabitDistCalculator<'_> {
         quantized_dists_table: &mut Vec<u8>,
         hacc_quantized_dists: &mut Vec<u32>,
     ) {
+        if let (Some(query), Some(vectors)) = (self.exact_query, self.exact_vectors) {
+            dists.clear();
+            dists.extend(
+                vectors
+                    .chunks_exact(self.dim)
+                    .map(|vector| l2(query, vector)),
+            );
+            quantized_dists.clear();
+            quantized_dists_table.clear();
+            hacc_quantized_dists.clear();
+            return;
+        }
+
         let code_len = rabit_binary_code_bytes(self.dim);
         let n = self.codes.len() / code_len;
         if n == 0 {
@@ -2072,6 +2134,22 @@ impl VectorStore for RabitQuantizationStorage {
         self.distance_type
     }
 
+    fn validate_hnsw_build(&self) -> Result<()> {
+        if self.distance_type != DistanceType::L2 {
+            return Err(Error::not_supported(format!(
+                "IVF_HNSW_RQ only supports L2 distance, got {}",
+                self.distance_type
+            )));
+        }
+        if self.hnsw_build_vectors.is_none() {
+            return Err(Error::invalid_input(format!(
+                "IVF_HNSW_RQ construction requires the transient {} column",
+                RABIT_HNSW_BUILD_VECTOR_COLUMN
+            )));
+        }
+        Ok(())
+    }
+
     // qr = (q-c)
     #[inline(never)]
     fn dist_calculator(&self, qr: Arc<dyn Array>, dist_q_c: f32) -> Self::DistanceCalculator<'_> {
@@ -2227,10 +2305,15 @@ impl VectorStore for RabitQuantizationStorage {
         })
     }
 
-    // TODO: implement this
-    // This method is required for HNSW, we can't support HNSW_RABIT before this is implemented
-    fn dist_calculator_from_id(&self, _: u32) -> Self::DistanceCalculator<'_> {
-        unimplemented!("RabitQ does not support dist_calculator_from_id")
+    fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
+        let vectors = self.hnsw_build_vectors.as_ref().expect(
+            "RabitQ stored-vector distances require exact HNSW build vectors; \
+             HNSW construction validates this invariant before use",
+        );
+        let dim = vectors.value_length() as usize;
+        let values = vectors.values().as_primitive::<Float32Type>().values();
+        let start = id as usize * dim;
+        RabitDistCalculator::for_hnsw_build(dim, &values[start..start + dim], values)
     }
 }
 
@@ -2420,11 +2503,46 @@ impl QuantizerStorage for RabitQuantizationStorage {
     type Metadata = RabitQuantizationMetadata;
 
     fn try_from_batch(
-        batch: RecordBatch,
+        mut batch: RecordBatch,
         metadata: &Self::Metadata,
         distance_type: DistanceType,
         fri: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
+        let hnsw_build_vectors = match batch.column_by_name(RABIT_HNSW_BUILD_VECTOR_COLUMN) {
+            Some(vectors) => {
+                if distance_type != DistanceType::L2 {
+                    return Err(Error::not_supported(format!(
+                        "IVF_HNSW_RQ only supports L2 distance, got {}",
+                        distance_type
+                    )));
+                }
+                let vectors = vectors.as_fixed_size_list_opt().ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "{} must be a FixedSizeList<Float32>, got {}",
+                        RABIT_HNSW_BUILD_VECTOR_COLUMN,
+                        vectors.data_type()
+                    ))
+                })?;
+                if vectors.value_type() != DataType::Float32
+                    || vectors.value_length() as usize != metadata.rotated_dim()
+                    || vectors.null_count() != 0
+                    || vectors.values().null_count() != 0
+                {
+                    return Err(Error::invalid_input(format!(
+                        "{} must contain non-null Float32 vectors with dimension {}, got {}",
+                        RABIT_HNSW_BUILD_VECTOR_COLUMN,
+                        metadata.rotated_dim(),
+                        vectors.data_type()
+                    )));
+                }
+                Some(vectors.clone())
+            }
+            None => None,
+        };
+        if hnsw_build_vectors.is_some() {
+            batch = batch.drop_column(RABIT_HNSW_BUILD_VECTOR_COLUMN)?;
+        }
+
         let distance_type = match (metadata.query_estimator, distance_type) {
             (RabitQueryEstimator::RawQuery, DistanceType::Cosine) => DistanceType::L2,
             _ => distance_type,
@@ -2532,6 +2650,7 @@ impl QuantizerStorage for RabitQuantizationStorage {
             packed_ex_codes,
             ex_add_factors,
             ex_scale_factors,
+            hnsw_build_vectors,
         };
 
         match build_frag_reuse_mapping(fri.as_deref(), &storage.row_ids) {
@@ -2586,12 +2705,13 @@ impl QuantizerStorage for RabitQuantizationStorage {
             UInt8Array::from(new_codes),
             num_code_bytes as i32,
         )?;
+        let indices = UInt32Array::from(indices);
         let batch = if new_row_ids.is_empty() {
             RecordBatch::new_empty(self.schema().clone())
         } else {
             let codes = Arc::new(pack_codes(&new_codes));
             self.batch
-                .take(&UInt32Array::from(indices))?
+                .take(&indices)?
                 .replace_column_by_name(ROW_ID, Arc::new(new_row_ids.clone()))?
                 .replace_column_by_name(RABIT_CODE_COLUMN, codes)?
         };
@@ -2623,6 +2743,14 @@ impl QuantizerStorage for RabitQuantizationStorage {
         let ex_scale_factors = batch
             .column_by_name(EX_SCALE_FACTORS_COLUMN)
             .map(|factors| factors.as_primitive::<Float32Type>().clone());
+        let hnsw_build_vectors = self
+            .hnsw_build_vectors
+            .as_ref()
+            .map(|vectors| {
+                arrow::compute::take(vectors, &indices, None)
+                    .map(|vectors| vectors.as_fixed_size_list().clone())
+            })
+            .transpose()?;
 
         Ok(Self {
             metadata: self.metadata.clone(),
@@ -2636,6 +2764,7 @@ impl QuantizerStorage for RabitQuantizationStorage {
             packed_ex_codes,
             ex_add_factors,
             ex_scale_factors,
+            hnsw_build_vectors,
             row_ids: new_row_ids,
         })
     }

--- a/rust/lance-index/src/vector/bq/transform.rs
+++ b/rust/lance-index/src/vector/bq/transform.rs
@@ -10,7 +10,7 @@ use arrow_array::{
     Array, ArrowNativeTypeOp, FixedSizeListArray, Float32Array, RecordBatch, UInt32Array,
 };
 use arrow_schema::DataType;
-use lance_arrow::RecordBatchExt;
+use lance_arrow::{FixedSizeListArrayExt, RecordBatchExt};
 use lance_core::{Error, Result};
 use lance_linalg::distance::{DistanceType, norm_squared_fsl};
 use tracing::instrument;
@@ -18,7 +18,8 @@ use tracing::instrument;
 use crate::vector::bq::builder::RabitQuantizer;
 use crate::vector::bq::rabit_ex_bits;
 use crate::vector::bq::storage::{
-    RABIT_BLOCKED_EX_CODE_COLUMN, RABIT_CODE_COLUMN, RabitQueryEstimator,
+    RABIT_BLOCKED_EX_CODE_COLUMN, RABIT_CODE_COLUMN, RABIT_HNSW_BUILD_VECTOR_COLUMN,
+    RabitQueryEstimator,
 };
 use crate::vector::quantizer::Quantization;
 use crate::vector::transform::Transformer;
@@ -60,6 +61,7 @@ pub struct RQTransformer {
     centroids_norm_square: Option<Float32Array>,
     rotated_centroids: Option<Vec<f32>>,
     vector_column: String,
+    keep_hnsw_build_vectors: bool,
 }
 
 impl RQTransformer {
@@ -83,7 +85,13 @@ impl RQTransformer {
             centroids_norm_square,
             rotated_centroids,
             vector_column: vector_column.into(),
+            keep_hnsw_build_vectors: false,
         })
+    }
+
+    pub fn keep_hnsw_build_vectors(mut self) -> Self {
+        self.keep_hnsw_build_vectors = true;
+        self
     }
 }
 
@@ -324,7 +332,10 @@ impl Transformer for RQTransformer {
             }
         };
 
-        let rq_codes = self.rq.quantize_split(residual_vectors)?;
+        let mut rq_codes = self.rq.quantize_split(residual_vectors)?;
+        let rotated_residuals = rq_codes.rotated_residuals.as_deref().ok_or_else(|| {
+            Error::internal("RabitQ quantization did not return rotated residuals".to_string())
+        })?;
         let codes_fsl = rq_codes.binary_codes.as_fixed_size_list();
         debug_assert_eq!(codes_fsl.len(), batch.num_rows());
 
@@ -415,9 +426,6 @@ impl Transformer for RQTransformer {
             let ex_bits = rabit_ex_bits(self.rq.num_bits())?;
             let ex_codes = rq_codes.ex_codes;
             let ex_res_dot_dists = rq_codes.ex_res_dot_dists;
-            let rotated_residuals = rq_codes.rotated_residuals.ok_or_else(|| {
-                Error::internal("RabitQ quantization did not return rotated residuals".to_string())
-            })?;
             let ex_code_values = rq_codes.ex_code_values;
             if ex_bits != 0
                 && (ex_codes.is_none() || ex_res_dot_dists.is_none() || ex_code_values.is_none())
@@ -434,7 +442,7 @@ impl Transformer for RQTransformer {
             let raw_query_factors = compute_raw_query_factors(
                 self.distance_type,
                 &res_norm_square,
-                &rotated_residuals,
+                rotated_residuals,
                 rotated_centroids,
                 part_ids,
                 ex_code_values.as_deref(),
@@ -475,6 +483,24 @@ impl Transformer for RQTransformer {
                 batch = batch
                     .try_with_column(EX_SCALE_FACTORS_FIELD.clone(), Arc::new(ex_scale_factors))?;
             }
+        }
+
+        if self.keep_hnsw_build_vectors {
+            let rotated_residuals = rq_codes.rotated_residuals.take().ok_or_else(|| {
+                Error::internal("RabitQ quantization did not return rotated residuals".to_string())
+            })?;
+            let hnsw_build_vectors = FixedSizeListArray::try_new_from_values(
+                Float32Array::from(rotated_residuals),
+                self.rq.dim() as i32,
+            )?;
+            batch = batch.try_with_column(
+                arrow_schema::Field::new(
+                    RABIT_HNSW_BUILD_VECTOR_COLUMN,
+                    hnsw_build_vectors.data_type().clone(),
+                    false,
+                ),
+                Arc::new(hnsw_build_vectors),
+            )?;
         }
 
         let batch = batch

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -887,6 +887,7 @@ pub async fn merge_partial_vector_auxiliary_files(
                     "IVF_HNSW_FLAT" => SupportedIvfIndexType::IvfHnswFlat,
                     "IVF_HNSW_PQ" => SupportedIvfIndexType::IvfHnswPq,
                     "IVF_HNSW_SQ" => SupportedIvfIndexType::IvfHnswSq,
+                    "IVF_HNSW_RQ" => SupportedIvfIndexType::IvfHnswRq,
                     other => {
                         return Err(Error::index(format!(
                             "Unsupported index type in shard index.idx: {}",
@@ -959,6 +960,12 @@ pub async fn merge_partial_vector_auxiliary_files(
         let fv = format_version.unwrap_or(LanceFileVersion::V2_0);
 
         match idx_type {
+            SupportedIvfIndexType::IvfHnswRq => {
+                return Err(Error::not_supported(
+                    "Physical IVF_HNSW_RQ shard merging requires exact build vectors; \
+                     merge logical shard indices instead",
+                ));
+            }
             SupportedIvfIndexType::IvfSq => {
                 // Handle Scalar Quantization (SQ) storage for IVF_SQ
                 let sq_json = if let Some(sq_json) =

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -1193,6 +1193,7 @@ impl IvfSubIndex for HNSW {
     where
         Self: Sized,
     {
+        storage.validate_hnsw_build()?;
         let builder = HnswBuilder::with_params(params, storage);
 
         log::debug!(

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -58,6 +58,29 @@ pub fn new_ivf_transformer_with_quantizer(
     quantizer: Quantizer,
     range: Option<Range<u32>>,
 ) -> Result<IvfTransformer> {
+    new_ivf_transformer_with_quantizer_and_options(
+        centroids,
+        metric_type,
+        vector_column,
+        quantizer,
+        range,
+        IvfTransformerOptions::default(),
+    )
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IvfTransformerOptions {
+    pub keep_rq_hnsw_build_vectors: bool,
+}
+
+pub fn new_ivf_transformer_with_quantizer_and_options(
+    centroids: FixedSizeListArray,
+    metric_type: MetricType,
+    vector_column: &str,
+    quantizer: Quantizer,
+    range: Option<Range<u32>>,
+    options: IvfTransformerOptions,
+) -> Result<IvfTransformer> {
     match quantizer {
         Quantizer::Flat(_) | Quantizer::FlatBin(_) => Ok(IvfTransformer::new_flat(
             centroids,
@@ -79,9 +102,14 @@ pub fn new_ivf_transformer_with_quantizer(
             sq,
             range,
         )),
-        Quantizer::Rabit(rq) => {
-            IvfTransformer::with_rq(centroids, metric_type, vector_column, rq, range)
-        }
+        Quantizer::Rabit(rq) => IvfTransformer::with_rq(
+            centroids,
+            metric_type,
+            vector_column,
+            rq,
+            range,
+            options.keep_rq_hnsw_build_vectors,
+        ),
     }
 }
 
@@ -280,6 +308,7 @@ impl IvfTransformer {
         vector_column: &str,
         rq: RabitQuantizer,
         range: Option<Range<u32>>,
+        keep_hnsw_build_vectors: bool,
     ) -> Result<Self> {
         let mut transforms: Vec<Arc<dyn Transformer>> =
             vec![Arc::new(super::transform::Flatten::new(vector_column))];
@@ -313,12 +342,14 @@ impl IvfTransformer {
             vector_column,
         )));
 
-        transforms.push(Arc::new(RQTransformer::new(
-            rq,
-            distance_type,
-            centroids.clone(),
-            vector_column,
-        )?));
+        let rq_transformer =
+            RQTransformer::new(rq, distance_type, centroids.clone(), vector_column)?;
+        let rq_transformer = if keep_hnsw_build_vectors {
+            rq_transformer.keep_hnsw_build_vectors()
+        } else {
+            rq_transformer
+        };
+        transforms.push(Arc::new(rq_transformer));
 
         Ok(Self::new(centroids, distance_type, transforms))
     }

--- a/rust/lance-index/src/vector/shared/partition_merger.rs
+++ b/rust/lance-index/src/vector/shared/partition_merger.rs
@@ -39,6 +39,7 @@ pub enum SupportedIvfIndexType {
     IvfHnswFlat,
     IvfHnswPq,
     IvfHnswSq,
+    IvfHnswRq,
 }
 
 impl SupportedIvfIndexType {
@@ -52,6 +53,7 @@ impl SupportedIvfIndexType {
             Self::IvfHnswFlat => "IVF_HNSW_FLAT",
             Self::IvfHnswPq => "IVF_HNSW_PQ",
             Self::IvfHnswSq => "IVF_HNSW_SQ",
+            Self::IvfHnswRq => "IVF_HNSW_RQ",
         }
     }
 
@@ -67,6 +69,7 @@ impl SupportedIvfIndexType {
             "IVF_HNSW_FLAT" => Some(Self::IvfHnswFlat),
             "IVF_HNSW_PQ" => Some(Self::IvfHnswPq),
             "IVF_HNSW_SQ" => Some(Self::IvfHnswSq),
+            "IVF_HNSW_RQ" => Some(Self::IvfHnswRq),
             _ => None,
         }
     }
@@ -115,6 +118,7 @@ impl SupportedIvfIndexType {
             (true, false, false, false) => Self::IvfHnswFlat,
             (true, true, false, false) => Self::IvfHnswPq,
             (true, false, true, false) => Self::IvfHnswSq,
+            (true, false, false, true) => Self::IvfHnswRq,
             _ => {
                 return Err(Error::not_supported_source(
                     "Unsupported index type combination detected".into(),

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -400,6 +400,12 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     /// Return [DistanceType].
     fn distance_type(&self) -> DistanceType;
 
+    /// Validate that this storage can supply exact stored-vector distances for
+    /// HNSW construction.
+    fn validate_hnsw_build(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Get the lance ROW ID from one vector.
     fn row_id(&self, id: u32) -> u64;
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1996,6 +1996,7 @@ impl DirectoryNamespace {
             "IVF_HNSW_FLAT" => Ok(IndexType::IvfHnswFlat),
             "IVF_HNSW_SQ" => Ok(IndexType::IvfHnswSq),
             "IVF_HNSW_PQ" => Ok(IndexType::IvfHnswPq),
+            "IVF_HNSW_RQ" => Ok(IndexType::IvfHnswRq),
             other => Err(NamespaceError::InvalidInput {
                 message: format!("Unsupported index_type '{}'", other),
             }
@@ -2138,6 +2139,15 @@ impl DirectoryNamespace {
                     IvfBuildParams::default(),
                     HnswBuildParams::default(),
                     PQBuildParams::default(),
+                ),
+            },
+            IndexType::IvfHnswRq => DirectoryIndexParams::Vector {
+                index_type,
+                params: VectorIndexParams::with_ivf_hnsw_rq_params(
+                    Self::parse_metric_type(request.distance_type.as_deref())?,
+                    IvfBuildParams::default(),
+                    HnswBuildParams::default(),
+                    RQBuildParams::default(),
                 ),
             },
             other => {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1414,12 +1414,7 @@ impl DatasetIndexExt for Dataset {
         }
 
         let mut merged_segment = if all_vector {
-            crate::index::vector::ivf::merge_segments(
-                self.object_store.as_ref(),
-                &self.indices_dir(),
-                source_segments,
-            )
-            .await?
+            crate::index::vector::ivf::merge_segments(self, source_segments).await?
         } else if all_inverted {
             crate::index::scalar::inverted::merge_segments(self, source_segments).await?
         } else if all_fmindex {
@@ -2403,6 +2398,20 @@ impl DatasetIndexInternalExt for Dataset {
 
                     "IVF_HNSW_PQ" => {
                         let ivf = IVFIndex::<HNSW, ProductQuantizer>::try_new(
+                            self.object_store.clone(),
+                            index_dir,
+                            uuid.to_owned(),
+                            frag_reuse_index,
+                            self.metadata_cache.as_ref(),
+                            index_cache,
+                            file_sizes,
+                        )
+                        .await?;
+                        Ok(wrap_ivf(ivf))
+                    }
+
+                    "IVF_HNSW_RQ" => {
+                        let ivf = IVFIndex::<HNSW, RabitQuantizer>::try_new(
                             self.object_store.clone(),
                             index_dir,
                             uuid.to_owned(),

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -358,7 +358,8 @@ impl<'a> CreateIndexBuilder<'a> {
                 | IndexType::IvfRq
                 | IndexType::IvfHnswFlat
                 | IndexType::IvfHnswPq
-                | IndexType::IvfHnswSq,
+                | IndexType::IvfHnswSq
+                | IndexType::IvfHnswRq,
                 LANCE_VECTOR_INDEX,
             ) => {
                 // Vector index params.
@@ -807,6 +808,7 @@ fn is_builtin_vector_index(index_type: IndexType, params: &dyn IndexParams) -> b
                 | IndexType::IvfHnswFlat
                 | IndexType::IvfHnswPq
                 | IndexType::IvfHnswSq
+                | IndexType::IvfHnswRq
         )
         && params.as_any().is::<VectorIndexParams>()
 }
@@ -885,6 +887,7 @@ fn uses_segment_commit_path(index_type: IndexType, params: &dyn IndexParams) -> 
                 | IndexType::IvfHnswFlat
                 | IndexType::IvfHnswPq
                 | IndexType::IvfHnswSq
+                | IndexType::IvfHnswRq
         )
         && params.as_any().is::<VectorIndexParams>()
     {

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -478,6 +478,30 @@ impl VectorIndexParams {
         }
     }
 
+    /// Create index parameters with `IVF`, `HNSW`, and `RQ` stages.
+    ///
+    /// `IVF_HNSW_RQ` currently supports only [`DistanceType::L2`]. Other
+    /// distance types are rejected when the index build is prepared.
+    pub fn with_ivf_hnsw_rq_params(
+        metric_type: MetricType,
+        ivf: IvfBuildParams,
+        hnsw: HnswBuildParams,
+        rq: RQBuildParams,
+    ) -> Self {
+        let stages = vec![
+            StageParams::Ivf(ivf),
+            StageParams::Hnsw(hnsw),
+            StageParams::RQ(rq),
+        ];
+        Self {
+            stages,
+            metric_type,
+            version: IndexFileVersion::V3,
+            skip_transpose: false,
+            runtime_hints: HashMap::new(),
+        }
+    }
+
     pub fn index_type(&self) -> IndexType {
         let len = self.stages.len();
         match (len, self.stages.get(1), self.stages.last()) {
@@ -489,6 +513,7 @@ impl VectorIndexParams {
             (2, _, Some(StageParams::Hnsw(_))) => IndexType::IvfHnswFlat,
             (3, Some(StageParams::Hnsw(_)), Some(StageParams::PQ(_))) => IndexType::IvfHnswPq,
             (3, Some(StageParams::Hnsw(_)), Some(StageParams::SQ(_))) => IndexType::IvfHnswSq,
+            (3, Some(StageParams::Hnsw(_)), Some(StageParams::RQ(_))) => IndexType::IvfHnswRq,
             _ => IndexType::Vector,
         }
     }
@@ -549,7 +574,7 @@ async fn prepare_vector_segment_build(
     }
 
     let index_type = params.index_type();
-    if index_type == IndexType::IvfRq {
+    if matches!(index_type, IndexType::IvfRq | IndexType::IvfHnswRq) {
         let Some(StageParams::RQ(rq_params)) = stages.last() else {
             return Err(Error::index(format!(
                 "{mode}: invalid stages: {:?}",
@@ -557,6 +582,12 @@ async fn prepare_vector_segment_build(
             )));
         };
         validate_supported_rq_num_bits(rq_params.num_bits)?;
+    }
+    if index_type == IndexType::IvfHnswRq && params.metric_type != DistanceType::L2 {
+        return Err(Error::not_supported(format!(
+            "{mode}: IVF_HNSW_RQ only supports L2 distance, got {}",
+            params.metric_type
+        )));
     }
 
     let num_partitions = match (ivf_params0.num_partitions, ivf_params0.centroids.as_ref()) {
@@ -904,6 +935,39 @@ pub(crate) async fn build_distributed_vector_index(
                 hnsw_params.clone(),
                 frag_reuse_index,
             )?
+            .with_fragment_filter(fragment_filter)
+            .with_progress(progress.clone())
+            .build()
+            .await?;
+            return Ok((segment_uuid, summary.files));
+        }
+
+        IndexType::IvfHnswRq => {
+            let StageParams::Hnsw(hnsw_params) = &stages[1] else {
+                return Err(Error::index(format!(
+                    "Build Distributed Vector Index: invalid stages: {:?}",
+                    stages
+                )));
+            };
+            let StageParams::RQ(rq_params) = &stages[2] else {
+                return Err(Error::index(format!(
+                    "Build Distributed Vector Index: invalid stages: {:?}",
+                    stages
+                )));
+            };
+
+            let summary = IvfIndexBuilder::<HNSW, RabitQuantizer>::new(
+                filtered_dataset,
+                column.to_owned(),
+                index_dir.clone(),
+                params.metric_type,
+                shuffler,
+                Some(ivf_params),
+                Some(rq_params.clone()),
+                hnsw_params.clone(),
+                frag_reuse_index,
+            )?
+            .with_ivf(make_ivf_model())
             .with_fragment_filter(fragment_filter)
             .with_progress(progress.clone())
             .build()
@@ -1279,6 +1343,36 @@ async fn build_vector_index_impl(
             .await?;
             Ok(summary.files)
         }
+        IndexType::IvfHnswRq => {
+            let StageParams::Hnsw(hnsw_params) = &stages[1] else {
+                return Err(Error::index(format!(
+                    "Build Vector Index: invalid stages: {:?}",
+                    stages
+                )));
+            };
+            let StageParams::RQ(rq_params) = &stages[2] else {
+                return Err(Error::index(format!(
+                    "Build Vector Index: invalid stages: {:?}",
+                    stages
+                )));
+            };
+            let summary = IvfIndexBuilder::<HNSW, RabitQuantizer>::new(
+                dataset.clone(),
+                column.to_owned(),
+                dataset.indices_dir().clone().join(uuid.to_string()),
+                params.metric_type,
+                shuffler,
+                Some(ivf_params),
+                Some(rq_params.clone()),
+                hnsw_params.clone(),
+                frag_reuse_index,
+            )?
+            .with_optional_fragment_filter(fragment_ids)
+            .with_progress(progress.clone())
+            .build()
+            .await?;
+            Ok(summary.files)
+        }
         _ => Err(Error::index(format!(
             "Build Vector Index: invalid index type: {:?}",
             index_type
@@ -1536,9 +1630,22 @@ pub(crate) async fn build_vector_index_incremental(
                     return Ok(summary);
                 }
                 QuantizationType::Rabit => {
-                    return Err(Error::index(
-                        "Rabit quantization is not supported for HNSW index".to_string(),
-                    ));
+                    let summary = IvfIndexBuilder::<HNSW, RabitQuantizer>::new_incremental(
+                        dataset.clone(),
+                        column.to_owned(),
+                        index_dir,
+                        params.metric_type,
+                        shuffler,
+                        hnsw_params.clone(),
+                        frag_reuse_index,
+                        OptimizeOptions::append(),
+                    )?
+                    .with_ivf(ivf_model)
+                    .with_quantizer(quantizer.try_into()?)
+                    .with_progress(progress.clone())
+                    .build()
+                    .await?;
+                    return Ok(summary);
                 }
             }
         }
@@ -1910,9 +2017,14 @@ pub async fn initialize_vector_index(
                     )
                 }
                 QuantizationType::Rabit => {
-                    return Err(Error::index(
-                        "Rabit quantization is not supported for HNSW index".to_string(),
-                    ));
+                    let rabit_quantizer: RabitQuantizer = quantizer.try_into()?;
+                    let rabit_params = derive_rabit_params(&rabit_quantizer);
+                    VectorIndexParams::with_ivf_hnsw_rq_params(
+                        metric_type,
+                        ivf_params,
+                        hnsw_params,
+                        rabit_params,
+                    )
                 }
             }
         }

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -33,7 +33,9 @@ use lance_index::frag_reuse::FragReuseIndex;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::progress::{IndexBuildProgress, NoopIndexBuildProgress};
-use lance_index::vector::bq::storage::{RABIT_CODE_COLUMN, unpack_codes};
+use lance_index::vector::bq::storage::{
+    RABIT_CODE_COLUMN, RABIT_HNSW_BUILD_VECTOR_COLUMN, unpack_codes,
+};
 use lance_index::vector::kmeans::KMeansParams;
 use lance_index::vector::pq::storage::transpose;
 use lance_index::vector::quantizer::{
@@ -179,6 +181,11 @@ pub struct VectorIndexBuildSummary {
 }
 
 impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> {
+    fn needs_rq_hnsw_build_vectors() -> bool {
+        Q::quantization_type() == QuantizationType::Rabit
+            && matches!(SubIndexType::try_from(S::name()), Ok(SubIndexType::Hnsw))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         dataset: Dataset,
@@ -346,10 +353,38 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         log::info!("remap {} partitions", ivf.num_partitions());
         let existing_index = self.existing_indices[0].clone();
         let mapping = Arc::new(mapping.clone());
+        let rebuild_rq_hnsw = Self::needs_rq_hnsw_build_vectors();
+        let dataset = if rebuild_rq_hnsw {
+            Some(self.dataset.clone().ok_or_else(|| {
+                Error::invalid_input("Dataset is required to remap IVF_HNSW_RQ indices")
+            })?)
+        } else {
+            None
+        };
+        let quantizer = if rebuild_rq_hnsw {
+            Some(self.quantizer.clone().ok_or_else(|| {
+                Error::invalid_input("Quantizer is required to remap IVF_HNSW_RQ indices")
+            })?)
+        } else {
+            None
+        };
+        let centroids = if rebuild_rq_hnsw {
+            Some(ivf.centroids.clone().ok_or_else(|| {
+                Error::invalid_input("IVF centroids are required to remap IVF_HNSW_RQ indices")
+            })?)
+        } else {
+            None
+        };
+        let column = self.column.clone();
+        let distance_type = self.distance_type;
         let build_iter =
             (0..ivf.num_partitions()).map(move |part_id| {
                 let existing_index = existing_index.clone();
                 let mapping = mapping.clone();
+                let dataset = dataset.clone();
+                let quantizer = quantizer.clone();
+                let centroids = centroids.clone();
+                let column = column.clone();
                 async move {
                     let ivf_index = existing_index
                         .as_any()
@@ -361,6 +396,63 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let part = part.as_any().downcast_ref::<PartitionEntry<S, Q>>().ok_or(
                         Error::internal("failed to downcast partition entry".to_string()),
                     )?;
+
+                    if rebuild_rq_hnsw {
+                        let dataset = dataset.as_ref().ok_or_else(|| {
+                            Error::internal(
+                                "IVF_HNSW_RQ remap dataset was validated before partition rebuild"
+                                    .to_string(),
+                            )
+                        })?;
+                        let quantizer = quantizer.ok_or_else(|| {
+                            Error::internal(
+                            "IVF_HNSW_RQ remap quantizer was validated before partition rebuild"
+                                .to_string(),
+                        )
+                        })?;
+                        let centroids = centroids.ok_or_else(|| {
+                            Error::internal(
+                            "IVF_HNSW_RQ remap centroids were validated before partition rebuild"
+                                .to_string(),
+                        )
+                        })?;
+                        let mut seen = HashSet::new();
+                        let (source_row_ids, remapped_row_ids): (Vec<_>, Vec<_>) = part
+                            .storage
+                            .row_ids()
+                            .filter_map(|old_row_id| {
+                                let new_row_id = match mapping.get(*old_row_id) {
+                                    None => *old_row_id,
+                                    Some(Some(new_row_id)) => new_row_id,
+                                    Some(None) => return None,
+                                };
+                                seen.insert(new_row_id).then_some((*old_row_id, new_row_id))
+                            })
+                            .unzip();
+                        if source_row_ids.is_empty() {
+                            return Ok(None);
+                        }
+
+                        let batch = Self::transform_rq_hnsw_rows(
+                            dataset,
+                            centroids,
+                            quantizer.clone(),
+                            part_id,
+                            &column,
+                            source_row_ids,
+                            Some(remapped_row_ids),
+                        )
+                        .await?;
+                        if batch.num_rows() == 0 {
+                            return Err(Error::index(format!(
+                                "Remapping IVF_HNSW_RQ partition {part_id} produced no vectors"
+                            )));
+                        }
+                        let storage = StorageBuilder::new(column, distance_type, quantizer, None)?
+                            .build(vec![batch])?;
+                        let index = part.index.remap(&mapping, &storage)?;
+                        return Ok(Some((storage, index, 0.0)));
+                    }
 
                     let storage = part.storage.remap(&mapping)?;
                     let index = part.index.remap(&mapping, &storage)?;
@@ -650,6 +742,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         self
     }
 
+    /// Record that an incremental build has no new, unindexed rows.
+    pub fn without_unindexed_data(&mut self) -> &mut Self {
+        self.shuffle_reader = Some(Arc::new(EmptyReader));
+        self
+    }
+
     // shuffle the unindexed data and existing indices
     // data must be with schema | ROW_ID | vector_column |
     // the shuffled data will be with schema | ROW_ID | PART_ID | code_column |
@@ -681,12 +779,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let code_column = quantizer.column();
 
         let transformer = Arc::new(
-            lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
+            lance_index::vector::ivf::new_ivf_transformer_with_quantizer_and_options(
                 ivf.centroids.clone().unwrap(),
                 self.distance_type,
                 &self.column,
                 quantizer.into(),
                 None,
+                lance_index::vector::ivf::IvfTransformerOptions {
+                    keep_rq_hnsw_build_vectors: Self::needs_rq_hnsw_build_vectors(),
+                },
             )?,
         );
 
@@ -889,6 +990,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
         let distance_type = self.distance_type;
         let column = self.column.clone();
+        let dataset = self.dataset.clone();
+        let centroids = self
+            .ivf
+            .as_ref()
+            .and_then(|ivf| ivf.centroids.clone())
+            .ok_or_else(|| Error::invalid_input("IVF centroids not set before build"))?;
+        let needs_rq_hnsw_build_vectors = Self::needs_rq_hnsw_build_vectors();
         let frag_reuse_index = self.frag_reuse_index.clone();
         let partition_adjustment = Arc::new(partition_adjustment);
         let build_iter =
@@ -902,6 +1010,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let quantizer = quantizer.clone();
                     let sub_index_params = sub_index_params.clone();
                     let column = column.clone();
+                    let dataset = dataset.clone();
+                    let centroids = centroids.clone();
                     let frag_reuse_index = frag_reuse_index.clone();
                     let partition_adjustment = partition_adjustment.clone();
                     async move {
@@ -954,6 +1064,29 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             loss += extra_loss;
                         }
 
+                        if needs_rq_hnsw_build_vectors
+                            && batches.iter().any(|batch| {
+                                batch
+                                    .column_by_name(RABIT_HNSW_BUILD_VECTOR_COLUMN)
+                                    .is_none()
+                            })
+                        {
+                            let dataset = dataset.as_ref().ok_or_else(|| {
+                                Error::invalid_input(
+                                    "Dataset is required to rebuild IVF_HNSW_RQ partitions",
+                                )
+                            })?;
+                            batches = Self::regenerate_rq_hnsw_batches(
+                                dataset,
+                                centroids,
+                                quantizer.clone(),
+                                partition,
+                                &column,
+                                batches,
+                            )
+                            .await?;
+                        }
+
                         spawn_cpu(move || {
                             // Apply assign_batch for join operations (splits no
                             // longer use assign_batches)
@@ -1002,6 +1135,100 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(stream::iter(build_iter)
             .buffered(get_num_compute_intensive_cpus())
             .boxed())
+    }
+
+    async fn regenerate_rq_hnsw_batches(
+        dataset: &Dataset,
+        centroids: FixedSizeListArray,
+        quantizer: Q,
+        partition: usize,
+        column: &str,
+        batches: Vec<RecordBatch>,
+    ) -> Result<Vec<RecordBatch>> {
+        let mut rebuilt = Vec::with_capacity(batches.len());
+
+        for batch in batches {
+            if batch
+                .column_by_name(RABIT_HNSW_BUILD_VECTOR_COLUMN)
+                .is_some()
+            {
+                rebuilt.push(batch);
+                continue;
+            }
+
+            let mut seen = HashSet::new();
+            let row_ids = batch[ROW_ID]
+                .as_primitive::<UInt64Type>()
+                .values()
+                .iter()
+                .copied()
+                .filter(|row_id| seen.insert(*row_id))
+                .collect::<Vec<_>>();
+            let row_ids = dataset.filter_deleted_ids(&row_ids).await?;
+            if row_ids.is_empty() {
+                continue;
+            }
+
+            let transformed = Self::transform_rq_hnsw_rows(
+                dataset,
+                centroids.clone(),
+                quantizer.clone(),
+                partition,
+                column,
+                row_ids,
+                None,
+            )
+            .await?;
+            if transformed.num_rows() > 0 {
+                rebuilt.push(transformed);
+            }
+        }
+
+        Ok(rebuilt)
+    }
+
+    async fn transform_rq_hnsw_rows(
+        dataset: &Dataset,
+        centroids: FixedSizeListArray,
+        quantizer: Q,
+        partition: usize,
+        column: &str,
+        source_row_ids: Vec<u64>,
+        remapped_row_ids: Option<Vec<u64>>,
+    ) -> Result<RecordBatch> {
+        if let Some(remapped_row_ids) = remapped_row_ids.as_ref()
+            && remapped_row_ids.len() != source_row_ids.len()
+        {
+            return Err(Error::invalid_input(format!(
+                "IVF_HNSW_RQ source and remapped row ID counts differ: {} != {}",
+                source_row_ids.len(),
+                remapped_row_ids.len()
+            )));
+        }
+        let partition = u32::try_from(partition)
+            .map_err(|_| Error::invalid_input("IVF partition id exceeds u32"))?;
+        let projection = Arc::new(dataset.schema().project(&[column])?);
+        let raw_batch = dataset
+            .take_rows(&source_row_ids, ProjectionRequest::Schema(projection))
+            .await?;
+        let output_row_ids = remapped_row_ids.unwrap_or(source_row_ids);
+        let raw_batch = raw_batch.try_with_column(
+            ROW_ID_FIELD.clone(),
+            Arc::new(UInt64Array::from(output_row_ids)),
+        )?;
+        let transformer = lance_index::vector::ivf::new_ivf_transformer_with_quantizer_and_options(
+            centroids,
+            DistanceType::L2,
+            column,
+            quantizer.into(),
+            Some(partition..partition + 1),
+            lance_index::vector::ivf::IvfTransformerOptions {
+                keep_rq_hnsw_build_vectors: true,
+            },
+        )?;
+        Ok(transformer
+            .transform(&raw_batch)?
+            .drop_column(PART_ID_COLUMN)?)
     }
 
     #[instrument(name = "build_index", level = "debug", skip_all)]
@@ -1663,12 +1890,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         .boxed();
 
         let transformer = Arc::new(
-            lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
+            lance_index::vector::ivf::new_ivf_transformer_with_quantizer_and_options(
                 new_centroids.clone(),
                 self.distance_type,
                 &self.column,
                 quantizer.into(),
                 None,
+                lance_index::vector::ivf::IvfTransformerOptions {
+                    keep_rq_hnsw_build_vectors: Self::needs_rq_hnsw_build_vectors(),
+                },
             )?,
         );
 
@@ -1965,12 +2195,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         };
 
         let transformer = Arc::new(
-            lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
+            lance_index::vector::ivf::new_ivf_transformer_with_quantizer_and_options(
                 centroids.clone(),
                 self.distance_type,
                 vector_field.name().as_str(),
                 quantizer.into(),
                 None,
+                lance_index::vector::ivf::IvfTransformerOptions {
+                    keep_rq_hnsw_build_vectors: Self::needs_rq_hnsw_build_vectors(),
+                },
             )?,
         );
 

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -17,7 +17,9 @@ use lance_file::reader::FileReaderOptions;
 use lance_index::pb::VectorIndexDetails;
 use lance_index::pb::VectorMetricType;
 use lance_index::pb::index::Implementation;
-use lance_index::pb::vector_index_details::{Compression, FlatCompression, rabit_quantization};
+use lance_index::pb::vector_index_details::{
+    Compression, FlatCompression, RabitQuantization, rabit_quantization,
+};
 use lance_index::{INDEX_FILE_NAME, INDEX_METADATA_SCHEMA_KEY, pb};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::traits::Reader;
@@ -171,6 +173,17 @@ pub fn vector_index_details_default() -> prost_types::Any {
     prost_types::Any::from_msg(&details).unwrap()
 }
 
+fn rq_params_from_details(rq: RabitQuantization) -> Option<RQBuildParams> {
+    let rotation_type = match rabit_quantization::RotationType::try_from(rq.rotation_type).ok()? {
+        rabit_quantization::RotationType::Matrix => RQRotationType::Matrix,
+        rabit_quantization::RotationType::Fast => RQRotationType::Fast,
+    };
+    Some(RQBuildParams::with_rotation_type(
+        rq.num_bits as u8,
+        rotation_type,
+    ))
+}
+
 /// Apply stored runtime hints from `VectorIndexDetails` back into build params.
 ///
 /// Known `lance.*` keys are parsed and applied to the appropriate stage. Unknown
@@ -280,16 +293,7 @@ pub fn vector_params_from_details(details: &prost_types::Any) -> Option<VectorIn
             },
         ),
         (None, Some(Compression::Rq(rq))) => {
-            let rotation_type =
-                match rabit_quantization::RotationType::try_from(rq.rotation_type).ok()? {
-                    rabit_quantization::RotationType::Matrix => RQRotationType::Matrix,
-                    rabit_quantization::RotationType::Fast => RQRotationType::Fast,
-                };
-            VectorIndexParams::with_ivf_rq_params(
-                metric,
-                ivf,
-                RQBuildParams::with_rotation_type(rq.num_bits as u8, rotation_type),
-            )
+            VectorIndexParams::with_ivf_rq_params(metric, ivf, rq_params_from_details(rq)?)
         }
         (Some(hnsw), Some(Compression::Pq(pq))) => VectorIndexParams::with_ivf_hnsw_pq_params(
             metric,
@@ -309,6 +313,12 @@ pub fn vector_params_from_details(details: &prost_types::Any) -> Option<VectorIn
                 num_bits: sq.num_bits as u16,
                 ..Default::default()
             },
+        ),
+        (Some(hnsw), Some(Compression::Rq(rq))) => VectorIndexParams::with_ivf_hnsw_rq_params(
+            metric,
+            ivf,
+            hnsw,
+            rq_params_from_details(rq)?,
         ),
         (Some(hnsw), _) => VectorIndexParams::ivf_hnsw(metric, ivf, hnsw),
         _ => VectorIndexParams::with_ivf_flat_params(metric, ivf),
@@ -613,6 +623,7 @@ async fn convert_v3_metadata_to_details(
         SupportedIvfIndexType::IvfHnswFlat => (true, CompressionKind::Flat),
         SupportedIvfIndexType::IvfHnswPq => (true, CompressionKind::Pq),
         SupportedIvfIndexType::IvfHnswSq => (true, CompressionKind::Sq),
+        SupportedIvfIndexType::IvfHnswRq => (true, CompressionKind::Rq),
     };
 
     let hnsw_index_config = if has_hnsw {
@@ -809,6 +820,17 @@ mod tests {
                 Some(Compression::Sq(ScalarQuantization { num_bits: 8 }))
             )),
             "IVF_HNSW_SQ"
+        );
+        assert_eq!(
+            derive_vector_index_type(&make_details(
+                VectorMetricType::L2,
+                hnsw,
+                Some(Compression::Rq(RabitQuantization {
+                    num_bits: 5,
+                    rotation_type: 1,
+                }))
+            )),
+            "IVF_HNSW_RQ"
         );
     }
 
@@ -1276,6 +1298,7 @@ mod tests {
         IvfHnswFlat,
         IvfHnswPq,
         IvfHnswSq,
+        IvfHnswRq,
     }
 
     fn build_roundtrip_params(combo: Combo, metric: DistanceType) -> VectorIndexParams {
@@ -1332,6 +1355,12 @@ mod tests {
             Combo::IvfHnswFlat => VectorIndexParams::ivf_hnsw(metric, ivf, hnsw),
             Combo::IvfHnswPq => VectorIndexParams::with_ivf_hnsw_pq_params(metric, ivf, hnsw, pq),
             Combo::IvfHnswSq => VectorIndexParams::with_ivf_hnsw_sq_params(metric, ivf, hnsw, sq),
+            Combo::IvfHnswRq => VectorIndexParams::with_ivf_hnsw_rq_params(
+                metric,
+                ivf,
+                hnsw,
+                RQBuildParams::with_rotation_type(5, RQRotationType::Fast),
+            ),
         }
     }
 
@@ -1344,6 +1373,7 @@ mod tests {
     #[case::ivf_hnsw_flat(Combo::IvfHnswFlat)]
     #[case::ivf_hnsw_pq(Combo::IvfHnswPq)]
     #[case::ivf_hnsw_sq(Combo::IvfHnswSq)]
+    #[case::ivf_hnsw_rq(Combo::IvfHnswRq)]
     fn test_vector_index_details_roundtrip(
         #[case] combo: Combo,
         #[values(DistanceType::L2, DistanceType::Cosine)] metric: DistanceType,
@@ -1434,6 +1464,19 @@ mod tests {
                     panic!("expected SQ stage");
                 };
                 assert_eq!(sq.num_bits, 8);
+            }
+            Combo::IvfHnswRq => {
+                let StageParams::Hnsw(hnsw) = &restored.stages[1] else {
+                    panic!("expected HNSW stage");
+                };
+                assert_eq!(hnsw.m, 30);
+                assert_eq!(hnsw.ef_construction, 200);
+                assert_eq!(hnsw.max_level, 5);
+                let StageParams::RQ(rq) = &restored.stages[2] else {
+                    panic!("expected RQ stage");
+                };
+                assert_eq!(rq.num_bits, 5);
+                assert_eq!(rq.rotation_type, RQRotationType::Fast);
             }
         }
     }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -732,7 +732,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .await?
         }
         // IVF_HNSW_FLAT
-        (SubIndexType::Hnsw, QuantizationType::Flat) => {
+        (SubIndexType::Hnsw, QuantizationType::Flat | QuantizationType::FlatBin) => {
             if element_type == DataType::UInt8 {
                 IvfIndexBuilder::<HNSW, FlatBinQuantizer>::new_incremental(
                     dataset.clone(),
@@ -811,12 +811,25 @@ pub(crate) async fn optimize_vector_indices_v2(
             .build()
             .await?
         }
-        (sub_index_type, quantization_type) => {
-            unimplemented!(
-                "unsupported index type: {}, {}",
-                sub_index_type,
-                quantization_type
-            )
+        // IVF_HNSW_RQ
+        (SubIndexType::Hnsw, QuantizationType::Rabit) => {
+            IvfIndexBuilder::<HNSW, RabitQuantizer>::new_incremental(
+                dataset.clone(),
+                vector_column.to_owned(),
+                index_dir,
+                distance_type,
+                shuffler,
+                HnswBuildParams::default(),
+                frag_reuse_index,
+                options.clone(),
+            )?
+            .with_ivf(ivf_model.clone())
+            .with_quantizer(quantizer.try_into()?)
+            .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
+            .shuffle_data_input(unindexed)
+            .build()
+            .await?
         }
     };
 
@@ -2275,24 +2288,16 @@ async fn write_ivf_hnsw_file(
 
 /// Merge one caller-defined group of source segments into a single segment.
 pub(crate) async fn merge_segments(
-    object_store: &ObjectStore,
-    indices_dir: &Path,
+    dataset: &Dataset,
     segments: Vec<TableIndexMetadata>,
 ) -> Result<TableIndexMetadata> {
-    merge_segments_with_progress(
-        object_store,
-        indices_dir,
-        segments,
-        lance_index::progress::noop_progress(),
-    )
-    .await
+    merge_segments_with_progress(dataset, segments, lance_index::progress::noop_progress()).await
 }
 
 /// Merge one caller-defined group of source segments into a single segment and
 /// report progress through the provided callback.
 pub(crate) async fn merge_segments_with_progress(
-    object_store: &ObjectStore,
-    indices_dir: &Path,
+    dataset: &Dataset,
     segments: Vec<TableIndexMetadata>,
     progress: Arc<dyn lance_index::progress::IndexBuildProgress>,
 ) -> Result<TableIndexMetadata> {
@@ -2316,22 +2321,58 @@ pub(crate) async fn merge_segments_with_progress(
     }
 
     let index_version = infer_source_index_version(&segments)?;
-    let segment_uuid = Uuid::new_v4();
-    let final_dir = indices_dir.clone().join(segment_uuid.to_string());
-    let files = merge_segments_to_dir(
-        object_store,
-        indices_dir,
-        &final_dir,
-        &segments,
-        None,
-        progress,
+    let indices_dir = dataset.indices_dir();
+    let source_index_paths = segments
+        .iter()
+        .map(|segment| {
+            indices_dir
+                .clone()
+                .join(segment.uuid.to_string())
+                .join(INDEX_FILE_NAME)
+        })
+        .collect::<Vec<_>>();
+    let scheduler = ScanScheduler::new(
+        dataset.object_store.clone(),
+        SchedulerConfig::max_bandwidth(&dataset.object_store),
+    );
+    let hnsw_metadata = read_hnsw_index_metadata_from_sources(
+        dataset.object_store.as_ref(),
+        &scheduler,
+        &source_index_paths,
     )
     .await?;
+
+    let (segment_uuid, files) = if hnsw_metadata
+        .as_ref()
+        .is_some_and(|metadata| metadata.index_type == "IVF_HNSW_RQ")
+    {
+        merge_ivf_hnsw_rq_segments(
+            dataset,
+            &indices_dir,
+            &segments,
+            &source_index_paths,
+            &scheduler,
+            progress,
+        )
+        .await?
+    } else {
+        let segment_uuid = Uuid::new_v4();
+        let final_dir = indices_dir.clone().join(segment_uuid.to_string());
+        let files = merge_segments_to_dir(
+            dataset.object_store.as_ref(),
+            &indices_dir,
+            &final_dir,
+            &segments,
+            None,
+            progress,
+        )
+        .await?;
+        (segment_uuid, files)
+    };
 
     merged_segment = TableIndexMetadata {
         uuid: segment_uuid,
         fragment_bitmap: Some(fragment_bitmap),
-        index_details: Some(Arc::new(crate::index::vector_index_details_default())),
         index_version,
         created_at: Some(chrono::Utc::now()),
         base_id: None,
@@ -2339,6 +2380,129 @@ pub(crate) async fn merge_segments_with_progress(
         ..merged_segment
     };
     Ok(merged_segment)
+}
+
+async fn merge_ivf_hnsw_rq_segments(
+    dataset: &Dataset,
+    indices_dir: &Path,
+    segments: &[TableIndexMetadata],
+    source_index_paths: &[Path],
+    scheduler: &Arc<ScanScheduler>,
+    progress: Arc<dyn lance_index::progress::IndexBuildProgress>,
+) -> Result<(Uuid, Vec<IndexFile>)> {
+    let field_id = *segments[0]
+        .fields
+        .first()
+        .ok_or_else(|| Error::invalid_input("IVF_HNSW_RQ segment is missing a field id"))?;
+    let column = dataset.schema().field_path(field_id)?;
+    let hnsw_params = read_hnsw_build_params_from_sources(
+        dataset.object_store.as_ref(),
+        scheduler,
+        source_index_paths,
+    )
+    .await?;
+
+    let mut existing_indices = Vec::<Arc<dyn VectorIndex>>::with_capacity(segments.len());
+    let mut common_ivf: Option<IvfModel> = None;
+    let mut common_quantizer: Option<RabitQuantizer> = None;
+    let mut common_distance_type: Option<DistanceType> = None;
+
+    for segment in segments {
+        let index = v2::IVFIndex::<HNSW, RabitQuantizer>::try_new(
+            dataset.object_store.clone(),
+            indices_dir.clone(),
+            segment.uuid,
+            None,
+            dataset.metadata_cache.as_ref(),
+            dataset.index_cache.for_index(&segment.uuid, None),
+            segment.file_size_map(),
+        )
+        .await?;
+        let ivf = index.ivf_model();
+        let quantizer: RabitQuantizer = index.quantizer().try_into()?;
+        let distance_type = index.metric_type();
+
+        if let Some(common_ivf) = common_ivf.as_ref() {
+            if common_ivf.centroids != ivf.centroids {
+                return Err(Error::invalid_input(format!(
+                    "IVF centroids mismatch while merging IVF_HNSW_RQ segment {}",
+                    segment.uuid
+                )));
+            }
+        } else {
+            common_ivf = Some(ivf.clone());
+        }
+        if let Some(common_quantizer) = common_quantizer.as_ref() {
+            if !rabit_quantizer_params_eq(common_quantizer, &quantizer) {
+                return Err(Error::invalid_input(format!(
+                    "RQ parameters mismatch while merging IVF_HNSW_RQ segment {}",
+                    segment.uuid
+                )));
+            }
+        } else {
+            common_quantizer = Some(quantizer);
+        }
+        if let Some(common_distance_type) = common_distance_type {
+            if common_distance_type != distance_type {
+                return Err(Error::invalid_input(format!(
+                    "Distance type mismatch while merging IVF_HNSW_RQ segment {}: expected {}, got {}",
+                    segment.uuid, common_distance_type, distance_type
+                )));
+            }
+        } else {
+            common_distance_type = Some(distance_type);
+        }
+
+        existing_indices.push(Arc::new(index));
+    }
+
+    let common_ivf = common_ivf.ok_or_else(|| Error::index("No IVF_HNSW_RQ indices found"))?;
+    let common_quantizer =
+        common_quantizer.ok_or_else(|| Error::index("No IVF_HNSW_RQ quantizer found"))?;
+    let distance_type =
+        common_distance_type.ok_or_else(|| Error::index("No IVF_HNSW_RQ distance type found"))?;
+    let segment_uuid = Uuid::new_v4();
+    let final_dir = indices_dir.clone().join(segment_uuid.to_string());
+    let temp_dir = lance_core::utils::tempfile::TempStdDir::default();
+    let temp_dir_path = Path::from_filesystem_path(&temp_dir)?;
+    let shuffler = create_ivf_shuffler(
+        temp_dir_path,
+        common_ivf.num_partitions(),
+        dataset_format_version(dataset),
+        Some(progress.clone()),
+    );
+    let frag_reuse_index = dataset.open_frag_reuse_index(&NoOpMetricsCollector).await?;
+    let mut builder = IvfIndexBuilder::<HNSW, RabitQuantizer>::new_incremental(
+        dataset.clone(),
+        column,
+        final_dir,
+        distance_type,
+        shuffler,
+        hnsw_params,
+        frag_reuse_index,
+        OptimizeOptions::merge(existing_indices.len()),
+    )?;
+    builder
+        .with_ivf(common_ivf)
+        .with_quantizer(common_quantizer)
+        .with_existing_indices(existing_indices)
+        .without_unindexed_data()
+        .with_progress(progress);
+    let summary = builder.build().await?;
+    Ok((segment_uuid, summary.files))
+}
+
+fn rabit_quantizer_params_eq(left: &RabitQuantizer, right: &RabitQuantizer) -> bool {
+    let left = left.metadata_ref();
+    let right = right.metadata_ref();
+    // Each distributed segment may generate an independent random rotation.
+    // The merge rereads exact vectors from the Dataset and requantizes every row
+    // with the first segment's model, so only the requested RQ configuration must match.
+    left.rotation_type == right.rotation_type
+        && left.code_dim == right.code_dim
+        && left.num_bits == right.num_bits
+        && left.packed == right.packed
+        && left.query_estimator == right.query_estimator
 }
 
 /// Merge the selected input segments into `final_dir`.

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1343,15 +1343,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> Index for IVFIndex<S, 
             (SubIndexType::Flat, QuantizationType::Rabit) => IndexType::IvfRq,
             (SubIndexType::Hnsw, QuantizationType::Product) => IndexType::IvfHnswPq,
             (SubIndexType::Hnsw, QuantizationType::Scalar) => IndexType::IvfHnswSq,
+            (SubIndexType::Hnsw, QuantizationType::Rabit) => IndexType::IvfHnswRq,
             (SubIndexType::Hnsw, QuantizationType::Flat)
             | (SubIndexType::Hnsw, QuantizationType::FlatBin) => IndexType::IvfHnswFlat,
-            (sub_index_type, quantization_type) => {
-                unimplemented!(
-                    "unsupported index type: {}, {}",
-                    sub_index_type,
-                    quantization_type
-                )
-            }
         }
     }
 
@@ -1943,6 +1937,7 @@ pub type IvfFlatIndex = IVFIndex<FlatIndex, FlatQuantizer>;
 pub type IvfPq = IVFIndex<FlatIndex, ProductQuantizer>;
 pub type IvfHnswSqIndex = IVFIndex<HNSW, ScalarQuantizer>;
 pub type IvfHnswPqIndex = IVFIndex<HNSW, ProductQuantizer>;
+pub type IvfHnswRqIndex = IVFIndex<HNSW, RabitQuantizer>;
 
 async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
     state: &IvfIndexState<Q>,
@@ -2038,16 +2033,21 @@ mod tests {
     use arrow::{array::AsArray, datatypes::Float32Type};
     use arrow_array::{
         Array, ArrayRef, ArrowPrimitiveType, FixedSizeListArray, Float32Array, Int64Array,
-        ListArray, RecordBatch, RecordBatchIterator, UInt64Array,
+        ListArray, RecordBatch, RecordBatchIterator, UInt64Array, make_array,
     };
-    use arrow_buffer::OffsetBuffer;
+    use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer};
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use itertools::Itertools;
     use lance_arrow::FixedSizeListArrayExt;
+    #[cfg(feature = "slow_tests")]
+    use lance_index::vector::bq::builder::RabitQuantizer;
     use lance_index::vector::bq::{
         RQBuildParams, RQRotationType,
         ex_dot::{blocked_ex_code_bytes, padded_query_len},
-        storage::{RABIT_BLOCKED_EX_CODE_COLUMN, RabitQuantizationMetadata, RabitQueryEstimator},
+        storage::{
+            RABIT_BLOCKED_EX_CODE_COLUMN, RABIT_HNSW_BUILD_VECTOR_COLUMN,
+            RabitQuantizationMetadata, RabitQueryEstimator,
+        },
         transform::{EX_ADD_FACTORS_COLUMN, EX_SCALE_FACTORS_COLUMN},
     };
     use lance_index::vector::storage::VectorStore;
@@ -3778,6 +3778,7 @@ mod tests {
     #[case::flat("IVF_HNSW_FLAT")]
     #[case::pq("IVF_HNSW_PQ")]
     #[case::sq("IVF_HNSW_SQ")]
+    #[case::rq("IVF_HNSW_RQ")]
     #[tokio::test]
     async fn test_merge_existing_hnsw_segments_rebuilds_graph(#[case] expected_index_type: &str) {
         let test_dir = TempStrDir::default();
@@ -3808,6 +3809,12 @@ mod tests {
                 prepare_global_ivf(&dataset, "vector").await,
                 HnswBuildParams::default(),
                 SQBuildParams::default(),
+            ),
+            "IVF_HNSW_RQ" => VectorIndexParams::with_ivf_hnsw_rq_params(
+                DistanceType::L2,
+                prepare_global_ivf(&dataset, "vector").await,
+                HnswBuildParams::default(),
+                RQBuildParams::with_rotation_type(5, RQRotationType::Fast),
             ),
             other => panic!("unexpected HNSW index type {other}"),
         };
@@ -3950,8 +3957,7 @@ mod tests {
 
         let progress = Arc::new(RecordingProgress::default());
         let merged_segment = crate::index::vector::ivf::merge_segments_with_progress(
-            dataset.object_store.as_ref(),
-            &dataset.indices_dir(),
+            &dataset,
             segments,
             progress.clone(),
         )
@@ -4558,6 +4564,369 @@ mod tests {
     }
 
     #[rstest]
+    #[case::one_bit(1)]
+    #[case::five_bits(5)]
+    #[tokio::test]
+    async fn test_build_reopen_and_query_ivf_hnsw_rq(#[case] num_bits: u8) {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+        let params = VectorIndexParams::with_ivf_hnsw_rq_params(
+            DistanceType::L2,
+            IvfBuildParams::new(4),
+            HnswBuildParams::default(),
+            RQBuildParams::with_rotation_type(num_bits, RQRotationType::Fast),
+        );
+
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("ivf_hnsw_rq".to_string()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices_by_name("ivf_hnsw_rq").await.unwrap();
+        assert_eq!(indices.len(), 1);
+        let scheduler = ScanScheduler::new(
+            Arc::new(ObjectStore::local()),
+            SchedulerConfig::default_for_testing(),
+        );
+        let reader = open_rq_aux_reader(&dataset, scheduler, &indices[0].uuid.to_string()).await;
+        assert!(
+            reader
+                .schema()
+                .field(RABIT_HNSW_BUILD_VECTOR_COLUMN)
+                .is_none(),
+            "exact HNSW build vectors must not be persisted"
+        );
+
+        drop(dataset);
+        let reopened = Dataset::open(test_uri).await.unwrap();
+        test_recall::<Float32Type>(params, 4, 0.5, "vector", &reopened, vectors).await;
+    }
+
+    #[tokio::test]
+    async fn test_ivf_hnsw_rq_skips_null_vectors() {
+        let test_dir = TempStrDir::default();
+        let (batch, schema) = generate_batch::<Float32Type>(NUM_ROWS, None, 0.0..1.0, false);
+        let nulls = NullBuffer::new(BooleanBuffer::from_iter(
+            (0..NUM_ROWS).map(|row| row.is_multiple_of(2)),
+        ));
+        let vectors = make_array(
+            batch["vector"]
+                .clone()
+                .to_data()
+                .into_builder()
+                .nulls(Some(nulls))
+                .build()
+                .unwrap(),
+        );
+        let num_non_null = vectors.len() - vectors.logical_null_count();
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![batch["id"].clone(), vectors]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+        let mut dataset = Dataset::write(batches, test_dir.as_str(), None)
+            .await
+            .unwrap();
+        let params = VectorIndexParams::with_ivf_hnsw_rq_params(
+            DistanceType::L2,
+            IvfBuildParams::new(4),
+            HnswBuildParams::default(),
+            RQBuildParams::with_rotation_type(5, RQRotationType::Fast),
+        );
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
+
+        let query = Float32Array::from(vec![0.0; DIM]);
+        let results = dataset
+            .scan()
+            .nearest("vector", &query, NUM_ROWS)
+            .unwrap()
+            .ef(10_000)
+            .minimum_nprobes(4)
+            .try_into_batch()
+            .await
+            .unwrap();
+        let recall = results.num_rows() as f32 / num_non_null as f32;
+        assert_ge!(recall, 0.99);
+        assert_eq!(results["vector"].logical_null_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_ivf_hnsw_rq_remap_after_compaction() {
+        let params = VectorIndexParams::with_ivf_hnsw_rq_params(
+            DistanceType::L2,
+            IvfBuildParams::new(4),
+            HnswBuildParams::default(),
+            RQBuildParams::with_rotation_type(5, RQRotationType::Fast),
+        );
+        test_remap(params, 4, 0.5).await;
+    }
+
+    #[cfg(feature = "slow_tests")]
+    #[tokio::test]
+    async fn test_ivf_hnsw_rq_benchmark() {
+        const BENCH_ROWS: usize = 100_000;
+        const BENCH_QUERIES: usize = 32;
+        const K: usize = 10;
+        const NLIST: usize = 4;
+        const NUM_BITS: u8 = 5;
+        const HNSW_EF: [usize; 3] = [20, 50, 100];
+
+        async fn write_benchmark_dataset(
+            uri: &str,
+            batch: RecordBatch,
+            schema: SchemaRef,
+        ) -> Dataset {
+            let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+            Dataset::write(
+                batches,
+                uri,
+                Some(WriteParams {
+                    mode: WriteMode::Overwrite,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap()
+        }
+
+        async fn measure_queries(
+            dataset: &Dataset,
+            queries: &[ArrayRef],
+            ground_truths: &[HashSet<u64>],
+            nprobes: usize,
+            ef: Option<usize>,
+        ) -> (f64, f64, f64, f32) {
+            async fn query(
+                dataset: &Dataset,
+                query: &dyn Array,
+                nprobes: usize,
+                ef: Option<usize>,
+            ) -> RecordBatch {
+                let mut scan = dataset.scan();
+                scan.nearest("vector", query, K).unwrap();
+                scan.nprobes(nprobes).with_row_id().fast_search();
+                if let Some(ef) = ef {
+                    scan.ef(ef);
+                }
+                scan.try_into_batch().await.unwrap()
+            }
+
+            for query_vector in queries.iter().take(3) {
+                query(dataset, query_vector.as_ref(), nprobes, ef).await;
+            }
+
+            let mut latencies_us = Vec::with_capacity(queries.len());
+            let mut matches = 0usize;
+            for (query_vector, ground_truth) in queries.iter().zip(ground_truths) {
+                let started = std::time::Instant::now();
+                let result = query(dataset, query_vector.as_ref(), nprobes, ef).await;
+                latencies_us.push(started.elapsed().as_secs_f64() * 1_000_000.0);
+                let row_ids = result[ROW_ID]
+                    .as_primitive::<UInt64Type>()
+                    .values()
+                    .iter()
+                    .copied()
+                    .collect::<HashSet<_>>();
+                assert_eq!(row_ids.len(), K);
+                matches += row_ids.intersection(ground_truth).count();
+            }
+
+            latencies_us.sort_by(f64::total_cmp);
+            let percentile = |percent: usize| {
+                let index = ((latencies_us.len() - 1) * percent).div_ceil(100);
+                latencies_us[index]
+            };
+            let mean_us = latencies_us.iter().sum::<f64>() / latencies_us.len() as f64;
+            let recall = matches as f32 / (queries.len() * K) as f32;
+            (mean_us, percentile(50), percentile(95), recall)
+        }
+
+        async fn index_size_bytes(dataset: &Dataset) -> u64 {
+            dataset
+                .load_indices_by_name("vector_idx")
+                .await
+                .unwrap()
+                .iter()
+                .map(|index| {
+                    index
+                        .total_size_bytes()
+                        .expect("new index metadata should contain file sizes")
+                })
+                .sum()
+        }
+
+        let test_dir = TempStrDir::default();
+        let base_uri = test_dir.as_str();
+        let (all_rows, schema) =
+            generate_batch::<Float32Type>(BENCH_ROWS + BENCH_QUERIES, None, 0.0..1.0, false);
+        let vectors = all_rows["vector"].as_fixed_size_list();
+        let queries = (BENCH_ROWS..BENCH_ROWS + BENCH_QUERIES)
+            .map(|row| vectors.value(row))
+            .collect::<Vec<_>>();
+        let data = all_rows.slice(0, BENCH_ROWS);
+
+        // Build one seed index outside the measured region. Its centroids and rotation
+        // are reused by both measured builds so the comparison only changes FLAT vs HNSW.
+        let seed_uri = format!("{base_uri}/seed");
+        let mut seed = write_benchmark_dataset(&seed_uri, data.clone(), schema.clone()).await;
+        let seed_params = VectorIndexParams::with_ivf_rq_params(
+            DistanceType::L2,
+            IvfBuildParams::new(NLIST),
+            RQBuildParams::with_rotation_type(NUM_BITS, RQRotationType::Fast),
+        );
+        seed.create_index(
+            &["vector"],
+            IndexType::Vector,
+            Some("vector_idx".to_string()),
+            &seed_params,
+            true,
+        )
+        .await
+        .unwrap();
+        let seed_index_meta = seed.load_indices_by_name("vector_idx").await.unwrap();
+        let seed_index = seed
+            .open_vector_index("vector", &seed_index_meta[0].uuid, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        let centroids = seed_index
+            .ivf_model()
+            .centroids
+            .clone()
+            .expect("IVF_RQ index should persist centroids");
+        let seed_quantizer = RabitQuantizer::try_from(seed_index.quantizer()).unwrap();
+        let rotation = seed_quantizer.metadata_ref().clone();
+
+        let mut shared_rq = RQBuildParams::with_rotation_type(NUM_BITS, RQRotationType::Fast);
+        shared_rq.rotation = Some(rotation);
+        let shared_ivf = IvfBuildParams {
+            centroids: Some(Arc::new(centroids)),
+            ..IvfBuildParams::new(NLIST)
+        };
+
+        let mut ground_truths = Vec::with_capacity(queries.len());
+        for query in &queries {
+            ground_truths
+                .push(ground_truth(&seed, "vector", query.as_ref(), K, DistanceType::L2).await);
+        }
+
+        let rq_uri = format!("{base_uri}/ivf_rq");
+        let mut rq_dataset = write_benchmark_dataset(&rq_uri, data.clone(), schema.clone()).await;
+        let rq_params = VectorIndexParams::with_ivf_rq_params(
+            DistanceType::L2,
+            shared_ivf.clone(),
+            shared_rq.clone(),
+        );
+        let started = std::time::Instant::now();
+        rq_dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vector_idx".to_string()),
+                &rq_params,
+                true,
+            )
+            .await
+            .unwrap();
+        let rq_build_seconds = started.elapsed().as_secs_f64();
+        let rq_size_bytes = index_size_bytes(&rq_dataset).await;
+        let rq_query = measure_queries(&rq_dataset, &queries, &ground_truths, NLIST, None).await;
+
+        let hnsw_uri = format!("{base_uri}/ivf_hnsw_rq");
+        let mut hnsw_dataset = write_benchmark_dataset(&hnsw_uri, data, schema).await;
+        let hnsw_params = VectorIndexParams::with_ivf_hnsw_rq_params(
+            DistanceType::L2,
+            shared_ivf,
+            HnswBuildParams::default(),
+            shared_rq,
+        );
+        let started = std::time::Instant::now();
+        hnsw_dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vector_idx".to_string()),
+                &hnsw_params,
+                true,
+            )
+            .await
+            .unwrap();
+        let hnsw_build_seconds = started.elapsed().as_secs_f64();
+        let hnsw_size_bytes = index_size_bytes(&hnsw_dataset).await;
+        let mut hnsw_queries = Vec::new();
+        for ef in HNSW_EF {
+            hnsw_queries.push((
+                ef,
+                measure_queries(&hnsw_dataset, &queries, &ground_truths, NLIST, Some(ef)).await,
+            ));
+        }
+
+        let result = serde_json::json!({
+            "dataset": {
+                "rows": BENCH_ROWS,
+                "dimension": DIM,
+                "queries": BENCH_QUERIES,
+                "k": K,
+                "nlist": NLIST,
+                "nprobes": NLIST,
+                "num_bits": NUM_BITS,
+            },
+            "ivf_rq": {
+                "build_seconds": rq_build_seconds,
+                "index_size_bytes": rq_size_bytes,
+                "query_mean_us": rq_query.0,
+                "query_p50_us": rq_query.1,
+                "query_p95_us": rq_query.2,
+                "recall_at_10": rq_query.3,
+            },
+            "ivf_hnsw_rq": hnsw_queries.iter().map(|(ef, query)| serde_json::json!({
+                "ef": ef,
+                "build_seconds": hnsw_build_seconds,
+                "index_size_bytes": hnsw_size_bytes,
+                "query_mean_us": query.0,
+                "query_p50_us": query.1,
+                "query_p95_us": query.2,
+                "recall_at_10": query.3,
+                "speedup_vs_ivf_rq": rq_query.0 / query.0,
+            })).collect::<Vec<_>>(),
+        });
+        println!("IVF_HNSW_RQ_BENCHMARK_JSON={result}");
+
+        assert!(
+            hnsw_queries
+                .iter()
+                .any(|(_, query)| { query.3 + 0.05 >= rq_query.3 && query.0 < rq_query.0 }),
+            "IVF_HNSW_RQ must provide lower mean latency within five recall points of IVF_RQ: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ivf_hnsw_rq_rejects_non_l2_metric() {
+        let test_dir = TempStrDir::default();
+        let (mut dataset, _) =
+            generate_test_dataset::<Float32Type>(test_dir.as_str(), 0.0..1.0).await;
+        let params = VectorIndexParams::with_ivf_hnsw_rq_params(
+            DistanceType::Cosine,
+            IvfBuildParams::new(4),
+            HnswBuildParams::default(),
+            RQBuildParams::default(),
+        );
+
+        let error = dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("IVF_HNSW_RQ only supports L2"));
+    }
+
+    #[rstest]
     #[case::l2(DistanceType::L2, 9)]
     #[case::cosine(DistanceType::Cosine, 9)]
     // ex_bits=3 and ex_bits=5 have no FastScan support and use the bit-plane
@@ -4913,6 +5282,12 @@ mod tests {
                 Default::default(),
                 Default::default()
             ), IndexType::IvfHnswSq),
+            (VectorIndexParams::with_ivf_hnsw_rq_params(
+                DistanceType::L2,
+                IvfBuildParams::new(4),
+                Default::default(),
+                RQBuildParams::with_rotation_type(5, RQRotationType::Fast)
+            ), IndexType::IvfHnswRq),
         )]
         index: (VectorIndexParams, IndexType),
     ) {
@@ -4954,7 +5329,7 @@ mod tests {
             );
 
             let sub_index = match index_type {
-                IndexType::IvfHnswPq | IndexType::IvfHnswSq => "HNSW",
+                IndexType::IvfHnswPq | IndexType::IvfHnswSq | IndexType::IvfHnswRq => "HNSW",
                 IndexType::IvfPq => "PQ",
                 _ => "FLAT",
             };


### PR DESCRIPTION
## Summary

- add `IVF_HNSW_RQ` across the Rust, Python, Java, JNI, namespace, metadata, and distributed-index surfaces
- build HNSW with transient exact rotated residual vectors while persisting only the graph and RaBitQ storage
- rebuild exact graphs for incremental updates, row-id remapping, and logical segment merging
- support 1-bit and multi-bit RaBitQ; reject non-L2 metrics at the build boundary

Exact build vectors are removed from the storage batch before the auxiliary index file is written. Reopen and query paths therefore depend only on persisted HNSW and RaBitQ data and do not use vector reconstruction fallback.

## Benchmark

Controlled synthetic benchmark: 100,000 rows, 32 dimensions, 32 queries, k=10, 4 IVF partitions, all partitions probed, 5-bit RaBitQ, shared centroids and rotation.

| Index | ef | Recall@10 | Mean query | P95 | Speedup | Build | Size |
|---|---:|---:|---:|---:|---:|---:|---:|
| IVF_RQ | - | 90.31% | 3.715 ms | 4.062 ms | 1.00x | 0.152 s | 5.78 MB |
| IVF_HNSW_RQ | 20 | 78.75% | 2.558 ms | 2.931 ms | 1.45x | 2.247 s | 24.34 MB |
| IVF_HNSW_RQ | 50 | 89.69% | 2.701 ms | 3.059 ms | 1.38x | 2.247 s | 24.34 MB |
| IVF_HNSW_RQ | 100 | 90.31% | 3.151 ms | 3.440 ms | 1.18x | 2.247 s | 24.34 MB |

At equal recall (`ef=100`), IVF_HNSW_RQ reduced mean latency by 15.2% (1.179x speedup). At `ef=50`, it lost 0.625 recall percentage points and reduced mean latency by 27.3% (1.376x speedup). In this small controlled workload, graph construction was about 14.7x slower and the index was about 4.21x larger. These are microbenchmark results, not production throughput claims.

Command:

```shell
cargo test --release -p lance --features slow_tests test_ivf_hnsw_rq_benchmark -- --nocapture
```

## Testing

- `cargo test -p lance ivf_hnsw_rq -- --nocapture` (8 passed)
- `cargo test -p lance test_merge_existing_hnsw_segments_rebuilds_graph -- --nocapture` (4 passed: FLAT/PQ/SQ/RQ)
- `cargo check -p lance-index --tests`
- `cargo check -p lance --tests`
- `cargo check -p lance-namespace-impls --tests`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo fmt --all -- --check`
- `uv run pytest python/tests/test_vector_index.py::test_create_reopen_and_query_ivf_hnsw_rq_index`
- `uv run make lint`
- Java `JNITest#testIvfHnswRqIndexParams` and `VectorIndexTest#testCreateIvfHnswRqIndex`
- Java Spotless, Checkstyle, and JNI Clippy
