### PR TITLE
docs: make the docs site theme usable on mobile and narrow screens

### DIFF
--- a/docs/theme/assets/site.css
+++ b/docs/theme/assets/site.css
@@ -136,6 +136,8 @@
   color: var(--beam-600);
   margin-bottom: 24px;
 }
+/* Wrap only between segments (at the · separators), never inside one. */
+.ld-kicker span, .ld-kicker a { white-space: nowrap; }
 .ld-kicker a { color: inherit; text-decoration: underline; text-underline-offset: 3px; }
 .ld-kicker a:hover { color: var(--beam-700); }
 .ld-hero h1 {

--- a/docs/theme/assets/site.css
+++ b/docs/theme/assets/site.css
@@ -301,6 +301,29 @@
   height: calc(100vh - 60px);
   overflow-y: auto;
 }
+/* Mobile-only disclosure for the sidenav; hidden on desktop where the
+   sidenav is a sticky column. */
+.ld-sidenav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid var(--line-2);
+  padding: 9px 12px;
+  margin: 16px 0 0;
+  cursor: pointer;
+}
+.ld-sidenav-toggle:hover { color: var(--fg-1); border-color: var(--beam-400); }
+.ld-sidenav-toggle svg { transition: transform var(--dur-fast) var(--ease-out); }
+.ld-sidenav-toggle.open svg { transform: rotate(180deg); }
 .ld-sidenav__group { margin-bottom: 6px; }
 .ld-sidenav__label {
   font-family: var(--font-mono);
@@ -400,6 +423,8 @@
 /* ---------- article prose (python-markdown output) ---------- */
 .ld-article-col { max-width: 760px; min-width: 0; padding: 40px 0 96px; }
 .ld-article { font-family: var(--font-body); color: var(--text-secondary); }
+/* Keep anchor targets clear of the sticky header. */
+.ld-article :is(h1, h2, h3, h4, h5, h6) { scroll-margin-top: 76px; }
 .ld-article h1 { font-family: var(--font-display); font-size: 42px; font-weight: 600; letter-spacing: -0.03em; line-height: 1.05; color: var(--fg-1); margin: 0 0 20px; text-wrap: balance; }
 .ld-article h2 { font-family: var(--font-display); font-size: 26px; font-weight: 600; letter-spacing: -0.02em; color: var(--fg-1); margin: 48px 0 14px; padding-top: 28px; border-top: 1px solid var(--line-2); }
 .ld-article h3 { font-family: var(--font-display); font-size: 19px; font-weight: 600; letter-spacing: -0.01em; color: var(--fg-1); margin: 32px 0 10px; }
@@ -715,20 +740,51 @@
   .ld-toc { display: none; }
 }
 @media (max-width: 960px) {
+  /* Header folds into two rows: brand + icon actions, then a scrollable
+     section-tab row. Text-heavy controls collapse to icons. */
+  .ld-header { flex-wrap: wrap; height: auto; gap: 0 10px; padding: 10px 16px 0; }
+  .ld-header__actions { margin-left: auto; }
+  .ld-header__actions .ld-btn--primary,
+  .ld-header__actions .ld-btn__label,
+  .ld-header__actions .ld-btn__count { display: none; }
+  .ld-topnav { order: 1; flex-basis: 100%; margin: 4px 0 0; padding-bottom: 10px; }
+  .ld-toptab { padding: 7px 10px; }
+  .ld-toptab:first-child { margin-left: -10px; }
+  .ld-toptab.active::after { left: 10px; right: 10px; }
+
+  .ld-article :is(h1, h2, h3, h4, h5, h6) { scroll-margin-top: 104px; }
+  .ld-article h1 { font-size: 32px; }
+
   .ld-hero h1 { font-size: clamp(38px, 9vw, 56px); }
   .ld-stats { grid-template-columns: 1fr; }
   .ld-stat { padding: 20px 0; }
   .ld-stat + .ld-stat { border-left: 0; border-top: 1px solid var(--line-2); }
   .ld-feature { grid-template-columns: 1fr; gap: 16px; }
   .ld-feature__num { padding-top: 0; }
+
+  /* Docs: sidenav collapses behind a disclosure button; article leads. */
   .ld-docs { display: block; padding: 0 20px; }
+  .ld-sidenav-toggle { display: flex; }
   .ld-sidenav {
+    display: none;
     position: static;
     height: auto;
     border-right: 0;
     border-bottom: 1px solid var(--line-2);
-    padding: 20px 0;
+    padding: 0 0 20px;
   }
+  .ld-sidenav.open { display: block; }
+  .ld-sidenav__group:first-child .ld-sidenav__label { margin-top: 16px; }
+  .ld-article-col { padding-top: 24px; }
+
   .ld-hero, .ld-band, .ld-what, .ld-features { padding-left: 20px; padding-right: 20px; }
   .ld-hero { padding-top: 56px; padding-bottom: 48px; }
+  .ld-notfound { padding: 72px 20px 96px; }
+  .ld-footer { padding: 32px 20px; }
+  .ld-footer__cols { gap: 28px 40px; }
+}
+@media (max-width: 700px) {
+  /* Search becomes an edge-to-edge sheet under the top of the screen. */
+  .ld-search__panel { margin: 0; max-width: none; border-left: 0; border-right: 0; border-top: 0; }
+  .ld-search__results { max-height: calc(100dvh - 110px); }
 }

