### PR TITLE
fix(fts): preserve parameter compatibility

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -7547,6 +7547,37 @@ mod tests {
         assert!(error.to_string().contains("metadata access denied"));
     }
 
+    #[tokio::test]
+    async fn params_metadata_ignores_unknown_fields() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let expected = InvertedIndexParams::default();
+        let mut params = serde_json::to_value(&expected).unwrap();
+        let params = params.as_object_mut().unwrap();
+        params.insert("skip_merge".to_owned(), true.into());
+        params.insert(
+            "future_parameter".to_owned(),
+            serde_json::json!({ "enabled": true }),
+        );
+        let metadata =
+            HashMap::from([("params".to_owned(), serde_json::to_string(params).unwrap())]);
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(Schema::empty()))
+            .await
+            .unwrap();
+        writer.finish_with_metadata(metadata).await.unwrap();
+
+        let actual = InvertedIndex::load_params(store.as_ref()).await.unwrap();
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+    }
+
     async fn write_single_partition_index(
         store: Arc<LanceIndexStore>,
         params: InvertedIndexParams,

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -172,8 +172,8 @@ pub struct InvertedIndexParams {
     pub(crate) format_version: Option<InvertedListFormatVersion>,
 }
 
+// Unknown fields must remain ignored because these params are persisted across Lance versions.
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct RawInvertedIndexParams {
     // Input-only preset expanded before constructing normalized params.
     analyzer: Option<String>,
@@ -1388,6 +1388,23 @@ mod tests {
         let err = InvertedIndexParams::from_training_json(r#"{"format_version": -1}"#).unwrap_err();
         assert!(matches!(&err, lance_core::Error::Arrow { .. }));
         assert!(err.to_string().contains("got -1"));
+    }
+
+    #[test]
+    fn test_training_json_ignores_unknown_fields() {
+        let params = InvertedIndexParams::from_training_json(
+            r#"{
+                "lower_case": false,
+                "skip_merge": true,
+                "future_parameter": {"enabled": true}
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!params.lower_case);
+        let normalized = params.to_training_json().unwrap();
+        assert!(normalized.get("skip_merge").is_none());
+        assert!(normalized.get("future_parameter").is_none());
     }
 
     #[test]


### PR DESCRIPTION
`InvertedIndexParams` is persisted in FTS index metadata and shared across Lance versions. PR #7681 added `deny_unknown_fields`, causing existing indexes that still contain retired fields such as `skip_merge` to fail to load. This also breaks `bench_regress` against its existing Wikipedia FTS index.

Restore Serde's tolerant-reader behavior so historical and future metadata fields are ignored while validation for recognized parameters remains intact. Regression coverage exercises both training JSON and the on-disk `metadata.lance` loading path.