### PR TITLE
feat(scanner): push dynamic filters into FilteredReadExec

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -12457,6 +12457,81 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     }
 
     #[tokio::test]
+    async fn test_topk_dynamic_filter_pushdown() {
+        // A `SortExec` with a fetch (TopK) produces a dynamic filter that DataFusion's
+        // Post-phase `FilterPushdown` rule threads down into `FilteredReadExec`. This checks
+        // both that the filter reaches the scan and that the results stay correct (the pushed
+        // filter must never drop a row that belongs in the top-k).
+        use arrow_array::Int64Array;
+        let n = 4000i64;
+        // Distinct values that decrease as rows are written, so the ordering does not match the
+        // physical row order and the top-k spans every fragment.
+        let id_array = Int64Array::from_iter_values(0..n);
+        let value_array = Int64Array::from_iter_values((0..n).map(|i| n - i));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int64, false),
+            ArrowField::new("value", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(id_array), Arc::new(value_array)],
+        )
+        .unwrap();
+        let test_dir = TempStrDir::default();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema.clone());
+        let dataset = Dataset::write(
+            reader,
+            &test_dir,
+            Some(WriteParams {
+                max_rows_per_file: 1000,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.fragments().len(), 4);
+
+        let make_scanner = || {
+            let mut scanner = dataset.scan();
+            scanner
+                .project(&["id", "value"])
+                .unwrap()
+                .order_by(Some(vec![ColumnOrdering {
+                    column_name: "value".to_string(),
+                    ascending: true,
+                    nulls_first: true,
+                }]))
+                .unwrap();
+            scanner.limit(Some(10), None).unwrap();
+            scanner
+        };
+
+        // The dynamic filter is threaded into the LanceRead node.
+        let plan = make_scanner().explain_plan(true).await.unwrap();
+        assert!(
+            plan.contains("pushdown_filters=[DynamicFilter"),
+            "expected a pushed-down dynamic filter on LanceRead, got plan:\n{plan}"
+        );
+
+        // Results are the ten smallest values, in order, regardless of the pushed filter.
+        let batches = make_scanner()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let batch = concat_batches(&batches[0].schema(), &batches).unwrap();
+        assert_eq!(batch.num_rows(), 10);
+        let values = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_primitive::<Int64Type>()
+            .values();
+        assert_eq!(values, &(1..=10).collect::<Vec<i64>>());
+    }
+
+    #[tokio::test]
     async fn test_limit_with_ordering_not_pushed_down() {
         // This test verifies the fix for a bug where limit/offset could be pushed down
         // even when ordering was specified. When ordering is present, we need to load

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -7,10 +7,14 @@ use std::{ops::Range, sync::Arc};
 
 use arrow_array::RecordBatch;
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
+use datafusion::common::config::ConfigOptions;
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
+};
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
 use datafusion::physical_plan::{
@@ -18,7 +22,8 @@ use datafusion::physical_plan::{
     execution_plan::{Boundedness, EmissionType},
 };
 use datafusion_expr::Expr;
-use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
+use datafusion_physical_expr::utils::collect_columns;
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr, conjunction};
 use datafusion_physical_plan::Statistics;
 use datafusion_physical_plan::filter::FilterExec;
 use datafusion_physical_plan::metrics::{BaselineMetrics, Count, MetricsSet, Time};
@@ -1358,6 +1363,21 @@ impl FilteredReadStream {
         }
     }
 
+    // Apply filters pushed down from parent operators to the fully-projected output
+    // batches. `predicate` references only output columns, so it is applied after the
+    // read/projection stage rather than fused into the per-fragment scan filter.
+    fn apply_pushdown_filters(
+        stream: SendableRecordBatchStream,
+        predicate: Arc<dyn PhysicalExpr>,
+    ) -> SendableRecordBatchStream {
+        let schema = stream.schema();
+        let filtered = stream.map(move |batch| {
+            let batch = batch?;
+            datafusion_physical_plan::filter::batch_filter(&batch, &predicate)
+        });
+        Box::pin(RecordBatchStreamAdapter::new(schema, filtered))
+    }
+
     fn apply_soft_limit<S>(stream: S, limit: u64) -> impl Stream<Item = Result<ReadBatchFut>>
     where
         S: Stream<Item = Result<ReadBatchFut>>,
