### PR TITLE
feat: add cache summary diagnostics

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -25,7 +25,14 @@ pub type CacheEntry = Arc<dyn Any + Send + Sync>;
 /// Iterator over cache keys currently known to a backend.
 pub type CacheKeyIterator<'a> = Box<dyn Iterator<Item = InternalCacheKey> + Send + 'a>;
 
-/// Iterator over cache entries currently known to a backend.
+/// Iterator over [`CacheEntryRecord`] values currently known to a backend.
+///
+/// ```
+/// # use lance_core::cache::CacheEntryRecordIterator;
+/// fn cached_type_names(records: CacheEntryRecordIterator<'_>) -> Vec<&'static str> {
+///     records.map(|record| record.key.type_name()).collect()
+/// }
+/// ```
 pub type CacheEntryRecordIterator<'a> = Box<dyn Iterator<Item = CacheEntryRecord> + Send + 'a>;
 
 /// Structured cache key passed to [`CacheBackend`] methods.
@@ -75,6 +82,23 @@ impl InternalCacheKey {
 /// `size_bytes` is the backend's per-entry weighted size for capacity
 /// accounting. Backends may include key overhead or physical storage overhead
 /// according to the same accounting they use for eviction.
+///
+/// ```
+/// # use std::sync::Arc;
+/// # use lance_core::cache::{CacheEntryRecord, InternalCacheKey};
+/// let record = CacheEntryRecord {
+///     key: InternalCacheKey::new(
+///         Arc::<str>::from("dataset/"),
+///         Arc::<str>::from("manifest/1"),
+///         "Manifest",
+///     ),
+///     size_bytes: 128,
+/// };
+///
+/// assert_eq!(record.key.prefix(), "dataset/");
+/// assert_eq!(record.key.key(), "manifest/1");
+/// assert_eq!(record.size_bytes, 128);
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheEntryRecord {
     pub key: InternalCacheKey,
@@ -144,8 +168,14 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
 
     /// Return an iterator over cache entries currently known to this backend.
     ///
-    /// This is intended for diagnostics and summary APIs. Backends that cannot
-    /// enumerate entries cheaply or accurately should return `None`.
+    /// This is intended for diagnostics and summary APIs such as
+    /// [`LanceCache::entry_records`](super::LanceCache::entry_records).
+    /// Backends that cannot enumerate entries cheaply or accurately should
+    /// return `None`, which callers treat as unsupported inventory rather than
+    /// an empty cache. The default implementation returns `None`.
+    ///
+    /// In-memory backends such as [`MokaCacheBackend`](super::MokaCacheBackend)
+    /// can implement this by returning records from their local inventory.
     async fn entry_records(&self) -> Option<CacheEntryRecordIterator<'_>> {
         None
     }

--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -25,6 +25,9 @@ pub type CacheEntry = Arc<dyn Any + Send + Sync>;
 /// Iterator over cache keys currently known to a backend.
 pub type CacheKeyIterator<'a> = Box<dyn Iterator<Item = InternalCacheKey> + Send + 'a>;
 
+/// Iterator over cache entries currently known to a backend.
+pub type CacheEntryRecordIterator<'a> = Box<dyn Iterator<Item = CacheEntryRecord> + Send + 'a>;
+
 /// Structured cache key passed to [`CacheBackend`] methods.
 ///
 /// CacheBackend impls receive these ready-made from [`LanceCache`](super::LanceCache)
@@ -65,6 +68,17 @@ impl InternalCacheKey {
     pub fn starts_with(&self, prefix: &str) -> bool {
         self.prefix.starts_with(prefix)
     }
+}
+
+/// Diagnostic inventory record for one cached entry.
+///
+/// `size_bytes` is the backend's per-entry weighted size for capacity
+/// accounting. Backends may include key overhead or physical storage overhead
+/// according to the same accounting they use for eviction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheEntryRecord {
+    pub key: InternalCacheKey,
+    pub size_bytes: usize,
 }
 
 /// Low-level pluggable cache backend.
@@ -125,6 +139,14 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// `None`. An empty iterator means key inventory is supported and the
     /// cache currently has no entries.
     async fn keys(&self) -> Option<CacheKeyIterator<'_>> {
+        None
+    }
+
+    /// Return an iterator over cache entries currently known to this backend.
+    ///
+    /// This is intended for diagnostics and summary APIs. Backends that cannot
+    /// enumerate entries cheaply or accurately should return `None`.
+    async fn entry_records(&self) -> Option<CacheEntryRecordIterator<'_>> {
         None
     }
 

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -50,7 +50,10 @@ pub mod codec;
 mod entry_io;
 mod moka;
 
-pub use backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
+pub use backend::{
+    CacheBackend, CacheEntry, CacheEntryRecord, CacheEntryRecordIterator, CacheKeyIterator,
+    InternalCacheKey,
+};
 pub use codec::{
     CacheCodec, CacheCodecImpl, CacheDecode, CacheMissReason, MAGIC, has_cache_envelope,
 };
@@ -280,6 +283,20 @@ impl LanceCache {
                 .keys()
                 .await?
                 .filter(|key| key.starts_with(&self.prefix)),
+        ))
+    }
+
+    /// Return diagnostic entry records currently stored under this cache's prefix.
+    ///
+    /// Returns `None` when the backend does not support entry inventory. The
+    /// iterator is intended for diagnostics and may be weakly consistent with
+    /// concurrent cache mutations.
+    pub async fn entry_records(&self) -> Option<CacheEntryRecordIterator<'_>> {
+        Some(Box::new(
+            self.cache
+                .entry_records()
+                .await?
+                .filter(|record| record.key.starts_with(&self.prefix)),
         ))
     }
 
