### PR TITLE
feat(sql): register additional tables for Dataset.sql queries

### DIFF
--- a/java/lance-jni/src/sql.rs
+++ b/java/lance-jni/src/sql.rs
@@ -5,7 +5,7 @@ use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET};
 use crate::error::Result;
 use crate::traits::FromJString;
 use crate::{Error, JNIEnvExt, RT, block_on};
-use arrow::ffi_stream::FFI_ArrowArrayStream;
+use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use jni::JNIEnv;
 use jni::objects::{JClass, JObject, JString};
 use jni::sys::{JNI_TRUE, jboolean, jlong};
@@ -23,6 +23,8 @@ pub extern "system" fn Java_org_lance_SqlQuery_intoBatchRecords(
     with_row_id: jboolean,
     with_row_addr: jboolean,
     stream_addr: jlong,
+    extra_table_name: JObject,
+    extra_stream_addr: jlong,
 ) {
     ok_or_throw_without_return!(
         env,
@@ -34,11 +36,14 @@ pub extern "system" fn Java_org_lance_SqlQuery_intoBatchRecords(
             with_row_id,
             with_row_addr,
             stream_addr,
+            extra_table_name,
+            extra_stream_addr,
         )
         .map_err(|e| Error::input_error(e.to_string()))
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inner_into_batch_records(
     env: &mut JNIEnv,
     java_dataset: JObject,
@@ -47,6 +52,8 @@ fn inner_into_batch_records(
     with_row_id: jboolean,
     with_row_addr: jboolean,
     stream_addr: jlong,
+    extra_table_name: JObject,
+    extra_stream_addr: jlong,
 ) -> Result<()> {
     let builder = sql_builder(
         env,
@@ -55,6 +62,8 @@ fn inner_into_batch_records(
         table_name,
         with_row_id,
         with_row_addr,
+        extra_table_name,
+        extra_stream_addr,
     )?;
 
     let stream = block_on(async move {
@@ -69,6 +78,7 @@ fn inner_into_batch_records(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sql_builder(
     env: &mut JNIEnv,
     java_dataset: JObject,
@@ -76,9 +86,12 @@ fn sql_builder(
     table_name: JObject,
     with_row_id: jboolean,
     with_row_addr: jboolean,
+    extra_table_name: JObject,
+    extra_stream_addr: jlong,
 ) -> Result<SqlQueryBuilder> {
     let sql_str = sql.extract(env)?;
     let table_str = env.get_string_opt(&table_name)?;
+    let extra_name = env.get_string_opt(&extra_table_name)?;
 
     let dataset_guard =
         unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
@@ -91,6 +104,20 @@ fn sql_builder(
 
     if let Some(table) = table_str {
         builder = builder.table_name(table.as_str())
+    }
+
+    // An additional in-memory Arrow relation (the caller exported it to a C-Data stream). Import it to
+    // RecordBatches and register it under `extra_name`, so the SQL can semi-join it natively.
+    if extra_stream_addr != 0 {
+        let name = extra_name
+            .ok_or_else(|| Error::input_error("extra table stream given without a name".to_string()))?;
+        let stream_ptr = extra_stream_addr as *mut FFI_ArrowArrayStream;
+        let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr)? };
+        let mut batches = Vec::new();
+        for batch in reader {
+            batches.push(batch.map_err(|e| Error::input_error(e.to_string()))?);
+        }
+        builder = builder.register_arrow(name.as_str(), batches)?;
     }
 
     Ok(builder)

--- a/java/lance-jni/src/sql.rs
+++ b/java/lance-jni/src/sql.rs
@@ -23,8 +23,8 @@ pub extern "system" fn Java_org_lance_SqlQuery_intoBatchRecords(
     with_row_id: jboolean,
     with_row_addr: jboolean,
     stream_addr: jlong,
-    extra_table_name: JObject,
-    extra_stream_addr: jlong,
+    extra_table_names: JObject,
+    extra_stream_addrs: JObject,
 ) {
     ok_or_throw_without_return!(
         env,
@@ -36,8 +36,8 @@ pub extern "system" fn Java_org_lance_SqlQuery_intoBatchRecords(
             with_row_id,
             with_row_addr,
             stream_addr,
-            extra_table_name,
-            extra_stream_addr,
+            extra_table_names,
+            extra_stream_addrs,
         )
         .map_err(|e| Error::input_error(e.to_string()))
     )
@@ -52,8 +52,8 @@ fn inner_into_batch_records(
     with_row_id: jboolean,
     with_row_addr: jboolean,
     stream_addr: jlong,
-    extra_table_name: JObject,
-    extra_stream_addr: jlong,
+    extra_table_names: JObject,
+    extra_stream_addrs: JObject,
 ) -> Result<()> {
     let builder = sql_builder(
         env,
@@ -62,8 +62,8 @@ fn inner_into_batch_records(
         table_name,
         with_row_id,
         with_row_addr,
-        extra_table_name,
-        extra_stream_addr,
+        extra_table_names,
+        extra_stream_addrs,
     )?;
 
     let stream = block_on(async move {
@@ -86,12 +86,15 @@ fn sql_builder(
     table_name: JObject,
     with_row_id: jboolean,
     with_row_addr: jboolean,
-    extra_table_name: JObject,
-    extra_stream_addr: jlong,
+    extra_table_names: JObject,
+    extra_stream_addrs: JObject,
 ) -> Result<SqlQueryBuilder> {
     let sql_str = sql.extract(env)?;
     let table_str = env.get_string_opt(&table_name)?;
-    let extra_name = env.get_string_opt(&extra_table_name)?;
+    // Read every env-derived input before taking the dataset guard below, which holds a mutable borrow of `env`
+    // for its lifetime (a second `env` borrow while it is alive would not compile).
+    let names = env.get_strings(&extra_table_names)?;
+    let addrs = env.get_longs(&extra_stream_addrs)?;
 
     let dataset_guard =
         unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
@@ -106,12 +109,10 @@ fn sql_builder(
         builder = builder.table_name(table.as_str())
     }
 
-    // An additional in-memory Arrow relation (the caller exported it to a C-Data stream). Import it to
-    // RecordBatches and register it under `extra_name`, so the SQL can semi-join it natively.
-    if extra_stream_addr != 0 {
-        let name = extra_name
-            .ok_or_else(|| Error::input_error("extra table stream given without a name".to_string()))?;
-        let stream_ptr = extra_stream_addr as *mut FFI_ArrowArrayStream;
+    // Register each caller-supplied relation (parallel name/address lists, read above). Each stream was exported
+    // to a C-Data stream on the Java side; import it to RecordBatches and register it under its name.
+    for (name, addr) in names.into_iter().zip(addrs) {
+        let stream_ptr = addr as *mut FFI_ArrowArrayStream;
         let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr)? };
         let mut batches = Vec::new();
         for batch in reader {

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -33,6 +33,7 @@ public class SqlQuery {
   private boolean withRowAddr = false;
   private final List<String> extraTableNames = new ArrayList<>();
   private final List<Long> extraStreamAddresses = new ArrayList<>();
+  private boolean consumed = false;
 
   public SqlQuery(Dataset dataset, String sql) {
     this.dataset = dataset;
@@ -51,8 +52,19 @@ public class SqlQuery {
    * {@link ArrowArrayStream} handle and should close it afterwards (typically via try-with-resources), as with
    * {@code MergeInsert}. May be called multiple times to register multiple tables; if a name is registered twice,
    * the later registration replaces the earlier one at query time (DataFusion register semantics).
+   *
+   * <p>Because the registered stream is consumed on the first {@link #intoBatchRecords()} call, a query with
+   * registered relations is single-use; calling {@link #intoBatchRecords()} a second time throws.
+   *
+   * @throws IllegalArgumentException if {@code name} is null or blank, or {@code stream} is null
    */
   public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("table name must be non-empty");
+    }
+    if (stream == null) {
+      throw new IllegalArgumentException("stream must not be null");
+    }
     this.extraTableNames.add(name);
     this.extraStreamAddresses.add(stream.memoryAddress());
     return this;
@@ -69,6 +81,16 @@ public class SqlQuery {
   }
 
   public ArrowReader intoBatchRecords() throws IOException {
+    if (consumed) {
+      throw new IllegalStateException(
+          "intoBatchRecords() was already called on this SqlQuery; a query with registered Arrow relations is "
+              + "single-use because the registered streams are consumed. Build a new query and re-register them.");
+    }
+    // A query with registered streams is one-shot: the native call consumes the streams, so mark it consumed
+    // regardless of outcome to prevent a later call from handing JNI dead stream pointers.
+    if (!extraTableNames.isEmpty()) {
+      consumed = true;
+    }
     try (ArrowArrayStream s = ArrowArrayStream.allocateNew(dataset.allocator())) {
       intoBatchRecords(
           dataset,

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -46,15 +46,17 @@ public class SqlQuery {
   }
 
   /**
-   * Register an additional in-memory Arrow relation (exported to {@code stream} via the C Data Interface) as a
-   * table named {@code name}, joinable in the SQL alongside the dataset. {@link #intoBatchRecords()} consumes the
-   * stream during the native call (it takes ownership of the underlying C stream); the caller still owns the
-   * {@link ArrowArrayStream} handle and should close it afterwards (typically via try-with-resources), as with
-   * {@code MergeInsert}. May be called multiple times to register multiple tables; if a name is registered twice,
-   * the later registration replaces the earlier one (deduplicated when the query is built).
+   * Register an additional in-memory Arrow relation (exported to {@code stream} via the C Data
+   * Interface) as a table named {@code name}, joinable in the SQL alongside the dataset. {@link
+   * #intoBatchRecords()} consumes the stream during the native call (it takes ownership of the
+   * underlying C stream); the caller still owns the {@link ArrowArrayStream} handle and should
+   * close it afterwards (typically via try-with-resources), as with {@code MergeInsert}. May be
+   * called multiple times to register multiple tables; if a name is registered twice, the later
+   * registration replaces the earlier one (deduplicated when the query is built).
    *
-   * <p>Because the registered stream is consumed on the first {@link #intoBatchRecords()} call, a query with
-   * registered relations is single-use; calling {@link #intoBatchRecords()} a second time throws.
+   * <p>Because the registered stream is consumed on the first {@link #intoBatchRecords()} call, a
+   * query with registered relations is single-use; calling {@link #intoBatchRecords()} a second
+   * time throws.
    *
    * @throws IllegalArgumentException if {@code name} is null or blank, or {@code stream} is null
    * @throws IllegalStateException if the query was already run via {@link #intoBatchRecords()}
@@ -62,13 +64,16 @@ public class SqlQuery {
   public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
     if (consumed) {
       throw new IllegalStateException(
-          "registerArrow cannot be called after intoBatchRecords(); build a new query and re-register relations.");
+          "registerArrow cannot be called after intoBatchRecords(); build a new query and "
+              + "re-register relations.");
     }
     if (name == null || name.trim().isEmpty()) {
-      throw new IllegalArgumentException("registerArrow: table name must be non-empty, got: " + name);
+      throw new IllegalArgumentException(
+          "registerArrow: table name must be non-empty, got: " + name);
     }
     if (stream == null) {
-      throw new IllegalArgumentException("registerArrow: stream must not be null (table name: " + name + ")");
+      throw new IllegalArgumentException(
+          "registerArrow: stream must not be null (table name: " + name + ")");
     }
     this.extraTableNames.add(name);
     this.extraStreamAddresses.add(stream.memoryAddress());
@@ -88,12 +93,14 @@ public class SqlQuery {
   public ArrowReader intoBatchRecords() throws IOException {
     if (consumed) {
       throw new IllegalStateException(
-          "intoBatchRecords() was already called on this SqlQuery; a query with registered Arrow relations is "
-              + "single-use because the registered streams are consumed. Build a new query and re-register them.");
+          "intoBatchRecords() was already called on this SqlQuery; a query with registered "
+              + "Arrow relations is single-use because the registered streams are consumed. "
+              + "Build a new query and re-register them.");
     }
     try (ArrowArrayStream s = ArrowArrayStream.allocateNew(dataset.allocator())) {
-      // A query with registered streams is one-shot: the native call below consumes them. Mark it consumed here,
-      // just before the native call, so a failure in the output-stream allocation above does not brick a retry.
+      // A query with registered streams is one-shot: the native call below consumes them. Mark it
+      // consumed just before that call, so a failed output-stream allocation does not brick a
+      // retry.
       if (!extraTableNames.isEmpty()) {
         consumed = true;
       }

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -51,7 +51,7 @@ public class SqlQuery {
    * stream during the native call (it takes ownership of the underlying C stream); the caller still owns the
    * {@link ArrowArrayStream} handle and should close it afterwards (typically via try-with-resources), as with
    * {@code MergeInsert}. May be called multiple times to register multiple tables; if a name is registered twice,
-   * the later registration replaces the earlier one at query time (DataFusion register semantics).
+   * the later registration replaces the earlier one (deduplicated when the query is built).
    *
    * <p>Because the registered stream is consumed on the first {@link #intoBatchRecords()} call, a query with
    * registered relations is single-use; calling {@link #intoBatchRecords()} a second time throws.
@@ -60,10 +60,10 @@ public class SqlQuery {
    */
   public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
     if (name == null || name.trim().isEmpty()) {
-      throw new IllegalArgumentException("table name must be non-empty");
+      throw new IllegalArgumentException("registerArrow: table name must be non-empty, got: " + name);
     }
     if (stream == null) {
-      throw new IllegalArgumentException("stream must not be null");
+      throw new IllegalArgumentException("registerArrow: stream must not be null (table name: " + name + ")");
     }
     this.extraTableNames.add(name);
     this.extraStreamAddresses.add(stream.memoryAddress());

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -57,8 +57,13 @@ public class SqlQuery {
    * registered relations is single-use; calling {@link #intoBatchRecords()} a second time throws.
    *
    * @throws IllegalArgumentException if {@code name} is null or blank, or {@code stream} is null
+   * @throws IllegalStateException if the query was already run via {@link #intoBatchRecords()}
    */
   public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
+    if (consumed) {
+      throw new IllegalStateException(
+          "registerArrow cannot be called after intoBatchRecords(); build a new query and re-register relations.");
+    }
     if (name == null || name.trim().isEmpty()) {
       throw new IllegalArgumentException("registerArrow: table name must be non-empty, got: " + name);
     }
@@ -86,12 +91,12 @@ public class SqlQuery {
           "intoBatchRecords() was already called on this SqlQuery; a query with registered Arrow relations is "
               + "single-use because the registered streams are consumed. Build a new query and re-register them.");
     }
-    // A query with registered streams is one-shot: the native call consumes the streams, so mark it consumed
-    // regardless of outcome to prevent a later call from handing JNI dead stream pointers.
-    if (!extraTableNames.isEmpty()) {
-      consumed = true;
-    }
     try (ArrowArrayStream s = ArrowArrayStream.allocateNew(dataset.allocator())) {
+      // A query with registered streams is one-shot: the native call below consumes them. Mark it consumed here,
+      // just before the native call, so a failure in the output-stream allocation above does not brick a retry.
+      if (!extraTableNames.isEmpty()) {
+        consumed = true;
+      }
       intoBatchRecords(
           dataset,
           sql,

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -29,6 +29,8 @@ public class SqlQuery {
   private String table = DEFAULT_TABLE_NAME;
   private boolean withRowId = false;
   private boolean withRowAddr = false;
+  private String extraTableName = null;
+  private long extraStreamAddress = 0L;
 
   public SqlQuery(Dataset dataset, String sql) {
     this.dataset = dataset;
@@ -37,6 +39,19 @@ public class SqlQuery {
 
   public SqlQuery tableName(String tableName) {
     this.table = tableName;
+    return this;
+  }
+
+  /**
+   * Register an additional in-memory Arrow relation (exported to {@code stream} via the C Data Interface) as a
+   * table named {@code name}, joinable in the SQL alongside the dataset. {@link #intoBatchRecords()} consumes the
+   * stream during the native call (it takes ownership of the underlying C stream); the caller still owns the
+   * {@link ArrowArrayStream} handle and should close it afterwards (typically via try-with-resources), as with
+   * {@code MergeInsert}. Only one extra table is supported per query; the last call wins.
+   */
+  public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
+    this.extraTableName = name;
+    this.extraStreamAddress = stream.memoryAddress();
     return this;
   }
 
@@ -53,7 +68,14 @@ public class SqlQuery {
   public ArrowReader intoBatchRecords() throws IOException {
     try (ArrowArrayStream s = ArrowArrayStream.allocateNew(dataset.allocator())) {
       intoBatchRecords(
-          dataset, sql, Optional.ofNullable(table), withRowId, withRowAddr, s.memoryAddress());
+          dataset,
+          sql,
+          Optional.ofNullable(table),
+          withRowId,
+          withRowAddr,
+          s.memoryAddress(),
+          Optional.ofNullable(extraTableName),
+          extraStreamAddress);
       return Data.importArrayStream(dataset.allocator(), s);
     }
   }
@@ -64,7 +86,9 @@ public class SqlQuery {
       Optional<String> tableName,
       boolean withRowId,
       boolean withRowAddr,
-      long streamAddress)
+      long streamAddress,
+      Optional<String> extraTableName,
+      long extraStreamAddress)
       throws IOException;
 
   @Override

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -19,6 +19,8 @@ import org.apache.arrow.c.Data;
 import org.apache.arrow.vector.ipc.ArrowReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class SqlQuery {
@@ -29,8 +31,8 @@ public class SqlQuery {
   private String table = DEFAULT_TABLE_NAME;
   private boolean withRowId = false;
   private boolean withRowAddr = false;
-  private String extraTableName = null;
-  private long extraStreamAddress = 0L;
+  private final List<String> extraTableNames = new ArrayList<>();
+  private final List<Long> extraStreamAddresses = new ArrayList<>();
 
   public SqlQuery(Dataset dataset, String sql) {
     this.dataset = dataset;
@@ -47,11 +49,12 @@ public class SqlQuery {
    * table named {@code name}, joinable in the SQL alongside the dataset. {@link #intoBatchRecords()} consumes the
    * stream during the native call (it takes ownership of the underlying C stream); the caller still owns the
    * {@link ArrowArrayStream} handle and should close it afterwards (typically via try-with-resources), as with
-   * {@code MergeInsert}. Only one extra table is supported per query; the last call wins.
+   * {@code MergeInsert}. May be called multiple times to register multiple tables; if a name is registered twice,
+   * the later registration replaces the earlier one at query time (DataFusion register semantics).
    */
   public SqlQuery registerArrow(String name, ArrowArrayStream stream) {
-    this.extraTableName = name;
-    this.extraStreamAddress = stream.memoryAddress();
+    this.extraTableNames.add(name);
+    this.extraStreamAddresses.add(stream.memoryAddress());
     return this;
   }
 
@@ -74,8 +77,8 @@ public class SqlQuery {
           withRowId,
           withRowAddr,
           s.memoryAddress(),
-          Optional.ofNullable(extraTableName),
-          extraStreamAddress);
+          extraTableNames,
+          extraStreamAddresses);
       return Data.importArrayStream(dataset.allocator(), s);
     }
   }
@@ -87,8 +90,8 @@ public class SqlQuery {
       boolean withRowId,
       boolean withRowAddr,
       long streamAddress,
-      Optional<String> extraTableName,
-      long extraStreamAddress)
+      List<String> extraTableNames,
+      List<Long> extraStreamAddresses)
       throws IOException;
 
   @Override

--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -51,8 +51,14 @@ public class SqlQuery {
    * #intoBatchRecords()} consumes the stream during the native call (it takes ownership of the
    * underlying C stream); the caller still owns the {@link ArrowArrayStream} handle and should
    * close it afterwards (typically via try-with-resources), as with {@code MergeInsert}. May be
-   * called multiple times to register multiple tables; if a name is registered twice, the later
-   * registration replaces the earlier one (deduplicated when the query is built).
+   * called multiple times to register multiple tables.
+   *
+   * <p>{@code name} is parsed as a SQL identifier, so an unquoted name is lowercased ({@code IDs}
+   * registers the table {@code ids}) while a quoted one keeps its case ({@code "IDs"} registers the
+   * table {@code IDs}). If two names resolve to the same table, the later registration replaces the
+   * earlier one (deduplicated when the query is built). A name that resolves to the query's own
+   * {@link #tableName(String)} would hide the dataset, so {@link #intoBatchRecords()} rejects it
+   * with an {@link IllegalArgumentException}.
    *
    * <p>Because the registered stream is consumed on the first {@link #intoBatchRecords()} call, a
    * query with registered relations is single-use; calling {@link #intoBatchRecords()} a second

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -190,6 +190,31 @@ public class SqlQueryTest {
     }
   }
 
+  @Test
+  public void testRegisterArrowValidationAndReuse() throws Exception {
+    // registerArrow rejects invalid inputs at the boundary.
+    try (VectorSchemaRoot ids = idTable(1, 2);
+        ArrowArrayStream stream = toStream(ids)) {
+      SqlQuery q = dataset.sql("select id from " + NAME).tableName(NAME);
+      Assertions.assertThrows(IllegalArgumentException.class, () -> q.registerArrow("", stream));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> q.registerArrow(null, stream));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> q.registerArrow("ids", null));
+    }
+
+    // A query with registered relations is single-use: the registered stream is consumed on the first call, so a
+    // second intoBatchRecords() throws rather than handing JNI a dead stream.
+    try (VectorSchemaRoot ids = idTable(1, 2);
+        ArrowArrayStream stream = toStream(ids)) {
+      SqlQuery q =
+          dataset
+              .sql("select id from " + NAME + " where id in (select id from ids)")
+              .tableName(NAME)
+              .registerArrow("ids", stream);
+      q.intoBatchRecords().close();
+      Assertions.assertThrows(IllegalStateException.class, q::intoBatchRecords);
+    }
+  }
+
   /** Build a single-column (`id`: Int32) in-memory relation. */
   private VectorSchemaRoot idTable(int... ids) {
     Schema schema =

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -13,17 +13,32 @@
  */
 package org.lance;
 
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class SqlQueryTest {
   private static final String NAME = "sqlquery_test_dataset";
@@ -107,5 +122,55 @@ public class SqlQueryTest {
         "Schema<id: Int(32, true), name: Utf8, _rowid: Int(64, false), _rowaddr: Int(64, false)>",
         reader.getVectorSchemaRoot().getSchema().toString());
     reader.close();
+  }
+
+  @Test
+  public void testRegisterArrow() throws Exception {
+    // An additional in-memory Arrow relation (column `id`) to semi-join against the dataset; 100 is absent.
+    Schema idSchema =
+        new Schema(Collections.singletonList(Field.nullable("id", new ArrowType.Int(32, true))));
+    try (VectorSchemaRoot ids = VectorSchemaRoot.create(idSchema, allocator)) {
+      ids.allocateNew();
+      IntVector idVector = (IntVector) ids.getVector("id");
+      int[] wanted = {1, 5, 39, 100};
+      for (int i = 0; i < wanted.length; i++) {
+        idVector.setSafe(i, wanted[i]);
+      }
+      ids.setRowCount(wanted.length);
+
+      // The native side consumes the stream; we allocate and close it (try-with-resources).
+      try (ArrowArrayStream stream = toStream(ids)) {
+        ArrowReader reader =
+            dataset
+                .sql("select id from " + NAME + " where id in (select id from filter_ids) order by id")
+                .tableName(NAME)
+                .registerArrow("filter_ids", stream)
+                .intoBatchRecords();
+        List<Integer> got = new ArrayList<>();
+        while (reader.loadNextBatch()) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          for (int i = 0; i < root.getRowCount(); i++) {
+            got.add((Integer) root.getVector(0).getObject(i));
+          }
+        }
+        reader.close();
+        // 100 is not in the dataset; the rest are the intersection, in order.
+        Assertions.assertEquals(Arrays.asList(1, 5, 39), got);
+      }
+    }
+  }
+
+  /** Serialize a single-batch root to a self-contained Arrow C-Data stream (mirrors MergeInsertTest). */
+  private ArrowArrayStream toStream(VectorSchemaRoot root) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    ArrowStreamReader reader = new ArrowStreamReader(new ByteArrayInputStream(out.toByteArray()), allocator);
+    ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator);
+    Data.exportArrayStream(allocator, reader, stream);
+    return stream;
   }
 }

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -223,6 +223,15 @@ public class SqlQueryTest {
             IllegalStateException.class, () -> q.registerArrow("more", moreStream));
       }
     }
+
+    // A relation whose name resolves to the query's own table name would hide the dataset, so the
+    // native build rejects it (the Rust InvalidInput surfaces as IllegalArgumentException).
+    try (VectorSchemaRoot ids = idTable(1, 2);
+        ArrowArrayStream stream = toStream(ids)) {
+      SqlQuery q =
+          dataset.sql("select id from " + NAME).tableName(NAME).registerArrow(NAME, stream);
+      Assertions.assertThrows(IllegalArgumentException.class, q::intoBatchRecords);
+    }
   }
 
   /** Build a single-column (`id`: Int32) in-memory relation. */

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -225,12 +225,18 @@ public class SqlQueryTest {
     }
 
     // A relation whose name resolves to the query's own table name would hide the dataset, so the
-    // native build rejects it (the Rust InvalidInput surfaces as IllegalArgumentException).
+    // native build rejects it (the Rust InvalidInput surfaces as IllegalArgumentException). Assert
+    // on the message too: DataFusion's own "table already exists" error maps to the same exception.
     try (VectorSchemaRoot ids = idTable(1, 2);
         ArrowArrayStream stream = toStream(ids)) {
       SqlQuery q =
           dataset.sql("select id from " + NAME).tableName(NAME).registerArrow(NAME, stream);
-      Assertions.assertThrows(IllegalArgumentException.class, q::intoBatchRecords);
+      IllegalArgumentException error =
+          Assertions.assertThrows(IllegalArgumentException.class, q::intoBatchRecords);
+      Assertions.assertTrue(
+          error.getMessage().contains("resolves to")
+              && error.getMessage().contains("the query's table name '" + NAME + "'"),
+          "unexpected message: " + error.getMessage());
     }
   }
 

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -212,6 +212,13 @@ public class SqlQueryTest {
               .registerArrow("ids", stream);
       q.intoBatchRecords().close();
       Assertions.assertThrows(IllegalStateException.class, q::intoBatchRecords);
+
+      // Registering another relation after the query is consumed is also rejected (would be unexecutable).
+      try (VectorSchemaRoot more = idTable(3);
+          ArrowArrayStream moreStream = toStream(more)) {
+        Assertions.assertThrows(
+            IllegalStateException.class, () -> q.registerArrow("more", moreStream));
+      }
     }
   }
 

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -126,7 +126,7 @@ public class SqlQueryTest {
 
   @Test
   public void testRegisterArrow() throws Exception {
-    // An additional in-memory Arrow relation (column `id`) to semi-join against the dataset; 100 is absent.
+    // An in-memory Arrow relation (column `id`) to semi-join against the dataset; 100 is absent.
     Schema idSchema =
         new Schema(Collections.singletonList(Field.nullable("id", new ArrowType.Int(32, true))));
     try (VectorSchemaRoot ids = VectorSchemaRoot.create(idSchema, allocator)) {
@@ -142,7 +142,10 @@ public class SqlQueryTest {
       try (ArrowArrayStream stream = toStream(ids)) {
         ArrowReader reader =
             dataset
-                .sql("select id from " + NAME + " where id in (select id from filter_ids) order by id")
+                .sql(
+                    "select id from "
+                        + NAME
+                        + " where id in (select id from filter_ids) order by id")
                 .tableName(NAME)
                 .registerArrow("filter_ids", stream)
                 .intoBatchRecords();
@@ -162,7 +165,7 @@ public class SqlQueryTest {
 
   @Test
   public void testRegisterArrowMultiple() throws Exception {
-    // Register two relations in one query and join both; only ids in the dataset and in both survive.
+    // Register two relations in one query and join both; only ids present in all three survive.
     try (VectorSchemaRoot a = idTable(1, 2, 3, 10);
         VectorSchemaRoot b = idTable(2, 3, 4, 10);
         ArrowArrayStream sa = toStream(a);
@@ -201,8 +204,8 @@ public class SqlQueryTest {
       Assertions.assertThrows(IllegalArgumentException.class, () -> q.registerArrow("ids", null));
     }
 
-    // A query with registered relations is single-use: the registered stream is consumed on the first call, so a
-    // second intoBatchRecords() throws rather than handing JNI a dead stream.
+    // A query with registered relations is single-use: the stream is consumed on the first call,
+    // so a second intoBatchRecords() throws rather than handing JNI a dead stream.
     try (VectorSchemaRoot ids = idTable(1, 2);
         ArrowArrayStream stream = toStream(ids)) {
       SqlQuery q =
@@ -213,7 +216,7 @@ public class SqlQueryTest {
       q.intoBatchRecords().close();
       Assertions.assertThrows(IllegalStateException.class, q::intoBatchRecords);
 
-      // Registering another relation after the query is consumed is also rejected (would be unexecutable).
+      // Registering another relation after the query is consumed is also rejected.
       try (VectorSchemaRoot more = idTable(3);
           ArrowArrayStream moreStream = toStream(more)) {
         Assertions.assertThrows(
@@ -236,7 +239,10 @@ public class SqlQueryTest {
     return root;
   }
 
-  /** Serialize a single-batch root to a self-contained Arrow C-Data stream (mirrors MergeInsertTest). */
+  /**
+   * Serialize a single-batch root to a self-contained Arrow C-Data stream (mirrors
+   * MergeInsertTest).
+   */
   private ArrowArrayStream toStream(VectorSchemaRoot root) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
@@ -244,7 +250,8 @@ public class SqlQueryTest {
       writer.writeBatch();
       writer.end();
     }
-    ArrowStreamReader reader = new ArrowStreamReader(new ByteArrayInputStream(out.toByteArray()), allocator);
+    ArrowStreamReader reader =
+        new ArrowStreamReader(new ByteArrayInputStream(out.toByteArray()), allocator);
     ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator);
     Data.exportArrayStream(allocator, reader, stream);
     return stream;

--- a/java/src/test/java/org/lance/SqlQueryTest.java
+++ b/java/src/test/java/org/lance/SqlQueryTest.java
@@ -160,6 +160,50 @@ public class SqlQueryTest {
     }
   }
 
+  @Test
+  public void testRegisterArrowMultiple() throws Exception {
+    // Register two relations in one query and join both; only ids in the dataset and in both survive.
+    try (VectorSchemaRoot a = idTable(1, 2, 3, 10);
+        VectorSchemaRoot b = idTable(2, 3, 4, 10);
+        ArrowArrayStream sa = toStream(a);
+        ArrowArrayStream sb = toStream(b)) {
+      ArrowReader reader =
+          dataset
+              .sql(
+                  "select id from "
+                      + NAME
+                      + " where id in (select id from a) and id in (select id from b) order by id")
+              .tableName(NAME)
+              .registerArrow("a", sa)
+              .registerArrow("b", sb)
+              .intoBatchRecords();
+      List<Integer> got = new ArrayList<>();
+      while (reader.loadNextBatch()) {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+        for (int i = 0; i < root.getRowCount(); i++) {
+          got.add((Integer) root.getVector(0).getObject(i));
+        }
+      }
+      reader.close();
+      // a = {1,2,3,10}, b = {2,3,4,10}, dataset ids 0..39, so the intersection is {2,3,10}.
+      Assertions.assertEquals(Arrays.asList(2, 3, 10), got);
+    }
+  }
+
+  /** Build a single-column (`id`: Int32) in-memory relation. */
+  private VectorSchemaRoot idTable(int... ids) {
+    Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("id", new ArrowType.Int(32, true))));
+    VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+    root.allocateNew();
+    IntVector idVector = (IntVector) root.getVector("id");
+    for (int i = 0; i < ids.length; i++) {
+      idVector.setSafe(i, ids[i]);
+    }
+    root.setRowCount(ids.length);
+    return root;
+  }
+
   /** Serialize a single-batch root to a self-contained Arrow C-Data stream (mirrors MergeInsertTest). */
   private ArrowArrayStream toStream(VectorSchemaRoot root) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5618,6 +5618,26 @@ class SqlQueryBuilder:
         self._builder = self._builder.blob_handling(blob_handling)
         return self
 
+    def register_arrow(
+        self, name: str, data: Union[pa.Table, pa.RecordBatchReader]
+    ) -> "SqlQueryBuilder":
+        """
+        Register an in-memory Arrow relation that the query can join.
+
+        The relation is exposed under ``name`` and can be referenced like any
+        other table in the SQL (for example joined or used in a subquery). It
+        must be non-empty, since the schema is derived from the provided data.
+
+        Parameters
+        ----------
+        name: str
+            The name the relation is registered under in the query.
+        data: pyarrow.Table or pyarrow.RecordBatchReader
+            The in-memory relation to register. Must be non-empty.
+        """
+        self._builder = self._builder.register_arrow(name, data)
+        return self
+
     def build(self) -> SqlQuery:
         """
         Build the query.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5628,6 +5628,13 @@ class SqlQueryBuilder:
         other table in the SQL (for example joined or used in a subquery). It
         must be non-empty, since the schema is derived from the provided data.
 
+        ``name`` is parsed as a SQL identifier, so an unquoted name is lowercased
+        (``IDs`` registers the table ``ids``) while a quoted one keeps its case
+        (``"IDs"``). If two names resolve to the same table, the later
+        registration wins. A name that resolves to the query's own
+        :meth:`table_name` would hide the dataset and is rejected by
+        :meth:`build`.
+
         Parameters
         ----------
         name: str

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5632,8 +5632,12 @@ class SqlQueryBuilder:
         (``IDs`` registers the table ``ids``) while a quoted one keeps its case
         (``"IDs"``). If two names resolve to the same table, the later
         registration wins. A name that resolves to the query's own
-        :meth:`table_name` would hide the dataset and is rejected by
-        :meth:`build`.
+        :meth:`table_name` would hide the dataset and is rejected.
+
+        Registered names are validated when the query is executed, not when
+        :meth:`build` returns, so a rejected name raises from
+        :meth:`SqlQuery.to_batch_records` (as ``ValueError``) or
+        :meth:`SqlQuery.to_stream_reader` (as ``OSError``).
 
         Parameters
         ----------

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5634,6 +5634,19 @@ class SqlQueryBuilder:
             The name the relation is registered under in the query.
         data: pyarrow.Table or pyarrow.RecordBatchReader
             The in-memory relation to register. Must be non-empty.
+
+        Examples
+        --------
+        Register an in-memory relation and semi-join it in the query::
+
+            ids = pa.table({"id": [1, 2, 3]})
+            batches = (
+                dataset.sql("SELECT * FROM d WHERE id IN (SELECT id FROM ids)")
+                .table_name("d")
+                .register_arrow("ids", ids)
+                .build()
+                .to_batch_records()
+            )
         """
         self._builder = self._builder.register_arrow(name, data)
         return self

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -5648,17 +5648,20 @@ def test_dataset_sql(tmp_path: Path):
     assert pa.Table.from_batches(complex_result) == expected_complex
 
 
-def test_dataset_sql_register_arrow(tmp_path: Path):
+@pytest.mark.parametrize("as_reader", [False, True], ids=["table", "reader"])
+def test_dataset_sql_register_arrow(tmp_path: Path, as_reader: bool):
     table = pa.table({"id": [1, 2, 3, 4, 5], "value": ["a", "b", "c", "d", "e"]})
     ds = lance.write_dataset(table, tmp_path / "test")
 
-    # A subset of ids to join against, including one id (99) not in the dataset.
+    # A subset of ids to join against, including one id (99) not in the dataset. Exercise both accepted input
+    # forms: a pyarrow Table and a RecordBatchReader.
     ids = pa.table({"id": [4, 2, 99]})
+    data = ids.to_reader() if as_reader else ids
 
     result = (
         ds.sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids) ORDER BY id")
         .table_name("t")
-        .register_arrow("ids", ids)
+        .register_arrow("ids", data)
         .build()
         .to_batch_records()
     )
@@ -5666,6 +5669,18 @@ def test_dataset_sql_register_arrow(tmp_path: Path):
     # Only the intersection, in ascending order.
     expected = pa.table({"id": [2, 4]})
     assert pa.Table.from_batches(result) == expected
+
+
+def test_dataset_sql_register_arrow_empty(tmp_path: Path):
+    table = pa.table({"id": [1, 2, 3]})
+    ds = lance.write_dataset(table, tmp_path / "test")
+
+    # An empty relation has no batches to derive a schema from, so registration raises (translated to ValueError
+    # by the PyO3 binding).
+    schema = pa.schema([("id", pa.int64())])
+    empty = pa.RecordBatchReader.from_batches(schema, [])
+    with pytest.raises(ValueError):
+        ds.sql("SELECT id FROM ids").table_name("t").register_arrow("ids", empty)
 
 
 def test_file_reader_options(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -5648,6 +5648,26 @@ def test_dataset_sql(tmp_path: Path):
     assert pa.Table.from_batches(complex_result) == expected_complex
 
 
+def test_dataset_sql_register_arrow(tmp_path: Path):
+    table = pa.table({"id": [1, 2, 3, 4, 5], "value": ["a", "b", "c", "d", "e"]})
+    ds = lance.write_dataset(table, tmp_path / "test")
+
+    # A subset of ids to join against, including one id (99) not in the dataset.
+    ids = pa.table({"id": [4, 2, 99]})
+
+    result = (
+        ds.sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids) ORDER BY id")
+        .table_name("t")
+        .register_arrow("ids", ids)
+        .build()
+        .to_batch_records()
+    )
+
+    # Only the intersection, in ascending order.
+    expected = pa.table({"id": [2, 4]})
+    assert pa.Table.from_batches(result) == expected
+
+
 def test_file_reader_options(tmp_path: Path):
     """Test cache_repetition_index and validate_on_decode options"""
     # Create a dataset with large repetitive strings to test cache_repetition_index

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -5653,8 +5653,8 @@ def test_dataset_sql_register_arrow(tmp_path: Path, as_reader: bool):
     table = pa.table({"id": [1, 2, 3, 4, 5], "value": ["a", "b", "c", "d", "e"]})
     ds = lance.write_dataset(table, tmp_path / "test")
 
-    # A subset of ids to join against, including one id (99) not in the dataset. Exercise both accepted input
-    # forms: a pyarrow Table and a RecordBatchReader.
+    # A subset of ids to join against, including one id (99) not in the dataset.
+    # Exercise both accepted input forms: a pyarrow Table and a RecordBatchReader.
     ids = pa.table({"id": [4, 2, 99]})
     data = ids.to_reader() if as_reader else ids
 
@@ -5675,8 +5675,8 @@ def test_dataset_sql_register_arrow_empty(tmp_path: Path):
     table = pa.table({"id": [1, 2, 3]})
     ds = lance.write_dataset(table, tmp_path / "test")
 
-    # An empty relation has no batches to derive a schema from, so registration raises (translated to ValueError
-    # by the PyO3 binding).
+    # An empty relation has no batches to derive a schema from, so registration
+    # raises (translated to ValueError by the PyO3 binding).
     schema = pa.schema([("id", pa.int64())])
     empty = pa.RecordBatchReader.from_batches(schema, [])
     with pytest.raises(ValueError):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -5671,6 +5671,28 @@ def test_dataset_sql_register_arrow(tmp_path: Path, as_reader: bool):
     assert pa.Table.from_batches(result) == expected
 
 
+@pytest.mark.parametrize("name", ["t", "T", '"t"'], ids=["exact", "case", "quoted"])
+def test_dataset_sql_register_arrow_table_name_collision(tmp_path: Path, name: str):
+    table = pa.table({"id": [1, 2, 3]})
+    ds = lance.write_dataset(table, tmp_path / "test")
+
+    # A registered name that resolves to the query's own table name would hide the
+    # dataset. The check lives in the Rust builder, which runs when the query is
+    # executed rather than when build() returns, so build() itself succeeds.
+    builder = (
+        ds.sql("SELECT id FROM t")
+        .table_name("t")
+        .register_arrow(name, pa.table({"id": [4]}))
+    )
+    query = builder.build()
+
+    # to_batch_records surfaces Lance errors as ValueError, to_stream_reader as OSError.
+    with pytest.raises(ValueError, match="resolves to"):
+        query.to_batch_records()
+    with pytest.raises(OSError, match="resolves to"):
+        builder.build().to_stream_reader()
+
+
 def test_dataset_sql_register_arrow_empty(tmp_path: Path):
     table = pa.table({"id": [1, 2, 3]})
     ds = lance.write_dataset(table, tmp_path / "test")

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4093,6 +4093,26 @@ impl SqlQueryBuilder {
         })
     }
 
+    /// Register an in-memory Arrow relation that the SQL query can join.
+    ///
+    /// The relation is exposed under `name` and can be referenced like any other
+    /// table in the query. The `data` may be a pyarrow `Table` or
+    /// `RecordBatchReader` (ingested the same way as `add`/`merge_insert`), and
+    /// must be non-empty since the schema is derived from its batches.
+    #[pyo3(signature = (name, data))]
+    fn register_arrow(&self, name: &str, data: &Bound<PyAny>) -> PyResult<Self> {
+        let reader = convert_reader(data)?;
+        let batches = reader
+            .collect::<std::result::Result<Vec<RecordBatch>, _>>()
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        let builder = self
+            .builder
+            .clone()
+            .register_arrow(name, batches)
+            .infer_error()?;
+        Ok(Self { builder })
+    }
+
     /// Build the SQL query.
     fn build(&self) -> PyResult<SqlQuery> {
         Ok(SqlQuery {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4099,6 +4099,12 @@ impl SqlQueryBuilder {
     /// table in the query. The `data` may be a pyarrow `Table` or
     /// `RecordBatchReader` (ingested the same way as `add`/`merge_insert`), and
     /// must be non-empty since the schema is derived from its batches.
+    ///
+    /// `name` is parsed as a SQL identifier, so an unquoted name is lowercased
+    /// (`IDs` registers the table `ids`) while a quoted one keeps its case
+    /// (`"IDs"`). If two names resolve to the same table, the later registration
+    /// wins. A name that resolves to the query's own `table_name` would hide the
+    /// dataset and is rejected by `build`.
     #[pyo3(signature = (name, data))]
     fn register_arrow(&self, name: &str, data: &Bound<PyAny>) -> PyResult<Self> {
         let reader = convert_reader(data)?;

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4104,7 +4104,11 @@ impl SqlQueryBuilder {
     /// (`IDs` registers the table `ids`) while a quoted one keeps its case
     /// (`"IDs"`). If two names resolve to the same table, the later registration
     /// wins. A name that resolves to the query's own `table_name` would hide the
-    /// dataset and is rejected by `build`.
+    /// dataset and is rejected.
+    ///
+    /// Registered names are validated when the query is executed, not when
+    /// `build()` returns, so a rejected name raises from `to_batch_records()`
+    /// (as `ValueError`) or `to_stream_reader()` (as `OSError`).
     #[pyo3(signature = (name, data))]
     fn register_arrow(&self, name: &str, data: &Bound<PyAny>) -> PyResult<Self> {
         let reader = convert_reader(data)?;

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -582,7 +582,11 @@ mod tests {
 
     /// A one-batch relation `(id: Int32)` from `ids`.
     fn ids_batch(ids: Vec<i32>) -> RecordBatch {
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
         RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(ids))]).unwrap()
     }
 
@@ -664,7 +668,9 @@ mod tests {
         let schema = ids_batch(vec![]).schema();
 
         // The general path: register any TableProvider (here a MemTable) and join it.
-        let table = Arc::new(MemTable::try_new(schema.clone(), vec![vec![ids_batch(vec![7, 88])]]).unwrap());
+        let table = Arc::new(
+            MemTable::try_new(schema.clone(), vec![vec![ids_batch(vec![7, 88])]]).unwrap(),
+        );
         let results = ds
             .sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids) ORDER BY id")
             .table_name("t")
@@ -707,6 +713,9 @@ mod tests {
             matches!(&err, lance_core::Error::InvalidInput { .. }),
             "expected InvalidInput, got {err:?}"
         );
-        assert!(err.to_string().contains("non-empty"), "message should mention the empty name: {err}");
+        assert!(
+            err.to_string().contains("non-empty"),
+            "message should mention the empty name: {err}"
+        );
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -199,6 +199,11 @@ impl SqlQueryBuilder {
         // registered, so a later duplicate wins.
         let mut registered = std::collections::HashSet::new();
         for (name, provider) in self.extra_tables.into_iter().rev() {
+            if name.trim().is_empty() {
+                return Err(lance_core::Error::invalid_input(format!(
+                    "registered table name must be non-empty, got '{name}'"
+                )));
+            }
             if registered.insert(name.clone()) {
                 ctx.register_table(name, provider)?;
             }
@@ -687,5 +692,21 @@ mod tests {
             .await
             .unwrap();
         pretty_assertions::assert_eq!(collect_ids(&results), Vec::<i32>::new());
+
+        // A blank relation name is rejected when the query is built.
+        let blank = Arc::new(MemTable::try_new(ids_batch(vec![]).schema(), vec![vec![]]).unwrap());
+        let err = ds
+            .sql("SELECT 1")
+            .table_name("t")
+            .register_table("  ", blank)
+            .build()
+            .await
+            .err()
+            .expect("expected an error for a blank table name");
+        assert!(
+            matches!(&err, lance_core::Error::InvalidInput { .. }),
+            "expected InvalidInput, got {err:?}"
+        );
+        assert!(err.to_string().contains("non-empty"), "message should mention the empty name: {err}");
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -58,6 +58,43 @@ impl SqlQueryBuilder {
     /// Register an additional table named `name` in the query's DataFusion context, joinable alongside the
     /// dataset. Accepts any `TableProvider`, such as a `MemTable` (an in-memory Arrow relation), another Lance
     /// dataset's `LanceTableProvider`, or a view. May be called more than once; a later duplicate name wins.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use tokio::runtime::Runtime;
+    /// # use arrow_array::{RecordBatch, RecordBatchIterator, Int32Array};
+    /// # use arrow_schema::{Schema, Field, DataType};
+    /// # use datafusion::datasource::MemTable;
+    /// # use lance::dataset::{WriteParams, Dataset};
+    /// #
+    /// # let rt = Runtime::new().unwrap();
+    /// # rt.block_on(async {
+    /// # let test_dir = tempfile::tempdir().unwrap();
+    /// # let uri = test_dir.path().to_str().unwrap().to_string();
+    /// # let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    /// # let batch = RecordBatch::try_new(
+    /// #     schema.clone(),
+    /// #     vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    /// # ).unwrap();
+    /// # let reader = RecordBatchIterator::new(vec![batch.clone()].into_iter().map(Ok), schema.clone());
+    /// # let dataset = Dataset::write(reader, &uri, Some(WriteParams::default())).await.unwrap();
+    /// #
+    /// // Register any `TableProvider` (here a `MemTable`) and join it in the query.
+    /// let ids = Arc::new(MemTable::try_new(schema.clone(), vec![vec![batch]]).unwrap());
+    /// let batches = dataset
+    ///     .sql("SELECT id FROM data WHERE id IN (SELECT id FROM ids)")
+    ///     .table_name("data")
+    ///     .register_table("ids", ids)
+    ///     .build()
+    ///     .await?
+    ///     .into_batch_records()
+    ///     .await?;
+    /// # assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+    /// # Ok::<(), lance_core::Error>(())
+    /// # }).unwrap();
+    /// ```
     pub fn register_table(mut self, name: &str, provider: Arc<dyn TableProvider>) -> Self {
         self.extra_tables.push((name.to_string(), provider));
         self
@@ -66,6 +103,45 @@ impl SqlQueryBuilder {
     /// Convenience over [`Self::register_table`] that wraps in-memory Arrow `batches` in a `MemTable`. `batches`
     /// must be non-empty (the schema is derived from the first batch); for an empty relation, build a `MemTable`
     /// yourself and pass it to [`Self::register_table`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use tokio::runtime::Runtime;
+    /// # use arrow_array::{RecordBatch, RecordBatchIterator, Int32Array};
+    /// # use arrow_schema::{Schema, Field, DataType};
+    /// # use lance::dataset::{WriteParams, Dataset};
+    /// #
+    /// # let rt = Runtime::new().unwrap();
+    /// # rt.block_on(async {
+    /// # let test_dir = tempfile::tempdir().unwrap();
+    /// # let uri = test_dir.path().to_str().unwrap().to_string();
+    /// # let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    /// # let batch = RecordBatch::try_new(
+    /// #     schema.clone(),
+    /// #     vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+    /// # ).unwrap();
+    /// # let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+    /// # let dataset = Dataset::write(reader, &uri, Some(WriteParams::default())).await.unwrap();
+    /// #
+    /// // A caller-supplied relation to semi-join against the dataset.
+    /// let ids = RecordBatch::try_new(
+    ///     Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+    ///     vec![Arc::new(Int32Array::from(vec![2, 3]))],
+    /// ).unwrap();
+    /// let batches = dataset
+    ///     .sql("SELECT id FROM data WHERE id IN (SELECT id FROM ids)")
+    ///     .table_name("data")
+    ///     .register_arrow("ids", vec![ids])?
+    ///     .build()
+    ///     .await?
+    ///     .into_batch_records()
+    ///     .await?;
+    /// # assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 2);
+    /// # Ok::<(), lance_core::Error>(())
+    /// # }).unwrap();
+    /// ```
     pub fn register_arrow(self, name: &str, batches: Vec<RecordBatch>) -> lance_core::Result<Self> {
         let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
             lance_core::Error::invalid_input(
@@ -118,8 +194,14 @@ impl SqlQueryBuilder {
             provider = provider.with_blob_handling(blob_handling);
         }
         ctx.register_table(self.table_name, Arc::new(provider))?;
-        for (name, provider) in self.extra_tables {
-            ctx.register_table(name, provider)?;
+        // Register the extra tables, keeping the LAST provider for a name registered more than once (registering
+        // the same name into the context twice would otherwise error). Iterate in reverse and skip names already
+        // registered, so a later duplicate wins.
+        let mut registered = std::collections::HashSet::new();
+        for (name, provider) in self.extra_tables.into_iter().rev() {
+            if registered.insert(name.clone()) {
+                ctx.register_table(name, provider)?;
+            }
         }
         register_functions(&ctx);
         let df = ctx.sql(&self.sql).await?;
@@ -502,7 +584,7 @@ mod tests {
     fn collect_ids(batches: &[RecordBatch]) -> Vec<i32> {
         batches
             .iter()
-            .flat_map(|b| b.column(0).as_primitive::<Int32Type>().values().to_vec())
+            .flat_map(|b| b["id"].as_primitive::<Int32Type>().values().to_vec())
             .collect()
     }
 
@@ -537,11 +619,38 @@ mod tests {
             .into_batch_records()
             .await
             .unwrap();
-        pretty_assertions::assert_eq!(counted[0].column(0).as_primitive::<Int64Type>().value(0), 4);
+        pretty_assertions::assert_eq!(counted[0]["n"].as_primitive::<Int64Type>().value(0), 4);
 
-        // register_arrow with no batches cannot derive a schema, so it returns an error (not a silent skip).
-        let err = ds.sql("SELECT 1").table_name("t").register_arrow("ids", vec![]);
-        assert_true!(err.is_err());
+        // Registering the same name twice: the later relation replaces the earlier one.
+        let dup = ds
+            .sql("SELECT id FROM ids ORDER BY id")
+            .table_name("t")
+            .register_arrow("ids", vec![ids_batch(vec![1, 2])])
+            .unwrap()
+            .register_arrow("ids", vec![ids_batch(vec![7, 8, 9])])
+            .unwrap()
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(collect_ids(&dup), vec![7, 8, 9]);
+
+        // register_arrow with no batches cannot derive a schema, so it returns an InvalidInput error.
+        let err = ds
+            .sql("SELECT 1")
+            .table_name("t")
+            .register_arrow("ids", vec![])
+            .unwrap_err();
+        assert!(
+            matches!(err, lance_core::Error::InvalidInput { .. }),
+            "expected InvalidInput, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("schema"),
+            "message should mention the missing schema: {err}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -5,6 +5,7 @@ use crate::Dataset;
 use crate::datafusion::LanceTableProvider;
 use crate::dataset::utils::SchemaAdapter;
 use arrow_array::RecordBatch;
+use datafusion::common::TableReference;
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::execution::SendableRecordBatchStream;
@@ -57,7 +58,13 @@ impl SqlQueryBuilder {
 
     /// Register an additional table named `name` in the query's DataFusion context, joinable alongside the
     /// dataset. Accepts any `TableProvider`, such as a `MemTable` (an in-memory Arrow relation), another Lance
-    /// dataset's `LanceTableProvider`, or a view. May be called more than once; a later duplicate name wins.
+    /// dataset's `LanceTableProvider`, or a view.
+    ///
+    /// `name` is parsed as a SQL identifier, so an unquoted name is lowercased (`IDs` registers the table
+    /// `ids`) while a quoted one keeps its case (`"IDs"` registers the table `IDs`). May be called more than
+    /// once; if two names resolve to the same table, the later registration wins. Registering a name that
+    /// resolves to the query's own [`Self::table_name`] would hide the dataset, so [`Self::build`] rejects it
+    /// with an invalid-input error.
     ///
     /// # Examples
     ///
@@ -189,11 +196,23 @@ impl SqlQueryBuilder {
         let ctx = SessionContext::new();
         let row_id = self.with_row_id;
         let row_addr = self.with_row_addr;
+        // DataFusion parses a table name as a SQL identifier, lowercasing the unquoted parts, and
+        // resolves it to a catalog.schema.table slot. Resolve names the same way here so the
+        // duplicate detection below keys on the identifier DataFusion will actually register.
+        let config = ctx.copied_config();
+        let catalog_options = &config.options().catalog;
+        let resolve = |name: &str| {
+            TableReference::from(name).resolve(
+                &catalog_options.default_catalog,
+                &catalog_options.default_schema,
+            )
+        };
+        let dataset_table = resolve(&self.table_name);
         let mut provider = LanceTableProvider::new(self.dataset.clone(), row_id, row_addr);
         if let Some(blob_handling) = self.blob_handling {
             provider = provider.with_blob_handling(blob_handling);
         }
-        ctx.register_table(self.table_name, Arc::new(provider))?;
+        ctx.register_table(self.table_name.as_str(), Arc::new(provider))?;
         // Register the extra tables, keeping the LAST provider for a name registered more than once (registering
         // the same name into the context twice would otherwise error). Iterate in reverse and skip names already
         // registered, so a later duplicate wins.
@@ -204,7 +223,17 @@ impl SqlQueryBuilder {
                     "registered table name must be non-empty, got '{name}'"
                 )));
             }
-            if registered.insert(name.clone()) {
+            let table_ref = resolve(&name);
+            // An extra table on the dataset's own slot would hide the dataset from the query, so
+            // reject it rather than letting either one silently win.
+            if table_ref == dataset_table {
+                return Err(lance_core::Error::invalid_input(format!(
+                    "registered table name '{name}' resolves to '{table_ref}', the same table as \
+                     the query's table name '{}'; register it under a different name",
+                    self.table_name
+                )));
+            }
+            if registered.insert(table_ref) {
                 ctx.register_table(name, provider)?;
             }
         }
@@ -272,6 +301,7 @@ mod tests {
     use lance_core::datatypes::BlobHandling;
     use lance_datagen::{array, gen_batch};
     use lance_file::version::LanceFileVersion;
+    use rstest::rstest;
 
     #[tokio::test]
     async fn test_sql_execute() {
@@ -716,6 +746,87 @@ mod tests {
         assert!(
             err.to_string().contains("non-empty"),
             "message should mention the empty name: {err}"
+        );
+    }
+
+    /// DataFusion parses a registered name as a SQL identifier, so two spellings of the same
+    /// unquoted identifier are one table and the later registration wins.
+    #[rstest]
+    #[case::later_lowercase("IDs", "ids")]
+    #[case::later_mixed_case("ids", "IDs")]
+    #[case::later_quoted("ids", "\"ids\"")]
+    #[tokio::test]
+    async fn test_sql_register_duplicate_name_ignores_case(
+        #[case] first: &str,
+        #[case] second: &str,
+    ) {
+        let ds = ids_dataset("memory://").await;
+
+        let results = ds
+            .sql("SELECT id FROM ids ORDER BY id")
+            .table_name("t")
+            .register_arrow(first, vec![ids_batch(vec![1, 2])])
+            .unwrap()
+            .register_arrow(second, vec![ids_batch(vec![7, 8, 9])])
+            .unwrap()
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(collect_ids(&results), vec![7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn test_sql_register_quoted_name_keeps_case() {
+        let ds = ids_dataset("memory://").await;
+
+        // A quoted identifier is not lowercased, so `"IDs"` and `ids` are two different tables and
+        // both stay registered.
+        let results = ds
+            .sql(r#"SELECT id FROM "IDs" UNION ALL SELECT id FROM ids ORDER BY id"#)
+            .table_name("t")
+            .register_arrow(r#""IDs""#, vec![ids_batch(vec![1, 2])])
+            .unwrap()
+            .register_arrow("ids", vec![ids_batch(vec![7, 8, 9])])
+            .unwrap()
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(collect_ids(&results), vec![1, 2, 7, 8, 9]);
+    }
+
+    /// A registered name that resolves to the query's own table name would shadow the dataset, so
+    /// it is rejected instead of reaching DataFusion's opaque "table already exists" error.
+    #[rstest]
+    #[case::exact("t")]
+    #[case::different_case("T")]
+    #[case::quoted("\"t\"")]
+    #[tokio::test]
+    async fn test_sql_register_collides_with_table_name(#[case] name: &str) {
+        let ds = ids_dataset("memory://").await;
+
+        let err = ds
+            .sql("SELECT id FROM t")
+            .table_name("t")
+            .register_arrow(name, vec![ids_batch(vec![1, 2])])
+            .unwrap()
+            .build()
+            .await
+            .err()
+            .expect("expected an error for a name colliding with the query's table name");
+        assert!(
+            matches!(&err, lance_core::Error::InvalidInput { .. }),
+            "expected InvalidInput, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains(name) && message.contains("table name 't'"),
+            "message should name the registered table and the query table: {message}"
         );
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -6,6 +6,7 @@ use crate::datafusion::LanceTableProvider;
 use crate::dataset::utils::SchemaAdapter;
 use arrow_array::RecordBatch;
 use datafusion::dataframe::DataFrame;
+use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
 use futures::TryStreamExt;
@@ -33,6 +34,12 @@ pub struct SqlQueryBuilder {
 
     /// Override how blob columns are materialized for this query.
     pub(crate) blob_handling: Option<BlobHandling>,
+
+    /// Additional tables to register in the DataFusion context before running the query (name to provider).
+    /// This lets a `Dataset.sql` query join a caller-supplied relation, such as an in-memory `MemTable` (for
+    /// example a ranked id set to semi-join), another Lance dataset (`LanceTableProvider`), or a custom
+    /// `TableProvider`.
+    pub(crate) extra_tables: Vec<(String, Arc<dyn TableProvider>)>,
 }
 
 impl SqlQueryBuilder {
@@ -44,7 +51,30 @@ impl SqlQueryBuilder {
             with_row_id: false,
             with_row_addr: false,
             blob_handling: None,
+            extra_tables: Vec::new(),
         }
+    }
+
+    /// Register an additional table named `name` in the query's DataFusion context, joinable alongside the
+    /// dataset. Accepts any `TableProvider`, such as a `MemTable` (an in-memory Arrow relation), another Lance
+    /// dataset's `LanceTableProvider`, or a view. May be called more than once; a later duplicate name wins.
+    pub fn register_table(mut self, name: &str, provider: Arc<dyn TableProvider>) -> Self {
+        self.extra_tables.push((name.to_string(), provider));
+        self
+    }
+
+    /// Convenience over [`Self::register_table`] that wraps in-memory Arrow `batches` in a `MemTable`. `batches`
+    /// must be non-empty (the schema is derived from the first batch); for an empty relation, build a `MemTable`
+    /// yourself and pass it to [`Self::register_table`].
+    pub fn register_arrow(self, name: &str, batches: Vec<RecordBatch>) -> lance_core::Result<Self> {
+        let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
+            lance_core::Error::invalid_input(
+                "register_arrow requires a non-empty relation to derive a schema; \
+                 use register_table with a MemTable for an empty relation"
+                    .to_string(),
+            )
+        })?;
+        Ok(self.register_table(name, Arc::new(MemTable::try_new(schema, vec![batches])?)))
     }
 
     /// The table name to register in the datafusion context.
@@ -88,6 +118,9 @@ impl SqlQueryBuilder {
             provider = provider.with_blob_handling(blob_handling);
         }
         ctx.register_table(self.table_name, Arc::new(provider))?;
+        for (name, provider) in self.extra_tables {
+            ctx.register_table(name, provider)?;
+        }
         register_functions(&ctx);
         let df = ctx.sql(&self.sql).await?;
         Ok(SqlQuery::new(df))
@@ -146,6 +179,7 @@ mod tests {
     use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
     use arrow_schema::Schema as ArrowSchema;
     use arrow_schema::{DataType, Field};
+    use datafusion::datasource::MemTable;
     use lance_arrow::ARROW_EXT_NAME_KEY;
     use lance_arrow::json::ARROW_JSON_EXT_NAME;
     use lance_core::datatypes::BlobHandling;
@@ -448,5 +482,101 @@ mod tests {
         pretty_assertions::assert_eq!(batch.num_rows(), 1);
         pretty_assertions::assert_eq!(batch.num_columns(), 1);
         pretty_assertions::assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 1);
+    }
+
+    /// A dataset with an `id` column = 0..=99 across 10 fragments (for the register-table tests below).
+    async fn ids_dataset(uri: &str) -> Dataset {
+        gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .into_dataset(uri, FragmentCount::from(10), FragmentRowCount::from(10))
+            .await
+            .unwrap()
+    }
+
+    /// A one-batch relation `(id: Int32)` from `ids`.
+    fn ids_batch(ids: Vec<i32>) -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new("id", DataType::Int32, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(ids))]).unwrap()
+    }
+
+    fn collect_ids(batches: &[RecordBatch]) -> Vec<i32> {
+        batches
+            .iter()
+            .flat_map(|b| b.column(0).as_primitive::<Int32Type>().values().to_vec())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_sql_register_arrow() {
+        let ds = ids_dataset("memory://test_sql_register_arrow").await;
+
+        // Semi-join against a registered in-memory relation; 200 is absent from the dataset.
+        let results = ds
+            .sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids) ORDER BY id")
+            .table_name("t")
+            .register_arrow("ids", vec![ids_batch(vec![5, 10, 42, 200])])
+            .unwrap()
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        // 200 is dropped (not in the dataset); the rest are the intersection, in order.
+        pretty_assertions::assert_eq!(collect_ids(&results), vec![5, 10, 42]);
+
+        // The registered relation is also selectable directly.
+        let counted = ds
+            .sql("SELECT count(*) AS n FROM ids")
+            .table_name("t")
+            .register_arrow("ids", vec![ids_batch(vec![5, 10, 42, 200])])
+            .unwrap()
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(counted[0].column(0).as_primitive::<Int64Type>().value(0), 4);
+
+        // register_arrow with no batches cannot derive a schema, so it returns an error (not a silent skip).
+        let err = ds.sql("SELECT 1").table_name("t").register_arrow("ids", vec![]);
+        assert_true!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_sql_register_table_provider() {
+        let ds = ids_dataset("memory://test_sql_register_table_provider").await;
+        let schema = ids_batch(vec![]).schema();
+
+        // The general path: register any TableProvider (here a MemTable) and join it.
+        let table = Arc::new(MemTable::try_new(schema.clone(), vec![vec![ids_batch(vec![7, 88])]]).unwrap());
+        let results = ds
+            .sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids) ORDER BY id")
+            .table_name("t")
+            .register_table("ids", table)
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(collect_ids(&results), vec![7, 88]);
+
+        // An empty registered relation is a valid table (schema, zero rows), so the semi-join returns zero rows
+        // rather than a "table not found" error. (`vec![vec![]]` is one partition with no batches; MemTable
+        // requires at least one partition.)
+        let empty = Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap());
+        let results = ds
+            .sql("SELECT id FROM t WHERE id IN (SELECT id FROM ids)")
+            .table_name("t")
+            .register_table("ids", empty)
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        pretty_assertions::assert_eq!(collect_ids(&results), Vec::<i32>::new());
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -749,14 +749,18 @@ mod tests {
         );
     }
 
-    /// DataFusion parses a registered name as a SQL identifier, so two spellings of the same
-    /// unquoted identifier are one table and the later registration wins.
+    /// DataFusion parses a registered name as a SQL identifier and resolves it to a
+    /// catalog.schema.table slot, so two spellings of the same table are one registration and the
+    /// later one wins.
     #[rstest]
     #[case::later_lowercase("IDs", "ids")]
     #[case::later_mixed_case("ids", "IDs")]
     #[case::later_quoted("ids", "\"ids\"")]
+    #[case::later_schema_qualified("ids", "public.ids")]
+    #[case::earlier_fully_qualified("datafusion.public.ids", "ids")]
+    #[case::both_qualified("public.IDs", "datafusion.public.ids")]
     #[tokio::test]
-    async fn test_sql_register_duplicate_name_ignores_case(
+    async fn test_sql_register_duplicate_name_resolution(
         #[case] first: &str,
         #[case] second: &str,
     ) {

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -143,12 +143,12 @@ impl SqlQueryBuilder {
     /// # }).unwrap();
     /// ```
     pub fn register_arrow(self, name: &str, batches: Vec<RecordBatch>) -> lance_core::Result<Self> {
+        let n_batches = batches.len();
         let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
-            lance_core::Error::invalid_input(
-                "register_arrow requires a non-empty relation to derive a schema; \
-                 use register_table with a MemTable for an empty relation"
-                    .to_string(),
-            )
+            lance_core::Error::invalid_input(format!(
+                "register_arrow for table '{name}' requires a non-empty relation to derive a schema \
+                 (received {n_batches} batches); use register_table with a MemTable for an empty relation"
+            ))
         })?;
         Ok(self.register_table(name, Arc::new(MemTable::try_new(schema, vec![batches])?)))
     }


### PR DESCRIPTION
### Summary

Adds a way to register extra in-memory / provider-backed tables in the DataFusion `SessionContext` that backs `Dataset.sql(...)`, so a query can join a caller-supplied relation instead of encoding it as a large literal `IN (...)` list.

New API:

- **Rust** `SqlQueryBuilder::register_table(name: &str, provider: Arc<dyn TableProvider>) -> Self` and a convenience `SqlQueryBuilder::register_arrow(name: &str, batches: Vec<RecordBatch>) -> Result<Self>`.
- **Java** `SqlQuery.registerArrow(String name, ArrowArrayStream stream)`.
- **Python** `SqlQueryBuilder.register_arrow(name, data)` (accepts a pyarrow `Table` or `RecordBatchReader`).

Example (Rust): semi-join a caller-supplied id set.

```rust
let results = ds
    .sql("SELECT * FROM t WHERE id IN (SELECT id FROM wanted)")
    .table_name("t")
    .register_arrow("wanted", vec![id_batch])?
    .build()
    .await?
    .into_batch_records()
    .await?;
```

### Motivation

`Dataset.sql` today can only reference the dataset itself. To scope a query by a set of ids (or to join another table) the only options are:

1. inline the values as a literal `IN (...)` list, which is expensive to parse/plan for large sets, or
2. bypass `SqlQueryBuilder` entirely and hand-build a `SessionContext`, registering a `LanceTableProvider` plus the other table (this is what the "join two datasets" example in `docs/src/integrations/datafusion.md` currently requires).

Option 2 is Rust-only. The Java and Python bindings have no way to add a table to a `Dataset.sql` query at all. This change exposes the capability through the builder so all three bindings can do it, and so the common case (join an in-memory Arrow relation) is a one-liner.

### Design decisions (and alternatives considered)

**Table type is `Arc<dyn TableProvider>`, not `Vec<RecordBatch>` or a reader.** `SqlQueryBuilder` is `#[derive(Clone, Debug)]` and the Python binding clones it on every builder call, so any stored field must be `Clone + Debug`. That rules out `impl RecordBatchReader` / `SendableRecordBatchStream` (neither is `Clone`). `Arc<dyn TableProvider>` is `Clone + Debug`, is the most general option (callers can register a `MemTable`, another dataset's `LanceTableProvider`, a view, etc.), and matches DataFusion's own `SessionContext::register_table(_, Arc<dyn TableProvider>)`.

**`register_arrow` is a thin, fallible convenience.** `register_table` stays infallible like the other builder methods (`table_name`, `with_row_id`, ...). `register_arrow` wraps `Vec<RecordBatch>` in a `MemTable`, which is the fallible part, so it returns `Result<Self>` and keeps that fallibility at the boundary rather than in `build()`.

**Naming.** `register_table` follows the existing in-tree precedent (`FtsQueryUDTFBuilder::register_table`) and DataFusion's `register_table`, rather than `with_table`. `with_*` in this builder is reserved for scalar toggles.

**Empty relations.** `register_arrow` requires at least one batch (it derives the schema from the first) and returns an error otherwise, since an empty `Vec<RecordBatch>` has no schema. If you need to register an empty relation, build a `MemTable` with a known schema and use `register_table`; the query then returns zero rows rather than failing with "table not found". (An earlier approach stored `Vec<RecordBatch>` and skipped empty inputs in `build()`, which silently produced a "table not found" error at query time; moving to `TableProvider` removes that footgun because a provider always carries a schema.)

**`name: &str`** matches the other builder methods. Schema-qualified names work as-is, since the name is parsed through `TableReference`; `impl Into<TableReference>` would only make that explicit in the signature.

**Duplicate names / multiple calls.** `register_table` may be called more than once; a later duplicate name wins, deduplicated in `build()` (DataFusion's `register_table` rejects a duplicate rather than replacing it). Dedup keys on the resolved `TableReference`, matching how DataFusion itself resolves the name: unquoted identifiers are lowercased, quoted ones keep their case, and `ids` / `public.ids` / `datafusion.public.ids` collapse onto one slot. Keying on the raw string instead would let `"IDs"` and `"ids"` both through, and DataFusion would then hard-error on the collision.

**Collision with the query's own table.** Registering an extra table that resolves to the same reference as `table_name` is rejected in `build()` with an `InvalidInput` naming the registered name, its resolved reference, and the query's table name. Last-wins would silently shadow the dataset itself, so this is a caller error rather than something to resolve.

**In-memory vs streaming.** `register_arrow` builds a `MemTable`, so its input is materialized. That is by design for an in-memory relation the caller already holds; for a large or streaming source, pass a custom `TableProvider` to `register_table` rather than collecting it. A `MemTable` is used here because a `TableProvider` must be re-scannable (self-joins, multi-partition planning), which a one-shot reader cannot satisfy.

### Cross-language notes

- **Java:** the input is an `ArrowArrayStream` imported through the JNI (`ArrowArrayStreamReader::from_raw`), the same pattern `MergeInsert` uses.
  Ownership: the native call consumes (takes ownership of) the C stream; the caller owns the Java `ArrowArrayStream` handle and closes it afterwards (e.g. try-with-resources), as `MergeInsertTest` does. `registerArrow` may be called multiple times to register multiple tables, matching Rust and Python.
 `registerArrow` rejects a null/blank name or a null stream. A query with registered relations is single-use: the streams are consumed on the first `intoBatchRecords()`, so a second `intoBatchRecords()`, or a `registerArrow` after it, throws.
- **Python:** `register_arrow` accepts a pyarrow `Table`/`RecordBatchReader` via the existing `convert_reader` helper. A general `register_table` was not added because Python has no Rust `TableProvider` to pass; the existing `FFILanceTableProvider` + the external `datafusion` package already cover provider-level joins (see `docs/src/integrations/datafusion.md`). A Python `register_table` accepting an object implementing `__datafusion_table_provider__` could be a follow-up.
  Validation runs when the query is executed (`to_batch_records()` / `to_stream_reader()`), not when `build()` returns, since `build()` only clones the builder. Note the two terminal methods currently surface the same error as different types (`ValueError` vs `OSError`); that predates this PR.