@@ -1689,6 +1709,12 @@ pub struct FilteredReadExec {
     // When execute is first called we will initialize the FilteredReadStream.  In order to support
     // multiple partitions, each partition will share the stream.
     running_stream: Arc<AsyncMutex<Option<FilteredReadStream>>>,
+    // Filters pushed down from parent operators via DataFusion's physical filter-pushdown
+    // protocol (e.g. TopK / hash-join dynamic filters). These are evaluated against the
+    // output schema per batch at execute time. Because a dynamic filter can tighten during
+    // execution (a TopK threshold moves as its heap fills), we re-read the current predicate
+    // on every batch rather than snapshotting it at plan time.
+    pushdown_filters: Vec<Arc<dyn PhysicalExpr>>,
 }
 
 /// Public plan for distributed execution - uses bitmap for flexibility
@@ -1814,6 +1840,7 @@ impl FilteredReadExec {
             metrics,
             index_input,
             plan: Arc::new(OnceCell::new()),
+            pushdown_filters: Vec::new(),
         })
     }
 
@@ -1950,6 +1977,12 @@ impl FilteredReadExec {
         let metrics = self.metrics.clone();
         let index_input = self.index_input.clone();
         let plan_cell = self.plan.clone();
+        // A conjunction of the filters pushed down from parent operators. Built once, but
+        // evaluated per batch: a `DynamicFilterPhysicalExpr` re-reads its current (possibly
+        // tightened) predicate on every `evaluate`, so a TopK threshold that moves during
+        // execution is honored without rebuilding this expression.
+        let pushdown_predicate = (!self.pushdown_filters.is_empty())
+            .then(|| conjunction(self.pushdown_filters.iter().cloned()));
 
         let stream = futures::stream::once(async move {
             let mut running_stream = running_stream_lock.lock().await;
@@ -2011,6 +2044,10 @@ impl FilteredReadExec {
                 }
                 (None, None) => inner,
             };
+            let stream = match pushdown_predicate {
+                Some(predicate) => FilteredReadStream::apply_pushdown_filters(stream, predicate),
+                None => stream,
+            };
             DataFusionResult::<SendableRecordBatchStream>::Ok(stream)
         })
         .try_flatten();
@@ -2047,11 +2084,22 @@ impl DisplayAs for FilteredReadExec {
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>()
             .join(", ");
+        let pushdown_filters = if self.pushdown_filters.is_empty() {
+            String::new()
+        } else {
+            let exprs = self
+                .pushdown_filters
+                .iter()
+                .map(|f| f.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(", pushdown_filters=[{exprs}]")
+        };
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(
                     f,
-                    "LanceRead: uri={}, projection=[{}], num_fragments={}, range_before={:?}, range_after={:?}, row_id={}, row_addr={}, full_filter={}, refine_filter={}",
+                    "LanceRead: uri={}, projection=[{}], num_fragments={}, range_before={:?}, range_after={:?}, row_id={}, row_addr={}, full_filter={}, refine_filter={}{}",
                     self.dataset.data_dir(),
                     columns,
                     self.options
@@ -2073,12 +2121,13 @@ impl DisplayAs for FilteredReadExec {
                         .as_ref()
                         .map(|i| i.to_string())
                         .unwrap_or("--".to_string()),
+                    pushdown_filters,
                 )
             }
             DisplayFormatType::TreeRender => {
                 write!(
                     f,
-                    "LanceRead\nuri={}\nprojection=[{}]\nnum_fragments={}\nrange_before={:?}\nrange_after={:?}\nrow_id={}\nrow_addr={}\nfull_filter={}\nrefine_filter={}",
+                    "LanceRead\nuri={}\nprojection=[{}]\nnum_fragments={}\nrange_before={:?}\nrange_after={:?}\nrow_id={}\nrow_addr={}\nfull_filter={}\nrefine_filter={}{}",
                     self.dataset.data_dir(),
                     columns,
                     self.options
@@ -2100,6 +2149,7 @@ impl DisplayAs for FilteredReadExec {
                         .as_ref()
                         .map(|i| i.to_string())
                         .unwrap_or("true".to_string()),
+                    pushdown_filters,
                 )
             }
         }
@@ -2264,6 +2314,7 @@ impl ExecutionPlan for FilteredReadExec {
                 running_stream: Arc::new(AsyncMutex::new(None)),
                 index_input,
                 plan: Arc::new(OnceCell::new()),
+                pushdown_filters: self.pushdown_filters.clone(),
             }))
         }
     }
