### PR TITLE
fix(core): bound SlotBackoff retry sleeps and fix slot overflow

### DIFF
--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -77,6 +77,16 @@ impl Backoff {
     }
 }
 
+/// Upper bound on the number of retry slots.
+///
+/// Slots double each attempt to spread contending writers apart, but past a few
+/// hundred the count already exceeds any realistic number of concurrent
+/// committers, so further doubling only inflates the wait without reducing
+/// collisions. Capping the count also bounds a single backoff to
+/// `(MAX_SLOTS - 1) * unit` instead of letting it grow without limit as
+/// `attempt` climbs.
+const MAX_SLOTS: u32 = 128;
+
 /// SlotBackoff is a backoff strategy that randomly chooses a time slot to retry.
 ///
 /// This is useful when you have multiple tasks that can't overlap, and each
@@ -138,10 +148,15 @@ impl SlotBackoff {
     }
 
     pub fn next_backoff(&mut self) -> Duration {
-        let num_slots = self.base.saturating_pow(self.attempt + self.starting_i);
+        let num_slots = self
+            .base
+            .saturating_pow(self.attempt.saturating_add(self.starting_i))
+            .min(MAX_SLOTS);
         let slot_i = self.rng.random_range(0..num_slots);
         self.attempt += 1;
-        Duration::from_millis((slot_i * self.unit) as u64)
+        // Widen before multiplying: `unit` is the first-attempt latency, which
+        // can be large enough that a `u32` slot * unit product would overflow.
+        Duration::from_millis(slot_i as u64 * self.unit as u64)
     }
 }
 
@@ -227,5 +242,45 @@ mod tests {
             );
             assert_eq!(backoff.attempt(), 3);
         }
+    }
+
+    #[test]
+    fn test_slot_backoff_high_attempt_is_bounded() {
+        // Without the slot cap the wait grows unbounded with `attempt`. The cap
+        // holds every backoff to `(MAX_SLOTS - 1) * unit`.
+        let unit = 100_000; // 100s first attempt
+        let mut backoff = SlotBackoff::default().with_unit(unit);
+        let max_backoff = Duration::from_millis((MAX_SLOTS - 1) as u64 * unit as u64);
+        for _ in 0..40 {
+            assert!(backoff.next_backoff() <= max_backoff);
+        }
+        assert_eq!(backoff.attempt(), 40);
+    }
+
+    #[test]
+    fn test_slot_backoff_large_unit_does_not_overflow() {
+        // `slot_i * unit` as a u32 product overflows once unit exceeds
+        // `u32::MAX / (MAX_SLOTS - 1)`; the u64 widening must prevent that. Pin a
+        // lower bound so a reverted widening fails here even in release builds
+        // (where the u32 product would wrap to a smaller value) rather than only
+        // in debug (where it panics).
+        let unit = u32::MAX; // far above the u32-overflow threshold
+        let mut backoff = SlotBackoff::default().with_unit(unit);
+        // Drive attempts into the capped regime, then require a non-zero slot so
+        // the product is actually exercised.
+        let mut saw_nonzero = false;
+        for _ in 0..200 {
+            let backoff_ms = backoff.next_backoff().as_millis();
+            if backoff_ms > 0 {
+                // A wrapped u32 product would be < unit; the true product is a
+                // multiple of unit, so this lower bound catches truncation.
+                assert!(backoff_ms >= unit as u128, "{backoff_ms} wrapped");
+                saw_nonzero = true;
+            }
+        }
+        assert!(
+            saw_nonzero,
+            "expected at least one non-zero slot in 200 draws"
+        );
     }
 }

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -283,4 +283,14 @@ mod tests {
             "expected at least one non-zero slot in 200 draws"
         );
     }
