### PR TITLE
chore: reduce CodeRabbit review noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,8 @@
 language: en-US
 early_access: false
 reviews:
-  profile: assertive
+  profile: quiet
+  high_level_summary: false
   poem: false
   review_status: true
   auto_review:


### PR DESCRIPTION
CodeRabbit currently uses the assertive review profile and automatically appends a high-level summary to PR descriptions. This produces more low-signal output than is useful for this repository and modifies author-owned PR text.

Use the quiet profile so automated review focuses on the most important findings, and disable automatic high-level summaries. Authors can still opt in for an individual PR with the `<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated review settings to provide quieter, more focused feedback.
  * Disabled high-level review summaries in favor of concise, targeted comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->` placeholder.