@@ -2330,7 +2381,10 @@ impl ExecutionPlan for FilteredReadExec {
             updated_options,
             self.index_input.clone(),
         ) {
-            Ok(exec) => Some(Arc::new(exec)),
+            Ok(mut exec) => {
+                exec.pushdown_filters = self.pushdown_filters.clone();
+                Some(Arc::new(exec))
+            }
             Err(e) => {
                 log::warn!(
                     "Failed to create FilteredReadExec for {} with fetch limit: {}",
@@ -2340,6 +2394,69 @@ impl ExecutionPlan for FilteredReadExec {
                 None
             }
         }
+    }
+
+    // We accept filters offered by our parents (the routing/analysis happens in the
+    // parent's `gather_filters_for_pushdown`, so by the time they reach us they are
+    // already remapped to our output schema). We absorb any filter whose columns are
+    // all produced by this scan and apply it per batch at execute time. This mirrors
+    // `DataSourceExec`, which likewise leaves `gather_filters_for_pushdown` at its
+    // default and does all the work here.
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        // Only absorb Post-phase filters (dynamic filters from TopK / hash joins). Pre-phase
+        // static predicates are already handled by Lance's logical filter plan (baked into
+        // `full_filter`), so absorbing them here would double-apply. This also keeps the scan
+        // out of the way of static filter pushdown on the merge_insert path, which runs the
+        // default DataFusion optimizer (both phases).
+        if phase != FilterPushdownPhase::Post {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        let output_schema = self.schema();
+        let column_in_schema = |column: &datafusion_physical_expr::expressions::Column| {
+            output_schema
+                .fields()
+                .get(column.index())
+                .is_some_and(|field| field.name() == column.name())
+        };
+
+        let mut new_filters = self.pushdown_filters.clone();
+        let mut support = Vec::with_capacity(child_pushdown_result.parent_filters.len());
+        let mut absorbed_any = false;
+        for parent in &child_pushdown_result.parent_filters {
+            let evaluable = collect_columns(&parent.filter).iter().all(column_in_schema);
+            if evaluable {
+                new_filters.push(Arc::clone(&parent.filter));
+                support.push(PushedDown::Yes);
+                absorbed_any = true;
+            } else {
+                support.push(PushedDown::No);
+            }
+        }
+
+        if !absorbed_any {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        let new_node = Arc::new(Self {
+            dataset: self.dataset.clone(),
+            options: self.options.clone(),
+            properties: self.properties.clone(),
+            metrics: self.metrics.clone(),
+            index_input: self.index_input.clone(),
+            plan: Arc::new(OnceCell::new()),
+            running_stream: Arc::new(AsyncMutex::new(None)),
+            pushdown_filters: new_filters,
+        });
+        Ok(
+            FilterPushdownPropagation::with_parent_pushdown_result(support)
+                .with_updated_node(new_node as Arc<dyn ExecutionPlan>),
+        )
     }
 }
 
@@ -4172,5 +4289,105 @@ mod tests {
         let capped_result = concat_batches(&schema2, &batches2).unwrap();
 
         assert_eq!(default_result.num_rows(), capped_result.num_rows());
+    }
+
+    async fn dataset_with_value_column() -> (TempStrDir, Arc<Dataset>) {
+        use arrow_array::Int64Array;
+        let tmp = TempStrDir::default();
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "value",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from_iter_values(0..200))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema.clone());
+        let dataset = Dataset::write(reader, tmp.as_str(), None).await.unwrap();
+        (tmp, Arc::new(dataset))
+    }
+
+    #[tokio::test]
+    async fn test_handle_child_pushdown_result_absorbs_dynamic_filter() {
+        use datafusion::physical_plan::display::DisplayableExecutionPlan;
+        use datafusion_expr::Operator;
+        use datafusion_physical_expr::expressions::{
+            BinaryExpr, DynamicFilterPhysicalExpr, col, lit,
+        };
+        use datafusion_physical_plan::filter_pushdown::{
+            ChildFilterPushdownResult, ChildPushdownResult,
+        };
+
+        let (_tmp, dataset) = dataset_with_value_column().await;
+        let options = FilteredReadOptions::basic_full_read(&dataset);
+        let exec = Arc::new(FilteredReadExec::try_new(dataset.clone(), options, None).unwrap());
+
+        let schema = exec.schema();
+        let value_col = col("value", &schema).unwrap();
+        // A dynamic filter starts as `true` (nothing pruned) and is tightened by its producer.
+        let dynamic = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::clone(&value_col)],
+            lit(true),
+        ));
+        let dynamic_expr: Arc<dyn PhysicalExpr> = dynamic.clone();
+
+        let offer = |phase| {
+            (exec.clone() as Arc<dyn ExecutionPlan>).handle_child_pushdown_result(
+                phase,
+                ChildPushdownResult {
+                    parent_filters: vec![ChildFilterPushdownResult {
+                        filter: Arc::clone(&dynamic_expr),
+                        child_results: vec![],
+                    }],
+                    self_filters: vec![],
+                },
+                &ConfigOptions::default(),
+            )
+        };
+
+        // Pre phase is declined: static filters remain the logical plan's responsibility.
+        let pre = offer(FilterPushdownPhase::Pre).unwrap();
+        assert!(pre.updated_node.is_none());
+        assert!(matches!(pre.filters.as_slice(), [PushedDown::No]));
+
+        // Post phase absorbs the dynamic filter and rewrites the node. Each call returns an
+        // independent node (fresh cached stream), so we build one per execution below.
+        let post = offer(FilterPushdownPhase::Post).unwrap();
+        assert!(matches!(post.filters.as_slice(), [PushedDown::Yes]));
+        let node_before = post.updated_node.expect("node should be rewritten");
+        assert!(
+            format!(
+                "{}",
+                DisplayableExecutionPlan::new(node_before.as_ref()).one_line()
+            )
+            .contains("pushdown_filters=["),
+            "rewritten node should display the absorbed filter"
+        );
+        let node_after = offer(FilterPushdownPhase::Post)
+            .unwrap()
+            .updated_node
+            .unwrap();
+
+        // While the filter is still `true`, nothing is dropped.
+        assert_eq!(execute_and_count(&node_before).await, 200);
+
+        // The predicate is read at execute time, so tightening it after pushdown (as a TopK /
+        // hash join would once its threshold / build side is known) takes effect: only value < 50.
+        dynamic
+            .update(Arc::new(BinaryExpr::new(
+                value_col,
+                Operator::Lt,
+                lit(50i64),
+            )))
+            .unwrap();
+        assert_eq!(execute_and_count(&node_after).await, 50);
+    }
+
+    async fn execute_and_count(plan: &Arc<dyn ExecutionPlan>) -> usize {
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        batches.iter().map(|b| b.num_rows()).sum()
     }
 }

