### PR TITLE
feat(dataset): add column write APIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
 
   linux-build:
     runs-on: "ubuntu-24.04-8x"
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       # Need up-to-date compilers for kernels
       CC: clang

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1602,7 +1602,7 @@ impl Dataset {
         .await
     }
 
-    pub(crate) async fn apply_commit(
+    pub async fn apply_commit(
         &mut self,
         transaction: Transaction,
         write_config: &ManifestWriteConfig,
@@ -3420,6 +3420,204 @@ impl Dataset {
         schema_evolution::add_columns(self, transforms, read_columns, batch_size).await
     }
 
+    /// Write new column data for a single fragment, returning a `DataReplacementGroup`
+    /// that can be committed with `commit_data_replacements`.
+    ///
+    /// This is the building block for distributed column writes: each worker
+    /// writes its assigned fragments independently, then one worker commits all
+    /// the replacements atomically.
+    ///
+    /// The `data` iterator must produce exactly the physical row count for the
+    /// fragment (including nulls for filtered-out rows).
+    pub async fn write_fragment_column(
+        &self,
+        fragment_id: u64,
+        data: impl Iterator<Item = Result<RecordBatch>> + Send,
+        schema: &lance_core::datatypes::Schema,
+    ) -> Result<transaction::DataReplacementGroup> {
+        self.write_fragment_column_stream(fragment_id, stream::iter(data), schema)
+            .await
+    }
+
+    /// Streaming variant of [`Self::write_fragment_column`]: pulls batches from
+    /// an async `Stream` one at a time. A caller that assembles the replacement
+    /// column from many out-of-line sources (e.g. checkpoint files fetched from
+    /// an object store) then holds only one batch in memory rather than
+    /// materializing the whole column up front. The iterator entry point above
+    /// wraps a synchronous iterator as a stream.
+    pub async fn write_fragment_column_stream(
+        &self,
+        fragment_id: u64,
+        data: impl Stream<Item = Result<RecordBatch>> + Send,
+        schema: &lance_core::datatypes::Schema,
+    ) -> Result<transaction::DataReplacementGroup> {
+        use lance_file::writer::{FileWriter, FileWriterOptions};
+        use lance_table::format::DataFile;
+        use uuid::Uuid;
+
+        let file_name = format!("{}.lance", Uuid::new_v4());
+        let path = self.data_dir().join(file_name.as_str());
+
+        let format_version = self.manifest.data_storage_format.lance_file_version()?;
+
+        let writer = self.object_store.create(&path).await?;
+        let mut file_writer = FileWriter::try_new(
+            writer,
+            schema.clone(),
+            FileWriterOptions {
+                format_version: Some(format_version),
+                ..Default::default()
+            },
+        )?;
+
+        let mut data = std::pin::pin!(data);
+        while let Some(batch_result) = data.next().await {
+            let batch = batch_result?;
+            file_writer.write_batch(&batch).await?;
+        }
+        let field_id_mapping = file_writer.field_id_to_column_indices().to_vec();
+        file_writer.finish().await?;
+        let field_ids: Vec<i32> = field_id_mapping
+            .iter()
+            .map(|(field_id, _)| *field_id as i32)
+            .collect();
+        let column_indices: Vec<i32> = field_id_mapping
+            .iter()
+            .map(|(_, column_index)| *column_index as i32)
+            .collect();
+
+        let (major, minor) = match file_writer.version().resolve() {
+            lance_encoding::version::LanceFileVersion::Legacy => (0, 1),
+            version => version.to_numbers(),
+        };
+
+        let data_file = DataFile {
+            path: file_name,
+            fields: field_ids.into(),
+            column_indices: column_indices.into(),
+            file_major_version: major,
+            file_minor_version: minor,
+            file_size_bytes: Default::default(),
+            base_id: None,
+        };
+
+        Ok(transaction::DataReplacementGroup(fragment_id, data_file))
+    }
+
+    /// Commit a set of `DataReplacementGroup`s as a new dataset version.
+    ///
+    /// Each group adds a new data file to its fragment. Use with
+    /// `write_fragment_column` for distributed column writes.
+    /// Commit per-fragment column writes as a new dataset version using Merge.
+    ///
+    /// Takes the DataReplacementGroups (mapping fragment_id -> data file),
+    /// merges the new data files into the existing fragment metadata,
+    /// and extends the schema with the new column.
+    pub async fn commit_column_writes(
+        &mut self,
+        replacements: Vec<transaction::DataReplacementGroup>,
+        new_column_schema: &lance_core::datatypes::Schema,
+        transaction_properties: Option<Arc<std::collections::HashMap<String, String>>>,
+    ) -> Result<()> {
+        use lance_table::format::Fragment;
+
+        let replacement_map: std::collections::HashMap<u64, &lance_table::format::DataFile> =
+            replacements.iter().map(|r| (r.0, &r.1)).collect();
+
+        // Merge-vs-Merge conflicts are not rebased automatically; the
+        // conflict resolver asks the caller to retry. Rebuild the fragment
+        // list and schema from the latest version each attempt so a
+        // concurrent column commit's data files are preserved.
+        const MAX_COMMIT_RETRIES: usize = 5;
+        let mut attempt = 0;
+        loop {
+            // Build new schema = existing + new columns. Skip fields that
+            // are already present (incremental column writes: the column
+            // exists in the schema and only fragments missing its data
+            // file are written).
+            let mut schema = self.schema().clone();
+            for field in &new_column_schema.fields {
+                if schema.field_by_id(field.id).is_none() {
+                    schema.fields.push(field.clone());
+                }
+            }
+
+            let mut fragments = Vec::new();
+            let mut applied = 0usize;
+            for frag in self.get_fragments() {
+                let frag_id = frag.id() as u64;
+                let mut new_frag: Fragment = frag.metadata().clone();
+                if let Some(data_file) = replacement_map.get(&frag_id) {
+                    applied += 1;
+                    // Tombstone the replaced fields in existing files (same
+                    // mechanism as the update-columns path) so the new file
+                    // is authoritative for fragments that already covered
+                    // the column (e.g. inserts that wrote nulls inline).
+                    let replaced: std::collections::HashSet<i32> =
+                        data_file.fields.iter().copied().collect();
+                    for file in &mut new_frag.files {
+                        let new_fields: std::sync::Arc<[i32]> = file
+                            .fields
+                            .iter()
+                            .map(|field| if replaced.contains(field) { -2 } else { *field })
+                            .collect::<Vec<_>>()
+                            .into();
+                        file.fields = new_fields;
+                    }
+                    new_frag
+                        .files
+                        .retain(|file| file.fields.iter().any(|&field| field != -2));
+                    new_frag.files.push((*data_file).clone());
+                }
+                fragments.push(new_frag);
+            }
+
+            // Data-integrity guard: every replacement MUST land on a current
+            // fragment. If some don't (the rebase above checked out a version
+            // where a concurrent compaction rewrote those fragments into new
+            // ids), the replacement column files for the orphaned fragments
+            // would be silently dropped, committing a column with missing
+            // (null) data. Fail loudly instead so the caller re-derives the
+            // column against the current fragments (the per-fragment write
+            // keys on fragment id + source signature, both of which change on
+            // compaction, so a re-run recomputes correctly). Without this the
+            // failure was a silent partial backfill.
+            if applied < replacement_map.len() {
+                return Err(Error::internal(format!(
+                    "commit_column_writes: {} of {} column replacements reference fragments no \
+                     longer in the dataset (concurrent compaction rewrote them after the column \
+                     was computed); refusing to commit a partial column. Re-run the backfill \
+                     against the current fragments.",
+                    replacement_map.len() - applied,
+                    replacement_map.len(),
+                )));
+            }
+
+            let operation = transaction::Operation::Merge { fragments, schema };
+            let mut transaction =
+                transaction::Transaction::new(self.manifest.version, operation, None);
+            transaction.transaction_properties = transaction_properties.clone();
+            match self
+                .apply_commit(transaction, &Default::default(), &Default::default())
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(e)
+                    if attempt < MAX_COMMIT_RETRIES
+                        && e.to_string().contains("Retryable commit conflict") =>
+                {
+                    attempt += 1;
+                    log::info!(
+                        "commit_column_writes: retryable conflict (attempt {}), rebasing on latest",
+                        attempt
+                    );
+                    self.checkout_latest().await?;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     /// Modify columns in the dataset, changing their name, type, or nullability.
     ///
     /// If only changing the name or nullability of a column, this is a zero-copy
@@ -3814,7 +4012,7 @@ impl DatasetTakeRows for Dataset {
 }
 
 #[derive(Debug)]
-pub(crate) struct ManifestWriteConfig {
+pub struct ManifestWriteConfig {
     auto_set_feature_flags: bool,              // default true
     timestamp: Option<SystemTime>,             // default None
     use_stable_row_ids: bool,                  // default false

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -13,7 +13,7 @@ use crate::dataset::transaction::{DataReplacementGroup, Operation};
 use crate::dataset::{AutoCleanupParams, MergeInsertBuilder, ProjectionRequest, UpdateBuilder};
 use crate::index::DatasetIndexExt;
 use crate::{Dataset, Error};
-use lance_core::ROW_ADDR;
+use lance_core::{ROW_ADDR, datatypes::Schema as LanceSchema};
 use lance_index::IndexType;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
@@ -340,6 +340,179 @@ async fn test_merge_on_row_addr(
     for i in 0..key.len() {
         assert_eq!(key.value(i) + 1, new_value.value(i));
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_write_fragment_column_records_dataset_storage_version(
+    #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1, LanceFileVersion::V2_2)]
+    data_storage_version: LanceFileVersion,
+) {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("value", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(Int32Array::from(vec![10, 20])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            data_storage_version: Some(data_storage_version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let output_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "derived",
+        DataType::Int32,
+        false,
+    )]));
+    let output_batch = RecordBatch::try_new(
+        output_schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![20, 40]))],
+    )
+    .unwrap();
+    let mut lance_schema = LanceSchema::try_from(output_schema.as_ref()).unwrap();
+    lance_schema.fields[0].id = dataset.manifest.max_field_id() + 1;
+
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let replacement = dataset
+        .write_fragment_column(
+            fragment_id,
+            vec![Ok(output_batch)].into_iter(),
+            &lance_schema,
+        )
+        .await
+        .unwrap();
+    let expected_version = data_storage_version.resolve().to_numbers();
+    assert_eq!(
+        (
+            replacement.1.file_major_version,
+            replacement.1.file_minor_version
+        ),
+        expected_version
+    );
+
+    dataset
+        .commit_column_writes(vec![replacement], &lance_schema, None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    let field_id = dataset.schema().field("derived").unwrap().id;
+    let mut saw_output_file = false;
+    for fragment in dataset.get_fragments() {
+        for file in &fragment.metadata().files {
+            if file.fields.contains(&field_id) {
+                saw_output_file = true;
+                assert_eq!(
+                    (file.file_major_version, file.file_minor_version),
+                    expected_version
+                );
+            }
+        }
+    }
+    assert!(saw_output_file, "committed output file should be present");
+}
+
+/// Data-integrity regression: a column backfill computes per-fragment column
+/// replacements, then a concurrent compaction rewrites those fragments into new
+/// ids before the commit. `commit_column_writes` must FAIL (the replacements are
+/// orphaned) rather than silently commit a column with null data for the rewritten
+/// fragments. (Previously it iterated only the current fragments and dropped
+/// replacements that no longer matched, committing a partial/null column.)
+#[tokio::test]
+async fn test_commit_column_writes_rejects_orphaned_replacements_after_compaction() {
+    use crate::dataset::optimize::{CompactionOptions, compact_files};
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("value", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(Int32Array::from(vec![10, 20])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    // One fragment per row -> two fragments to compact together.
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    let orig_frag_ids: Vec<u64> = dataset
+        .get_fragments()
+        .iter()
+        .map(|f| f.id() as u64)
+        .collect();
+
+    // Compute a "derived" column replacement for EACH fragment (a backfill).
+    let output_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "derived",
+        DataType::Int32,
+        false,
+    )]));
+    let mut lance_schema = LanceSchema::try_from(output_schema.as_ref()).unwrap();
+    lance_schema.fields[0].id = dataset.manifest.max_field_id() + 1;
+    let mut replacements = Vec::new();
+    for (i, frag_id) in orig_frag_ids.iter().enumerate() {
+        let out = RecordBatch::try_new(
+            output_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![(i as i32 + 1) * 100]))],
+        )
+        .unwrap();
+        let r = dataset
+            .write_fragment_column(*frag_id, vec![Ok(out)].into_iter(), &lance_schema)
+            .await
+            .unwrap();
+        replacements.push(r);
+    }
+
+    // A concurrent compaction rewrites the fragments into new ids, orphaning the
+    // replacements computed above.
+    compact_files(&mut dataset, CompactionOptions::default(), None)
+        .await
+        .unwrap();
+    let new_frag_ids: Vec<u64> = dataset
+        .get_fragments()
+        .iter()
+        .map(|f| f.id() as u64)
+        .collect();
+    assert!(
+        new_frag_ids.iter().all(|id| !orig_frag_ids.contains(id)),
+        "compaction should have produced new fragment ids; orig={orig_frag_ids:?} new={new_frag_ids:?}"
+    );
+
+    // Committing the stale replacements must FAIL rather than silently commit a
+    // 'derived' column with missing data.
+    let err = dataset
+        .commit_column_writes(replacements, &lance_schema, None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no longer in the dataset"),
+        "expected orphaned-replacement data-integrity error, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2834,14 +2834,6 @@ impl Transaction {
         }
     }
 
-    fn is_vector_index(index: &IndexMetadata) -> bool {
-        if let Some(details) = &index.index_details {
-            details.type_url.ends_with("VectorIndexDetails")
-        } else {
-            false
-        }
-    }
-
     /// Remove data files that only contain tombstoned fields (-2)
     /// These files no longer contain any live data and can be safely dropped
     fn remove_tombstoned_data_files(fragments: &mut [Fragment]) {
@@ -2912,15 +2904,19 @@ impl Transaction {
                     });
 
                 if non_empty_indices.is_empty() {
-                    // All indices are empty - for scalar indices, keep only the first (oldest) one
-                    // For vector indices, remove all of them
+                    // All indices are empty -- keep only the oldest definition.
+                    //
+                    // Fork divergence from upstream Lance, which drops empty
+                    // VECTOR indexes here. We retain the *definition* so a full
+                    // materialized-view refresh -- which replaces every fragment
+                    // and thus empties the index -- never leaves the view without
+                    // its declared index. The scanner flat-scans unindexed
+                    // fragments (an empty index is still correct), and the
+                    // planner reindexes once enough rows accrue.
                     let mut sorted_indices = empty_indices;
                     sorted_indices.sort_by_key(|index: &&IndexMetadata| index.dataset_version); // Sort by ascending dataset_version
 
-                    // Keep only the first (oldest) if it's not a vector index
-                    if let Some(oldest) = sorted_indices.first()
-                        && !Self::is_vector_index(oldest)
-                    {
+                    if let Some(oldest) = sorted_indices.first() {
                         uuids_to_keep.insert(oldest.uuid);
                     }
                 } else {
@@ -2930,18 +2926,12 @@ impl Transaction {
                     }
                 }
             } else {
-                // Single index - keep it unless it's an empty vector index
+                // Single index whose column is still in schema: keep it,
+                // including an empty vector index (fork divergence -- see the
+                // all-empty note above; needed so a full MV refresh never drops
+                // the view's declared vector index).
                 if let Some(index) = same_name_indices.first() {
-                    let is_empty = index
-                        .effective_fragment_bitmap(&existing_fragments)
-                        .as_ref()
-                        .is_none_or(|bitmap| bitmap.is_empty());
-                    let is_vector = Self::is_vector_index(index);
-
-                    // Keep the index unless it's an empty vector index
-                    if !is_empty || !is_vector {
-                        uuids_to_keep.insert(index.uuid);
-                    }
+                    uuids_to_keep.insert(index.uuid);
                 }
             }
         }
