### PR TITLE
fix(fts): restore format version environment fallback

### DIFF
--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -9,15 +9,20 @@ migrate.
 ## 9.0.0
 
 * Newly created FTS / inverted indexes now default to format v4 instead of v1.
-  The `LANCE_FTS_FORMAT_VERSION` environment variable no longer controls the
-  format used for newly created indexes. Users who need a specific older index
-  layout should pass the index creation parameter `format_version` explicitly.
+  Format selection follows this priority: an explicit index creation parameter
+  `format_version`, then the `LANCE_FTS_FORMAT_VERSION` environment variable,
+  then v4 when neither is set. This preserves the environment variable as a
+  compatibility fallback for deployments that use it as a global rollout
+  switch. An invalid environment variable value fails index creation instead of
+  silently selecting v4; an explicit `format_version` takes precedence even
+  when the environment variable is invalid.
 
 * This affects users who create FTS / inverted indexes and need those indexes to
   be readable by older Lance versions, or who depend on the v1 index layout. In
-  those cases, pass `format_version=1` when creating the index. Otherwise, newly
-  created indexes will use v4 by default, and older Lance readers may not be able
-  to read them.
+  those cases, pass `format_version=1` when creating the index, or set
+  `LANCE_FTS_FORMAT_VERSION=1` for a process-wide rollout. When neither setting
+  is present, newly created indexes use v4, and older Lance readers may not be
+  able to read them.
 
   ```python
   dataset.create_scalar_index("text", "INVERTED", format_version=1)

--- a/java/src/main/java/org/lance/index/scalar/InvertedIndexParams.java
+++ b/java/src/main/java/org/lance/index/scalar/InvertedIndexParams.java
@@ -264,8 +264,8 @@ public final class InvertedIndexParams {
     /**
      * Configure the on-disk FTS format version to write when creating a new index.
      *
-     * <p>If unset, Lance writes v4 for either supported block size. {@code formatVersion = 3} is
-     * experimental and is only valid with {@code blockSize = 256}.
+     * <p>If unset, Lance uses {@code LANCE_FTS_FORMAT_VERSION} when present and otherwise writes
+     * v4. {@code formatVersion = 3} is experimental and is only valid with {@code blockSize = 256}.
      *
      * @param formatVersion FTS format version, must be 1, 2, 3, or 4
      * @return this builder

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3371,7 +3371,8 @@ class LanceDataset(pa.dataset.Dataset):
             This is for the ``INVERTED`` / ``FTS`` index. Explicit on-disk FTS
             format version to write when creating a new index. Accepts ``1``,
             ``2``, ``3``, ``4``, ``"v1"``, ``"v2"``, ``"v3"``, or ``"v4"``.
-            If unset, Lance writes v4 for either supported block size.
+            If unset, Lance uses ``LANCE_FTS_FORMAT_VERSION`` when present and
+            otherwise writes v4.
             ``format_version=3`` is experimental and is only valid with
             ``block_size=256``.
 

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -7,6 +7,8 @@ import random
 import re
 import shutil
 import string
+import subprocess
+import sys
 import uuid
 import zipfile
 from datetime import date, datetime, timedelta
@@ -5520,15 +5522,92 @@ def test_describe_indices(tmp_path, format_version, expected_format_version):
         assert index.num_rows_indexed == 50
 
 
-def test_create_inverted_index_defaults_to_v4_and_ignores_env(tmp_path, monkeypatch):
-    monkeypatch.setenv("LANCE_FTS_FORMAT_VERSION", "1")
-    data = pa.table({"text": ["document about lance database"]})
-    ds = lance.write_dataset(data, tmp_path)
+def _run_fts_format_creation_probe(
+    tmp_path, env_value, creation_options=None, expected_format_version=None
+):
+    script = """
+import json
+import sys
 
-    ds.create_scalar_index("text", index_type="INVERTED")
+import lance
+import pyarrow as pa
 
-    indices = ds.describe_indices()
-    assert indices[0].segments[0].index_version == 4
+dataset = lance.write_dataset(
+    pa.table({"text": ["document about lance database"]}), sys.argv[1]
+)
+dataset.create_scalar_index(
+    "text", index_type="INVERTED", **json.loads(sys.argv[2])
+)
+expected_format_version = json.loads(sys.argv[3])
+if expected_format_version is not None:
+    actual_format_version = dataset.describe_indices()[0].segments[0].index_version
+    assert actual_format_version == expected_format_version
+"""
+    env = os.environ.copy()
+    if env_value is None:
+        env.pop("LANCE_FTS_FORMAT_VERSION", None)
+    else:
+        env["LANCE_FTS_FORMAT_VERSION"] = env_value
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(tmp_path),
+            json.dumps(creation_options or {}),
+            json.dumps(expected_format_version),
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_value", "creation_options", "expected_format_version"),
+    [
+        ("1", {}, 1),
+        ("2", {}, 2),
+        ("3", {"block_size": 256}, 3),
+        ("4", {}, 4),
+    ],
+)
+def test_create_inverted_index_uses_env_format_version(
+    tmp_path, env_value, creation_options, expected_format_version
+):
+    result = _run_fts_format_creation_probe(
+        tmp_path,
+        env_value,
+        creation_options,
+        expected_format_version,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_create_inverted_index_explicit_format_version_overrides_env(tmp_path):
+    result = _run_fts_format_creation_probe(
+        tmp_path,
+        "invalid",
+        {"format_version": 1},
+        1,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_create_inverted_index_defaults_to_v4_without_env(tmp_path):
+    result = _run_fts_format_creation_probe(tmp_path, None, expected_format_version=4)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_create_inverted_index_rejects_invalid_env_format_version(tmp_path):
+    result = _run_fts_format_creation_probe(tmp_path, "invalid")
+
+    assert result.returncode != 0
+    assert "LANCE_FTS_FORMAT_VERSION" in result.stderr
+    assert "invalid" in result.stderr
 
 
 def test_create_inverted_index_rejects_invalid_format_version(tmp_path):

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -42,6 +42,7 @@ pub const LEGACY_BLOCK_SIZE: usize = 128;
 /// This intentionally matches [`LEGACY_BLOCK_SIZE`] today but may evolve independently.
 pub const DEFAULT_BLOCK_SIZE: usize = 128;
 pub const VALID_BLOCK_SIZES: [usize; 2] = [128, 256];
+const LANCE_FTS_FORMAT_VERSION_ENV_KEY: &str = "LANCE_FTS_FORMAT_VERSION";
 
 /// Tokenizer configs
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -158,7 +159,9 @@ pub struct InvertedIndexParams {
     /// On-disk FTS format version to write when creating a new index.
     ///
     /// This is a build-time only parameter and is not persisted with the index.
-    /// If unset, Lance writes v4 for either supported block size.
+    /// If unset, new index creation falls back to
+    /// `LANCE_FTS_FORMAT_VERSION`, then v4 when the environment variable is
+    /// also unset.
     /// `format_version = 3` is experimental and is only valid with
     /// `block_size = 256`.
     #[serde(
@@ -496,6 +499,26 @@ where
     }
 }
 
+fn resolve_creation_format_version(
+    explicit: Option<InvertedListFormatVersion>,
+) -> Result<InvertedListFormatVersion> {
+    if let Some(format_version) = explicit {
+        return Ok(format_version);
+    }
+
+    match env::var(LANCE_FTS_FORMAT_VERSION_ENV_KEY) {
+        Ok(value) => resolve_fts_format_version(Some(&value)).map_err(|err| {
+            Error::invalid_input(format!(
+                "invalid {LANCE_FTS_FORMAT_VERSION_ENV_KEY} value {value:?}: {err}"
+            ))
+        }),
+        Err(env::VarError::NotPresent) => resolve_fts_format_version(None),
+        Err(env::VarError::NotUnicode(value)) => Err(Error::invalid_input(format!(
+            "invalid {LANCE_FTS_FORMAT_VERSION_ENV_KEY} value {value:?}: expected UTF-8 value 1, 2, 3, or 4"
+        ))),
+    }
+}
+
 fn deserialize_explicit_option<'de, D, T>(
     deserializer: D,
 ) -> std::result::Result<Option<Option<T>>, D::Error>
@@ -796,9 +819,10 @@ impl InvertedIndexParams {
 
     /// Set the on-disk FTS format version to use when creating a new index.
     ///
-    /// If unset, Lance writes v4 for either supported block size. Existing
-    /// indexes keep their own on-disk format during update and optimize
-    /// operations.
+    /// If unset, new index creation falls back to
+    /// `LANCE_FTS_FORMAT_VERSION`, then v4 when the environment variable is
+    /// also unset. Existing indexes keep their own on-disk format during
+    /// update and optimize operations.
     /// `format_version = 3` is experimental and is only valid with
     /// `block_size = 256`.
     pub fn format_version(mut self, format_version: InvertedListFormatVersion) -> Self {
@@ -848,8 +872,8 @@ impl InvertedIndexParams {
         Ok(value)
     }
 
-    /// Deserialize params for new index training, using current creation defaults
-    /// for omitted fields.
+    /// Deserialize params for new index training, using the environment
+    /// compatibility fallback and current creation defaults for omitted fields.
     pub(crate) fn from_training_json(params: &str) -> Result<Self> {
         let supplied = serde_json::from_str::<serde_json::Value>(params)?;
         let mut value = serde_json::to_value(Self::default())?;
@@ -862,7 +886,8 @@ impl InvertedIndexParams {
             .expect("inverted index params should serialize to a JSON object");
         object.extend(supplied.clone());
 
-        let params: Self = serde_json::from_value(value)?;
+        let mut params: Self = serde_json::from_value(value)?;
+        params.format_version = Some(resolve_creation_format_version(params.format_version)?);
         params.validate_format_version()?;
         Ok(params)
     }


### PR DESCRIPTION
## Context

New FTS / inverted index creation defaults to format v4, but the rollout also stopped honoring `LANCE_FTS_FORMAT_VERSION` when `format_version` is omitted. Deployments that rely on this process-wide compatibility switch could therefore create indexes unreadable by older readers despite retaining the rollout setting.

This restores the established precedence: an explicit creation parameter wins, otherwise the environment variable is used, and v4 remains the default when neither is present. Invalid environment values fail clearly. The fallback is limited to new-index training, so append, optimize, and other maintenance operations continue preserving each index's existing format.

Regression coverage exercises the precedence and error cases in isolated subprocesses, and the migration and binding documentation now describe the compatibility behavior.
