### PR TITLE
fix(mem_wal): harden shard open and fail reads on a poisoned writer

### DIFF
--- a/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
@@ -10,7 +10,9 @@
 //!    index maintained, opens `mem_wal_writer` with a `ShardWriterConfig`
 //!    sized to hold the largest checkpoint without flushing, and times
 //!    `writer.put(batch)` calls. Index updates therefore go through the
-//!    parallel `IndexStore::insert_batches_parallel` path. At each
+//!    `IndexStore::insert_batches` path, which indexes inline at or below
+//!    `PARALLEL_INDEX_MIN_ROWS` rows and spawns a thread per index above it —
+//!    so the checkpoint sizes here straddle that crossover. At each
 //!    checkpoint, queries are issued against `active_memtable_ref()` via
 //!    `MemTableScanner::nearest`.
 //!

--- a/rust/lance/src/dataset/mem_wal/hnsw/graph.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/graph.rs
@@ -594,9 +594,12 @@ impl HnswGraph {
     }
 
     fn validate_source(&self, vectors: &impl VectorSource, needed_len: usize) -> Result<()> {
+        // Not caller input: the graph was sized below what the memtable holds.
+        // See the matching note in `storage.rs::append_batch`.
         if needed_len > self.nodes.len() {
-            return Err(Error::invalid_input(format!(
-                "graph capacity {} exhausted: need {needed_len}",
+            return Err(Error::internal(format!(
+                "HNSW graph capacity {} exhausted: need {needed_len}; \
+                 the graph is sized below the memtable's row capacity",
                 self.nodes.len()
             )));
         }

--- a/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
@@ -269,11 +269,8 @@ impl ArrowFixedSizeListVectorStore {
             )));
         };
 
-        // Exhaustion is not a caller-input problem — the batch is well-formed and
-        // has already passed the memtable's schema gate. It means the HNSW store
-        // was sized below what the memtable will hold before it flushes, which is
-        // a shard-construction bug. `invalid_input` mislabelled it as the writer's
-        // fault and hid that.
+        // Exhaustion is a shard-construction bug (store sized below the memtable),
+        // not caller input — hence `internal`, not `invalid_input`.
         let start = self.committed_len.load(Ordering::Relaxed);
         let end = start.checked_add(num_rows).ok_or_else(|| {
             Error::internal(format!(
@@ -292,9 +289,10 @@ impl ArrowFixedSizeListVectorStore {
         let batch_idx = self.committed_batches.load(Ordering::Relaxed);
         if batch_idx >= self.max_batches {
             return Err(Error::internal(format!(
-                "HNSW vector store max_batches {} exhausted; \
-                 the store is sized below the memtable's batch capacity",
-                self.max_batches
+                "HNSW vector store max_batches {} exhausted at batch_idx {} \
+                 (inserting rows [{}..{})); the store is sized below the \
+                 memtable's batch capacity",
+                self.max_batches, batch_idx, start, end
             )));
         }
 

--- a/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
@@ -269,24 +269,31 @@ impl ArrowFixedSizeListVectorStore {
             )));
         };
 
+        // Exhaustion is not a caller-input problem — the batch is well-formed and
+        // has already passed the memtable's schema gate. It means the HNSW store
+        // was sized below what the memtable will hold before it flushes, which is
+        // a shard-construction bug. `invalid_input` mislabelled it as the writer's
+        // fault and hid that.
         let start = self.committed_len.load(Ordering::Relaxed);
         let end = start.checked_add(num_rows).ok_or_else(|| {
-            Error::invalid_input(format!(
+            Error::internal(format!(
                 "vector count overflow: start={}, batch_len={}",
                 start, num_rows
             ))
         })?;
         if end > self.capacity {
-            return Err(Error::invalid_input(format!(
-                "capacity {} exhausted: inserting rows [{}..{})",
+            return Err(Error::internal(format!(
+                "HNSW vector store capacity {} exhausted: inserting rows [{}..{}); \
+                 the store is sized below the memtable's row capacity",
                 self.capacity, start, end
             )));
         }
 
         let batch_idx = self.committed_batches.load(Ordering::Relaxed);
         if batch_idx >= self.max_batches {
-            return Err(Error::invalid_input(format!(
-                "max_batches {} exhausted",
+            return Err(Error::internal(format!(
+                "HNSW vector store max_batches {} exhausted; \
+                 the store is sized below the memtable's batch capacity",
                 self.max_batches
             )));
         }

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -881,7 +881,7 @@ impl IndexStore {
 
     /// Insert multiple batches into every index.
     ///
-    /// Above [`PARALLEL_INDEX_MIN_ROWS`] rows each index runs on its own thread, which
+    /// Above `PARALLEL_INDEX_MIN_ROWS` rows each index runs on its own thread, which
     /// maximizes parallelism when several indexes are maintained. At or below it they run
     /// inline on the calling thread: the spawn is one OS thread *per index*, and for a
     /// handful of rows that costs more than the indexing itself.

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -58,6 +58,19 @@ use pk_key::encode_pk_batch;
 /// [`BTreeMemIndex`]'s byte backend indexes it directly.
 const PK_KEY_COLUMN: &str = "__pk_key__";
 
+/// Row count at or below which [`IndexStore::insert_batches`] indexes inline
+/// rather than spawning a thread per index.
+///
+/// The spawn is one OS thread *per index* — tens of microseconds each, and a table can
+/// carry several BTrees alongside its HNSW and FTS — so for a small batch it costs more
+/// than the indexing it parallelizes. Small batches are not the exceptional case: a
+/// durable put triggers a WAL flush covering only the batch it just inserted, so this
+/// path is routinely called with a single short batch.
+///
+/// The crossover depends on per-row HNSW cost, which varies with dimension and
+/// `ef_construction`; tune against `benches/mem_wal/vector/mem_wal_index_micro.rs`.
+const PARALLEL_INDEX_MIN_ROWS: usize = 64;
+
 /// The memtable's primary-key index, used to answer "newest visible version of
 /// this key" for dedup. Single-column PKs reuse the column's compact typed
 /// [`BTreeMemIndex`] (no second copy); composite PKs key a `BTreeMemIndex` on
@@ -728,43 +741,136 @@ impl IndexStore {
         }
     }
 
-    /// Insert multiple batches into all indexes with cross-batch optimization.
+    /// Insert multiple batches into every index.
+    ///
+    /// Above [`PARALLEL_INDEX_MIN_ROWS`] rows each index runs on its own thread, which
+    /// maximizes parallelism when several indexes are maintained. At or below it they run
+    /// inline on the calling thread: the spawn is one OS thread *per index*, and for a
+    /// handful of rows that costs more than the indexing itself.
+    ///
+    /// Returns a map of index names to their update durations for performance tracking.
     #[instrument(name = "idx_insert_batches", level = "debug", skip_all, fields(batch_count = batches.len()))]
-    pub fn insert_batches(&self, batches: &[StoredBatch]) -> Result<()> {
+    pub fn insert_batches(
+        &self,
+        batches: &[StoredBatch],
+    ) -> Result<std::collections::HashMap<String, std::time::Duration>> {
+        use std::time::Instant;
+
         if batches.is_empty() {
-            return Ok(());
+            return Ok(std::collections::HashMap::new());
         }
 
         let track_pk_overrides = self.should_track_pk_overrides();
-        // BTree indexes: iterate batches (no cross-batch optimization benefit)
-        for index in self.btree_indexes.values() {
+
+        // One task per index, boxed so the inline and the threaded path drive the very
+        // same closures. Each reports whether it saw an already-present PK.
+        type IndexTask<'a> = Box<dyn Fn() -> Result<bool> + Send + Sync + 'a>;
+        let mut tasks: Vec<(&str, IndexTask<'_>)> = Vec::new();
+
+        for (name, index) in &self.btree_indexes {
             let track_this_index = track_pk_overrides && self.is_single_pk_btree(index);
-            let mut had_existing = false;
-            for stored in batches {
-                if track_this_index {
-                    had_existing |=
-                        index.insert_and_report_existing(&stored.data, stored.row_offset)?;
-                } else {
-                    index.insert(&stored.data, stored.row_offset)?;
-                }
+            tasks.push((
+                name.as_str(),
+                Box::new(move || {
+                    let mut had_existing = false;
+                    for stored in batches {
+                        if track_this_index {
+                            had_existing |= index
+                                .insert_and_report_existing(&stored.data, stored.row_offset)?;
+                        } else {
+                            index.insert(&stored.data, stored.row_offset)?;
+                        }
+                    }
+                    Ok(had_existing)
+                }),
+            ));
+        }
+
+        for (name, index) in &self.hnsw_indexes {
+            tasks.push((
+                name.as_str(),
+                Box::new(move || index.insert_batches(batches).map(|_| false)),
+            ));
+        }
+
+        for (name, index) in &self.fts_indexes {
+            tasks.push((
+                name.as_str(),
+                Box::new(move || {
+                    for stored in batches {
+                        index.insert(&stored.data, stored.row_offset)?;
+                    }
+                    Ok(false)
+                }),
+            ));
+        }
+
+        // Keep the raw `Duration` so sub-millisecond timings (the steady state for BTree
+        // updates) survive instead of truncating to 0.
+        let total_rows: usize = batches.iter().map(|b| b.num_rows).sum();
+        let results: Vec<(&str, std::time::Duration, Result<bool>)> =
+            if tasks.len() < 2 || total_rows <= PARALLEL_INDEX_MIN_ROWS {
+                tasks
+                    .iter()
+                    .map(|(name, task)| {
+                        let start = Instant::now();
+                        let result = task();
+                        (*name, start.elapsed(), result)
+                    })
+                    .collect()
+            } else {
+                std::thread::scope(|scope| {
+                    let handles: Vec<_> = tasks
+                        .iter()
+                        .map(|(name, task)| {
+                            let handle = scope.spawn(move || {
+                                let start = Instant::now();
+                                let result = task();
+                                (start.elapsed(), result)
+                            });
+                            (*name, handle)
+                        })
+                        .collect();
+
+                    handles
+                        .into_iter()
+                        .map(|(name, handle)| match handle.join() {
+                            Ok((duration, result)) => (name, duration, result),
+                            Err(_) => (
+                                name,
+                                std::time::Duration::ZERO,
+                                Err(Error::internal(format!("Index '{}' thread panicked", name))),
+                            ),
+                        })
+                        .collect()
+                })
+            };
+
+        // Every task ran to completion whether or not a peer failed (the threaded path
+        // joins all handles unconditionally). Keep the first error; there is no rollback,
+        // so a failure here is terminal for the writer.
+        let mut first_error: Option<Error> = None;
+        let mut had_existing_pk = false;
+        let mut duration_map =
+            std::collections::HashMap::<String, std::time::Duration>::with_capacity(results.len());
+
+        for (name, duration, result) in results {
+            duration_map.insert(name.to_string(), duration);
+            match result {
+                Ok(had_existing) => had_existing_pk |= had_existing,
+                Err(e) if first_error.is_none() => first_error = Some(e),
+                Err(_) => {}
             }
-            self.mark_pk_overrides_if_needed(had_existing);
         }
 
-        // HNSW indexes: use batched insert
-        for index in self.hnsw_indexes.values() {
-            index.insert_batches(batches)?;
+        if let Some(e) = first_error {
+            return Err(e);
         }
+        self.mark_pk_overrides_if_needed(had_existing_pk);
 
-        // FTS indexes: iterate batches (potential future optimization)
-        for index in self.fts_indexes.values() {
-            for stored in batches {
-                index.insert(&stored.data, stored.row_offset)?;
-            }
-        }
-
-        // Single-column PK aliases a `btree_indexes` entry (maintained above);
-        // a composite PK has its own index, maintained here.
+        // Single-column PK aliases a `btree_indexes` entry — its task above already
+        // maintained it. A composite PK has its own index; maintain it here before the
+        // watermark advances so the visible prefix is fully indexed.
         let mut had_existing = false;
         for stored in batches {
             had_existing |=
@@ -776,142 +882,7 @@ impl IndexStore {
         let max_bp = batches.iter().map(|b| b.batch_position).max().unwrap();
         self.advance_max_visible_batch_position(max_bp);
 
-        Ok(())
-    }
-
-    /// Insert multiple batches into all indexes in parallel.
-    ///
-    /// Each individual index runs in its own thread, regardless of type.
-    /// This maximizes parallelism when multiple indexes are maintained.
-    ///
-    /// This is used during WAL flush to parallelize index updates with WAL I/O.
-    /// Insert batches into all indexes in parallel.
-    ///
-    /// Returns a map of index names to their update durations for performance tracking.
-    #[allow(clippy::print_stderr)]
-    #[instrument(name = "idx_insert_batches_parallel", level = "debug", skip_all, fields(batch_count = batches.len()))]
-    pub fn insert_batches_parallel(
-        &self,
-        batches: &[StoredBatch],
-    ) -> Result<std::collections::HashMap<String, std::time::Duration>> {
-        use std::time::Instant;
-
-        if batches.is_empty() {
-            return Ok(std::collections::HashMap::new());
-        }
-
-        let track_pk_overrides = self.should_track_pk_overrides();
-        // Use std::thread::scope for parallel CPU-bound work
-        std::thread::scope(|scope| {
-            // Each handle returns (index_name, index_type, duration, Result)
-            let mut handles: Vec<(
-                &str,
-                &str,
-                std::thread::ScopedJoinHandle<'_, (std::time::Duration, Result<bool>)>,
-            )> = Vec::new();
-
-            // Spawn a thread for each BTree index
-            for (name, index) in &self.btree_indexes {
-                let track_this_index = track_pk_overrides && self.is_single_pk_btree(index);
-                let handle = scope.spawn(move || -> (std::time::Duration, Result<bool>) {
-                    let start = Instant::now();
-                    let result = (|| {
-                        let mut had_existing = false;
-                        for stored in batches {
-                            if track_this_index {
-                                had_existing |= index
-                                    .insert_and_report_existing(&stored.data, stored.row_offset)?;
-                            } else {
-                                index.insert(&stored.data, stored.row_offset)?;
-                            }
-                        }
-                        Ok(had_existing)
-                    })();
-                    (start.elapsed(), result)
-                });
-                handles.push((name.as_str(), "btree", handle));
-            }
-
-            // Spawn a thread for each HNSW index
-            for (name, index) in &self.hnsw_indexes {
-                let handle = scope.spawn(move || -> (std::time::Duration, Result<bool>) {
-                    let start = Instant::now();
-                    let result = index.insert_batches(batches).map(|_| false);
-                    (start.elapsed(), result)
-                });
-                handles.push((name.as_str(), "hnsw", handle));
-            }
-
-            // Spawn a thread for each FTS index
-            for (name, index) in &self.fts_indexes {
-                let handle = scope.spawn(move || -> (std::time::Duration, Result<bool>) {
-                    let start = Instant::now();
-                    let result = (|| {
-                        for stored in batches {
-                            index.insert(&stored.data, stored.row_offset)?;
-                        }
-                        Ok(false)
-                    })();
-                    (start.elapsed(), result)
-                });
-                handles.push((name.as_str(), "fts", handle));
-            }
-
-            // Collect results, log timing, and check for errors. Keep the raw
-            // `Duration` so sub-millisecond timings (the steady-state case for
-            // BTree updates) are preserved instead of getting truncated to 0.
-            let mut first_error: Option<Error> = None;
-            let mut timings: Vec<(&str, &str, std::time::Duration)> = Vec::new();
-            let mut had_existing_pk = false;
-
-            for (name, idx_type, handle) in handles {
-                match handle.join() {
-                    Ok((duration, Ok(had_existing))) => {
-                        timings.push((name, idx_type, duration));
-                        had_existing_pk |= had_existing;
-                    }
-                    Ok((duration, Err(e))) => {
-                        timings.push((name, idx_type, duration));
-                        if first_error.is_none() {
-                            first_error = Some(e);
-                        }
-                    }
-                    Err(_) => {
-                        if first_error.is_none() {
-                            first_error =
-                                Some(Error::internal(format!("Index '{}' thread panicked", name)));
-                        }
-                    }
-                }
-            }
-
-            if let Some(e) = first_error {
-                return Err(e);
-            }
-            self.mark_pk_overrides_if_needed(had_existing_pk);
-
-            let duration_map: std::collections::HashMap<String, std::time::Duration> = timings
-                .into_iter()
-                .map(|(name, _idx_type, duration)| (name.to_string(), duration))
-                .collect();
-
-            // Single-column PK aliases a `btree_indexes` entry — its thread above
-            // already maintained it (and joined). A composite PK has its own
-            // index; maintain it here before the watermark advances so the
-            // visible prefix is fully indexed.
-            let mut had_existing = false;
-            for stored in batches {
-                had_existing |=
-                    self.insert_composite_pk(&stored.data, stored.row_offset, track_pk_overrides)?;
-            }
-            self.mark_pk_overrides_if_needed(had_existing);
-
-            // Update global watermark to the max batch position
-            let max_bp = batches.iter().map(|b| b.batch_position).max().unwrap();
-            self.advance_max_visible_batch_position(max_bp);
-
-            Ok(duration_map)
-        })
+        Ok(duration_map)
     }
 
     /// Get a BTree index by name.
@@ -1007,6 +978,7 @@ mod tests {
     use arrow_array::{Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use log::warn;
+    use rstest::rstest;
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -1046,6 +1018,21 @@ mod tests {
                     "goodbye world",
                     "hello again",
                 ])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn create_sized_batch(schema: &ArrowSchema, start_id: i32, num_rows: usize) -> RecordBatch {
+        let ids: Vec<i32> = (0..num_rows as i32).map(|i| start_id + i).collect();
+        let names: Vec<String> = ids.iter().map(|id| format!("name-{id}")).collect();
+        let descriptions: Vec<String> = ids.iter().map(|id| format!("hello world {id}")).collect();
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(descriptions)),
             ],
         )
         .unwrap()
@@ -1529,6 +1516,40 @@ mod tests {
         // Insert without batch position shouldn't change watermark
         registry.insert(&batch, 6).unwrap();
         assert_eq!(registry.max_visible_batch_position(), 10);
+    }
+
+    /// `insert_batches` picks the inline or the threaded path by row count, so
+    /// exercise both and assert they leave the same index state: every row indexed
+    /// exactly once, in every index, with a timing reported for each.
+    #[rstest]
+    #[case::inline(8)]
+    #[case::threaded(PARALLEL_INDEX_MIN_ROWS + 64)]
+    fn test_insert_batches_indexes_every_row_once(#[case] num_rows: usize) {
+        let schema = create_test_schema();
+        let mut registry = IndexStore::new();
+        registry.add_btree("id_idx".to_string(), 0, "id".to_string());
+        registry.add_fts("desc_idx".to_string(), 2, "description".to_string());
+
+        let batch = create_sized_batch(&schema, 0, num_rows);
+        let durations = registry
+            .insert_batches(&[StoredBatch::new(batch, 0, 2)])
+            .unwrap();
+
+        assert_eq!(durations.len(), 2, "expected one timing per index");
+        assert!(durations.contains_key("id_idx"));
+        assert!(durations.contains_key("desc_idx"));
+
+        let btree = registry.get_btree("id_idx").unwrap();
+        for id in 0..num_rows as i32 {
+            let positions = btree.get(&ScalarValue::Int32(Some(id)));
+            assert_eq!(
+                positions.len(),
+                1,
+                "id={id} should be indexed exactly once, got {positions:?}"
+            );
+        }
+        assert_eq!(registry.get_fts("desc_idx").unwrap().doc_count(), num_rows);
+        assert_eq!(registry.max_visible_batch_position(), 2);
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -23,6 +23,7 @@ mod pk_key;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
 
 use datafusion::common::ScalarValue;
 
@@ -892,8 +893,6 @@ impl IndexStore {
         &self,
         batches: &[StoredBatch],
     ) -> Result<std::collections::HashMap<String, std::time::Duration>> {
-        use std::time::Instant;
-
         if batches.is_empty() {
             return Ok(std::collections::HashMap::new());
         }

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -28,6 +28,7 @@ use datafusion::common::ScalarValue;
 
 use super::memtable::batch_store::StoredBatch;
 use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Schema as ArrowSchema};
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::{Error, Result};
 use lance_index::pbold;
@@ -92,6 +93,143 @@ enum PkIndex {
 // ============================================================================
 // Index Store
 // ============================================================================
+
+/// Validate every configured in-memory index, and the composite primary key,
+/// against the shard schema. Call once at shard open, before any write can land.
+///
+/// This is what makes poison-and-replay *terminating*. An index insert that
+/// fails deterministically on a row that is already WAL-durable cannot be
+/// recovered from: the writer poisons, the operator reopens, replay re-reads the
+/// same WAL rows, the same insert fails again, and `open()` propagates it — a
+/// shard that never comes back. Every such failure is an index *config*
+/// disagreeing with the schema, never a property of the data, so one pass here
+/// closes the whole class before a single row is accepted.
+///
+/// The data-dependent errors inside the index layer are already unreachable
+/// through `put`: `MemTable::insert_batches_only` does a full `Arc<Schema>`
+/// equality check, so a batch that would trip one is rejected before it reaches
+/// the batch store, let alone the WAL.
+pub fn validate_index_configs(
+    configs: &[MemIndexConfig],
+    schema: &ArrowSchema,
+    pk_columns: &[String],
+) -> Result<()> {
+    for config in configs {
+        let column = config.column();
+        let field = schema.field_with_name(column).map_err(|_| {
+            Error::invalid_input(format!(
+                "index '{}' is configured on column '{}', which is not in the shard schema; \
+                 available columns: [{}]",
+                config.name(),
+                column,
+                schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })?;
+
+        match config {
+            // BTree falls back to per-row `ScalarValue` extraction, so it
+            // accepts any column type the schema can hold. Existence is the
+            // only precondition.
+            MemIndexConfig::BTree(_) => {}
+            MemIndexConfig::Fts(_) => {
+                if !matches!(
+                    field.data_type(),
+                    DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+                ) {
+                    return Err(Error::invalid_input(format!(
+                        "FTS index '{}' requires a Utf8, LargeUtf8, or Utf8View column; \
+                         column '{}' is {:?}",
+                        config.name(),
+                        column,
+                        field.data_type()
+                    )));
+                }
+            }
+            MemIndexConfig::Hnsw(_) => match field.data_type() {
+                DataType::FixedSizeList(item, dim) => {
+                    if item.data_type() != &DataType::Float32 {
+                        return Err(Error::invalid_input(format!(
+                            "HNSW index '{}' requires a FixedSizeList<Float32> column; \
+                             column '{}' has item type {:?}",
+                            config.name(),
+                            column,
+                            item.data_type()
+                        )));
+                    }
+                    // `HnswMemIndex.dim` is a placeholder until the first batch
+                    // pins it (`hnsw.rs`), so a zero-width vector would only
+                    // surface at insert time — i.e. on already-durable data.
+                    if *dim <= 0 {
+                        return Err(Error::invalid_input(format!(
+                            "HNSW index '{}' requires a vector dimension > 0; column '{}' has \
+                             dimension {dim}",
+                            config.name(),
+                            column,
+                        )));
+                    }
+                }
+                other => {
+                    return Err(Error::invalid_input(format!(
+                        "HNSW index '{}' requires a FixedSizeList<Float32> column; \
+                         column '{}' is {:?}",
+                        config.name(),
+                        column,
+                        other
+                    )));
+                }
+            },
+        }
+    }
+
+    // A single-column PK aliases a BTree entry (any type). Only a *composite* PK
+    // builds an order-preserving encoded key, and only some types encode.
+    if pk_columns.len() > 1 {
+        for column in pk_columns {
+            let field = schema.field_with_name(column).map_err(|_| {
+                Error::invalid_input(format!(
+                    "primary-key column '{column}' is not in the shard schema"
+                ))
+            })?;
+            if !is_encodable_pk_type(field.data_type()) {
+                return Err(Error::invalid_input(format!(
+                    "composite primary-key column '{column}' has type {:?}, which has no \
+                     order-preserving key encoding",
+                    field.data_type()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Types `pk_key::encode_value` can encode into an order-preserving composite key.
+fn is_encodable_pk_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Boolean
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Binary
+            | DataType::LargeBinary
+            | DataType::FixedSizeBinary(_)
+    )
+}
 
 /// Configuration for an index in MemWAL.
 ///
@@ -1482,6 +1620,105 @@ mod tests {
         // Also test field_id lookup
         assert!(registry.get_btree_by_field_id(0).is_some());
         assert!(registry.get_fts_by_field_id(2).is_some());
+    }
+
+    fn vector_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("description", DataType::Utf8, true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+                true,
+            ),
+            Field::new(
+                "f64_vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 4),
+                true,
+            ),
+        ]))
+    }
+
+    /// Every index config that would fail *deterministically* on insert must be
+    /// rejected at open instead. Such a config also fails on WAL replay, so once
+    /// a row is durable the shard could never reopen — poison-and-replay would
+    /// not terminate.
+    #[rstest]
+    #[case::btree_ok(MemIndexConfig::BTree(BTreeIndexConfig {
+        name: "idx".into(), field_id: 0, column: "id".into(),
+    }), None)]
+    #[case::btree_missing_column(MemIndexConfig::BTree(BTreeIndexConfig {
+        name: "idx".into(), field_id: 9, column: "nope".into(),
+    }), Some("not in the shard schema"))]
+    #[case::fts_ok(MemIndexConfig::Fts(FtsIndexConfig::new(
+        "idx".into(), 1, "description".into(),
+    )), None)]
+    #[case::fts_non_utf8(MemIndexConfig::Fts(FtsIndexConfig::new(
+        "idx".into(), 0, "id".into(),
+    )), Some("requires a Utf8, LargeUtf8, or Utf8View column"))]
+    #[case::fts_missing_column(MemIndexConfig::Fts(FtsIndexConfig::new(
+        "idx".into(), 9, "nope".into(),
+    )), Some("not in the shard schema"))]
+    #[case::hnsw_ok(MemIndexConfig::Hnsw(Box::new(HnswIndexConfig::new(
+        "idx".into(), 2, "vector".into(), DistanceType::L2,
+    ))), None)]
+    #[case::hnsw_not_a_vector(MemIndexConfig::Hnsw(Box::new(HnswIndexConfig::new(
+        "idx".into(), 0, "id".into(), DistanceType::L2,
+    ))), Some("requires a FixedSizeList<Float32> column"))]
+    #[case::hnsw_wrong_item_type(MemIndexConfig::Hnsw(Box::new(HnswIndexConfig::new(
+        "idx".into(), 3, "f64_vector".into(), DistanceType::L2,
+    ))), Some("item type Float64"))]
+    #[case::hnsw_missing_column(MemIndexConfig::Hnsw(Box::new(HnswIndexConfig::new(
+        "idx".into(), 9, "nope".into(), DistanceType::L2,
+    ))), Some("not in the shard schema"))]
+    fn test_validate_index_configs(
+        #[case] config: MemIndexConfig,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let schema = vector_schema();
+        let result = validate_index_configs(&[config], &schema, &[]);
+        match expected_error {
+            None => result.expect("valid config must pass validation"),
+            Some(fragment) => {
+                let message = result
+                    .expect_err("invalid config must be rejected")
+                    .to_string();
+                assert!(
+                    message.contains(fragment),
+                    "error must explain the mismatch; wanted {fragment:?}, got {message:?}"
+                );
+            }
+        }
+    }
+
+    /// A composite PK builds an order-preserving encoded key, so its columns must
+    /// be encodable. A single-column PK aliases a BTree entry, which accepts any
+    /// type — so it must *not* be rejected here.
+    #[test]
+    fn test_validate_composite_pk_column_types() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new(
+                "coords",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 2),
+                true,
+            ),
+        ]));
+
+        validate_index_configs(&[], &schema, &["id".into(), "name".into()])
+            .expect("Int32 + Utf8 composite PK must be encodable");
+
+        let err = validate_index_configs(&[], &schema, &["id".into(), "coords".into()])
+            .expect_err("a FixedSizeList PK column has no order-preserving encoding");
+        assert!(
+            err.to_string().contains("order-preserving key encoding"),
+            "error must name the reason, got {err}"
+        );
+
+        // A single-column PK of the same type is fine: it aliases a BTree.
+        validate_index_configs(&[], &schema, &["coords".into()])
+            .expect("single-column PK aliases a BTree and accepts any type");
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -1142,13 +1142,20 @@ impl FtsMemIndex {
     fn insert_batch(&self, batch: &RecordBatch, row_offset: u64) -> Result<()> {
         let st = self.state.load_full();
 
+        // A missing column is a config error, not an empty document: silently
+        // appending an empty batch would leave the index empty forever while the
+        // shard reported healthy. BTree and HNSW both reject this; so do we.
+        // `validate_index_configs` catches it at open, so reaching here means a
+        // batch got past the memtable's schema-equality gate.
         let Some(col_idx) = batch
             .schema()
             .column_with_name(&self.column_name)
             .map(|(idx, _)| idx)
         else {
-            // A missing column has no searchable documents.
-            return Ok(());
+            return Err(Error::invalid_input(format!(
+                "FTS index column '{}' is not in the inserted batch schema",
+                self.column_name
+            )));
         };
 
         let column = batch.column(col_idx);

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -592,7 +592,7 @@ impl WalFlusher {
             let index_future = async {
                 let start = Instant::now();
                 let per_index = tokio::task::spawn_blocking(move || {
-                    idx_registry.insert_batches_parallel(&stored_batches)
+                    idx_registry.insert_batches(&stored_batches)
                 })
                 .await
                 .map_err(|e| Error::internal(format!("Index update task panicked: {}", e)))??;

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -2082,6 +2082,10 @@ impl ShardWriter {
 
     /// Get current MemTable statistics. Returns an error in WAL-only mode
     /// (no MemTable exists).
+    ///
+    /// Deliberately does *not* `check_poisoned`, unlike the read and write
+    /// paths: a poisoned writer is exactly when an operator most needs to see
+    /// its state, and the caller deciding whether to evict reads these stats.
     pub async fn memtable_stats(&self) -> Result<MemTableStats> {
         let state_lock = self.memtable_state_lock()?;
         let state = state_lock.read().await;
@@ -2110,8 +2114,9 @@ impl ShardWriter {
     /// The scanner captures the current `max_visible_batch_position` from the
     /// `IndexStore` at construction time to ensure consistent visibility.
     ///
-    /// Returns an error in WAL-only mode.
+    /// Returns an error in WAL-only mode, or if the writer is poisoned.
     pub async fn scan(&self) -> Result<MemTableScanner> {
+        self.wal_flusher.check_poisoned()?;
         let state_lock = self.memtable_state_lock()?;
         let state = state_lock.read().await;
         Ok(state.memtable.scan())
@@ -2121,10 +2126,11 @@ impl ShardWriter {
     /// Prefer [`Self::in_memory_memtable_refs`] on the read path — it also
     /// carries frozen-awaiting-flush generations.
     ///
-    /// Returns an error in WAL-only mode.
+    /// Returns an error in WAL-only mode, or if the writer is poisoned.
     pub async fn active_memtable_ref(
         &self,
     ) -> Result<crate::dataset::mem_wal::scanner::InMemoryMemTableRef> {
+        self.wal_flusher.check_poisoned()?;
         let state_lock = self.memtable_state_lock()?;
         let state = state_lock.read().await;
         Ok(in_memory_ref(&state.memtable))
@@ -2136,10 +2142,11 @@ impl ShardWriter {
     /// path uses this instead of [`Self::active_memtable_ref`] so a
     /// concurrent reader sees no hole while a flush drains.
     ///
-    /// Returns an error in WAL-only mode.
+    /// Returns an error in WAL-only mode, or if the writer is poisoned.
     pub async fn in_memory_memtable_refs(
         &self,
     ) -> Result<crate::dataset::mem_wal::scanner::InMemoryMemTables> {
+        self.wal_flusher.check_poisoned()?;
         let state_lock = self.memtable_state_lock()?;
         let state = state_lock.read().await;
         Ok(crate::dataset::mem_wal::scanner::InMemoryMemTables {
@@ -4918,8 +4925,9 @@ mod tests {
     }
 
     // A durable write whose WAL PUT keeps failing poisons the writer with a
-    // typed persistence failure; the next write fails fast with the same reason;
-    // and once storage heals, reopening replays the WAL and writes resume.
+    // typed persistence failure; the next write *and every read* fail fast with
+    // the same reason; and once storage heals, reopening replays the WAL and
+    // writes resume.
     #[tokio::test]
     async fn test_writer_poisons_on_persistence_failure_and_recovers_on_reopen() {
         let (store, base_path, controls) = failing_memory_store().await;
@@ -4958,6 +4966,31 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.fence_reason(), Some(FenceReason::PersistenceFailure));
+
+        // ...and rejects *reads* too. Batch 0 was committed to the BatchStore
+        // before its WAL PUT failed, so a poisoned writer that still served
+        // reads would hand out a row that is not durable and that replay will
+        // not reproduce — a divergent snapshot. Mirrors SlateDB's
+        // `check_closed()` at the top of every read.
+        for reason in [
+            writer.scan().await.err().and_then(|e| e.fence_reason()),
+            writer
+                .active_memtable_ref()
+                .await
+                .err()
+                .and_then(|e| e.fence_reason()),
+            writer
+                .in_memory_memtable_refs()
+                .await
+                .err()
+                .and_then(|e| e.fence_reason()),
+        ] {
+            assert_eq!(reason, Some(FenceReason::PersistenceFailure));
+        }
+
+        // Stats stay readable: this is what an operator (and the eviction path)
+        // inspects to decide what to do about the poisoned shard.
+        writer.memtable_stats().await.unwrap();
         drop(writer);
 
         // Storage heals: reopening replays the WAL and accepts writes again.

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -926,7 +926,7 @@ async fn replay_memtable_from_wal(
                     stored.push(s.clone());
                 }
             }
-            tokio::task::spawn_blocking(move || indexes.insert_batches_parallel(&stored))
+            tokio::task::spawn_blocking(move || indexes.insert_batches(&stored))
                 .await
                 .map_err(|e| {
                     Error::internal(format!("WAL replay index update task panicked: {}", e))

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -37,6 +37,7 @@ use uuid::Uuid;
 
 pub use super::index::{
     BTreeIndexConfig, BTreeMemIndex, FtsIndexConfig, HnswIndexConfig, IndexStore, MemIndexConfig,
+    validate_index_configs,
 };
 pub use super::memtable::CacheConfig;
 pub use super::memtable::MemTable;
@@ -1476,6 +1477,13 @@ impl ShardWriter {
         let pk_fields = lance_schema.unenforced_primary_key();
         let pk_field_ids: Vec<i32> = pk_fields.iter().map(|f| f.id).collect();
         let pk_columns: Vec<String> = pk_fields.iter().map(|f| f.name.clone()).collect();
+
+        // Reject an index config that disagrees with the schema *before* a
+        // single row is accepted. Such a config fails deterministically on every
+        // insert, including inserts replayed from the WAL — so once a row is
+        // durable the shard can never reopen. Fail the open instead.
+        validate_index_configs(index_configs, schema.as_ref(), &pk_columns)?;
+
         let mut memtable = MemTable::with_capacity(
             schema.clone(),
             manifest.current_generation,
@@ -5064,6 +5072,45 @@ mod tests {
         );
 
         writer_b.close().await.unwrap();
+    }
+
+    /// An index config that disagrees with the schema fails `open()` outright.
+    /// It must not be allowed to accept writes: the insert would fail
+    /// deterministically on every batch, including batches replayed from the
+    /// WAL, so once a row was durable the shard could never reopen. Before this
+    /// check, an FTS index on a non-Utf8 column silently indexed nothing and the
+    /// shard reported healthy.
+    #[tokio::test]
+    async fn test_open_rejects_index_config_that_disagrees_with_schema() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = schema_with_pk();
+        let shard_id = Uuid::new_v4();
+
+        // `id` is Int32, not a string column.
+        let bad_fts = MemIndexConfig::Fts(FtsIndexConfig::new(
+            "bad_fts".to_string(),
+            0,
+            "id".to_string(),
+        ));
+
+        let Err(err) = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            memtable_config_with_pk(shard_id),
+            schema,
+            vec![bad_fts],
+        )
+        .await
+        else {
+            panic!("open must reject an FTS index on a non-Utf8 column");
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("bad_fts") && message.contains("Utf8"),
+            "error must name the index and the constraint, got: {message}"
+        );
     }
 
     /// Replay is a no-op on a fresh shard: the MemTable starts empty.


### PR DESCRIPTION
## Stack: 1/3 — foundational hardening

This is the first of three stacked PRs that split the former #7791 (WAL poison / read-visibility / flush-interval) into reviewable pieces. It carries the changes that stand on their own, independent of the visibility redesign:

- **perf(mem_wal): index small batches inline instead of one thread per index** — stop spawning a thread per index for tiny batches; index inline.
- **fix(mem_wal): fail reads on a poisoned writer** — once a writer self-fences, reads must surface the failure instead of returning a silently truncated view.
- **fix(mem_wal): reject index configs that disagree with the schema at shard open** — validate FTS/HNSW/BTree/PK column types and existence once at `open()`, before any row is accepted. A config that fails deterministically on every insert (including WAL replay) makes poison-and-replay non-terminating; reject it up front. Also errors (instead of silently indexing nothing) when an FTS column is missing from a batch, and relabels HNSW capacity-exhaustion as `internal` rather than `invalid_input`.

Reviewable independently of the two PRs stacked on top.

**Stack**
1. **this PR** — foundational hardening → `main`
2. hamersaw/lance#1 — read-visibility redesign → this branch
3. hamersaw/lance#2 — flush-interval ticker → PR 2's branch

Splits the former #7791 into three reviewable pieces; #7791 can be closed once this stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
