### PR TITLE
test(vector): tolerate SIMD distance rounding

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2468,7 +2468,7 @@ def test_vector_index_distance_range(tmp_path):
     assert np.all(index_distances >= distance_range[0]) and np.all(
         index_distances < distance_range[1]
     )
-    assert np.allclose(brute_distances, index_distances, rtol=0.0, atol=0.0)
+    assert np.allclose(brute_distances, index_distances, rtol=1e-5, atol=0.0)
 
 
 # =============================================================================


### PR DESCRIPTION
## What is the bug?

`test_vector_index_distance_range` requires exact equality between brute-force and indexed `float32` distances. The two paths can use different scalar and runtime-dispatched SIMD reduction orders, producing a few ULPs of rounding difference even when the results are equivalent.

## What issues does this cause?

The test fails intermittently on x86 CI across unrelated changes, while the returned IDs, ordering, and distance-range checks all pass.

## How does this PR fix the problem?

Use a relative tolerance of `1e-5` for the distance comparison while retaining `atol=0.0`. This matches the expected precision of the alternative `float32` kernels without weakening the range or result checks.

## Validation

- `uv run pytest python/tests/test_vector_index.py::test_vector_index_distance_range -q`
- `uv run make lint`