--- a/rust/lance/src/io/exec/optimizer.rs
+++ b/rust/lance/src/io/exec/optimizer.rs
@@ -180,5 +180,15 @@ pub fn get_physical_optimizer() -> PhysicalOptimizer {
         // Insert exchange nodes (RepartitionExec, CoalescePartitionsExec) where needed
         // to satisfy distribution requirements as exec nodes migrate to multi-partition output.
         Arc::new(datafusion::physical_optimizer::enforce_distribution::EnforceDistribution::new()),
+        // Post-phase filter pushdown wires the dynamic filters produced by upstream operators
+        // (e.g. a TopK `SortExec` or a hash join) into `FilteredReadExec`, so the scan can drop
+        // rows before they flow up into a downstream `TakeExec` / sort. Runs last (after
+        // `LimitPushdown` has turned `SortExec` into a TopK that emits a dynamic filter). Only
+        // the Post phase is installed: static `WHERE` predicates are already handled by Lance's
+        // logical filter plan, and running the Pre phase here would double-apply them.
+        Arc::new(
+            datafusion::physical_optimizer::filter_pushdown::FilterPushdown::new_post_optimization(
+            ),
+        ),
     ])
 }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -13,7 +13,11 @@ use arrow_array::{Array, BooleanArray, UInt32Array};
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
 use datafusion::common::Statistics;
