### PR TITLE
fix(index): reuse cached FTS document lengths

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -6131,12 +6131,75 @@ const fn build_dequantized_doc_lengths() -> [u32; 256] {
     table
 }
 
+#[derive(Debug, Clone)]
+enum NumTokens {
+    Owned(Vec<u32>),
+    Shared(ScalarBuffer<u32>),
+}
+
+impl Default for NumTokens {
+    fn default() -> Self {
+        Self::Owned(Vec::new())
+    }
+}
+
+impl std::ops::Deref for NumTokens {
+    type Target = [u32];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(values) => values,
+            Self::Shared(values) => values,
+        }
+    }
+}
+
+impl DeepSizeOf for NumTokens {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        match self {
+            Self::Owned(values) => values.deep_size_of_children(context),
+            Self::Shared(values) => values.deep_size_of_children(context),
+        }
+    }
+}
+
+impl NumTokens {
+    fn with_capacity(capacity: usize) -> Self {
+        Self::Owned(Vec::with_capacity(capacity))
+    }
+
+    fn into_owned(self) -> Vec<u32> {
+        match self {
+            Self::Owned(values) => values,
+            Self::Shared(values) => values.to_vec(),
+        }
+    }
+
+    fn push(&mut self, value: u32) {
+        match self {
+            Self::Owned(values) => values.push(value),
+            Self::Shared(values) => {
+                let mut owned = values.to_vec();
+                owned.push(value);
+                *self = Self::Owned(owned);
+            }
+        }
+    }
+
+    fn memory_size(&self) -> usize {
+        match self {
+            Self::Owned(values) => values.capacity() * std::mem::size_of::<u32>(),
+            Self::Shared(values) => values.inner().capacity(),
+        }
+    }
+}
+
 // DocSet is a mapping from row ids to the number of tokens in the document
 // It's used to sort the documents by the bm25 score
 #[derive(Debug, Clone, Default)]
 pub struct DocSet {
     row_ids: Vec<u64>,
-    num_tokens: Vec<u32>,
+    num_tokens: NumTokens,
     // (row_id, doc_id) pairs sorted by row_id
     inv: Vec<(u64, u32)>,
 
@@ -6301,11 +6364,20 @@ impl DocSet {
     /// `num_tokens_by_row_id` calls, and the per-partition caller
     /// resolves doc_id → row_id for the surviving top-K post-wand.
     pub fn from_num_tokens_only(num_tokens_col: &arrow_array::UInt32Array) -> Self {
-        let num_tokens = num_tokens_col.values().to_vec();
-        let total_tokens = num_tokens.iter().map(|&n| n as u64).sum();
+        let total_tokens = num_tokens_col.values().iter().map(|&n| n as u64).sum();
+        Self::from_cached_num_tokens(num_tokens_col, total_tokens)
+    }
+
+    /// Build a zero-copy num-tokens-only view from an Arrow column and its
+    /// already-computed total. The caller must guarantee that `total_tokens`
+    /// is the sum of `num_tokens_col`.
+    pub(crate) fn from_cached_num_tokens(
+        num_tokens_col: &arrow_array::UInt32Array,
+        total_tokens: u64,
+    ) -> Self {
         Self {
             row_ids: Vec::new(),
-            num_tokens,
+            num_tokens: NumTokens::Shared(num_tokens_col.values().clone()),
             inv: Vec::new(),
             total_tokens,
             scoring_quantized: false,
@@ -6342,7 +6414,7 @@ impl DocSet {
             let total_tokens = num_tokens.iter().map(|&x| x as u64).sum();
             return Ok(Self {
                 row_ids,
-                num_tokens,
+                num_tokens: NumTokens::Owned(num_tokens),
                 inv: Vec::new(),
                 total_tokens,
                 scoring_quantized: false,
@@ -6385,7 +6457,7 @@ impl DocSet {
             let total_tokens = num_tokens.iter().map(|&x| x as u64).sum();
             return Ok(Self {
                 row_ids,
-                num_tokens,
+                num_tokens: NumTokens::Owned(num_tokens),
                 inv,
                 total_tokens,
                 scoring_quantized: false,
@@ -6406,7 +6478,7 @@ impl DocSet {
         let total_tokens = num_tokens.iter().map(|&x| x as u64).sum();
         Ok(Self {
             row_ids,
-            num_tokens,
+            num_tokens: NumTokens::Owned(num_tokens),
             inv,
             total_tokens,
             scoring_quantized: false,
@@ -6420,7 +6492,8 @@ impl DocSet {
         let mut removed = Vec::new();
         let len = self.len();
         let row_ids = std::mem::replace(&mut self.row_ids, Vec::with_capacity(len));
-        let num_tokens = std::mem::replace(&mut self.num_tokens, Vec::with_capacity(len));
+        let num_tokens =
+            std::mem::replace(&mut self.num_tokens, NumTokens::with_capacity(len)).into_owned();
         self.invalidate_norms();
         self.total_tokens = 0;
         for (doc_id, (row_id, num_token)) in std::iter::zip(row_ids, num_tokens).enumerate() {
@@ -6511,7 +6584,7 @@ impl DocSet {
 
     pub(crate) fn memory_size(&self) -> usize {
         self.row_ids.capacity() * std::mem::size_of::<u64>()
-            + self.num_tokens.capacity() * std::mem::size_of::<u32>()
+            + self.num_tokens.memory_size()
             + self.inv.capacity() * std::mem::size_of::<(u64, u32)>()
     }
 }
@@ -7168,6 +7241,53 @@ mod tests {
         let metadata = HashMap::from([(POSTING_BLOCK_SIZE_KEY.to_owned(), "129".to_owned())]);
         let err = parse_posting_block_size(&metadata).unwrap_err();
         assert!(err.to_string().contains("block_size"));
+    }
+
+    #[test]
+    fn test_num_tokens_only_reuses_sliced_arrow_storage() {
+        let docs = {
+            let source = UInt32Array::from(vec![999, 7, 16, 1024, 888]);
+            let sliced = source.slice(1, 3);
+            let mut docs = DocSet::from_num_tokens_only(&sliced);
+
+            let NumTokens::Shared(values) = &docs.num_tokens else {
+                panic!("num-tokens-only DocSet must retain shared Arrow storage");
+            };
+            assert!(values.ptr_eq(sliced.values()));
+            assert_eq!(values.as_ref(), &[7, 16, 1024]);
+            assert_eq!(docs.total_tokens_num(), 1047);
+            docs.set_quantized_scoring(true);
+            assert_eq!(docs.scoring_norms().unwrap().len(), 3);
+            assert_eq!(
+                docs.scoring_num_tokens(0),
+                dequantize_doc_length(quantize_doc_length(7))
+            );
+            assert_eq!(
+                docs.scoring_num_tokens(2),
+                dequantize_doc_length(quantize_doc_length(1024))
+            );
+            docs
+        };
+
+        assert_eq!(docs.len(), 3);
+        assert_eq!(docs.num_tokens(0), 7);
+        assert_eq!(docs.num_tokens(2), 1024);
+    }
+
+    #[test]
+    fn test_cached_num_tokens_uses_supplied_total_and_full_stays_owned() {
+        const CACHED_TOTAL_MARKER: u64 = 123_456;
+
+        let num_tokens = UInt32Array::from(vec![3, 5, 8]);
+        let docs = DocSet::from_cached_num_tokens(&num_tokens, CACHED_TOTAL_MARKER);
+        assert_eq!(docs.total_tokens_num(), CACHED_TOTAL_MARKER);
+        assert!(matches!(&docs.num_tokens, NumTokens::Shared(_)));
+
+        let row_ids = UInt64Array::from(vec![10, 20, 30]);
+        let full = DocSet::from_columns(&row_ids, &num_tokens, false, None).unwrap();
+        assert!(matches!(&full.num_tokens, NumTokens::Owned(_)));
+        assert_eq!(full.total_tokens_num(), 16);
+        assert_eq!(full.row_id(1), 20);
     }
 
     #[test]
@@ -8826,6 +8946,59 @@ mod tests {
 
         let second = index.aggregate_corpus_stats().await.unwrap();
         assert_eq!(second, first);
+    }
+
+    #[tokio::test]
+    async fn test_stats_then_num_tokens_view_reuses_shared_storage() {
+        let (index, _counter, _tmpdir) = load_counted_v2_index(100, LanceCache::no_cache()).await;
+        let partition = index.partitions[0].clone();
+
+        assert_eq!(index.aggregate_corpus_stats().await.unwrap(), (100, 100));
+        assert_eq!(partition.docs.total_tokens_cached(), Some(100));
+
+        let views =
+            futures::future::join_all((0..8).map(|_| partition.docs.ensure_num_tokens_loaded()))
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>>>()
+                .unwrap();
+        let first = &views[0];
+        assert!(views.iter().all(|view| Arc::ptr_eq(first, view)));
+        assert!(!first.has_row_ids());
+        assert!(matches!(&first.num_tokens, NumTokens::Shared(_)));
+        assert_eq!(first.total_tokens_num(), 100);
+
+        let all_rows = RowAddrMask::all_rows();
+        let wand_view = partition.docs.docs_for_wand(&all_rows).await.unwrap();
+        assert!(Arc::ptr_eq(first, &wand_view));
+
+        let filtered = RowAddrMask::allow_nothing();
+        let full = partition.docs.docs_for_wand(&filtered).await.unwrap();
+        assert!(full.has_row_ids());
+        assert!(matches!(&full.num_tokens, NumTokens::Owned(_)));
+        assert_eq!(full.total_tokens_num(), 100);
+        assert_eq!(
+            partition.docs.resolve_row_ids(&[0, 99]).await.unwrap(),
+            [0, 99]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_total_and_num_tokens_view_initialization() {
+        let (index, _counter, _tmpdir) = load_counted_v2_index(100, LanceCache::no_cache()).await;
+        let docs = index.partitions[0].docs.clone();
+
+        let totals = futures::future::join_all((0..8).map(|_| docs.total_tokens_num()));
+        let views = futures::future::join_all((0..8).map(|_| docs.ensure_num_tokens_loaded()));
+        let (totals, views) = tokio::join!(totals, views);
+
+        let totals = totals.into_iter().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(totals, vec![100; 8]);
+        let views = views.into_iter().collect::<Result<Vec<_>>>().unwrap();
+        let first = &views[0];
+        assert!(views.iter().all(|view| Arc::ptr_eq(first, view)));
+        assert!(matches!(&first.num_tokens, NumTokens::Shared(_)));
+        assert_eq!(docs.total_tokens_cached(), Some(100));
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -7157,7 +7157,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     use crate::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
     use lance_tokenizer::{Language, SimpleTokenizer, StopWordFilter, TextAnalyzer};
@@ -8712,10 +8712,40 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct DocsOpenControl {
+        docs_file: String,
+        block_next_open: AtomicBool,
+        fail_next_open: AtomicBool,
+        open_started: tokio::sync::Notify,
+        release_open: tokio::sync::Notify,
+    }
+
+    impl DocsOpenControl {
+        fn new(docs_file: String) -> Self {
+            Self {
+                docs_file,
+                block_next_open: AtomicBool::new(false),
+                fail_next_open: AtomicBool::new(false),
+                open_started: tokio::sync::Notify::new(),
+                release_open: tokio::sync::Notify::new(),
+            }
+        }
+
+        fn block_next(&self) {
+            self.block_next_open.store(true, Ordering::SeqCst);
+        }
+
+        fn fail_next(&self) {
+            self.fail_next_open.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
     struct CountingStore {
         inner: Arc<dyn IndexStore>,
         posting_file: String,
         counter: Arc<PostingMetadataCounter>,
+        docs_open_control: Option<Arc<DocsOpenControl>>,
     }
 
     impl DeepSizeOf for CountingStore {
@@ -8734,6 +8764,7 @@ mod tests {
                 inner: self.inner.clone(),
                 posting_file: self.posting_file.clone(),
                 counter: self.counter.clone(),
+                docs_open_control: self.docs_open_control.clone(),
             })
         }
         fn io_parallelism(&self) -> usize {
@@ -8744,6 +8775,7 @@ mod tests {
                 inner: self.inner.with_io_priority(io_priority),
                 posting_file: self.posting_file.clone(),
                 counter: self.counter.clone(),
+                docs_open_control: self.docs_open_control.clone(),
             })
         }
         async fn new_index_file(
@@ -8754,6 +8786,19 @@ mod tests {
             self.inner.new_index_file(name, schema).await
         }
         async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
+            if let Some(control) = self
+                .docs_open_control
+                .as_ref()
+                .filter(|control| name == control.docs_file)
+            {
+                if control.fail_next_open.swap(false, Ordering::SeqCst) {
+                    return Err(Error::io("injected docs-file open failure"));
+                }
+                if control.block_next_open.swap(false, Ordering::SeqCst) {
+                    control.open_started.notify_one();
+                    control.release_open.notified().await;
+                }
+            }
             let reader = self.inner.open_index_file(name).await?;
             if name == self.posting_file {
                 Ok(Arc::new(CountingPostingReader {
@@ -8804,6 +8849,14 @@ mod tests {
         num_tokens: usize,
         cache: LanceCache,
     ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>, TempObjDir) {
+        load_counted_v2_index_with_docs_open_control(num_tokens, cache, None).await
+    }
+
+    async fn load_counted_v2_index_with_docs_open_control(
+        num_tokens: usize,
+        cache: LanceCache,
+        docs_open_control: Option<Arc<DocsOpenControl>>,
+    ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>, TempObjDir) {
         let tmpdir = TempObjDir::default();
         let inner_store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -8846,6 +8899,7 @@ mod tests {
             inner: inner_store,
             posting_file: posting_file_path(0),
             counter: counter.clone(),
+            docs_open_control,
         });
         let index = InvertedIndex::load(counting_store, None, &cache)
             .await
@@ -8998,6 +9052,79 @@ mod tests {
         let first = &views[0];
         assert!(views.iter().all(|view| Arc::ptr_eq(first, view)));
         assert!(matches!(&first.num_tokens, NumTokens::Shared(_)));
+        assert_eq!(docs.total_tokens_cached(), Some(100));
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_stats_initialization_cannot_publish_partial_docset_state() {
+        let control = Arc::new(DocsOpenControl::new(doc_file_path(0)));
+        let (index, _counter, _tmpdir) = load_counted_v2_index_with_docs_open_control(
+            100,
+            LanceCache::no_cache(),
+            Some(control.clone()),
+        )
+        .await;
+        let docs = index.partitions[0].docs.clone();
+
+        control.block_next();
+        let stats_task = tokio::spawn({
+            let docs = docs.clone();
+            async move { docs.total_tokens_num().await }
+        });
+        control.open_started.notified().await;
+
+        let full_task = tokio::spawn({
+            let docs = docs.clone();
+            async move { docs.ensure_loaded().await }
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !docs.is_full_loaded_for_test() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("full DocSet should be published while the stats read is blocked");
+
+        // Before num-tokens state was published as one snapshot, cancelling
+        // both tasks here could leave `full` initialized but `total_tokens`
+        // empty. The next WAND getter would accept that partial state.
+        if !full_task.is_finished() {
+            full_task.abort();
+        }
+        let _ = full_task.await;
+        stats_task.abort();
+        assert!(stats_task.await.unwrap_err().is_cancelled());
+
+        let wand_docs = docs.ensure_num_tokens_loaded().await.unwrap();
+        assert!(wand_docs.has_row_ids());
+        assert_eq!(wand_docs.total_tokens_num(), 100);
+        assert_eq!(docs.total_tokens_cached(), Some(100));
+    }
+
+    #[tokio::test]
+    async fn test_failed_num_tokens_snapshot_initialization_can_retry() {
+        let control = Arc::new(DocsOpenControl::new(doc_file_path(0)));
+        let (index, _counter, _tmpdir) = load_counted_v2_index_with_docs_open_control(
+            100,
+            LanceCache::no_cache(),
+            Some(control.clone()),
+        )
+        .await;
+        let docs = index.partitions[0].docs.clone();
+
+        control.fail_next();
+        let error = docs.total_tokens_num().await.unwrap_err();
+        assert!(matches!(error, Error::IO { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("injected docs-file open failure")
+        );
+        assert_eq!(docs.total_tokens_cached(), None);
+
+        let wand_docs = docs.ensure_num_tokens_loaded().await.unwrap();
+        assert!(!wand_docs.has_row_ids());
+        assert_eq!(wand_docs.total_tokens_num(), 100);
         assert_eq!(docs.total_tokens_cached(), Some(100));
     }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -7157,7 +7157,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
     use lance_tokenizer::{Language, SimpleTokenizer, StopWordFilter, TextAnalyzer};
@@ -8712,40 +8712,10 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct DocsOpenControl {
-        docs_file: String,
-        block_next_open: AtomicBool,
-        fail_next_open: AtomicBool,
-        open_started: tokio::sync::Notify,
-        release_open: tokio::sync::Notify,
-    }
-
-    impl DocsOpenControl {
-        fn new(docs_file: String) -> Self {
-            Self {
-                docs_file,
-                block_next_open: AtomicBool::new(false),
-                fail_next_open: AtomicBool::new(false),
-                open_started: tokio::sync::Notify::new(),
-                release_open: tokio::sync::Notify::new(),
-            }
-        }
-
-        fn block_next(&self) {
-            self.block_next_open.store(true, Ordering::SeqCst);
-        }
-
-        fn fail_next(&self) {
-            self.fail_next_open.store(true, Ordering::SeqCst);
-        }
-    }
-
-    #[derive(Debug)]
     struct CountingStore {
         inner: Arc<dyn IndexStore>,
         posting_file: String,
         counter: Arc<PostingMetadataCounter>,
-        docs_open_control: Option<Arc<DocsOpenControl>>,
     }
 
     impl DeepSizeOf for CountingStore {
@@ -8764,7 +8734,6 @@ mod tests {
                 inner: self.inner.clone(),
                 posting_file: self.posting_file.clone(),
                 counter: self.counter.clone(),
-                docs_open_control: self.docs_open_control.clone(),
             })
         }
         fn io_parallelism(&self) -> usize {
@@ -8775,7 +8744,6 @@ mod tests {
                 inner: self.inner.with_io_priority(io_priority),
                 posting_file: self.posting_file.clone(),
                 counter: self.counter.clone(),
-                docs_open_control: self.docs_open_control.clone(),
             })
         }
         async fn new_index_file(
@@ -8786,19 +8754,6 @@ mod tests {
             self.inner.new_index_file(name, schema).await
         }
         async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
-            if let Some(control) = self
-                .docs_open_control
-                .as_ref()
-                .filter(|control| name == control.docs_file)
-            {
-                if control.fail_next_open.swap(false, Ordering::SeqCst) {
-                    return Err(Error::io("injected docs-file open failure"));
-                }
-                if control.block_next_open.swap(false, Ordering::SeqCst) {
-                    control.open_started.notify_one();
-                    control.release_open.notified().await;
-                }
-            }
             let reader = self.inner.open_index_file(name).await?;
             if name == self.posting_file {
                 Ok(Arc::new(CountingPostingReader {
@@ -8849,14 +8804,6 @@ mod tests {
         num_tokens: usize,
         cache: LanceCache,
     ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>, TempObjDir) {
-        load_counted_v2_index_with_docs_open_control(num_tokens, cache, None).await
-    }
-
-    async fn load_counted_v2_index_with_docs_open_control(
-        num_tokens: usize,
-        cache: LanceCache,
-        docs_open_control: Option<Arc<DocsOpenControl>>,
-    ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>, TempObjDir) {
         let tmpdir = TempObjDir::default();
         let inner_store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -8899,7 +8846,6 @@ mod tests {
             inner: inner_store,
             posting_file: posting_file_path(0),
             counter: counter.clone(),
-            docs_open_control,
         });
         let index = InvertedIndex::load(counting_store, None, &cache)
             .await
@@ -9052,79 +8998,6 @@ mod tests {
         let first = &views[0];
         assert!(views.iter().all(|view| Arc::ptr_eq(first, view)));
         assert!(matches!(&first.num_tokens, NumTokens::Shared(_)));
-        assert_eq!(docs.total_tokens_cached(), Some(100));
-    }
-
-    #[tokio::test]
-    async fn test_cancelled_stats_initialization_cannot_publish_partial_docset_state() {
-        let control = Arc::new(DocsOpenControl::new(doc_file_path(0)));
-        let (index, _counter, _tmpdir) = load_counted_v2_index_with_docs_open_control(
-            100,
-            LanceCache::no_cache(),
-            Some(control.clone()),
-        )
-        .await;
-        let docs = index.partitions[0].docs.clone();
-
-        control.block_next();
-        let stats_task = tokio::spawn({
-            let docs = docs.clone();
-            async move { docs.total_tokens_num().await }
-        });
-        control.open_started.notified().await;
-
-        let full_task = tokio::spawn({
-            let docs = docs.clone();
-            async move { docs.ensure_loaded().await }
-        });
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while !docs.is_full_loaded_for_test() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("full DocSet should be published while the stats read is blocked");
-
-        // Before num-tokens state was published as one snapshot, cancelling
-        // both tasks here could leave `full` initialized but `total_tokens`
-        // empty. The next WAND getter would accept that partial state.
-        if !full_task.is_finished() {
-            full_task.abort();
-        }
-        let _ = full_task.await;
-        stats_task.abort();
-        assert!(stats_task.await.unwrap_err().is_cancelled());
-
-        let wand_docs = docs.ensure_num_tokens_loaded().await.unwrap();
-        assert!(wand_docs.has_row_ids());
-        assert_eq!(wand_docs.total_tokens_num(), 100);
-        assert_eq!(docs.total_tokens_cached(), Some(100));
-    }
-
-    #[tokio::test]
-    async fn test_failed_num_tokens_snapshot_initialization_can_retry() {
-        let control = Arc::new(DocsOpenControl::new(doc_file_path(0)));
-        let (index, _counter, _tmpdir) = load_counted_v2_index_with_docs_open_control(
-            100,
-            LanceCache::no_cache(),
-            Some(control.clone()),
-        )
-        .await;
-        let docs = index.partitions[0].docs.clone();
-
-        control.fail_next();
-        let error = docs.total_tokens_num().await.unwrap_err();
-        assert!(matches!(error, Error::IO { .. }));
-        assert!(
-            error
-                .to_string()
-                .contains("injected docs-file open failure")
-        );
-        assert_eq!(docs.total_tokens_cached(), None);
-
-        let wand_docs = docs.ensure_num_tokens_loaded().await.unwrap();
-        assert!(!wand_docs.has_row_ids());
-        assert_eq!(wand_docs.total_tokens_num(), 100);
         assert_eq!(docs.total_tokens_cached(), Some(100));
     }
 

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -182,14 +182,6 @@ impl LazyDocSet {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn is_full_loaded_for_test(&self) -> bool {
-        match self {
-            Self::Loaded(_) => true,
-            Self::Deferred(d) => d.full.initialized(),
-        }
-    }
-
     /// Sync read of cached `total_tokens`. Returns `None` for a
     /// `Deferred` LazyDocSet that hasn't yet had any of
     /// `total_tokens_num` / `ensure_num_tokens_loaded` / `ensure_loaded`
@@ -375,5 +367,39 @@ impl DeferredDocSet {
         let batch = reader.read_ranges(&ranges, Some(&[ROW_ID])).await?;
         let arr = batch[ROW_ID].as_primitive::<UInt64Type>();
         Ok((0..arr.len()).map(|i| arr.value(i)).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scalar::lance_format::LanceIndexStore;
+    use lance_core::cache::LanceCache;
+    use lance_core::utils::tempfile::TempObjDir;
+    use lance_io::object_store::ObjectStore;
+
+    #[tokio::test]
+    async fn test_full_docset_is_a_complete_cached_snapshot() {
+        let temp_dir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            temp_dir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let docs = LazyDocSet::new(store, "unused".to_owned(), 3, false, None, false);
+        assert_eq!(docs.total_tokens_cached(), None);
+
+        let row_ids = UInt64Array::from(vec![10, 20, 30]);
+        let num_tokens = UInt32Array::from(vec![3, 5, 8]);
+        let full = Arc::new(DocSet::from_columns(&row_ids, &num_tokens, false, None).unwrap());
+        let LazyDocSet::Deferred(deferred) = &docs else {
+            panic!("expected a deferred DocSet");
+        };
+        deferred.full.set(full.clone()).unwrap();
+
+        let wand_docs = docs.ensure_num_tokens_loaded().await.unwrap();
+        assert!(Arc::ptr_eq(&wand_docs, &full));
+        assert_eq!(wand_docs.total_tokens_num(), 16);
+        assert_eq!(docs.total_tokens_cached(), Some(16));
     }
 }

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -19,9 +19,10 @@ use std::sync::Arc;
 
 use arrow::array::AsArray;
 use arrow::datatypes::{UInt32Type, UInt64Type};
-use arrow_array::{UInt32Array, UInt64Array};
+use arrow_array::{Array, UInt32Array, UInt64Array};
 use lance_core::ROW_ID;
 use lance_core::Result;
+use lance_core::deepsize::DeepSizeOf;
 use tokio::sync::OnceCell;
 
 use crate::scalar::RowIdRemapper;
@@ -102,7 +103,7 @@ impl std::fmt::Debug for LazyDocSet {
     }
 }
 
-impl lance_core::deepsize::DeepSizeOf for LazyDocSet {
+impl DeepSizeOf for LazyDocSet {
     fn deep_size_of_children(&self, ctx: &mut lance_core::deepsize::Context) -> usize {
         match self {
             Self::Loaded(l) => l.docs.deep_size_of_children(ctx),
@@ -117,11 +118,17 @@ impl lance_core::deepsize::DeepSizeOf for LazyDocSet {
                         .unwrap_or(0)
                     + d.num_tokens_col
                         .get()
-                        .map(|arr| arr.len() * std::mem::size_of::<u32>())
+                        .map(|arr| {
+                            let arr: &dyn Array = arr.as_ref();
+                            arr.deep_size_of_children(ctx)
+                        })
                         .unwrap_or(0)
                     + d.row_ids_col
                         .get()
-                        .map(|arr| arr.len() * std::mem::size_of::<u64>())
+                        .map(|arr| {
+                            let arr: &dyn Array = arr.as_ref();
+                            arr.deep_size_of_children(ctx)
+                        })
                         .unwrap_or(0)
             }
         }
@@ -214,9 +221,8 @@ impl LazyDocSet {
     /// Materialize a DocSet that carries num_tokens but no row_ids.
     /// Used by the deferred-row_id scoring path; the per-partition
     /// caller resolves surviving doc_ids -> row_ids post-wand via
-    /// [`Self::resolve_row_ids`]. The result is NOT cached on the
-    /// LazyDocSet -- a later `ensure_loaded` must still produce a
-    /// full DocSet.
+    /// [`Self::resolve_row_ids`]. The tokens-only result is cached separately;
+    /// a later `ensure_loaded` must still produce a full DocSet.
     pub async fn ensure_num_tokens_loaded(&self) -> Result<Arc<DocSet>> {
         match self {
             Self::Loaded(l) => Ok(l.docs.clone()),
@@ -260,18 +266,17 @@ impl DeferredDocSet {
     }
 
     async fn total_tokens_num(&self) -> Result<u64> {
-        if let Some(v) = self.total_tokens.get() {
-            return Ok(*v);
-        }
-        if let Some(full) = self.full.get() {
-            let v = full.total_tokens_num();
-            let _ = self.total_tokens.set(v);
-            return Ok(v);
-        }
-        let col = self.num_tokens_column().await?;
-        let sum: u64 = col.values().iter().map(|&n| n as u64).sum();
-        let _ = self.total_tokens.set(sum);
-        Ok(sum)
+        let total_tokens = self
+            .total_tokens
+            .get_or_try_init(|| async {
+                if let Some(full) = self.full.get() {
+                    return Result::Ok(full.total_tokens_num());
+                }
+                let col = self.num_tokens_column().await?;
+                Result::Ok(col.values().iter().map(|&n| n as u64).sum())
+            })
+            .await?;
+        Ok(*total_tokens)
     }
 
     async fn num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
@@ -328,7 +333,9 @@ impl DeferredDocSet {
             })
             .await?
             .clone();
-        let _ = self.total_tokens.set(docs.total_tokens_num());
+        self.total_tokens
+            .get_or_init(|| async { docs.total_tokens_num() })
+            .await;
         Ok(docs)
     }
 
@@ -336,17 +343,17 @@ impl DeferredDocSet {
         if let Some(full) = self.full.get() {
             return Ok(full.clone());
         }
+        let total_tokens = self.total_tokens_num().await?;
         let docs = self
             .tokens_only
             .get_or_try_init(|| async {
                 let num_tokens = self.num_tokens_column().await?;
-                let mut docs = DocSet::from_num_tokens_only(num_tokens.as_ref());
+                let mut docs = DocSet::from_cached_num_tokens(num_tokens.as_ref(), total_tokens);
                 docs.set_quantized_scoring(self.quantized_scoring);
                 Result::Ok(Arc::new(docs))
             })
             .await?
             .clone();
-        let _ = self.total_tokens.set(docs.total_tokens_num());
         Ok(docs)
     }
 

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -50,6 +50,16 @@ pub struct LoadedDocSet {
     total_tokens: u64,
 }
 
+/// Atomically published num-tokens state for deferred scoring.
+///
+/// Keeping the Arrow column and the zero-copy `DocSet` view that carries its
+/// total in one `OnceCell` prevents cancellation from exposing a partially
+/// initialized scoring cache.
+struct NumTokensSnapshot {
+    column: Arc<UInt32Array>,
+    docs: Arc<DocSet>,
+}
+
 /// Store-backed DocSet view that loads on demand and caches.
 ///
 /// Holds the [`IndexStore`] and docs-file path rather than an open
@@ -70,19 +80,13 @@ pub struct DeferredDocSet {
     quantized_scoring: bool,
     /// Doc count cached at construction so `len()` stays sync + IO-free.
     num_rows: usize,
-    /// `sum(num_tokens)` cached on first compute.
-    total_tokens: OnceCell<u64>,
-    /// `NUM_TOKEN_COL` arrow buffer cached on first read.
-    num_tokens_col: OnceCell<Arc<UInt32Array>>,
+    /// `NUM_TOKEN_COL` and its zero-copy scoring view carrying the cached sum,
+    /// published together on first read.
+    num_tokens: OnceCell<NumTokensSnapshot>,
     /// `ROW_ID` arrow buffer cached on first read.
     row_ids_col: OnceCell<Arc<UInt64Array>>,
     /// Full DocSet, materialized on first `ensure_loaded`.
     full: OnceCell<Arc<DocSet>>,
-    /// num_tokens-only DocSet, materialized on first
-    /// `ensure_num_tokens_loaded`. Cached because wand scoring calls this
-    /// once per query per partition; rebuilding it copied the whole
-    /// num_tokens column (tens of MB per partition) on every query.
-    tokens_only: OnceCell<Arc<DocSet>>,
 }
 
 impl std::fmt::Debug for LazyDocSet {
@@ -96,7 +100,11 @@ impl std::fmt::Debug for LazyDocSet {
             Self::Deferred(d) => f
                 .debug_struct("LazyDocSet::Deferred")
                 .field("num_rows", &d.num_rows)
-                .field("total_tokens_loaded", &d.total_tokens.initialized())
+                .field(
+                    "total_tokens_loaded",
+                    &(d.num_tokens.initialized() || d.full.initialized()),
+                )
+                .field("num_tokens_loaded", &d.num_tokens.initialized())
                 .field("full_loaded", &d.full.initialized())
                 .finish(),
         }
@@ -112,15 +120,12 @@ impl DeepSizeOf for LazyDocSet {
                     .get()
                     .map(|d| d.deep_size_of_children(ctx))
                     .unwrap_or(0)
-                    + d.tokens_only
+                    + d.num_tokens
                         .get()
-                        .map(|d| d.deep_size_of_children(ctx))
-                        .unwrap_or(0)
-                    + d.num_tokens_col
-                        .get()
-                        .map(|arr| {
-                            let arr: &dyn Array = arr.as_ref();
-                            arr.deep_size_of_children(ctx)
+                        .map(|snapshot| {
+                            let arr: &dyn Array = snapshot.column.as_ref();
+                            snapshot.docs.deep_size_of_children(ctx)
+                                + arr.deep_size_of_children(ctx)
                         })
                         .unwrap_or(0)
                     + d.row_ids_col
@@ -152,11 +157,9 @@ impl LazyDocSet {
             frag_reuse_index,
             quantized_scoring,
             num_rows,
-            total_tokens: OnceCell::new(),
-            num_tokens_col: OnceCell::new(),
+            num_tokens: OnceCell::new(),
             row_ids_col: OnceCell::new(),
             full: OnceCell::new(),
-            tokens_only: OnceCell::new(),
         }))
     }
 
@@ -179,6 +182,14 @@ impl LazyDocSet {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_full_loaded_for_test(&self) -> bool {
+        match self {
+            Self::Loaded(_) => true,
+            Self::Deferred(d) => d.full.initialized(),
+        }
+    }
+
     /// Sync read of cached `total_tokens`. Returns `None` for a
     /// `Deferred` LazyDocSet that hasn't yet had any of
     /// `total_tokens_num` / `ensure_num_tokens_loaded` / `ensure_loaded`
@@ -187,7 +198,15 @@ impl LazyDocSet {
     pub fn total_tokens_cached(&self) -> Option<u64> {
         match self {
             Self::Loaded(l) => Some(l.total_tokens),
-            Self::Deferred(d) => d.total_tokens.get().copied(),
+            Self::Deferred(d) => d
+                .full
+                .get()
+                .map(|docs| docs.total_tokens_num())
+                .or_else(|| {
+                    d.num_tokens
+                        .get()
+                        .map(|snapshot| snapshot.docs.total_tokens_num())
+                }),
         }
     }
 
@@ -266,32 +285,29 @@ impl DeferredDocSet {
     }
 
     async fn total_tokens_num(&self) -> Result<u64> {
-        let total_tokens = self
-            .total_tokens
-            .get_or_try_init(|| async {
-                if let Some(full) = self.full.get() {
-                    return Result::Ok(full.total_tokens_num());
-                }
-                let col = self.num_tokens_column().await?;
-                Result::Ok(col.values().iter().map(|&n| n as u64).sum())
-            })
-            .await?;
-        Ok(*total_tokens)
+        if let Some(full) = self.full.get() {
+            return Ok(full.total_tokens_num());
+        }
+        Ok(self.num_tokens_snapshot().await?.docs.total_tokens_num())
     }
 
-    async fn num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
-        self.num_tokens_col
+    async fn num_tokens_snapshot(&self) -> Result<&NumTokensSnapshot> {
+        self.num_tokens
             .get_or_try_init(|| async {
                 let reader = self.reader().await?;
                 let batch = reader
                     .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
                     .await?;
-                Result::Ok(Arc::new(
-                    batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>().clone(),
-                ))
+                let column = Arc::new(batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>().clone());
+                let total_tokens = column.values().iter().map(|&n| n as u64).sum();
+                let mut docs = DocSet::from_cached_num_tokens(column.as_ref(), total_tokens);
+                docs.set_quantized_scoring(self.quantized_scoring);
+                Result::Ok(NumTokensSnapshot {
+                    column,
+                    docs: Arc::new(docs),
+                })
             })
             .await
-            .cloned()
     }
 
     async fn row_ids_column(&self) -> Result<Arc<UInt64Array>> {
@@ -311,12 +327,11 @@ impl DeferredDocSet {
             .get_or_try_init(|| async {
                 // If the stats path already pulled NUM_TOKEN_COL,
                 // read only ROW_ID and rebuild from the two columns.
-                let mut docs = if self.num_tokens_col.get().is_some() {
-                    let num_tokens = self.num_tokens_column().await?;
+                let mut docs = if let Some(num_tokens) = self.num_tokens.get() {
                     let row_ids = self.row_ids_column().await?;
                     DocSet::from_columns(
                         row_ids.as_ref(),
-                        num_tokens.as_ref(),
+                        num_tokens.column.as_ref(),
                         self.is_legacy,
                         self.frag_reuse_index.clone(),
                     )?
@@ -333,9 +348,6 @@ impl DeferredDocSet {
             })
             .await?
             .clone();
-        self.total_tokens
-            .get_or_init(|| async { docs.total_tokens_num() })
-            .await;
         Ok(docs)
     }
 
@@ -343,18 +355,7 @@ impl DeferredDocSet {
         if let Some(full) = self.full.get() {
             return Ok(full.clone());
         }
-        let total_tokens = self.total_tokens_num().await?;
-        let docs = self
-            .tokens_only
-            .get_or_try_init(|| async {
-                let num_tokens = self.num_tokens_column().await?;
-                let mut docs = DocSet::from_cached_num_tokens(num_tokens.as_ref(), total_tokens);
-                docs.set_quantized_scoring(self.quantized_scoring);
-                Result::Ok(Arc::new(docs))
-            })
-            .await?
-            .clone();
-        Ok(docs)
+        Ok(self.num_tokens_snapshot().await?.docs.clone())
     }
 
     async fn resolve_row_ids(&self, doc_ids: &[u32]) -> Result<Vec<u64>> {


### PR DESCRIPTION
## Why

FTS corpus stats already read and cache each partition's Arrow document-length column and compute its total token count. The first WAND match then copied that entire column into a new Vec and summed it again while building the num-tokens-only DocSet. On large partitions this introduced O(rows) anonymous-page work for every PE/index partition even when no index parts were loaded.

## What

Make the num-tokens-only DocSet retain a shared ScalarBuffer view and accept the previously cached total. Full DocSet materialization remains owned for masks, fragment reuse, remapping, and row-id semantics. Total initialization is single-flight, and retained-memory accounting deduplicates the shared Arrow storage.

This removes the confirmed first-touch copy and repeated sum without changing WAND behavior or broadening prewarm or cache scope.
