### PR TITLE
fix(fts): deterministic top-k tiebreak for tied scores

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -13,6 +13,8 @@ pub const COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC: &str =
     "compound_peak_address_resolution_batch_size";
 pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_overflows";
 pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
+pub const FTS_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "fts_score_floor_overflows";
+pub const FTS_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "fts_peak_buffered_candidates";
 
 /// A trait used by the index to report metrics
 ///
@@ -102,6 +104,13 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record unresolved score floors that required a resolved-key retry.
     fn record_compound_score_floor_overflows(&self, _num_overflows: usize) {}
+
+    /// Record FTS partitions whose k-th-score tie band outgrew the collector's
+    /// buffer, so the partition was searched again against resolved row addresses.
+    fn record_fts_score_floor_overflows(&self, _num_overflows: usize) {}
+
+    /// Record a candidate-buffer high-water mark for the cross-partition FTS merge.
+    fn record_fts_peak_buffered_candidates(&self, _num_candidates: usize) {}
 
     /// Record a candidate-buffer high-water mark for compound FTS.
     fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}

--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -15,6 +15,7 @@ pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_ov
 pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
 pub const FTS_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "fts_score_floor_overflows";
 pub const FTS_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "fts_peak_buffered_candidates";
+pub const FTS_ELEMENT_BAND_TRUNCATIONS_METRIC: &str = "fts_element_band_truncations";
 
 /// A trait used by the index to report metrics
 ///
@@ -111,6 +112,10 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record a candidate-buffer high-water mark for the cross-partition FTS merge.
     fn record_fts_peak_buffered_candidates(&self, _num_candidates: usize) {}
+
+    /// Record FTS partitions that filled their retained band while already ordering
+    /// by row address, so the elements of one row fell back to a DocId proxy.
+    fn record_fts_element_band_truncations(&self, _num_truncations: usize) {}
 
     /// Record a candidate-buffer high-water mark for compound FTS.
     fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1841,8 +1841,19 @@ impl PartialOrd for ScoredDoc {
 }
 
 impl Ord for ScoredDoc {
+    /// The FTS result order (score DESC, row_id ASC, doc_index ASC) expressed
+    /// "best is greatest", so a lower row_id compares as greater here.
+    ///
+    /// A total tiebreak makes top-k a stable prefix across `k` (top-k1 is an
+    /// ordered prefix of top-k2), which tied-score pagination needs. This
+    /// orientation also makes a `Reverse`-wrapped min-heap peek at the worst
+    /// candidate to evict first, and `into_sorted_vec` over `Reverse<ScoredDoc>`
+    /// yield the results in final order.
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.score.cmp(&other.score)
+        self.score
+            .cmp(&other.score)
+            .then_with(|| other.row_id.cmp(&self.row_id))
+            .then_with(|| other.doc_index.cmp(&self.doc_index))
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -93,6 +93,43 @@ impl CacheKey for DocRowIdsKey {
     }
 }
 
+/// One partition's element coordinate columns, one per coordinate rank.
+///
+/// Cached like [`CachedDocRowIds`], because the final top-k resolves the same
+/// documents repeatedly: the cross-partition merge compacts its tie band against
+/// resolved keys and then resolves the survivors again at the end.
+#[derive(Debug)]
+pub(super) struct CachedDocCoordinates {
+    pub(crate) coordinates: Vec<Arc<UInt32Array>>,
+}
+
+impl DeepSizeOf for CachedDocCoordinates {
+    fn deep_size_of_children(&self, _context: &mut lance_core::deepsize::Context) -> usize {
+        self.coordinates
+            .iter()
+            .map(|column| column.len() * std::mem::size_of::<u32>())
+            .sum()
+    }
+}
+
+/// Cache key for one partition's [`CachedDocCoordinates`].
+#[derive(Debug, Clone)]
+pub(super) struct DocCoordinatesKey {
+    pub(crate) partition_id: u64,
+}
+
+impl CacheKey for DocCoordinatesKey {
+    type ValueType = CachedDocCoordinates;
+
+    fn key(&self) -> Cow<'_, str> {
+        format!("doc-coordinates-{}", self.partition_id).into()
+    }
+
+    fn type_name() -> &'static str {
+        "DocCoordinates"
+    }
+}
+
 /// Exact document lengths plus the optional quantized scoring representation.
 #[derive(Debug)]
 pub(super) struct DocLengths {
@@ -1019,62 +1056,72 @@ impl PartitionDocuments {
                 .collect());
         }
 