+use datafusion::common::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+};
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricValue, MetricsSet,
 };
@@ -21,7 +25,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
-use datafusion_physical_expr::EquivalenceProperties;
+use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr};
 use futures::FutureExt;
 use futures::stream::{FuturesOrdered, Stream, StreamExt, TryStreamExt};
 use lance_arrow::RecordBatchExt;
@@ -695,6 +699,30 @@ impl ExecutionPlan for TakeExec {
     fn supports_limit_pushdown(&self) -> bool {
         true
     }
+
+    // A `TakeExec` fetches extra ("late materialized") columns for the rows produced
+    // by its input, so it is transparent to filters that reference only the input's
+    // columns. Forwarding those filters down lets a dynamic filter (e.g. a TopK or
+    // hash-join filter) reach the underlying scan, which then drops rows before the
+    // take fetches their wide columns. Filters that reference take-added columns are
+    // marked unsupported by `from_child` and stay above the take.
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
 }
 
 #[cfg(test)]
@@ -811,6 +839,74 @@ mod tests {
         assert_eq!(
             schema.fields.iter().map(|f| f.name()).collect::<Vec<_>>(),
             vec!["i", ROW_ID, "s"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_take_filter_pushdown_pass_through() {
+        use datafusion::physical_plan::filter_pushdown::PushedDown;
+        use datafusion_expr::Operator;
+        use datafusion_physical_expr::expressions::{BinaryExpr, col, lit};
+
+        let TestFixture { dataset, .. } = test_fixture().await;
+
+        // Input scans "i" (+ row id); the take adds the wider "s" column.
+        let scan_arrow_schema = ArrowSchema::new(vec![Field::new("i", DataType::Int32, false)]);
+        let scan_schema = Arc::new(Schema::try_from(&scan_arrow_schema).unwrap());
+        let config = LanceScanConfig {
+            with_row_id: true,
+            ..Default::default()
+        };
+        let input = Arc::new(LanceScanExec::new(
+            dataset.clone(),
+            dataset.fragments().clone(),
+            None,
+            scan_schema,
+            config,
+        ));
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
+        let take_exec: Arc<dyn ExecutionPlan> = Arc::new(
+            TakeExec::try_new(dataset, input, projection)
+                .unwrap()
+                .unwrap(),
+        );
+
+        let out_schema = take_exec.schema();
+        // A filter on "i" is produced by the input, so it routes down; a filter on the
+        // take-added "s" cannot, so it stays above the take.
+        let filter_i: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            col("i", &out_schema).unwrap(),
+            Operator::Lt,
+            lit(5i32),
+        ));
+        let filter_s: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            col("s", &out_schema).unwrap(),
+            Operator::Eq,
+            lit("str-1"),
+        ));
+
+        let desc = take_exec
+            .gather_filters_for_pushdown(
+                FilterPushdownPhase::Post,
+                vec![filter_i, filter_s],
+                &ConfigOptions::default(),
+            )
+            .unwrap();
+
+        let per_child = desc.parent_filters();
+        assert_eq!(per_child.len(), 1, "TakeExec has a single child");
+        let routed = &per_child[0];
+        assert_eq!(routed.len(), 2);
+        assert!(
+            matches!(routed[0].discriminant, PushedDown::Yes),
+            "filter on input column should route down to the scan"
+        );
+        assert!(
+            matches!(routed[1].discriminant, PushedDown::No),
+            "filter on a take-added column must stay above the take"
         );
     }
 


