### PR TITLE
test(io): stop test_cloud_paths from resolving S3 region over network

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1256,14 +1256,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_cloud_paths() {
+        // Provide a region for the S3 cases so opening the URL does not make a
+        // live network call to resolve the bucket region, which is flaky and
+        // fails without network access (see `resolve_s3_region`).
+        let registry = Arc::new(ObjectStoreRegistry::default());
+        let s3_params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([(String::from("region"), String::from("us-east-1"))]),
+            ))),
+            ..ObjectStoreParams::default()
+        };
+
         let uri = "s3://bucket/foo.lance";
-        let (store, path) = ObjectStore::from_uri(uri).await.unwrap();
+        let (store, path) = ObjectStore::from_uri_and_params(registry.clone(), uri, &s3_params)
+            .await
+            .unwrap();
         assert_eq!(store.scheme, "s3");
         assert_eq!(path.to_string(), "foo.lance");
 
-        let (store, path) = ObjectStore::from_uri("s3+ddb://bucket/foo.lance")
-            .await
-            .unwrap();
+        let (store, path) = ObjectStore::from_uri_and_params(
+            registry.clone(),
+            "s3+ddb://bucket/foo.lance",
+            &s3_params,
+        )
+        .await
+        .unwrap();
         assert_eq!(store.scheme, "s3");
         assert_eq!(path.to_string(), "foo.lance");
 
@@ -1314,7 +1331,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("s3://bucket/foo.lance", None)]
+    // Provide a region for S3 to avoid a live bucket-region lookup (see `test_cloud_paths`).
+    #[case("s3://bucket/foo.lance",
+      Some(HashMap::from([(String::from("region"), String::from("us-east-1"))])))]
     #[case("gs://bucket/foo.lance", None)]
     #[case("az://account/bucket/foo.lance",
       Some(HashMap::from([


### PR DESCRIPTION
`object_store::tests::test_cloud_paths` is failing on `main` in the Rust CI job.

The test opens `s3://bucket/foo.lance` with no region configured. `resolve_s3_region` then makes a live HEAD request to `bucket.s3.amazonaws.com` to read the `x-amz-bucket-region` header. That request is flaky in CI: when the header is absent the call fails with `RegionParse { bucket: "bucket" }`, panicking the `.unwrap()`. In the same failing run, `test_block_size_used_cloud::case_1` — which hits the identical code path — passed, confirming the failure is non-deterministic network behavior, not a logic regression.

The affected tests only verify URL/path parsing, so they have no reason to reach the network. This passes a static `region` storage option for the S3 cases, which short-circuits `resolve_s3_region` before any request is made. `test_block_size_used_cloud`'s S3 case shares the same flaw and is fixed the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud storage testing reliability by using a fixed S3 region configuration.
  * Prevented tests from requiring live region resolution when validating S3 paths and block size behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->