### PR TITLE
fix(mem-wal): expose typed writer fence detection

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -477,26 +477,44 @@ impl Error {
         .build()
     }
 
-    /// The [`FenceReason`] if this is [`Error::Fenced`], else `None`. Prefer this
-    /// over matching the error message to decide how to react to a fence.
+    /// The [`FenceReason`] if this error or one of its typed sources is
+    /// [`Error::Fenced`], else `None`. Prefer this over matching the error
+    /// message to decide how to react to a fence.
     pub fn fence_reason(&self) -> Option<FenceReason> {
         match self {
             Self::Fenced { reason, .. } => Some(*reason),
-            _ => None,
+            _ => std::error::Error::source(self).and_then(error_source_fence_reason),
         }
     }
 
     /// Return whether this error or one of its typed sources reports that a
     /// MemWAL writer was superseded by a successor's epoch claim.
     ///
+    /// This is the peer-takeover predicate for errors created by
+    /// [`Error::fenced_by_peer`]. Use [`Error::fence_reason`] when callers also
+    /// need to distinguish errors created by [`Error::writer_poisoned`].
+    ///
     /// Persistence failures also fence a writer internally, but return `false`
     /// here because they are not peer epoch takeovers and generally require a
     /// different recovery policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lance_core::{Error, FenceReason};
+    ///
+    /// let peer_fence = Error::fenced_by_peer("successor claimed epoch 4");
+    /// assert!(peer_fence.is_mem_wal_fenced());
+    /// assert_eq!(
+    ///     peer_fence.fence_reason(),
+    ///     Some(FenceReason::PeerClaimedEpoch)
+    /// );
+    ///
+    /// let persistence_failure = Error::writer_poisoned("WAL write failed");
+    /// assert!(!persistence_failure.is_mem_wal_fenced());
+    /// ```
     pub fn is_mem_wal_fenced(&self) -> bool {
-        if self.fence_reason() == Some(FenceReason::PeerClaimedEpoch) {
-            return true;
-        }
-        std::error::Error::source(self).is_some_and(error_source_is_mem_wal_fenced)
+        self.fence_reason() == Some(FenceReason::PeerClaimedEpoch)
     }
 
     #[track_caller]
