### PR TITLE
fix(exec): preserve order when coalescing a sorted multi-partition plan

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -26,12 +26,14 @@ use datafusion::{
         runtime_env::RuntimeEnvBuilder,
     },
     physical_plan::{
-        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+        DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+        SendableRecordBatchStream,
         analyze::AnalyzeExec,
         coalesce_partitions::CoalescePartitionsExec,
         display::DisplayableExecutionPlan,
         execution_plan::{Boundedness, CardinalityEffect, EmissionType},
         metrics::MetricValue,
+        sorts::sort_preserving_merge::SortPreservingMergeExec,
         stream::RecordBatchStreamAdapter,
         streaming::PartitionStream,
     },
@@ -612,8 +614,17 @@ pub fn execute_plan(
     // Coalesce to a single partition if the optimizer left more than one.
     // EnforceDistribution may remove RepartitionExec(1) nodes when the parent
     // declares UnspecifiedDistribution, leaving multi-partition plans here.
+    //
+    // If the plan carries an output ordering (e.g. a top-k `SortExec` whose
+    // result was later repartitioned to parallelize downstream operators),
+    // a plain `CoalescePartitionsExec` would scramble that order because it
+    // merges partitions in scheduling-dependent order. Use an order-preserving
+    // merge in that case instead, mirroring what `EnforceDistribution` itself
+    // does when it needs to merge an ordered, multi-partition plan.
     let plan: Arc<dyn ExecutionPlan> = if plan.properties().partitioning.partition_count() == 1 {
         plan
+    } else if let Some(ordering) = plan.output_ordering() {
+        Arc::new(SortPreservingMergeExec::new(ordering.clone(), plan))
     } else {
         Arc::new(CoalescePartitionsExec::new(plan))
     };

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -7084,6 +7084,57 @@ mod test {
         assert_eq!(expected_i, actual_i);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_flat_knn_large_limit_preserves_global_order() {
+        // Regression test for https://github.com/lance-format/lance/issues/7865.
+        //
+        // An exact (flat, no vector index) KNN search with a limit larger than one
+        // output batch (BATCH_SIZE_FALLBACK = 8192 rows) used to be able to return
+        // results in the wrong global order: `execute_plan` coalesced the
+        // partitions the physical optimizer parallelizes above the top-k `SortExec`
+        // with a plain `CoalescePartitionsExec`, which does not preserve order.
+        // This only reproduces at real (> 1) parallelism, which is why the
+        // plan-shape tests elsewhere (pinned to `target_parallelism(1)`) never
+        // caught it.
+        let dim = 16u32;
+        let frag_count = 4u32;
+        let rows_per_fragment = 5_000u32;
+        let k = 12_000usize; // > BATCH_SIZE_FALLBACK, so results span multiple batches
+
+        let dataset = gen_batch()
+            .col("vec", array::rand_vec::<Float32Type>(Dimension::from(dim)))
+            .into_ram_dataset(
+                FragmentCount::from(frag_count),
+                FragmentRowCount::from(rows_per_fragment),
+            )
+            .await
+            .unwrap();
+
+        let query = Float32Array::from(vec![0.0_f32; dim as usize]);
+
+        // The bug is a scheduling race between parallel partitions, so run
+        // several iterations to reliably catch it if the ordering guarantee
+        // regresses.
+        for _ in 0..10 {
+            let mut scan = dataset.scan();
+            scan.nearest("vec", &query, k).unwrap();
+            scan.target_parallelism(8);
+
+            let batch = scan.try_into_batch().await.unwrap();
+            assert_eq!(batch.num_rows(), k);
+
+            let distances = batch[DIST_COL].as_primitive::<Float32Type>();
+            for pair in distances.values().windows(2) {
+                assert!(
+                    pair[0] <= pair[1],
+                    "flat KNN results must be globally sorted by distance, found {} before {}",
+                    pair[0],
+                    pair[1]
+                );
+            }
+        }
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_refine_factor(


### PR DESCRIPTION
## Summary

An exact (flat, no vector index) KNN search with a `limit` larger than one output batch (~8192 rows) could return results in the wrong global order.

`EnforceDistribution` may repartition a sorted, single-partition plan (e.g. the top-k `SortExec` built by `flat_knn`) to parallelize downstream operators that don't care about partitioning, such as the always-present `_distance IS NOT NULL` filter. `execute_plan` then reassembled the partitions with a plain `CoalescePartitionsExec`, which merges in scheduling-dependent order — scrambling the otherwise-correct global ordering. This only manifests at real (`> 1`) parallelism, which is why the existing plan-shape tests (pinned to `target_parallelism(1)`) never caught it.

The fix makes `execute_plan`'s final coalesce order-preserving: when the plan carries an output ordering, use `SortPreservingMergeExec` instead of `CoalescePartitionsExec`, mirroring what `EnforceDistribution` itself does when it needs to merge an ordered, multi-partition plan elsewhere in the tree.

## Test plan

- Added `test_flat_knn_large_limit_preserves_global_order` in `rust/lance/src/dataset/scanner.rs`: a flat KNN query with `limit` (12,000) spanning multiple output batches at real parallelism (`target_parallelism(8)`, `#[tokio::test(flavor = "multi_thread")]`), asserting the returned `_distance` column is globally non-decreasing across 10 iterations.
  - Confirmed this test reliably fails on `upstream/main` (reproduces the reported misordering) and passes reliably with the fix.
- `cargo test -p lance-datafusion`, `cargo test -p lance --lib dataset::scanner::`, `io::exec::`, and `dataset::mem_wal::` all pass.
- `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` pass.

Fixes #7865