### PR TITLE
fix(ngram): recheck contains() with sub-trigram needle instead of dropping rows

### DIFF
--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -903,7 +903,12 @@ impl ScalarQueryParser for TextQueryParser {
         };
 
         let query = match func.name() {
-            "contains" if args.len() == 2 => TextQuery::StringContains(pattern),
+            "contains" if args.len() == 2 => {
+                if self.index_type == "NGram" && pattern.len() < crate::scalar::ngram::NGRAM_N {
+                    return None;
+                }
+                TextQuery::StringContains(pattern)
+            }
             "regexp_like" | "regexp_match" if self.supports_regex => {
                 let pattern = match args.get(2) {
                     Some(flags_expr) => apply_regex_flags(&pattern, flags_expr)?,

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -833,6 +833,10 @@ pub struct TextQueryParser {
     index_type: String,
     needs_recheck: bool,
     supports_regex: bool,
+    /// The shortest `contains` pattern (in characters, not bytes) the index can
+    /// say anything useful about.  Shorter patterns bypass the index entirely so
+    /// they are answered by a full scan.  Use 0 for indices with no such limit.
+    min_contains_chars: usize,
 }
 
 impl TextQueryParser {
@@ -841,12 +845,14 @@ impl TextQueryParser {
         index_type: String,
         needs_recheck: bool,
         supports_regex: bool,
+        min_contains_chars: usize,
     ) -> Self {
         Self {
             index_name,
             index_type,
             needs_recheck,
             supports_regex,
+            min_contains_chars,
         }
     }
 }
@@ -904,7 +910,11 @@ impl ScalarQueryParser for TextQueryParser {
 
         let query = match func.name() {
             "contains" if args.len() == 2 => {
-                if self.index_type == "NGram" && pattern.len() < crate::scalar::ngram::NGRAM_N {
+                // A pattern shorter than the index's token width produces no
+                // tokens, so the index can only answer "recheck everything".
+                // Leave it to a full scan instead.  The count is in characters
+                // because tokenizers split on characters, not bytes.
+                if pattern.chars().count() < self.min_contains_chars {
                     return None;
                 }
                 TextQuery::StringContains(pattern)

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -2492,6 +2492,8 @@ impl ScalarIndexPlugin for FMIndexPlugin {
             false,
             // supports_regex: regex acceleration is only implemented for ngram.
             false,
+            // min_contains_chars: the FM-index can match a needle of any length.
+            0,
         )))
     }
     async fn load_index(

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -114,7 +114,13 @@ fn tokenize_visitor(tokenizer: &TextAnalyzer, text: &str, mut visitor: impl FnMu
 const ALPHA_SPAN: usize = 37;
 const MAX_TOKEN: usize = ALPHA_SPAN.pow(2) + ALPHA_SPAN;
 const MIN_TOKEN: usize = 0;
-pub(crate) const NGRAM_N: usize = 3;
+/// The width, in characters, of the tokens stored in an ngram index.
+///
+/// Trigrams are the standard choice for substring search: they are selective
+/// enough to prune well while keeping the token space small enough
+/// (`ALPHA_SPAN^3`) to address with a `u32`.  This must match the tokenizer
+/// configured in [`NGRAM_TOKENIZER`].
+const NGRAM_N: usize = 3;
 
 // Convert an ngram (string) to a token (u32).  This helps avoid heap allocations
 // and it makes it easier to partition the tokens for shuffling
@@ -436,7 +442,10 @@ impl ScalarIndex for NGramIndex {
             .ok_or_else(|| Error::invalid_input_source("Query is not a TextQuery".into()))?;
         match query {
             TextQuery::StringContains(substr) => {
-                if substr.len() < NGRAM_N {
+                // Count characters, not bytes: the tokenizer splits on
+                // characters, so a two character multi-byte needle is just as
+                // untokenizable as a two byte one.
+                if substr.chars().count() < NGRAM_N {
                     // We know nothing on short searches, need to recheck all
                     return Ok(SearchResult::at_least(RowAddrTreeMap::new()));
                 }
@@ -454,6 +463,12 @@ impl ScalarIndex for NGramIndex {
                 // At least one token was missing, so we know there are zero results
                 if missing {
                     return Ok(SearchResult::exact(RowAddrTreeMap::new()));
+                }
+                // The needle was long enough but still yielded no tokens (e.g. the
+                // tokenizer's filters dropped every character).  As with a short
+                // needle, the index knows nothing and every row must be rechecked.
+                if row_offsets.is_empty() {
+                    return Ok(SearchResult::at_least(RowAddrTreeMap::new()));
                 }
                 let posting_lists = futures::stream::iter(
                     row_offsets
@@ -1496,6 +1511,9 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
             true,
             // supports_regex: the ngram index can answer regex queries.
             true,
+            // min_contains_chars: a needle shorter than one trigram yields no
+            // tokens, so the index cannot narrow the search at all.
+            NGRAM_N,
         )))
     }
 
@@ -1763,6 +1781,30 @@ mod tests {
         let res = index
             .search(
                 &TextQuery::StringContains("ab".to_string()),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        let expected = SearchResult::at_least(RowAddrTreeMap::new());
+        assert_eq!(expected, res);
+
+        // Two characters but four bytes: still too short to tokenize, so the
+        // length check must count characters and not bytes.
+        let res = index
+            .search(
+                &TextQuery::StringContains("éé".to_string()),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        let expected = SearchResult::at_least(RowAddrTreeMap::new());
+        assert_eq!(expected, res);
+
+        // Long enough to tokenize, but the tokenizer's alphanumeric filter drops
+        // every trigram, so again we know nothing.
+        let res = index
+            .search(
+                &TextQuery::StringContains("---".to_string()),
                 &NoOpMetricsCollector,
             )
             .await

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -114,7 +114,7 @@ fn tokenize_visitor(tokenizer: &TextAnalyzer, text: &str, mut visitor: impl FnMu
 const ALPHA_SPAN: usize = 37;
 const MAX_TOKEN: usize = ALPHA_SPAN.pow(2) + ALPHA_SPAN;
 const MIN_TOKEN: usize = 0;
-const NGRAM_N: usize = 3;
+pub(crate) const NGRAM_N: usize = 3;
 
 // Convert an ngram (string) to a token (u32).  This helps avoid heap allocations
 // and it makes it easier to partition the tokens for shuffling

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -9183,6 +9183,85 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_ngram_contains_untokenizable_needle() {
+        // A needle the tokenizer cannot turn into a trigram must fall back to a
+        // full recheck rather than silently matching nothing.  Byte length is
+        // not a usable proxy for this: "éé" is two characters but four bytes.
+        let unit = ["ééb", "aéé", "abc", "dog", "éab"];
+        let values: Vec<&str> = unit.iter().copied().cycle().take(60).collect();
+        let array = StringArray::from_iter_values(values);
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "text",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let write_params = WriteParams {
+            max_rows_per_file: 20, // 60 rows -> 3 fragments
+            ..Default::default()
+        };
+        let mut dataset = Dataset::write(
+            reader,
+            "memory://test_ngram_contains_utf8",
+            Some(write_params),
+        )
+        .await
+        .unwrap();
+        dataset
+            .create_index(
+                &["text"],
+                IndexType::NGram,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        async fn count(dataset: &Dataset, filter: &str) -> usize {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let batches = scan
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            batches.iter().map(|b| b.num_rows()).sum()
+        }
+
+        async fn plan_of(dataset: &Dataset, filter: &str) -> String {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let plan = scan.create_plan().await.unwrap();
+            format!(
+                "{}",
+                datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+            )
+        }
+
+        // Each unit value appears 12 times in the 60 rows.
+        // Two characters (four bytes): shorter than a trigram, so the index is
+        // bypassed and "ééb" / "aéé" are still found.
+        assert_eq!(count(&dataset, "contains(text, 'éé')").await, 24);
+        let plan_str = plan_of(&dataset, "contains(text, 'éé')").await;
+        assert!(
+            !plan_str.contains("ScalarIndexQuery"),
+            "expected NO ngram index usage for a two character needle, got plan:\n{plan_str}"
+        );
+
+        // Three characters: long enough to tokenize, so the index is used.
+        assert_eq!(count(&dataset, "contains(text, 'ééb')").await, 12);
+        let plan_str = plan_of(&dataset, "contains(text, 'ééb')").await;
+        assert!(
+            plan_str.contains("ScalarIndexQuery") && plan_str.contains("NGram"),
+            "expected ngram index usage for a three character needle, got plan:\n{plan_str}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_like_prefix_with_btree_index() {
         // Create dataset with string data that has various prefixes
         // Avoid LIKE special characters (%, _) in data to keep tests simple

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -9077,6 +9077,56 @@ mod test {
                 "expected ngram index usage for `{filter}`, got plan:\n{plan_str}"
             );
         }
+
+        // contains with >= 3 characters (uses index)
+        assert_eq!(
+            matched(&dataset, "contains(s, 'rhino')").await,
+            ["rhino", "rhino horn", "rhinos nose"]
+        );
+        assert_eq!(
+            matched(&dataset, "contains(s, 'cat')").await,
+            ["cat", "cat dog", "catalog", "category", "scatter"]
+        );
+
+        // contains with < 3 characters (must NOT use index, i.e., falls back to full scan, and returns correct results)
+        assert_eq!(
+            matched(&dataset, "contains(s, 'ca')").await,
+            ["cat", "cat dog", "catalog", "category", "scatter"]
+        );
+        assert_eq!(
+            matched(&dataset, "contains(s, 'a')").await,
+            [
+                "cat", "cat dog", "catalog", "category", "dogma", "elephant", "scatter"
+            ]
+        );
+
+        // Verify index is used for contains >= 3 characters, but NOT used for < 3 characters
+        for filter in ["contains(s, 'rhino')", "contains(s, 'cat')"] {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let plan = scan.create_plan().await.unwrap();
+            let plan_str = format!(
+                "{}",
+                datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+            );
+            assert!(
+                plan_str.contains("ScalarIndexQuery") && plan_str.contains("NGram"),
+                "expected ngram index usage for `{filter}`, got plan:\n{plan_str}"
+            );
+        }
+        for filter in ["contains(s, 'ca')", "contains(s, 'a')"] {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let plan = scan.create_plan().await.unwrap();
+            let plan_str = format!(
+                "{}",
+                datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+            );
+            assert!(
+                !plan_str.contains("ScalarIndexQuery"),
+                "expected NO ngram index usage for `{filter}`, got plan:\n{plan_str}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

An NGRAM-indexed contains(col, needle) returns zero rows when needle is shorter than the trigram width (NGRAM_N = 3), even when rows match. It should fall back to a full recheck and return the same rows as an unindexed scan.

Fixes #7841.

## Root cause

For a sub-trigram needle no trigram can be derived, so NGramIndex::search returns SearchResult::at_least(RowAddrTreeMap::new()). AtLeast is documented as a lower bound (a subset of the true matches), so AtLeast(empty) means “the index knows nothing, recheck every row”. The scan path instead treated that empty lower bound as the final answer and emitted zero rows.

LIKE and regexp_match avoid this: their query parser returns None for patterns the index cannot serve, which keeps the predicate out of the index and forces a full-scan recheck. The contains path did not do this, which is why it was the only one affected.

## Fix

Make the contains path in TextQueryParser return None when the index is NGram and pattern.len() < NGRAM_N, matching how LIKE/regexp_match already bypass the index. The condition is identical to the one NGramIndex::search uses (substr.len() < NGRAM_N), so the parser bypasses under exactly the case where the index would return an empty lower bound.

# Changes:

	•	ngram.rs: expose NGRAM_N as pub(crate) so the parser can reference it.
	•	expression.rs: bypass the index for sub-trigram contains needles.
	•	scanner.rs: regression test asserting sub-trigram contains returns correct rows and produces no ScalarIndexQuery in the plan, while >= 3 character needles still use the index.

## Testing

	•	cargo test -p lance-index: 847 passed, 0 failed.
	•	cargo test -p lance test_ngram_regex_index_scan: passed.
	•	cargo fmt and cargo clippy clean on both crates.