-        let ranges = doc_ids
-            .iter()
-            .map(|doc_id| {
-                let index = doc_id.as_usize();
-                index..index + 1
-            })
-            .collect::<Vec<_>>();
-        let coordinate_names = (0..self.coordinate_rank)
-            .map(doc_index_storage_column)
-            .collect::<Vec<_>>();
-        let projection = coordinate_names
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
-        let batch = self
-            .reader()
-            .await?
-            .read_ranges(&ranges, Some(&projection))
-            .await?;
-        if batch.num_rows() != row_ids.len() {
-            return Err(corrupt_docs(
-                &self.path,
-                format!(
-                    "document coordinate projection returned {} rows for {} candidates",
-                    batch.num_rows(),
-                    row_ids.len()
-                ),
-            ));
-        }
-        let coordinate_columns = coordinate_names
-            .iter()
-            .map(|name| {
-                let column = required_u32_column(&batch, name, &self.path)?;
-                if column.null_count() != 0 {
-                    return Err(corrupt_docs(
-                        &self.path,
-                        format!("document coordinate column {name} contains null values"),
-                    ));
-                }
-                Ok(column)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
+        let coordinates = self.coordinate_columns().await?;
         Ok(row_ids
             .into_iter()
-            .enumerate()
-            .map(|(index, row_id)| {
+            .zip(doc_ids)
+            .map(|(row_id, doc_id)| {
                 (
                     row_id,
-                    coordinate_columns
+                    coordinates
                         .iter()
-                        .map(|column| column.value(index))
+                        .map(|column| column.value(doc_id.as_usize()))
                         .collect(),
                 )
             })
             .collect())
+    }
+
+    /// One partition's element coordinate columns, read once and cached.
+    ///
+    /// Reading whole columns rather than the candidate rows keeps repeated
+    /// resolutions of the same documents off the object store: the merge resolves
+    /// its tie band once per compaction and once more for the final ranking.
+    async fn coordinate_columns(&self) -> Result<Vec<Arc<UInt32Array>>> {
+        let store = self.store.clone();
+        let path = self.path.clone();
+        let num_docs = self.num_docs;
+        let coordinate_rank = self.coordinate_rank;
+        let cached = self
+            .index_cache
+            .get_or_insert_with_key(
+                DocCoordinatesKey {
+                    partition_id: self.partition_id,
+                },
+                || async move {
+                    let names = (0..coordinate_rank)
+                        .map(doc_index_storage_column)
+                        .collect::<Vec<_>>();
+                    let projection = names.iter().map(String::as_str).collect::<Vec<_>>();
+                    let reader = store.open_index_file(&path).await?;
+                    let batch = reader.read_range(0..num_docs, Some(&projection)).await?;
+                    let coordinates = names
+                        .iter()
+                        .map(|name| {
+                            let column = required_u32_column(&batch, name, &path)?;
+                            if column.null_count() != 0 {
+                                return Err(corrupt_docs(
+                                    &path,
+                                    format!("document coordinate column {name} contains null values"),
+                                ));
+                            }
+                            if column.len() != num_docs {
+                                return Err(corrupt_docs(
+                                    &path,
+                                    format!(
+                                        "document coordinate column {name} has {} rows but the file footer reports {num_docs}",
+                                        column.len()
+                                    ),
+                                ));
+                            }
+                            Ok(Arc::new(column.clone()))
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(CachedDocCoordinates { coordinates })
+                },
+            )
+            .await?;
+        Ok(cached.coordinates.clone())
     }
 
     fn validate_doc_ids(&self, doc_ids: &[DocId]) -> Result<()> {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -61,6 +61,7 @@ use tracing::{info, instrument, warn};
 
 use super::documents::{
     DocId, DocLengths, DocVisibility, PartitionDocumentStore, PartitionDocuments,
+    ResidentAddressProjection,
 };
 use super::encoding::{MAX_POSTING_BLOCK_SIZE, PositionBlockBuilder};
 use super::impact::{IMPACT_LEVEL1_BLOCKS, ImpactSkipData, ImpactSkipDataBuilder};

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -697,7 +697,7 @@ impl InvertedPartition {
         shared_threshold: Arc<AtomicU32>,
     ) -> Result<Vec<DocCandidate<u64>>> {
         let documents = LegacyWandDocuments::new(docs, mask);
-        let (candidates, score_floor_overflow) = self.bm25_search_with_documents(
+        let (candidates, band) = self.bm25_search_with_documents(
             &documents,
             params,
             operator,
@@ -707,7 +707,7 @@ impl InvertedPartition {
             shared_threshold,
         )?;
         debug_assert!(
-            !score_floor_overflow,
+            !band.score_floor_overflow,
             "legacy postings carry row addresses, so their ties never defer"
         );
         Ok(candidates)
@@ -715,9 +715,8 @@ impl InvertedPartition {
 
     /// Search one modern partition.
     ///
-    /// Returns the candidates plus [`Wand::score_floor_overflow`]: when set, the
-    /// walk could not order its whole k-th-score tie band by row address and the
-    /// caller must retry with `addresses` attached.
+    /// Returns the candidates plus what the walk gave up on its tie band, which
+    /// tells the caller whether to retry the partition with `addresses` attached.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn bm25_search_modern(
         &self,
@@ -730,7 +729,7 @@ impl InvertedPartition {
         impact_scorer: Option<Arc<MemBM25Scorer>>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
-    ) -> Result<(Vec<DocCandidate<DocId>>, bool)> {
+    ) -> Result<(Vec<DocCandidate<DocId>>, WandBandStatus)> {
         if visibility.is_all() {
             let documents = ModernWandDocuments::all(lengths).with_addresses(addresses);
             self.bm25_search_with_documents(
@@ -768,22 +767,22 @@ impl InvertedPartition {
         impact_scorer: Option<Arc<MemBM25Scorer>>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
-    ) -> Result<(Vec<DocCandidate<D::Candidate>>, bool)> {
+    ) -> Result<(Vec<DocCandidate<D::Candidate>>, WandBandStatus)> {
         if postings.is_empty() {
-            return Ok((Vec::new(), false));
+            return Ok((Vec::new(), WandBandStatus::default()));
         }
 
         if let Some(scorer) = impact_scorer {
             let mut wand = Wand::new(operator, postings.into_iter(), documents, scorer)
                 .with_shared_threshold(shared_threshold);
             let hits = wand.search(params, metrics)?;
-            Ok((hits, wand.score_floor_overflow()))
+            Ok((hits, WandBandStatus::of(&wand)))
         } else {
             let scorer = IndexBM25Scorer::new(std::iter::once(self));
             let mut wand = Wand::new(operator, postings.into_iter(), documents, scorer)
                 .with_shared_threshold(shared_threshold);
             let hits = wand.search(params, metrics)?;
-            Ok((hits, wand.score_floor_overflow()))
+            Ok((hits, WandBandStatus::of(&wand)))
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -697,7 +697,7 @@ impl InvertedPartition {
         shared_threshold: Arc<AtomicU32>,
     ) -> Result<Vec<DocCandidate<u64>>> {
         let documents = LegacyWandDocuments::new(docs, mask);
-        self.bm25_search_with_documents(
+        let (candidates, score_floor_overflow) = self.bm25_search_with_documents(
             &documents,
             params,
             operator,
@@ -705,23 +705,34 @@ impl InvertedPartition {
             impact_scorer,
             metrics,
             shared_threshold,
-        )
+        )?;
+        debug_assert!(
+            !score_floor_overflow,
+            "legacy postings carry row addresses, so their ties never defer"
+        );
+        Ok(candidates)
     }
 
+    /// Search one modern partition.
+    ///
+    /// Returns the candidates plus [`Wand::score_floor_overflow`]: when set, the
+    /// walk could not order its whole k-th-score tie band by row address and the
+    /// caller must retry with `addresses` attached.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn bm25_search_modern(
         &self,
         lengths: &DocLengths,
         visibility: &DocVisibility,
+        addresses: Option<&ResidentAddressProjection>,
         params: &FtsSearchParams,
         operator: Operator,
         postings: Vec<PostingIterator>,
         impact_scorer: Option<Arc<MemBM25Scorer>>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
-    ) -> Result<Vec<DocCandidate<DocId>>> {
+    ) -> Result<(Vec<DocCandidate<DocId>>, bool)> {
         if visibility.is_all() {
-            let documents = ModernWandDocuments::all(lengths);
+            let documents = ModernWandDocuments::all(lengths).with_addresses(addresses);
             self.bm25_search_with_documents(
                 &documents,
                 params,
@@ -732,7 +743,8 @@ impl InvertedPartition {
                 shared_threshold,
             )
         } else {
-            let documents = ModernWandDocuments::filtered(lengths, visibility);
+            let documents =
+                ModernWandDocuments::filtered(lengths, visibility).with_addresses(addresses);
             self.bm25_search_with_documents(
                 &documents,
                 params,
@@ -756,22 +768,23 @@ impl InvertedPartition {
         impact_scorer: Option<Arc<MemBM25Scorer>>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
-    ) -> Result<Vec<DocCandidate<D::Candidate>>> {
+    ) -> Result<(Vec<DocCandidate<D::Candidate>>, bool)> {
         if postings.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
 
-        let hits = if let Some(scorer) = impact_scorer {
+        if let Some(scorer) = impact_scorer {
             let mut wand = Wand::new(operator, postings.into_iter(), documents, scorer)
                 .with_shared_threshold(shared_threshold);
-            wand.search(params, metrics)?
+            let hits = wand.search(params, metrics)?;
+            Ok((hits, wand.score_floor_overflow()))
         } else {
             let scorer = IndexBM25Scorer::new(std::iter::once(self));
             let mut wand = Wand::new(operator, postings.into_iter(), documents, scorer)
                 .with_shared_threshold(shared_threshold);
-            wand.search(params, metrics)?
-        };
-        Ok(hits)
+            let hits = wand.search(params, metrics)?;
+            Ok((hits, wand.score_floor_overflow()))
+        }
     }
 
     pub async fn into_builder(self) -> Result<InnerBuilder> {

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -626,11 +626,13 @@ impl InvertedIndex {
             .buffer_unordered(get_num_compute_intensive_cpus().min(32))
             .map_ok(|results| stream::iter(results.into_iter().map(Result::Ok)))
             .try_flatten();
+        let mut band_truncations = 0;
         while let Some(scored) = parts.try_next().await? {
-            if scored.score_floor_overflow {
+            if scored.band.score_floor_overflow {
                 retries.push((scored.partition_ordinal, scored.part));
                 continue;
             }
+            band_truncations += usize::from(scored.band.band_truncated);
             merge_modern_partition(
                 &mut ranked,
                 limit,
@@ -686,7 +688,7 @@ impl InvertedIndex {
                     })
                     .await?;
                     debug_assert!(
-                        !scored.score_floor_overflow,
+                        !scored.band.score_floor_overflow,
                         "an address-ordered retry cannot overflow its score floor"
                     );
                     Result::Ok(Some(scored))
@@ -697,6 +699,7 @@ impl InvertedIndex {
                 let Some(scored) = scored else {
                     continue;
                 };
+                band_truncations += usize::from(scored.band.band_truncated);
                 merge_modern_partition(
                     &mut ranked,
                     limit,
@@ -708,6 +711,10 @@ impl InvertedIndex {
                 metrics.record_fts_peak_buffered_candidates(ranked.buffered());
                 self.compact_modern_candidates(&mut ranked, limit).await?;
             }
+        }
+
+        if band_truncations > 0 {
+            metrics.record_fts_element_band_truncations(band_truncations);
         }
 
         Ok(ranked.into_vec())

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -484,7 +484,7 @@ impl InvertedIndex {
         }
         self.document_projections_resident
             .store(false, Ordering::Release);
-        let resolved = self.resolve_deferred_modern_candidates(ranked).await?;
+        let resolved = self.resolve_deferred_modern_candidates(&ranked).await?;
         Ok(rank_resolved_documents(resolved, limit))
     }
 
@@ -528,7 +528,7 @@ impl InvertedIndex {
         }
         let limit = request.limit;
         let ranked = self.bm25_search_modern_candidates(request).await?;
-        let resolved = self.resolve_deferred_modern_candidates(ranked).await?;
+        let resolved = self.resolve_deferred_modern_candidates(&ranked).await?;
         Ok(rank_resolved_documents(resolved, limit))
     }
 
@@ -639,58 +639,112 @@ impl InvertedIndex {
                 scorer,
                 &mut idf_cache,
             )?;
+            metrics.record_fts_peak_buffered_candidates(ranked.buffered());
+            self.compact_modern_candidates(&mut ranked, limit).await?;
         }
 
-        for (partition_ordinal, part) in retries {
-            let documents = part.docs.modern().cloned().ok_or_else(|| {
-                Error::internal("modern index contains legacy partition documents")
-            })?;
-            // Loading the addresses lets the retry order the tie band exactly, with
-            // a heap bounded by `limit`. It costs no extra read for a partition that
-            // reaches the final top-k, whose addresses are resolved either way.
-            let addresses = documents.address_projection().await?;
-            let Some(mut loaded) = load_modern_partition(
-                partition_ordinal,
-                part,
-                tokens.clone(),
-                params.clone(),
-                operator,
-                mask.clone(),
-                metrics.clone(),
-                impact_scorer.clone(),
-                impact_shared_threshold.clone(),
-            )
-            .await?
-            else {
-                continue;
-            };
-            loaded.addresses = Some(addresses);
-            let retry_params = params.clone();
-            let retry_metrics = metrics.clone();
-            let scored = spawn_cpu(move || {
-                score_modern_partition(
-                    loaded,
-                    retry_params.as_ref(),
-                    operator,
-                    retry_metrics.as_ref(),
-                )
-            })
-            .await?;
-            debug_assert!(
-                !scored.score_floor_overflow,
-                "an address-ordered retry cannot overflow its score floor"
-            );
-            merge_modern_partition(
-                &mut ranked,
-                limit,
-                scored.partition_ordinal,
-                scored.candidates,
-                scorer,
-                &mut idf_cache,
-            )?;
+        if !retries.is_empty() {
+            metrics.record_fts_score_floor_overflows(retries.len());
+            // Retries repeat a partition's posting load and WAND walk, so they run
+            // with the same concurrency as the main pass instead of serially behind
+            // it. A broad tied query can overflow every partition at once.
+            let concurrency = get_num_compute_intensive_cpus().min(32);
+            let mut retried = stream::iter(retries.into_iter().map(|(partition_ordinal, part)| {
+                let tokens = tokens.clone();
+                let params = params.clone();
+                let mask = mask.clone();
+                let metrics = metrics.clone();
+                let impact_scorer = impact_scorer.clone();
+                let impact_shared_threshold = impact_shared_threshold.clone();
+                async move {
+                    let documents = part.docs.modern().cloned().ok_or_else(|| {
+                        Error::internal("modern index contains legacy partition documents")
+                    })?;
+                    // Loading the addresses lets the retry order the tie band
+                    // exactly, with a heap bounded by `limit`. It costs no extra
+                    // read for a partition that reaches the final top-k, whose
+                    // addresses are resolved either way.
+                    let addresses = documents.address_projection().await?;
+                    let Some(mut loaded) = load_modern_partition(
+                        partition_ordinal,
+                        part,
+                        tokens,
+                        params.clone(),
+                        operator,
+                        mask,
+                        metrics.clone(),
+                        impact_scorer,
+                        impact_shared_threshold,
+                    )
+                    .await?
+                    else {
+                        return Result::Ok(None);
+                    };
+                    loaded.addresses = Some(addresses);
+                    let scored = spawn_cpu(move || {
+                        score_modern_partition(loaded, params.as_ref(), operator, metrics.as_ref())
+                    })
+                    .await?;
+                    debug_assert!(
+                        !scored.score_floor_overflow,
+                        "an address-ordered retry cannot overflow its score floor"
+                    );
+                    Result::Ok(Some(scored))
+                }
+            }))
+            .buffer_unordered(concurrency);
+            while let Some(scored) = retried.try_next().await? {
+                let Some(scored) = scored else {
+                    continue;
+                };
+                merge_modern_partition(
+                    &mut ranked,
+                    limit,
+                    scored.partition_ordinal,
+                    scored.candidates,
+                    scorer,
+                    &mut idf_cache,
+                )?;
+                metrics.record_fts_peak_buffered_candidates(ranked.buffered());
+                self.compact_modern_candidates(&mut ranked, limit).await?;
+            }
         }
 
         Ok(ranked.into_vec())
+    }
+
+    /// Keep the cross-partition tie band bounded.
+    ///
+    /// The merge retains every candidate tied at the k-th score, and with enough
+    /// partitions contributing to one tie group that band is the only unbounded
+    /// buffer on this path. Once it passes `limit + SCORE_FLOOR_BUFFER` the merge
+    /// resolves what it holds, keeps the exact top-k by
+    /// `(score DESC, row_id ASC, doc_index ASC)` and starts a fresh band. That is
+    /// still exact: every later candidate is compared against a k-th entry that is
+    /// now the true k-th of everything seen so far.
+    ///
+    /// The resolution costs address reads for partitions that may not survive, so
+    /// it only runs past the bound. A no-tie query never reaches it.
+    async fn compact_modern_candidates(
+        &self,
+        ranked: &mut ModernCandidates,
+        limit: usize,
+    ) -> Result<()> {
+        if ranked.buffered() <= limit.saturating_add(SCORE_FLOOR_BUFFER) {
+            return Ok(());
+        }
+        let candidates = std::mem::take(ranked).into_vec();
+        let resolved = self.resolve_deferred_modern_candidates(&candidates).await?;
+        let mut order = (0..candidates.len()).collect::<Vec<_>>();
+        order.sort_unstable_by(|&left, &right| resolved[right].cmp(&resolved[left]));
+        order.truncate(limit);
+        *ranked = ModernCandidates::from_ranked(
+            order
+                .into_iter()
+                .map(|rank| candidates[rank].clone())
+                .collect(),
+        );
+        Ok(())
     }
 
     fn resolve_resident_modern_candidates(
@@ -744,7 +798,7 @@ impl InvertedIndex {
 
     async fn resolve_deferred_modern_candidates(
         &self,
-        ranked: Vec<ScoredPartitionDoc>,
+        ranked: &[ScoredPartitionDoc],
     ) -> Result<Vec<ScoredDoc>> {
         let mut resolved_documents = ranked
             .iter()

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -477,13 +477,15 @@ impl InvertedIndex {
         &self,
         request: ModernSearchRequest<'_>,
     ) -> Result<Vec<ScoredDoc>> {
+        let limit = request.limit;
         let ranked = self.bm25_search_modern_candidates(request).await?;
         if let Some(result) = self.resolve_resident_modern_candidates(&ranked)? {
-            return Ok(result);
+            return Ok(rank_resolved_documents(result, limit));
         }
         self.document_projections_resident
             .store(false, Ordering::Release);
-        self.resolve_deferred_modern_candidates(ranked).await
+        let resolved = self.resolve_deferred_modern_candidates(ranked).await?;
+        Ok(rank_resolved_documents(resolved, limit))
     }
 
     async fn bm25_search_modern_deferred(
@@ -524,14 +526,16 @@ impl InvertedIndex {
                 .try_collect::<Vec<_>>()
                 .await?;
         }
+        let limit = request.limit;
         let ranked = self.bm25_search_modern_candidates(request).await?;
-        self.resolve_deferred_modern_candidates(ranked).await
+        let resolved = self.resolve_deferred_modern_candidates(ranked).await?;
+        Ok(rank_resolved_documents(resolved, limit))
     }
 
     async fn bm25_search_modern_candidates(
         &self,
         request: ModernSearchRequest<'_>,
-    ) -> Result<Vec<Reverse<ScoredPartitionDoc>>> {
+    ) -> Result<Vec<ScoredPartitionDoc>> {
         let ModernSearchRequest {
             tokens,
             params,
@@ -570,86 +574,17 @@ impl InvertedIndex {
                 let impact_shared_threshold = impact_shared_threshold.clone();
                 async move {
                     let loads = chunk.into_iter().map(|(partition_ordinal, part)| {
-                        let tokens = tokens.clone();
-                        let params = params.clone();
-                        let mask = mask.clone();
-                        let metrics = metrics.clone();
-                        let impact_scorer = impact_scorer.clone();
-                        let impact_shared_threshold = impact_shared_threshold.clone();
-                        async move {
-                            let LoadedPostings {
-                                postings,
-                                grouped_expansions,
-                                impact_safe,
-                                exact_scoring_required,
-                            } = part
-                                .load_posting_lists(
-                                    tokens.as_ref(),
-                                    params.as_ref(),
-                                    operator,
-                                    impact_scorer.as_ref(),
-                                    metrics.as_ref(),
-                                    false,
-                                )
-                                .await?;
-                            if postings.is_empty() {
-                                return Result::Ok(None);
-                            }
-                            let documents = part.docs.modern().cloned().ok_or_else(|| {
-                                Error::internal("modern index contains legacy partition documents")
-                            })?;
-                            let materialize_selected = operator == Operator::Or
-                                && mask.max_len().is_some_and(|selected| {
-                                    u128::from(selected).saturating_mul(100)
-                                        <= u128::from(*FLAT_SEARCH_PERCENT_THRESHOLD)
-                                            .saturating_mul(documents.len() as u128)
-                                });
-                            let visibility = match documents
-                                .immediate_visibility(mask.clone(), materialize_selected)
-                            {
-                                Some(visibility) => visibility,
-                                None => {
-                                    documents
-                                        .visibility(mask.clone(), materialize_selected)
-                                        .await?
-                                }
-                            };
-                            if visibility.is_empty() {
-                                return Result::Ok(None);
-                            }
-                            let lengths = match documents.cached_lengths() {
-                                Some(lengths) => lengths,
-                                None => documents.lengths().await?,
-                            };
-                            let max_position = postings
-                                .iter()
-                                .map(|posting| posting.term_index() as usize)
-                                .max()
-                                .unwrap_or_default();
-                            let mut tokens_by_position = vec![String::new(); max_position + 1];
-                            for posting in &postings {
-                                tokens_by_position[posting.term_index() as usize] =
-                                    posting.token().to_owned();
-                            }
-                            let use_global_scorer = impact_safe || exact_scoring_required;
-                            let threshold = if use_global_scorer {
-                                impact_shared_threshold
-                            } else {
-                                Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()))
-                            };
-                            let wand_scorer = use_global_scorer.then(|| impact_scorer.clone());
-                            Result::Ok(Some((
-                                partition_ordinal,
-                                part,
-                                lengths,
-                                visibility,
-                                postings,
-                                wand_scorer,
-                                threshold,
-                                tokens_by_position,
-                                grouped_expansions,
-                            )))
-                        }
+                        load_modern_partition(
+                            partition_ordinal,
+                            part,
+                            tokens.clone(),
+                            params.clone(),
+                            operator,
+                            mask.clone(),
+                            metrics.clone(),
+                            impact_scorer.clone(),
+                            impact_shared_threshold.clone(),
+                        )
                     });
                     let loaded = stream::iter(loads)
                         .buffer_unordered(io_parallelism)
@@ -663,39 +598,17 @@ impl InvertedIndex {
                     }
 
                     let results = spawn_cpu(move || {
-                        let mut results = Vec::with_capacity(loaded.len());
-                        for (
-                            partition_ordinal,
-                            part,
-                            lengths,
-                            visibility,
-                            postings,
-                            wand_scorer,
-                            threshold,
-                            tokens_by_position,
-                            grouped_expansions,
-                        ) in loaded
-                        {
-                            let candidates = part.bm25_search_modern(
-                                lengths.as_ref(),
-                                &visibility,
-                                params.as_ref(),
-                                operator,
-                                postings,
-                                wand_scorer,
-                                metrics.as_ref(),
-                                threshold,
-                            )?;
-                            results.push((
-                                partition_ordinal,
-                                PartitionCandidates {
-                                    tokens_by_position,
-                                    grouped_expansions,
-                                    candidates,
-                                },
-                            ));
-                        }
-                        Result::Ok(results)
+                        loaded
+                            .into_iter()
+                            .map(|partition| {
+                                score_modern_partition(
+                                    partition,
+                                    params.as_ref(),
+                                    operator,
+                                    metrics.as_ref(),
+                                )
+                            })
+                            .collect::<Result<Vec<_>>>()
                     })
                     .await?;
                     Result::Ok(results)
@@ -703,29 +616,86 @@ impl InvertedIndex {
             })
             .collect::<Vec<_>>();
 
-        let mut ranked = BinaryHeap::new();
+        let mut ranked = ModernCandidates::default();
         let mut idf_cache = HashMap::new();
+        // Partitions whose k-th-score tie band outgrew the collector's buffer.
+        // Their candidates are not the exact top-k, so they are rescored below
+        // against resolved row addresses instead of being merged here.
+        let mut retries = Vec::new();
         let mut parts = stream::iter(parts)
             .buffer_unordered(get_num_compute_intensive_cpus().min(32))
             .map_ok(|results| stream::iter(results.into_iter().map(Result::Ok)))
             .try_flatten();
-        while let Some((partition_ordinal, partition)) = parts.try_next().await? {
-            for (doc_id, score) in rescore_partition_candidates(partition, scorer, &mut idf_cache) {
-                push_scored_partition_doc(
-                    &mut ranked,
-                    limit,
-                    PartitionDocId::try_new(partition_ordinal, doc_id)?,
-                    score,
-                );
+        while let Some(scored) = parts.try_next().await? {
+            if scored.score_floor_overflow {
+                retries.push((scored.partition_ordinal, scored.part));
+                continue;
             }
+            merge_modern_partition(
+                &mut ranked,
+                limit,
+                scored.partition_ordinal,
+                scored.candidates,
+                scorer,
+                &mut idf_cache,
+            )?;
         }
 
-        Ok(ranked.into_sorted_vec())
+        for (partition_ordinal, part) in retries {
+            let documents = part.docs.modern().cloned().ok_or_else(|| {
+                Error::internal("modern index contains legacy partition documents")
+            })?;
+            // Loading the addresses lets the retry order the tie band exactly, with
+            // a heap bounded by `limit`. It costs no extra read for a partition that
+            // reaches the final top-k, whose addresses are resolved either way.
+            let addresses = documents.address_projection().await?;
+            let Some(mut loaded) = load_modern_partition(
+                partition_ordinal,
+                part,
+                tokens.clone(),
+                params.clone(),
+                operator,
+                mask.clone(),
+                metrics.clone(),
+                impact_scorer.clone(),
+                impact_shared_threshold.clone(),
+            )
+            .await?
+            else {
+                continue;
+            };
+            loaded.addresses = Some(addresses);
+            let retry_params = params.clone();
+            let retry_metrics = metrics.clone();
+            let scored = spawn_cpu(move || {
+                score_modern_partition(
+                    loaded,
+                    retry_params.as_ref(),
+                    operator,
+                    retry_metrics.as_ref(),
+                )
+            })
+            .await?;
+            debug_assert!(
+                !scored.score_floor_overflow,
+                "an address-ordered retry cannot overflow its score floor"
+            );
+            merge_modern_partition(
+                &mut ranked,
+                limit,
+                scored.partition_ordinal,
+                scored.candidates,
+                scorer,
+                &mut idf_cache,
+            )?;
+        }
+
+        Ok(ranked.into_vec())
     }
 
     fn resolve_resident_modern_candidates(
         &self,
-        ranked: &[Reverse<ScoredPartitionDoc>],
+        ranked: &[ScoredPartitionDoc],
     ) -> Result<Option<Vec<ScoredDoc>>> {
         if self.partitions.iter().any(|partition| {
             partition
@@ -737,10 +707,10 @@ impl InvertedIndex {
         }
         let mut resolved_documents = ranked
             .iter()
-            .map(|Reverse(candidate)| ScoredDoc::new(0, candidate.score.0))
+            .map(|candidate| ScoredDoc::new(0, candidate.score.0))
             .collect::<Vec<_>>();
         let mut by_partition = BTreeMap::<usize, Vec<(usize, DocId)>>::new();
-        for (rank, Reverse(candidate)) in ranked.iter().enumerate() {
+        for (rank, candidate) in ranked.iter().enumerate() {
             let partition_ordinal = candidate.document.partition_ordinal();
             let doc_id = candidate.document.doc_id;
             by_partition
@@ -774,14 +744,14 @@ impl InvertedIndex {
 
     async fn resolve_deferred_modern_candidates(
         &self,
-        ranked: Vec<Reverse<ScoredPartitionDoc>>,
+        ranked: Vec<ScoredPartitionDoc>,
     ) -> Result<Vec<ScoredDoc>> {
         let mut resolved_documents = ranked
             .iter()
-            .map(|Reverse(candidate)| ScoredDoc::new(0, candidate.score.0))
+            .map(|candidate| ScoredDoc::new(0, candidate.score.0))
             .collect::<Vec<_>>();
         let mut by_partition = BTreeMap::<usize, Vec<(usize, DocId)>>::new();
-        for (rank, Reverse(candidate)) in ranked.iter().enumerate() {
+        for (rank, candidate) in ranked.iter().enumerate() {
             let partition_ordinal = candidate.document.partition_ordinal();
             let doc_id = candidate.document.doc_id;
             by_partition

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -174,6 +174,11 @@ impl ModernCandidates {
         }
     }
 
+    /// Candidates held for the final selection: the top-k plus the tie band.
+    pub(super) fn buffered(&self) -> usize {
+        self.heap.len() + self.tie_band.len()
+    }
+
     /// The candidates whose addresses have to be resolved: the top-k plus the tie
     /// band. Returning more than `limit` is safe, the final ranking truncates.
     pub(super) fn into_vec(self) -> Vec<ScoredPartitionDoc> {
@@ -185,6 +190,15 @@ impl ModernCandidates {
             .collect::<Vec<_>>();
         candidates.extend(self.tie_band);
         candidates
+    }
+
+    /// Rebuild from candidates already ordered best first, as the exact top-k with
+    /// an empty tie band.
+    pub(super) fn from_ranked(ordered: Vec<ScoredPartitionDoc>) -> Self {
+        Self {
+            heap: ordered.into_iter().map(Reverse).collect(),
+            tie_band: Vec::new(),
+        }
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -108,7 +108,9 @@ pub(super) fn push_scored_key(
     score: f32,
 ) {
     // A NaN score is never competitive. It has to be rejected before the total
-    // order sees it, because `total_cmp` ranks NaN above every real score.
+    // order sees it, because `total_cmp` ranks NaN above every real score, which
+    // would put it at the top of the result. The WAND collector still admits one
+    // into an under-filled heap, so the two layers are not identical here.
     if score.is_nan() {
         return;
     }
@@ -233,14 +235,33 @@ pub(super) struct LoadedModernPartition {
     pub(super) addresses: Option<ResidentAddressProjection>,
 }
 
+/// What one WAND search had to give up on its retained tie band.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct WandBandStatus {
+    /// See [`Wand::score_floor_overflow`]. When set, the candidates are missing
+    /// part of the partition's k-th-score tie band and must not be merged: the
+    /// partition is searched again with row addresses attached.
+    pub(super) score_floor_overflow: bool,
+    /// See [`Wand::band_truncated`]. A retry cannot improve on it, so it is only
+    /// reported.
+    pub(super) band_truncated: bool,
+}
+
+impl WandBandStatus {
+    pub(super) fn of<S: Scorer, D: WandDocuments>(wand: &Wand<'_, S, D>) -> Self {
+        Self {
+            score_floor_overflow: wand.score_floor_overflow(),
+            band_truncated: wand.band_truncated(),
+        }
+    }
+}
+
 /// Candidates one modern partition contributed to the global merge.
 pub(super) struct ScoredModernPartition {
     pub(super) partition_ordinal: usize,
     pub(super) part: Arc<InvertedPartition>,
     pub(super) candidates: PartitionCandidates<DocId>,
-    /// See [`Wand::score_floor_overflow`]. When set, `candidates` is missing part
-    /// of the partition's k-th-score tie band and must not be merged.
-    pub(super) score_floor_overflow: bool,
+    pub(super) band: WandBandStatus,
 }
 
 /// Load everything the CPU scoring phase needs for one modern partition.
@@ -356,7 +377,7 @@ pub(super) fn score_modern_partition(
         grouped_expansions,
         addresses,
     } = partition;
-    let (candidates, score_floor_overflow) = part.bm25_search_modern(
+    let (candidates, band) = part.bm25_search_modern(
         lengths.as_ref(),
         &visibility,
         addresses.as_ref(),
@@ -375,7 +396,7 @@ pub(super) fn score_modern_partition(
             grouped_expansions,
             candidates,
         },
-        score_floor_overflow,
+        band,
     })
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -95,38 +95,294 @@ pub(super) fn address_read_concurrency(io_parallelism: usize, largest_read_bytes
     )
 }
 
+/// Merge one legacy candidate into the global top-k.
+///
+/// Legacy candidates already carry row addresses, so the heap evicts on the full
+/// `(score DESC, row_id ASC)` key and `into_sorted_vec` yields the final order
+/// directly. A score tie with a lower row_id wins, a higher one loses, whatever
+/// order candidates arrive in.
 pub(super) fn push_scored_key(
     candidates: &mut BinaryHeap<Reverse<ScoredDoc>>,
     limit: usize,
     key: u64,
     score: f32,
 ) {
+    // A NaN score is never competitive. It has to be rejected before the total
+    // order sees it, because `total_cmp` ranks NaN above every real score.
+    if score.is_nan() {
+        return;
+    }
+    let candidate = ScoredDoc::new(key, score);
     if candidates.len() < limit {
-        candidates.push(Reverse(ScoredDoc::new(key, score)));
-    } else if candidates
-        .peek()
-        .is_some_and(|candidate| candidate.0.score.0 < score)
-    {
+        candidates.push(Reverse(candidate));
+    } else if candidates.peek().is_some_and(|worst| worst.0 < candidate) {
         candidates.pop();
-        candidates.push(Reverse(ScoredDoc::new(key, score)));
+        candidates.push(Reverse(candidate));
     }
 }
 
-pub(super) fn push_scored_partition_doc(
-    candidates: &mut BinaryHeap<Reverse<ScoredPartitionDoc>>,
-    limit: usize,
-    document: PartitionDocId,
-    score: f32,
-) {
-    if candidates.len() < limit {
-        candidates.push(Reverse(ScoredPartitionDoc::new(document, score)));
-    } else if candidates
-        .peek()
-        .is_some_and(|candidate| candidate.0.score.0 < score)
-    {
-        candidates.pop();
-        candidates.push(Reverse(ScoredPartitionDoc::new(document, score)));
+/// The global top-k of a modern search, as the merge can express it before row
+/// addresses are known.
+#[derive(Default)]
+pub(super) struct ModernCandidates {
+    /// The best `limit` candidates by score.
+    heap: BinaryHeap<Reverse<ScoredPartitionDoc>>,
+    /// Candidates tied at the current k-th score that the heap has no room for.
+    /// Cleared whenever the k-th score rises, so it holds just the current tie
+    /// band and stays empty for a query without ties.
+    tie_band: Vec<ScoredPartitionDoc>,
+}
+
+impl ModernCandidates {
+    /// Merge one candidate.
+    ///
+    /// Modern candidates carry dense DocIds whose row addresses are resolved only
+    /// after selection, so a k-th-score tie cannot be ordered here. Every tied
+    /// candidate is retained instead, and [`rank_resolved_documents`] picks the
+    /// exact top-k once the addresses are known.
+    fn push(&mut self, limit: usize, document: PartitionDocId, score: f32) {
+        if score.is_nan() {
+            return;
+        }
+        let candidate = ScoredPartitionDoc::new(document, score);
+        if self.heap.len() < limit {
+            self.heap.push(Reverse(candidate));
+            return;
+        }
+        let Some(Reverse(worst)) = self.heap.peek() else {
+            return;
+        };
+        let worst_score = worst.score;
+        match candidate.score.cmp(&worst_score) {
+            // Below the k-th score: never competitive.
+            std::cmp::Ordering::Less => {}
+            // Tied at the k-th score: a potential winner once addresses resolve.
+            std::cmp::Ordering::Equal => self.tie_band.push(candidate),
+            std::cmp::Ordering::Greater => {
+                let Some(Reverse(displaced)) = self.heap.pop() else {
+                    return;
+                };
+                self.heap.push(Reverse(candidate));
+                let kth = self.heap.peek().map(|Reverse(entry)| entry.score);
+                if kth.is_some_and(|kth| kth > worst_score) {
+                    // The k-th score rose past the band: none of its members can win.
+                    self.tie_band.clear();
+                } else {
+                    self.tie_band.push(displaced);
+                }
+            }
+        }
     }
+
+    /// The candidates whose addresses have to be resolved: the top-k plus the tie
+    /// band. Returning more than `limit` is safe, the final ranking truncates.
+    pub(super) fn into_vec(self) -> Vec<ScoredPartitionDoc> {
+        let mut candidates = self
+            .heap
+            .into_vec()
+            .into_iter()
+            .map(|Reverse(candidate)| candidate)
+            .collect::<Vec<_>>();
+        candidates.extend(self.tie_band);
+        candidates
+    }
+}
+
+/// Order resolved FTS documents by `(score DESC, row_id ASC)` and keep the exact
+/// top-k.
+///
+/// This is where the deterministic tiebreak is finally settled for modern
+/// indexes: the merge above hands over the top-k plus its k-th-score tie group,
+/// and the row addresses resolved in between decide which tied documents win.
+pub(super) fn rank_resolved_documents(
+    mut documents: Vec<ScoredDoc>,
+    limit: usize,
+) -> Vec<ScoredDoc> {
+    documents.sort_unstable_by(|left, right| right.cmp(left));
+    documents.truncate(limit);
+    documents
+}
+
+/// One modern partition prepared for scoring.
+pub(super) struct LoadedModernPartition {
+    partition_ordinal: usize,
+    part: Arc<InvertedPartition>,
+    lengths: Arc<DocLengths>,
+    visibility: DocVisibility,
+    postings: Vec<PostingIterator>,
+    wand_scorer: Option<Arc<MemBM25Scorer>>,
+    threshold: Arc<AtomicU32>,
+    tokens_by_position: Vec<String>,
+    grouped_expansions: Vec<GroupedExpansionTerms>,
+    /// Set on the retry that follows a k-th-score tie overflow, so the walk orders
+    /// ties by row address instead of deferring them to the global merge.
+    pub(super) addresses: Option<ResidentAddressProjection>,
+}
+
+/// Candidates one modern partition contributed to the global merge.
+pub(super) struct ScoredModernPartition {
+    pub(super) partition_ordinal: usize,
+    pub(super) part: Arc<InvertedPartition>,
+    pub(super) candidates: PartitionCandidates<DocId>,
+    /// See [`Wand::score_floor_overflow`]. When set, `candidates` is missing part
+    /// of the partition's k-th-score tie band and must not be merged.
+    pub(super) score_floor_overflow: bool,
+}
+
+/// Load everything the CPU scoring phase needs for one modern partition.
+///
+/// `Ok(None)` means the partition cannot contribute: no matching postings, or
+/// nothing visible under the prefilter.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn load_modern_partition(
+    partition_ordinal: usize,
+    part: Arc<InvertedPartition>,
+    tokens: Arc<Tokens>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+    impact_scorer: Arc<MemBM25Scorer>,
+    impact_shared_threshold: Arc<AtomicU32>,
+) -> Result<Option<LoadedModernPartition>> {
+    let LoadedPostings {
+        postings,
+        grouped_expansions,
+        impact_safe,
+        exact_scoring_required,
+    } = part
+        .load_posting_lists(
+            tokens.as_ref(),
+            params.as_ref(),
+            operator,
+            impact_scorer.as_ref(),
+            metrics.as_ref(),
+            false,
+        )
+        .await?;
+    if postings.is_empty() {
+        return Ok(None);
+    }
+    let documents = part
+        .docs
+        .modern()
+        .cloned()
+        .ok_or_else(|| Error::internal("modern index contains legacy partition documents"))?;
+    let materialize_selected = operator == Operator::Or
+        && mask.max_len().is_some_and(|selected| {
+            u128::from(selected).saturating_mul(100)
+                <= u128::from(*FLAT_SEARCH_PERCENT_THRESHOLD)
+                    .saturating_mul(documents.len() as u128)
+        });
+    let visibility = match documents.immediate_visibility(mask.clone(), materialize_selected) {
+        Some(visibility) => visibility,
+        None => {
+            documents
+                .visibility(mask.clone(), materialize_selected)
+                .await?
+        }
+    };
+    if visibility.is_empty() {
+        return Ok(None);
+    }
+    let lengths = match documents.cached_lengths() {
+        Some(lengths) => lengths,
+        None => documents.lengths().await?,
+    };
+    let max_position = postings
+        .iter()
+        .map(|posting| posting.term_index() as usize)
+        .max()
+        .unwrap_or_default();
+    let mut tokens_by_position = vec![String::new(); max_position + 1];
+    for posting in &postings {
+        tokens_by_position[posting.term_index() as usize] = posting.token().to_owned();
+    }
+    let use_global_scorer = impact_safe || exact_scoring_required;
+    let threshold = if use_global_scorer {
+        impact_shared_threshold
+    } else {
+        Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()))
+    };
+    let wand_scorer = use_global_scorer.then_some(impact_scorer);
+    Ok(Some(LoadedModernPartition {
+        partition_ordinal,
+        part,
+        lengths,
+        visibility,
+        postings,
+        wand_scorer,
+        threshold,
+        tokens_by_position,
+        grouped_expansions,
+        // A partition whose addresses are already in memory orders its k-th-score
+        // ties during the walk. The rest defer them, and an oversized tie band
+        // there is retried with the addresses loaded.
+        addresses: documents.resident_address_projection(),
+    }))
+}
+
+/// Run one modern partition's WAND search. Pure CPU work, so it can run on the
+/// compute pool.
+pub(super) fn score_modern_partition(
+    partition: LoadedModernPartition,
+    params: &FtsSearchParams,
+    operator: Operator,
+    metrics: &dyn MetricsCollector,
+) -> Result<ScoredModernPartition> {
+    let LoadedModernPartition {
+        partition_ordinal,
+        part,
+        lengths,
+        visibility,
+        postings,
+        wand_scorer,
+        threshold,
+        tokens_by_position,
+        grouped_expansions,
+        addresses,
+    } = partition;
+    let (candidates, score_floor_overflow) = part.bm25_search_modern(
+        lengths.as_ref(),
+        &visibility,
+        addresses.as_ref(),
+        params,
+        operator,
+        postings,
+        wand_scorer,
+        metrics,
+        threshold,
+    )?;
+    Ok(ScoredModernPartition {
+        partition_ordinal,
+        part,
+        candidates: PartitionCandidates {
+            tokens_by_position,
+            grouped_expansions,
+            candidates,
+        },
+        score_floor_overflow,
+    })
+}
+
+/// Rescore one partition's candidates with the corpus-wide statistics and merge
+/// them into the global top-k.
+pub(super) fn merge_modern_partition(
+    ranked: &mut ModernCandidates,
+    limit: usize,
+    partition_ordinal: usize,
+    candidates: PartitionCandidates<DocId>,
+    scorer: &MemBM25Scorer,
+    idf_cache: &mut HashMap<String, f32>,
+) -> Result<()> {
+    for (doc_id, score) in rescore_partition_candidates(candidates, scorer, idf_cache) {
+        ranked.push(
+            limit,
+            PartitionDocId::try_new(partition_ordinal, doc_id)?,
+            score,
+        );
+    }
+    Ok(())
 }
 
 pub(super) fn rescore_partition_candidates<C>(

--- a/rust/lance-index/src/scalar/inverted/index/tests.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests.rs
@@ -150,3 +150,4 @@ mod prewarm_cache;
 mod query;
 mod scoring;
 mod stats;
+mod topk_tiebreak;

--- a/rust/lance-index/src/scalar/inverted/index/tests.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests.rs
@@ -32,7 +32,7 @@ use arrow_array::{ArrayRef, Float32Array, RecordBatch, StringArray, UInt32Array,
 use arrow_schema::{DataType, Field, Schema};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use crate::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_tokenizer::{Language, SimpleTokenizer, StopWordFilter, TextAnalyzer};

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -465,10 +465,11 @@ async fn search_test_impact_partition(
     let documents = partition.docs.modern().unwrap();
     let lengths = documents.lengths().await.unwrap();
     let visibility = documents.visibility(NoFilter.mask(), false).await.unwrap();
-    partition
+    let (candidates, score_floor_overflow) = partition
         .bm25_search_modern(
             lengths.as_ref(),
             &visibility,
+            None,
             params,
             Operator::Or,
             postings,
@@ -476,7 +477,9 @@ async fn search_test_impact_partition(
             &NoOpMetricsCollector,
             shared_threshold,
         )
-        .unwrap()
+        .unwrap();
+    assert!(!score_floor_overflow);
+    candidates
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -465,7 +465,7 @@ async fn search_test_impact_partition(
     let documents = partition.docs.modern().unwrap();
     let lengths = documents.lengths().await.unwrap();
     let visibility = documents.visibility(NoFilter.mask(), false).await.unwrap();
-    let (candidates, score_floor_overflow) = partition
+    let (candidates, band) = partition
         .bm25_search_modern(
             lengths.as_ref(),
             &visibility,
@@ -478,7 +478,7 @@ async fn search_test_impact_partition(
             shared_threshold,
         )
         .unwrap();
-    assert!(!score_floor_overflow);
+    assert!(!band.score_floor_overflow);
     candidates
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
@@ -388,9 +388,11 @@ async fn test_fts_topk_tied_scores_bound_the_cross_partition_band() {
         peak > LIMIT,
         "premise: the tie band must actually be exercised, peak {peak}"
     );
+    // Compaction runs between partitions, so the peak is the compacted band
+    // plus whatever the next partition contributed in one go.
     assert!(
         peak <= bound + PER_PARTITION as usize,
-        "the merge band must be compacted back under {bound} between partitions, peak {peak}"
+        "the merge band must be compacted back under {bound} between partitions,              leaving room for one partition's contribution on top, peak {peak}"
     );
 }
 
@@ -432,6 +434,175 @@ async fn test_fts_topk_tied_scores_wider_than_the_collector_buffer() {
     );
     assert_eq!(top5, vec![BASE + 1, BASE + 2, BASE + 3, BASE + 4, BASE + 5]);
     assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+}
+
+/// Counts reads of the element coordinate columns across every partition.
+#[derive(Default, Debug)]
+struct CoordinateReadCounter {
+    reads: AtomicUsize,
+}
+
+struct CountingCoordinateReader {
+    inner: Arc<dyn IndexReader>,
+    counter: Arc<CoordinateReadCounter>,
+}
+
+#[cfg_attr(coverage, coverage(off))]
+#[async_trait]
+impl IndexReader for CountingCoordinateReader {
+    async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
+        self.inner.read_record_batch(n, batch_size).await
+    }
+    async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
+        self.inner.read_global_buffer(index).await
+    }
+    async fn read_range(
+        &self,
+        range: std::ops::Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        if projection.is_some_and(|columns| columns.contains(&doc_index_storage_column(0).as_str()))
+        {
+            self.counter.reads.fetch_add(1, Ordering::Relaxed);
+        }
+        self.inner.read_range(range, projection).await
+    }
+    async fn num_batches(&self, batch_size: u64) -> u32 {
+        self.inner.num_batches(batch_size).await
+    }
+    fn num_rows(&self) -> usize {
+        self.inner.num_rows()
+    }
+    fn schema(&self) -> &lance_core::datatypes::Schema {
+        self.inner.schema()
+    }
+}
+
+#[derive(Debug)]
+struct CountingCoordinateStore {
+    inner: Arc<dyn IndexStore>,
+    counter: Arc<CoordinateReadCounter>,
+}
+
+#[cfg_attr(coverage, coverage(off))]
+impl DeepSizeOf for CountingCoordinateStore {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.inner.deep_size_of_children(context)
+    }
+}
+
+#[cfg_attr(coverage, coverage(off))]
+#[async_trait]
+impl IndexStore for CountingCoordinateStore {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn clone_arc(&self) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.clone(),
+            counter: self.counter.clone(),
+        })
+    }
+    fn io_parallelism(&self) -> usize {
+        self.inner.io_parallelism()
+    }
+    fn with_io_priority(&self, io_priority: u64) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.with_io_priority(io_priority),
+            counter: self.counter.clone(),
+        })
+    }
+    async fn new_index_file(
+        &self,
+        name: &str,
+        schema: Arc<arrow_schema::Schema>,
+    ) -> Result<Box<dyn crate::scalar::IndexWriter>> {
+        self.inner.new_index_file(name, schema).await
+    }
+    async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
+        Ok(Arc::new(CountingCoordinateReader {
+            inner: self.inner.open_index_file(name).await?,
+            counter: self.counter.clone(),
+        }))
+    }
+    async fn copy_index_file(
+        &self,
+        name: &str,
+        dest_store: &dyn IndexStore,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.copy_index_file(name, dest_store).await
+    }
+    async fn copy_index_file_to(
+        &self,
+        name: &str,
+        new_name: &str,
+        dest_store: &dyn IndexStore,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner
+            .copy_index_file_to(name, new_name, dest_store)
+            .await
+    }
+    async fn rename_index_file(
+        &self,
+        name: &str,
+        new_name: &str,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.rename_index_file(name, new_name).await
+    }
+    async fn delete_index_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_index_file(name).await
+    }
+    async fn list_files_with_sizes(&self) -> Result<Vec<crate::scalar::IndexFile>> {
+        self.inner.list_files_with_sizes().await
+    }
+}
+
+#[tokio::test]
+async fn test_element_fts_resolves_coordinates_once_per_partition() {
+    // The merge compacts its tie band after every partition once past the bound,
+    // and each compaction re-resolves the candidates of every partition merged so
+    // far. Resolving coordinates straight from the docs file made that quadratic
+    // in the number of partitions, so the columns are read once and cached.
+    const PARTITIONS: u64 = 8;
+    const PER_PARTITION: u64 = 100;
+    let tmpdir = TempObjDir::default();
+    let inner = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    for partition_id in 0..PARTITIONS {
+        let elements = (0..PER_PARTITION)
+            .map(|element| (partition_id * 1_000 + element, element as u32))
+            .collect::<Vec<_>>();
+        build_tied_element_partition(&inner, partition_id, &elements).await;
+    }
+    write_test_metadata(
+        &inner,
+        (0..PARTITIONS).collect(),
+        InvertedIndexParams::default(),
+    )
+    .await;
+
+    let counter = Arc::new(CoordinateReadCounter::default());
+    let store: Arc<dyn IndexStore> = Arc::new(CountingCoordinateStore {
+        inner: inner.clone(),
+        counter: counter.clone(),
+    });
+    let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+    let index = InvertedIndex::load(store, None, &cache).await.unwrap();
+
+    let documents = search_alpha_documents(&index, 4).await;
+    assert_eq!(
+        documents,
+        vec![(0, vec![0]), (1, vec![1]), (2, vec![2]), (3, vec![3])],
+        "the exact lowest row_ids, ordered by row_id then doc_index"
+    );
+    let reads = counter.reads.load(Ordering::Relaxed);
+    assert!(
+        reads <= PARTITIONS as usize,
+        "coordinates must be read once per partition, got {reads} reads for {PARTITIONS} partitions"
+    );
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use super::*;
+
+// Deterministic top-k tiebreak (score DESC, row_id ASC).
+//
+// A BM25 top-k that breaks ties arbitrarily is not a stable prefix across `k`:
+// top-k1 is not a prefix of top-k2, so paginating a tied-score query (a broad
+// term where many documents share `(tf, doc_len)`) duplicates and skips rows.
+// Four coupled pieces fix that, all keyed on the row address:
+//   1. `ScoredDoc::cmp` is the total order used for the final sort.
+//   2. `wand::TopKCollector` evicts on the full key when the walk knows row
+//      addresses, and retains the whole k-th-score tie band when it does not.
+//   3. `wand::admit_ties_floor` lowers the WAND threshold one ULP so the
+//      score-only prune kernels keep, rather than drop, that band, including a
+//      slower partition's ties behind the shared cross-partition floor.
+//   4. `ModernCandidates::push` keeps the band across partitions and
+//      `rank_resolved_documents` re-selects once addresses are resolved.
+//
+// The tests below cover a single partition, a post-compaction address order that
+// diverges from DocId order, several partitions, and a tie band wide enough to
+// overflow the collector's buffer and force the address-ordered retry.
+
+struct MaskPreFilter {
+    mask: Arc<RowAddrMask>,
+}
+
+#[cfg_attr(coverage, coverage(off))]
+#[async_trait]
+impl PreFilter for MaskPreFilter {
+    async fn wait_for_ready(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+
+    fn mask(&self) -> Arc<RowAddrMask> {
+        self.mask.clone()
+    }
+
+    fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64> {
+        self.mask.selected_indices(row_ids)
+    }
+}
+
+/// Build one partition whose documents all score identically: term "alpha"
+/// once, doc length 1. `row_ids` is indexed by DocId, so passing an unsorted
+/// slice models a post-compaction remap.
+async fn build_tied_partition(store: &Arc<LanceIndexStore>, partition_id: u64, row_ids: &[u64]) {
+    let mut builder = InnerBuilder::new(partition_id, false, TokenSetFormat::default());
+    builder.tokens.add("alpha".to_owned());
+    builder.posting_lists.push(PostingListBuilder::new(false));
+    for (doc_id, &row_id) in row_ids.iter().enumerate() {
+        builder.posting_lists[0].add(doc_id as u32, PositionRecorder::Count(1));
+        builder.docs.append(row_id, 1);
+    }
+    builder.write(store.as_ref()).await.unwrap();
+}
+
+async fn load_tied_index(partitions: &[(u64, Vec<u64>)]) -> (TempObjDir, Arc<InvertedIndex>) {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    for (partition_id, row_ids) in partitions {
+        build_tied_partition(&store, *partition_id, row_ids).await;
+    }
+    write_test_metadata(
+        &store,
+        partitions.iter().map(|(id, _)| *id).collect(),
+        InvertedIndexParams::default(),
+    )
+    .await;
+    let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+    let index = InvertedIndex::load(store, None, &cache).await.unwrap();
+    (tmpdir, index)
+}
+
+async fn search_alpha_with(
+    index: &InvertedIndex,
+    limit: usize,
+    prefilter: Arc<dyn PreFilter>,
+) -> Vec<u64> {
+    let (row_ids, scores) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(limit))),
+            Operator::Or,
+            prefilter,
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap();
+    // Every document ties, so the premise of these tests is that the returned
+    // scores are all identical; without that the row_id order proves nothing.
+    for window in scores.windows(2) {
+        assert!(
+            (window[0] - window[1]).abs() < 1e-6,
+            "premise: scores must be tied, got {scores:?}"
+        );
+    }
+    row_ids
+}
+
+async fn search_alpha(index: &InvertedIndex, limit: usize) -> Vec<u64> {
+    search_alpha_with(index, limit, Arc::new(NoFilter)).await
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_stable_prefix_single_partition() {
+    let (_tmpdir, index) =
+        load_tied_index(&[(0, vec![100, 101, 102, 103, 104, 105, 106, 107])]).await;
+
+    let top3 = search_alpha(&index, 3).await;
+    let top5 = search_alpha(&index, 5).await;
+    let top8 = search_alpha(&index, 8).await;
+    assert_eq!(
+        top3,
+        vec![100, 101, 102],
+        "top-3 must be the lowest 3 row_ids in order"
+    );
+    assert_eq!(top5, vec![100, 101, 102, 103, 104]);
+    assert_eq!(top8, vec![100, 101, 102, 103, 104, 105, 106, 107]);
+    // Stable prefix: a smaller k is an exact ordered prefix of a larger k, so
+    // paginating never duplicates or skips a row.
+    assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+    assert_eq!(top5, top8[..5], "top-5 must be a prefix of top-8");
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_resolve_by_row_id_not_doc_id() {
+    // Row addresses no longer ascend with DocId, as after a compaction remap.
+    // Postings are still walked in DocId order, so a collector that kept the
+    // first documents it saw would return 105, 100, 107 instead of 100, 101, 102.
+    let (_tmpdir, index) =
+        load_tied_index(&[(0, vec![105, 100, 107, 102, 104, 101, 106, 103])]).await;
+
+    let top3 = search_alpha(&index, 3).await;
+    let top5 = search_alpha(&index, 5).await;
+    assert_eq!(
+        top3,
+        vec![100, 101, 102],
+        "the tie band must resolve by row_id, not by DocId or encounter order"
+    );
+    assert_eq!(top5, vec![100, 101, 102, 103, 104]);
+    assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_stable_prefix_across_partitions() {
+    // Tied documents split across partitions with interleaved row_ids, so the
+    // shared cross-partition WAND floor and the merge must resolve ties by
+    // row_id no matter which partition finishes first (`buffer_unordered`).
+    let (_tmpdir, index) =
+        load_tied_index(&[(0, vec![100, 102, 104, 106]), (1, vec![101, 103, 105, 107])]).await;
+
+    let top3 = search_alpha(&index, 3).await;
+    let top6 = search_alpha(&index, 6).await;
+    assert_eq!(
+        top3,
+        vec![100, 101, 102],
+        "cross-partition ties must resolve by row_id"
+    );
+    assert_eq!(top6, vec![100, 101, 102, 103, 104, 105]);
+    assert_eq!(top3, top6[..3], "top-3 must be a prefix of top-6");
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_are_stable_across_repeated_searches() {
+    // Twelve partitions all tied at one score, with row_ids striped across them
+    // so the correct top-6 draws one document from each of six partitions. The
+    // partitions complete in whatever order `buffer_unordered` yields, so
+    // repeating the query checks directly that the result does not depend on it.
+    const PARTITIONS: u64 = 12;
+    let partitions = (0..PARTITIONS)
+        .map(|partition_id| {
+            let row_ids = (0..3)
+                .map(|offset| partition_id + offset * PARTITIONS)
+                .collect::<Vec<_>>();
+            (partition_id, row_ids)
+        })
+        .collect::<Vec<_>>();
+    let (_tmpdir, index) = load_tied_index(&partitions).await;
+
+    let expected_top6 = vec![0, 1, 2, 3, 4, 5];
+    for _ in 0..8 {
+        assert_eq!(search_alpha(&index, 3).await, expected_top6[..3]);
+        assert_eq!(search_alpha(&index, 6).await, expected_top6);
+    }
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_survive_a_prefilter() {
+    // An explicit allow-list routes the search off the unfiltered fast path.
+    // The partition then loads its addresses to build visibility, so the walk
+    // settles the tie itself instead of deferring it to the merge.
+    let row_ids = [105u64, 100, 107, 102, 104, 101, 106, 103];
+    let (_tmpdir, index) = load_tied_index(&[(0, row_ids.to_vec())]).await;
+    let allow_all = || -> Arc<dyn PreFilter> {
+        Arc::new(MaskPreFilter {
+            mask: Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
+                row_ids.iter().copied(),
+            ))),
+        })
+    };
+
+    let top3 = search_alpha_with(&index, 3, allow_all()).await;
+    let top5 = search_alpha_with(&index, 5, allow_all()).await;
+    assert_eq!(
+        top3,
+        vec![100, 101, 102],
+        "the filtered path must resolve ties by row_id too"
+    );
+    assert_eq!(top5, vec![100, 101, 102, 103, 104]);
+    assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_wider_than_the_collector_buffer() {
+    // The tie band is far wider than the collector's buffer, and row addresses
+    // descend with DocId, so the winners sit at the very end of the walk. A
+    // collector that truncated its band would answer with the highest row_ids;
+    // the overflow retry reloads the partition's addresses and orders exactly.
+    const NUM_DOCS: u64 = 512;
+    const BASE: u64 = 10_000;
+    let row_ids = (0..NUM_DOCS)
+        .map(|doc_id| BASE + NUM_DOCS - doc_id)
+        .collect::<Vec<_>>();
+    let (_tmpdir, index) = load_tied_index(&[(0, row_ids)]).await;
+
+    let top3 = search_alpha(&index, 3).await;
+    let top5 = search_alpha(&index, 5).await;
+    assert_eq!(
+        top3,
+        vec![BASE + 1, BASE + 2, BASE + 3],
+        "the exact lowest row_ids, which the walk only reaches at its last DocIds"
+    );
+    assert_eq!(top5, vec![BASE + 1, BASE + 2, BASE + 3, BASE + 4, BASE + 5]);
+    assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+}

--- a/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
@@ -392,7 +392,8 @@ async fn test_fts_topk_tied_scores_bound_the_cross_partition_band() {
     // plus whatever the next partition contributed in one go.
     assert!(
         peak <= bound + PER_PARTITION as usize,
-        "the merge band must be compacted back under {bound} between partitions,              leaving room for one partition's contribution on top, peak {peak}"
+        "the merge band must be compacted back under {bound} between partitions, \
+         leaving room for one partition's contribution on top, peak {peak}"
     );
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/topk_tiebreak.rs
@@ -112,25 +112,23 @@ async fn search_alpha(index: &InvertedIndex, limit: usize) -> Vec<u64> {
     search_alpha_with(index, limit, Arc::new(NoFilter)).await
 }
 
-#[tokio::test]
-async fn test_fts_topk_tied_scores_stable_prefix_single_partition() {
-    let (_tmpdir, index) =
-        load_tied_index(&[(0, vec![100, 101, 102, 103, 104, 105, 106, 107])]).await;
-
-    let top3 = search_alpha(&index, 3).await;
-    let top5 = search_alpha(&index, 5).await;
-    let top8 = search_alpha(&index, 8).await;
-    assert_eq!(
-        top3,
-        vec![100, 101, 102],
-        "top-3 must be the lowest 3 row_ids in order"
-    );
-    assert_eq!(top5, vec![100, 101, 102, 103, 104]);
-    assert_eq!(top8, vec![100, 101, 102, 103, 104, 105, 106, 107]);
-    // Stable prefix: a smaller k is an exact ordered prefix of a larger k, so
-    // paginating never duplicates or skips a row.
-    assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
-    assert_eq!(top5, top8[..5], "top-5 must be a prefix of top-8");
+/// Search for "alpha" and return `(row_id, doc_index)` per hit, so an
+/// element-granularity result can be checked down to the element.
+async fn search_alpha_documents(index: &InvertedIndex, limit: usize) -> Vec<(u64, Vec<u32>)> {
+    index
+        .bm25_search_documents(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(limit))),
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|document| (document.row_id, document.doc_index))
+        .collect()
 }
 
 #[tokio::test]
@@ -221,6 +219,181 @@ async fn test_fts_topk_tied_scores_survive_a_prefilter() {
     assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
 }
 
+/// Build one element-granularity partition. Each entry is `(row_id, doc_index)`
+/// and is appended in the given order, so `row_ids` indexed by DocId can
+/// disagree with the element coordinates the result must be ordered by.
+async fn build_tied_element_partition(
+    store: &Arc<LanceIndexStore>,
+    partition_id: u64,
+    elements: &[(u64, u32)],
+) {
+    let mut builder = InnerBuilder::new(partition_id, false, TokenSetFormat::default());
+    builder.docs = DocSet::with_coordinate_rank(1);
+    builder.tokens.add("alpha".to_owned());
+    builder.posting_lists.push(PostingListBuilder::new(false));
+    for (doc_id, &(row_id, doc_index)) in elements.iter().enumerate() {
+        builder.posting_lists[0].add(doc_id as u32, PositionRecorder::Count(1));
+        builder
+            .docs
+            .append_with_doc_index(row_id, 1, &[doc_index])
+            .unwrap();
+    }
+    builder.write(store.as_ref()).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_elements_of_one_row_resolve_by_doc_index() {
+    // Element documents of one row share its address, so the WAND ordering key
+    // ranks the row but not its elements. The winning element is visited after
+    // the heap is full, which a collector that let the address key settle the
+    // tie would drop, and no later sort could bring it back.
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    build_tied_element_partition(&store, 0, &[(100, 1), (100, 2), (100, 0), (50, 0)]).await;
+    write_test_metadata(&store, vec![0], InvertedIndexParams::default()).await;
+    let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+    let index = InvertedIndex::load(store, None, &cache).await.unwrap();
+
+    let expected = vec![(50, vec![0]), (100, vec![0])];
+    // Cold: the walk defers addresses, so the whole k-th-score band is retained.
+    assert_eq!(search_alpha_documents(&index, 2).await, expected);
+
+    // Prewarmed: the address projection is resident, so the walk ranks by row
+    // address and only the elements of one row stay ambiguous.
+    index.partitions[0]
+        .docs
+        .modern()
+        .unwrap()
+        .prewarm()
+        .await
+        .unwrap();
+    assert!(index.has_resident_document_projections());
+    assert_eq!(search_alpha_documents(&index, 2).await, expected);
+
+    // Stable prefix across k, down to the element.
+    let top4 = search_alpha_documents(&index, 4).await;
+    assert_eq!(
+        top4,
+        vec![
+            (50, vec![0]),
+            (100, vec![0]),
+            (100, vec![1]),
+            (100, vec![2])
+        ]
+    );
+    assert_eq!(top4[..2], expected);
+}
+
+/// Captures the FTS buffer high-water marks the merge reports.
+#[derive(Default)]
+struct FtsBufferMetrics {
+    peak_buffered: AtomicUsize,
+    score_floor_overflows: AtomicUsize,
+}
+
+#[cfg_attr(coverage, coverage(off))]
+impl MetricsCollector for FtsBufferMetrics {
+    fn record_parts_loaded(&self, _num_parts: usize) {}
+    fn record_comparisons(&self, _num_comparisons: usize) {}
+    fn record_index_loads(&self, _num_loads: usize) {}
+    fn record_fts_peak_buffered_candidates(&self, num_candidates: usize) {
+        self.peak_buffered
+            .fetch_max(num_candidates, Ordering::Relaxed);
+    }
+    fn record_fts_score_floor_overflows(&self, num_overflows: usize) {
+        self.score_floor_overflows
+            .fetch_add(num_overflows, Ordering::Relaxed);
+    }
+}
+
+#[test]
+fn test_push_scored_key_breaks_legacy_ties_by_row_id() {
+    // The legacy merge holds row addresses, so it settles a score tie on the
+    // spot: a lower row_id evicts the worst tied entry and a higher one loses,
+    // whatever order the candidates arrive in.
+    let mut candidates = BinaryHeap::new();
+    for (row_id, score) in [(20u64, 1.0f32), (10, 1.0), (5, 1.0), (30, 1.0), (15, 0.5)] {
+        push_scored_key(&mut candidates, 2, row_id, score);
+    }
+    let ranked = candidates
+        .into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(doc)| (doc.row_id, doc.score.0))
+        .collect::<Vec<_>>();
+    assert_eq!(ranked, vec![(5, 1.0), (10, 1.0)]);
+}
+
+#[test]
+fn test_push_scored_key_rejects_nan_scores() {
+    // A NaN score is not a rank. `OrderedFloat` compares with `total_cmp`, which
+    // sorts NaN above every real score, so the legacy merge drops it instead of
+    // letting it take the top of the result. Before the tiebreak the same
+    // candidate slipped into an under-filled heap and came back first.
+    let mut candidates = BinaryHeap::new();
+    push_scored_key(&mut candidates, 4, 7, f32::NAN);
+    assert!(candidates.is_empty(), "NaN must never become a candidate");
+
+    push_scored_key(&mut candidates, 4, 1, 1.0);
+    push_scored_key(&mut candidates, 4, 2, f32::NAN);
+    let ranked = candidates
+        .into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(doc)| doc.row_id)
+        .collect::<Vec<_>>();
+    assert_eq!(ranked, vec![1]);
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_bound_the_cross_partition_band() {
+    // Every document ties, so each partition hands the merge its whole
+    // `limit + SCORE_FLOOR_BUFFER` band. Six of those overrun the merge's own
+    // bound several times over, which is the one buffer on this path that grows
+    // with the number of partitions rather than with `limit`.
+    const PARTITIONS: u64 = 6;
+    const PER_PARTITION: u64 = 100;
+    const LIMIT: usize = 4;
+    let partitions = (0..PARTITIONS)
+        .map(|partition_id| {
+            let base = partition_id * 1_000;
+            (partition_id, (0..PER_PARTITION).map(|d| base + d).collect())
+        })
+        .collect::<Vec<_>>();
+    let (_tmpdir, index) = load_tied_index(&partitions).await;
+
+    let metrics = Arc::new(FtsBufferMetrics::default());
+    let (row_ids, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(LIMIT))),
+            Operator::Or,
+            Arc::new(NoFilter),
+            metrics.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        row_ids,
+        vec![0, 1, 2, 3],
+        "compacting the band must not change the exact top-k"
+    );
+
+    let peak = metrics.peak_buffered.load(Ordering::Relaxed);
+    let bound = LIMIT + SCORE_FLOOR_BUFFER;
+    assert!(
+        peak > LIMIT,
+        "premise: the tie band must actually be exercised, peak {peak}"
+    );
+    assert!(
+        peak <= bound + PER_PARTITION as usize,
+        "the merge band must be compacted back under {bound} between partitions, peak {peak}"
+    );
+}
+
 #[tokio::test]
 async fn test_fts_topk_tied_scores_wider_than_the_collector_buffer() {
     // The tie band is far wider than the collector's buffer, and row addresses
@@ -234,7 +407,23 @@ async fn test_fts_topk_tied_scores_wider_than_the_collector_buffer() {
         .collect::<Vec<_>>();
     let (_tmpdir, index) = load_tied_index(&[(0, row_ids)]).await;
 
-    let top3 = search_alpha(&index, 3).await;
+    let metrics = Arc::new(FtsBufferMetrics::default());
+    let (top3, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(3))),
+            Operator::Or,
+            Arc::new(NoFilter),
+            metrics.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        metrics.score_floor_overflows.load(Ordering::Relaxed),
+        1,
+        "the retry must be visible in metrics, not silent extra work"
+    );
     let top5 = search_alpha(&index, 5).await;
     assert_eq!(
         top3,
@@ -243,4 +432,51 @@ async fn test_fts_topk_tied_scores_wider_than_the_collector_buffer() {
     );
     assert_eq!(top5, vec![BASE + 1, BASE + 2, BASE + 3, BASE + 4, BASE + 5]);
     assert_eq!(top3, top5[..3], "top-3 must be a prefix of top-5");
+}
+
+#[tokio::test]
+async fn test_fts_topk_tied_scores_retry_every_overflowed_partition() {
+    // Every partition overflows its tie band at once, which is what a broad
+    // single-term query over quantized doc lengths looks like. All of them are
+    // rescored against resolved addresses, concurrently, and the answer is still
+    // the exact lowest row_ids.
+    const PARTITIONS: u64 = 5;
+    const PER_PARTITION: u64 = 200;
+    const BASE: u64 = 10_000;
+    let partitions = (0..PARTITIONS)
+        .map(|partition_id| {
+            // Row addresses descend with DocId, so the winners sit at the end of
+            // each walk, past the point where the band overflows.
+            let row_ids = (0..PER_PARTITION)
+                .map(|doc_id| BASE + partition_id + (PER_PARTITION - doc_id) * PARTITIONS)
+                .collect::<Vec<_>>();
+            (partition_id, row_ids)
+        })
+        .collect::<Vec<_>>();
+    let (_tmpdir, index) = load_tied_index(&partitions).await;
+
+    let metrics = Arc::new(FtsBufferMetrics::default());
+    let (top5, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(5))),
+            Operator::Or,
+            Arc::new(NoFilter),
+            metrics.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        metrics.score_floor_overflows.load(Ordering::Relaxed),
+        PARTITIONS as usize,
+        "every partition must be retried"
+    );
+    // The lowest addresses are the last DocId of each partition, one per
+    // partition: BASE + partition_id + PARTITIONS.
+    let expected = (0..PARTITIONS)
+        .map(|partition_id| BASE + partition_id + PARTITIONS)
+        .collect::<Vec<_>>();
+    assert_eq!(top5, expected);
+    assert_eq!(search_alpha(&index, 3).await, expected[..3]);
 }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -21,7 +21,7 @@ use crate::metrics::MetricsCollector;
 
 use super::{
     CompressedPositionStorage,
-    documents::{DocId, DocLengths, DocVisibility},
+    documents::{DocId, DocLengths, DocVisibility, ResidentAddressProjection},
     impact::{IMPACT_LEVEL1_BLOCKS, ImpactScoreCache, ImpactSkipData},
     index::{PositionStreamCodec, dequantize_doc_length},
     query::Operator,
@@ -41,26 +41,75 @@ use super::{DocInfo, builder::BLOCK_SIZE};
 
 const TERMINATED_DOC_ID: u64 = u64::MAX;
 
-/// Top-k heap entry: (scored doc, doc length, posting doc id, frequency slot).
-/// The (term, freq) pairs live outside the heap so heap churn moves a compact
-/// tuple instead of a `Vec`.
-type TopKHeap = BinaryHeap<Reverse<(ScoredDoc, u32, u64, u32)>>;
+/// The maximum number of documents a deferred collector buffers beyond `limit`
+/// while it holds the k-th-score tie band. Matches the compound collector's
+/// bound (`compound::SCORE_FLOOR_RESOLUTION_BATCH_SIZE`) so both FTS paths cap
+/// their unresolved working set the same way.
+const SCORE_FLOOR_BUFFER: usize = 128;
+
+/// One live top-k candidate. The (term, freq) pairs live outside the heap in a
+/// [`FrequencySlots`] slot so heap churn moves a compact record instead of a `Vec`.
+#[derive(Debug, Clone)]
+struct TopKEntry {
+    doc: ScoredDoc,
+    /// Tie-break key. The real row address when the walk can resolve one, and a
+    /// partition-local DocId proxy otherwise (see [`TieHandling`]).
+    order_key: u64,
+    doc_length: u32,
+    posting_doc_id: u64,
+    frequency_slot: u32,
+}
+
+impl PartialEq for TopKEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for TopKEntry {}
+
+impl PartialOrd for TopKEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TopKEntry {
+    /// The FTS total order (score DESC, key ASC) expressed "best is greatest",
+    /// so a `Reverse`-wrapped max-heap peeks at the entry to evict first: the
+    /// lowest score, then the highest key.
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.doc
+            .score
+            .cmp(&other.doc.score)
+            .then_with(|| other.order_key.cmp(&self.order_key))
+    }
+}
+
+type TopKHeap = BinaryHeap<Reverse<TopKEntry>>;
 
 /// Reusable (term, freq) storage for live heap candidates. Replacing the k-th
 /// result reuses its slot and retained `Vec` capacity, so memory stays bounded
 /// by the live top-k rather than every historical heap admission.
 struct FrequencySlots {
     slots: Vec<Vec<(u32, u32)>>,
+    /// Slots whose entry left the heap without a replacement, ready for reuse.
+    free: Vec<u32>,
 }
 
 impl FrequencySlots {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             slots: Vec::with_capacity(capacity),
+            free: Vec::new(),
         }
     }
 
     fn push(&mut self, pairs: impl Iterator<Item = (u32, u32)>) -> Result<u32> {
+        if let Some(slot) = self.free.pop() {
+            self.replace(slot, pairs)?;
+            return Ok(slot);
+        }
         let slot = u32::try_from(self.slots.len()).map_err(|_| {
             Error::internal(format!(
                 "FTS top-k frequency slot count {} exceeds u32::MAX",
@@ -83,6 +132,13 @@ impl FrequencySlots {
         Ok(())
     }
 
+    /// Move a slot's pairs out and return the slot to the free list.
+    fn release(&mut self, slot: u32) -> Result<Vec<(u32, u32)>> {
+        let pairs = self.take(slot)?;
+        self.free.push(slot);
+        Ok(pairs)
+    }
+
     fn take(&mut self, slot: u32) -> Result<Vec<(u32, u32)>> {
         let num_slots = self.slots.len();
         self.slots
@@ -96,28 +152,93 @@ impl FrequencySlots {
     }
 }
 
+/// A document tied at the k-th score that the heap has no room for. It owns its
+/// frequencies because it never held a frequency slot.
+struct TieCandidate {
+    doc: ScoredDoc,
+    doc_length: u32,
+    posting_doc_id: u64,
+    freqs: Vec<(u32, u32)>,
+}
+
+/// How a collector orders documents that tie at the k-th score.
+///
+/// FTS results are ordered `(score DESC, row_id ASC)`. Whether that order can be
+/// decided inside the WAND walk depends on what the walk knows about a document:
+/// legacy postings carry row addresses, modern postings carry dense DocIds whose
+/// address order is only known once the addresses are resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TieHandling {
+    /// `order_key` is the row address, so the final order is exact here and the
+    /// heap alone holds the answer.
+    ByRowAddress,
+    /// `order_key` is a DocId proxy. Documents tied at the k-th score that the
+    /// heap cannot hold are kept in a side band so the caller can re-select by
+    /// address afterwards. Past `max_buffered` retained documents the collector
+    /// reports [`TopKCollector::score_floor_overflow`] instead of silently
+    /// dropping ties.
+    RetainScoreFloor { max_buffered: usize },
+}
+
 /// Owns the top-k heap and the frequency slots referenced by its entries.
 struct TopKCollector {
     limit: usize,
     heap: TopKHeap,
     frequency_slots: FrequencySlots,
+    tie_handling: TieHandling,
+    /// Documents tied at the current k-th score that did not fit in the heap.
+    /// Deferred mode only, and cleared whenever the k-th score rises, so it holds
+    /// just the current tie band and stays empty for a query without ties.
+    tie_band: Vec<TieCandidate>,
+    score_floor_overflow: bool,
 }
 
 impl TopKCollector {
-    fn new(limit: usize, initial_capacity: usize) -> Self {
+    /// Collector for a walk whose document keys are row addresses.
+    fn by_row_address(limit: usize, initial_capacity: usize) -> Self {
+        Self::new(limit, initial_capacity, TieHandling::ByRowAddress)
+    }
+
+    /// Collector for a walk whose document keys are DocId proxies. It retains the
+    /// k-th-score tie band up to `limit + SCORE_FLOOR_BUFFER` documents.
+    fn retaining_score_floor(limit: usize, initial_capacity: usize) -> Self {
+        Self::new(
+            limit,
+            initial_capacity,
+            TieHandling::RetainScoreFloor {
+                max_buffered: limit.saturating_add(SCORE_FLOOR_BUFFER),
+            },
+        )
+    }
+
+    fn new(limit: usize, initial_capacity: usize, tie_handling: TieHandling) -> Self {
         let initial_capacity = initial_capacity.min(limit);
         Self {
             limit,
             heap: BinaryHeap::with_capacity(initial_capacity),
             frequency_slots: FrequencySlots::with_capacity(initial_capacity),
+            tie_handling,
+            tie_band: Vec::new(),
+            score_floor_overflow: false,
         }
     }
 
-    /// Insert a competitive result. When the heap is full, its evicted entry's
-    /// frequency slot is cleared and reused before the replacement is pushed.
+    /// True when the walk dropped part of its k-th-score tie band. The caller must
+    /// discard these candidates and retry the partition with resolved row
+    /// addresses, otherwise the final order is not the exact top-k.
+    fn score_floor_overflow(&self) -> bool {
+        self.score_floor_overflow
+    }
+
+    /// Insert a competitive result.
+    ///
+    /// Returns whether the document entered the heap. When the heap is full, the
+    /// evicted entry's frequency slot is cleared and reused before the replacement
+    /// is pushed.
     fn insert(
         &mut self,
         doc: ScoredDoc,
+        order_key: u64,
         doc_length: u32,
         posting_doc_id: u64,
         pairs: impl Iterator<Item = (u32, u32)>,
@@ -133,36 +254,146 @@ impl TopKCollector {
             )));
         }
 
-        let frequency_slot = if self.heap.len() == self.limit {
-            let Some(kth_score) = self.heap.peek().map(|entry| entry.0.0.score.0) else {
-                return Err(Error::internal(
-                    "FTS top-k heap is empty while its nonzero limit is reached",
-                ));
-            };
-            // Preserve the existing collector semantics for non-finite custom
-            // scorer output: only a strictly greater raw f32 replaces k-th.
-            if doc.score.0.partial_cmp(&kth_score) != Some(std::cmp::Ordering::Greater) {
-                return Ok(false);
+        if self.heap.len() < self.limit {
+            let frequency_slot = self.frequency_slots.push(pairs)?;
+            self.heap.push(Reverse(TopKEntry {
+                doc,
+                order_key,
+                doc_length,
+                posting_doc_id,
+                frequency_slot,
+            }));
+            return Ok(true);
+        }
+
+        let Some(Reverse(worst)) = self.heap.peek() else {
+            return Err(Error::internal(
+                "FTS top-k heap is empty while its nonzero limit is reached",
+            ));
+        };
+        // A NaN custom-scorer score is never competitive. Dropping it here keeps
+        // NaN out of the ordering key and preserves the pre-tiebreak semantics for
+        // non-finite scorer output.
+        if doc.score.0.is_nan() {
+            return Ok(false);
+        }
+        let worst_score = worst.doc.score;
+        let worst_order_key = worst.order_key;
+        // A collector that already overflowed produces discarded results, so it
+        // stops retaining ties and stays inside its buffer bound.
+        let retained_band = match self.tie_handling {
+            TieHandling::RetainScoreFloor { max_buffered } if !self.score_floor_overflow => {
+                Some(max_buffered)
             }
-            let Some(Reverse((_, _, _, frequency_slot))) = self.heap.pop() else {
-                return Err(Error::internal(
-                    "FTS top-k heap entry disappeared during replacement",
-                ));
-            };
-            self.frequency_slots.replace(frequency_slot, pairs)?;
-            frequency_slot
-        } else {
-            self.frequency_slots.push(pairs)?
+            _ => None,
         };
 
-        self.heap
-            .push(Reverse((doc, doc_length, posting_doc_id, frequency_slot)));
-        Ok(true)
+        match doc.score.cmp(&worst_score) {
+            // Below the k-th score: never competitive.
+            std::cmp::Ordering::Less => Ok(false),
+            std::cmp::Ordering::Equal => match retained_band {
+                // The order key is the real row address, so the tie is decided here:
+                // a lower address ranks higher and evicts the worst entry.
+                None => {
+                    if order_key >= worst_order_key {
+                        return Ok(false);
+                    }
+                    self.replace_worst(doc, order_key, doc_length, posting_doc_id, pairs)?;
+                    Ok(true)
+                }
+                // A DocId proxy cannot decide the tie, so the document is kept in
+                // the band for the address-resolved re-selection downstream.
+                Some(max_buffered) => {
+                    if self.buffered() >= max_buffered {
+                        self.score_floor_overflow = true;
+                        return Ok(false);
+                    }
+                    self.tie_band.push(TieCandidate {
+                        doc,
+                        doc_length,
+                        posting_doc_id,
+                        freqs: pairs.collect(),
+                    });
+                    Ok(false)
+                }
+            },
+            // Strictly better on score: it always enters the heap.
+            std::cmp::Ordering::Greater => {
+                let Some(max_buffered) = retained_band else {
+                    self.replace_worst(doc, order_key, doc_length, posting_doc_id, pairs)?;
+                    return Ok(true);
+                };
+                let Some(Reverse(displaced)) = self.heap.pop() else {
+                    return Err(Error::internal(
+                        "FTS top-k heap entry disappeared during replacement",
+                    ));
+                };
+                let frequency_slot = self.frequency_slots.push(pairs)?;
+                self.heap.push(Reverse(TopKEntry {
+                    doc,
+                    order_key,
+                    doc_length,
+                    posting_doc_id,
+                    frequency_slot,
+                }));
+                let kth = self
+                    .heap
+                    .peek()
+                    .map(|Reverse(entry)| entry.doc.score)
+                    .ok_or_else(|| Error::internal("FTS top-k heap is empty right after a push"))?;
+                let freqs = self.frequency_slots.release(displaced.frequency_slot)?;
+                if kth > worst_score {
+                    // The k-th score rose past the band: none of its members can win.
+                    self.tie_band.clear();
+                } else if self.buffered() >= max_buffered {
+                    self.score_floor_overflow = true;
+                } else {
+                    self.tie_band.push(TieCandidate {
+                        doc: displaced.doc,
+                        doc_length: displaced.doc_length,
+                        posting_doc_id: displaced.posting_doc_id,
+                        freqs,
+                    });
+                }
+                Ok(true)
+            }
+        }
+    }
+
+    /// Documents held for the final selection: the heap plus the retained band.
+    fn buffered(&self) -> usize {
+        self.heap.len() + self.tie_band.len()
+    }
+
+    /// Pop the worst entry and push `doc` in its place, reusing its frequency slot.
+    fn replace_worst(
+        &mut self,
+        doc: ScoredDoc,
+        order_key: u64,
+        doc_length: u32,
+        posting_doc_id: u64,
+        pairs: impl Iterator<Item = (u32, u32)>,
+    ) -> Result<()> {
+        let Some(Reverse(worst)) = self.heap.pop() else {
+            return Err(Error::internal(
+                "FTS top-k heap entry disappeared during replacement",
+            ));
+        };
+        let frequency_slot = worst.frequency_slot;
+        self.frequency_slots.replace(frequency_slot, pairs)?;
+        self.heap.push(Reverse(TopKEntry {
+            doc,
+            order_key,
+            doc_length,
+            posting_doc_id,
+            frequency_slot,
+        }));
+        Ok(())
     }
 
     fn kth_score_if_full(&self) -> Option<f32> {
         if self.heap.len() == self.limit {
-            self.heap.peek().map(|entry| entry.0.0.score.0)
+            self.heap.peek().map(|entry| entry.0.doc.score.0)
         } else {
             None
         }
@@ -175,20 +406,33 @@ impl TopKCollector {
         let Self {
             heap,
             mut frequency_slots,
+            tie_band,
             ..
         } = self;
-        heap.into_iter()
-            .map(
-                |Reverse((doc, doc_length, posting_doc_id, frequency_slot))| {
-                    Ok(DocCandidate {
-                        document: to_candidate(doc.row_id),
-                        posting_doc_id,
-                        freqs: frequency_slots.take(frequency_slot)?,
-                        doc_length,
-                    })
-                },
-            )
-            .collect()
+        let mut candidates = heap
+            .into_iter()
+            .map(|Reverse(entry)| {
+                Ok(DocCandidate {
+                    document: to_candidate(entry.doc.row_id),
+                    posting_doc_id: entry.posting_doc_id,
+                    freqs: frequency_slots.take(entry.frequency_slot)?,
+                    doc_length: entry.doc_length,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // The retained ties may beat a heap entry once addresses are resolved. The
+        // caller re-selects by `(score, row_id)`, so returning more than `limit`
+        // documents is safe.
+        candidates.reserve(tie_band.len());
+        for tie in tie_band {
+            candidates.push(DocCandidate {
+                document: to_candidate(tie.doc.row_id),
+                posting_doc_id: tie.posting_doc_id,
+                freqs: tie.freqs,
+                doc_length: tie.doc_length,
+            });
+        }
+        Ok(candidates)
     }
 
     #[cfg(test)]
@@ -1559,6 +1803,21 @@ pub(super) trait WandDocuments {
     fn candidate_from_key(&self, key: u64) -> Self::Candidate;
     fn flat_documents(&self) -> Option<FlatDocuments<'_>>;
     fn flat_doc_length(&self, doc_id: u64, document_key: u64, compressed: bool) -> u32;
+
+    /// Whether [`WandDocuments::tie_order_key`] returns real row addresses.
+    ///
+    /// FTS results are ordered `(score DESC, row_id ASC)`. When this is true the
+    /// walk can settle k-th-score ties itself; when it is false the ordering key
+    /// is only a DocId proxy and the collector retains the tie band so the caller
+    /// can re-select once addresses are resolved.
+    fn orders_ties_by_address(&self) -> bool;
+
+    /// Key used to break score ties inside one partition's top-k: the row address
+    /// when [`WandDocuments::orders_ties_by_address`] is true, the document key
+    /// otherwise.
+    fn tie_order_key(&self, document_key: u64) -> u64 {
+        document_key
+    }
 }
 
 pub(super) trait ModernVisibility {
@@ -1603,6 +1862,9 @@ impl ModernVisibility for &DocVisibility {
 pub(super) struct ModernWandDocuments<'a, V> {
     lengths: &'a DocLengths,
     visibility: V,
+    /// Attached only when the partition's row addresses are already in memory.
+    /// The walk then orders k-th-score ties exactly instead of deferring them.
+    addresses: Option<&'a ResidentAddressProjection>,
 }
 
 impl<'a> ModernWandDocuments<'a, AllModernDocuments> {
@@ -1610,6 +1872,7 @@ impl<'a> ModernWandDocuments<'a, AllModernDocuments> {
         Self {
             lengths,
             visibility: AllModernDocuments,
+            addresses: None,
         }
     }
 }
@@ -1619,7 +1882,20 @@ impl<'a> ModernWandDocuments<'a, &'a DocVisibility> {
         Self {
             lengths,
             visibility,
+            addresses: None,
         }
+    }
+}
+
+impl<'a, V> ModernWandDocuments<'a, V> {
+    /// Order k-th-score ties by row address instead of deferring them, using an
+    /// address projection the caller already holds in memory.
+    pub(crate) fn with_addresses(
+        mut self,
+        addresses: Option<&'a ResidentAddressProjection>,
+    ) -> Self {
+        self.addresses = addresses;
+        self
     }
 }
 
@@ -1678,6 +1954,18 @@ impl<V: ModernVisibility> WandDocuments for ModernWandDocuments<'_, V> {
 
     fn flat_doc_length(&self, doc_id: u64, _document_key: u64, _compressed: bool) -> u32 {
         self.scoring_num_tokens(doc_id as u32)
+    }
+
+    fn orders_ties_by_address(&self) -> bool {
+        self.addresses.is_some()
+    }
+
+    fn tie_order_key(&self, document_key: u64) -> u64 {
+        // A dead slot has no current address; it is not visible to the walk, so
+        // sorting it last only guards against it winning a tie.
+        self.addresses
+            .and_then(|addresses| addresses.address(DocId::new(document_key as u32)))
+            .unwrap_or(u64::MAX)
     }
 }
 
@@ -1750,6 +2038,11 @@ impl WandDocuments for LegacyWandDocuments<'_> {
             self.docs.num_tokens_by_row_id(document_key)
         }
     }
+
+    // Legacy document keys are row addresses, so the walk orders ties exactly.
+    fn orders_ties_by_address(&self) -> bool {
+        true
+    }
 }
 
 // Most unit tests exercise WAND in isolation with an in-memory complete
@@ -1808,6 +2101,11 @@ impl WandDocuments for DocSet {
         } else {
             self.num_tokens_by_row_id(document_key)
         }
+    }
+
+    // `document_key` is a row address whenever this in-memory DocSet carries one.
+    fn orders_ties_by_address(&self) -> bool {
+        self.has_row_ids()
     }
 }
 
@@ -1973,6 +2271,9 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     // k-th score (`atomic_store_max_f32`) and prunes against the running value
     // -- a lower bound on the global k-th, so it never drops a real top-k doc.
     shared_threshold: Option<Arc<AtomicU32>>,
+    // Set when the last search dropped part of its k-th-score tie band because
+    // the walk could not order ties by row address (see `TieHandling`).
+    score_floor_overflow: bool,
 }
 
 /// Monotonically raise an f32 stored in an `AtomicU32` to `val`. CAS loop (not a
@@ -1985,6 +2286,22 @@ fn atomic_store_max_f32(slot: &AtomicU32, val: f32) {
             Err(actual) => cur = actual,
         }
     }
+}
+
+/// Lower a competitive-score threshold by one ULP so the score-only WAND prune
+/// tests (`score <= threshold`) and their admit mirrors (`score > threshold`)
+/// keep, rather than drop, documents whose score equals the k-th best.
+///
+/// This is the admit-ties half of the deterministic tiebreak: the pruning kernels
+/// stay score-only and fast, and the equal-score band survives to be ordered by
+/// row_id in the collector and in the cross-partition merge. Documents strictly
+/// below the k-th score are still pruned, so non-tied queries keep their pruning
+/// power: a block max rarely bit-equals the running k-th score. For a zero or
+/// negative input `next_down` drops below zero, which the `threshold > 0.0` guards
+/// read as "no threshold yet".
+#[inline]
+fn admit_ties_floor(threshold: f32) -> f32 {
+    threshold.next_down()
 }
 
 // we were using row id as doc id in the past, which is u64,
@@ -2037,6 +2354,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             documents,
             scorer,
             shared_threshold: None,
+            score_floor_overflow: false,
         }
     }
 
@@ -2046,6 +2364,26 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     fn with_bulk_and_mode(mut self, mode: BulkAndMode) -> Self {
         self.bulk_and_mode_override = Some(mode);
         self
+    }
+
+    /// Build the top-k collector for one walk.
+    ///
+    /// The document adapter decides whether k-th-score ties can be settled during
+    /// the walk or must be deferred (see [`WandDocuments::orders_ties_by_address`]).
+    fn new_collector(&self, limit: usize, initial_capacity: usize) -> TopKCollector {
+        if self.documents.orders_ties_by_address() {
+            TopKCollector::by_row_address(limit, initial_capacity)
+        } else {
+            TopKCollector::retaining_score_floor(limit, initial_capacity)
+        }
+    }
+
+    /// Whether the last search dropped part of its k-th-score tie band.
+    ///
+    /// The candidates it returned are then only the exact top-k up to that band,
+    /// so the caller must retry the partition with resolved row addresses.
+    pub(crate) fn score_floor_overflow(&self) -> bool {
+        self.score_floor_overflow
     }
 
     /// Share one cross-partition top-k floor across a query's partitions.
@@ -2071,6 +2409,14 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
     /// Set the pruning threshold from this partition's k-th best, raised to the
     /// shared cross-partition floor when one is attached.
+    ///
+    /// The stored value sits one ULP below the k-th score ([`admit_ties_floor`]) so
+    /// documents tied at the k-th score are admitted rather than pruned; the
+    /// collector and the cross-partition merge then order them by row_id. The raw
+    /// k-th score is what gets published to the shared floor, so every partition
+    /// lowers from the same basis. The tiebreak holds for `wand_factor <= 1.0` (the
+    /// default); a larger factor lifts the floor above the k-th score and may prune
+    /// ties.
     fn update_threshold(&mut self, local_kth: f32, wand_factor: f32) {
         let mut t = local_kth * wand_factor;
         if let Some(shared) = self.shared_threshold.as_ref() {
@@ -2080,14 +2426,19 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 t = g;
             }
         }
-        self.threshold = t;
+        self.threshold = admit_ties_floor(t);
     }
 
-    /// Raise the local threshold to the shared cross-partition floor, picking up
-    /// updates published by sibling partitions.
+    /// Raise the local threshold to the shared cross-partition floor published by
+    /// sibling partitions.
+    ///
+    /// Lowered one ULP like [`Wand::update_threshold`], so a tie at the shared k-th
+    /// score is not pruned by whichever partition published first. The merge
+    /// resolves it by row_id, which makes the result independent of partition
+    /// completion order.
     fn raise_to_shared_floor(&mut self, wand_factor: f32) {
         if let Some(shared) = self.shared_threshold.as_ref() {
-            let g = f32::from_bits(shared.load(Ordering::Relaxed)) * wand_factor;
+            let g = admit_ties_floor(f32::from_bits(shared.load(Ordering::Relaxed)) * wand_factor);
             if g > self.threshold {
                 self.threshold = g;
             }
@@ -2151,7 +2502,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             return self.and_bulk_search(params, metrics);
         }
 
-        let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut candidates = self.new_collector(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons = 0;
         let mut and_search_stats = (self.operator == Operator::And).then_some(AndSearchStats {
             pruned_before_return_start: self.and_candidates_pruned_before_return,
@@ -2201,6 +2552,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
             if candidates.insert(
                 ScoredDoc::new(document_key, score),
+                self.documents.tie_order_key(document_key),
                 doc_length,
                 posting_doc_id,
                 self.iter_term_freqs(),
@@ -2237,6 +2589,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             metrics.record_freqs_collected(and_stats.freqs_collected);
         }
 
+        self.score_floor_overflow = candidates.score_floor_overflow();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -2266,7 +2619,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             .unwrap_or(false);
 
         let mut num_comparisons = 0;
-        let mut candidates = TopKCollector::new(limit, 0);
+        let mut candidates = self.new_collector(limit, 0);
         for (doc_id, document_key) in documents {
             num_comparisons += 1;
             self.move_head_before_target_to_tail(doc_id);
@@ -2314,6 +2667,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
             if candidates.insert(
                 ScoredDoc::new(document_key, score),
+                self.documents.tie_order_key(document_key),
                 doc_length,
                 doc_id,
                 self.iter_term_freqs(),
@@ -2326,6 +2680,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
         metrics.record_comparisons(num_comparisons);
 
+        self.score_floor_overflow = candidates.score_floor_overflow();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -2362,7 +2717,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         let total_sum_upper_bound_factor = score_sum_upper_bound_factor(clauses.len());
 
         let mut acc = WindowAccumulator::new(clauses.len());
-        let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut candidates = self.new_collector(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let norm_k = self.norm_k_cache();
         let norm_k_ref = norm_k
             .as_ref()
@@ -2588,6 +2943,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                     let doc_length = self.documents.scoring_num_tokens(doc as u32);
                                     if candidates.insert(
                                         ScoredDoc::new(document_key, total),
+                                        self.documents.tie_order_key(document_key),
                                         doc_length,
                                         doc,
                                         std::iter::once((essential_term, freq)).chain(
@@ -2781,6 +3137,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                 .unwrap_or_else(|| self.documents.scoring_num_tokens(doc as u32));
                             if candidates.insert(
                                 ScoredDoc::new(document_key, score),
+                                self.documents.tie_order_key(document_key),
                                 doc_length,
                                 doc,
                                 clauses.iter().enumerate().filter_map(|(i, clause)| {
@@ -2817,6 +3174,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         metrics.record_comparisons(num_comparisons);
 
+        self.score_floor_overflow = candidates.score_floor_overflow();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -3226,7 +3584,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
         }
 
-        let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut candidates = self.new_collector(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons: usize = 0;
         let mut stats = AndSearchStats {
             pruned_before_return_start: self.and_candidates_pruned_before_return,
@@ -3530,6 +3888,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
                     if candidates.insert(
                         ScoredDoc::new(document_key, score),
+                        self.documents.tie_order_key(document_key),
                         doc_length,
                         u64::from(doc),
                         wins.iter().zip(self.lead.iter()).zip(offs.iter()).map(
@@ -3571,6 +3930,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         metrics.record_and_full_scores(stats.full_scores);
         metrics.record_freqs_collected(stats.freqs_collected);
 
+        self.score_floor_overflow = candidates.score_floor_overflow();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -4756,12 +5116,13 @@ mod tests {
     fn test_top_k_collector_reuses_frequency_slots() -> Result<()> {
         const LIMIT: usize = 8;
         const NUM_DOCS: usize = 10_000;
-        let mut collector = TopKCollector::new(LIMIT, LIMIT);
+        let mut collector = TopKCollector::by_row_address(LIMIT, LIMIT);
 
         for doc in 0..NUM_DOCS {
             let num_terms = doc % 4 + 1;
             let inserted = collector.insert(
                 ScoredDoc::new(doc as u64, doc as f32),
+                doc as u64,
                 num_terms as u32,
                 doc as u64,
                 (0..num_terms).map(|term| (term as u32, doc as u32)),
@@ -4782,6 +5143,173 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(candidate.freqs, expected_freqs);
         }
+        Ok(())
+    }
+
+    // Deterministic top-k tiebreak (score DESC, row_id ASC).
+    //
+    // A BM25 top-k that breaks ties arbitrarily is not a stable prefix across `k`:
+    // top-k1 is not a prefix of top-k2, so paginating a tied-score query (a broad
+    // term where many documents share `(tf, doc_len)`) duplicates and skips rows.
+    // The collector settles the tie when it knows row addresses and retains the
+    // whole k-th-score band when it does not, and `admit_ties_floor` keeps the
+    // WAND pruning kernels from dropping that band in the first place.
+
+    /// Insert one document scored `score`, ordered by `order_key`.
+    fn insert_tie_candidate(
+        collector: &mut TopKCollector,
+        order_key: u64,
+        score: f32,
+    ) -> Result<bool> {
+        collector.insert(
+            ScoredDoc::new(order_key, score),
+            order_key,
+            1,
+            order_key,
+            std::iter::once((0u32, 1u32)),
+        )
+    }
+
+    fn collected_keys(collector: TopKCollector) -> Result<Vec<u64>> {
+        let mut keys = collector
+            .into_candidates(|key| key)?
+            .into_iter()
+            .map(|candidate| candidate.document)
+            .collect::<Vec<_>>();
+        keys.sort_unstable();
+        Ok(keys)
+    }
+
+    #[rstest]
+    #[case::one(1.0)]
+    #[case::small(f32::MIN_POSITIVE)]
+    #[case::large(1e30)]
+    fn test_admit_ties_floor_sits_just_below_kth(#[case] kth: f32) {
+        // A document tied at the k-th score must pass the `score > threshold` admit
+        // test, so the floor sits strictly below the k-th score, exactly one ULP down.
+        let floor = admit_ties_floor(kth);
+        assert!(floor < kth, "floor {floor} must be < kth {kth}");
+        assert_eq!(floor, kth.next_down());
+    }
+
+    #[test]
+    fn test_admit_ties_floor_zero_negative_and_nan() {
+        // Zero and negative inputs drop below zero, which the `threshold > 0.0`
+        // prune guards read as "no threshold yet" (pruning disabled).
+        assert!(admit_ties_floor(0.0) < 0.0);
+        assert!(admit_ties_floor(-1.0) < -1.0);
+        // NaN stays NaN; it is never a competitive score and is guarded at insert time.
+        assert!(admit_ties_floor(f32::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_top_k_collector_by_row_address_evicts_on_full_key() -> Result<()> {
+        // The ordering key is the row address, so a score tie is decided here: a
+        // lower address evicts the worst tied entry, a higher one loses.
+        let mut collector = TopKCollector::by_row_address(2, 2);
+        assert!(insert_tie_candidate(&mut collector, 20, 1.0)?);
+        assert!(insert_tie_candidate(&mut collector, 10, 1.0)?); // heap full {10, 20}
+        assert!(insert_tie_candidate(&mut collector, 5, 1.0)?); // ties, lower address
+        assert!(!insert_tie_candidate(&mut collector, 30, 1.0)?); // ties, higher address
+        assert!(!insert_tie_candidate(&mut collector, 15, 0.5)?); // below the k-th score
+        assert!(!collector.score_floor_overflow());
+        assert_eq!(
+            collected_keys(collector)?,
+            vec![5, 10],
+            "the two lowest addresses among the tie"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_retains_score_floor_band() -> Result<()> {
+        // Deferred mode: the ordering key is a DocId proxy, so every document tied
+        // at the k-th score must survive for the address-resolved re-selection. A
+        // tie is retained beside the heap rather than in it, hence the `false`.
+        let mut collector = TopKCollector::retaining_score_floor(2, 2);
+        assert!(insert_tie_candidate(&mut collector, 10, 1.0)?);
+        assert!(insert_tie_candidate(&mut collector, 11, 1.0)?);
+        assert!(!insert_tie_candidate(&mut collector, 5, 1.0)?);
+        assert!(!insert_tie_candidate(&mut collector, 20, 1.0)?);
+        assert!(!collector.score_floor_overflow());
+        assert_eq!(
+            collected_keys(collector)?,
+            vec![5, 10, 11, 20],
+            "the whole tie band is kept, not just the first two seen"
+        );
+
+        // Once the k-th score rises past the band, none of its members can win.
+        let mut collector = TopKCollector::retaining_score_floor(2, 2);
+        assert!(insert_tie_candidate(&mut collector, 0, 1.0)?);
+        assert!(insert_tie_candidate(&mut collector, 1, 1.0)?);
+        assert!(!insert_tie_candidate(&mut collector, 2, 1.0)?);
+        assert!(insert_tie_candidate(&mut collector, 3, 2.0)?); // k-th still 1.0
+        assert!(insert_tie_candidate(&mut collector, 4, 2.0)?); // k-th rises to 2.0
+        assert_eq!(collected_keys(collector)?, vec![3, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_score_floor_overflow_stays_bounded() -> Result<()> {
+        const LIMIT: usize = 3;
+        let max_buffered = LIMIT + SCORE_FLOOR_BUFFER;
+        let mut collector = TopKCollector::retaining_score_floor(LIMIT, LIMIT);
+        for key in 0..(max_buffered as u64 + 50) {
+            collector.insert(
+                ScoredDoc::new(key, 1.0),
+                key,
+                1,
+                key,
+                std::iter::once((0u32, 1u32)),
+            )?;
+        }
+        assert!(
+            collector.score_floor_overflow(),
+            "a tie band wider than the buffer must report an overflow"
+        );
+        let buffered = collector.buffered();
+        assert!(
+            buffered <= max_buffered,
+            "buffered {buffered} must stay within {max_buffered}"
+        );
+        // Only the heap takes frequency slots; retained ties own their frequencies.
+        assert!(collector.num_frequency_slots() <= LIMIT);
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_recycles_slots_while_retaining_ties() -> Result<()> {
+        // A retained band that the k-th score rises past is dropped wholesale, and
+        // the frequency slots of the documents that moved into it must come back.
+        const LIMIT: usize = 2;
+        let mut collector = TopKCollector::retaining_score_floor(LIMIT, LIMIT);
+        for round in 0..50u64 {
+            for tie in 0..8u64 {
+                let key = round * 8 + tie;
+                collector.insert(
+                    ScoredDoc::new(key, round as f32),
+                    key,
+                    1,
+                    key,
+                    std::iter::once((0u32, 1u32)),
+                )?;
+            }
+        }
+        assert!(!collector.score_floor_overflow());
+        assert!(
+            collector.num_frequency_slots() <= LIMIT + 1,
+            "slot count {} grew with the number of dropped bands",
+            collector.num_frequency_slots()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_rejects_nan_scores() -> Result<()> {
+        let mut collector = TopKCollector::by_row_address(1, 1);
+        assert!(insert_tie_candidate(&mut collector, 1, 1.0)?);
+        assert!(!insert_tie_candidate(&mut collector, 0, f32::NAN)?);
+        assert_eq!(collected_keys(collector)?, vec![1]);
         Ok(())
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -49,17 +49,45 @@ const TERMINATED_DOC_ID: u64 = u64::MAX;
 pub(super) const SCORE_FLOOR_BUFFER: usize = 128;
 
 /// As much of the FTS result order `(score DESC, row_id ASC)` as the WAND walk
-/// can see. Ordered "best is greatest", so a `Reverse`-wrapped max-heap peeks at
-/// the entry to evict first.
+/// can see. Ordered "best is greatest".
 ///
 /// `order_key` is the row address when the walk can resolve one and a constant
-/// otherwise (see [`WandDocuments::tie_order_key`]), so this key is a partial
-/// picture of the result order: two candidates comparing equal are documents the
-/// walk cannot rank, and the collector retains both.
+/// otherwise (see [`WandDocuments::tie_order_key`]), so this is a partial picture
+/// of the result order: two candidates comparing equal are documents the walk
+/// cannot rank, and the collector retains both rather than choosing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TopKKey {
+struct TopKRankKey {
     score: OrderedFloat,
     order_key: u64,
+}
+
+impl PartialOrd for TopKRankKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TopKRankKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score
+            .cmp(&other.score)
+            .then_with(|| other.order_key.cmp(&self.order_key))
+    }
+}
+
+/// The rank key plus the posting DocId, which makes the heap order total.
+///
+/// The DocId is not part of the result order: it only keeps the heap
+/// deterministic and, once the retained band hits its cap, decides which
+/// candidates of an unrankable group to keep. Documents are appended in
+/// coordinate order, so for an index this writer produces the DocId ascends with
+/// `doc_index` inside a row; a rebuilt or merged index preserves that relative
+/// order too. It is a proxy, though, not a format guarantee, which is why it is
+/// consulted only past the cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TopKKey {
+    rank: TopKRankKey,
+    posting_doc_id: u64,
 }
 
 impl PartialOrd for TopKKey {
@@ -70,9 +98,9 @@ impl PartialOrd for TopKKey {
 
 impl Ord for TopKKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.score
-            .cmp(&other.score)
-            .then_with(|| other.order_key.cmp(&self.order_key))
+        self.rank
+            .cmp(&other.rank)
+            .then_with(|| other.posting_doc_id.cmp(&self.posting_doc_id))
     }
 }
 
@@ -88,10 +116,17 @@ struct TopKEntry {
 }
 
 impl TopKEntry {
-    fn key(&self) -> TopKKey {
-        TopKKey {
+    fn rank_key(&self) -> TopKRankKey {
+        TopKRankKey {
             score: self.doc.score,
             order_key: self.order_key,
+        }
+    }
+
+    fn key(&self) -> TopKKey {
+        TopKKey {
+            rank: self.rank_key(),
+            posting_doc_id: self.posting_doc_id,
         }
     }
 }
@@ -191,21 +226,21 @@ struct TieCandidate {
     freqs: Vec<(u32, u32)>,
 }
 
-/// How much the WAND walk knows about the final result order, which decides how
-/// wide the retained tie band can get.
+/// What the WAND walk knows about the final result order, which decides whether a
+/// full retained band can be recovered from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TieHandling {
     /// `order_key` is the row address. Candidates the walk cannot rank are then
     /// documents of one row that also tie on score, differing only in the element
-    /// coordinate the walk cannot see, so the band is bounded by that row's tied
-    /// element count and needs no cap. It stays empty for a row-granularity index,
-    /// where one row address maps to one document.
+    /// coordinate the walk cannot see. It stays empty for a row-granularity index,
+    /// where one row address maps to one document. A full band cannot be recovered
+    /// by rereading anything, so it degrades to the DocId proxy and reports
+    /// [`TopKCollector::band_truncated`].
     ByRowAddress,
-    /// `order_key` is a constant, so the band is the whole k-th-score group. It is
-    /// capped at `max_buffered`; past that the collector reports
-    /// [`TopKCollector::score_floor_overflow`] instead of silently dropping ties,
-    /// and the caller retries the partition with addresses attached.
-    DeferredAddresses { max_buffered: usize },
+    /// `order_key` is a constant, so the band is the whole k-th-score group. A full
+    /// band reports [`TopKCollector::score_floor_overflow`] and the caller retries
+    /// the partition with addresses attached.
+    DeferredAddresses,
 }
 
 /// Owns the top-k heap and the frequency slots referenced by its entries.
@@ -214,11 +249,16 @@ struct TopKCollector {
     heap: TopKHeap,
     frequency_slots: FrequencySlots,
     tie_handling: TieHandling,
+    /// Cap on `limit + tie_band.len()`. Both modes need one: a deferred walk can
+    /// tie the whole corpus at the k-th score, and nothing bounds how many elements
+    /// a single list row holds.
+    max_buffered: usize,
     /// Candidates the walk cannot rank against the current k-th entry and the heap
     /// has no room for. Cleared whenever the k-th key improves, so it holds just
     /// the current tie band and stays empty for a query without ties.
     tie_band: Vec<TieCandidate>,
     score_floor_overflow: bool,
+    band_truncated: bool,
 }
 
 impl TopKCollector {
@@ -227,17 +267,9 @@ impl TopKCollector {
         Self::new(limit, initial_capacity, TieHandling::ByRowAddress)
     }
 
-    /// Collector for a walk that resolves row addresses only afterwards. It
-    /// retains the k-th-score tie band up to `limit + SCORE_FLOOR_BUFFER`
-    /// documents.
+    /// Collector for a walk that resolves row addresses only afterwards.
     fn deferring_addresses(limit: usize, initial_capacity: usize) -> Self {
-        Self::new(
-            limit,
-            initial_capacity,
-            TieHandling::DeferredAddresses {
-                max_buffered: limit.saturating_add(SCORE_FLOOR_BUFFER),
-            },
-        )
+        Self::new(limit, initial_capacity, TieHandling::DeferredAddresses)
     }
 
     fn new(limit: usize, initial_capacity: usize, tie_handling: TieHandling) -> Self {
@@ -247,8 +279,10 @@ impl TopKCollector {
             heap: BinaryHeap::with_capacity(initial_capacity),
             frequency_slots: FrequencySlots::with_capacity(initial_capacity),
             tie_handling,
+            max_buffered: limit.saturating_add(SCORE_FLOOR_BUFFER),
             tie_band: Vec::new(),
             score_floor_overflow: false,
+            band_truncated: false,
         }
     }
 
@@ -257,6 +291,14 @@ impl TopKCollector {
     /// addresses, otherwise the final order is not the exact top-k.
     fn score_floor_overflow(&self) -> bool {
         self.score_floor_overflow
+    }
+
+    /// True when an address-ordered walk filled its band and fell back to the DocId
+    /// proxy. Rereading cannot recover it, so the caller reports it rather than
+    /// retrying: elements of that one row past the cap may order by DocId instead
+    /// of by `doc_index`.
+    fn band_truncated(&self) -> bool {
+        self.band_truncated
     }
 
     /// Insert a competitive result.
@@ -295,15 +337,22 @@ impl TopKCollector {
             return Ok(true);
         }
 
-        // A NaN custom-scorer score is never competitive. Dropping it here keeps
-        // NaN out of the ordering key and preserves the pre-tiebreak semantics for
-        // non-finite scorer output.
+        // A NaN custom-scorer score is never competitive once the heap is full.
+        // Dropping it here keeps NaN out of the ordering key and preserves the
+        // pre-tiebreak semantics for non-finite scorer output.
+        //
+        // An under-filled heap still admits it, as it always has, and the merge then
+        // drops it: a partition can contribute one candidate fewer than `limit`.
+        // That predates the tiebreak and is left alone here.
         if doc.score.0.is_nan() {
             return Ok(false);
         }
         let candidate = TopKKey {
-            score: doc.score,
-            order_key,
+            rank: TopKRankKey {
+                score: doc.score,
+                order_key,
+            },
+            posting_doc_id,
         };
         let Some(Reverse(worst)) = self.heap.peek() else {
             return Err(Error::internal(
@@ -312,26 +361,43 @@ impl TopKCollector {
         };
         let worst_key = worst.key();
 
-        match candidate.cmp(&worst_key) {
-            // Ranks below the k-th entry: never competitive.
-            std::cmp::Ordering::Less => Ok(false),
-            // The walk cannot rank this against the k-th entry, so it keeps the
-            // document for the resolved re-selection downstream.
-            std::cmp::Ordering::Equal => {
-                if self.band_is_full() {
-                    self.score_floor_overflow = true;
-                    return Ok(false);
-                }
+        // Equal rank keys mean the walk cannot rank these two documents. The heap
+        // order still separates them through the DocId proxy, but that is not the
+        // result order, so the loser is retained instead of dropped.
+        if candidate.rank == worst_key.rank {
+            if self.band_is_full() {
+                self.record_band_full();
+            } else if candidate > worst_key {
+                // Wins the proxy, so it takes the heap slot and the displaced entry
+                // becomes the retained one.
+                let displaced = self.replace_worst_retaining(
+                    doc,
+                    order_key,
+                    doc_length,
+                    posting_doc_id,
+                    pairs,
+                )?;
+                self.tie_band.push(displaced);
+                return Ok(true);
+            } else {
                 self.tie_band.push(TieCandidate {
                     doc,
                     doc_length,
                     posting_doc_id,
                     freqs: pairs.collect(),
                 });
-                Ok(false)
+                return Ok(false);
             }
+        }
+
+        match candidate.cmp(&worst_key) {
+            // Ranks below the k-th entry: never competitive.
+            std::cmp::Ordering::Less | std::cmp::Ordering::Equal => Ok(false),
             // Ranks above the k-th entry: it always enters the heap.
             std::cmp::Ordering::Greater => {
+                // Checked before the pop, which would otherwise make the buffer look
+                // one candidate emptier than it is.
+                let band_full = self.band_is_full();
                 let Some(Reverse(displaced)) = self.heap.pop() else {
                     return Err(Error::internal(
                         "FTS top-k heap entry disappeared during replacement",
@@ -343,12 +409,12 @@ impl TopKCollector {
                     .heap
                     .peek()
                     .map_or(candidate, |Reverse(entry)| entry.key().min(candidate));
-                let retain_displaced = if kth > worst_key {
-                    // The k-th key rose past the band: none of its members can win.
+                let retain_displaced = if kth.rank > worst_key.rank {
+                    // The k-th rank rose past the band: none of its members can win.
                     self.tie_band.clear();
                     false
-                } else if self.band_is_full() {
-                    self.score_floor_overflow = true;
+                } else if band_full {
+                    self.record_band_full();
                     false
                 } else {
                     true
@@ -392,18 +458,59 @@ impl TopKCollector {
         }
     }
 
+    /// Pop the worst entry, push `doc` in its place with a fresh slot, and return
+    /// the displaced entry owning its frequencies.
+    fn replace_worst_retaining(
+        &mut self,
+        doc: ScoredDoc,
+        order_key: u64,
+        doc_length: u32,
+        posting_doc_id: u64,
+        pairs: impl Iterator<Item = (u32, u32)>,
+    ) -> Result<TieCandidate> {
+        let Some(Reverse(displaced)) = self.heap.pop() else {
+            return Err(Error::internal(
+                "FTS top-k heap entry disappeared during replacement",
+            ));
+        };
+        let frequency_slot = self.frequency_slots.push(pairs)?;
+        self.heap.push(Reverse(TopKEntry {
+            doc,
+            order_key,
+            doc_length,
+            posting_doc_id,
+            frequency_slot,
+        }));
+        let freqs = self.frequency_slots.release(displaced.frequency_slot)?;
+        Ok(TieCandidate {
+            doc: displaced.doc,
+            doc_length: displaced.doc_length,
+            posting_doc_id: displaced.posting_doc_id,
+            freqs,
+        })
+    }
+
+    /// Record that the band could not take another candidate.
+    ///
+    /// A deferred walk can be retried with addresses. An address-ordered one has
+    /// nothing to reread, so it keeps ranking the heap on the DocId proxy: the
+    /// documents the result order would pick still reach the final selection, but
+    /// the rest of the unrankable group past the cap is dropped.
+    fn record_band_full(&mut self) {
+        match self.tie_handling {
+            TieHandling::ByRowAddress => self.band_truncated = true,
+            TieHandling::DeferredAddresses => self.score_floor_overflow = true,
+        }
+    }
+
     /// Documents held for the final selection: the heap plus the retained band.
     fn buffered(&self) -> usize {
         self.heap.len() + self.tie_band.len()
     }
 
-    /// Whether the retained band has reached its cap. Only a walk that defers row
-    /// addresses has one; see [`TieHandling`].
+    /// Whether the retained band has reached its cap.
     fn band_is_full(&self) -> bool {
-        match self.tie_handling {
-            TieHandling::ByRowAddress => false,
-            TieHandling::DeferredAddresses { max_buffered } => self.buffered() >= max_buffered,
-        }
+        self.buffered() >= self.max_buffered
     }
 
     fn kth_score_if_full(&self) -> Option<f32> {
@@ -1839,9 +1946,15 @@ pub(super) trait WandDocuments {
     /// band so the caller can re-select once addresses are resolved.
     fn orders_ties_by_address(&self) -> bool;
 
-    /// Key used to rank score ties inside one partition's top-k: the row address
-    /// when [`WandDocuments::orders_ties_by_address`] is true, and a constant
-    /// otherwise, which makes every score tie compare equal and be retained.
+    /// Key used to rank score ties inside one partition's top-k.
+    ///
+    /// Implementations that report [`WandDocuments::orders_ties_by_address`] return
+    /// the row address here. A deferred walk returns a constant instead, which makes
+    /// every score tie compare equal and be retained. This default returns the
+    /// document key, which is what the legacy adapter wants (its key is the row
+    /// address); the test-only [`DocSet`] adapter inherits it too, so a wand unit
+    /// test over a DocSet without row_ids ranks by a DocId that production would
+    /// have deferred, and does not exercise the retained band.
     fn tie_order_key(&self, document_key: u64) -> u64 {
         document_key
     }
@@ -2307,6 +2420,9 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     // Set when the last search dropped part of its k-th-score tie band because
     // the walk could not order ties by row address (see `TieHandling`).
     score_floor_overflow: bool,
+    // Set when an address-ordered search filled its band and fell back to the
+    // DocId proxy for the elements of one row.
+    band_truncated: bool,
 }
 
 /// Monotonically raise an f32 stored in an `AtomicU32` to `val`. CAS loop (not a
@@ -2388,6 +2504,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             scorer,
             shared_threshold: None,
             score_floor_overflow: false,
+            band_truncated: false,
         }
     }
 
@@ -2417,6 +2534,13 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     /// so the caller must retry the partition with resolved row addresses.
     pub(crate) fn score_floor_overflow(&self) -> bool {
         self.score_floor_overflow
+    }
+
+    /// Whether the last search filled its band while already ordering by row
+    /// address. See [`TopKCollector::band_truncated`]: a retry cannot improve on
+    /// it, so the caller only reports it.
+    pub(crate) fn band_truncated(&self) -> bool {
+        self.band_truncated
     }
 
     /// Share one cross-partition top-k floor across a query's partitions.
@@ -2623,6 +2747,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
 
         self.score_floor_overflow = candidates.score_floor_overflow();
+        self.band_truncated = candidates.band_truncated();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -2714,6 +2839,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         metrics.record_comparisons(num_comparisons);
 
         self.score_floor_overflow = candidates.score_floor_overflow();
+        self.band_truncated = candidates.band_truncated();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -3208,6 +3334,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         metrics.record_comparisons(num_comparisons);
 
         self.score_floor_overflow = candidates.score_floor_overflow();
+        self.band_truncated = candidates.band_truncated();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -3964,6 +4091,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         metrics.record_freqs_collected(stats.freqs_collected);
 
         self.score_floor_overflow = candidates.score_floor_overflow();
+        self.band_truncated = candidates.band_truncated();
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
@@ -5325,14 +5453,14 @@ mod tests {
     #[test]
     fn test_top_k_collector_retains_score_floor_band() -> Result<()> {
         // A walk that defers row addresses has a constant ordering key, so every
-        // document tied at the k-th score compares equal and must survive for the
-        // address-resolved re-selection. It is retained beside the heap rather than
-        // in it, hence the `false`.
+        // document tied at the k-th score shares one rank key and must survive for
+        // the address-resolved re-selection, whether it lands in the heap or beside
+        // it. The DocId proxy only decides which side of that split it lands on.
         let mut collector = TopKCollector::deferring_addresses(2, 2);
         assert!(insert_deferred(&mut collector, 10, 1.0)?);
         assert!(insert_deferred(&mut collector, 11, 1.0)?);
-        assert!(!insert_deferred(&mut collector, 5, 1.0)?);
-        assert!(!insert_deferred(&mut collector, 20, 1.0)?);
+        assert!(insert_deferred(&mut collector, 5, 1.0)?); // wins the proxy, heap
+        assert!(!insert_deferred(&mut collector, 20, 1.0)?); // loses it, band
         assert!(!collector.score_floor_overflow());
         assert_eq!(
             collected_keys(collector)?,
@@ -5348,6 +5476,51 @@ mod tests {
         assert!(insert_deferred(&mut collector, 3, 2.0)?); // k-th still 1.0
         assert!(insert_deferred(&mut collector, 4, 2.0)?); // k-th rises to 2.0
         assert_eq!(collected_keys(collector)?, vec![3, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_bounds_the_element_band() -> Result<()> {
+        // Nothing bounds how many elements a list row holds, so an address-ordered
+        // walk caps its band too. Past the cap the heap keeps ranking on the DocId
+        // proxy, so the documents the final order would pick survive even though
+        // the rest of the group is dropped.
+        const ROW: u64 = 100;
+        const LIMIT: usize = 2;
+        let max_buffered = LIMIT + SCORE_FLOOR_BUFFER;
+        let collect = || -> Result<(Vec<u64>, bool, usize)> {
+            let mut collector = TopKCollector::by_row_address(LIMIT, LIMIT);
+            // Descending DocIds, so the documents the result order wants arrive last
+            // and a collector that kept whatever it saw first would miss them.
+            for document_key in (0..(max_buffered as u64 + 50)).rev() {
+                insert_at_address(&mut collector, document_key, ROW, 1.0)?;
+            }
+            let truncated = collector.band_truncated();
+            let buffered = collector.buffered();
+            assert!(
+                !collector.score_floor_overflow(),
+                "an address-ordered walk has nothing to retry"
+            );
+            Ok((collected_keys(collector)?, truncated, buffered))
+        };
+
+        let (kept, truncated, buffered) = collect()?;
+        assert!(
+            truncated,
+            "an element band wider than the buffer must report a truncation"
+        );
+        assert!(
+            buffered <= max_buffered,
+            "buffered {buffered} must stay within {max_buffered}"
+        );
+        assert_eq!(
+            kept[..LIMIT],
+            [0, 1],
+            "the documents the result order picks must survive the truncation"
+        );
+
+        let (repeated, _, _) = collect()?;
+        assert_eq!(kept, repeated, "the truncation must be deterministic");
         Ok(())
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -18,6 +18,7 @@ use lance_core::{Error, Result};
 use lance_select::RowAddrMask;
 
 use crate::metrics::MetricsCollector;
+use crate::vector::graph::OrderedFloat;
 
 use super::{
     CompressedPositionStorage,
@@ -45,24 +46,59 @@ const TERMINATED_DOC_ID: u64 = u64::MAX;
 /// while it holds the k-th-score tie band. Matches the compound collector's
 /// bound (`compound::SCORE_FLOOR_RESOLUTION_BATCH_SIZE`) so both FTS paths cap
 /// their unresolved working set the same way.
-const SCORE_FLOOR_BUFFER: usize = 128;
+pub(super) const SCORE_FLOOR_BUFFER: usize = 128;
+
+/// As much of the FTS result order `(score DESC, row_id ASC)` as the WAND walk
+/// can see. Ordered "best is greatest", so a `Reverse`-wrapped max-heap peeks at
+/// the entry to evict first.
+///
+/// `order_key` is the row address when the walk can resolve one and a constant
+/// otherwise (see [`WandDocuments::tie_order_key`]), so this key is a partial
+/// picture of the result order: two candidates comparing equal are documents the
+/// walk cannot rank, and the collector retains both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TopKKey {
+    score: OrderedFloat,
+    order_key: u64,
+}
+
+impl PartialOrd for TopKKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TopKKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score
+            .cmp(&other.score)
+            .then_with(|| other.order_key.cmp(&self.order_key))
+    }
+}
 
 /// One live top-k candidate. The (term, freq) pairs live outside the heap in a
 /// [`FrequencySlots`] slot so heap churn moves a compact record instead of a `Vec`.
 #[derive(Debug, Clone)]
 struct TopKEntry {
     doc: ScoredDoc,
-    /// Tie-break key. The real row address when the walk can resolve one, and a
-    /// partition-local DocId proxy otherwise (see [`TieHandling`]).
     order_key: u64,
     doc_length: u32,
     posting_doc_id: u64,
     frequency_slot: u32,
 }
 
+impl TopKEntry {
+    fn key(&self) -> TopKKey {
+        TopKKey {
+            score: self.doc.score,
+            order_key: self.order_key,
+        }
+    }
+}
+
 impl PartialEq for TopKEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == std::cmp::Ordering::Equal
+        self.key() == other.key()
     }
 }
 
@@ -75,14 +111,8 @@ impl PartialOrd for TopKEntry {
 }
 
 impl Ord for TopKEntry {
-    /// The FTS total order (score DESC, key ASC) expressed "best is greatest",
-    /// so a `Reverse`-wrapped max-heap peeks at the entry to evict first: the
-    /// lowest score, then the highest key.
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.doc
-            .score
-            .cmp(&other.doc.score)
-            .then_with(|| other.order_key.cmp(&self.order_key))
+        self.key().cmp(&other.key())
     }
 }
 
@@ -161,23 +191,21 @@ struct TieCandidate {
     freqs: Vec<(u32, u32)>,
 }
 
-/// How a collector orders documents that tie at the k-th score.
-///
-/// FTS results are ordered `(score DESC, row_id ASC)`. Whether that order can be
-/// decided inside the WAND walk depends on what the walk knows about a document:
-/// legacy postings carry row addresses, modern postings carry dense DocIds whose
-/// address order is only known once the addresses are resolved.
+/// How much the WAND walk knows about the final result order, which decides how
+/// wide the retained tie band can get.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TieHandling {
-    /// `order_key` is the row address, so the final order is exact here and the
-    /// heap alone holds the answer.
+    /// `order_key` is the row address. Candidates the walk cannot rank are then
+    /// documents of one row that also tie on score, differing only in the element
+    /// coordinate the walk cannot see, so the band is bounded by that row's tied
+    /// element count and needs no cap. It stays empty for a row-granularity index,
+    /// where one row address maps to one document.
     ByRowAddress,
-    /// `order_key` is a DocId proxy. Documents tied at the k-th score that the
-    /// heap cannot hold are kept in a side band so the caller can re-select by
-    /// address afterwards. Past `max_buffered` retained documents the collector
-    /// reports [`TopKCollector::score_floor_overflow`] instead of silently
-    /// dropping ties.
-    RetainScoreFloor { max_buffered: usize },
+    /// `order_key` is a constant, so the band is the whole k-th-score group. It is
+    /// capped at `max_buffered`; past that the collector reports
+    /// [`TopKCollector::score_floor_overflow`] instead of silently dropping ties,
+    /// and the caller retries the partition with addresses attached.
+    DeferredAddresses { max_buffered: usize },
 }
 
 /// Owns the top-k heap and the frequency slots referenced by its entries.
@@ -186,9 +214,9 @@ struct TopKCollector {
     heap: TopKHeap,
     frequency_slots: FrequencySlots,
     tie_handling: TieHandling,
-    /// Documents tied at the current k-th score that did not fit in the heap.
-    /// Deferred mode only, and cleared whenever the k-th score rises, so it holds
-    /// just the current tie band and stays empty for a query without ties.
+    /// Candidates the walk cannot rank against the current k-th entry and the heap
+    /// has no room for. Cleared whenever the k-th key improves, so it holds just
+    /// the current tie band and stays empty for a query without ties.
     tie_band: Vec<TieCandidate>,
     score_floor_overflow: bool,
 }
@@ -199,13 +227,14 @@ impl TopKCollector {
         Self::new(limit, initial_capacity, TieHandling::ByRowAddress)
     }
 
-    /// Collector for a walk whose document keys are DocId proxies. It retains the
-    /// k-th-score tie band up to `limit + SCORE_FLOOR_BUFFER` documents.
-    fn retaining_score_floor(limit: usize, initial_capacity: usize) -> Self {
+    /// Collector for a walk that resolves row addresses only afterwards. It
+    /// retains the k-th-score tie band up to `limit + SCORE_FLOOR_BUFFER`
+    /// documents.
+    fn deferring_addresses(limit: usize, initial_capacity: usize) -> Self {
         Self::new(
             limit,
             initial_capacity,
-            TieHandling::RetainScoreFloor {
+            TieHandling::DeferredAddresses {
                 max_buffered: limit.saturating_add(SCORE_FLOOR_BUFFER),
             },
         )
@@ -266,94 +295,97 @@ impl TopKCollector {
             return Ok(true);
         }
 
-        let Some(Reverse(worst)) = self.heap.peek() else {
-            return Err(Error::internal(
-                "FTS top-k heap is empty while its nonzero limit is reached",
-            ));
-        };
         // A NaN custom-scorer score is never competitive. Dropping it here keeps
         // NaN out of the ordering key and preserves the pre-tiebreak semantics for
         // non-finite scorer output.
         if doc.score.0.is_nan() {
             return Ok(false);
         }
-        let worst_score = worst.doc.score;
-        let worst_order_key = worst.order_key;
-        // A collector that already overflowed produces discarded results, so it
-        // stops retaining ties and stays inside its buffer bound.
-        let retained_band = match self.tie_handling {
-            TieHandling::RetainScoreFloor { max_buffered } if !self.score_floor_overflow => {
-                Some(max_buffered)
-            }
-            _ => None,
+        let candidate = TopKKey {
+            score: doc.score,
+            order_key,
         };
+        let Some(Reverse(worst)) = self.heap.peek() else {
+            return Err(Error::internal(
+                "FTS top-k heap is empty while its nonzero limit is reached",
+            ));
+        };
+        let worst_key = worst.key();
 
-        match doc.score.cmp(&worst_score) {
-            // Below the k-th score: never competitive.
+        match candidate.cmp(&worst_key) {
+            // Ranks below the k-th entry: never competitive.
             std::cmp::Ordering::Less => Ok(false),
-            std::cmp::Ordering::Equal => match retained_band {
-                // The order key is the real row address, so the tie is decided here:
-                // a lower address ranks higher and evicts the worst entry.
-                None => {
-                    if order_key >= worst_order_key {
-                        return Ok(false);
-                    }
-                    self.replace_worst(doc, order_key, doc_length, posting_doc_id, pairs)?;
-                    Ok(true)
+            // The walk cannot rank this against the k-th entry, so it keeps the
+            // document for the resolved re-selection downstream.
+            std::cmp::Ordering::Equal => {
+                if self.band_is_full() {
+                    self.score_floor_overflow = true;
+                    return Ok(false);
                 }
-                // A DocId proxy cannot decide the tie, so the document is kept in
-                // the band for the address-resolved re-selection downstream.
-                Some(max_buffered) => {
-                    if self.buffered() >= max_buffered {
-                        self.score_floor_overflow = true;
-                        return Ok(false);
-                    }
-                    self.tie_band.push(TieCandidate {
-                        doc,
-                        doc_length,
-                        posting_doc_id,
-                        freqs: pairs.collect(),
-                    });
-                    Ok(false)
-                }
-            },
-            // Strictly better on score: it always enters the heap.
+                self.tie_band.push(TieCandidate {
+                    doc,
+                    doc_length,
+                    posting_doc_id,
+                    freqs: pairs.collect(),
+                });
+                Ok(false)
+            }
+            // Ranks above the k-th entry: it always enters the heap.
             std::cmp::Ordering::Greater => {
-                let Some(max_buffered) = retained_band else {
-                    self.replace_worst(doc, order_key, doc_length, posting_doc_id, pairs)?;
-                    return Ok(true);
-                };
                 let Some(Reverse(displaced)) = self.heap.pop() else {
                     return Err(Error::internal(
                         "FTS top-k heap entry disappeared during replacement",
                     ));
                 };
-                let frequency_slot = self.frequency_slots.push(pairs)?;
-                self.heap.push(Reverse(TopKEntry {
-                    doc,
-                    order_key,
-                    doc_length,
-                    posting_doc_id,
-                    frequency_slot,
-                }));
+                // The k-th key after the replacement is the smaller of what the pop
+                // exposed and the newcomer, both known without pushing first.
                 let kth = self
                     .heap
                     .peek()
-                    .map(|Reverse(entry)| entry.doc.score)
-                    .ok_or_else(|| Error::internal("FTS top-k heap is empty right after a push"))?;
-                let freqs = self.frequency_slots.release(displaced.frequency_slot)?;
-                if kth > worst_score {
-                    // The k-th score rose past the band: none of its members can win.
+                    .map_or(candidate, |Reverse(entry)| entry.key().min(candidate));
+                let retain_displaced = if kth > worst_key {
+                    // The k-th key rose past the band: none of its members can win.
                     self.tie_band.clear();
-                } else if self.buffered() >= max_buffered {
+                    false
+                } else if self.band_is_full() {
                     self.score_floor_overflow = true;
+                    false
                 } else {
+                    true
+                };
+
+                if retain_displaced {
+                    // The displaced entry keeps its frequencies, so the newcomer
+                    // takes another slot and the released one serves the next
+                    // replacement.
+                    let frequency_slot = self.frequency_slots.push(pairs)?;
+                    self.heap.push(Reverse(TopKEntry {
+                        doc,
+                        order_key,
+                        doc_length,
+                        posting_doc_id,
+                        frequency_slot,
+                    }));
+                    let freqs = self.frequency_slots.release(displaced.frequency_slot)?;
                     self.tie_band.push(TieCandidate {
                         doc: displaced.doc,
                         doc_length: displaced.doc_length,
                         posting_doc_id: displaced.posting_doc_id,
                         freqs,
                     });
+                } else {
+                    // Nothing keeps the displaced frequencies, so the slot and its
+                    // retained capacity are reused in place. This is the path every
+                    // improving candidate of a query without ties takes.
+                    let frequency_slot = displaced.frequency_slot;
+                    self.frequency_slots.replace(frequency_slot, pairs)?;
+                    self.heap.push(Reverse(TopKEntry {
+                        doc,
+                        order_key,
+                        doc_length,
+                        posting_doc_id,
+                        frequency_slot,
+                    }));
                 }
                 Ok(true)
             }
@@ -365,30 +397,13 @@ impl TopKCollector {
         self.heap.len() + self.tie_band.len()
     }
 
-    /// Pop the worst entry and push `doc` in its place, reusing its frequency slot.
-    fn replace_worst(
-        &mut self,
-        doc: ScoredDoc,
-        order_key: u64,
-        doc_length: u32,
-        posting_doc_id: u64,
-        pairs: impl Iterator<Item = (u32, u32)>,
-    ) -> Result<()> {
-        let Some(Reverse(worst)) = self.heap.pop() else {
-            return Err(Error::internal(
-                "FTS top-k heap entry disappeared during replacement",
-            ));
-        };
-        let frequency_slot = worst.frequency_slot;
-        self.frequency_slots.replace(frequency_slot, pairs)?;
-        self.heap.push(Reverse(TopKEntry {
-            doc,
-            order_key,
-            doc_length,
-            posting_doc_id,
-            frequency_slot,
-        }));
-        Ok(())
+    /// Whether the retained band has reached its cap. Only a walk that defers row
+    /// addresses has one; see [`TieHandling`].
+    fn band_is_full(&self) -> bool {
+        match self.tie_handling {
+            TieHandling::ByRowAddress => false,
+            TieHandling::DeferredAddresses { max_buffered } => self.buffered() >= max_buffered,
+        }
     }
 
     fn kth_score_if_full(&self) -> Option<f32> {
@@ -438,6 +453,18 @@ impl TopKCollector {
     #[cfg(test)]
     fn num_frequency_slots(&self) -> usize {
         self.frequency_slots.slots.len()
+    }
+
+    /// Smallest retained capacity across the live slots. A slot whose buffer was
+    /// handed to a retained tie comes back at zero.
+    #[cfg(test)]
+    fn min_frequency_slot_capacity(&self) -> usize {
+        self.frequency_slots
+            .slots
+            .iter()
+            .map(Vec::capacity)
+            .min()
+            .unwrap_or_default()
     }
 }
 const LINEAR_BLOCK_SKIP_LIMIT: usize = 8;
@@ -1807,14 +1834,14 @@ pub(super) trait WandDocuments {
     /// Whether [`WandDocuments::tie_order_key`] returns real row addresses.
     ///
     /// FTS results are ordered `(score DESC, row_id ASC)`. When this is true the
-    /// walk can settle k-th-score ties itself; when it is false the ordering key
-    /// is only a DocId proxy and the collector retains the tie band so the caller
-    /// can re-select once addresses are resolved.
+    /// walk can rank score ties between rows itself; when it is false the ordering
+    /// key carries no information and the collector retains the whole k-th-score
+    /// band so the caller can re-select once addresses are resolved.
     fn orders_ties_by_address(&self) -> bool;
 
-    /// Key used to break score ties inside one partition's top-k: the row address
-    /// when [`WandDocuments::orders_ties_by_address`] is true, the document key
-    /// otherwise.
+    /// Key used to rank score ties inside one partition's top-k: the row address
+    /// when [`WandDocuments::orders_ties_by_address`] is true, and a constant
+    /// otherwise, which makes every score tie compare equal and be retained.
     fn tie_order_key(&self, document_key: u64) -> u64 {
         document_key
     }
@@ -1961,8 +1988,14 @@ impl<V: ModernVisibility> WandDocuments for ModernWandDocuments<'_, V> {
     }
 
     fn tie_order_key(&self, document_key: u64) -> u64 {
-        // A dead slot has no current address; it is not visible to the walk, so
-        // sorting it last only guards against it winning a tie.
+        // Element documents of one row share its address, so this key ranks rows
+        // but not the elements within a row. The collector keeps every candidate it
+        // cannot rank, and the final sort settles them on `doc_index`.
+        //
+        // A dead slot has no current address. It is not visible to the walk, so
+        // ranking it last only guards against it winning a tie. Without a
+        // projection the key is that same constant for every document, which makes
+        // the collector retain the whole k-th-score band.
         self.addresses
             .and_then(|addresses| addresses.address(DocId::new(document_key as u32)))
             .unwrap_or(u64::MAX)
@@ -2374,7 +2407,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         if self.documents.orders_ties_by_address() {
             TopKCollector::by_row_address(limit, initial_capacity)
         } else {
-            TopKCollector::retaining_score_floor(limit, initial_capacity)
+            TopKCollector::deferring_addresses(limit, initial_capacity)
         }
     }
 
@@ -5155,19 +5188,44 @@ mod tests {
     // whole k-th-score band when it does not, and `admit_ties_floor` keeps the
     // WAND pruning kernels from dropping that band in the first place.
 
-    /// Insert one document scored `score`, ordered by `order_key`.
-    fn insert_tie_candidate(
+    /// The ordering key a walk that defers row addresses hands the collector: one
+    /// constant for every document, so every score tie compares equal.
+    const DEFERRED_ORDER_KEY: u64 = u64::MAX;
+
+    /// Insert a document the walk can rank by row address. `document_key` doubles
+    /// as the address so the assertions can read the result back.
+    fn insert_addressed(
         collector: &mut TopKCollector,
-        order_key: u64,
+        document_key: u64,
+        score: f32,
+    ) -> Result<bool> {
+        insert_at_address(collector, document_key, document_key, score)
+    }
+
+    /// Insert a document at an explicit address, so several documents can share
+    /// one address the way the elements of a list row do.
+    fn insert_at_address(
+        collector: &mut TopKCollector,
+        document_key: u64,
+        address: u64,
         score: f32,
     ) -> Result<bool> {
         collector.insert(
-            ScoredDoc::new(order_key, score),
-            order_key,
+            ScoredDoc::new(document_key, score),
+            address,
             1,
-            order_key,
+            document_key,
             std::iter::once((0u32, 1u32)),
         )
+    }
+
+    /// Insert a document into a collector whose walk defers row addresses.
+    fn insert_deferred(
+        collector: &mut TopKCollector,
+        document_key: u64,
+        score: f32,
+    ) -> Result<bool> {
+        insert_at_address(collector, document_key, DEFERRED_ORDER_KEY, score)
     }
 
     fn collected_keys(collector: TopKCollector) -> Result<Vec<u64>> {
@@ -5207,12 +5265,14 @@ mod tests {
         // The ordering key is the row address, so a score tie is decided here: a
         // lower address evicts the worst tied entry, a higher one loses.
         let mut collector = TopKCollector::by_row_address(2, 2);
-        assert!(insert_tie_candidate(&mut collector, 20, 1.0)?);
-        assert!(insert_tie_candidate(&mut collector, 10, 1.0)?); // heap full {10, 20}
-        assert!(insert_tie_candidate(&mut collector, 5, 1.0)?); // ties, lower address
-        assert!(!insert_tie_candidate(&mut collector, 30, 1.0)?); // ties, higher address
-        assert!(!insert_tie_candidate(&mut collector, 15, 0.5)?); // below the k-th score
+        assert!(insert_addressed(&mut collector, 20, 1.0)?);
+        assert!(insert_addressed(&mut collector, 10, 1.0)?); // heap full {10, 20}
+        assert!(insert_addressed(&mut collector, 5, 1.0)?); // ties, lower address
+        assert!(!insert_addressed(&mut collector, 30, 1.0)?); // ties, higher address
+        assert!(!insert_addressed(&mut collector, 15, 0.5)?); // below the k-th score
         assert!(!collector.score_floor_overflow());
+        // Distinct addresses leave nothing the walk cannot rank.
+        assert!(collector.tie_band.is_empty());
         assert_eq!(
             collected_keys(collector)?,
             vec![5, 10],
@@ -5222,15 +5282,57 @@ mod tests {
     }
 
     #[test]
+    fn test_top_k_collector_retains_element_documents_of_one_row() -> Result<()> {
+        // Element documents of one row share its address, so the address key cannot
+        // rank them and only `doc_index` can, which the walk never sees. Evicting
+        // one of them here would pick an arbitrary element, so both are retained and
+        // the resolved re-selection settles it.
+        const ROW: u64 = 100;
+        let mut collector = TopKCollector::by_row_address(2, 2);
+        assert!(insert_at_address(&mut collector, 11, ROW, 1.0)?);
+        assert!(insert_at_address(&mut collector, 12, ROW, 1.0)?);
+        // A lower address outranks the row whatever its elements' coordinates are,
+        // so it takes a heap slot and the element it displaced stays a candidate.
+        assert!(insert_at_address(&mut collector, 10, 50, 1.0)?);
+        assert!(!collector.score_floor_overflow());
+        assert_eq!(
+            collected_keys(collector)?,
+            vec![10, 11, 12],
+            "both elements of the tied row must reach the resolved re-selection"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_ranks_rows_around_a_tied_element_row() -> Result<()> {
+        // The element band is still bounded by the row it belongs to: a strictly
+        // higher address loses outright, and a rising k-th key drops the band.
+        const ROW: u64 = 100;
+        let mut collector = TopKCollector::by_row_address(2, 2);
+        assert!(insert_at_address(&mut collector, 11, ROW, 1.0)?);
+        assert!(insert_at_address(&mut collector, 12, ROW, 1.0)?);
+        assert!(!insert_at_address(&mut collector, 13, 200, 1.0)?); // higher address
+        assert!(insert_at_address(&mut collector, 10, 50, 1.0)?); // lower address
+        assert!(insert_at_address(&mut collector, 9, 60, 2.0)?); // better score
+        assert_eq!(
+            collected_keys(collector)?,
+            vec![9, 10],
+            "a rising k-th key drops the element band"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_top_k_collector_retains_score_floor_band() -> Result<()> {
-        // Deferred mode: the ordering key is a DocId proxy, so every document tied
-        // at the k-th score must survive for the address-resolved re-selection. A
-        // tie is retained beside the heap rather than in it, hence the `false`.
-        let mut collector = TopKCollector::retaining_score_floor(2, 2);
-        assert!(insert_tie_candidate(&mut collector, 10, 1.0)?);
-        assert!(insert_tie_candidate(&mut collector, 11, 1.0)?);
-        assert!(!insert_tie_candidate(&mut collector, 5, 1.0)?);
-        assert!(!insert_tie_candidate(&mut collector, 20, 1.0)?);
+        // A walk that defers row addresses has a constant ordering key, so every
+        // document tied at the k-th score compares equal and must survive for the
+        // address-resolved re-selection. It is retained beside the heap rather than
+        // in it, hence the `false`.
+        let mut collector = TopKCollector::deferring_addresses(2, 2);
+        assert!(insert_deferred(&mut collector, 10, 1.0)?);
+        assert!(insert_deferred(&mut collector, 11, 1.0)?);
+        assert!(!insert_deferred(&mut collector, 5, 1.0)?);
+        assert!(!insert_deferred(&mut collector, 20, 1.0)?);
         assert!(!collector.score_floor_overflow());
         assert_eq!(
             collected_keys(collector)?,
@@ -5239,12 +5341,12 @@ mod tests {
         );
 
         // Once the k-th score rises past the band, none of its members can win.
-        let mut collector = TopKCollector::retaining_score_floor(2, 2);
-        assert!(insert_tie_candidate(&mut collector, 0, 1.0)?);
-        assert!(insert_tie_candidate(&mut collector, 1, 1.0)?);
-        assert!(!insert_tie_candidate(&mut collector, 2, 1.0)?);
-        assert!(insert_tie_candidate(&mut collector, 3, 2.0)?); // k-th still 1.0
-        assert!(insert_tie_candidate(&mut collector, 4, 2.0)?); // k-th rises to 2.0
+        let mut collector = TopKCollector::deferring_addresses(2, 2);
+        assert!(insert_deferred(&mut collector, 0, 1.0)?);
+        assert!(insert_deferred(&mut collector, 1, 1.0)?);
+        assert!(!insert_deferred(&mut collector, 2, 1.0)?);
+        assert!(insert_deferred(&mut collector, 3, 2.0)?); // k-th still 1.0
+        assert!(insert_deferred(&mut collector, 4, 2.0)?); // k-th rises to 2.0
         assert_eq!(collected_keys(collector)?, vec![3, 4]);
         Ok(())
     }
@@ -5253,15 +5355,9 @@ mod tests {
     fn test_top_k_collector_score_floor_overflow_stays_bounded() -> Result<()> {
         const LIMIT: usize = 3;
         let max_buffered = LIMIT + SCORE_FLOOR_BUFFER;
-        let mut collector = TopKCollector::retaining_score_floor(LIMIT, LIMIT);
+        let mut collector = TopKCollector::deferring_addresses(LIMIT, LIMIT);
         for key in 0..(max_buffered as u64 + 50) {
-            collector.insert(
-                ScoredDoc::new(key, 1.0),
-                key,
-                1,
-                key,
-                std::iter::once((0u32, 1u32)),
-            )?;
+            insert_deferred(&mut collector, key, 1.0)?;
         }
         assert!(
             collector.score_floor_overflow(),
@@ -5278,21 +5374,55 @@ mod tests {
     }
 
     #[test]
+    fn test_top_k_collector_reuses_slots_when_no_tie_is_retained() -> Result<()> {
+        // A deferred walk over strictly improving scores retains nothing, so every
+        // replacement must reuse the displaced entry's slot in place. Allocating a
+        // slot for the newcomer and releasing the displaced one instead would add a
+        // slot and hand its buffer away, which is exactly what `FrequencySlots`
+        // exists to avoid.
+        const LIMIT: usize = 4;
+        const NUM_PAIRS: u32 = 4;
+        let mut collector = TopKCollector::deferring_addresses(LIMIT, LIMIT);
+        for doc in 0..1_000u64 {
+            collector.insert(
+                ScoredDoc::new(doc, doc as f32),
+                DEFERRED_ORDER_KEY,
+                1,
+                doc,
+                (0..NUM_PAIRS).map(|term| (term, doc as u32)),
+            )?;
+        }
+        assert!(collector.tie_band.is_empty());
+        assert_eq!(
+            collector.num_frequency_slots(),
+            LIMIT,
+            "an improving candidate must not allocate a slot beyond the heap"
+        );
+        assert!(
+            collector.min_frequency_slot_capacity() >= NUM_PAIRS as usize,
+            "a reused slot must keep its retained capacity"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_collector_rejects_nan_scores() -> Result<()> {
+        let mut collector = TopKCollector::by_row_address(1, 1);
+        assert!(insert_addressed(&mut collector, 1, 1.0)?);
+        assert!(!insert_addressed(&mut collector, 0, f32::NAN)?);
+        assert_eq!(collected_keys(collector)?, vec![1]);
+        Ok(())
+    }
+
+    #[test]
     fn test_top_k_collector_recycles_slots_while_retaining_ties() -> Result<()> {
         // A retained band that the k-th score rises past is dropped wholesale, and
         // the frequency slots of the documents that moved into it must come back.
         const LIMIT: usize = 2;
-        let mut collector = TopKCollector::retaining_score_floor(LIMIT, LIMIT);
+        let mut collector = TopKCollector::deferring_addresses(LIMIT, LIMIT);
         for round in 0..50u64 {
             for tie in 0..8u64 {
-                let key = round * 8 + tie;
-                collector.insert(
-                    ScoredDoc::new(key, round as f32),
-                    key,
-                    1,
-                    key,
-                    std::iter::once((0u32, 1u32)),
-                )?;
+                insert_deferred(&mut collector, round * 8 + tie, round as f32)?;
             }
         }
         assert!(!collector.score_floor_overflow());
@@ -5301,15 +5431,6 @@ mod tests {
             "slot count {} grew with the number of dropped bands",
             collector.num_frequency_slots()
         );
-        Ok(())
-    }
-
-    #[test]
-    fn test_top_k_collector_rejects_nan_scores() -> Result<()> {
-        let mut collector = TopKCollector::by_row_address(1, 1);
-        assert!(insert_tie_candidate(&mut collector, 1, 1.0)?);
-        assert!(!insert_tie_candidate(&mut collector, 0, f32::NAN)?);
-        assert_eq!(collected_keys(collector)?, vec![1]);
         Ok(())
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4120,6 +4120,10 @@ impl Scanner {
                     fts_node,
                     schema,
                 )?);
+                // The aggregate above groups on `_rowid` alone, collapsing a
+                // row's elements into one `max(_score)`, so its output carries no
+                // coordinate for the sort key to pick up. Element ordering inside a
+                // MultiMatch row is a separate, pre-existing gap.
                 let sort_exprs = fts_result_sort_exprs(fts_node.schema().as_ref())?;
 
                 // `params.limit` is the recursive planning contract. Compound

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4566,7 +4566,7 @@ impl Scanner {
         )?);
         // A `SortExec` top-k is not stable, so it sorts on the full FTS key rather
         // than on score alone. Both inputs need that: the union interleaves two
-        // independent plans, and a flat-only scan arrives in fragment order.
+        // independent plans, and a flat-only scan interleaves its fragments.
         let sort_exprs = fts_result_sort_exprs(plan.schema().as_ref())?;
         Ok(Arc::new(
             SortExec::new(sort_exprs, plan).with_fetch(params.limit),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -208,6 +208,41 @@ fn supports_compound_scorer(query: &FtsQuery) -> bool {
     columns.len() == 1
 }
 
+/// The FTS result order: `(score DESC, row_id ASC)`, plus `doc_index ASC` when
+/// the plan carries element coordinates.
+///
+/// A `SortExec` top-k is not stable, so an FTS top-k taken over a union of
+/// independent plans has to sort on the whole key or a tie resolves by batch
+/// arrival order. For list-element granularity one row address covers every
+/// element of that row, and only `doc_index` separates them.
+fn fts_result_sort_exprs(schema: &ArrowSchema) -> Result<LexOrdering> {
+    let ascending = SortOptions {
+        descending: false,
+        nulls_first: false,
+    };
+    let mut sort_exprs = vec![
+        PhysicalSortExpr {
+            expr: expressions::col(SCORE_COL, schema)?,
+            options: SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+        },
+        PhysicalSortExpr {
+            expr: expressions::col(ROW_ID, schema)?,
+            options: ascending,
+        },
+    ];
+    if schema.field_with_name(DOC_INDEX_COL).is_ok() {
+        sort_exprs.push(PhysicalSortExpr {
+            expr: expressions::col(DOC_INDEX_COL, schema)?,
+            options: ascending,
+        });
+    }
+    LexOrdering::new(sort_exprs)
+        .ok_or_else(|| Error::internal("FTS result ordering is unexpectedly empty".to_string()))
+}
+
 fn contains_phrase_query(query: &FtsQuery) -> bool {
     match query {
         FtsQuery::Phrase(_) => true,
@@ -4085,26 +4120,11 @@ impl Scanner {
                     fts_node,
                     schema,
                 )?);
-                let sort_exprs = [
-                    PhysicalSortExpr {
-                        expr: expressions::col(SCORE_COL, fts_node.schema().as_ref())?,
-                        options: SortOptions {
-                            descending: true,
-                            nulls_first: false,
-                        },
-                    },
-                    PhysicalSortExpr {
-                        expr: expressions::col(ROW_ID, fts_node.schema().as_ref())?,
-                        options: SortOptions {
-                            descending: false,
-                            nulls_first: false,
-                        },
-                    },
-                ];
+                let sort_exprs = fts_result_sort_exprs(fts_node.schema().as_ref())?;
 
                 // `params.limit` is the recursive planning contract. Compound
                 // parents pass `None` when they require every candidate.
-                Arc::new(SortExec::new(sort_exprs.into(), fts_node).with_fetch(params.limit))
+                Arc::new(SortExec::new(sort_exprs, fts_node).with_fetch(params.limit))
             }
             FtsQuery::Boolean(query) => {
                 // TODO: rewrite the query for better performance
@@ -4541,26 +4561,11 @@ impl Scanner {
             Partitioning::RoundRobinBatch(1),
         )?);
         // Indexed and flat hits arrive from independent plans, so the top-k over
-        // their union sorts on the full FTS key (score DESC, row_id ASC) rather than
-        // on score alone, which a `SortExec` top-k does not break deterministically.
-        let sort_exprs = [
-            PhysicalSortExpr {
-                expr: expressions::col(SCORE_COL, plan.schema().as_ref())?,
-                options: SortOptions {
-                    descending: true,
-                    nulls_first: false,
-                },
-            },
-            PhysicalSortExpr {
-                expr: expressions::col(ROW_ID, plan.schema().as_ref())?,
-                options: SortOptions {
-                    descending: false,
-                    nulls_first: false,
-                },
-            },
-        ];
+        // their union sorts on the full FTS key rather than on score alone, which a
+        // `SortExec` top-k does not break deterministically.
+        let sort_exprs = fts_result_sort_exprs(plan.schema().as_ref())?;
         Ok(Arc::new(
-            SortExec::new(sort_exprs.into(), plan).with_fetch(params.limit),
+            SortExec::new(sort_exprs, plan).with_fetch(params.limit),
         ))
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4564,9 +4564,9 @@ impl Scanner {
             plan,
             Partitioning::RoundRobinBatch(1),
         )?);
-        // Indexed and flat hits arrive from independent plans, so the top-k over
-        // their union sorts on the full FTS key rather than on score alone, which a
-        // `SortExec` top-k does not break deterministically.
+        // A `SortExec` top-k is not stable, so it sorts on the full FTS key rather
+        // than on score alone. Both inputs need that: the union interleaves two
+        // independent plans, and a flat-only scan arrives in fragment order.
         let sort_exprs = fts_result_sort_exprs(plan.schema().as_ref())?;
         Ok(Arc::new(
             SortExec::new(sort_exprs, plan).with_fetch(params.limit),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4540,15 +4540,27 @@ impl Scanner {
             plan,
             Partitioning::RoundRobinBatch(1),
         )?);
-        let sort_expr = PhysicalSortExpr {
-            expr: expressions::col(SCORE_COL, plan.schema().as_ref())?,
-            options: SortOptions {
-                descending: true,
-                nulls_first: false,
+        // Indexed and flat hits arrive from independent plans, so the top-k over
+        // their union sorts on the full FTS key (score DESC, row_id ASC) rather than
+        // on score alone, which a `SortExec` top-k does not break deterministically.
+        let sort_exprs = [
+            PhysicalSortExpr {
+                expr: expressions::col(SCORE_COL, plan.schema().as_ref())?,
+                options: SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                },
             },
-        };
+            PhysicalSortExpr {
+                expr: expressions::col(ROW_ID, plan.schema().as_ref())?,
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                },
+            },
+        ];
         Ok(Arc::new(
-            SortExec::new([sort_expr].into(), plan).with_fetch(params.limit),
+            SortExec::new(sort_exprs.into(), plan).with_fetch(params.limit),
         ))
     }
 
@@ -13225,7 +13237,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   Take: columns="_rowid, _score, (s)"
     CoalesceBatchesExec: target_batch_size=8192
-      SortExec: expr=[_score@1 DESC NULLS LAST], preserve_partitioning=[false]
+      SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
         CoalescePartitionsExec
           UnionExec
             MatchQuery: column=s, query=[hello]
@@ -13234,7 +13246,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         } else {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   LanceRead: uri=..., projection=[s], source=stream(_rowid)
-    SortExec: expr=[_score@1 DESC NULLS LAST], preserve_partitioning=[false]
+    SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
       CoalescePartitionsExec
         UnionExec
           MatchQuery: column=s, query=[hello]
@@ -13287,7 +13299,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   Take: columns="_rowid, _score, (s)"
     CoalesceBatchesExec: target_batch_size=8192
-      SortExec: expr=[_score@1 DESC NULLS LAST], preserve_partitioning=[false]
+      SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
         CoalescePartitionsExec
           UnionExec
             MatchQuery: column=s, query=[hello]
@@ -13309,7 +13321,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         } else {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   LanceRead: uri=..., projection=[s], source=stream(_rowid)
-    SortExec: expr=[_score@1 DESC NULLS LAST], preserve_partitioning=[false]
+    SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
       CoalescePartitionsExec
         UnionExec
           MatchQuery: column=s, query=[hello]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -20,7 +20,7 @@ use lance_arrow::FixedSizeListArrayExt;
 use crate::dataset::write::{WriteMode, WriteParams};
 use crate::index::DatasetIndexExt;
 use arrow::array::{AsArray, GenericListBuilder, GenericStringBuilder};
-use arrow::datatypes::UInt64Type;
+use arrow::datatypes::{UInt32Type, UInt64Type};
 use arrow_array::RecordBatch;
 use arrow_array::{Array, GenericStringArray, LargeListArray, ListArray, StructArray, UInt64Array};
 use arrow_array::{
@@ -47,7 +47,7 @@ use lance_index::metrics::{
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
-    DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
+    DOC_INDEX_COL, DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
     query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
@@ -1560,6 +1560,127 @@ async fn test_match_query_tie_is_a_stable_prefix_with_unindexed_rows() {
         assert_eq!(
             compound_fts_results(&dataset, query.clone(), Some(9)).await,
             exhaustive[..9]
+        );
+    }
+}
+
+/// One `(row_id, doc_index, score)` per hit of an element-granularity FTS scan,
+/// in result order.
+async fn element_fts_results(
+    dataset: &Dataset,
+    query: FtsQuery,
+    limit: Option<i64>,
+) -> Vec<(u64, u32, f32)> {
+    let mut scan = dataset.scan();
+    scan.with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    let doc_indices = batch[DOC_INDEX_COL].as_list::<i32>();
+    (0..batch.num_rows())
+        .map(|row| {
+            let coordinates = doc_indices.value(row);
+            let coordinates = coordinates.as_primitive::<UInt32Type>();
+            assert_eq!(
+                coordinates.len(),
+                1,
+                "a list-element FTS hit carries one coordinate"
+            );
+            (row_ids[row], coordinates.value(0), scores[row])
+        })
+        .collect()
+}
+
+fn tag_lists(rows: &[&[&str]]) -> ArrayRef {
+    let mut builder = GenericListBuilder::<i32, _>::new(GenericStringBuilder::<i32>::new());
+    for row in rows {
+        for value in *row {
+            builder.values().append_value(value);
+        }
+        builder.append(true);
+    }
+    Arc::new(builder.finish())
+}
+
+#[tokio::test]
+async fn test_element_fts_tie_is_a_stable_prefix_with_unindexed_rows() {
+    // Every element of every row holds the same term, so all hits tie on score and
+    // one row_id covers several results. Only `doc_index` separates them, and the
+    // top-k over the union of indexed and flat hits has to sort on it too.
+    let indexed = RecordBatch::try_from_iter(vec![(
+        "tags",
+        tag_lists(&[&["alpha", "alpha", "alpha"], &["alpha", "alpha", "alpha"]]),
+    )])
+    .unwrap();
+    let schema = indexed.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![indexed].into_iter().map(Ok), schema.clone()),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    dataset
+        .create_index(
+            &["tags"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default().document_granularity(DocumentGranularity::ListElement),
+            true,
+        )
+        .await
+        .unwrap();
+    let appended =
+        RecordBatch::try_from_iter(vec![("tags", tag_lists(&[&["alpha", "alpha", "alpha"]]))])
+            .unwrap();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+            Some(WriteParams {
+                max_rows_per_file: 1,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let query: FtsQuery = MatchQuery::new("alpha".to_owned())
+        .with_column(Some("tags".to_owned()))
+        .with_document_granularity(DocumentGranularity::ListElement)
+        .into();
+    let exhaustive = element_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(exhaustive.len(), 9, "three elements in each of three rows");
+    let keys = exhaustive
+        .iter()
+        .map(|(row_id, doc_index, _)| (*row_id, *doc_index))
+        .collect::<Vec<_>>();
+    let mut ascending = keys.clone();
+    ascending.sort_unstable();
+    assert_eq!(
+        keys, ascending,
+        "tied element hits must come back by (row_id, doc_index) ASC"
+    );
+
+    for limit in [1, 2, 4, 7] {
+        let limited = element_fts_results(&dataset, query.clone(), Some(limit as i64)).await;
+        assert_eq!(
+            limited,
+            exhaustive[..limit],
+            "top-{limit} must be an ordered prefix of the exhaustive result"
+        );
+    }
+    for _ in 0..5 {
+        assert_eq!(
+            element_fts_results(&dataset, query.clone(), Some(3)).await,
+            exhaustive[..3]
         );
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1448,6 +1448,122 @@ async fn test_compound_tie_uses_resolved_row_id() {
     );
 }
 
+#[tokio::test]
+async fn test_match_query_tie_is_a_stable_prefix_across_limits() {
+    // Every row holds the same single term, so every hit ties on BM25 and the
+    // result order is decided entirely by the row_id tiebreak. A plain match query
+    // does not go through the compound scorer, so this covers the WAND collector,
+    // the cross-partition merge and the segment merge in `search_segments`.
+    // The segments are committed in reverse order to keep segment ordinal order
+    // from accidentally agreeing with row_id order.
+    const NUM_ROWS: usize = 384;
+    let batch = arrow_array::record_batch!(("text", Utf8, vec!["common"; NUM_ROWS])).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 128,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index_with_order(&mut dataset, "text", false, true).await;
+
+    let query: FtsQuery = MatchQuery::new("common".to_owned())
+        .with_column(Some("text".to_owned()))
+        .into();
+    let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(exhaustive.len(), NUM_ROWS);
+    let top_score = exhaustive[0].1;
+    assert!(
+        exhaustive
+            .iter()
+            .all(|(_, score)| (score - top_score).abs() < 1e-6),
+        "premise: every document must tie on score"
+    );
+    let row_ids = exhaustive
+        .iter()
+        .map(|(row_id, _)| *row_id)
+        .collect::<Vec<_>>();
+    let mut ascending = row_ids.clone();
+    ascending.sort_unstable();
+    assert_eq!(row_ids, ascending, "tied hits must come back by row_id ASC");
+
+    for limit in [1, 5, 129, 200] {
+        let limited = compound_fts_results(&dataset, query.clone(), Some(limit as i64)).await;
+        assert_eq!(
+            limited,
+            exhaustive[..limit],
+            "top-{limit} must be an ordered prefix of the exhaustive result"
+        );
+    }
+
+    // Segments and partitions complete in whatever order the search streams yield,
+    // so repeat the query to check the result does not depend on it.
+    for _ in 0..5 {
+        assert_eq!(
+            compound_fts_results(&dataset, query.clone(), Some(10)).await,
+            exhaustive[..10]
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_match_query_tie_is_a_stable_prefix_with_unindexed_rows() {
+    // Rows appended after indexing are scored on the flat path, so the top-k runs
+    // over the union of indexed and flat hits. That union is the one place where a
+    // score-only sort could still scramble a tie.
+    const INDEXED_ROWS: usize = 16;
+    const APPENDED_ROWS: usize = 16;
+    let batch = arrow_array::record_batch!(("text", Utf8, vec!["common"; INDEXED_ROWS])).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone()),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 8,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "text", false).await;
+    let appended =
+        arrow_array::record_batch!(("text", Utf8, vec!["common"; APPENDED_ROWS])).unwrap();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+            Some(WriteParams {
+                max_rows_per_file: 8,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let query: FtsQuery = MatchQuery::new("common".to_owned())
+        .with_column(Some("text".to_owned()))
+        .into();
+    let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(exhaustive.len(), INDEXED_ROWS + APPENDED_ROWS);
+    for limit in [1, 4, 17, 30] {
+        let limited = compound_fts_results(&dataset, query.clone(), Some(limit as i64)).await;
+        assert_eq!(
+            limited,
+            exhaustive[..limit],
+            "top-{limit} must be an ordered prefix of the exhaustive result"
+        );
+    }
+    for _ in 0..5 {
+        assert_eq!(
+            compound_fts_results(&dataset, query.clone(), Some(9)).await,
+            exhaustive[..9]
+        );
+    }
+}
+
 fn nested_fts_batch(
     ids: Vec<u64>,
     a_values: Vec<Option<&str>>,

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1564,6 +1564,60 @@ async fn test_match_query_tie_is_a_stable_prefix_with_unindexed_rows() {
     }
 }
 
+#[tokio::test]
+async fn test_match_query_tie_is_a_stable_prefix_without_an_index() {
+    // With no FTS index every hit is scored on the flat path, and the leaf top-k is
+    // a `SortExec` over a scan that carries no ranking of its own. Only the sort key
+    // decides which of the tied rows survive the fetch.
+    const NUM_ROWS: usize = 64;
+    let batch = arrow_array::record_batch!(("text", Utf8, vec!["common"; NUM_ROWS])).unwrap();
+    let schema = batch.schema();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 8,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 8);
+
+    let query: FtsQuery = MatchQuery::new("common".to_owned())
+        .with_column(Some("text".to_owned()))
+        .into();
+    // An unlimited flat plan has no top-k above it, so this is a source of the tied
+    // hits, not of their order.
+    let mut expected = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(expected.len(), NUM_ROWS);
+    let top_score = expected[0].1;
+    assert!(
+        expected
+            .iter()
+            .all(|(_, score)| (score - top_score).abs() < 1e-6),
+        "premise: every document must tie on score"
+    );
+    expected.sort_unstable_by_key(|(row_id, _)| *row_id);
+
+    for limit in [1, 9, 33] {
+        let limited = compound_fts_results(&dataset, query.clone(), Some(limit as i64)).await;
+        assert_eq!(
+            limited,
+            expected[..limit],
+            "top-{limit} must be the lowest tied row_ids, in row_id order"
+        );
+    }
+    // The eight fragments feed the sort concurrently, so repeat the query to check
+    // the result does not depend on the order they arrive in.
+    for _ in 0..5 {
+        assert_eq!(
+            compound_fts_results(&dataset, query.clone(), Some(5)).await,
+            expected[..5]
+        );
+    }
+}
+
 /// One `(row_id, doc_index, score)` per hit of an element-granularity FTS scan,
 /// in result order.
 async fn element_fts_results(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -47,7 +47,8 @@ use lance_index::metrics::{
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, FREQS_COLLECTED_METRIC,
-    FTS_PEAK_BUFFERED_CANDIDATES_METRIC, FTS_SCORE_FLOOR_OVERFLOWS_METRIC, MetricsCollector,
+    FTS_ELEMENT_BAND_TRUNCATIONS_METRIC, FTS_PEAK_BUFFERED_CANDIDATES_METRIC,
+    FTS_SCORE_FLOOR_OVERFLOWS_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -1071,6 +1072,7 @@ pub struct FtsIndexMetrics {
     compound_peak_buffered_candidates: Gauge,
     fts_score_floor_overflows: Count,
     fts_peak_buffered_candidates: Gauge,
+    fts_element_band_truncations: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1104,6 +1106,8 @@ impl FtsIndexMetrics {
                 .new_count(FTS_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
             fts_peak_buffered_candidates: metrics
                 .new_gauge(FTS_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
+            fts_element_band_truncations: metrics
+                .new_count(FTS_ELEMENT_BAND_TRUNCATIONS_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1184,6 +1188,10 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_fts_peak_buffered_candidates(&self, num_candidates: usize) {
         self.fts_peak_buffered_candidates.set_max(num_candidates);
+    }
+
+    fn record_fts_element_band_truncations(&self, num_truncations: usize) {
+        self.fts_element_band_truncations.add(num_truncations);
     }
 }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -46,7 +46,8 @@ use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
+    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, FREQS_COLLECTED_METRIC,
+    FTS_PEAK_BUFFERED_CANDIDATES_METRIC, FTS_SCORE_FLOOR_OVERFLOWS_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -1068,6 +1069,8 @@ pub struct FtsIndexMetrics {
     compound_peak_address_resolution_batch_size: Gauge,
     compound_score_floor_overflows: Count,
     compound_peak_buffered_candidates: Gauge,
+    fts_score_floor_overflows: Count,
+    fts_peak_buffered_candidates: Gauge,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1097,6 +1100,10 @@ impl FtsIndexMetrics {
                 .new_count(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
             compound_peak_buffered_candidates: metrics
                 .new_gauge(COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
+            fts_score_floor_overflows: metrics
+                .new_count(FTS_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
+            fts_peak_buffered_candidates: metrics
+                .new_gauge(FTS_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1169,6 +1176,14 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_compound_peak_buffered_candidates(&self, num_candidates: usize) {
         self.compound_peak_buffered_candidates
             .set_max(num_candidates);
+    }
+
+    fn record_fts_score_floor_overflows(&self, num_overflows: usize) {
+        self.fts_score_floor_overflows.add(num_overflows);
+    }
+
+    fn record_fts_peak_buffered_candidates(&self, num_candidates: usize) {
+        self.fts_peak_buffered_candidates.set_max(num_candidates);
     }
 }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -328,9 +328,19 @@ async fn search_segments(
 
     while let Some(documents) = searches.try_next().await? {
         for document in documents {
+            // Segments complete in whatever order `buffer_unordered` yields, so the
+            // merge evicts on the full `(score DESC, row_id ASC)` key: a score tie
+            // with a lower row_id wins whichever segment produced it. A NaN score is
+            // rejected first, because the total order ranks NaN above every real score.
+            if document.score.0.is_nan() {
+                continue;
+            }
             if candidates.len() < limit {
                 candidates.push(std::cmp::Reverse(document));
-            } else if candidates.peek().unwrap().0.score < document.score {
+            } else if candidates
+                .peek()
+                .is_some_and(|std::cmp::Reverse(worst)| *worst < document)
+            {
                 candidates.pop();
                 candidates.push(std::cmp::Reverse(document));
             }


### PR DESCRIPTION
## Problem

Lance's BM25 top-k resolves equal scores by encounter and pruning order, which varies with `k` and with the order partitions finish. So `top-k1` is not an ordered prefix of `top-k2`, and paginating a broad tied-score term (many docs sharing tf and doc length, so identical BM25) duplicates and skips rows across `from/size` pages.

Lucene avoids this with a deterministic secondary sort `(score DESC, docId ASC)`. This PR brings the same guarantee to Lance's plain FTS path: `supports_compound_scorer` returns false for a top-level `Match`/`Phrase`, so the most common query runs `MatchQueryExec`/`PhraseQueryExec` → `bm25_search` → `wand::TopKCollector`, which is score-only. The collector mirrors the compound scorer's shape so the two cannot drift.

## Change

- `ScoredDoc::cmp` breaks score ties by ascending row id, then ascending `doc_index` for list-element granularity.
- The per-partition collector compares on `(score, order_key)` and **retains rather than ranks** whatever compares equal. The order key is the resolved row address, which is unique per document, so at row granularity the tie band stays empty and the hot path is one pop and one push. In deferred mode equal means a score tie; for list elements it means same row and same score, which is exactly the ambiguity the WAND walk cannot see.
- The WAND threshold sits one ULP below the k-th score (`admit_ties_floor`), so score-only prune tests keep, not drop, docs tied at the k-th. The pruning kernels are untouched.
- Both tie bands are bounded at `limit + 128`. A deferred overflow reports `fts_score_floor_overflows` and retries the affected partitions in parallel with an address projection attached; an element band that overflows reports `fts_element_band_truncations` and degrades to ranking on the posting DocId.
- The cross-partition merge compacts past the bound, keeping the exact top-k by `(score, row_id, doc_index)` and restarting the band.
- The cross-segment merge (`search_segments`) and the indexed/flat union sort both carry the full key, with `_doc_index` appended when the schema is element-granular.
- Element coordinate columns are cached per partition, so repeated resolution during compaction is a slice read rather than an O(P²) scatter read.

## Row ids

`ScoredDoc.row_id` in the collector holds a document key: a row address for legacy indexes, a dense per-partition `DocId` for modern ones. Address order matches DocId order only for un-remapped partitions, so the tiebreak keys on the resolved row address.

Correctness within a dataset version does not depend on stable row ids; the key only needs to be unique and comparable, which holds for both legacy row addresses and stable row ids. Stable row ids additionally keep the order stable across compaction. This mirrors Lucene, whose `docId` tiebreak is deterministic within a searcher version but not stable across segment merges.

## Legacy path

`push_scored_key` evicts on the full key, and drops NaN scores rather than admitting them. `OrderedFloat` uses `total_cmp`, so an admitted NaN would rank first in an under-filled heap; the WAND collector drops NaN once full, so both layers now agree. NaN is unreachable from stock BM25 and only arises from a caller-supplied scorer.

## Tests

- Stable prefix (`top-k1` is an ordered prefix of `top-k2`) across partitions, across segments committed in reverse order, through a prefilter, with unindexed rows in the union, and repeated over 12 striped partitions.
- Element-document ties resolved by `doc_index`, end to end and through the indexed/flat union.
- Bounds: the collector band, the element band, and the cross-partition merge band each assert the bound holds and that the correct documents survive.
- Overflow retry, including every partition overflowing at once, asserting the metric and exact results.
- Collector units for full-key eviction, slot reuse, NaN rejection, and `admit_ties_floor` at zero, negative, and NaN.
- Legacy `push_scored_key` tiebreak and NaN rejection.
- `cargo test -p lance-index --lib` 974 passed, `-p lance --lib` 2700 passed.

## Performance

The change is a no-op on the non-tied path by construction: row-granularity order keys are unique, so the tie band stays empty and the collector does one pop and one push as before. The one thing that needed measuring is `admit_ties_floor`, which lowers the WAND pruning threshold by one ULP.

`cargo bench -p lance-index --bench inverted`, 1M docs, criterion (10 s measurement, 10 samples), Apple M3 Max. Both bench binaries built up front and run interleaved with alternating order across 10 rounds; round 0 discarded as warm-up, rounds 1-9 measured, each with its own `CRITERION_HOME`.

| case | before (median) | after (median) | paired mean Δ |
|---|---|---|---|
| `invert_search(1000000)` | 20.42 ms | 20.89 ms | **-0.02%** |
| `invert_phrase_search(1000000)` | 6.39 ms | 6.26 ms | **-1.89%** |
| `invert_indexing(1000000)` | 9.66 s | 9.54 s | **+0.40%** |

Run-to-run spread is 5-8% for search and 13-15% for indexing, so read the paired per-round mean rather than the medians.

- **Search is unchanged.** Paired mean -0.02%. Per-round deltas swing ±4% but track run order (-1.70% when `before` ran first, +2.07% when `after` did), which is thermal. The one-ULP threshold change costs no measurable pruning power: on a Zipf corpus a block max rarely bit-equals the running k-th score.
- **Phrase search is ~2% faster,** consistent in sign (8 of 9 rounds, both order splits agree), but smaller than the absolute spread and marginal under multiple-comparison correction. Treat as "not a regression".
- **Indexing is unchanged.** The `ScoredDoc::cmp` tiebreak adds no measurable build cost; the +0.40% is one outlier round (sign test p=0.51).