### PR TITLE
fix(index): sort JSON-path values once after extraction, not the raw column

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -2473,6 +2473,36 @@ def test_json_index():
     )
 
 
+def test_json_index_non_exact_floats():
+    # A JSON-path btree index is trained on the value extracted from the JSON
+    # column, not on the raw column itself, so the index build must sort by
+    # the extracted value rather than assuming the raw column's order matches
+    # it. Without that, range/equality queries silently miss rows whenever
+    # the extracted floats are not exactly representable in float64 (#7485).
+    vals = ['{"latitude": 10.5}', '{"latitude": 40.1}', '{"latitude": -3.2}']
+    tbl = pa.table({"data": pa.array(vals, pa.json_())})
+    ds = lance.write_dataset(tbl, "memory://test")
+    ds.create_scalar_index(
+        "data",
+        IndexConfig(
+            index_type="json",
+            parameters={"target_index_type": "btree", "path": "latitude"},
+        ),
+    )
+
+    for filter in [
+        "json_get_float(data, 'latitude') > 0",
+        "json_get_float(data, 'latitude') >= 10.5",
+        "json_get_float(data, 'latitude') = 40.1",
+        "json_get_float(data, 'latitude') = 10.5",
+        "json_get_float(data, 'latitude') < 100",
+    ]:
+        assert "ScalarIndexQuery" in ds.scanner(filter=filter).explain_plan()
+        assert ds.to_table(filter=filter) == ds.to_table(
+            filter=filter, use_scalar_index=False
+        ), filter
+
+
 def test_null_handling():
     tbl = pa.table(
         {

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -368,11 +368,12 @@ impl JsonTrainingRequest {
         // would sort by the wrong key and still need re-sorting after extraction. Ask
         // for unordered input instead and let `train_index` sort the extracted value
         // stream itself, once, right before handing it to the target trainer.
-        let ordering = match target_criteria.ordering {
-            TrainingOrdering::Values => TrainingOrdering::None,
-            other => other,
-        };
-        let mut criteria = TrainingCriteria::new(ordering);
+        //
+        // This is safe for `Addresses` too: `scan_training_data` only special-cases
+        // `Values` (it calls `order_by` only then); an `Addresses` or `None` criteria
+        // both fall through to the same unordered-scan behavior, since the scan already
+        // returns rows in row-address order by default.
+        let mut criteria = TrainingCriteria::new(TrainingOrdering::None);
         criteria.needs_row_ids = target_criteria.needs_row_ids;
         criteria.needs_row_addrs = target_criteria.needs_row_addrs;
         Self {

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -8,22 +8,24 @@ use std::{
 };
 
 use arrow_array::{Array, LargeBinaryArray, RecordBatch, StructArray, UInt8Array};
-use arrow_schema::{DataType, Field, Field as ArrowField, Schema};
+use arrow_schema::{DataType, Field, Field as ArrowField, Schema, SortOptions};
 use async_trait::async_trait;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::{
     execution::SendableRecordBatchStream,
-    physical_plan::{ExecutionPlan, projection::ProjectionExec},
+    physical_plan::{ExecutionPlan, projection::ProjectionExec, sorts::sort::SortExec},
 };
 use datafusion_common::{ScalarValue, config::ConfigOptions};
 use datafusion_expr::{Expr, Operator, ScalarUDF};
 use datafusion_physical_expr::{
-    PhysicalExpr, ScalarFunctionExpr,
+    PhysicalExpr, PhysicalSortExpr, ScalarFunctionExpr,
     expressions::{Column, Literal},
 };
 use futures::StreamExt;
 use lance_core::deepsize::DeepSizeOf;
-use lance_datafusion::exec::{LanceExecutionOptions, OneShotExec, get_session_context};
+use lance_datafusion::exec::{
+    LanceExecutionOptions, OneShotExec, execute_plan, get_session_context,
+};
 use lance_datafusion::udf::json::JsonbType;
 use prost::Message;
 use roaring::RoaringBitmap;
@@ -40,7 +42,8 @@ use crate::{
         UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
         registry::{
-            BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingRequest, VALUE_COLUMN_NAME,
+            BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+            VALUE_COLUMN_NAME,
         },
     },
 };
@@ -354,13 +357,28 @@ impl ScalarQueryParser for JsonQueryParser {
 pub struct JsonTrainingRequest {
     parameters: JsonIndexParameters,
     target_request: Box<dyn TrainingRequest>,
+    criteria: TrainingCriteria,
 }
 
 impl JsonTrainingRequest {
     pub fn new(parameters: JsonIndexParameters, target_request: Box<dyn TrainingRequest>) -> Self {
+        let target_criteria = target_request.criteria();
+        // The scanner can only sort its output by the raw JSON column, not by the value
+        // at `path` that this plugin extracts from it, so a `Values`-ordered scan here
+        // would sort by the wrong key and still need re-sorting after extraction. Ask
+        // for unordered input instead and let `train_index` sort the extracted value
+        // stream itself, once, right before handing it to the target trainer.
+        let ordering = match target_criteria.ordering {
+            TrainingOrdering::Values => TrainingOrdering::None,
+            other => other,
+        };
+        let mut criteria = TrainingCriteria::new(ordering);
+        criteria.needs_row_ids = target_criteria.needs_row_ids;
+        criteria.needs_row_addrs = target_criteria.needs_row_addrs;
         Self {
             parameters,
             target_request,
+            criteria,
         }
     }
 }
@@ -371,7 +389,7 @@ impl TrainingRequest for JsonTrainingRequest {
     }
 
     fn criteria(&self) -> &TrainingCriteria {
-        self.target_request.criteria()
+        &self.criteria
     }
 }
 
@@ -665,6 +683,35 @@ impl JsonIndexPlugin {
             futures::stream::iter(converted_batches.into_iter().map(Ok)),
         )))
     }
