### PR TITLE
feat(python): add parallel overwrite support to write_dataset

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7302,6 +7302,149 @@ class LanceStats:
         return self._ds.data_stats()
 
 
+# Parallel writes (n_jobs >= 2) currently support only mode="overwrite".
+#
+# "create" and "append" are intentionally excluded: the parallel path writes
+# fragments and then commits them with a single LanceOperation.Overwrite. That
+# operation ("overwrite or create", no read_version) can reproduce neither the
+# atomic create-only guarantee the native writer enforces, nor append's
+# conflict-detection/retry semantics, so supporting those modes here would
+# silently weaken their concurrency guarantees.
+# TODO(#1980): extend parallel writes to create/append once the fragment-commit
+# path can preserve their transaction semantics (most likely a Rust-core impl,
+# which owns these semantics and could be shared across all bindings).
+_PARALLEL_WRITE_SUPPORTED_MODES = ("overwrite",)
+
+
+def _validate_n_jobs(n_jobs: Optional[int]) -> None:
+    """Validate the ``n_jobs`` argument of :func:`write_dataset`.
+
+    ``None`` and ``1`` are always accepted and select the existing sequential
+    write path. Any other value must be an ``int`` >= 1. ``bool`` is rejected
+    explicitly because ``True``/``False`` are almost always a mistake for a
+    worker count.
+    """
+    if n_jobs is None:
+        return
+    if isinstance(n_jobs, bool) or not isinstance(n_jobs, int):
+        raise TypeError(
+            f"n_jobs must be an int or None, got {type(n_jobs).__name__}: {n_jobs!r}"
+        )
+    if n_jobs < 1:
+        raise ValueError(f"n_jobs must be >= 1, got {n_jobs}")
+
+
+def _ensure_parallel_write_supported(
+    data_obj: ReaderLike,
+    mode: str,
+    *,
+    unsupported: List[tuple[str, bool]],
+) -> None:
+    """Reject requests that the parallel write path cannot faithfully honor.
+
+    Parallel writes (``n_jobs >= 2``) fan a single in-memory table out into
+    concurrent :func:`lance.fragment.write_fragments` calls followed by one
+    commit. That path only reproduces a subset of :func:`write_dataset`
+    behavior, so anything it cannot honor is rejected with a clear error rather
+    than being silently ignored or run sequentially.
+    """
+    if not isinstance(data_obj, pa.Table):
+        raise TypeError(
+            "n_jobs >= 2 is only supported for in-memory pyarrow.Table input, got "
+            f"{type(data_obj).__name__}. Convert the input to a pyarrow.Table, or "
+            "use the default n_jobs=1 for other input types."
+        )
+    if mode not in _PARALLEL_WRITE_SUPPORTED_MODES:
+        raise ValueError(
+            "n_jobs >= 2 currently only supports mode='overwrite' "
+            f"(create/append are not yet supported), got mode={mode!r}."
+        )
+    set_options = sorted(name for name, is_set in unsupported if is_set)
+    if set_options:
+        raise ValueError(
+            "n_jobs >= 2 cannot be combined with the following option(s): "
+            f"{', '.join(set_options)}. Use the default n_jobs=1 to use them."
+        )
+
+
+def _write_dataset_parallel(
+    table: pa.Table,
+    uri: Union[str, Path, LanceDataset],
+    *,
+    n_jobs: int,
+    max_rows_per_file: int,
+    max_rows_per_group: int,
+    max_bytes_per_file: int,
+    data_storage_version: Optional[str],
+    storage_options: Optional[Dict[str, str]],
+    enable_v2_manifest_paths: bool,
+) -> LanceDataset:
+    """Write ``table`` with ``n_jobs`` parallel ``write_fragments`` calls and
+    commit the resulting fragments in a single ``LanceOperation.Overwrite``.
+
+    The caller guarantees ``table`` is a non-empty ``pyarrow.Table``,
+    ``n_jobs >= 2`` and ``mode == "overwrite"`` (the only mode parallel writes
+    currently support). Fragments are collected in partition order so the
+    committed layout is deterministic.
+
+    Failure semantics: if a worker fails, no commit is performed and the dataset
+    is never updated, but fragment files written by already-completed workers are
+    left uncommitted in storage. This matches the low-level
+    :func:`lance.fragment.write_fragments` API used for distributed writes.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from .fragment import write_fragments
+
+    if isinstance(uri, Path):
+        uri = os.fspath(uri)
+
+    num_rows = table.num_rows
+    # Ceil division so every row falls into exactly one contiguous partition.
+    partition_size = -(-num_rows // n_jobs)
+    partitions = []
+    offset = 0
+    while offset < num_rows:
+        length = min(partition_size, num_rows - offset)
+        partitions.append(table.slice(offset, length))
+        offset += length
+    # Effective worker count is capped at the number of non-empty partitions, so
+    # a small table with a large n_jobs never spawns idle or empty workers.
+    num_workers = len(partitions)
+
+    def _write_partition(partition: pa.Table) -> List[FragmentMetadata]:
+        return write_fragments(
+            partition,
+            uri,
+            mode="overwrite",
+            max_rows_per_file=max_rows_per_file,
+            max_rows_per_group=max_rows_per_group,
+            max_bytes_per_file=max_bytes_per_file,
+            data_storage_version=data_storage_version,
+            storage_options=storage_options,
+        )
+
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        # executor.map preserves input (partition) order and, when materialized,
+        # raises the first worker error before we reach the commit below — so a
+        # failed parallel write never produces a partial dataset version.
+        per_partition_fragments = list(executor.map(_write_partition, partitions))
+
+    fragments = [
+        fragment
+        for partition_fragments in per_partition_fragments
+        for fragment in partition_fragments
+    ]
+
+    operation = LanceOperation.Overwrite(table.schema, fragments)
+    return LanceDataset.commit(
+        uri,
+        operation,
+        storage_options=storage_options,
+        enable_v2_manifest_paths=enable_v2_manifest_paths,
+    )
+
+
 def write_dataset(
     data_obj: ReaderLike,
     uri: Optional[Union[str, Path, LanceDataset]] = None,
@@ -7311,6 +7454,7 @@ def write_dataset(
     max_rows_per_file: int = 1024 * 1024,
     max_rows_per_group: int = 1024,
     max_bytes_per_file: int = 90 * 1024 * 1024 * 1024,
+    n_jobs: Optional[int] = None,
     commit_lock: Optional[CommitLock] = None,
     progress: Optional[FragmentWriteProgress] = None,
     storage_options: Optional[Dict[str, str]] = None,
@@ -7363,6 +7507,23 @@ def write_dataset(
         means larger groups may cause this to be overshot meaningfully. This
         defaults to 90 GB, since we have a hard limit of 100 GB per file on
         object stores.
+    n_jobs: int, optional, default None
+        Number of parallel workers to use when writing a large in-memory
+        ``pyarrow.Table``. ``None`` (the default) and ``1`` use the existing
+        sequential write path unchanged. When ``n_jobs >= 2``, the table is
+        split into that many contiguous partitions that are written concurrently
+        with :func:`lance.fragment.write_fragments` and then committed in a
+        single ``LanceOperation.Overwrite`` transaction. The effective number of
+        workers is capped at the number of non-empty partitions. This is
+        currently only supported for in-memory ``pyarrow.Table`` input with
+        ``mode="overwrite"``; ``create`` and ``append`` are not yet supported for
+        ``n_jobs >= 2`` (the parallel commit cannot reproduce their concurrency
+        semantics — use the default ``n_jobs=1`` for those modes). Requesting
+        ``n_jobs >= 2`` with an unsupported input type, mode or option raises an
+        error. Parallel writes produce multiple fragments; the exact fragment
+        count is not part of the public API. If any worker fails, no commit is
+        performed (though fragment files from completed workers may be left
+        uncommitted in storage).
     commit_lock : CommitLock, optional
         A custom commit lock.  Only needed if your object store does not support
         atomic commits.  See the user guide for more details.
@@ -7492,6 +7653,40 @@ def write_dataset(
             "Must specify either 'uri' or both 'namespace_client' and 'table_id'."
         )
 
+    _validate_n_jobs(n_jobs)
+    parallel_write = n_jobs is not None and n_jobs >= 2
+    if parallel_write:
+        # Validate the parallel request up front, before any namespace side
+        # effects (declare_table / describe_table) can occur.
+        _ensure_parallel_write_supported(
+            data_obj,
+            mode,
+            unsupported=[
+                ("schema", schema is not None),
+                ("namespace_client", namespace_client is not None),
+                ("table_id", table_id is not None),
+                ("initial_bases", initial_bases is not None),
+                ("target_bases", target_bases is not None),
+                ("target_all_bases", target_all_bases is not None),
+                ("base_store_params", base_store_params is not None),
+                ("commit_lock", commit_lock is not None),
+                ("progress", progress is not None),
+                ("auto_cleanup_options", auto_cleanup_options is not None),
+                ("commit_message", commit_message is not None),
+                ("transaction_properties", transaction_properties is not None),
+                ("enable_stable_row_ids", enable_stable_row_ids),
+                ("external_blob_mode", external_blob_mode != "reference"),
+                (
+                    "allow_external_blob_outside_bases",
+                    allow_external_blob_outside_bases,
+                ),
+                (
+                    "blob_pack_file_size_threshold",
+                    blob_pack_file_size_threshold is not None,
+                ),
+            ],
+        )
+
     # Handle namespace-based dataset writing
     if namespace_client is not None:
         if table_id is None:
@@ -7561,6 +7756,22 @@ def write_dataset(
             data_storage_version = "legacy"
         else:
             data_storage_version = "stable"
+
+    if parallel_write and data_obj.num_rows > 0:
+        # An empty table cannot be split into non-empty partitions, so it falls
+        # through to the standard path below, which writes an empty dataset.
+        _validate_schema(data_obj.schema)
+        return _write_dataset_parallel(
+            data_obj,
+            uri,
+            n_jobs=n_jobs,
+            max_rows_per_file=max_rows_per_file,
+            max_rows_per_group=max_rows_per_group,
+            max_bytes_per_file=max_bytes_per_file,
+            data_storage_version=data_storage_version,
+            storage_options=storage_options,
+            enable_v2_manifest_paths=enable_v2_manifest_paths,
+        )
 
     reader = _coerce_reader(data_obj, schema)
     _validate_schema(reader.schema)

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -6217,3 +6217,196 @@ def test_all_files(tmp_path):
     assert result.schema.field("size_bytes").type == pa.int64()
     assert result.num_rows >= 2  # at least manifest + data file
     assert all(s > 0 for s in result.column("size_bytes").to_pylist())
+
+
+# --- write_dataset(n_jobs=...) parallel in-memory writes (issue #1980) ---
+
+
+def _n_jobs_table(num_rows: int = 1000) -> pa.Table:
+    return pa.table(
+        {
+            "id": pa.array(range(num_rows), pa.int64()),
+            "val": pa.array([float(i) for i in range(num_rows)], pa.float32()),
+        }
+    )
+
+
+@pytest.mark.parametrize("n_jobs", [None, 1])
+@pytest.mark.parametrize("mode", ["create", "overwrite", "append"])
+def test_write_dataset_n_jobs_sequential_all_modes(tmp_path: Path, n_jobs, mode):
+    # n_jobs None/1 must behave exactly like the sequential path in every mode.
+    table = _n_jobs_table(1000)
+    uri = str(tmp_path / "ds")
+
+    lance.write_dataset(table, uri, mode=mode, n_jobs=n_jobs)
+
+    ds = lance.dataset(uri)
+    assert ds.count_rows() == table.num_rows
+    assert ds.schema == table.schema
+    assert ds.to_table().sort_by("id").to_pydict() == table.sort_by("id").to_pydict()
+
+
+@pytest.mark.parametrize("n_jobs", [2, 4])
+def test_write_dataset_n_jobs_parallel_correctness(tmp_path: Path, n_jobs):
+    table = _n_jobs_table(1000)
+    uri = str(tmp_path / "ds")
+
+    lance.write_dataset(table, uri, mode="overwrite", n_jobs=n_jobs)
+
+    ds = lance.dataset(uri)
+    assert ds.count_rows() == table.num_rows
+    assert ds.schema == table.schema
+    assert ds.to_table().sort_by("id").to_pydict() == table.sort_by("id").to_pydict()
+
+
+@pytest.mark.parametrize("mode", ["create", "append"])
+@pytest.mark.parametrize("n_jobs", [2, 4])
+def test_write_dataset_n_jobs_unsupported_mode_rejected(tmp_path: Path, n_jobs, mode):
+    # Parallel writes currently support only mode="overwrite"; create/append
+    # must raise clearly rather than silently degrade their semantics.
+    table = _n_jobs_table(10)
+    with pytest.raises(ValueError, match="only supports mode='overwrite'"):
+        lance.write_dataset(table, str(tmp_path / "ds"), mode=mode, n_jobs=n_jobs)
+
+
+def test_write_dataset_n_jobs_produces_multiple_fragments(tmp_path: Path):
+    table = _n_jobs_table(1000)
+    uri = str(tmp_path / "ds")
+
+    lance.write_dataset(table, uri, mode="overwrite", n_jobs=4)
+
+    ds = lance.dataset(uri)
+    # Parallel writes fan out into several fragments. The exact count is not a
+    # public guarantee, so only assert that more than one fragment was produced.
+    assert len(ds.get_fragments()) > 1
+    assert ds.count_rows() == 1000
+
+
+def test_write_dataset_n_jobs_one_matches_sequential(tmp_path: Path):
+    table = _n_jobs_table(1000)
+    seq_uri = str(tmp_path / "seq")
+    one_uri = str(tmp_path / "one")
+
+    lance.write_dataset(table, seq_uri, mode="create")
+    lance.write_dataset(table, one_uri, mode="create", n_jobs=1)
+
+    seq = lance.dataset(seq_uri)
+    one = lance.dataset(one_uri)
+    # n_jobs=1 must be identical to the sequential path, including fragment layout.
+    assert len(one.get_fragments()) == len(seq.get_fragments())
+    assert one.to_table().to_pydict() == seq.to_table().to_pydict()
+
+
+@pytest.mark.parametrize("bad", [0, -1, -5])
+def test_write_dataset_n_jobs_invalid_value(tmp_path: Path, bad):
+    table = _n_jobs_table(10)
+    with pytest.raises(ValueError, match="n_jobs must be >= 1"):
+        lance.write_dataset(table, str(tmp_path / "ds"), n_jobs=bad)
+
+
+@pytest.mark.parametrize("bad", [2.5, "2", True, False])
+def test_write_dataset_n_jobs_invalid_type(tmp_path: Path, bad):
+    table = _n_jobs_table(10)
+    with pytest.raises(TypeError, match="n_jobs must be an int or None"):
+        lance.write_dataset(table, str(tmp_path / "ds"), n_jobs=bad)
+
+
+def test_write_dataset_n_jobs_oversized_workers(tmp_path: Path):
+    table = _n_jobs_table(3)
+    uri = str(tmp_path / "ds")
+
+    # More workers requested than rows: must succeed and cap effective workers
+    # at the number of non-empty partitions (no empty fragments).
+    lance.write_dataset(table, uri, mode="overwrite", n_jobs=100)
+
+    ds = lance.dataset(uri)
+    assert ds.count_rows() == 3
+    assert 1 <= len(ds.get_fragments()) <= 3
+    assert ds.to_table().sort_by("id").to_pydict() == table.sort_by("id").to_pydict()
+
+
+@pytest.mark.parametrize("n_jobs", [2, 4])
+def test_write_dataset_n_jobs_empty_table(tmp_path: Path, n_jobs):
+    table = _n_jobs_table(0)
+    uri = str(tmp_path / "ds")
+
+    # An empty table cannot be partitioned; this must not create a zero-worker
+    # executor and must write a valid empty dataset.
+    lance.write_dataset(table, uri, mode="overwrite", n_jobs=n_jobs)
+
+    ds = lance.dataset(uri)
+    assert ds.count_rows() == 0
+    assert ds.schema == table.schema
+
+
+def test_write_dataset_n_jobs_null_values(tmp_path: Path):
+    num_rows = 100
+    table = pa.table(
+        {
+            "id": pa.array(range(num_rows), pa.int64()),
+            "maybe": pa.array([None] * num_rows, pa.int64()),
+        }
+    )
+    uri = str(tmp_path / "ds")
+
+    lance.write_dataset(table, uri, mode="overwrite", n_jobs=4)
+
+    ds = lance.dataset(uri)
+    assert ds.count_rows() == num_rows
+    assert ds.to_table().column("maybe").null_count == num_rows
+
+
+def test_write_dataset_n_jobs_unsupported_input_type(tmp_path: Path):
+    table = _n_jobs_table(10)
+
+    with pytest.raises(TypeError, match="only supported for in-memory pyarrow.Table"):
+        lance.write_dataset(table.to_reader(), str(tmp_path / "reader"), n_jobs=2)
+
+    with pytest.raises(TypeError, match="only supported for in-memory pyarrow.Table"):
+        lance.write_dataset(table.to_pandas(), str(tmp_path / "pandas"), n_jobs=2)
+
+
+def test_write_dataset_n_jobs_unsupported_option(tmp_path: Path):
+    table = _n_jobs_table(10)
+    with pytest.raises(ValueError, match="cannot be combined with"):
+        lance.write_dataset(
+            table,
+            str(tmp_path / "ds"),
+            mode="overwrite",
+            n_jobs=2,
+            commit_message="hello",
+        )
+
+
+def test_write_dataset_n_jobs_schema_not_silently_ignored(tmp_path: Path):
+    table = _n_jobs_table(10)
+    # The parallel path uses table.schema directly, so an explicit schema= must
+    # be rejected rather than silently ignored.
+    other_schema = pa.schema(
+        [pa.field("id", pa.int64()), pa.field("val", pa.float64())]
+    )
+    with pytest.raises(ValueError, match="cannot be combined with.*schema"):
+        lance.write_dataset(
+            table,
+            str(tmp_path / "ds"),
+            mode="overwrite",
+            n_jobs=2,
+            schema=other_schema,
+        )
+
+
+def test_write_dataset_n_jobs_worker_failure_no_commit(tmp_path: Path, monkeypatch):
+    table = _n_jobs_table(1000)
+    uri = str(tmp_path / "ds")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(lance.fragment, "write_fragments", boom)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        lance.write_dataset(table, uri, mode="overwrite", n_jobs=4)
+
+    # A failed worker must prevent the commit, so no dataset version exists.
+    with pytest.raises(ValueError):
+        lance.dataset(uri)


### PR DESCRIPTION
## Why

`lance.write_dataset` currently consumes its input as a single stream and writes one file at a time. For large, fully in-memory tables, this can leave available CPU and I/O capacity underused. In #1980, the reporter observed low CPU and network utilization while writing a large in-memory table and improved throughput by manually distributing the work across threads.

A maintainer confirmed the single-stream behavior, welcomed an `n_jobs` parameter, and provided a reference approach based on parallel `write_fragments` calls followed by one commit. This PR brings that approach into the public API for the subset where the existing fragment-commit primitives can preserve correct behavior.

## What

This PR adds an optional `n_jobs` parameter to `lance.write_dataset`.

- `n_jobs=None` and `n_jobs=1` preserve the existing sequential path.
- `n_jobs &gt;= 2` partitions an in-memory `pyarrow.Table` into contiguous, non-empty slices.
- The slices are written concurrently with `lance.fragment.write_fragments`.
- Fragment results are collected in deterministic partition order.
- All fragments are committed through one final `LanceOperation.Overwrite`.
- The effective number of workers is capped at the number of non-empty partitions.
- No new dependency is introduced; the implementation uses `concurrent.futures.ThreadPoolExecutor`.

If a worker raises an exception, the final commit is not performed, so no partial dataset version is created.

## Scope and backward compatibility

The parallel path currently supports:

- in-memory `pyarrow.Table` inputs
- `mode="overwrite"`

Parallel `create` and `append` are explicitly rejected rather than silently weakening their existing transaction guarantees. The public fragment-commit path cannot currently reproduce the native writer's atomic create-only behavior or append conflict/retry semantics.

Unsupported input types and incompatible options also raise descriptive errors.

Existing callers are unaffected because omitting `n_jobs`, or setting it to `1`, follows the original sequential path.

## Tests

Added coverage for:

- sequential compatibility for `n_jobs=None` and `n_jobs=1`
- parallel correctness for `n_jobs=2` and `n_jobs=4`
- row-count, schema, and full-content preservation
- zero, negative, Boolean, and non-integer values
- worker counts larger than the number of rows
- empty tables
- null-valued columns
- unsupported inputs, modes, and options
- explicit `schema=` with parallel mode
- multiple-fragment output without treating the exact count as an API guarantee
- worker failure before the final commit

```bash
# Run from python/
uv run pytest python/tests/test_dataset.py -k "n_jobs" -q
# 29 passed

uv run pytest python/tests/test_dataset.py -q
# 236 passed, 5 skipped

uv run make lint
# Ruff, Pyright, Rust checks, and Clippy passed

The reported warnings were pre-existing and came from files unrelated to this change.
```

## Benchmark

Local macOS SSD benchmark using identical in-memory tables, `mode="overwrite"`, one warm-up, and five measured repetitions. Each run verified row count, schema, and full content.

These results are local-storage measurements only, not Azure or production proof.

### 3,000,000 rows × 7 columns (~160 MB)

| `n_jobs` | Median time | Speedup |
|---:|---:|---:|
| 1 | 0.358 s | 1.00× |
| 2 | 0.327 s | 1.09× |
| 4 | 0.319 s | 1.12× |

### 1,500,000 rows × 61 columns (~698 MB)

| `n_jobs` | Median time | Speedup |
|---:|---:|---:|
| 1 | 1.492 s | 1.00× |
| 2 | 1.370 s | 1.09× |
| 4 | 1.279 s | 1.17× |

The local results show a modest but consistent improvement that increases with worker count and workload size. The network-bound object-storage workload described in the issue was not reproduced here.

## Known limitations

- Parallel mode currently supports only in-memory `pyarrow.Table` inputs.
- Parallel mode currently supports only `mode="overwrite"`.
- Fragment files written before a worker failure may remain uncommitted in storage.
- Object-store performance has not been measured.

## Open questions for maintainers

- Should the parallel orchestration remain in Python, or should the worker count eventually move into the Rust write path so it can be shared across bindings?
- Should the public parameter remain `n_jobs`, as requested in the issue, or follow Lance conventions such as `num_workers` or `*_concurrency`?

## Acceptance criteria

- [x] Adds opt-in parallel writing to `lance.write_dataset`
- [x] Preserves existing behavior for `n_jobs=None` and `n_jobs=1`
- [x] Preserves row count, schema, and data content
- [x] Rejects invalid worker counts with descriptive errors
- [x] Prevents a final commit when a worker fails
- [x] Clearly rejects unsupported modes, inputs, and options
- [x] Adds automated tests for the new behavior
- [x] Passes formatting, lint, type, and relevant Rust checks
- [x] Introduces no new dependency

Closes #1980