@@ -736,11 +754,11 @@ fn error_source_is_not_found(source: &(dyn std::error::Error + 'static)) -> bool
     source.source().is_some_and(error_source_is_not_found)
 }
 
-fn error_source_is_mem_wal_fenced(source: &(dyn std::error::Error + 'static)) -> bool {
+fn error_source_fence_reason(source: &(dyn std::error::Error + 'static)) -> Option<FenceReason> {
     if let Some(error) = source.downcast_ref::<Error>() {
-        return error.is_mem_wal_fenced();
+        return error.fence_reason();
     }
-    source.source().is_some_and(error_source_is_mem_wal_fenced)
+    source.source().and_then(error_source_fence_reason)
 }
 
 pub trait LanceOptionExt<T> {
@@ -990,6 +1008,12 @@ impl Clone for CloneableError {
                 FenceReason::PeerClaimedEpoch => Error::fenced_by_peer(message.clone()),
                 FenceReason::PersistenceFailure => Error::writer_poisoned(message.clone()),
             }),
+            error if error.fence_reason() == Some(FenceReason::PeerClaimedEpoch) => {
+                Self(Error::fenced_by_peer(error.to_string()))
+            }
+            error if error.fence_reason() == Some(FenceReason::PersistenceFailure) => {
+                Self(Error::writer_poisoned(error.to_string()))
+            }
             Error::Timeout { message, .. } => Self(Error::timeout(message.clone())),
             Error::IO { source, .. } => Self(Error::io(source.to_string())),
             error => Self(Error::cloned(error.to_string())),
@@ -1024,7 +1048,32 @@ mod test {
         assert!(wrapped.is_mem_wal_fenced());
 
         assert!(!Error::io("ordinary object-store failure").is_mem_wal_fenced());
-        assert!(!Error::writer_poisoned("WAL persistence failed").is_mem_wal_fenced());
+        let persistence_failure = Error::writer_poisoned("WAL persistence failed");
+        assert!(!persistence_failure.is_mem_wal_fenced());
+        let wrapped = Error::wrapped(Box::new(persistence_failure));
+        assert_eq!(
+            wrapped.fence_reason(),
+            Some(FenceReason::PersistenceFailure)
+        );
+        assert!(!wrapped.is_mem_wal_fenced());
+    }
+
+    #[test]
+    fn cloneable_error_preserves_nested_fence_reason() {
+        for (error, expected) in [
+            (
+                Error::fenced_by_peer("peer fence"),
+                FenceReason::PeerClaimedEpoch,
+            ),
+            (
+                Error::writer_poisoned("persistence fence"),
+                FenceReason::PersistenceFailure,
+            ),
+        ] {
+            let wrapped = Error::wrapped(Box::new(error));
+            let cloned = CloneableError(wrapped).clone();
+            assert_eq!(cloned.0.fence_reason(), Some(expected));
+        }
     }
 
     #[test]

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -1033,6 +1033,7 @@ impl<T: Clone> From<Result<T>> for CloneableResult<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rstest::rstest;
     use std::error::Error as _;
     use std::fmt;
 
@@ -1058,22 +1059,25 @@ mod test {
         assert!(!wrapped.is_mem_wal_fenced());
     }
 
-    #[test]
-    fn cloneable_error_preserves_nested_fence_reason() {
-        for (error, expected) in [
-            (
-                Error::fenced_by_peer("peer fence"),
-                FenceReason::PeerClaimedEpoch,
-            ),
-            (
-                Error::writer_poisoned("persistence fence"),
-                FenceReason::PersistenceFailure,
-            ),
-        ] {
-            let wrapped = Error::wrapped(Box::new(error));
-            let cloned = CloneableError(wrapped).clone();
-            assert_eq!(cloned.0.fence_reason(), Some(expected));
-        }
+    #[rstest]
+    #[case::direct_peer(false, FenceReason::PeerClaimedEpoch)]
+    #[case::direct_persistence(false, FenceReason::PersistenceFailure)]
+    #[case::nested_peer(true, FenceReason::PeerClaimedEpoch)]
+    #[case::nested_persistence(true, FenceReason::PersistenceFailure)]
+    fn cloneable_error_preserves_fence_reason(#[case] nested: bool, #[case] expected: FenceReason) {
+        let error = match expected {
+            FenceReason::PeerClaimedEpoch => Error::fenced_by_peer("peer fence"),
+            FenceReason::PersistenceFailure => Error::writer_poisoned("persistence fence"),
+        };
+        let error = if nested {
+            Error::wrapped(Box::new(error))
+        } else {
+            error
+        };
+        let original = CloneableError(error);
+        let cloned = original.clone();
+        assert_eq!(original.0.fence_reason(), Some(expected));
+        assert_eq!(cloned.0.fence_reason(), Some(expected));
     }
 
     #[test]

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -486,6 +486,19 @@ impl Error {
         }
     }
 
+    /// Return whether this error or one of its typed sources reports that a
+    /// MemWAL writer was superseded by a successor's epoch claim.
+    ///
+    /// Persistence failures also fence a writer internally, but return `false`
+    /// here because they are not peer epoch takeovers and generally require a
+    /// different recovery policy.
+    pub fn is_mem_wal_fenced(&self) -> bool {
+        if self.fence_reason() == Some(FenceReason::PeerClaimedEpoch) {
+            return true;
+        }
+        std::error::Error::source(self).is_some_and(error_source_is_mem_wal_fenced)
+    }
+
     #[track_caller]
     pub fn io_source(source: BoxedError) -> Self {
         IOSnafu.into_error(source)
@@ -721,6 +734,13 @@ fn error_source_is_not_found(source: &(dyn std::error::Error + 'static)) -> bool
             || std::error::Error::source(error).is_some_and(error_source_is_not_found);
     }
     source.source().is_some_and(error_source_is_not_found)
+}
+
+fn error_source_is_mem_wal_fenced(source: &(dyn std::error::Error + 'static)) -> bool {
+    if let Some(error) = source.downcast_ref::<Error>() {
+        return error.is_mem_wal_fenced();
+    }
+    source.source().is_some_and(error_source_is_mem_wal_fenced)
 }
 
 pub trait LanceOptionExt<T> {
@@ -964,6 +984,12 @@ impl Clone for CloneableError {
             error if error.is_not_found() => Self(Error::wrapped(Box::new(DisplayError(
                 Error::not_found(error.to_string()),
             )))),
+            Error::Fenced {
+                reason, message, ..
+            } => Self(match reason {
+                FenceReason::PeerClaimedEpoch => Error::fenced_by_peer(message.clone()),
+                FenceReason::PersistenceFailure => Error::writer_poisoned(message.clone()),
+            }),
             Error::Timeout { message, .. } => Self(Error::timeout(message.clone())),
             Error::IO { source, .. } => Self(Error::io(source.to_string())),
             error => Self(Error::cloned(error.to_string())),
@@ -985,6 +1011,21 @@ mod test {
     use super::*;
     use std::error::Error as _;
     use std::fmt;
+
+    #[test]
+    fn mem_wal_fence_predicate_is_typed_and_source_aware() {
+        let fenced = Error::fenced_by_peer(
+            "local epoch 3 < stored epoch 4 for shard 00000000-0000-0000-0000-000000000000",
+        );
+        assert!(fenced.is_mem_wal_fenced());
+        assert!(fenced.to_string().contains("Writer fenced"));
+
+        let wrapped = Error::wrapped(Box::new(fenced));
+        assert!(wrapped.is_mem_wal_fenced());
+
+        assert!(!Error::io("ordinary object-store failure").is_mem_wal_fenced());
+        assert!(!Error::writer_poisoned("WAL persistence failed").is_mem_wal_fenced());
+    }
 
     #[test]
     fn cloneable_error_preserves_not_found_contract() {

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -846,6 +846,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_manifest_version_conflict_detection() {
+        let (store, base_path, _controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+        let manifest = create_test_manifest(shard_id, 1, 1);
+
+        manifest_store.write(&manifest).await.unwrap();
+        let conflict = manifest_store.write(&manifest).await.unwrap_err();
+        assert!(is_manifest_version_conflict(&conflict));
+        assert!(conflict.to_string().contains("already exists"));
+
+        assert!(!is_manifest_version_conflict(&Error::io(
+            "ordinary manifest I/O failure"
+        )));
+    }
+
+    #[tokio::test]
     async fn test_claim_epoch_refuses_sealed_manifest() {
         // A `Sealed` manifest is the drop-table 2PC in-doubt marker:
         // `claim_epoch` must refuse it with a distinguishable error rather

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -482,7 +482,7 @@ impl ShardManifestStore {
                         .map(|m| m.writer_epoch)
                         .unwrap_or(0);
                     if latest_epoch >= next_epoch {
-                        return Err(Error::io(format!(
+                        return Err(Error::fenced_by_peer(format!(
                             "Failed to claim shard {} (version {}): another writer claimed epoch {} (>= our target {}): {}",
                             self.shard_id, next_version, latest_epoch, next_epoch, write_err
                         )));

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -29,6 +29,7 @@
 
 use object_store::ObjectStoreExt;
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -53,6 +54,24 @@ use super::util::{manifest_filename, parse_bit_reversed_filename, shard_manifest
 #[derive(Debug, Serialize, Deserialize)]
 struct VersionHint {
     version: u64,
+}
+
+#[derive(Debug)]
+struct ManifestWriteError {
+    message: String,
+    source: object_store::Error,
+}
+
+impl Display for ManifestWriteError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.message, self.source)
+    }
+}
+
+impl std::error::Error for ManifestWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
 }
 
 /// Store for reading and writing shard manifests.
@@ -204,21 +223,27 @@ impl ShardManifestStore {
                 .await
             {
                 Ok(()) => {}
-                Err(object_store::Error::AlreadyExists { .. }) => {
+                Err(error @ object_store::Error::AlreadyExists { .. }) => {
                     // Clean up temp file
                     let _ = self.object_store.delete(&temp_path).await;
-                    return Err(Error::io(format!(
-                        "Manifest version {} already exists for shard {}",
-                        version, self.shard_id
-                    )));
+                    return Err(manifest_write_error(
+                        format!(
+                            "Manifest version {} already exists for shard {}",
+                            version, self.shard_id
+                        ),
+                        error,
+                    ));
                 }
-                Err(e) => {
+                Err(error) => {
                     // Clean up temp file
                     let _ = self.object_store.delete(&temp_path).await;
-                    return Err(Error::io(format!(
-                        "Failed to write manifest version {} for shard {}: {}",
-                        version, self.shard_id, e
-                    )));
+                    return Err(manifest_write_error(
+                        format!(
+                            "Failed to write manifest version {} for shard {}",
+                            version, self.shard_id
+                        ),
+                        error,
+                    ));
                 }
             }
         } else {
@@ -232,18 +257,19 @@ impl ShardManifestStore {
                 .inner
                 .put_opts(&path, Bytes::from(bytes).into(), put_opts)
                 .await
-                .map_err(|e| {
-                    if matches!(e, object_store::Error::AlreadyExists { .. }) {
-                        Error::io(format!(
+                .map_err(|error| {
+                    let message = if matches!(&error, object_store::Error::AlreadyExists { .. }) {
+                        format!(
                             "Manifest version {} already exists for shard {}",
                             version, self.shard_id
-                        ))
+                        )
                     } else {
-                        Error::io(format!(
-                            "Failed to write manifest version {} for shard {}: {}",
-                            version, self.shard_id, e
-                        ))
-                    }
+                        format!(
+                            "Failed to write manifest version {} for shard {}",
+                            version, self.shard_id
+                        )
+                    };
+                    manifest_write_error(message, error)
                 })?;
         }
 
@@ -481,10 +507,20 @@ impl ShardManifestStore {
                         .await?
                         .map(|m| m.writer_epoch)
                         .unwrap_or(0);
-                    if latest_epoch >= next_epoch {
+                    let is_confirmed_conflict = is_manifest_version_conflict(&write_err);
+                    if latest_epoch > next_epoch
+                        || (latest_epoch == next_epoch && is_confirmed_conflict)
+                    {
                         return Err(Error::fenced_by_peer(format!(
                             "Failed to claim shard {} (version {}): another writer claimed epoch {} (>= our target {}): {}",
                             self.shard_id, next_version, latest_epoch, next_epoch, write_err
+                        )));
+                    }
+                    if latest_epoch == next_epoch {
+                        return Err(Error::io(format!(
+                            "Failed to confirm ownership after claiming epoch {} for shard {} \
+                             (version {}); the manifest write may have committed: {}",
+                            next_epoch, self.shard_id, next_version, write_err
                         )));
                     }
                     last_write_err = Some(write_err);
@@ -579,7 +615,7 @@ impl ShardManifestStore {
                 }
                 Err(e) => {
                     // Check if it's a version conflict (can retry) vs other error
-                    let is_version_conflict = e.to_string().contains("already exists");
+                    let is_version_conflict = is_manifest_version_conflict(&e);
 
                     if is_version_conflict && attempt < MAX_RETRIES - 1 {
                         continue;
@@ -597,9 +633,29 @@ impl ShardManifestStore {
     }
 }
 
+fn is_manifest_version_conflict(error: &Error) -> bool {
+    let mut source = std::error::Error::source(error);
+    while let Some(current) = source {
+        if let Some(store_error) = current.downcast_ref::<object_store::Error>() {
+            return matches!(
+                store_error,
+                object_store::Error::AlreadyExists { .. }
+                    | object_store::Error::Precondition { .. }
+            );
+        }
+        source = current.source();
+    }
+    false
+}
+
+fn manifest_write_error(message: String, source: object_store::Error) -> Error {
+    Error::io_source(Box::new(ManifestWriteError { message, source }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::mem_wal::test_util::failing_memory_store;
     use tempfile::TempDir;
 
     async fn create_local_store() -> (Arc<ObjectStore>, Path, TempDir) {
@@ -768,6 +824,25 @@ mod tests {
         assert_eq!(second_epoch, 2);
         assert_eq!(second.version, 3);
         assert_eq!(second.wal_entry_position_last_seen, 42);
+    }
+
+    #[tokio::test]
+    async fn test_claim_epoch_lost_ack_is_not_peer_fence() {
+        let (store, base_path, controls) = failing_memory_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+        controls.set_manifest_lost_ack(true);
+        controls.fail_manifest_puts(1);
+
+        let error = manifest_store.claim_epoch(0).await.unwrap_err();
+        assert!(
+            !error.is_mem_wal_fenced(),
+            "an ambiguous response for our own committed claim is not a peer fence: {error}"
+        );
+        assert!(error.to_string().contains("may have committed"));
+
+        let committed = manifest_store.read_latest().await.unwrap().unwrap();
+        assert_eq!(committed.writer_epoch, 1);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -340,13 +340,13 @@ impl MemTable {
             .map(|cell| cell.reader())
     }
 
-    pub(crate) fn create_typed_memtable_flush_completion(&self) -> MemTableFlushWatcher {
+    pub(crate) fn create_typed_memtable_flush_completion(&self) -> Result<MemTableFlushWatcher> {
         self.typed_memtable_flush_completion
             .lock()
-            .unwrap()
+            .map_err(|_| Error::internal("typed memtable flush completion mutex poisoned"))?
             .as_ref()
-            .expect("typed memtable flush completion cell should exist")
-            .reader()
+            .map(|cell| cell.reader())
+            .ok_or_else(|| Error::internal("typed memtable flush completion already signaled"))
     }
 
     /// Signal that the memtable flush has finished, with the outcome.
@@ -356,14 +356,23 @@ impl MemTable {
     /// (e.g. `ShardWriter::wait_for_flush_drain`) sees the closed channel
     /// and returns `Err` instead of receiving the actual outcome.
     pub fn signal_memtable_flush_complete(&self, result: DurabilityResult) {
-        if let Some(cell) = self.memtable_flush_completion.lock().unwrap().take() {
+        let cell = self.memtable_flush_completion.lock().unwrap().take();
+        if let Some(cell) = cell {
             cell.write(result);
+        } else {
+            debug_assert!(false, "memtable flush completion signaled more than once");
         }
     }
 
     pub(crate) fn signal_typed_memtable_flush_complete(&self, result: MemTableFlushResult) {
-        if let Some(cell) = self.typed_memtable_flush_completion.lock().unwrap().take() {
+        let cell = self.typed_memtable_flush_completion.lock().unwrap().take();
+        if let Some(cell) = cell {
             cell.write(result);
+        } else {
+            debug_assert!(
+                false,
+                "typed memtable flush completion signaled more than once"
+            );
         }
     }
 
@@ -863,6 +872,55 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_typed_memtable_flush_completion_reports_result() {
+        let memtable = MemTable::new(create_test_schema(), 1, vec![]).unwrap();
+        let mut watcher = memtable.create_typed_memtable_flush_completion().unwrap();
+
+        memtable.signal_typed_memtable_flush_complete(Ok(()));
+        assert!(matches!(watcher.await_value().await, Some(Ok(()))));
+
+        let error = memtable
+            .create_typed_memtable_flush_completion()
+            .expect_err("completion reader should not be created after signaling");
+        assert!(error.to_string().contains("already signaled"));
+    }
+
+    #[test]
+    fn test_typed_memtable_flush_completion_reports_poisoned_mutex() {
+        let memtable = MemTable::new(create_test_schema(), 1, vec![]).unwrap();
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = memtable.typed_memtable_flush_completion.lock().unwrap();
+            panic!("poison typed completion mutex");
+        }));
+        assert!(poisoned.is_err());
+
+        let error = memtable
+            .create_typed_memtable_flush_completion()
+            .expect_err("completion reader should not be created from a poisoned mutex");
+        assert!(error.to_string().contains("mutex poisoned"));
+    }
+
+    #[test]
+    fn test_duplicate_memtable_flush_completion_is_detected() {
+        let memtable = MemTable::new(create_test_schema(), 1, vec![]).unwrap();
+        memtable.signal_memtable_flush_complete(DurabilityResult::ok());
+        let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            memtable.signal_memtable_flush_complete(DurabilityResult::ok());
+        }));
+        assert_eq!(duplicate.is_err(), cfg!(debug_assertions));
+    }
+
+    #[test]
+    fn test_duplicate_typed_memtable_flush_completion_is_detected() {
+        let memtable = MemTable::new(create_test_schema(), 1, vec![]).unwrap();
+        memtable.signal_typed_memtable_flush_complete(Ok(()));
+        let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            memtable.signal_typed_memtable_flush_complete(Ok(()));
+        }));
+        assert_eq!(duplicate.is_err(), cfg!(debug_assertions));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -356,7 +356,11 @@ impl MemTable {
     /// (e.g. `ShardWriter::wait_for_flush_drain`) sees the closed channel
     /// and returns `Err` instead of receiving the actual outcome.
     pub fn signal_memtable_flush_complete(&self, result: DurabilityResult) {
-        let cell = self.memtable_flush_completion.lock().unwrap().take();
+        let cell = self
+            .memtable_flush_completion
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         if let Some(cell) = cell {
             cell.write(result);
         } else {
@@ -365,7 +369,11 @@ impl MemTable {
     }
 
     pub(crate) fn signal_typed_memtable_flush_complete(&self, result: MemTableFlushResult) {
-        let cell = self.typed_memtable_flush_completion.lock().unwrap().take();
+        let cell = self
+            .typed_memtable_flush_completion
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         if let Some(cell) = cell {
             cell.write(result);
         } else {
@@ -901,6 +909,34 @@ mod tests {
             .create_typed_memtable_flush_completion()
             .expect_err("completion reader should not be created from a poisoned mutex");
         assert!(error.to_string().contains("mutex poisoned"));
+    }
+
+    #[tokio::test]
+    async fn test_flush_completion_signals_through_poisoned_mutexes() {
+        let memtable = MemTable::new(create_test_schema(), 1, vec![]).unwrap();
+        let mut durability_watcher = memtable.create_memtable_flush_completion();
+        let mut typed_watcher = memtable.create_typed_memtable_flush_completion().unwrap();
+
+        let durability_poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = memtable.memtable_flush_completion.lock().unwrap();
+            panic!("poison durability completion mutex");
+        }));
+        assert!(durability_poisoned.is_err());
+
+        let typed_poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = memtable.typed_memtable_flush_completion.lock().unwrap();
+            panic!("poison typed completion mutex");
+        }));
+        assert!(typed_poisoned.is_err());
+
+        memtable.signal_memtable_flush_complete(DurabilityResult::ok());
+        memtable.signal_typed_memtable_flush_complete(Ok(()));
+
+        assert!(matches!(
+            durability_watcher.await_value().await,
+            Some(DurabilityResult::Durable)
+        ));
+        assert!(matches!(typed_watcher.await_value().await, Some(Ok(()))));
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -26,6 +26,9 @@ use super::write::{DurabilityResult, WalFlushResult};
 use crate::Dataset;
 use batch_store::BatchStore;
 
+pub(crate) type MemTableFlushResult = std::result::Result<(), WalFlushFailure>;
+pub(crate) type MemTableFlushWatcher = WatchableOnceCellReader<MemTableFlushResult>;
+
 /// Default batch store capacity when not specified.
 const DEFAULT_BATCH_CAPACITY: usize = 1024;
 
@@ -106,6 +109,10 @@ pub struct MemTable {
     /// Created when the memtable is frozen and set with a value when the flush completes.
     /// Used by backpressure to wait for oldest memtable flush completion.
     memtable_flush_completion: std::sync::Mutex<Option<WatchableOnceCell<DurabilityResult>>>,
+    /// Internal completion channel that preserves typed failure information for
+    /// `ShardWriter::wait_for_flush_drain` and `ShardWriter::close`.
+    typed_memtable_flush_completion:
+        std::sync::Mutex<Option<WatchableOnceCell<MemTableFlushResult>>>,
 }
 
 /// Cached Dataset with timestamp for eventual consistency.
@@ -226,6 +233,7 @@ impl MemTable {
         // wait on it even before the memtable is frozen. Every memtable will
         // eventually be frozen and flushed.
         let memtable_flush_cell = WatchableOnceCell::new();
+        let typed_memtable_flush_cell = WatchableOnceCell::new();
 
         Ok(Self {
             schema,
@@ -248,6 +256,7 @@ impl MemTable {
             frozen_at_wal_entry_position: None,
             wal_flush_completion: std::sync::Mutex::new(None),
             memtable_flush_completion: std::sync::Mutex::new(Some(memtable_flush_cell)),
+            typed_memtable_flush_completion: std::sync::Mutex::new(Some(typed_memtable_flush_cell)),
         })
     }
 
@@ -331,6 +340,15 @@ impl MemTable {
             .map(|cell| cell.reader())
     }
 
+    pub(crate) fn create_typed_memtable_flush_completion(&self) -> MemTableFlushWatcher {
+        self.typed_memtable_flush_completion
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("typed memtable flush completion cell should exist")
+            .reader()
+    }
+
     /// Signal that the memtable flush has finished, with the outcome.
     ///
     /// Must be called whether the flush succeeded or failed — otherwise the
@@ -339,6 +357,12 @@ impl MemTable {
     /// and returns `Err` instead of receiving the actual outcome.
     pub fn signal_memtable_flush_complete(&self, result: DurabilityResult) {
         if let Some(cell) = self.memtable_flush_completion.lock().unwrap().take() {
+            cell.write(result);
+        }
+    }
+
+    pub(crate) fn signal_typed_memtable_flush_complete(&self, result: MemTableFlushResult) {
+        if let Some(cell) = self.typed_memtable_flush_completion.lock().unwrap().take() {
             cell.write(result);
         }
     }

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -23,7 +23,7 @@ use lance_io::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreRegistry, WrappingObjectStore,
 };
 
-/// Knobs controlling injected WAL-entry write failures, shared with the test.
+/// Knobs controlling injected WAL and manifest write failures, shared with tests.
 #[derive(Debug, Default)]
 pub struct FailControls {
     /// Remaining WAL-entry `put_opts` calls to fail; saturates at 0. Set high to
@@ -57,10 +57,30 @@ impl FailControls {
     pub fn attempts(&self) -> usize {
         self.wal_put_attempts.load(Ordering::SeqCst)
     }
-    pub fn fail_manifest_puts(&self, n: usize) {
+    /// Fail the next `n` versioned manifest writes.
+    ///
+    /// Configure the [`FailControls`] returned by [`failing_memory_store`] before
+    /// invoking the manifest operation under test:
+    ///
+    /// ```text
+    /// let (_, _, controls) = failing_memory_store().await;
+    /// controls.fail_manifest_puts(1);
+    /// ```
+    pub(crate) fn fail_manifest_puts(&self, n: usize) {
         self.manifest_put_failures.store(n, Ordering::SeqCst);
     }
-    pub fn set_manifest_lost_ack(&self, v: bool) {
+
+    /// Commit failed manifest writes before returning the injected error.
+    ///
+    /// Use this with [`Self::fail_manifest_puts`] to simulate a lost
+    /// acknowledgement:
+    ///
+    /// ```text
+    /// let (_, _, controls) = failing_memory_store().await;
+    /// controls.set_manifest_lost_ack(true);
+    /// controls.fail_manifest_puts(1);
+    /// ```
+    pub(crate) fn set_manifest_lost_ack(&self, v: bool) {
         self.simulate_manifest_lost_ack.store(v, Ordering::SeqCst);
     }
 

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Test-only object store that injects WAL-write failures (for the WAL
-//! persistence-failure fencing path) and records the paths it serves (for
-//! asserting which opens actually resolved through a given `ObjectStoreParams`).
+//! Test-only object store that injects WAL and manifest write failures and
+//! records the paths it serves.
 
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
@@ -35,6 +34,10 @@ pub struct FailControls {
     simulate_lost_ack: AtomicBool,
     /// WAL-entry `put_opts` attempts observed, for assertions.
     wal_put_attempts: AtomicUsize,
+    /// Remaining versioned manifest writes to fail.
+    manifest_put_failures: AtomicUsize,
+    /// When failing a manifest write, commit it before reporting the failure.
+    simulate_manifest_lost_ack: AtomicBool,
     /// Every location written through this store.
     put_paths: StdMutex<Vec<String>>,
     /// Every location read through this store.
@@ -53,6 +56,12 @@ impl FailControls {
     }
     pub fn attempts(&self) -> usize {
         self.wal_put_attempts.load(Ordering::SeqCst)
+    }
+    pub fn fail_manifest_puts(&self, n: usize) {
+        self.manifest_put_failures.store(n, Ordering::SeqCst);
+    }
+    pub fn set_manifest_lost_ack(&self, v: bool) {
+        self.simulate_manifest_lost_ack.store(v, Ordering::SeqCst);
     }
 
     /// Did any write land on a path containing `needle`? An open that resolved
@@ -105,10 +114,14 @@ impl FailingObjectStore {
         location.as_ref().contains("/wal/")
     }
 
-    fn injected_error() -> object_store::Error {
+    fn is_versioned_manifest(location: &Path) -> bool {
+        location.as_ref().contains("/manifest/") && location.as_ref().ends_with(".binpb")
+    }
+
+    fn injected_error(operation: &str) -> object_store::Error {
         object_store::Error::Generic {
             store: "failing-test-store",
-            source: "injected transient WAL put failure".to_string().into(),
+            source: format!("injected {operation} failure").into(),
         }
     }
 }
@@ -144,8 +157,22 @@ impl OSObjectStore for FailingObjectStore {
                     // The write lands but we still report failure (lost ack).
                     let _ = self.inner.put_opts(location, payload, opts).await;
                 }
-                return Err(Self::injected_error());
+                return Err(Self::injected_error("transient WAL put"));
             }
+        } else if Self::is_versioned_manifest(location)
+            && self.controls.manifest_put_failures.load(Ordering::SeqCst) > 0
+        {
+            self.controls
+                .manifest_put_failures
+                .fetch_sub(1, Ordering::SeqCst);
+            if self
+                .controls
+                .simulate_manifest_lost_ack
+                .load(Ordering::SeqCst)
+            {
+                let _ = self.inner.put_opts(location, payload, opts).await;
+            }
+            return Err(Self::injected_error("manifest put"));
         }
         self.inner.put_opts(location, payload, opts).await
     }
@@ -229,8 +256,8 @@ pub fn observable_store_params() -> (ObjectStoreParams, Arc<FailControls>) {
     (params, controls)
 }
 
-/// Build an in-memory `ObjectStore` whose WAL-entry writes can be failed on
-/// demand. Returns the store, its base path, and the shared controls.
+/// Build an in-memory `ObjectStore` whose WAL and manifest writes can be failed
+/// on demand. Returns the store, its base path, and the shared controls.
 pub async fn failing_memory_store() -> (Arc<ObjectStore>, Path, Arc<FailControls>) {
     let (params, controls) = observable_store_params();
     let (store, base) = ObjectStore::from_uri_and_params(

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -1734,6 +1734,28 @@ mod tests {
         .unwrap()
     }
 
+    #[test]
+    fn test_wal_flush_failure_preserves_wrapped_fence_reason() {
+        for (error, expected) in [
+            (
+                Error::fenced_by_peer("peer claimed a newer epoch"),
+                FenceReason::PeerClaimedEpoch,
+            ),
+            (
+                Error::writer_poisoned("WAL persistence failed"),
+                FenceReason::PersistenceFailure,
+            ),
+        ] {
+            let wrapped = Error::wrapped(Box::new(error));
+            let restored = WalFlushFailure::from_error(&wrapped).into_error();
+            assert_eq!(restored.fence_reason(), Some(expected));
+            assert_eq!(
+                restored.is_mem_wal_fenced(),
+                expected == FenceReason::PeerClaimedEpoch
+            );
+        }
+    }
+
     fn build_test_flusher(
         store: Arc<ObjectStore>,
         base_path: &Path,

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -46,12 +46,6 @@ pub const WRITER_EPOCH_KEY: &str = "writer_epoch";
 /// replay skips sentinels via their empty batch list).
 pub const FENCE_SENTINEL_KEY: &str = "fence_sentinel";
 
-/// True if `error` is a peer fence (a successor claimed a higher epoch).
-#[cfg(test)]
-fn is_fence_error(error: &Error) -> bool {
-    error.fence_reason() == Some(FenceReason::PeerClaimedEpoch)
-}
-
 /// True if `error` is terminal for the writer (either fence kind): the WAL will
 /// never advance, so durability waiters must be woken and later writes rejected.
 fn is_terminal_failure(error: &Error) -> bool {
@@ -62,7 +56,7 @@ fn is_terminal_failure(error: &Error) -> bool {
 /// channels (`WalFlusher::terminal_error` and the per-flush `done` cell), since
 /// `lance_core::Error` is not `Clone`. Preserves the [`FenceReason`] so the typed
 /// [`Error::Fenced`] can be rebuilt rather than flattened to a string.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalFlushFailure {
     /// The fence reason if terminal; `None` for an ordinary flush error.
     pub fence_reason: Option<FenceReason>,
@@ -2224,9 +2218,10 @@ mod tests {
         // Predecessor's next append collides with the sentinel and is fenced.
         let err = first.append(vec![batch.clone()]).await.unwrap_err();
         assert!(
-            err.to_string().contains("Writer fenced"),
+            err.is_mem_wal_fenced(),
             "expected fence error from append, got: {err}"
         );
+        assert!(err.to_string().contains("Writer fenced"));
 
         // The sentinel is data-less: a tailer reads it back as zero batches so
         // replay skips it.
@@ -2284,7 +2279,7 @@ mod tests {
         let source = batch_store_source(&batch_store);
         let flush_err = flusher.flush(&source, batch_store.len()).await.unwrap_err();
         assert!(
-            is_fence_error(&flush_err),
+            flush_err.is_mem_wal_fenced(),
             "expected fence error from flush, got: {flush_err}"
         );
 
@@ -2293,7 +2288,7 @@ mod tests {
             .expect("watcher.wait() hung after a fenced flush")
             .expect_err("watcher must surface the fence, not report success");
         assert!(
-            is_fence_error(&err),
+            err.is_mem_wal_fenced(),
             "watcher must report the fence so the HTTP layer maps 410, got: {err}"
         );
     }

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -1704,6 +1704,7 @@ mod tests {
     use crate::dataset::mem_wal::test_util::failing_memory_store;
     use arrow_array::{Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
+    use rstest::rstest;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -1734,26 +1735,21 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn test_wal_flush_failure_preserves_wrapped_fence_reason() {
-        for (error, expected) in [
-            (
-                Error::fenced_by_peer("peer claimed a newer epoch"),
-                FenceReason::PeerClaimedEpoch,
-            ),
-            (
-                Error::writer_poisoned("WAL persistence failed"),
-                FenceReason::PersistenceFailure,
-            ),
-        ] {
-            let wrapped = Error::wrapped(Box::new(error));
-            let restored = WalFlushFailure::from_error(&wrapped).into_error();
-            assert_eq!(restored.fence_reason(), Some(expected));
-            assert_eq!(
-                restored.is_mem_wal_fenced(),
-                expected == FenceReason::PeerClaimedEpoch
-            );
-        }
+    #[rstest]
+    #[case::peer(FenceReason::PeerClaimedEpoch)]
+    #[case::persistence(FenceReason::PersistenceFailure)]
+    fn test_wal_flush_failure_preserves_wrapped_fence_reason(#[case] expected: FenceReason) {
+        let error = match expected {
+            FenceReason::PeerClaimedEpoch => Error::fenced_by_peer("peer claimed a newer epoch"),
+            FenceReason::PersistenceFailure => Error::writer_poisoned("WAL persistence failed"),
+        };
+        let wrapped = Error::wrapped(Box::new(error));
+        let restored = WalFlushFailure::from_error(&wrapped).into_error();
+        assert_eq!(restored.fence_reason(), Some(expected));
+        assert_eq!(
+            restored.is_mem_wal_fenced(),
+            expected == FenceReason::PeerClaimedEpoch
+        );
     }
 
     fn build_test_flusher(

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -47,6 +47,7 @@ pub use super::memtable::scanner::MemTableScanner;
 pub use super::util::{WatchableOnceCell, WatchableOnceCellReader};
 pub use super::wal::{WalEntry, WalEntryData, WalFlushFailure, WalFlushResult, WalFlusher};
 
+use super::memtable::MemTableFlushWatcher;
 use super::memtable::flush::TriggerMemTableFlush;
 use super::scanner::GenerationWarmer;
 use super::wal::{
@@ -608,9 +609,8 @@ impl Default for TaskExecutor {
 pub enum DurabilityResult {
     /// Write is now durable.
     Durable,
-    /// Write failed. The carrier preserves typed writer-fence information
-    /// across cloneable completion channels.
-    Failed(WalFlushFailure),
+    /// Write failed with an error message.
+    Failed(String),
 }
 
 impl DurabilityResult {
@@ -621,14 +621,7 @@ impl DurabilityResult {
 
     /// Create a failed durability result.
     pub fn err(msg: impl Into<String>) -> Self {
-        Self::Failed(WalFlushFailure {
-            fence_reason: None,
-            message: msg.into(),
-        })
-    }
-
-    fn from_error(error: &Error) -> Self {
-        Self::Failed(WalFlushFailure::from_error(error))
+        Self::Failed(msg.into())
     }
 
     /// Check if the result is durable.
@@ -640,7 +633,7 @@ impl DurabilityResult {
     pub fn into_result(self) -> Result<()> {
         match self {
             Self::Durable => Ok(()),
-            Self::Failed(failure) => Err(failure.into_error()),
+            Self::Failed(msg) => Err(Error::io(msg)),
         }
     }
 }
@@ -805,7 +798,7 @@ struct WriterState {
     /// Total size of frozen memtables (for backpressure).
     frozen_memtable_bytes: usize,
     /// Flush watchers for frozen memtables (for backpressure).
-    frozen_flush_watchers: VecDeque<(usize, DurabilityWatcher)>,
+    frozen_flush_watchers: VecDeque<(usize, DurabilityWatcher, MemTableFlushWatcher)>,
     /// Sealed memtables, kept queryable so a concurrent reader sees no hole
     /// between `freeze_memtable` and the flush task's manifest commit, and for
     /// `frozen_memtable_grace` beyond it so as-of reads stay batch-resolved.
@@ -1260,6 +1253,7 @@ impl SharedWriterState {
         // its cells and a failed send below can poison-and-return without leaving
         // partial state to unwind.
         let _memtable_flush_watcher = old_memtable.create_memtable_flush_completion();
+        let typed_memtable_flush_watcher = old_memtable.create_typed_memtable_flush_completion();
 
         // The outgoing memtable may still owe an index apply — the puts that
         // filled it triggered one, but the task need not have drained yet, and
@@ -1289,9 +1283,11 @@ impl SharedWriterState {
         let flush_watcher = old_memtable
             .get_memtable_flush_watcher()
             .expect("Flush watcher should exist after create_memtable_flush_completion");
-        state
-            .frozen_flush_watchers
-            .push_back((frozen_size, flush_watcher));
+        state.frozen_flush_watchers.push_back((
+            frozen_size,
+            flush_watcher,
+            typed_memtable_flush_watcher,
+        ));
 
         let frozen_memtable = Arc::new(old_memtable);
 
@@ -1471,7 +1467,7 @@ impl SharedWriterState {
             // First try frozen memtable watchers
             s.frozen_flush_watchers
                 .front()
-                .map(|(_, watcher)| watcher.clone())
+                .map(|(_, watcher, _)| watcher.clone())
                 // If no frozen memtables, use active memtable's watcher
                 .or_else(|| s.memtable.get_memtable_flush_watcher())
         })
@@ -2538,7 +2534,7 @@ impl ShardWriter {
     /// landed and been recorded in the manifest. Does not wait on the
     /// active memtable — call [`Self::force_seal_active`] first if you
     /// want everything-on-disk. Errors in WAL-only mode, or if any
-    /// awaited flush reports `DurabilityResult::Failed`.
+    /// awaited flush reports a typed completion failure.
     ///
     /// Useful in tests for deterministic post-flush assertions, and in
     /// production wherever a caller needs a synchronous fence after
@@ -2558,11 +2554,11 @@ impl ShardWriter {
         };
 
         loop {
-            let watchers: Vec<DurabilityWatcher> = {
+            let watchers: Vec<MemTableFlushWatcher> = {
                 let st = state_lock.read().await;
                 st.frozen_flush_watchers
                     .iter()
-                    .map(|(_, w)| w.clone())
+                    .map(|(_, _, w)| w.clone())
                     .collect()
             };
             if watchers.is_empty() {
@@ -2570,7 +2566,7 @@ impl ShardWriter {
             }
             for mut w in watchers {
                 match w.await_value().await {
-                    Some(durability) => durability.into_result()?,
+                    Some(result) => result.map_err(WalFlushFailure::into_error)?,
                     None => {
                         return Err(Error::io(
                             "MemTable flush handler exited before reporting completion",
@@ -2749,12 +2745,12 @@ impl ShardWriter {
                     }
                     st.frozen_flush_watchers
                         .iter()
-                        .map(|(_, w)| w.clone())
+                        .map(|(_, _, w)| w.clone())
                         .collect()
                 };
                 for mut watcher in watchers {
                     let stage_result = match watcher.await_value().await {
-                        Some(durability) => durability.into_result(),
+                        Some(result) => result.map_err(WalFlushFailure::into_error),
                         None => Err(Error::io(
                             "MemTable flush handler exited before reporting completion during close",
                         )),
@@ -3173,15 +3169,21 @@ impl MemTableFlushHandler {
         // backpressure state for this memtable, even on failure.
         let durability = match &flush_result {
             Ok(_) => DurabilityResult::ok(),
-            Err(e) => DurabilityResult::from_error(e),
+            Err(e) => DurabilityResult::err(e.to_string()),
         };
         memtable.signal_memtable_flush_complete(durability);
+        let typed_result = flush_result
+            .as_ref()
+            .map(|_| ())
+            .map_err(WalFlushFailure::from_error);
+        memtable.signal_typed_memtable_flush_complete(typed_result);
 
         {
             let mut state = self.state.write().await;
             // Backpressure drain: unconditional so `wait_for_flush_drain`
             // sees the watcher's error signal, not a dropped channel.
-            if let Some((_size, _watcher)) = state.frozen_flush_watchers.pop_front() {
+            if let Some((_size, _watcher, _typed_watcher)) = state.frozen_flush_watchers.pop_front()
+            {
                 state.frozen_memtable_bytes =
                     state.frozen_memtable_bytes.saturating_sub(memtable_size);
             }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -1253,7 +1253,7 @@ impl SharedWriterState {
         // its cells and a failed send below can poison-and-return without leaving
         // partial state to unwind.
         let _memtable_flush_watcher = old_memtable.create_memtable_flush_completion();
-        let typed_memtable_flush_watcher = old_memtable.create_typed_memtable_flush_completion();
+        let typed_memtable_flush_watcher = old_memtable.create_typed_memtable_flush_completion()?;
 
         // The outgoing memtable may still owe an index apply — the puts that
         // filled it triggered one, but the task need not have drained yet, and

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -608,8 +608,9 @@ impl Default for TaskExecutor {
 pub enum DurabilityResult {
     /// Write is now durable.
     Durable,
-    /// Write failed with an error message.
-    Failed(String),
+    /// Write failed. The carrier preserves typed writer-fence information
+    /// across cloneable completion channels.
+    Failed(WalFlushFailure),
 }
 
 impl DurabilityResult {
@@ -620,7 +621,14 @@ impl DurabilityResult {
 
     /// Create a failed durability result.
     pub fn err(msg: impl Into<String>) -> Self {
-        Self::Failed(msg.into())
+        Self::Failed(WalFlushFailure {
+            fence_reason: None,
+            message: msg.into(),
+        })
+    }
+
+    fn from_error(error: &Error) -> Self {
+        Self::Failed(WalFlushFailure::from_error(error))
     }
 
     /// Check if the result is durable.
@@ -632,7 +640,7 @@ impl DurabilityResult {
     pub fn into_result(self) -> Result<()> {
         match self {
             Self::Durable => Ok(()),
-            Self::Failed(msg) => Err(Error::io(msg)),
+            Self::Failed(failure) => Err(failure.into_error()),
         }
     }
 }
@@ -3165,7 +3173,7 @@ impl MemTableFlushHandler {
         // backpressure state for this memtable, even on failure.
         let durability = match &flush_result {
             Ok(_) => DurabilityResult::ok(),
-            Err(e) => DurabilityResult::err(e.to_string()),
+            Err(e) => DurabilityResult::from_error(e),
         };
         memtable.signal_memtable_flush_complete(durability);
 
@@ -5226,10 +5234,8 @@ mod tests {
             .put(vec![create_test_batch(&schema, 2, 1)])
             .await
             .expect_err("expected fence error");
-        assert!(
-            err.to_string().contains("Writer fenced"),
-            "unexpected error: {err}"
-        );
+        assert!(err.is_mem_wal_fenced(), "unexpected error: {err}");
+        assert!(err.to_string().contains("Writer fenced"));
 
         writer_b.close().await.unwrap();
     }
@@ -5272,10 +5278,8 @@ mod tests {
             .check_fenced()
             .await
             .expect_err("expected fence error");
-        assert!(
-            err.to_string().contains("Writer fenced"),
-            "unexpected error: {err}"
-        );
+        assert!(err.is_mem_wal_fenced(), "unexpected error: {err}");
+        assert!(err.to_string().contains("Writer fenced"));
 
         // B is the current writer and is not fenced.
         writer_b.check_fenced().await.unwrap();
@@ -6148,6 +6152,7 @@ mod tests {
             Some(FenceReason::PeerClaimedEpoch),
             "replay must abort with a typed peer-fence error, got: {err}"
         );
+        assert!(err.is_mem_wal_fenced());
         let msg = err.to_string();
         assert!(
             msg.contains("WAL replay aborted") && msg.contains("fenced"),
@@ -6309,7 +6314,7 @@ mod tests {
         // Writer B claims epoch 2 and writes its own entry (takes WAL
         // position 1). A is now fenced: A's next put will attempt WAL
         // position 1 (its cached next), collide with B's entry, and
-        // surface a "Writer fenced" error from `check_fenced`.
+        // surface a typed fence error from `check_fenced`.
         let writer_b = ShardWriter::open(
             store,
             base_path,
@@ -6346,6 +6351,8 @@ mod tests {
             r1.is_err() && r2.is_err(),
             "expected both concurrent puts on a fenced writer to fail, got r1={r1:?} r2={r2:?}",
         );
+        assert!(r1.as_ref().is_err_and(|error| error.is_mem_wal_fenced()));
+        assert!(r2.as_ref().is_err_and(|error| error.is_mem_wal_fenced()));
 
         writer_b.close().await.unwrap();
     }
@@ -6692,17 +6699,20 @@ mod tests {
         assert!(writer_b.epoch() > writer_a.epoch());
 
         let error = writer_a
+            .force_seal_active()
+            .await
+            .expect_err("force_seal_active must report the peer fence");
+        assert!(
+            error.is_mem_wal_fenced(),
+            "unexpected force_seal_active error: {error}"
+        );
+
+        let error = writer_a
             .close()
             .await
             .expect_err("close must propagate the fenced MemTable flush");
-        assert!(
-            matches!(error, Error::IO { .. }),
-            "unexpected error: {error}"
-        );
-        assert!(
-            error.to_string().contains("Writer fenced"),
-            "unexpected error: {error}"
-        );
+        assert!(error.is_mem_wal_fenced(), "unexpected error: {error}");
+        assert!(error.to_string().contains("Writer fenced"));
 
         writer_b.close().await.unwrap();
     }
@@ -6763,10 +6773,14 @@ mod tests {
             WriterMode::WalOnly { .. } => unreachable!("opened in memtable mode"),
         }
 
-        // The fenced flush fails; the drain surfaces that error.
+        // The fenced flush fails; the drain surfaces the typed error.
+        let error = writer_a
+            .wait_for_flush_drain()
+            .await
+            .expect_err("fenced flush should fail the drain");
         assert!(
-            writer_a.wait_for_flush_drain().await.is_err(),
-            "fenced flush should fail the drain"
+            error.is_mem_wal_fenced(),
+            "unexpected flush drain error: {error}"
         );
 
         // The hole did not reopen: the sealed generation is still queryable


### PR DESCRIPTION
## Summary

- add `Error::is_mem_wal_fenced()` for detecting peer epoch takeovers without parsing error text
- preserve typed fence reasons through WAL and MemTable completion channels
- distinguish confirmed epoch conflicts from ambiguous lost acknowledgements
- preserve the public `DurabilityResult::Failed(String)` API
- update MemWAL regressions for `put`, replay/open, `force_seal_active`, `wait_for_flush_drain`, and `close`

## Testing

- `cargo test -p lance-core --doc is_mem_wal_fenced`
- `cargo test -p lance-core fence`
- `cargo test -p lance fence`
- `cargo test -p lance dataset::mem_wal::manifest::tests::test_claim_epoch_lost_ack_is_not_peer_fence -- --exact`
- `cargo test -p lance dataset::mem_wal::write::tests::test_close_propagates_frozen_memtable_flush_failure -- --exact`
- `cargo test -p lance dataset::mem_wal::write::tests::test_frozen_retained_after_failed_flush -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`