+
+    /// Sort a `(value, row_id)` stream ascending by value.
+    ///
+    /// Target index types that require `TrainingOrdering::Values` (e.g. btree, whose
+    /// per-page min/max stats are taken from the first/last row of each page) need this
+    /// as the only sort in the JSON training path: `JsonTrainingRequest` requests
+    /// unordered input from the scanner, since the scanner can only sort on the raw
+    /// JSON column, not on the value at `path`.
+    async fn sort_stream_by_value(
+        data: SendableRecordBatchStream,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = Arc::new(OneShotExec::new(data));
+        let value_idx = input.schema().index_of(VALUE_COLUMN_NAME)?;
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new(VALUE_COLUMN_NAME, value_idx)),
+            options: SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+        };
+        let plan = Arc::new(SortExec::new([sort_expr].into(), input));
+        execute_plan(
+            plan,
+            LanceExecutionOptions {
+                use_spilling: true,
+                ..Default::default()
+            },
+        )
+    }
 }
 
 #[async_trait]
@@ -719,6 +766,17 @@ impl BasicTrainer for JsonIndexPlugin {
         // Convert the stream to properly typed values based on inferred type
         let converted_stream =
             Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
+
+        // `JsonTrainingRequest::criteria()` asked the scanner for unordered input (see
+        // its constructor), since the scanner can only sort on the raw JSON column, not
+        // on the value at `path`. If the target index needs value-ordered input, this is
+        // the one place that sort happens: on the extracted value, after extraction.
+        let converted_stream =
+            if request.target_request.criteria().ordering == TrainingOrdering::Values {
+                Self::sort_stream_by_value(converted_stream).await?
+            } else {
+                converted_stream
+            };
 
         // Update the target request with inferred type
         let registry = self.registry()?;
@@ -837,8 +895,11 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scalar::SargableQuery;
     use arrow_array::{ArrayRef, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
+    use rstest::rstest;
+    use std::ops::Bound;
     use std::sync::Arc;
 
     // Note: The old test_detect_json_value_type test has been removed as we now use
@@ -977,5 +1038,143 @@ mod tests {
                 .unwrap();
 
         assert_eq!(inferred_type, DataType::Utf8);
+    }
+
+    /// Regression test for https://github.com/lance-format/lance/issues/7485.
+    ///
+    /// A JSON-path btree index over float values returned wrong results because the
+    /// btree trainer assumes its input arrives sorted by value (page min/max come from
+    /// the first/last row of each page), but the value at `path` is extracted by this
+    /// plugin *after* the scanner has already produced its rows, so a scan sorted on
+    /// the raw JSON column does not sort the extracted value. This exercises the fix
+    /// end to end: `JsonTrainingRequest::criteria()` must ask for unordered input (so
+    /// the scanner does not waste time sorting on the wrong key), and `train_index` must
+    /// sort the extracted value stream itself before training the target btree.
+    ///
+    /// Rows are fed in raw storage order (not sorted by value) to simulate what an
+    /// unordered scan would produce.
+    ///
+    /// Each case below runs a spilling `SortExec` that reserves a non-spillable merge
+    /// buffer from the process-wide cached DataFusion memory pool (see
+    /// `get_session_context`); running the cases concurrently contends for that shared
+    /// pool and can spuriously exhaust it, so this guard serializes them.
+    static FLOAT_INDEX_CASE_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[rstest]
+    #[case::range_gt_zero(
+        SargableQuery::Range(Bound::Excluded(ScalarValue::Float64(Some(0.0))), Bound::Unbounded),
+        vec![0, 1]
+    )]
+    #[case::range_gte_page_min(
+        SargableQuery::Range(Bound::Included(ScalarValue::Float64(Some(10.5))), Bound::Unbounded),
+        vec![0, 1]
+    )]
+    #[case::equals_non_exact_float(
+        SargableQuery::Equals(ScalarValue::Float64(Some(40.1))),
+        vec![1]
+    )]
+    #[case::equals_exact_float(SargableQuery::Equals(ScalarValue::Float64(Some(10.5))), vec![0])]
+    #[case::range_covers_all(
+        SargableQuery::Range(Bound::Unbounded, Bound::Excluded(ScalarValue::Float64(Some(100.0)))),
+        vec![0, 1, 2]
+    )]
+    #[tokio::test]
+    async fn test_json_float_btree_index_unsorted_input(
+        #[case] query: SargableQuery,
+        #[case] expected: Vec<u64>,
+    ) {
+        let _guard = FLOAT_INDEX_CASE_GUARD.lock().await;
+
+        use crate::metrics::NoOpMetricsCollector;
+        use crate::progress::noop_progress;
+        use crate::registry::IndexPluginRegistry;
+        use crate::scalar::lance_format::LanceIndexStore;
+        use arrow_array::{LargeBinaryArray, UInt64Array};
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::stream;
+        use lance_core::cache::LanceCache;
+        use lance_core::utils::tempfile::TempObjDir;
+        use lance_io::object_store::ObjectStore;
+        use lance_select::RowAddrTreeMap;
+
+        // row0=10.5, row1=40.1, row2=-3.2: storage order does not match ascending value
+        // order (-3.2, 10.5, 40.1), so a btree trained on this order without an explicit
+        // value sort would record a corrupted page max of -3.2.
+        let json_data = [
+            r#"{"latitude": 10.5}"#,
+            r#"{"latitude": 40.1}"#,
+            r#"{"latitude": -3.2}"#,
+        ];
+        let jsonb: Vec<Vec<u8>> = json_data
+            .iter()
+            .map(|s| s.parse::<jsonb::OwnedJsonb>().unwrap().to_vec())
+            .collect();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(LargeBinaryArray::from(
+                    jsonb.iter().map(|v| Some(v.as_slice())).collect::<Vec<_>>(),
+                )) as ArrayRef,
+                Arc::new(UInt64Array::from(vec![0u64, 1, 2])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let data = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Ok(batch)]),
+        )) as SendableRecordBatchStream;
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let registry = IndexPluginRegistry::with_default_plugins();
+        let plugin = registry.get_plugin_by_name("json").unwrap();
+        let trainer = plugin.basic_trainer().unwrap();
+        let request = trainer
+            .new_training_request(
+                r#"{"target_index_type":"btree","path":"latitude"}"#,
+                &Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
+            )
+            .unwrap();
+
+        // The scanner must be asked for unordered input: only this plugin knows the
+        // order of the extracted value, so sorting on the raw JSON column would be
+        // wasted work that still leaves the extracted stream unsorted.
+        assert_eq!(request.criteria().ordering, TrainingOrdering::None);
+
+        let created = trainer
+            .train_index(data, store.as_ref(), request, None, noop_progress())
+            .await
+            .unwrap();
+
+        let index = plugin
+            .load_index(
+                store.clone(),
+                &created.index_details,
+                None,
+                &LanceCache::no_cache(),
+            )
+            .await
+            .unwrap();
+
+        let json_query = JsonQuery::new(Arc::new(query.clone()), "latitude".to_string());
+        let result = index
+            .search(&json_query, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            SearchResult::exact(RowAddrTreeMap::from_iter(expected.iter().copied())),
+            "query {query:?}"
+        );
     }
 }

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -772,6 +772,10 @@ impl BasicTrainer for JsonIndexPlugin {
         // its constructor), since the scanner can only sort on the raw JSON column, not
         // on the value at `path`. If the target index needs value-ordered input, this is
         // the one place that sort happens: on the extracted value, after extraction.
+        //
+        // Deliberately `request.target_request.criteria()` here, not `request.criteria()`:
+        // the latter is `JsonTrainingRequest`'s own criteria, which is always `None` (that's
+        // what asked the scanner for unordered input above) and would never take this branch.
         let converted_stream =
             if request.target_request.criteria().ordering == TrainingOrdering::Values {
                 Self::sort_stream_by_value(converted_stream).await?
@@ -1088,12 +1092,9 @@ mod tests {
 
         use crate::metrics::NoOpMetricsCollector;
         use crate::progress::noop_progress;
-        use crate::registry::IndexPluginRegistry;
         use crate::scalar::lance_format::LanceIndexStore;
         use arrow_array::{LargeBinaryArray, UInt64Array};
-        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
         use futures::stream;
-        use lance_core::cache::LanceCache;
         use lance_core::utils::tempfile::TempObjDir;
         use lance_io::object_store::ObjectStore;
         use lance_select::RowAddrTreeMap;

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -900,7 +900,7 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scalar::SargableQuery;
+    use crate::scalar::{SargableQuery, TextQuery};
     use arrow_array::{ArrayRef, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use rstest::rstest;
@@ -1045,6 +1045,86 @@ mod tests {
         assert_eq!(inferred_type, DataType::Utf8);
     }
 
+    /// Trains a JSON-path index of `target_index_type` over `json_docs` (fed to the
+    /// trainer in exactly the given order, with row ids `0..json_docs.len()`) and
+    /// returns the loaded index. `store` is a caller-owned `LanceIndexStore` so the
+    /// caller controls how long the backing `TempObjDir` stays alive.
+    async fn train_and_load_json_index(
+        store: Arc<dyn IndexStore>,
+        target_index_type: &str,
+        path: &str,
+        json_docs: &[&str],
+    ) -> Arc<dyn ScalarIndex> {
+        use crate::progress::noop_progress;
+        use arrow_array::{LargeBinaryArray, UInt64Array};
+        use futures::stream;
+
+        let jsonb: Vec<Vec<u8>> = json_docs
+            .iter()
+            .map(|s| s.parse::<jsonb::OwnedJsonb>().unwrap().to_vec())
+            .collect();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(LargeBinaryArray::from(
+                    jsonb.iter().map(|v| Some(v.as_slice())).collect::<Vec<_>>(),
+                )) as ArrayRef,
+                Arc::new(UInt64Array::from_iter_values(0..json_docs.len() as u64)) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let data = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Ok(batch)]),
+        )) as SendableRecordBatchStream;
+
+        let registry = IndexPluginRegistry::with_default_plugins();
+        let plugin = registry.get_plugin_by_name("json").unwrap();
+        let trainer = plugin.basic_trainer().unwrap();
+        let params = format!(r#"{{"target_index_type":"{target_index_type}","path":"{path}"}}"#);
+        let request = trainer
+            .new_training_request(
+                &params,
+                &Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
+            )
+            .unwrap();
+
+        // The scanner must be asked for unordered input: only this plugin knows the
+        // order of the extracted value, so sorting on the raw JSON column would be
+        // wasted work that either goes unused (non-`Values` targets) or still leaves
+        // the extracted stream unsorted (`Values` targets, see below).
+        assert_eq!(request.criteria().ordering, TrainingOrdering::None);
+
+        let created = trainer
+            .train_index(data, store.as_ref(), request, None, noop_progress())
+            .await
+            .unwrap();
+
+        plugin
+            .load_index(store, &created.index_details, None, &LanceCache::no_cache())
+            .await
+            .unwrap()
+    }
+
+    fn local_json_index_store() -> (Arc<dyn IndexStore>, lance_core::utils::tempfile::TempObjDir) {
+        use crate::scalar::lance_format::LanceIndexStore;
+        use lance_core::utils::tempfile::TempObjDir;
+        use lance_io::object_store::ObjectStore;
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        )) as Arc<dyn IndexStore>;
+        (store, tmpdir)
+    }
+
     /// Regression test for https://github.com/lance-format/lance/issues/7485.
     ///
     /// A JSON-path btree index over float values returned wrong results because the
