### PR TITLE
fix(table): route tos:// scheme to ConditionalPutCommitHandler

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1966,29 +1966,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_handler_from_url_conditional_put_schemes() {
+    #[rstest::rstest]
+    #[case::memory("memory://bucket-a/ds")]
+    #[case::shared_memory("shared-memory://bucket-a/ds")]
+    #[case::s3("s3://bucket-a/ds")]
+    #[case::gs("gs://bucket-a/ds")]
+    #[case::az("az://bucket-a/ds")]
+    #[case::abfss("abfss://bucket-a/ds")]
+    #[case::oss("oss://bucket-a/ds")]
+    #[case::cos("cos://bucket-a/ds")]
+    #[case::tos("tos://bucket-a/ds")]
+    async fn test_commit_handler_from_url_conditional_put_schemes(#[case] url: &str) {
         // Every scheme whose store supports atomic put-if-not-exists must
         // route to ConditionalPutCommitHandler — otherwise concurrent writers
         // fall through to UnsafeCommitHandler and silently clobber each
         // other's manifests.
-        for url in [
-            "memory://bucket-a/ds",
-            "shared-memory://bucket-a/ds",
-            "s3://bucket-a/ds",
-            "gs://bucket-a/ds",
-            "az://bucket-a/ds",
-            "abfss://bucket-a/ds",
-            "oss://bucket-a/ds",
-            "cos://bucket-a/ds",
-            "tos://bucket-a/ds",
-        ] {
-            let handler = commit_handler_from_url(url, &None).await.unwrap();
-            assert_eq!(
-                format!("{:?}", handler),
-                "ConditionalPutCommitHandler",
-                "{url} should route to ConditionalPutCommitHandler",
-            );
-        }
+        let handler = commit_handler_from_url(url, &None).await.unwrap();
+        assert_eq!(
+            format!("{:?}", handler),
+            "ConditionalPutCommitHandler",
+            "{url} should route to ConditionalPutCommitHandler",
+        );
     }
 
     /// A [CommitLock] whose lease records whether it was released, so we can

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1091,7 +1091,7 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" | "shared-memory" => {
+        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" | "tos" | "shared-memory" => {
             Ok(Arc::new(ConditionalPutCommitHandler))
         }
         #[cfg(not(feature = "dynamodb"))]
@@ -1966,12 +1966,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_handler_from_url_memory_schemes() {
-        // Both `memory://` and `shared-memory://` must route to
-        // ConditionalPutCommitHandler — otherwise concurrent writers fall
-        // through to UnsafeCommitHandler and silently clobber each other's
-        // manifests.
-        for url in ["memory://bucket-a/ds", "shared-memory://bucket-a/ds"] {
+    async fn test_commit_handler_from_url_conditional_put_schemes() {
+        // Every scheme whose store supports atomic put-if-not-exists must
+        // route to ConditionalPutCommitHandler — otherwise concurrent writers
+        // fall through to UnsafeCommitHandler and silently clobber each
+        // other's manifests.
+        for url in [
+            "memory://bucket-a/ds",
+            "shared-memory://bucket-a/ds",
+            "s3://bucket-a/ds",
+            "gs://bucket-a/ds",
+            "az://bucket-a/ds",
+            "abfss://bucket-a/ds",
+            "oss://bucket-a/ds",
+            "cos://bucket-a/ds",
+            "tos://bucket-a/ds",
+        ] {
             let handler = commit_handler_from_url(url, &None).await.unwrap();
             assert_eq!(
                 format!("{:?}", handler),


### PR DESCRIPTION
The TOS object store provider (#7019) supports atomic put-if-not-exists via OpenDAL (translated to `If-None-Match: *`), but commit_handler_from_url was never updated, so tos:// datasets fell through to UnsafeCommitHandler and concurrent writers could silently clobber each other's manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit handling by expanding which object-storage URL schemes use conditional put behavior (reducing fallback to unsafe handling).
  * Enhanced conditional commit protection to cover additional schemes beyond memory and shared-memory, including cloud object stores.
* **Tests**
  * Updated commit-handler unit tests to validate conditional-put behavior across a wider set of URL schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->