### PR TITLE
fix(python): allow blob writer cleanup across threads

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import gc
 import importlib
 import io
+import queue
 import subprocess
 import sys
 import tarfile
 import textwrap
+import threading
 import uuid
 from pathlib import Path
 
@@ -1377,6 +1380,44 @@ def test_packed_blob_writer_bulk_rejects_non_binary_array(tmp_path, payloads):
 
     packed.write_blob(b"still usable")
     assert len(packed.finish_array("blob")) == 1
+
+
+@pytest.mark.parametrize(
+    "open_writer",
+    [
+        pytest.param("open_packed_blob_writer", id="packed"),
+        pytest.param("open_dedicated_blob_writer", id="dedicated"),
+    ],
+)
+def test_failed_blob_writer_traceback_can_be_released_on_another_thread(
+    tmp_path, monkeypatch, open_writer
+):
+    failures = queue.Queue()
+
+    def fail_with_live_writer():
+        files = LanceFileSession(tmp_path)
+        writer = getattr(files, open_writer)("data-file.lance", 1)
+        assert writer.blob_id == 1
+        try:
+            raise OSError("simulated object-store write failure")
+        except OSError as error:
+            # The traceback retains this frame and its local writer, matching a
+            # writer-thread failure handed to an owning thread for propagation.
+            failures.put(error)
+
+    writer_thread = threading.Thread(target=fail_with_live_writer)
+    writer_thread.start()
+    writer_thread.join(timeout=10)
+    assert not writer_thread.is_alive()
+
+    unraisable = []
+    monkeypatch.setattr(sys, "unraisablehook", unraisable.append)
+    error = failures.get_nowait()
+    assert str(error) == "simulated object-store write failure"
+    del error
+    gc.collect()
+
+    assert unraisable == []
 
 
 def test_blob_extension_write_fragments_external_denied_by_default(tmp_path):

--- a/python/src/blob.rs
+++ b/python/src/blob.rs
@@ -13,12 +13,49 @@ use lance::{
     BlobDescriptor, BlobDescriptorArrayBuilder, BlobRange, DedicatedBlobWriter, PackedBlobWriter,
 };
 use pyo3::{
-    Bound, PyResult,
-    exceptions::PyValueError,
+    Bound, PyErr, PyResult,
+    exceptions::{PyRuntimeError, PyValueError},
     pyclass, pymethods,
     types::{PyAny, PyAnyMethods, PyDict, PyList, PyListMethods, PyModule, PyTypeMethods},
 };
-use std::{borrow::Cow, sync::Arc};
+use std::{
+    borrow::Cow,
+    sync::{Arc, Mutex},
+};
+
+fn with_writer<W, R>(
+    inner: &Mutex<Option<W>>,
+    writer_name: &str,
+    operation: impl FnOnce(&W) -> R,
+) -> PyResult<R> {
+    let guard = inner.lock().map_err(|_| poisoned_writer(writer_name))?;
+    let writer = guard.as_ref().ok_or_else(|| finished_writer(writer_name))?;
+    Ok(operation(writer))
+}
+
+fn writer_mut<'a, W>(inner: &'a mut Mutex<Option<W>>, writer_name: &str) -> PyResult<&'a mut W> {
+    inner
+        .get_mut()
+        .map_err(|_| poisoned_writer(writer_name))?
+        .as_mut()
+        .ok_or_else(|| finished_writer(writer_name))
+}
+
+fn take_writer<W>(inner: &mut Mutex<Option<W>>, writer_name: &str) -> PyResult<W> {
+    inner
+        .get_mut()
+        .map_err(|_| poisoned_writer(writer_name))?
+        .take()
+        .ok_or_else(|| finished_writer(writer_name))
+}
+
+fn finished_writer(writer_name: &str) -> PyErr {
+    PyValueError::new_err(format!("{writer_name} is already finished"))
+}
+
+fn poisoned_writer(writer_name: &str) -> PyErr {
+    PyRuntimeError::new_err(format!("{writer_name} lock is poisoned"))
+}
 
 /// Reconstruct the PyArrow equivalent of [`BlobDescriptorArrayBuilder::field`].
 ///
@@ -237,10 +274,10 @@ impl PyBlobDescriptorArrayBuilder {
     }
 }
 