@@ -1089,84 +1169,24 @@ mod tests {
         #[case] expected: Vec<u64>,
     ) {
         let _guard = FLOAT_INDEX_CASE_GUARD.lock().await;
-
         use crate::metrics::NoOpMetricsCollector;
-        use crate::progress::noop_progress;
-        use crate::scalar::lance_format::LanceIndexStore;
-        use arrow_array::{LargeBinaryArray, UInt64Array};
-        use futures::stream;
-        use lance_core::utils::tempfile::TempObjDir;
-        use lance_io::object_store::ObjectStore;
         use lance_select::RowAddrTreeMap;
 
         // row0=10.5, row1=40.1, row2=-3.2: storage order does not match ascending value
         // order (-3.2, 10.5, 40.1), so a btree trained on this order without an explicit
         // value sort would record a corrupted page max of -3.2.
-        let json_data = [
-            r#"{"latitude": 10.5}"#,
-            r#"{"latitude": 40.1}"#,
-            r#"{"latitude": -3.2}"#,
-        ];
-        let jsonb: Vec<Vec<u8>> = json_data
-            .iter()
-            .map(|s| s.parse::<jsonb::OwnedJsonb>().unwrap().to_vec())
-            .collect();
-
-        let schema = Arc::new(Schema::new(vec![
-            Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
-            Field::new(ROW_ID, DataType::UInt64, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(LargeBinaryArray::from(
-                    jsonb.iter().map(|v| Some(v.as_slice())).collect::<Vec<_>>(),
-                )) as ArrayRef,
-                Arc::new(UInt64Array::from(vec![0u64, 1, 2])) as ArrayRef,
+        let (store, _tmpdir) = local_json_index_store();
+        let index = train_and_load_json_index(
+            store,
+            "btree",
+            "latitude",
+            &[
+                r#"{"latitude": 10.5}"#,
+                r#"{"latitude": 40.1}"#,
+                r#"{"latitude": -3.2}"#,
             ],
         )
-        .unwrap();
-        let data = Box::pin(RecordBatchStreamAdapter::new(
-            schema,
-            stream::iter(vec![Ok(batch)]),
-        )) as SendableRecordBatchStream;
-
-        let tmpdir = TempObjDir::default();
-        let store = Arc::new(LanceIndexStore::new(
-            Arc::new(ObjectStore::local()),
-            tmpdir.clone(),
-            Arc::new(LanceCache::no_cache()),
-        ));
-
-        let registry = IndexPluginRegistry::with_default_plugins();
-        let plugin = registry.get_plugin_by_name("json").unwrap();
-        let trainer = plugin.basic_trainer().unwrap();
-        let request = trainer
-            .new_training_request(
-                r#"{"target_index_type":"btree","path":"latitude"}"#,
-                &Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
-            )
-            .unwrap();
-
-        // The scanner must be asked for unordered input: only this plugin knows the
-        // order of the extracted value, so sorting on the raw JSON column would be
-        // wasted work that still leaves the extracted stream unsorted.
-        assert_eq!(request.criteria().ordering, TrainingOrdering::None);
-
-        let created = trainer
-            .train_index(data, store.as_ref(), request, None, noop_progress())
-            .await
-            .unwrap();
-
-        let index = plugin
-            .load_index(
-                store.clone(),
-                &created.index_details,
-                None,
-                &LanceCache::no_cache(),
-            )
-            .await
-            .unwrap();
+        .await;
 
         let json_query = JsonQuery::new(Arc::new(query.clone()), "latitude".to_string());
         let result = index
@@ -1177,6 +1197,127 @@ mod tests {
             result,
             SearchResult::exact(RowAddrTreeMap::from_iter(expected.iter().copied())),
             "query {query:?}"
+        );
+    }
+
+    /// Regression test for a null value at `path` surviving `sort_stream_by_value`.
+    ///
+    /// `sort_stream_by_value` sorts the extracted `(value, row_id)` stream with
+    /// `nulls_first: true`. This checks that a null row's row_id stays paired with its
+    /// (null) value through that sort -- if the sort ever reordered values without their
+    /// row_ids, a null-valued row could be attributed to the wrong id -- and that the
+    /// resulting btree still answers `IsNull` and non-null range/equality queries
+    /// correctly with nulls mixed in and fed out of value order.
+    ///
+    /// Row 1's `path` is missing entirely, which is what actually produces a null in the
+    /// extracted value column (`extract_json_path_with_type` returns `None`, which
+    /// `json_extract_with_type_impl` turns into an arrow-null). An explicit JSON `null`
+    /// literal at `path` (e.g. `{"v": null}`) is a different, pre-existing case that
+    /// `convert_stream_by_type` does not yet handle (it tries to deserialize the JSONB
+    /// `null` bytes as the inferred type and errors) -- unrelated to this fix, so it's
+    /// out of scope here.
+    #[tokio::test]
+    async fn test_json_btree_index_null_at_path() {
+        use crate::metrics::NoOpMetricsCollector;
+        use lance_select::RowAddrTreeMap;
+
+        let _guard = FLOAT_INDEX_CASE_GUARD.lock().await;
+        let (store, _tmpdir) = local_json_index_store();
+        let index = train_and_load_json_index(
+            store,
+            "btree",
+            "v",
+            &[
+                r#"{"v": 40.1}"#,  // row 0
+                r#"{"other": 1}"#, // row 1: path missing -> null
+                r#"{"v": -3.2}"#,  // row 2
+                r#"{"v": 10.5}"#,  // row 3
+            ],
+        )
+        .await;
+
+        let search = |query: SargableQuery| {
+            let index = index.clone();
+            let json_query = JsonQuery::new(Arc::new(query), "v".to_string());
+            async move {
+                index
+                    .search(&json_query, &NoOpMetricsCollector)
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Range/equality queries carry row 1 in `nulls` (three-valued logic: `NULL > 0`
+        // is unknown, not false -- see `NullableRowAddrSet`), which is pre-existing
+        // btree/framework behavior. Asserting it exactly here is exactly the property
+        // this test targets: row 1's row_id must stay paired with its null value
+        // through `sort_stream_by_value`, not just be excluded from `selected`.
+        assert_eq!(
+            search(SargableQuery::IsNull()).await,
+            SearchResult::exact(RowAddrTreeMap::from_iter([1u64])),
+            "IsNull"
+        );
+        assert_eq!(
+            search(SargableQuery::Range(
+                Bound::Excluded(ScalarValue::Float64(Some(0.0))),
+                Bound::Unbounded,
+            ))
+            .await,
+            SearchResult::exact(RowAddrTreeMap::from_iter([0u64, 3]))
+                .with_nulls(RowAddrTreeMap::from_iter([1u64])),
+            "> 0"
+        );
+        assert_eq!(
+            search(SargableQuery::Equals(ScalarValue::Float64(Some(40.1)))).await,
+            SearchResult::exact(RowAddrTreeMap::from_iter([0u64]))
+                .with_nulls(RowAddrTreeMap::from_iter([1u64])),
+            "= 40.1"
+        );
+        assert_eq!(
+            search(SargableQuery::Range(
+                Bound::Unbounded,
+                Bound::Excluded(ScalarValue::Float64(Some(100.0))),
+            ))
+            .await,
+            SearchResult::exact(RowAddrTreeMap::from_iter([0u64, 2, 3]))
+                .with_nulls(RowAddrTreeMap::from_iter([1u64])),
+            "< 100 (null is neither < 100 nor >= 100)"
+        );
+    }
+
+    /// Regression coverage for the non-`Values`-ordering branch in `train_index`: a
+    /// JSON-path index over a target that does not need value-ordered input (ngram
+    /// requires `TrainingOrdering::None`) must skip `sort_stream_by_value` entirely and
+    /// still produce correct results from rows fed out of value order.
+    #[tokio::test]
+    async fn test_json_ngram_index_skips_value_sort() {
+        use crate::metrics::NoOpMetricsCollector;
+        use lance_select::RowAddrTreeMap;
+
+        let (store, _tmpdir) = local_json_index_store();
+        let index = train_and_load_json_index(
+            store,
+            "ngram",
+            "tag",
+            &[
+                r#"{"tag": "unique-charlie"}"#,
+                r#"{"tag": "unique-alpha"}"#,
+                r#"{"tag": "unique-bravo"}"#,
+            ],
+        )
+        .await;
+
+        let json_query = JsonQuery::new(
+            Arc::new(TextQuery::StringContains("unique-bravo".to_string())),
+            "tag".to_string(),
+        );
+        let result = index
+            .search(&json_query, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([2u64])),
         );
     }
 }


### PR DESCRIPTION
## Problem

A JSON-path scalar index (`target_index_type=btree`) returns wrong results when the
indexed path holds float64 values that are not exactly representable (e.g. `40.1`,
`-3.2`): ranges come back empty and equality misses rows.

Fixes #7485.

## Root cause

The btree trainer requires its input sorted by value (page min/max are taken from the
first/last row of each page). `scan_training_data` sorts by the *raw* JSON column when
the target requests `TrainingOrdering::Values`, but `JsonIndexPlugin` extracts a
different value (the value at `path`) from that column downstream, so the extracted
stream is not actually sorted by value. Silently corrupted page stats then cause range
and equality lookups to skip pages that hold matching rows.

## Relationship to #7493, #7771, #7819

All three open PRs diagnose this correctly and fix it by adding a second `SortExec`
after JSON extraction, on top of the raw-column sort the scanner already performs. That
raw-column sort is wasted work — it sorts a key nothing downstream uses.

This PR instead has `JsonTrainingRequest::criteria()` override the target's
`TrainingOrdering::Values` to `TrainingOrdering::None` when delegating to the scanner
(the scanner's sort can't help the extracted value anyway), and sorts the extracted
`(value, row_id)` stream once, in `train_index`, right before handing it to the target
trainer. Same correctness fix, one sort instead of two.

## Testing

- `test_json_float_btree_index_unsorted_input` (rust/lance-index/src/scalar/json.rs):
  builds a real JSON/btree index through the plugin trainer/registry with the issue's
  repro values fed in raw storage order, and asserts range/equality results across 5
  cases. Also asserts `JsonTrainingRequest::criteria().ordering == TrainingOrdering::None`.
- `test_json_index_non_exact_floats` (python/python/tests/test_scalar_index.py): the
  issue's repro end to end via `create_scalar_index` + `json_get_float` filters.

`cargo fmt --all`, `cargo clippy -p lance-index --tests -- -D warnings`, and
`uv run make lint` are clean.