@@ -4760,7 +4750,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retain_single_empty_vector_index() {
+    fn test_retain_single_empty_vector_index_is_kept() {
         let schema = create_test_schema(&[1]);
         let fragments = vec![Fragment::new(1)];
 
@@ -4774,8 +4764,10 @@ mod tests {
 
         Transaction::retain_relevant_indices(&mut indices, &schema, &fragments);
 
-        // Single empty vector index should be removed
-        assert_eq!(indices.len(), 0);
+        // Fork behavior: a single empty vector index DEFINITION is retained, so
+        // a full MV refresh (which empties every index) never leaves the view
+        // without its declared index. Upstream Lance drops it here.
+        assert_eq!(indices.len(), 1);
     }
 
     #[test]
@@ -4818,9 +4810,11 @@ mod tests {
         Transaction::retain_relevant_indices(&mut scalar_indices, &schema, &fragments);
         Transaction::retain_relevant_indices(&mut vector_indices, &schema, &fragments);
 
-        // Scalar should be kept, vector should be removed
+        // Both kept: a None bitmap is treated as empty, and the fork retains
+        // empty index definitions regardless of type (see
+        // test_retain_single_empty_vector_index_is_kept).
         assert_eq!(scalar_indices.len(), 1);
-        assert_eq!(vector_indices.len(), 0);
+        assert_eq!(vector_indices.len(), 1);
     }
 
     #[test]
@@ -4842,7 +4836,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retain_multiple_empty_vector_indices_removes_all() {
+    fn test_retain_multiple_empty_vector_indices_keeps_oldest() {
         let schema = create_test_schema(&[1]);
         let fragments = vec![Fragment::new(1)];
 
@@ -4854,8 +4848,10 @@ mod tests {
 
         Transaction::retain_relevant_indices(&mut indices, &schema, &fragments);
 
-        // All empty vector indices should be removed
-        assert_eq!(indices.len(), 0);
+        // Fork behavior: keep the oldest empty vector index definition (upstream
+        // removes all empty vector indices).
+        assert_eq!(indices.len(), 1);
+        assert_eq!(indices[0].dataset_version, 1);
     }
 
     #[test]
@@ -4948,10 +4944,11 @@ mod tests {
         Transaction::retain_relevant_indices(&mut scalar_indices, &schema, &fragments);
         Transaction::retain_relevant_indices(&mut vector_indices, &schema, &fragments);
 
-        // Scalar should be kept (single index, even if effective bitmap is empty)
-        // Vector should be removed (empty effective bitmap)
+        // Both kept: a single index of any type is retained even when its
+        // effective bitmap is empty (fork behavior -- empty vector definitions
+        // are preserved; the scanner flat-scans the unindexed rows).
         assert_eq!(scalar_indices.len(), 1);
-        assert_eq!(vector_indices.len(), 0);
+        assert_eq!(vector_indices.len(), 1);
     }
 
     #[test]
@@ -4967,11 +4964,12 @@ mod tests {
 
         Transaction::retain_relevant_indices(&mut indices, &schema, &fragments);
 
-        // idx_a (empty scalar) should be kept, idx_b (empty vector) removed, idx_c (non-empty) kept
-        assert_eq!(indices.len(), 2);
+        // All kept: distinct names are independent single-index groups, each
+        // retained even when empty (idx_b empty vector is now kept too).
+        assert_eq!(indices.len(), 3);
         assert!(indices.iter().any(|idx| idx.name == "idx_a"));
+        assert!(indices.iter().any(|idx| idx.name == "idx_b"));
         assert!(indices.iter().any(|idx| idx.name == "idx_c"));
-        assert!(!indices.iter().any(|idx| idx.name == "idx_b"));
     }
 
     #[test]
@@ -4987,7 +4985,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retain_all_indices_removed() {
+    fn test_retain_only_bad_field_removed() {
         let schema = create_test_schema(&[1]);
         let fragments = vec![Fragment::new(1)];
 
@@ -4999,7 +4997,12 @@ mod tests {
 
         Transaction::retain_relevant_indices(&mut indices, &schema, &fragments);
 
-        assert_eq!(indices.len(), 0);
+        // vec1 and vec2 are distinct single-index groups -- each empty vector
+        // definition is now kept. Only idx3 (field 99 not in schema) is dropped.
+        assert_eq!(indices.len(), 2);
+        assert!(indices.iter().any(|idx| idx.name == "vec1"));
+        assert!(indices.iter().any(|idx| idx.name == "vec2"));
+        assert!(!indices.iter().any(|idx| idx.name == "idx3"));
     }
 
     #[test]
@@ -5014,8 +5017,8 @@ mod tests {
             create_test_index("idx_a", 1, 3, Some(RoaringBitmap::new()), false),
             create_test_index("idx_a", 1, 1, Some(RoaringBitmap::new()), false), // Oldest
             create_test_index("idx_a", 1, 2, Some(RoaringBitmap::new()), false),
-            // Group "vec_b" - all empty vectors, remove all
-            create_test_index("vec_b", 1, 1, Some(RoaringBitmap::new()), true),
+            // Group "vec_b" - all empty vectors, keep oldest
+            create_test_index("vec_b", 1, 1, Some(RoaringBitmap::new()), true), // Oldest
             create_test_index("vec_b", 1, 2, Some(RoaringBitmap::new()), true),
             // Group "idx_c" - mixed empty/non-empty, keep non-empty
             create_test_index("idx_c", 2, 1, Some(RoaringBitmap::new()), false),
@@ -5029,8 +5032,8 @@ mod tests {
 
         Transaction::retain_relevant_indices(&mut indices, &schema, &fragments);
 
-        // Expected: frag_reuse, idx_a (oldest), idx_c (2 non-empty), idx_d = 5 total
-        assert_eq!(indices.len(), 5);
+        // Expected: frag_reuse, idx_a (oldest), vec_b (oldest), idx_c (2 non-empty), idx_d = 6 total
+        assert_eq!(indices.len(), 6);
 
         // Verify system index kept
         assert!(indices.iter().any(|idx| idx.name == FRAG_REUSE_INDEX_NAME));
@@ -5040,8 +5043,10 @@ mod tests {
         assert_eq!(idx_a_indices.len(), 1);
         assert_eq!(idx_a_indices[0].dataset_version, 1);
 
-        // Verify vec_b all removed
-        assert!(!indices.iter().any(|idx| idx.name == "vec_b"));
+        // Verify vec_b kept oldest only (empty vector definitions retained)
+        let vec_b_indices: Vec<_> = indices.iter().filter(|idx| idx.name == "vec_b").collect();
+        assert_eq!(vec_b_indices.len(), 1);
+        assert_eq!(vec_b_indices[0].dataset_version, 1);
 
         // Verify idx_c kept non-empty only
         let idx_c_indices: Vec<_> = indices.iter().filter(|idx| idx.name == "idx_c").collect();


### PR DESCRIPTION
Adds dataset column-write APIs and related transaction/test coverage for replacement column writes.

This is the Lance side needed by the distributed job framework branch so downstream clients can update generated columns without rewriting unrelated data.