@@ -659,6 +676,22 @@ mod tests {
             .collect()
     }
 
+    fn record_fields(
+        records: &[CacheEntryRecord],
+    ) -> BTreeSet<(String, String, &'static str, usize)> {
+        records
+            .iter()
+            .map(|record| {
+                (
+                    record.key.prefix().to_string(),
+                    record.key.key().to_string(),
+                    record.key.type_name(),
+                    record.size_bytes,
+                )
+            })
+            .collect()
+    }
+
     #[tokio::test]
     async fn test_cache_bytes() {
         let item = Arc::new(vec![1, 2, 3]);
@@ -895,6 +928,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_cache_entry_records_with_prefixes() {
+        let base = LanceCache::with_capacity(10_000);
+        let prefixed = base.with_key_prefix("ns");
+        let nested = prefixed.with_key_prefix("index");
+        let other = base.with_key_prefix("ns-other");
+
+        let root = Arc::new(vec![0]);
+        let child = Arc::new(vec![1]);
+        let nested_value = Arc::new(vec![2]);
+        let other_value = Arc::new(vec![3]);
+
+        base.insert_with_key(&TestKey::new("root"), root.clone())
+            .await;
+        prefixed
+            .insert_with_key(&TestKey::new("child"), child.clone())
+            .await;
+        nested
+            .insert_with_key(&TestKey::new("nested"), nested_value.clone())
+            .await;
+        other
+            .insert_with_key(&TestKey::new("other"), other_value.clone())
+            .await;
+
+        let key_size = std::mem::size_of::<InternalCacheKey>();
+        let base_records = base.entry_records().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            record_fields(&base_records),
+            BTreeSet::from([
+                (
+                    "".to_string(),
+                    "root".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "root".len() + cache_entry_size(&*root),
+                ),
+                (
+                    "ns/".to_string(),
+                    "child".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "child".len() + cache_entry_size(&*child),
+                ),
+                (
+                    "ns/index/".to_string(),
+                    "nested".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "nested".len() + cache_entry_size(&*nested_value),
+                ),
+                (
+                    "ns-other/".to_string(),
+                    "other".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "other".len() + cache_entry_size(&*other_value),
+                ),
+            ])
+        );
+
+        let prefixed_records = prefixed.entry_records().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            record_fields(&prefixed_records),
+            BTreeSet::from([
+                (
+                    "ns/".to_string(),
+                    "child".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "child".len() + cache_entry_size(&*child),
+                ),
+                (
+                    "ns/index/".to_string(),
+                    "nested".to_string(),
+                    TestKey::<Vec<i32>>::type_name(),
+                    key_size + "nested".len() + cache_entry_size(&*nested_value),
+                ),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_entry_records_use_clamped_weight() {
+        struct HugeValue;
+
+        impl DeepSizeOf for HugeValue {
+            fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+                u32::MAX as usize
+            }
+        }
+
+        let cache = LanceCache::with_capacity(usize::MAX);
+        cache
+            .insert_with_key(&TestKey::new("huge"), Arc::new(HugeValue))
+            .await;
+
+        let records = cache.entry_records().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].size_bytes, u32::MAX as usize);
+        assert_eq!(cache.size_bytes().await, u32::MAX as usize);
+    }
+
+    #[tokio::test]
     async fn test_cache_get_or_insert() {
         let cache = LanceCache::with_capacity(1000);
 
@@ -1010,6 +1140,7 @@ mod tests {
                 .is_none()
         );
         assert!(cache.keys().await.is_none());
+        assert!(cache.entry_records().await.is_none());
     }
 
     #[tokio::test]

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -291,6 +291,31 @@ impl LanceCache {
     /// Returns `None` when the backend does not support entry inventory. The
     /// iterator is intended for diagnostics and may be weakly consistent with
     /// concurrent cache mutations.
+    ///
+    /// ```
+    /// # use std::borrow::Cow;
+    /// # use std::sync::Arc;
+    /// # use lance_core::cache::{CacheKey, LanceCache};
+    /// # struct MyKey;
+    /// # impl CacheKey for MyKey {
+    /// #     type ValueType = Vec<i32>;
+    /// #     fn key(&self) -> Cow<'_, str> { Cow::Borrowed("values") }
+    /// #     fn type_name() -> &'static str { "VecI32" }
+    /// # }
+    /// # async fn example() {
+    /// let cache = LanceCache::with_capacity(1024);
+    /// let dataset_cache = cache.with_key_prefix("dataset");
+    /// dataset_cache.insert_with_key(&MyKey, Arc::new(vec![1, 2, 3])).await;
+    ///
+    /// let records: Vec<_> = dataset_cache
+    ///     .entry_records()
+    ///     .await
+    ///     .expect("Moka supports entry inventory")
+    ///     .collect();
+    /// assert_eq!(records.len(), 1);
+    /// assert!(records[0].key.prefix().starts_with("dataset/"));
+    /// # }
+    /// ```
     pub async fn entry_records(&self) -> Option<CacheEntryRecordIterator<'_>> {
         Some(Box::new(
             self.cache

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -11,7 +11,10 @@ use futures::Future;
 use crate::Result;
 
 use super::CacheCodec;
-use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
+use super::backend::{
+    CacheBackend, CacheEntry, CacheEntryRecord, CacheEntryRecordIterator, CacheKeyIterator,
+    InternalCacheKey,
+};
 
 /// Internal record stored in the moka cache.
 #[derive(Clone, Debug)]
@@ -24,6 +27,14 @@ struct MokaCacheEntry {
 /// Excludes the shared `prefix` `Arc<str>`, which isn't freed per eviction.
 fn key_footprint(key: &InternalCacheKey) -> usize {
     std::mem::size_of::<InternalCacheKey>() + key.key().len()
+}
+
+fn logical_entry_size(key: &InternalCacheKey, entry_size_bytes: usize) -> usize {
+    key_footprint(key).saturating_add(entry_size_bytes)
+}
+
+fn entry_weight(key: &InternalCacheKey, entry_size_bytes: usize) -> usize {
+    logical_entry_size(key, entry_size_bytes).min(u32::MAX as usize)
 }
 
 /// Default [`CacheBackend`] backed by a [moka](https://crates.io/crates/moka) cache.
@@ -47,10 +58,7 @@ impl MokaCacheBackend {
         let cache = moka::future::Cache::builder()
             .max_capacity(capacity as u64)
             .weigher(|key: &InternalCacheKey, entry: &MokaCacheEntry| {
-                key_footprint(key)
-                    .saturating_add(entry.size_bytes)
-                    .try_into()
-                    .unwrap_or(u32::MAX)
+                entry_weight(key, entry.size_bytes) as u32
             })
             .support_invalidation_closures()
             .build();
@@ -141,6 +149,15 @@ impl CacheBackend for MokaCacheBackend {
         ))
     }
 
+    async fn entry_records(&self) -> Option<CacheEntryRecordIterator<'_>> {
+        self.cache.run_pending_tasks().await;
+        Some(Box::new(self.cache.iter().map(|(key, entry)| {
+            let key = key.as_ref().clone();
+            let size_bytes = entry_weight(&key, entry.size_bytes);
+            CacheEntryRecord { key, size_bytes }
+        })))
+    }
+
     async fn num_entries(&self) -> usize {
         self.cache.run_pending_tasks().await;
         self.cache.entry_count() as usize
@@ -161,7 +178,7 @@ impl CacheBackend for MokaCacheBackend {
         // is async and can't be called from this synchronous context.
         self.cache
             .iter()
-            .map(|(key, entry)| key_footprint(key.as_ref()) + entry.size_bytes)
+            .map(|(key, entry)| logical_entry_size(key.as_ref(), entry.size_bytes))
             .sum()
     }
 }

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -178,7 +178,7 @@ impl CacheBackend for MokaCacheBackend {
         // is async and can't be called from this synchronous context.
         self.cache
             .iter()
-            .map(|(key, entry)| logical_entry_size(key.as_ref(), entry.size_bytes))
+            .map(|(key, entry)| entry_weight(key.as_ref(), entry.size_bytes))
             .sum()
     }
 }

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -476,7 +476,7 @@ fn checked_cache_summary_add(
     context: impl AsRef<str>,
 ) -> Result<usize> {
     current.checked_add(increment).ok_or_else(|| {
-        Error::invalid_input(format!(
+        Error::internal(format!(
             "Cache summary overflow while adding {increment} to {} (current value: {current})",
             context.as_ref()
         ))
@@ -780,6 +780,22 @@ mod tests {
         #[case] expected_component: &str,
     ) {
         assert_eq!(cache_key_component(key, type_name), expected_component);
+    }
+
+    #[test]
+    fn test_cache_summary_overflow_is_internal_error() {
+        let err = checked_cache_summary_add(usize::MAX, 1, "total size bytes").unwrap_err();
+
+        assert!(
+            matches!(
+                &err,
+                Error::Internal { message, .. }
+                    if message.contains("Cache summary overflow")
+                        && message.contains("total size bytes")
+                        && message.contains(&usize::MAX.to_string())
+            ),
+            "expected internal overflow error, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -27,7 +27,9 @@ pub(crate) mod index_extension;
 ///
 /// This is intended for diagnostics. It is computed from a weakly consistent
 /// snapshot of backend entry inventory and may race with concurrent cache
-/// insertions or evictions.
+/// insertions or evictions. A summary has total counts and sizes, grouped into
+/// [`CacheGroupSummary`] values, and each group contains
+/// [`CacheComponentSummary`] values.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CacheSummary {
     /// Number of entries included in this summary.
@@ -39,6 +41,10 @@ pub struct CacheSummary {
 }
 
 /// Summary of cache entries under one summary group.
+///
+/// In [`CacheSummary::groups`], index summaries use one group per Lance cache
+/// prefix while metadata summaries may use a synthetic group label to keep
+/// diagnostics compact.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CacheGroupSummary {
     /// Group label.
@@ -55,6 +61,10 @@ pub struct CacheGroupSummary {
 }
 
 /// Summary of one cache component within a cache summary group.
+///
+/// Components are compact key-derived labels paired with a value type. This
+/// keeps common key families, such as IVF partitions or manifest entries,
+/// visible without returning every cache key.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CacheComponentSummary {
     /// Compact component name derived from the cache key.
@@ -309,12 +319,27 @@ impl Session {
     ///
     /// Returns `None` when the configured index cache backend does not support
     /// entry inventory.
-    pub async fn index_cache_summary(&self) -> Option<CacheSummary> {
-        Some(summarize_cache_records(
-            self.index_cache.0.entry_records().await?,
-            cache_prefix_group,
-            index_cache_component,
-        ))
+    ///
+    /// ```
+    /// # use lance::session::Session;
+    /// # async fn example() -> lance::Result<()> {
+    /// let session = Session::default();
+    /// if let Some(summary) = session.index_cache_summary().await? {
+    ///     for group in &summary.groups {
+    ///         for component in &group.components {
+    ///             let _ = (group.cache_prefix.as_str(), component.component.as_str());
+    ///         }
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn index_cache_summary(&self) -> Result<Option<CacheSummary>> {
+        let Some(records) = self.index_cache.0.entry_records().await else {
+            return Ok(None);
+        };
+
+        summarize_cache_records(records, cache_prefix_group, index_cache_component).map(Some)
     }
 
     /// Return an iterator over keys currently held by the metadata cache.
@@ -340,12 +365,25 @@ impl Session {
     ///
     /// Returns `None` when the configured metadata cache backend does not
     /// support entry inventory.
-    pub async fn metadata_cache_summary(&self) -> Option<CacheSummary> {
-        Some(summarize_cache_records(
-            self.metadata_cache.0.entry_records().await?,
-            metadata_cache_group,
-            metadata_cache_component,
-        ))
+    ///
+    /// ```
+    /// # use lance::session::Session;
+    /// # async fn example() -> lance::Result<()> {
+    /// let session = Session::default();
+    /// if let Some(summary) = session.metadata_cache_summary().await? {
+    ///     let total_bytes = summary.total_size_bytes;
+    ///     let total_entries = summary.total_entries;
+    ///     let _ = (total_bytes, total_entries);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn metadata_cache_summary(&self) -> Result<Option<CacheSummary>> {
+        let Some(records) = self.metadata_cache.0.entry_records().await else {
+            return Ok(None);
+        };
+
+        summarize_cache_records(records, metadata_cache_group, metadata_cache_component).map(Some)
     }
 }
 
@@ -370,21 +408,32 @@ fn summarize_cache_records(
     records: impl Iterator<Item = CacheEntryRecord>,
     group_name: fn(&InternalCacheKey) -> String,
     component_name: fn(&InternalCacheKey) -> String,
-) -> CacheSummary {
+) -> Result<CacheSummary> {
     let mut groups = BTreeMap::<String, CacheGroupAccumulator>::new();
     let mut total_entries = 0usize;
     let mut total_size_bytes = 0usize;
 
     for record in records {
-        total_entries = total_entries.saturating_add(1);
-        total_size_bytes = total_size_bytes.saturating_add(record.size_bytes);
+        total_entries = checked_cache_summary_add(total_entries, 1, "total entry count")?;
+        total_size_bytes =
+            checked_cache_summary_add(total_size_bytes, record.size_bytes, "total size bytes")?;
 
-        let group = groups.entry(group_name(&record.key)).or_default();
-        group.entry_count = group.entry_count.saturating_add(1);
-        group.size_bytes = group.size_bytes.saturating_add(record.size_bytes);
+        let group_label = group_name(&record.key);
+        let group = groups.entry(group_label.clone()).or_default();
+        group.entry_count = checked_cache_summary_add(
+            group.entry_count,
+            1,
+            format!("entry count for cache group '{group_label}'"),
+        )?;
+        group.size_bytes = checked_cache_summary_add(
+            group.size_bytes,
+            record.size_bytes,
+            format!("size bytes for cache group '{group_label}'"),
+        )?;
 
         let component = component_name(&record.key);
         let type_name = record.key.type_name().to_string();
+        let component_label = format!("{component}/{type_name}");
         let component_summary = group
             .components
             .entry((component.clone(), type_name.clone()))
@@ -394,13 +443,19 @@ fn summarize_cache_records(
                 entry_count: 0,
                 size_bytes: 0,
             });
-        component_summary.entry_count = component_summary.entry_count.saturating_add(1);
-        component_summary.size_bytes = component_summary
-            .size_bytes
-            .saturating_add(record.size_bytes);
+        component_summary.entry_count = checked_cache_summary_add(
+            component_summary.entry_count,
+            1,
+            format!("entry count for cache component '{component_label}'"),
+        )?;
+        component_summary.size_bytes = checked_cache_summary_add(
+            component_summary.size_bytes,
+            record.size_bytes,
+            format!("size bytes for cache component '{component_label}'"),
+        )?;
     }
 
-    CacheSummary {
+    Ok(CacheSummary {
         total_entries,
         total_size_bytes,
         groups: groups
@@ -412,7 +467,20 @@ fn summarize_cache_records(
                 components: group.components.into_values().collect(),
             })
             .collect(),
-    }
+    })
+}
+
+fn checked_cache_summary_add(
+    current: usize,
+    increment: usize,
+    context: impl AsRef<str>,
+) -> Result<usize> {
+    current.checked_add(increment).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "Cache summary overflow while adding {increment} to {} (current value: {current})",
+            context.as_ref()
+        ))
+    })
 }
 
 fn cache_prefix_group(key: &InternalCacheKey) -> String {
@@ -478,6 +546,7 @@ mod tests {
     };
     use lance_index::vector::VectorIndex;
     use object_store::path::Path;
+    use rstest::rstest;
     use std::borrow::Cow;
     use std::pin::Pin;
     use tokio::io::AsyncWriteExt;
@@ -607,7 +676,7 @@ mod tests {
         let session = Session::new(10_000, 10_000, Default::default());
         let index_uuid = Uuid::nil();
 
-        let ds_index_cache = session.index_cache.for_dataset("memory://dataset");
+        let ds_index_cache = session.index_cache.for_dataset("memory://");
         let index_cache = ds_index_cache.for_index(&index_uuid, None);
         index_cache
             .insert_with_key(&TestKey("ivf-0"), Arc::new(vec![1]))
@@ -619,14 +688,11 @@ mod tests {
             .insert_with_key(&TestKey("page-0"), Arc::new(vec![3]))
             .await;
 
-        let index_summary = session.index_cache_summary().await.unwrap();
+        let index_summary = session.index_cache_summary().await.unwrap().unwrap();
         assert_eq!(index_summary.total_entries, 3);
         assert_eq!(index_summary.groups.len(), 1);
         let index_group = &index_summary.groups[0];
-        assert_eq!(
-            index_group.cache_prefix,
-            format!("memory://dataset/{index_uuid}")
-        );
+        assert_eq!(index_group.cache_prefix, format!("memory:///{index_uuid}"));
         assert_eq!(index_group.entry_count, 3);
         assert_eq!(index_group.components.len(), 2);
         assert_eq!(index_group.components[0].component, "ivf");
@@ -646,7 +712,7 @@ mod tests {
                 .sum::<usize>()
         );
 
-        let ds_metadata_cache = session.metadata_cache.for_dataset("memory://dataset");
+        let ds_metadata_cache = session.metadata_cache.for_dataset("memory://");
         ds_metadata_cache
             .insert_with_key(&TestKey("manifest/1"), Arc::new(vec![4]))
             .await;
@@ -659,7 +725,7 @@ mod tests {
             .insert_with_key(&TestKey(""), Arc::new(vec![6]))
             .await;
 
-        let metadata_summary = session.metadata_cache_summary().await.unwrap();
+        let metadata_summary = session.metadata_cache_summary().await.unwrap().unwrap();
         assert_eq!(metadata_summary.total_entries, 3);
         assert_eq!(metadata_summary.groups.len(), 1);
         let metadata_group = &metadata_summary.groups[0];
@@ -692,23 +758,28 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_cache_key_component_names_are_compact() {
-        let uuid = Uuid::nil();
-
-        assert_eq!(
-            cache_key_component(&format!("frag_reuse/{uuid}"), "FragReuseIndex"),
-            "frag_reuse"
-        );
-        assert_eq!(
-            cache_key_component(&format!("type/{uuid}"), "ScalarIndexDetails"),
-            "type"
-        );
-        assert_eq!(cache_key_component("12", "Vec<IndexMetadata>"), "version");
-        assert_eq!(cache_key_component("12", "Bitmap"), "Bitmap");
-        assert_eq!(cache_key_component("0:default", "FieldData"), "field_data");
-        assert_eq!(cache_key_component("ivf-12", "LegacyIVFPartition"), "ivf");
-        assert_eq!(cache_key_component("some-value", "Bitmap"), "Bitmap");
+    #[rstest]
+    #[case::frag_reuse(
+        "frag_reuse/00000000-0000-0000-0000-000000000000",
+        "FragReuseIndex",
+        "frag_reuse"
+    )]
+    #[case::type_details(
+        "type/00000000-0000-0000-0000-000000000000",
+        "ScalarIndexDetails",
+        "type"
+    )]
+    #[case::index_metadata_version("12", "Vec<IndexMetadata>", "version")]
+    #[case::numeric_bitmap_value("12", "Bitmap", "Bitmap")]
+    #[case::field_data("0:default", "FieldData", "field_data")]
+    #[case::ivf_partition("ivf-12", "LegacyIVFPartition", "ivf")]
+    #[case::scalar_value("some-value", "Bitmap", "Bitmap")]
+    fn test_cache_key_component_names_are_compact(
+        #[case] key: &str,
+        #[case] type_name: &str,
+        #[case] expected_component: &str,
+    ) {
+        assert_eq!(cache_key_component(key, type_name), expected_component);
     }
 
     #[tokio::test]
@@ -719,7 +790,7 @@ mod tests {
             Default::default(),
         );
 
-        assert!(session.index_cache_summary().await.is_none());
+        assert!(session.index_cache_summary().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use lance_core::cache::{CacheBackend, CacheKeyIterator, LanceCache};
+use lance_core::cache::{
+    CacheBackend, CacheEntryRecord, CacheKeyIterator, InternalCacheKey, LanceCache,
+};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use lance_index::IndexType;
@@ -20,6 +22,50 @@ use self::index_extension::IndexExtension;
 pub(crate) mod caches;
 pub mod index_caches;
 pub(crate) mod index_extension;
+
+/// Summary of entries currently held by one cache.
+///
+/// This is intended for diagnostics. It is computed from a weakly consistent
+/// snapshot of backend entry inventory and may race with concurrent cache
+/// insertions or evictions.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CacheSummary {
+    /// Number of entries included in this summary.
+    pub total_entries: usize,
+    /// Total backend-accounted size in bytes for entries included here.
+    pub total_size_bytes: usize,
+    /// Entries grouped by summary label.
+    pub groups: Vec<CacheGroupSummary>,
+}
+
+/// Summary of cache entries under one summary group.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CacheGroupSummary {
+    /// Group label.
+    ///
+    /// Index summaries use the Lance cache prefix. Metadata summaries may use
+    /// a synthetic label to keep diagnostics compact.
+    pub cache_prefix: String,
+    /// Number of entries under this group.
+    pub entry_count: usize,
+    /// Total backend-accounted size in bytes under this group.
+    pub size_bytes: usize,
+    /// Entries further grouped by component and value type.
+    pub components: Vec<CacheComponentSummary>,
+}
+
+/// Summary of one cache component within a cache summary group.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CacheComponentSummary {
+    /// Compact component name derived from the cache key.
+    pub component: String,
+    /// Lance cache value type name.
+    pub type_name: String,
+    /// Number of entries for this component and value type.
+    pub entry_count: usize,
+    /// Total backend-accounted size in bytes for this component and value type.
+    pub size_bytes: usize,
+}
 
 /// A user session holds the runtime state for a [`crate::Dataset`]
 ///
@@ -259,6 +305,18 @@ impl Session {
         self.index_cache.0.keys().await
     }
 
+    /// Return a compact read-time summary of entries held by the index cache.
+    ///
+    /// Returns `None` when the configured index cache backend does not support
+    /// entry inventory.
+    pub async fn index_cache_summary(&self) -> Option<CacheSummary> {
+        Some(summarize_cache_records(
+            self.index_cache.0.entry_records().await?,
+            cache_prefix_group,
+            index_cache_component,
+        ))
+    }
+
     /// Return an iterator over keys currently held by the metadata cache.
     ///
     /// Returns `None` when the metadata cache backend does not support key
@@ -277,6 +335,18 @@ impl Session {
     pub async fn metadata_cache_keys(&self) -> Option<CacheKeyIterator<'_>> {
         self.metadata_cache.0.keys().await
     }
+
+    /// Return a compact read-time summary of entries held by the metadata cache.
+    ///
+    /// Returns `None` when the configured metadata cache backend does not
+    /// support entry inventory.
+    pub async fn metadata_cache_summary(&self) -> Option<CacheSummary> {
+        Some(summarize_cache_records(
+            self.metadata_cache.0.entry_records().await?,
+            metadata_cache_group,
+            metadata_cache_component,
+        ))
+    }
 }
 
 impl Default for Session {
@@ -289,13 +359,129 @@ impl Default for Session {
     }
 }
 
+#[derive(Default)]
+struct CacheGroupAccumulator {
+    entry_count: usize,
+    size_bytes: usize,
+    components: BTreeMap<(String, String), CacheComponentSummary>,
+}
+
+fn summarize_cache_records(
+    records: impl Iterator<Item = CacheEntryRecord>,
+    group_name: fn(&InternalCacheKey) -> String,
+    component_name: fn(&InternalCacheKey) -> String,
+) -> CacheSummary {
+    let mut groups = BTreeMap::<String, CacheGroupAccumulator>::new();
+    let mut total_entries = 0usize;
+    let mut total_size_bytes = 0usize;
+
+    for record in records {
+        total_entries = total_entries.saturating_add(1);
+        total_size_bytes = total_size_bytes.saturating_add(record.size_bytes);
+
+        let group = groups.entry(group_name(&record.key)).or_default();
+        group.entry_count = group.entry_count.saturating_add(1);
+        group.size_bytes = group.size_bytes.saturating_add(record.size_bytes);
+
+        let component = component_name(&record.key);
+        let type_name = record.key.type_name().to_string();
+        let component_summary = group
+            .components
+            .entry((component.clone(), type_name.clone()))
+            .or_insert_with(|| CacheComponentSummary {
+                component,
+                type_name,
+                entry_count: 0,
+                size_bytes: 0,
+            });
+        component_summary.entry_count = component_summary.entry_count.saturating_add(1);
+        component_summary.size_bytes = component_summary
+            .size_bytes
+            .saturating_add(record.size_bytes);
+    }
+
+    CacheSummary {
+        total_entries,
+        total_size_bytes,
+        groups: groups
+            .into_iter()
+            .map(|(cache_prefix, group)| CacheGroupSummary {
+                cache_prefix,
+                entry_count: group.entry_count,
+                size_bytes: group.size_bytes,
+                components: group.components.into_values().collect(),
+            })
+            .collect(),
+    }
+}
+
+fn cache_prefix_group(key: &InternalCacheKey) -> String {
+    key.prefix().trim_end_matches('/').to_string()
+}
+
+fn metadata_cache_group(_key: &InternalCacheKey) -> String {
+    "<metadata>".to_string()
+}
+
+fn index_cache_component(key: &InternalCacheKey) -> String {
+    cache_key_component(key.key(), key.type_name())
+}
+
+fn metadata_cache_component(key: &InternalCacheKey) -> String {
+    cache_key_component(key.key(), key.type_name())
+}
+
+fn cache_key_component(key: &str, type_name: &str) -> String {
+    let has_path_separator = key.contains('/');
+    let key = key.split('/').next().unwrap_or_default();
+    if key.is_empty() {
+        return "<empty>".to_string();
+    }
+    if type_name == "Vec<IndexMetadata>" && key.chars().all(|ch| ch.is_ascii_digit()) {
+        return "version".to_string();
+    }
+    if let Some((column_index, view_tag)) = key.split_once(':')
+        && !column_index.is_empty()
+        && !view_tag.is_empty()
+        && column_index.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return "field_data".to_string();
+    }
+
+    for prefix in [
+        "ivf-",
+        "page-",
+        "postings-",
+        "posting-list-",
+        "posting-metadata-",
+        "positions-",
+    ] {
+        if key.starts_with(prefix) {
+            return prefix.trim_end_matches('-').to_string();
+        }
+    }
+
+    if has_path_separator {
+        return key.to_string();
+    }
+
+    type_name.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lance_core::cache::{CacheKey, UnsizedCacheKey};
+    use async_trait::async_trait;
+    use futures::Future;
+    use lance_core::cache::{
+        CacheBackend, CacheCodec, CacheEntry, CacheKey, InternalCacheKey, UnsizedCacheKey,
+    };
     use lance_index::vector::VectorIndex;
+    use object_store::path::Path;
     use std::borrow::Cow;
+    use std::pin::Pin;
     use tokio::io::AsyncWriteExt;
+    use uuid::Uuid;
 
     struct TestKey(&'static str);
     impl CacheKey for TestKey {
@@ -319,6 +505,51 @@ mod tests {
 
         fn type_name() -> &'static str {
             "TestUnsized"
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoInventoryBackend;
+
+    #[async_trait]
+    impl CacheBackend for NoInventoryBackend {
+        async fn get(
+            &self,
+            _key: &InternalCacheKey,
+            _codec: Option<CacheCodec>,
+        ) -> Option<CacheEntry> {
+            None
+        }
+
+        async fn insert(
+            &self,
+            _key: &InternalCacheKey,
+            _entry: CacheEntry,
+            _size_bytes: usize,
+            _codec: Option<CacheCodec>,
+        ) {
+        }
+
+        async fn get_or_insert<'a>(
+            &self,
+            _key: &InternalCacheKey,
+            loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
+            _codec: Option<CacheCodec>,
+        ) -> Result<(CacheEntry, bool)> {
+            let (entry, _) = loader.await?;
+            Ok((entry, false))
+        }
+
+        async fn invalidate_prefix(&self, _prefix: &str) {}
+
+        async fn clear(&self) {}
+
+        async fn num_entries(&self) -> usize {
+            0
+        }
+
+        async fn size_bytes(&self) -> usize {
+            0
         }
     }
 
@@ -369,6 +600,126 @@ mod tests {
         assert_eq!(metadata_keys[0].type_name(), "TestVec");
 
         assert_ne!(index_keys, metadata_keys);
+    }
+
+    #[tokio::test]
+    async fn test_session_cache_summaries() {
+        let session = Session::new(10_000, 10_000, Default::default());
+        let index_uuid = Uuid::nil();
+
+        let ds_index_cache = session.index_cache.for_dataset("memory://dataset");
+        let index_cache = ds_index_cache.for_index(&index_uuid, None);
+        index_cache
+            .insert_with_key(&TestKey("ivf-0"), Arc::new(vec![1]))
+            .await;
+        index_cache
+            .insert_with_key(&TestKey("ivf-1"), Arc::new(vec![2]))
+            .await;
+        index_cache
+            .insert_with_key(&TestKey("page-0"), Arc::new(vec![3]))
+            .await;
+
+        let index_summary = session.index_cache_summary().await.unwrap();
+        assert_eq!(index_summary.total_entries, 3);
+        assert_eq!(index_summary.groups.len(), 1);
+        let index_group = &index_summary.groups[0];
+        assert_eq!(
+            index_group.cache_prefix,
+            format!("memory://dataset/{index_uuid}")
+        );
+        assert_eq!(index_group.entry_count, 3);
+        assert_eq!(index_group.components.len(), 2);
+        assert_eq!(index_group.components[0].component, "ivf");
+        assert_eq!(index_group.components[0].type_name, "TestVec");
+        assert_eq!(index_group.components[0].entry_count, 2);
+        assert!(index_group.components[0].size_bytes > 0);
+        assert_eq!(index_group.components[1].component, "page");
+        assert_eq!(index_group.components[1].type_name, "TestVec");
+        assert_eq!(index_group.components[1].entry_count, 1);
+        assert!(index_group.components[1].size_bytes > 0);
+        assert_eq!(
+            index_summary.total_size_bytes,
+            index_group
+                .components
+                .iter()
+                .map(|component| component.size_bytes)
+                .sum::<usize>()
+        );
+
+        let ds_metadata_cache = session.metadata_cache.for_dataset("memory://dataset");
+        ds_metadata_cache
+            .insert_with_key(&TestKey("manifest/1"), Arc::new(vec![4]))
+            .await;
+        ds_metadata_cache
+            .insert_with_key(&TestKey("txn/1"), Arc::new(vec![5]))
+            .await;
+        let file_metadata_cache =
+            ds_metadata_cache.file_metadata_cache(&Path::from("data/0.lance"));
+        file_metadata_cache
+            .insert_with_key(&TestKey(""), Arc::new(vec![6]))
+            .await;
+
+        let metadata_summary = session.metadata_cache_summary().await.unwrap();
+        assert_eq!(metadata_summary.total_entries, 3);
+        assert_eq!(metadata_summary.groups.len(), 1);
+        let metadata_group = &metadata_summary.groups[0];
+        assert_eq!(metadata_group.cache_prefix, "<metadata>");
+        assert_eq!(
+            metadata_group
+                .components
+                .iter()
+                .map(|component| component.entry_count)
+                .sum::<usize>(),
+            3
+        );
+        assert!(
+            metadata_group
+                .components
+                .iter()
+                .any(|component| component.component == "manifest")
+        );
+        assert!(
+            metadata_group
+                .components
+                .iter()
+                .any(|component| component.component == "txn")
+        );
+        assert!(
+            metadata_group
+                .components
+                .iter()
+                .any(|component| component.component == "<empty>")
+        );
+    }
+
+    #[test]
+    fn test_cache_key_component_names_are_compact() {
+        let uuid = Uuid::nil();
+
+        assert_eq!(
+            cache_key_component(&format!("frag_reuse/{uuid}"), "FragReuseIndex"),
+            "frag_reuse"
+        );
+        assert_eq!(
+            cache_key_component(&format!("type/{uuid}"), "ScalarIndexDetails"),
+            "type"
+        );
+        assert_eq!(cache_key_component("12", "Vec<IndexMetadata>"), "version");
+        assert_eq!(cache_key_component("12", "Bitmap"), "Bitmap");
+        assert_eq!(cache_key_component("0:default", "FieldData"), "field_data");
+        assert_eq!(cache_key_component("ivf-12", "LegacyIVFPartition"), "ivf");
+        assert_eq!(cache_key_component("some-value", "Bitmap"), "Bitmap");
+    }
+
+    #[tokio::test]
+    async fn test_session_cache_summary_unsupported_backend() {
+        let session = Session::with_index_cache_backend(
+            Arc::new(NoInventoryBackend),
+            10_000,
+            Default::default(),
+        );
+
+        assert!(session.index_cache_summary().await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds read-time cache entry summary APIs for index and metadata caches, backed by optional cache entry inventory in Lance core.

Summaries aggregate by cache group, component, type, entry count, and weighted size so callers can avoid dumping raw cache keys.

## Index cache components

Index cache summaries group entries by index cache prefix. For a normal index this is the dataset URI plus index UUID; when fragment-reuse state is involved the prefix also includes the fragment-reuse UUID. Within each index group, the component field is a compact category instead of the raw cache key.

Tracked index-cache components include:

- `ivf`: IVF partition and sub-index entries from keys like `ivf-*`.
- `page`: page-oriented scalar index entries from keys like `page-*`.
- `postings`: inverted-index posting entries from keys like `postings-*`.
- `posting-list`: ngram posting-list entries from keys like `posting-list-*`.
- `posting-metadata`: inverted-index posting metadata from keys like `posting-metadata-*`.
- `positions`: inverted-index position entries from keys like `positions-*`.
- `frag_reuse`: fragment-reuse index entries from path-like keys such as `frag_reuse/<uuid>`.
- `type`: scalar index detail entries from path-like keys such as `type/<uuid>`.
- `version`: index metadata entries keyed by version numbers.
- otherwise, the value type name is used so scalar values and other id-like keys do not expand the summary cardinality.

## Example output

The Rust API returns `CacheSummary` structs. These examples show representative JSON-shaped renderings with illustrative counts and sizes.

### Vector index

```json
{
  "total_entries": 4,
  "total_size_bytes": 184320000,
  "groups": [
    {
      "cache_prefix": "s3://bucket/dataset/11111111-1111-1111-1111-111111111111",
      "entry_count": 4,
      "size_bytes": 184320000,
      "components": [
        {
          "component": "ivf",
          "type_name": "lance::index::vector::ivf::v2::PartitionEntry<...>",
          "entry_count": 4,
          "size_bytes": 184320000
        }
      ]
    }
  ]
}
```

### FTS / inverted index

```json
{
  "total_entries": 153,
  "total_size_bytes": 73400320,
  "groups": [
    {
      "cache_prefix": "s3://bucket/dataset/22222222-2222-2222-2222-222222222222",
      "entry_count": 153,
      "size_bytes": 73400320,
      "components": [
        {
          "component": "postings",
          "type_name": "PostingList",
          "entry_count": 96,
          "size_bytes": 50331648
        },
        {
          "component": "posting-metadata",
          "type_name": "PostingMetadata",
          "entry_count": 48,
          "size_bytes": 3145728
        },
        {
          "component": "positions",
          "type_name": "Position",
          "entry_count": 9,
          "size_bytes": 19922944
        }
      ]
    }
  ]
}
```

### Scalar index

```json
{
  "total_entries": 35,
  "total_size_bytes": 28311552,
  "groups": [
    {
      "cache_prefix": "s3://bucket/dataset/33333333-3333-3333-3333-333333333333",
      "entry_count": 35,
      "size_bytes": 28311552,
      "components": [
        {
          "component": "page",
          "type_name": "BTreePage",
          "entry_count": 32,
          "size_bytes": 25165824
        },
        {
          "component": "BTreeIndexState",
          "type_name": "BTreeIndexState",
          "entry_count": 1,
          "size_bytes": 2097152
        },
        {
          "component": "type",
          "type_name": "ScalarIndexDetails",
          "entry_count": 1,
          "size_bytes": 65536
        },
        {
          "component": "frag_reuse",
          "type_name": "FragReuseIndex",
          "entry_count": 1,
          "size_bytes": 983040
        }
      ]
    }
  ]
}
```