### PR DESCRIPTION
Makes `FilteredReadExec` a first-class DataFusion physical filter-pushdown *sink* (like `DataSourceExec`), so dynamic filters produced by upstream operators are threaded into the scan and evaluated there instead of only above it. Draft for #7562.

## What changed

- **`FilteredReadExec`** implements `handle_child_pushdown_result` (Post phase). It absorbs any offered filter whose columns are all produced by the scan, stores it, and applies it as a per-batch filter on the fully-projected output. `gather_filters_for_pushdown` is left at its default, mirroring `DataSourceExec`.
- **`TakeExec`** forwards filters that reference only its input's columns down to its child (mirrors `CoalesceBatchesExec`), so a filter can reach the scan beneath a take. Filters on take-added columns stay above it.
- **scanner** installs `FilterPushdown::new_post_optimization()` in `get_physical_optimizer()`. Post phase only — static `WHERE` predicates are already baked into `full_filter` by Lance's logical filter plan, so running the Pre phase here would double-apply them.

A `DynamicFilterPhysicalExpr` re-reads its current predicate on every `evaluate`, so a TopK threshold that tightens as the sort's heap fills is honored per batch without re-planning.

## Verified benefit: TopK (`ORDER BY … LIMIT`)

`SELECT id, value FROM t ORDER BY value LIMIT 10` now plans as:

```
SortExec: TopK(fetch=10), expr=[value ASC]
  LanceRead: projection=[id, value], pushdown_filters=[DynamicFilter [ value IS NULL OR value < 2 ]]
```

The scan drops rows the top-k provably can't contain before they reach the sort. With a wide, late-materialized column the win compounds — the scan reads only the narrow sort key, and the downstream `Take` fetches the wide column for the surviving rows only:

```
Take: columns="id, sortkey, _rowid, (wide)"
  SortExec: TopK(fetch=10), expr=[sortkey ASC]
    LanceRead: projection=[id, sortkey], full_filter=id >= 0, pushdown_filters=[DynamicFilter [ … ]]
```

## Scope / honest limitations

This is deliberately the smallest useful slice — the reusable protocol spine plus **CPU pruning** (rows dropped at the scan). Two larger wins are follow-ups:

1. **Scan I/O pruning (ZoneMap).** Today the pushed filter drops rows *after* decode; it does not yet skip scan I/O. A `ZoneMapIndex`/btree probe of the filter's `IsIn`/`Range` (both already answer `SargableQuery`) would give Parquet-style range skipping. Depends on #4522 (ubiquitous zone maps) and #7192 (large `IsIn`).
2. **merge_insert / hash join.** The protocol is wired uniformly, but in the current backfill plan the target `LanceRead` is the hash-join **build** side (`CollectLeft`, `Inner`), so DataFusion pushes the join's dynamic filter to the **probe** (the source), not the target scan. Filtering the target by source keys needs a join-side change, tracked separately.

## Tests

- `test_topk_dynamic_filter_pushdown` — multi-fragment TopK: the dynamic filter reaches `LanceRead` and results are exactly the true top-k.
- `test_handle_child_pushdown_result_absorbs_dynamic_filter` — unit test: Post-phase absorbs and rewrites (Pre-phase declines); a filter tightened *after* pushdown takes effect at execute time.
- `test_take_filter_pushdown_pass_through` — `TakeExec` routes an input-column filter down and keeps a take-added-column filter above.
- Existing take + merge_insert suites (183 tests) stay green.

`cargo fmt` and `cargo clippy -p lance --tests -- -D warnings` pass.