### PR TITLE
test: skip incompatible pylance / python versions in compat_test.py

### DIFF
--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
+import pytest
 from packaging.version import InvalidVersion, Version
 
 try:
@@ -110,18 +111,19 @@ _COMPAT_SKIP: list[tuple[str, tuple[int, int]]] = [
 
 
 def _skip_reason(lance_version: str) -> Optional[str]:
-    """Return a pytest.skip message if this lance/Python combo is whitelisted, else None."""
+    """Return a skip reason if this lance/Python combo is whitelisted, else None."""
+    try:
+        ver = Version(lance_version)
+    except InvalidVersion:
+        return None
     py = sys.version_info[:2]
     for max_lance, min_python in _COMPAT_SKIP:
-        try:
-            if Version(lance_version) <= Version(max_lance) and py >= min_python:
-                py_str = f"{py[0]}.{py[1]}"
-                return (
-                    f"Lance {lance_version} + Python {py_str}: whitelisted skip "
-                    f"(see _COMPAT_SKIP in venv_manager.py)"
-                )
-        except InvalidVersion:
-            pass
+        if ver <= Version(max_lance) and py >= min_python:
+            py_str = f"{py[0]}.{py[1]}"
+            return (
+                f"Lance {lance_version} + Python {py_str}: whitelisted skip "
+                f"(see _COMPAT_SKIP in venv_manager.py)"
+            )
     return None
 
 
@@ -407,8 +409,6 @@ class VenvExecutor:
 
         reason = _skip_reason(self.version)
         if reason:
-            import pytest
-
             pytest.skip(reason)
 
         # Ensure subprocess is running
@@ -460,8 +460,6 @@ class VenvExecutor:
 
         # Remove venv directory
         if self.venv_path.exists():
-            import shutil
-
             shutil.rmtree(self.venv_path)
         self._created = False
 

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -96,6 +96,35 @@ def _safe(ref: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "_", ref)
 
 
+# Explicit skip whitelist for known (lance_version, python_version) incompatibilities.
+# Each entry is (max_lance_version_inclusive, min_python_version_inclusive).
+# A test is skipped when the tested lance version <= max_lance AND the current
+# Python >= min_python.  Add entries here only after verifying the incompatibility
+# is a runtime/ABI issue rather than a format regression — anything NOT listed
+# will surface as a test failure so new problems are visible.
+_COMPAT_SKIP: list[tuple[str, tuple[int, int]]] = [
+    # lance 0.22.x abi3 wheel was built with old PyO3 (<0.23) that crashes on
+    # Python 3.14+ due to removed internal CPython APIs.
+    ("0.22.0", (3, 14)),
+]
+
+
+def _skip_reason(lance_version: str) -> Optional[str]:
+    """Return a pytest.skip message if this lance/Python combo is whitelisted, else None."""
+    py = sys.version_info[:2]
+    for max_lance, min_python in _COMPAT_SKIP:
+        try:
+            if Version(lance_version) <= Version(max_lance) and py >= min_python:
+                py_str = f"{py[0]}.{py[1]}"
+                return (
+                    f"Lance {lance_version} + Python {py_str}: whitelisted skip "
+                    f"(see _COMPAT_SKIP in venv_manager.py)"
+                )
+        except InvalidVersion:
+            pass
+    return None
+
+
 class VenvExecutor:
     """Manages a virtual environment with a specific Lance version."""
 
@@ -130,15 +159,29 @@ class VenvExecutor:
     def _marker_path(self) -> Path:
         return self.venv_path / ".compat_ref"
 
+    @staticmethod
+    def _python_version_tag() -> str:
+        return f"{sys.version_info.major}.{sys.version_info.minor}"
+
     def _validate_venv(self) -> bool:
-        """A cached venv is reusable if it exists and its recorded ref matches. A marker
-        file is used (not `pip show`) so source-built commit refs also validate."""
+        """A cached venv is reusable if it exists, its recorded ref matches, and it was
+        built with the same Python major.minor as the current interpreter.
+
+        The marker file format is two lines: `<lance_ref>\\n<python_major.minor>`.
+        Old single-line markers (no Python version) are treated as stale so the venv
+        is rebuilt — this handles cached venvs from a different Python installation."""
         if not self.python_path.exists():
             return False
         try:
-            return self._marker_path.read_text().strip() == self.version
+            lines = self._marker_path.read_text().strip().splitlines()
         except OSError:
             return False
+        if not lines or lines[0] != self.version:
+            return False
+        # Require a Python version line; single-line markers are stale.
+        if len(lines) < 2 or lines[1] != self._python_version_tag():
+            return False
+        return True
 
     def create(self):
         """Create the virtual environment and install the specified Lance version."""
@@ -170,7 +213,9 @@ class VenvExecutor:
                     self._install_release_wheel()
                 else:
                     self._build_from_source()
-                self._marker_path.write_text(self.version)
+                self._marker_path.write_text(
+                    f"{self.version}\n{self._python_version_tag()}"
+                )
         self._created = True
 
     def _install_wheel(self, wheel: str):
@@ -264,10 +309,13 @@ class VenvExecutor:
         # Start persistent subprocess
         runner_script = Path(__file__).parent / "venv_runner.py"
 
-        # Set PYTHONPATH to include the tests directory
+        # Set PYTHONPATH so the subprocess can import compat test modules.
+        # pytest adds the `tests/` directory (the first ancestor without __init__.py)
+        # to sys.path, so test modules are imported as `compat.<module>`.
         env = os.environ.copy()
         tests_dir = Path(__file__).parent.parent
         env["PYTHONPATH"] = str(tests_dir)
+        env.setdefault("RUST_BACKTRACE", "full")
 
         # Capture stderr to a file so a Rust panic (which crashes the runner) can be
         # surfaced in the error instead of an opaque "broken pipe".
@@ -357,6 +405,12 @@ class VenvExecutor:
         if not self._created:
             raise RuntimeError("Virtual environment not created. Call create() first.")
 
+        reason = _skip_reason(self.version)
+        if reason:
+            import pytest
+
+            pytest.skip(reason)
+
         # Ensure subprocess is running
         self._ensure_subprocess()
         try:
@@ -379,14 +433,16 @@ class VenvExecutor:
 
         except (BrokenPipeError, EOFError, struct.error) as e:
             # Subprocess died (usually a Rust panic); flush it, then surface that.
+            returncode = "unknown"
             if self._subprocess is not None:
                 try:
                     self._subprocess.wait(timeout=2)
+                    returncode = str(self._subprocess.returncode)
                 except Exception:
                     pass
             panic = self._last_panic()
             detail = panic or f"subprocess communication failed: {e}"
-            raise RuntimeError(f"Lance {self.version}: {detail}")
+            raise RuntimeError(f"Lance {self.version} (exit={returncode}): {detail}")
 
     def cleanup(self):
         """Remove the virtual environment directory and terminate subprocess."""


### PR DESCRIPTION
The compat_test runs older versions of pylance to generate old datasets.  When running python 3.14 it was failing with a segmentation fault.  It turns out the root cause is that older versions of pylance used a pyo3 library that didn't support python 3.14 (likely called functions that were since removed).  This fix skips the older compat_test runs on those versions (they will still be tested for the time being on 3.13)

This should help unblock https://github.com/lance-format/lance/pull/7728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility test handling by skipping known unsupported Lance/Python version combinations.
  * Tightened virtual-environment reuse so cached environments are rebuilt when Python-version metadata is missing or outdated.
  * Enhanced subprocess failure reporting by including the subprocess exit code and clearer panic/communication details.
* **Diagnostics**
  * Enabled full Rust backtraces for persistent subprocess execution to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->