### PR TITLE
feat: prototype xabi cache backend ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-cache-abi"
+version = "11.0.0-beta.2"
+dependencies = [
+ "futures",
+ "xabi",
+ "xabi-assert",
+]
+
+[[package]]
+name = "lance-cache-xabi-fixture"
+version = "0.0.0"
+dependencies = [
+ "lance-cache-abi",
+ "xabi",
+]
+
+[[package]]
 name = "lance-core"
 version = "11.0.0-beta.2"
 dependencies = [
@@ -4589,6 +4606,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "lance-arrow",
+ "lance-cache-abi",
  "lance-derive",
  "libc",
  "libm",
@@ -5242,6 +5260,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -10207,6 +10235,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d74af326b336ce3d0bb4f90a181bedc1a79de6eeccf51983339b5395e8aca"
+dependencies = [
+ "libloading",
+ "xabi-macros",
+]
+
+[[package]]
+name = "xabi-assert"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd399017ed5d647c7ed3612b0bc0b47eb5a5b7be315c89c2c4af462cdfd606e"
+dependencies = [
+ "xabi",
+]
+
+[[package]]
+name = "xabi-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9ded715a3002053fea77d239272e8bc8bbafd89dbdc8e0f1c8c21c2b3fc239"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = [
     "rust/examples",
     "rust/lance",
     "rust/lance-arrow",
+    "rust/lance-cache-abi",
+    "rust/lance-cache-abi/tests/fixtures/xabi-cache-plugin",
     "rust/lance-core",
     "rust/lance-datagen",
     "rust/lance-encoding",
@@ -60,6 +62,7 @@ arc-swap = "1.7"
 libc = "0.2.176"
 lance = { version = "=11.0.0-beta.2", path = "./rust/lance", default-features = false }
 lance-arrow = { version = "=11.0.0-beta.2", path = "./rust/lance-arrow" }
+lance-cache-abi = { version = "=11.0.0-beta.2", path = "./rust/lance-cache-abi" }
 lance-core = { version = "=11.0.0-beta.2", path = "./rust/lance-core" }
 lance-datafusion = { version = "=11.0.0-beta.2", path = "./rust/lance-datafusion" }
 lance-datagen = { version = "=11.0.0-beta.2", path = "./rust/lance-datagen" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -416,13 +416,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1014,9 +1014,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.2"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1175,7 +1175,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3806,6 +3806,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-cache-abi"
+version = "11.0.0-beta.2"
+dependencies = [
+ "xabi",
+]
+
+[[package]]
 name = "lance-core"
 version = "11.0.0-beta.2"
 dependencies = [
@@ -3822,6 +3829,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "lance-arrow",
+ "lance-cache-abi",
  "lance-derive",
  "libc",
  "libm",
@@ -4360,6 +4368,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -6501,9 +6519,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6511,22 +6529,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6542,9 +6560,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -6966,9 +6984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7490,11 +7508,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -8278,6 +8296,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d74af326b336ce3d0bb4f90a181bedc1a79de6eeccf51983339b5395e8aca"
+dependencies = [
+ "libloading",
+ "xabi-macros",
+]
+
+[[package]]
+name = "xabi-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9ded715a3002053fea77d239272e8bc8bbafd89dbdc8e0f1c8c21c2b3fc239"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -450,13 +450,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1131,9 +1131,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.2"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1295,7 +1295,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ dependencies = [
  "datafusion-proto-common",
  "datafusion-session",
  "futures",
- "libloading",
+ "libloading 0.9.0",
  "log",
  "prost",
  "semver",
@@ -3834,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "jieba-rs"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5bdea4dc241d589e179f39d2a778f31490f3370aa2f626223dbd930ebc5c9d"
+checksum = "a813bbf185c8c62eb6fcf54a223177b644824d91612045dfd80bb779acd080eb"
 dependencies = [
  "bytecount",
  "cedarwood",
@@ -4133,6 +4133,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-cache-abi"
+version = "11.0.0-beta.2"
+dependencies = [
+ "xabi",
+]
+
+[[package]]
 name = "lance-core"
 version = "11.0.0-beta.2"
 dependencies = [
@@ -4149,6 +4156,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "lance-arrow",
+ "lance-cache-abi",
  "lance-derive",
  "libc",
  "libm",
@@ -4654,6 +4662,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
 
 [[package]]
 name = "libloading"
@@ -7199,9 +7217,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7209,22 +7227,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7240,9 +7258,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -7744,9 +7762,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8296,11 +8314,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -9024,6 +9042,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d74af326b336ce3d0bb4f90a181bedc1a79de6eeccf51983339b5395e8aca"
+dependencies = [
+ "libloading 0.8.9",
+ "xabi-macros",
+]
+
+[[package]]
+name = "xabi-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9ded715a3002053fea77d239272e8bc8bbafd89dbdc8e0f1c8c21c2b3fc239"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/rust/lance-cache-abi/Cargo.toml
+++ b/rust/lance-cache-abi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "lance-cache-abi"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+description = "Dynamic cache backend ABI for Lance"
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+xabi = "=0.1.0"
+
+[dev-dependencies]
+futures.workspace = true
+xabi-assert = "=0.1.0"
+
+[lints]
+workspace = true

--- a/rust/lance-cache-abi/src/lib.rs
+++ b/rust/lance-cache-abi/src/lib.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Experimental xabi-backed contract for dynamically loaded Lance cache
+//! backends.
+//!
+//! This crate intentionally prototypes the cache backend ABI as a Rust async
+//! trait and lets xabi generate the C-compatible vtable, future polling, typed
+//! error transport, panic guards, and module lifetime checks.
+
+pub mod xabi_contract;
+
+pub use xabi_contract::*;

--- a/rust/lance-cache-abi/src/xabi_contract.rs
+++ b/rust/lance-cache-abi/src/xabi_contract.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Experimental xabi contract for dynamically loaded Lance cache backends.
+//!
+//! This prototype keeps the host-side cache policy out of the low-level ABI:
+//! Lance remains responsible for typed cache entries, `codec == None` fallback,
+//! singleflight, metrics, registration, and lifecycle policy. Dynamic backends
+//! only receive an async Rust-shaped contract for serialized cache bytes.
+
+use std::path::Path;
+
+/// Stable xabi contract identifier for Lance cache backends.
+pub const DYNAMIC_CACHE_BACKEND_TRAIT_ID: &str = "org.lance.cache.DynamicCacheBackend";
+
+/// Prototype contract version.
+///
+/// Keep this at `0` while the key model and backend lifecycle are still being
+/// validated. The generated xabi type names use an `XabiV1` prefix for xabi's
+/// own wire-generation format; that is separate from this Lance contract
+/// version.
+pub const DYNAMIC_CACHE_BACKEND_CONTRACT_VERSION: u32 = 0;
+
+/// A cache key represented as Lance's canonical opaque 16-byte value.
+///
+/// The byte representation is the contract. Dynamic backends should persist
+/// and compare these bytes directly instead of interpreting them as host-native
+/// integers or reconstructing logical key components.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct CacheKey128 {
+    bytes: CacheKey128Wire,
+}
+
+/// Wire representation of a cache key across the xabi boundary.
+pub type CacheKey128Wire = [u8; 16];
+
+impl CacheKey128 {
+    /// Build a key from its canonical bytes.
+    pub const fn from_bytes(bytes: CacheKey128Wire) -> Self {
+        Self { bytes }
+    }
+
+    /// Borrow the canonical bytes.
+    pub const fn as_bytes(&self) -> &CacheKey128Wire {
+        &self.bytes
+    }
+
+    /// Consume the key and return its canonical bytes.
+    pub const fn into_bytes(self) -> CacheKey128Wire {
+        self.bytes
+    }
+}
+
+impl xabi::XabiType for CacheKey128 {
+    type Wire = CacheKey128Wire;
+    const WIRE_TYPE_NAME: &'static str = "CacheKey128Wire";
+
+    fn into_wire(self) -> Self::Wire {
+        self.bytes
+    }
+
+    unsafe fn from_wire(wire: *const Self::Wire) -> xabi::Result<Self> {
+        let bytes = unsafe {
+            wire.as_ref()
+                .copied()
+                .ok_or(xabi::Error::NullPointer("CacheKey128Wire pointer"))?
+        };
+        Ok(Self::from_bytes(bytes))
+    }
+
+    fn collect_xabi_layout(collector: &mut dyn xabi::XabiLayoutCollector) {
+        const FIELDS: &[xabi::XabiFieldLayout] =
+            &[xabi::XabiFieldLayout::new("bytes", 0, "[u8; 16]")];
+        collector.push(xabi::XabiLayoutItem::Type(xabi::XabiTypeLayout::new(
+            concat!(module_path!(), "::CacheKey128Wire"),
+            xabi::XabiLayoutStability::Fixed,
+            std::mem::size_of::<CacheKey128Wire>(),
+            std::mem::align_of::<CacheKey128Wire>(),
+            FIELDS,
+        )));
+    }
+}
+
+/// Serialized cache entry bytes returned by a dynamic backend.
+#[xabi::data]
+#[derive(Debug, Eq, PartialEq)]
+pub struct CacheLookup {
+    /// Serialized payload bytes.
+    pub bytes: Vec<u8>,
+    /// Host-side cache weight originally associated with this entry.
+    pub size_bytes: usize,
+}
+
+/// Approximate backend size metrics.
+#[xabi::data]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CacheMeasure {
+    /// Approximate number of stored entries.
+    pub entries: usize,
+    /// Approximate weighted size in bytes.
+    pub size_bytes: usize,
+}
+
+/// Typed error payload returned by cache backend implementations.
+#[xabi::data]
+#[derive(Debug, Eq, PartialEq)]
+pub struct CacheAbiError {
+    /// Human-readable error message.
+    pub message: String,
+}
+
+impl From<xabi::Error> for CacheAbiError {
+    fn from(value: xabi::Error) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<xabi::XabiCallError<Self>> for CacheAbiError {
+    fn from(value: xabi::XabiCallError<Self>) -> Self {
+        match value {
+            xabi::XabiCallError::Runtime(err) => Self::from(err),
+            xabi::XabiCallError::Export(err) => err,
+        }
+    }
+}
+
+impl std::fmt::Display for CacheAbiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CacheAbiError {}
+
+/// Async cache backend contract generated through xabi.
+///
+/// This deliberately omits `invalidate_prefix`; prefix lifecycle remains a host
+/// adapter concern while the cache key contract settles on opaque bytes.
+#[xabi::xabi(
+    id = DYNAMIC_CACHE_BACKEND_TRAIT_ID,
+    version = DYNAMIC_CACHE_BACKEND_CONTRACT_VERSION
+)]
+pub trait DynamicCacheBackend {
+    /// Human-readable backend implementation name.
+    fn name(&self) -> String;
+
+    /// Look up serialized bytes by key.
+    async fn get(
+        &self,
+        key: CacheKey128,
+    ) -> std::result::Result<Option<CacheLookup>, CacheAbiError>;
+
+    /// Insert serialized bytes by key.
+    async fn insert(
+        &self,
+        key: CacheKey128,
+        value: &[u8],
+        size_bytes: usize,
+    ) -> std::result::Result<(), CacheAbiError>;
+
+    /// Clear all entries owned by this backend instance.
+    async fn clear(&self) -> std::result::Result<(), CacheAbiError>;
+
+    /// Return approximate backend size metrics.
+    async fn measure(&self) -> std::result::Result<CacheMeasure, CacheAbiError>;
+}
+
+/// Host-side handle for a dynamically loaded cache backend.
+pub type DynamicCacheBackendHandle = XabiV1HandleTraitDynamicCacheBackend;
+
+/// Owned in-process backend handle, useful for tests and host-side adapters.
+pub type OwnedDynamicCacheBackend = XabiV1OwnedTraitDynamicCacheBackend;
+
+/// Borrowed in-process backend handle.
+pub type BorrowedDynamicCacheBackend = XabiV1BorrowedTraitDynamicCacheBackend;
+
+/// Generated xabi contract descriptor.
+pub type DynamicCacheBackendAbi = XabiV1AbiTraitDynamicCacheBackend;
+
+/// Load the first matching cache backend export from a trusted dynamic library.
+///
+/// # Safety
+///
+/// Loading native code is unsafe. The caller must trust the library at `path`
+/// and ensure the loaded module follows the xabi and Lance cache contracts.
+pub unsafe fn load_backend(path: impl AsRef<Path>) -> xabi::Result<DynamicCacheBackendHandle> {
+    let module = unsafe { xabi::load(path) }?;
+    DynamicCacheBackendHandle::xabi_load(&module)
+}
+
+/// Load a named cache backend export from a trusted dynamic library.
+///
+/// # Safety
+///
+/// Loading native code is unsafe. The caller must trust the library at `path`
+/// and ensure the loaded module follows the xabi and Lance cache contracts.
+pub unsafe fn load_backend_named(
+    path: impl AsRef<Path>,
+    name: &str,
+) -> xabi::Result<DynamicCacheBackendHandle> {
+    let module = unsafe { xabi::load(path) }?;
+    DynamicCacheBackendHandle::xabi_load_named(&module, name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct InMemoryBackend {
+        entries: Mutex<HashMap<CacheKey128, (Vec<u8>, usize)>>,
+    }
+
+    impl DynamicCacheBackend for InMemoryBackend {
+        fn name(&self) -> String {
+            "in-memory-test".to_string()
+        }
+
+        async fn get(
+            &self,
+            key: CacheKey128,
+        ) -> std::result::Result<Option<CacheLookup>, CacheAbiError> {
+            let entries = self.entries.lock().map_err(|err| {
+                CacheAbiError::new(format!("cache backend mutex poisoned: {err}"))
+            })?;
+            Ok(entries
+                .get(&key)
+                .map(|(bytes, size_bytes)| CacheLookup::new(bytes.clone(), *size_bytes)))
+        }
+
+        async fn insert(
+            &self,
+            key: CacheKey128,
+            value: &[u8],
+            size_bytes: usize,
+        ) -> std::result::Result<(), CacheAbiError> {
+            let mut entries = self.entries.lock().map_err(|err| {
+                CacheAbiError::new(format!("cache backend mutex poisoned: {err}"))
+            })?;
+            entries.insert(key, (value.to_vec(), size_bytes));
+            Ok(())
+        }
+
+        async fn clear(&self) -> std::result::Result<(), CacheAbiError> {
+            let mut entries = self.entries.lock().map_err(|err| {
+                CacheAbiError::new(format!("cache backend mutex poisoned: {err}"))
+            })?;
+            entries.clear();
+            Ok(())
+        }
+
+        async fn measure(&self) -> std::result::Result<CacheMeasure, CacheAbiError> {
+            let entries = self.entries.lock().map_err(|err| {
+                CacheAbiError::new(format!("cache backend mutex poisoned: {err}"))
+            })?;
+            Ok(CacheMeasure::new(
+                entries.len(),
+                entries.values().map(|(_, size_bytes)| *size_bytes).sum(),
+            ))
+        }
+    }
+
+    #[test]
+    fn key128_round_trips_canonical_bytes() {
+        let bytes = [
+            0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x09, 0x87, 0x65,
+            0x43, 0x21,
+        ];
+        let key = CacheKey128::from_bytes(bytes);
+
+        assert_eq!(key.as_bytes(), &bytes);
+        assert_eq!(key.into_bytes(), bytes);
+    }
+
+    #[test]
+    fn owned_xabi_backend_round_trips_bytes() {
+        futures::executor::block_on(async {
+            let backend = OwnedDynamicCacheBackend::new(InMemoryBackend::default());
+            let backend = backend.xabi_borrow();
+            let key = CacheKey128::from_bytes([42; 16]);
+
+            backend
+                .insert(key, b"payload", 64)
+                .await
+                .expect("insert succeeds");
+
+            let hit = backend
+                .get(key)
+                .await
+                .expect("get succeeds")
+                .expect("entry is cached");
+            assert_eq!(hit.bytes, b"payload");
+            assert_eq!(hit.size_bytes, 64);
+
+            let measure = backend.measure().await.expect("measure succeeds");
+            assert_eq!(measure, CacheMeasure::new(1, 64));
+
+            backend.clear().await.expect("clear succeeds");
+            assert_eq!(backend.get(key).await.expect("get succeeds"), None);
+        });
+    }
+
+    #[test]
+    fn abi_layout_is_snapshotted() {
+        xabi_assert::assert_abi!(DynamicCacheBackendAbi);
+    }
+}

--- a/rust/lance-cache-abi/tests/fixtures/xabi-cache-plugin/Cargo.toml
+++ b/rust/lance-cache-abi/tests/fixtures/xabi-cache-plugin/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lance-cache-xabi-fixture"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+lance-cache-abi.workspace = true
+xabi = "=0.1.0"
+
+[lints]
+workspace = true

--- a/rust/lance-cache-abi/tests/fixtures/xabi-cache-plugin/src/lib.rs
+++ b/rust/lance-cache-abi/tests/fixtures/xabi-cache-plugin/src/lib.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use lance_cache_abi::{CacheAbiError, CacheKey128, CacheLookup, CacheMeasure, DynamicCacheBackend};
+
+type EntryMap = HashMap<CacheKey128, (Vec<u8>, usize)>;
+type EntryGuard<'a> = std::sync::MutexGuard<'a, EntryMap>;
+
+#[derive(Default)]
+struct MemoryBackend {
+    entries: Mutex<EntryMap>,
+}
+
+impl MemoryBackend {
+    fn lock_entries(&self) -> std::result::Result<EntryGuard<'_>, CacheAbiError> {
+        self.entries
+            .lock()
+            .map_err(|err| CacheAbiError::new(format!("cache backend mutex poisoned: {err}")))
+    }
+
+    fn reject_error_key(key: CacheKey128) -> std::result::Result<(), CacheAbiError> {
+        if key.as_bytes() == &[13; 16] {
+            return Err(CacheAbiError::new("fixture rejected key 13"));
+        }
+        Ok(())
+    }
+}
+
+#[xabi::module]
+mod exports {
+    use super::*;
+
+    #[xabi::xabi(name = "memory", version = 1)]
+    impl DynamicCacheBackend for MemoryBackend {
+        fn name(&self) -> String {
+            "memory-fixture".to_string()
+        }
+
+        async fn get(
+            &self,
+            key: CacheKey128,
+        ) -> std::result::Result<Option<CacheLookup>, CacheAbiError> {
+            Self::reject_error_key(key)?;
+            let entries = self.lock_entries()?;
+            Ok(entries
+                .get(&key)
+                .map(|(bytes, size_bytes)| CacheLookup::new(bytes.clone(), *size_bytes)))
+        }
+
+        async fn insert(
+            &self,
+            key: CacheKey128,
+            value: &[u8],
+            size_bytes: usize,
+        ) -> std::result::Result<(), CacheAbiError> {
+            Self::reject_error_key(key)?;
+            let mut entries = self.lock_entries()?;
+            entries.insert(key, (value.to_vec(), size_bytes));
+            Ok(())
+        }
+
+        async fn clear(&self) -> std::result::Result<(), CacheAbiError> {
+            self.lock_entries()?.clear();
+            Ok(())
+        }
+
+        async fn measure(&self) -> std::result::Result<CacheMeasure, CacheAbiError> {
+            let entries = self.lock_entries()?;
+            Ok(CacheMeasure::new(
+                entries.len(),
+                entries.values().map(|(_, size_bytes)| *size_bytes).sum(),
+            ))
+        }
+    }
+}

--- a/rust/lance-cache-abi/tests/xabi_dynamic_backend.rs
+++ b/rust/lance-cache-abi/tests/xabi_dynamic_backend.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use lance_cache_abi::{CacheKey128, CacheMeasure, load_backend_named};
+
+static FIXTURE_LIBRARY: OnceLock<PathBuf> = OnceLock::new();
+
+#[test]
+fn xabi_dynamic_backend_round_trips_through_real_library() {
+    futures::executor::block_on(async {
+        let library_path = fixture_library_path();
+        let backend = unsafe { load_backend_named(library_path, "memory") }
+            .expect("fixture backend loads through xabi");
+        let key = CacheKey128::from_bytes([
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfe, 0xed,
+            0xbe, 0xef,
+        ]);
+
+        assert_eq!(backend.name().expect("name is available"), "memory-fixture");
+        assert_eq!(backend.get(key).await.expect("miss is returned"), None);
+
+        backend
+            .insert(key, b"from-plugin", 128)
+            .await
+            .expect("insert succeeds through dynamic xabi handle");
+
+        let hit = backend
+            .get(key)
+            .await
+            .expect("get succeeds through dynamic xabi handle")
+            .expect("inserted key is present");
+        assert_eq!(hit.bytes, b"from-plugin");
+        assert_eq!(hit.size_bytes, 128);
+
+        assert_eq!(
+            backend.measure().await.expect("measure succeeds"),
+            CacheMeasure::new(1, 128)
+        );
+
+        backend.clear().await.expect("clear succeeds");
+        assert_eq!(backend.get(key).await.expect("cleared key misses"), None);
+    });
+}
+
+#[test]
+fn xabi_dynamic_backend_transports_typed_errors() {
+    futures::executor::block_on(async {
+        let library_path = fixture_library_path();
+        let backend = unsafe { load_backend_named(library_path, "memory") }
+            .expect("fixture backend loads through xabi");
+        let err = backend
+            .get(CacheKey128::from_bytes([13; 16]))
+            .await
+            .expect_err("fixture returns a typed export error");
+
+        assert_eq!(err.to_string(), "fixture rejected key 13");
+    });
+}
+
+fn fixture_library_path() -> &'static Path {
+    FIXTURE_LIBRARY.get_or_init(build_fixture_library).as_path()
+}
+
+fn build_fixture_library() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_dir = manifest_dir
+        .ancestors()
+        .nth(2)
+        .expect("lance-cache-abi lives under rust/")
+        .to_path_buf();
+    let target_dir = workspace_dir.join("target").join("xabi-fixtures");
+    let status = Command::new("cargo")
+        .args(["build", "-p", "lance-cache-xabi-fixture", "--target-dir"])
+        .arg(&target_dir)
+        .args(["--message-format", "short"])
+        .current_dir(&workspace_dir)
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_TARGET_DIR")
+        .status()
+        .expect("cargo build can be launched");
+    assert!(status.success(), "fixture cdylib build failed");
+
+    let profile_dir = target_dir.join("debug");
+    let library_path = profile_dir.join(dynamic_library_name("lance_cache_xabi_fixture"));
+    assert!(
+        library_path.exists(),
+        "fixture cdylib was not built at {}",
+        library_path.display()
+    );
+    library_path
+}
+
+fn dynamic_library_name(stem: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!("lib{stem}.dylib")
+    } else if cfg!(target_os = "windows") {
+        format!("{stem}.dll")
+    } else {
+        format!("lib{stem}.so")
+    }
+}

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/aarch64-apple-darwin.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/aarch64-apple-darwin.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=aarch64-apple-darwin
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=aarch64-unknown-linux-gnu
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-apple-darwin.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-apple-darwin.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=x86_64-apple-darwin
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-pc-windows-gnu.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-pc-windows-gnu.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=x86_64-pc-windows-gnu
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=x86_64-pc-windows-msvc
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-cache-abi/xabi/snapshots/org.lance.cache.DynamicCacheBackend/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,170 @@
+format=xabi-contract-snapshot-v1
+package=lance-cache-abi
+target=x86_64-unknown-linux-gnu
+
+contract org.lance.cache.DynamicCacheBackend
+  abi_version=0
+  rust_trait=lance_cache_abi::xabi_contract::DynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::CacheKey128Wire
+  stability=fixed
+  size=16
+  align=1
+  field.bytes offset=0 type=[u8; 16]
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheAbiError
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.message offset=16 type=XabiOwnedBytes
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheLookup
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.bytes offset=16 type=XabiOwnedBytes
+  field.size_bytes offset=40 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1DataCacheMeasure
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.entries offset=16 type=usize
+  field.size_bytes offset=24 type=usize
+
+type lance_cache_abi::xabi_contract::XabiV1OwnedRefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1RefTraitDynamicCacheBackend
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitDynamicCacheBackend
+
+type lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  stability=prefix
+  size=88
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitDynamicCacheBackend)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.get offset=56 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.insert offset=64 type=unsafe extern "C" fn(*mut c_void, *const <CacheKey128 as XabiType>::Wire, XabiBytes, *const <usize as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.clear offset=72 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.measure offset=80 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_cache_abi::xabi_contract::XabiV1VtableTraitDynamicCacheBackend
+  full_size=88
+  min_size=48

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -23,6 +23,7 @@ byteorder.workspace = true
 bytes.workspace = true
 datafusion-common = { workspace = true, optional = true }
 datafusion-sql = { workspace = true, optional = true }
+lance-cache-abi.workspace = true
 lance-derive.workspace = true
 futures.workspace = true
 itertools.workspace = true

--- a/rust/lance-core/src/cache/dynamic.rs
+++ b/rust/lance-core/src/cache/dynamic.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Host-side adapter for dynamic cache backend plugins.
+
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::Future;
+use lance_cache_abi::{CacheKey128, DynamicCacheBackendHandle};
+
+use crate::Result;
+use crate::error::Error;
+
+use super::backend::{CacheBackend, CacheEntry};
+use super::{CacheCodec, CacheDecode, InternalCacheKey, MokaCacheBackend};
+
+/// Adapter from Lance's typed [`CacheBackend`] trait to a dynamic byte backend.
+///
+/// Dynamic plugins only store serialized bytes. This adapter keeps Lance-side
+/// cache semantics in the host: entries without a [`CacheCodec`] stay in the
+/// in-memory fallback, serialized entries are decoded before returning to
+/// callers, and `get_or_insert` still deduplicates concurrent loads through
+/// the fallback cache.
+pub struct DynamicCacheBackendAdapter {
+    backend: DynamicCacheBackendHandle,
+    fallback: MokaCacheBackend,
+    serialized_entries: AtomicUsize,
+    serialized_size_bytes: AtomicUsize,
+}
+
+impl std::fmt::Debug for DynamicCacheBackendAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DynamicCacheBackendAdapter")
+            .field(
+                "serialized_entries",
+                &self.serialized_entries.load(Ordering::Relaxed),
+            )
+            .field(
+                "serialized_size_bytes",
+                &self.serialized_size_bytes.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl DynamicCacheBackendAdapter {
+    /// Create a dynamic backend adapter with a host-side memory fallback.
+    ///
+    /// `fallback_capacity_bytes` bounds the entries that cannot be serialized
+    /// yet (`codec == None`) and the in-process singleflight records used by
+    /// [`CacheBackend::get_or_insert`].
+    pub fn new(backend: DynamicCacheBackendHandle, fallback_capacity_bytes: usize) -> Self {
+        Self {
+            backend,
+            fallback: MokaCacheBackend::with_capacity(fallback_capacity_bytes),
+            serialized_entries: AtomicUsize::new(0),
+            serialized_size_bytes: AtomicUsize::new(0),
+        }
+    }
+
+    /// Load a named dynamic cache backend from a trusted native library.
+    ///
+    /// # Safety
+    ///
+    /// Loading native code is unsafe. The caller must trust the library at
+    /// `path` and ensure it follows the xabi and Lance cache contracts.
+    pub unsafe fn load_named(
+        path: impl AsRef<Path>,
+        name: &str,
+        fallback_capacity_bytes: usize,
+    ) -> Result<Self> {
+        let backend =
+            unsafe { lance_cache_abi::load_backend_named(path, name) }.map_err(|err| {
+                Error::invalid_input(format!(
+                    "failed to load dynamic cache backend {name:?}: {err}"
+                ))
+            })?;
+        Ok(Self::new(backend, fallback_capacity_bytes))
+    }
+
+    fn plugin_key(key: &InternalCacheKey) -> CacheKey128 {
+        CacheKey128::from_bytes(*key.as_bytes())
+    }
+
+    async fn get_serialized(
+        &self,
+        key: &InternalCacheKey,
+        codec: CacheCodec,
+    ) -> Option<CacheEntry> {
+        let plugin_key = Self::plugin_key(key);
+        let lookup = match self.backend.get(plugin_key).await {
+            Ok(lookup) => lookup?,
+            Err(error) => {
+                log::warn!("dynamic cache backend get failed: {error}");
+                return None;
+            }
+        };
+
+        let bytes = Bytes::from(lookup.bytes);
+        match codec.deserialize(&bytes) {
+            CacheDecode::Hit(entry) => Some(entry),
+            CacheDecode::Miss(reason) => {
+                log::debug!("dynamic cache entry rejected for key {:?}: {reason:?}", key);
+                None
+            }
+        }
+    }
+
+    async fn insert_serialized(
+        &self,
+        key: &InternalCacheKey,
+        entry: CacheEntry,
+        size_bytes: usize,
+        codec: CacheCodec,
+    ) -> bool {
+        let mut bytes = Vec::new();
+        if let Err(error) = codec.serialize(&entry, &mut bytes) {
+            log::warn!(
+                "dynamic cache entry serialization failed for key {:?}: {error}",
+                key
+            );
+            return false;
+        }
+
+        let plugin_key = Self::plugin_key(key);
+        if let Err(error) = self.backend.insert(plugin_key, &bytes, size_bytes).await {
+            log::warn!("dynamic cache backend insert failed: {error}");
+            return false;
+        }
+
+        self.serialized_entries.fetch_add(1, Ordering::Relaxed);
+        self.serialized_size_bytes
+            .fetch_add(size_bytes, Ordering::Relaxed);
+        true
+    }
+}
+
+#[async_trait]
+impl CacheBackend for DynamicCacheBackendAdapter {
+    async fn get(&self, key: &InternalCacheKey, codec: Option<CacheCodec>) -> Option<CacheEntry> {
+        match codec {
+            Some(codec) => self.get_serialized(key, codec).await,
+            None => self.fallback.get(key, None).await,
+        }
+    }
+
+    async fn insert(
+        &self,
+        key: &InternalCacheKey,
+        entry: CacheEntry,
+        size_bytes: usize,
+        codec: Option<CacheCodec>,
+    ) {
+        match codec {
+            Some(codec) => {
+                self.insert_serialized(key, entry, size_bytes, codec).await;
+            }
+            None => self.fallback.insert(key, entry, size_bytes, None).await,
+        }
+    }
+
+    async fn get_or_insert<'a>(
+        &self,
+        key: &InternalCacheKey,
+        loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
+        codec: Option<CacheCodec>,
+    ) -> Result<(CacheEntry, bool)> {
+        if let Some(entry) = self.get(key, codec).await {
+            return Ok((entry, true));
+        }
+
+        let (entry, size_bytes, was_cached) =
+            self.fallback.get_or_insert_record(key, loader).await?;
+
+        if !was_cached
+            && let Some(codec) = codec
+            && self
+                .insert_serialized(key, entry.clone(), size_bytes, codec)
+                .await
+        {
+            self.fallback.invalidate_key(key).await;
+        }
+
+        Ok((entry, was_cached))
+    }
+
+    async fn clear(&self) {
+        self.fallback.clear().await;
+        if let Err(error) = self.backend.clear().await {
+            log::warn!("dynamic cache backend clear failed: {error}");
+        }
+        self.serialized_entries.store(0, Ordering::Relaxed);
+        self.serialized_size_bytes.store(0, Ordering::Relaxed);
+    }
+
+    async fn num_entries(&self) -> usize {
+        match self.backend.measure().await {
+            Ok(measure) => {
+                self.serialized_entries
+                    .store(measure.entries, Ordering::Relaxed);
+                self.fallback
+                    .num_entries()
+                    .await
+                    .saturating_add(measure.entries)
+            }
+            Err(error) => {
+                log::warn!("dynamic cache backend measure failed: {error}");
+                self.fallback.num_entries().await
+            }
+        }
+    }
+
+    async fn size_bytes(&self) -> usize {
+        match self.backend.measure().await {
+            Ok(measure) => {
+                self.serialized_size_bytes
+                    .store(measure.size_bytes, Ordering::Relaxed);
+                self.fallback
+                    .size_bytes()
+                    .await
+                    .saturating_add(measure.size_bytes)
+            }
+            Err(error) => {
+                log::warn!("dynamic cache backend measure failed: {error}");
+                self.fallback.size_bytes().await
+            }
+        }
+    }
+
+    fn approx_num_entries(&self) -> usize {
+        self.fallback
+            .approx_num_entries()
+            .saturating_add(self.serialized_entries.load(Ordering::Relaxed))
+    }
+
+    fn approx_size_bytes(&self) -> usize {
+        self.fallback
+            .approx_size_bytes()
+            .saturating_add(self.serialized_size_bytes.load(Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::Arc;
+    use std::sync::OnceLock;
+
+    use super::*;
+    use crate::cache::{CacheCodecImpl, CacheEntryReader, CacheEntryWriter};
+    use crate::error::Error;
+
+    static FIXTURE_LIBRARY: OnceLock<PathBuf> = OnceLock::new();
+
+    #[derive(Debug, PartialEq)]
+    struct Widget {
+        n: u32,
+    }
+
+    impl CacheCodecImpl for Widget {
+        const TYPE_ID: &'static str = "test.dynamic.Widget";
+        const CURRENT_VERSION: u32 = 1;
+
+        fn serialize(&self, writer: &mut CacheEntryWriter<'_>) -> Result<()> {
+            writer.write_raw(&self.n.to_le_bytes())
+        }
+
+        fn deserialize(reader: &mut CacheEntryReader<'_>) -> Result<Self> {
+            let bytes = reader.read_raw()?;
+            let n = u32::from_le_bytes(
+                bytes
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| Error::io("invalid widget payload"))?,
+            );
+            Ok(Self { n })
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct RuntimeOnly {
+        label: String,
+    }
+
+    fn adapter() -> DynamicCacheBackendAdapter {
+        unsafe {
+            DynamicCacheBackendAdapter::load_named(fixture_library_path(), "memory", 1024 * 1024)
+                .expect("fixture backend loads through xabi")
+        }
+    }
+
+    fn key(discriminant: u8) -> InternalCacheKey {
+        InternalCacheKey::from_bytes([discriminant; 16])
+    }
+
+    #[tokio::test]
+    async fn codec_entries_round_trip_through_dynamic_backend() {
+        let backend = adapter();
+        let key = key(1);
+        let codec = CacheCodec::from_impl::<Widget>();
+        let entry: CacheEntry = Arc::new(Widget { n: 42 });
+
+        backend.insert(&key, entry, 4, Some(codec)).await;
+
+        let got = backend
+            .get(&key, Some(codec))
+            .await
+            .expect("entry should hit")
+            .downcast::<Widget>()
+            .expect("entry should decode as Widget");
+        assert_eq!(*got, Widget { n: 42 });
+        assert_eq!(backend.num_entries().await, 1);
+        assert_eq!(backend.size_bytes().await, 4);
+    }
+
+    #[tokio::test]
+    async fn entries_without_codec_use_host_fallback() {
+        let backend = adapter();
+        let key = key(2);
+        let entry: CacheEntry = Arc::new(RuntimeOnly {
+            label: "host-only".to_string(),
+        });
+
+        backend.insert(&key, entry, 9, None).await;
+
+        let got = backend
+            .get(&key, None)
+            .await
+            .expect("fallback entry should hit")
+            .downcast::<RuntimeOnly>()
+            .expect("entry should stay typed in fallback");
+        assert_eq!(
+            *got,
+            RuntimeOnly {
+                label: "host-only".to_string()
+            }
+        );
+        assert_eq!(backend.num_entries().await, 1);
+    }
+
+    #[tokio::test]
+    async fn get_or_insert_reports_dynamic_hit_as_cached() {
+        let backend = adapter();
+        let key = key(3);
+        let codec = CacheCodec::from_impl::<Widget>();
+        let entry: CacheEntry = Arc::new(Widget { n: 7 });
+
+        backend.insert(&key, entry, 4, Some(codec)).await;
+
+        let (got, was_cached) = backend
+            .get_or_insert(
+                &key,
+                Box::pin(async {
+                    let entry: CacheEntry = Arc::new(Widget { n: 99 });
+                    Ok((entry, 4))
+                }),
+                Some(codec),
+            )
+            .await
+            .expect("get_or_insert succeeds");
+
+        assert!(was_cached);
+        assert_eq!(*got.downcast::<Widget>().unwrap(), Widget { n: 7 });
+    }
+
+    fn fixture_library_path() -> &'static Path {
+        FIXTURE_LIBRARY.get_or_init(build_fixture_library).as_path()
+    }
+
+    fn build_fixture_library() -> PathBuf {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir
+            .ancestors()
+            .nth(2)
+            .expect("lance-core lives under rust/")
+            .to_path_buf();
+        let target_dir = workspace_dir.join("target").join("xabi-fixtures");
+        let status = Command::new("cargo")
+            .args(["build", "-p", "lance-cache-xabi-fixture", "--target-dir"])
+            .arg(&target_dir)
+            .args(["--message-format", "short"])
+            .current_dir(&workspace_dir)
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_TARGET_DIR")
+            .status()
+            .expect("cargo build can be launched");
+        assert!(status.success(), "fixture cdylib build failed");
+
+        let profile_dir = target_dir.join("debug");
+        let library_path = profile_dir.join(dynamic_library_name("lance_cache_xabi_fixture"));
+        assert!(
+            library_path.exists(),
+            "fixture cdylib was not built at {}",
+            library_path.display()
+        );
+        library_path
+    }
+
+    fn dynamic_library_name(stem: &str) -> String {
+        if cfg!(target_os = "macos") {
+            format!("lib{stem}.dylib")
+        } else if cfg!(target_os = "windows") {
+            format!("{stem}.dll")
+        } else {
+            format!("lib{stem}.so")
+        }
+    }
+}

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -48,6 +48,7 @@
 pub mod backend;
 mod backend_uri;
 pub mod codec;
+mod dynamic;
 mod entry_io;
 mod key;
 mod moka;
@@ -59,8 +60,10 @@ pub use backend_uri::{build_from_uri, parse_backend_uri};
 pub use codec::{
     CacheCodec, CacheCodecImpl, CacheDecode, CacheMissReason, MAGIC, has_cache_envelope,
 };
+pub use dynamic::DynamicCacheBackendAdapter;
 pub use entry_io::{CacheEntryReader, CacheEntryWriter};
 pub use key::{CACHE_KEY_FORMAT, CacheKeySchema, CacheNamespace, InternalCacheKey, KeyBuilder};
+pub use lance_cache_abi as dynamic_cache_abi;
 pub use moka::MokaCacheBackend;
 pub use quick::{QuickCacheBackend, recommended_cache_shards};
 pub use registry::{BackendBuildFn, BackendConfig, build_from_config, register_backend};

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -15,6 +15,8 @@ use crate::error::CloneableError;
 use super::backend::{CacheBackend, CacheEntry};
 use super::{CacheCodec, InternalCacheKey};
 
+type CacheLoader<'a> = Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>;
+
 /// Internal record stored in the moka cache.
 #[derive(Clone, Debug)]
 struct MokaCacheEntry {
@@ -101,6 +103,37 @@ impl MokaCacheBackend {
             .try_into()
             .unwrap_or(usize::MAX)
     }
+
+    pub(crate) async fn get_or_insert_record<'a>(
+        &self,
+        key: &InternalCacheKey,
+        loader: CacheLoader<'a>,
+    ) -> Result<(CacheEntry, usize, bool)> {
+        // Track whether the loader actually ran (= cache miss).
+        let was_miss = Arc::new(AtomicBool::new(false));
+        let was_miss_clone = was_miss.clone();
+
+        let init = async move {
+            was_miss_clone.store(true, Ordering::Relaxed);
+            loader
+                .await
+                .map(|(entry, size_bytes)| MokaCacheEntry { entry, size_bytes })
+                .map_err(CloneableError)
+        };
+
+        let owned_key = *key;
+        match self.cache.try_get_with(owned_key, init).await {
+            Ok(record) => {
+                let was_cached = !was_miss.load(Ordering::Relaxed);
+                Ok((record.entry, record.size_bytes, was_cached))
+            }
+            Err(error) => Err(Arc::unwrap_or_clone(error).0),
+        }
+    }
+
+    pub(crate) async fn invalidate_key(&self, key: &InternalCacheKey) {
+        self.cache.invalidate(key).await;
+    }
 }
 
 #[async_trait]
@@ -127,26 +160,8 @@ impl CacheBackend for MokaCacheBackend {
         loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
         _codec: Option<CacheCodec>,
     ) -> Result<(CacheEntry, bool)> {
-        // Track whether the loader actually ran (= cache miss).
-        let was_miss = Arc::new(AtomicBool::new(false));
-        let was_miss_clone = was_miss.clone();
-
-        let init = async move {
-            was_miss_clone.store(true, Ordering::Relaxed);
-            loader
-                .await
-                .map(|(entry, size_bytes)| MokaCacheEntry { entry, size_bytes })
-                .map_err(CloneableError)
-        };
-
-        let owned_key = *key;
-        match self.cache.try_get_with(owned_key, init).await {
-            Ok(record) => {
-                let was_cached = !was_miss.load(Ordering::Relaxed);
-                Ok((record.entry, was_cached))
-            }
-            Err(error) => Err(Arc::unwrap_or_clone(error).0),
-        }
+        let (entry, _, was_cached) = self.get_or_insert_record(key, loader).await?;
+        Ok((entry, was_cached))
     }
 
     async fn clear(&self) {

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -3306,6 +3306,57 @@ async fn test_fts_strict_prewarm_fails_missing_scalar_container() {
     );
 }
 
+mod dynamic_cache_fixture {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static FIXTURE_LIBRARY: OnceLock<PathBuf> = OnceLock::new();
+
+    pub fn library_path() -> &'static Path {
+        FIXTURE_LIBRARY.get_or_init(build_fixture_library).as_path()
+    }
+
+    fn build_fixture_library() -> PathBuf {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir
+            .ancestors()
+            .nth(2)
+            .expect("lance lives under rust/")
+            .to_path_buf();
+        let target_dir = workspace_dir.join("target").join("xabi-fixtures");
+        let status = Command::new("cargo")
+            .args(["build", "-p", "lance-cache-xabi-fixture", "--target-dir"])
+            .arg(&target_dir)
+            .args(["--message-format", "short"])
+            .current_dir(&workspace_dir)
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_TARGET_DIR")
+            .status()
+            .expect("cargo build can be launched");
+        assert!(status.success(), "fixture cdylib build failed");
+
+        let profile_dir = target_dir.join("debug");
+        let library_path = profile_dir.join(dynamic_library_name("lance_cache_xabi_fixture"));
+        assert!(
+            library_path.exists(),
+            "fixture cdylib was not built at {}",
+            library_path.display()
+        );
+        library_path
+    }
+
+    fn dynamic_library_name(stem: &str) -> String {
+        if cfg!(target_os = "macos") {
+            format!("lib{stem}.dylib")
+        } else if cfg!(target_os = "windows") {
+            format!("{stem}.dll")
+        } else {
+            format!("lib{stem}.so")
+        }
+    }
+}
+
 /// Validates the OSS-741 contract: after FTS prewarm through a serializing
 /// cache backend, FTS queries serve results without any further IO. The
 /// serializing backend forces every cache hit through the new
@@ -3421,6 +3472,97 @@ async fn test_fts_prewarm_with_serializing_backend_serves_query_with_no_io() {
         0,
         "FTS query should not perform IO after prewarm; the serializing cache \
          backend must serve every posting list and positions entry from memory"
+    );
+}
+
+/// End-to-end smoke test for a dynamic cache backend plugin: build and load a
+/// real `.so`, inject it through `Session::with_index_cache_backend`, prewarm a
+/// BTree index, then query from the cache without object-store IO.
+#[tokio::test]
+async fn test_btree_prewarm_with_dynamic_so_backend_serves_query_with_no_io() {
+    use lance_core::cache::{CacheBackend, DynamicCacheBackendAdapter};
+    use lance_io::assert_io_eq;
+
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    drop(tmpdir);
+
+    let num_rows = 16_384;
+    let values = Int32Array::from_iter_values(0..num_rows);
+    let ids = UInt64Array::from_iter_values(0..num_rows as u64);
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("value", DataType::Int32, false),
+            arrow_schema::Field::new("id", DataType::UInt64, false),
+        ])
+        .into(),
+        vec![Arc::new(values) as ArrayRef, Arc::new(ids) as ArrayRef],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(batches, &uri, None).await.unwrap();
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::BTree,
+            Some("value_idx".to_owned()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let backend = Arc::new(unsafe {
+        DynamicCacheBackendAdapter::load_named(
+            dynamic_cache_fixture::library_path(),
+            "memory",
+            128 * 1024 * 1024,
+        )
+        .expect("fixture dynamic cache backend should load")
+    });
+    let session = Arc::new(Session::with_index_cache_backend(
+        backend.clone(),
+        128 * 1024 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    let dataset = DatasetBuilder::from_uri(&uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap();
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    dataset.prewarm_index("value_idx").await.unwrap();
+
+    assert!(
+        backend.num_entries().await > 0,
+        "prewarm should have populated the dynamic .so cache adapter"
+    );
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    let result = dataset
+        .scan()
+        .project(&[ROW_ID])
+        .unwrap()
+        .filter("value >= 100 AND value < 200")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        result.num_rows(),
+        100,
+        "indexed filter should return correct results through the dynamic cache adapter"
+    );
+
+    let stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(
+        stats,
+        read_iops,
+        0,
+        "BTree filter query should not perform IO after prewarm; the dynamic .so \
+         cache backend must serve the index state and pages"
     );
 }
 


### PR DESCRIPTION
## Summary

  Prototype a xabi-backed dynamic cache backend ABI instead of publishing the current hand-written C vtable as v1.

  This keeps the Lance cache backend contract as a Rust async trait and lets xabi generate the C-compatible vtable,
  Future/Waker polling, typed error transport, panic guards, and module lifetime plumbing.

  Key choices:
  - keep the Lance contract version at `0`, not v1
  - represent the future u128 cache key as stable two-u64 `CacheKey128`
  - omit `invalidate_prefix` from the low-level contract
  - keep codec fallback, singleflight, metrics, registration, and lifecycle policy out of the low-level ABI
  - add a real cdylib fixture and host/plugin round-trip integration test
  - add an xabi ABI snapshot as the acceptance gate

  ## Verification

  - `cargo fmt --package lance-cache-abi --package lance-cache-xabi-fixture`
  - `CARGO_NET_OFFLINE=true cargo test -p lance-cache-abi`
  - `CARGO_NET_OFFLINE=true cargo check -p lance-core`
  - `CARGO_NET_OFFLINE=true cargo clippy -p lance-cache-abi --tests -- -D warnings`