### PR TITLE
feat: expose cached file metadata APIs on FileFragment

### DIFF
--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1620,7 +1620,7 @@ impl FileFragment {
     }
 
     /// Get the file metadata for this fragment, using the cache if available.
-    async fn get_file_metadata(
+    pub async fn get_file_metadata(
         &self,
         file_scheduler: &FileScheduler,
     ) -> Result<Arc<CachedFileMetadata>> {
@@ -1637,7 +1637,7 @@ impl FileFragment {
         Ok(file_metadata)
     }
 
-    async fn get_file_metadata_index(
+    pub async fn get_file_metadata_index(
         &self,
         file_scheduler: &FileScheduler,
         known_schema: Option<(Arc<Schema>, u64)>,


### PR DESCRIPTION
Make the full and indexed file metadata lookup methods public so callers can reuse the fragment's dataset-level metadata cache instead of loading metadata independently through FileReader.

I ran into this while trying to inspect the file footer of a fragment that had already been opened. The obvious option was to call FileReader::read_all_metadata, but that API reads directly from storage and does not reuse the dataset’s file metadata cache. This can result in another metadata I/O even though the fragment has already loaded the same information.

FileFragment already has cache-aware helpers for loading the full metadata or metadata index. This change makes get_file_metadata and get_file_metadata_index public so other fragment-level operations can reuse the existing cached metadata instead of reading it again through FileReader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed file metadata and metadata index access for broader integration and tooling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->