+
+    #[test]
+    fn test_slot_backoff_attempt_saturates() {
+        // At u32::MAX the counter must stay put rather than panic (debug) or
+        // wrap to 0 (release), which would restart the low-slot distribution.
+        let mut backoff = SlotBackoff::default();
+        backoff.attempt = u32::MAX;
+        let _ = backoff.next_backoff();
+        assert_eq!(backoff.attempt(), u32::MAX);
+    }
 }

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -153,7 +153,7 @@ impl SlotBackoff {
             .saturating_pow(self.attempt.saturating_add(self.starting_i))
             .min(MAX_SLOTS);
         let slot_i = self.rng.random_range(0..num_slots);
-        self.attempt += 1;
+        self.attempt = self.attempt.saturating_add(1);
         // Widen before multiplying: `unit` is the first-attempt latency, which
         // can be large enough that a `u32` slot * unit product would overflow.
         Duration::from_millis(slot_i as u64 * self.unit as u64)

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -259,29 +259,23 @@ mod tests {
 
     #[test]
     fn test_slot_backoff_large_unit_does_not_overflow() {
-        // `slot_i * unit` as a u32 product overflows once unit exceeds
-        // `u32::MAX / (MAX_SLOTS - 1)`; the u64 widening must prevent that. Pin a
-        // lower bound so a reverted widening fails here even in release builds
-        // (where the u32 product would wrap to a smaller value) rather than only
-        // in debug (where it panics).
-        let unit = u32::MAX; // far above the u32-overflow threshold
+        // With unit = u32::MAX, any slot >= 2 makes the old u32 `slot_i * unit`
+        // product overflow: a debug panic, or in release a wrap to a value that
+        // is no longer a multiple of unit. The u64 widening keeps every backoff
+        // an exact multiple of unit. Seed the RNG so the drawn slots — and thus
+        // this check — are deterministic rather than dependent on random draws.
+        let unit = u32::MAX;
         let mut backoff = SlotBackoff::default().with_unit(unit);
-        // Drive attempts into the capped regime, then require a non-zero slot so
-        // the product is actually exercised.
-        let mut saw_nonzero = false;
-        for _ in 0..200 {
+        backoff.rng = rand::rngs::SmallRng::seed_from_u64(0);
+        let mut saw_high_slot = false;
+        for _ in 0..64 {
             let backoff_ms = backoff.next_backoff().as_millis();
-            if backoff_ms > 0 {
-                // A wrapped u32 product would be < unit; the true product is a
-                // multiple of unit, so this lower bound catches truncation.
-                assert!(backoff_ms >= unit as u128, "{backoff_ms} wrapped");
-                saw_nonzero = true;
-            }
+            // `slot_i * unit` is always a multiple of unit; a wrapped u32
+            // product is not.
+            assert_eq!(backoff_ms % unit as u128, 0, "{backoff_ms} wrapped");
+            saw_high_slot |= backoff_ms >= 2 * unit as u128;
         }
-        assert!(
-            saw_nonzero,
-            "expected at least one non-zero slot in 200 draws"
-        );
+        assert!(saw_high_slot, "expected a slot >= 2 in 64 seeded draws");
     }
 
     #[test]

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -79,12 +79,11 @@ impl Backoff {
 
 /// Upper bound on the number of retry slots.
 ///
-/// Slots double each attempt to spread contending writers apart, but past a few
-/// hundred the count already exceeds any realistic number of concurrent
-/// committers, so further doubling only inflates the wait without reducing
-/// collisions. Capping the count also bounds a single backoff to
-/// `(MAX_SLOTS - 1) * unit` instead of letting it grow without limit as
-/// `attempt` climbs.
+/// Slots double each attempt to spread contending writers apart, but a hundred
+/// or so already exceeds any realistic number of concurrent committers, so
+/// further doubling only inflates the wait without reducing collisions. Capping
+/// the count also bounds a single backoff to `(MAX_SLOTS - 1) * unit` instead of
+/// letting it grow without limit as `attempt` climbs.
 const MAX_SLOTS: u32 = 128;
 
 /// SlotBackoff is a backoff strategy that randomly chooses a time slot to retry.
@@ -95,7 +94,7 @@ const MAX_SLOTS: u32 = 128;
 /// The `unit` represents the time it takes to complete one attempt. Future attempts
 /// are divided into time slots, and a random slot is chosen for the retry. The number
 /// of slots increases exponentially with each attempt. Initially, there are 4 slots,
-/// then 8, then 16, and so on.
+/// then 8, then 16, and so on, up to a fixed cap.
 ///
 /// Example:
 /// Suppose you have 10 tasks that can't overlap, each taking 1 second. The tasks
@@ -282,8 +281,10 @@ mod tests {
     fn test_slot_backoff_attempt_saturates() {
         // At u32::MAX the counter must stay put rather than panic (debug) or
         // wrap to 0 (release), which would restart the low-slot distribution.
-        let mut backoff = SlotBackoff::default();
-        backoff.attempt = u32::MAX;
+        let mut backoff = SlotBackoff {
+            attempt: u32::MAX,
+            ..Default::default()
+        };
         let _ = backoff.next_backoff();
         assert_eq!(backoff.attempt(), u32::MAX);
     }


### PR DESCRIPTION
## Summary

`SlotBackoff::next_backoff` doubled the slot count on every attempt with no ceiling, and computed the sleep as `(slot_i * self.unit) as u64` — a `u32 * u32` multiply that widens to `u64` only after the product is formed. Two problems followed:

1. At a high attempt count the `slot_i * unit` product overflows `u32`: a debug-build panic, or in release a wrapped, wrong sleep duration.
2. The slot count, and therefore the backoff, grew without bound as attempts climbed.

This is reachable on the default commit-retry path (20 retries). `unit` is set to the first attempt's latency plus 10% (`commit.rs`), so once the first commit takes a few seconds, a deep retry drives `slot_i` into the range where the product overflows.

## Change

Cap the slot count at `MAX_SLOTS` (128) and widen the operands to `u64` before multiplying. 128 slots already exceeds any realistic number of concurrent committers, so further doubling only lengthens the wait without reducing collisions. Every backoff is now bounded by `(MAX_SLOTS - 1) * unit`.

Capping the slot *count* rather than the resulting duration is deliberate: `SlotBackoff` spreads contending writers across random slots so they don't collide, and a duration clamp would map every high-attempt writer onto the same instant, recreating the thundering herd the type exists to prevent. A fixed 128-slot grid keeps writers uniformly distributed. Attempts 0-4 are unchanged (their slot counts are already below 128); the cap only affects attempt 5 and beyond, where the extra slots bought no throughput anyway (commit throughput is one per `unit` regardless of slot count).

## Follow-up (out of scope)

The cap is proportional to `unit`, not absolute, so a slow first attempt can still produce a multi-minute single sleep. The commit-path sleep has no timeout wrapper, unlike the write-retry path which bounds its sleep against a deadline. Bounding wall-clock regardless of `unit` is tracked separately in #7882.

## Test plan

- `test_slot_backoff` (existing) — low-attempt slot distributions, unchanged.
- `test_slot_backoff_high_attempt_is_bounded` — every backoff stays within `(MAX_SLOTS - 1) * unit` across many high attempts; fails if the cap is removed.
- `test_slot_backoff_large_unit_does_not_overflow` — with `unit = u32::MAX`, asserts a lower bound that a reverted `u32` multiply would violate in release (wraps to a smaller value) as well as debug (panics).
- `cargo fmt --all` and `cargo clippy -p lance-core --tests -- -D warnings` are clean.