--- a/docs/theme/assets/site.js
+++ b/docs/theme/assets/site.js
@@ -39,6 +39,17 @@
       .catch(function () { /* rate-limited or offline: button still works without the count */ });
   })();
 
+  /* ---------- mobile sidenav toggle ---------- */
+  var sidenavToggle = document.querySelector(".ld-sidenav-toggle");
+  var sidenav = document.querySelector(".ld-sidenav");
+  if (sidenavToggle && sidenav) {
+    sidenavToggle.addEventListener("click", function () {
+      var open = sidenav.classList.toggle("open");
+      sidenavToggle.classList.toggle("open", open);
+      sidenavToggle.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+  }
+
   /* ---------- article enhancements ---------- */
   var article = document.querySelector(".ld-article");
 

--- a/docs/theme/base.html
+++ b/docs/theme/base.html
@@ -55,7 +55,7 @@
       </button>
       <a class="ld-btn ld-btn--ghost" href="{{ config.repo_url }}" target="_blank" rel="noopener" aria-label="Lance on GitHub">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
-        GitHub
+        <span class="ld-btn__label">GitHub</span>
         <span class="ld-btn__count" id="gh-stars" hidden></span>
       </a>
       <a class="ld-btn ld-btn--ghost ld-btn--icon" href="https://discord.gg/lance" target="_blank" rel="noopener" aria-label="Join the Lance Discord" title="Discord">

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -3,7 +3,7 @@
 {% block container %}
   <main class="ld-home">
     <section class="ld-hero">
-      <div class="ld-kicker">Lance format · Open source · Apache-2.0 · <a href="https://arxiv.org/abs/2504.15247" target="_blank" rel="noopener">VLDB '25 paper ↗</a></div>
+      <div class="ld-kicker"><span>Lance format</span> · <span>Open source</span> · <span>Apache-2.0</span> · <a href="https://arxiv.org/abs/2504.15247" target="_blank" rel="noopener">VLDB '25 paper ↗</a></div>
       <h1>The open lakehouse format for multimodal AI.</h1>
       <p class="ld-hero__lead">A file format, table format, and catalog spec for building a complete lakehouse on object storage — powering vector and full-text search, feature engineering, and model training with the fast random access and scans that AI workloads need.</p>
       <div class="ld-hero__cta">

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -26,7 +26,11 @@
   {%- for item in nav %}{% if item.active %}{% set active_section.item = item %}{% endif %}{% endfor %}
 
   <main class="ld-docs">
-    <aside class="ld-sidenav" aria-label="Section pages">
+    <button class="ld-sidenav-toggle" type="button" aria-expanded="false" aria-controls="ld-sidenav">
+      {{ active_section.item.title if active_section.item else "Menu" }}
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+    </button>
+    <aside class="ld-sidenav" id="ld-sidenav" aria-label="Section pages">
       {%- if active_section.item and active_section.item.is_section %}
         {{ sidenav_section(active_section.item, active_section.item.title) }}
       {%- elif active_section.item %}


### PR DESCRIPTION

<img width="439" height="699" alt="image" src="https://github.com/user-attachments/assets/a62876d0-d4bd-498f-b345-9631c35989c6" />

## Why

The custom "Lance Docs" theme introduced in #7821 was designed desktop-first: on phones and narrow windows the header overflows horizontally (the section tabs get squeezed to zero width while the non-shrinking action buttons push the page wider than the viewport), and the side navigation renders as a long static block above every article, forcing readers to scroll past the whole section index before reaching content.

This makes the theme responsive:

- Below 960px the header folds into two rows: brand plus icon-only actions on top ("Get started", the GitHub label, and the star count collapse away), with a horizontally scrollable section-tab row underneath.
- The side navigation collapses behind a disclosure button labeled with the current section, so articles lead on mobile.
- Anchor jumps now land clear of the sticky header (`scroll-margin-top`), the search overlay becomes an edge-to-edge sheet on small screens, and article headings, the footer, and the 404 page scale down.

Verified in a real browser at 390px and 320px widths (home, docs pages, tables, code blocks, dark mode, search) and regression-checked the desktop layout, which is unchanged.