-#[pyclass(name = "PackedBlobWriter", skip_from_py_object, unsendable)]
+#[pyclass(name = "PackedBlobWriter", skip_from_py_object)]
 pub struct PyPackedBlobWriter {
     field: Option<Field>,
-    inner: Option<PackedBlobWriter>,
+    inner: Mutex<Option<PackedBlobWriter>>,
 }
 
 impl PyPackedBlobWriter {
@@ -255,20 +292,20 @@ impl PyPackedBlobWriter {
                 .infer_error()?;
         Ok(Self {
             field: None,
-            inner: Some(inner),
+            inner: Mutex::new(Some(inner)),
         })
     }
 
-    fn inner(&self) -> PyResult<&PackedBlobWriter> {
-        self.inner
-            .as_ref()
-            .ok_or_else(|| PyValueError::new_err("PackedBlobWriter is already finished"))
+    fn with_inner<R>(&self, operation: impl FnOnce(&PackedBlobWriter) -> R) -> PyResult<R> {
+        with_writer(&self.inner, "PackedBlobWriter", operation)
     }
 
     fn inner_mut(&mut self) -> PyResult<&mut PackedBlobWriter> {
-        self.inner
-            .as_mut()
-            .ok_or_else(|| PyValueError::new_err("PackedBlobWriter is already finished"))
+        writer_mut(&mut self.inner, "PackedBlobWriter")
+    }
+
+    fn take_inner(&mut self) -> PyResult<PackedBlobWriter> {
+        take_writer(&mut self.inner, "PackedBlobWriter")
     }
 }
 
@@ -276,12 +313,12 @@ impl PyPackedBlobWriter {
 impl PyPackedBlobWriter {
     #[getter]
     pub fn blob_id(&self) -> PyResult<u32> {
-        Ok(self.inner()?.blob_id())
+        self.with_inner(PackedBlobWriter::blob_id)
     }
 
     #[getter]
     pub fn path(&self) -> PyResult<String> {
-        Ok(self.inner()?.path().to_string())
+        self.with_inner(|writer| writer.path().to_string())
     }
 
     /// The descriptor field associated with the array returned by
@@ -328,10 +365,7 @@ impl PyPackedBlobWriter {
     pub fn write_blobs(&mut self, payloads: &Bound<'_, PyAny>) -> PyResult<()> {
         let payloads = extract_blob_payloads(payloads)?;
         let result = {
-            let writer = self
-                .inner
-                .as_mut()
-                .ok_or_else(|| PyValueError::new_err("PackedBlobWriter is already finished"))?;
+            let writer = self.inner_mut()?;
             rt().block_on(None, async {
                 for payloads in payloads {
                     match payloads.data_type() {
@@ -357,17 +391,14 @@ impl PyPackedBlobWriter {
                 // KeyboardInterrupt drops the async batch future. Remove the core
                 // writer as well so RAII cleanup runs and a completed prefix cannot
                 // be reused as a new batch.
-                self.inner.take();
+                self.take_inner()?;
                 Err(error)
             }
         }
     }
 
     pub fn finish(&mut self) -> PyResult<Vec<PyBlobDescriptor>> {
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| PyValueError::new_err("PackedBlobWriter is already finished"))?;
+        let inner = self.take_inner()?;
         let values = rt().block_on(None, inner.finish())?.infer_error()?;
         Ok(values.into_iter().map(Into::into).collect())
     }
@@ -403,10 +434,7 @@ impl PyPackedBlobWriter {
         py: pyo3::Python<'py>,
         field_name: String,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| PyValueError::new_err("PackedBlobWriter is already finished"))?;
+        let inner = self.take_inner()?;
         let values = rt().block_on(None, inner.finish())?.infer_error()?;
         let mut builder = BlobDescriptorArrayBuilder::new(field_name);
         builder.extend(values).infer_error()?;
@@ -418,9 +446,9 @@ impl PyPackedBlobWriter {
     }
 }
 
-#[pyclass(name = "DedicatedBlobWriter", skip_from_py_object, unsendable)]
+#[pyclass(name = "DedicatedBlobWriter", skip_from_py_object)]
 pub struct PyDedicatedBlobWriter {
-    inner: Option<DedicatedBlobWriter>,
+    inner: Mutex<Option<DedicatedBlobWriter>>,
 }
 
 impl PyDedicatedBlobWriter {
@@ -433,19 +461,21 @@ impl PyDedicatedBlobWriter {
             DedicatedBlobWriter::try_new(object_store.as_ref().clone(), data_file_path, blob_id)
                 .await
                 .infer_error()?;
-        Ok(Self { inner: Some(inner) })
+        Ok(Self {
+            inner: Mutex::new(Some(inner)),
+        })
     }
 
-    fn inner(&self) -> PyResult<&DedicatedBlobWriter> {
-        self.inner
-            .as_ref()
-            .ok_or_else(|| PyValueError::new_err("DedicatedBlobWriter is already finished"))
+    fn with_inner<R>(&self, operation: impl FnOnce(&DedicatedBlobWriter) -> R) -> PyResult<R> {
+        with_writer(&self.inner, "DedicatedBlobWriter", operation)
     }
 
     fn inner_mut(&mut self) -> PyResult<&mut DedicatedBlobWriter> {
-        self.inner
-            .as_mut()
-            .ok_or_else(|| PyValueError::new_err("DedicatedBlobWriter is already finished"))
+        writer_mut(&mut self.inner, "DedicatedBlobWriter")
+    }
+
+    fn take_inner(&mut self) -> PyResult<DedicatedBlobWriter> {
+        take_writer(&mut self.inner, "DedicatedBlobWriter")
     }
 }
 
@@ -453,12 +483,12 @@ impl PyDedicatedBlobWriter {
 impl PyDedicatedBlobWriter {
     #[getter]
     pub fn blob_id(&self) -> PyResult<u32> {
-        Ok(self.inner()?.blob_id())
+        self.with_inner(DedicatedBlobWriter::blob_id)
     }
 
     #[getter]
     pub fn path(&self) -> PyResult<String> {
-        Ok(self.inner()?.path().to_string())
+        self.with_inner(|writer| writer.path().to_string())
     }
 
     pub fn write(&mut self, data: Vec<u8>) -> PyResult<()> {
@@ -467,10 +497,7 @@ impl PyDedicatedBlobWriter {
     }
 
     pub fn finish(&mut self) -> PyResult<PyBlobDescriptor> {
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| PyValueError::new_err("DedicatedBlobWriter is already finished"))?;
+        let inner = self.take_inner()?;
         let value = rt().block_on(None, inner.finish())?.infer_error()?;
         Ok(value.into())
     }


### PR DESCRIPTION
## Summary

- make the Python `PackedBlobWriter` and `DedicatedBlobWriter` wrappers safe to release on a thread other than the one that created them
- replace PyO3's `unsendable` restriction with mutex-protected writer ownership
- add a production-shaped regression test covering both writer types

## Motivation

Geneva's Blob v2 checkpoint path prepares packed blob sidecars on a dedicated checkpoint-writer thread. During a large Azure benchmark, Azure returned `503 ServerBusy` from a multipart block `PUT`. The checkpoint thread propagated that object-store exception to the actor's owner thread.

The original exception retained its Python traceback. That traceback retained the checkpoint frame and its local `PackedBlobWriter`, so the last reference to the writer was eventually released by the owner thread rather than the checkpoint thread. Because the binding declared the writer as `#[pyclass(unsendable)]`, PyO3 emitted a second unraisable exception:

```text
RuntimeError: lance::blob::PyPackedBlobWriter is unsendable, but is being dropped on another thread
```

This secondary error appeared at unrelated Python stack locations, obscured the original Azure failure, and prevented normal RAII cleanup of the writer on that path. The same ownership problem applies to `DedicatedBlobWriter`, which used the same binding policy.

## Root cause

The core Rust blob writers are `Send`, so transferring ownership for destruction is safe. They are not `Sync`, however, because the underlying `dyn Writer` is not shareable for concurrent access. PyO3 0.28 requires ordinary Python classes to be both `Send` and `Sync`; simply removing `unsendable` therefore does not compile.

## Fix

Store each core writer as `Mutex<Option<Writer>>` and remove the `unsendable` annotation. The mutex makes the Python wrapper `Send + Sync` while retaining exclusive access to the non-`Sync` writer. Existing mutation and finish semantics remain unchanged:

- completed writers still raise the existing `ValueError`
- writer ownership is still consumed by `finish`
- failed bulk writes still drop their active writer through RAII
- a poisoned lock surfaces as a descriptive Python `RuntimeError`

There is no public Python API change.

## Regression coverage

The new parameterized test models the production lifetime directly:

1. create a packed or dedicated writer on a worker thread
2. raise and hand an exception containing that thread's traceback to the owner thread
3. release the exception and force garbage collection on the owner thread
4. assert that `sys.unraisablehook` receives no cross-thread destruction error

The test fails on `main` with the same `PyPackedBlobWriter is unsendable` / `PyDedicatedBlobWriter is unsendable` messages and passes with this change.

## Validation

- `uv run make build`
- `uv run pytest -q python/tests/test_blob.py -k 'packed_blob_writer or failed_blob_writer'` — 32 passed
- `uv run pytest -q python/tests/test_blob.py` — 139 passed
- `uv run make lint` — Ruff, Pyright (0 errors), Rust formatting, and Clippy passed
- commit hooks — Ruff, Ruff format, Rust formatting, and typos passed
