### PR TITLE
fix(core): validate CPU/IO env vars with a diagnosable error

### DIFF
--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -21,8 +21,8 @@ pub fn get_num_compute_intensive_cpus() -> usize {
 }
 
 fn calculate_num_compute_intensive_cpus() -> usize {
-    if let Ok(user_specified) = std::env::var("LANCE_CPU_THREADS") {
-        return user_specified.parse().unwrap();
+    if let Ok(raw) = std::env::var("LANCE_CPU_THREADS") {
+        return parse_env_usize("LANCE_CPU_THREADS", &raw, 1).unwrap_or_else(|e| panic!("{e}"));
     }
 
     let cpus = num_cpus::get();
@@ -42,12 +42,31 @@ fn calculate_num_compute_intensive_cpus() -> usize {
     num_cpus::get() - *IO_CORE_RESERVATION
 }
 
-pub static IO_CORE_RESERVATION: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("LANCE_IO_CORE_RESERVATION")
-        .unwrap_or("2".to_string())
+/// Parse an integer environment variable, rejecting values below `min`.
+///
+/// The error names the variable, so a bad value is diagnosable instead of
+/// surfacing as a bare `ParseIntError` or, for `LANCE_CPU_THREADS=0`, a panic
+/// deep inside tokio's `max_blocking_threads`.
+fn parse_env_usize(name: &str, raw: &str, min: usize) -> Result<usize, String> {
+    let value: usize = raw
+        .trim()
         .parse()
-        .unwrap()
-});
+        .map_err(|e| format!("environment variable {name} must be an integer, got {raw:?}: {e}"))?;
+    if value < min {
+        return Err(format!(
+            "environment variable {name} must be at least {min}, got {value}"
+        ));
+    }
+    Ok(value)
+}
+
+pub static IO_CORE_RESERVATION: LazyLock<usize> =
+    LazyLock::new(|| match std::env::var("LANCE_IO_CORE_RESERVATION") {
+        Ok(raw) => {
+            parse_env_usize("LANCE_IO_CORE_RESERVATION", &raw, 0).unwrap_or_else(|e| panic!("{e}"))
+        }
+        Err(_) => 2,
+    });
 
 fn create_runtime() -> Runtime {
     Builder::new_multi_thread()
@@ -167,4 +186,40 @@ pub fn spawn_cpu<
         let _ = send.send(result);
     });
     recv.map(|res| res.unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The env vars feed process-global `LazyLock`s that read once and are read
+    // in parallel by other tests, so the pure parser is tested directly rather
+    // than by mutating the environment.
+
+    #[test]
+    fn parses_valid_value_and_trims_surrounding_whitespace() {
+        assert_eq!(parse_env_usize("VAR", "8", 1).unwrap(), 8);
+        assert_eq!(parse_env_usize("VAR", " 8 ", 1).unwrap(), 8);
+    }
+
+    #[test]
+    fn rejects_non_integer_naming_the_variable() {
+        let err = parse_env_usize("LANCE_CPU_THREADS", "abc", 1).unwrap_err();
+        assert!(err.contains("LANCE_CPU_THREADS"), "{err}");
+        assert!(err.contains("must be an integer"), "{err}");
+    }
+
+    #[test]
+    fn rejects_value_below_minimum() {
+        // LANCE_CPU_THREADS=0 parses fine but would panic in tokio's
+        // max_blocking_threads(0); the minimum stops it at the boundary.
+        let err = parse_env_usize("LANCE_CPU_THREADS", "0", 1).unwrap_err();
+        assert!(err.contains("at least 1"), "{err}");
+    }
+
+    #[test]
+    fn allows_zero_when_minimum_is_zero() {
+        // LANCE_IO_CORE_RESERVATION=0 is valid: no cores reserved for IO.
+        assert_eq!(parse_env_usize("VAR", "0", 0).unwrap(), 0);
+    }
 }

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -60,6 +60,13 @@ fn parse_env_usize(name: &str, raw: &str, min: usize) -> Result<usize, String> {
     Ok(value)
 }
 
+/// Number of CPU cores held back for I/O and control tasks.
+///
+/// Overridable via the `LANCE_IO_CORE_RESERVATION` environment variable;
+/// defaults to `2` when unset. `0` is allowed (reserve nothing);
+/// [`get_num_compute_intensive_cpus`] subtracts this from the core count to
+/// size the compute pool. A non-integer value panics on first access with an
+/// error naming the variable.
 pub static IO_CORE_RESERVATION: LazyLock<usize> =
     LazyLock::new(|| match std::env::var("LANCE_IO_CORE_RESERVATION") {
         Ok(raw) => {


### PR DESCRIPTION
## Summary

`LANCE_CPU_THREADS` and `LANCE_IO_CORE_RESERVATION` were parsed with `.parse().unwrap()`. Two problems followed from a misconfigured value:

1. A non-integer value panicked inside the `LazyLock` initializer with a bare `ParseIntError` that named neither the variable nor the cause. A stray quote or trailing space (common in `.env` files, Docker, and k8s manifests) was enough to trigger it, and the process stayed panicked because the poisoned `LazyLock` re-panics on every subsequent access.
2. `LANCE_CPU_THREADS=0` parsed fine, then flowed into `create_runtime`'s `max_blocking_threads(0)`, which asserts inside tokio (`Max blocking threads cannot be set to 0`) on the first compute task. The panic surfaced deep in tokio, far from the actual misconfiguration, with no hint that the CPU-threads variable was at fault.

Both variables are documented as user-tunable in the performance guide, so a hand-set bad value is a realistic, reachable failure — not a corrupt-input edge case.

## Change

Route both through a small pure helper, `parse_env_usize(name, raw, min)`, which trims surrounding whitespace, names the offending variable in the error, and rejects values below a per-variable minimum. `LANCE_CPU_THREADS` must be at least 1 (the floor tokio requires); `LANCE_IO_CORE_RESERVATION` keeps allowing 0, meaning reserve no cores for IO. Unset still defaults to 2. Bad values still fail fast — the contract is unchanged — but now with an actionable message instead of a bare `ParseIntError` or an unrelated tokio assertion.

The only inputs newly rejected are ones that never worked: `LANCE_CPU_THREADS=0` (previously a guaranteed tokio assertion) and values that already panicked as unparseable. Whitespace-padded values that used to panic now parse, so the change only widens the set of accepted configurations aside from those two.

## Test plan

The variables feed process-global `LazyLock`s that read once and are read in parallel by other tests, so the environment cannot be mutated reliably from a test. The pure parser is unit-tested directly instead:

- `parses_valid_value_and_trims_surrounding_whitespace`
- `rejects_non_integer_naming_the_variable`
- `rejects_value_below_minimum` (the `LANCE_CPU_THREADS=0` case)
- `allows_zero_when_minimum_is_zero` (the `LANCE_IO_CORE_RESERVATION=0` case)

`cargo fmt --all` and `cargo clippy -p lance-core --tests -- -D warnings` are clean.
