### PR TITLE
test(mem_wal): cover cross-generation durable-put fencing end to end

### DIFF
--- a/rust/lance/tests/integration_tests.rs
+++ b/rust/lance/tests/integration_tests.rs
@@ -4,6 +4,7 @@
 // NOTE: we only create one integration test binary, to keep compilation overhead down.
 
 mod count_pushdown;
+mod mem_wal;
 #[cfg(feature = "slow_tests")]
 mod query;
 #[cfg(feature = "slow_tests")]

--- a/rust/lance/tests/mem_wal.rs
+++ b/rust/lance/tests/mem_wal.rs
@@ -4,6 +4,8 @@
 //! End-to-end MemWAL tests through the public [`ShardWriter`] surface, as
 //! opposed to the lib-level unit tests that can reach internals directly.
 
+use std::time::Duration;
+
 use arrow_array::record_batch;
 use lance::dataset::mem_wal::{ShardWriter, ShardWriterConfig};
 use lance_core::FenceReason;
@@ -32,7 +34,7 @@ async fn durable_put_does_not_alias_across_memtable_generations() {
         shard_id,
         durable_write: true,
         max_wal_buffer_size: 64 * 1024 * 1024,
-        max_wal_flush_interval: None,
+        max_wal_flush_interval: Some(Duration::from_millis(10)),
         max_memtable_size: 64 * 1024 * 1024,
         manifest_scan_batch_size: 2,
         ..Default::default()

--- a/rust/lance/tests/mem_wal.rs
+++ b/rust/lance/tests/mem_wal.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! End-to-end MemWAL tests through the public [`ShardWriter`] surface, as
+//! opposed to the lib-level unit tests that can reach internals directly.
+
+use arrow_array::record_batch;
+use lance::dataset::mem_wal::{ShardWriter, ShardWriterConfig};
+use lance_core::FenceReason;
+use lance_io::object_store::ObjectStore;
+use uuid::Uuid;
+
+/// A durable put into a post-rotation MemTable must be acknowledged only by
+/// its own WAL flush, never by a flush from an older generation.
+///
+/// Batch positions restart at 0 in every MemTable generation. A durability
+/// watch keyed on that generation-local position is satisfied by the previous
+/// generation's flush at the same position — so the first durable put after a
+/// rotation used to return success before its own WAL append completed. Here
+/// a peer writer has claimed a higher epoch in between, so the false success
+/// is observable: the put's own flush is fenced, and the put must surface
+/// that fence instead of reporting durability.
+#[tokio::test]
+async fn durable_put_does_not_alias_across_memtable_generations() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let base_uri = format!("file://{}", temp_dir.path().display());
+    let (store, base_path) = ObjectStore::from_uri(&base_uri).await.unwrap();
+    let shard_id = Uuid::new_v4();
+    let first_batch = record_batch!(("id", Int32, [1])).unwrap();
+    let schema = first_batch.schema();
+    let config = ShardWriterConfig {
+        shard_id,
+        durable_write: true,
+        max_wal_buffer_size: 64 * 1024 * 1024,
+        max_wal_flush_interval: None,
+        max_memtable_size: 64 * 1024 * 1024,
+        manifest_scan_batch_size: 2,
+        ..Default::default()
+    };
+
+    let writer_a = ShardWriter::open(
+        store.clone(),
+        base_path.clone(),
+        base_uri.clone(),
+        config.clone(),
+        schema.clone(),
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    // Write and fully flush generation N, then rotate to generation N+1.
+    writer_a.put(vec![first_batch]).await.unwrap();
+    let first_generation = writer_a.memtable_stats().await.unwrap().generation;
+    writer_a.force_seal_active().await.unwrap();
+    writer_a.wait_for_flush_drain().await.unwrap();
+    assert_eq!(
+        writer_a.memtable_stats().await.unwrap().generation,
+        first_generation + 1
+    );
+
+    // A peer claims a higher epoch, fencing writer A's next WAL append.
+    let writer_b = ShardWriter::open(store, base_path, base_uri, config, schema, vec![])
+        .await
+        .unwrap();
+    assert!(writer_b.epoch() > writer_a.epoch());
+
+    // Generation N+1's first durable put lands at the same local batch
+    // position (0..1) that generation N already flushed. It must wait for its
+    // own flush and therefore surface the fence, not ack from the stale
+    // generation.
+    let second_batch = record_batch!(("id", Int32, [2])).unwrap();
+    let error = writer_a
+        .put(vec![second_batch])
+        .await
+        .expect_err("generation-2 durable put must wait for its own WAL flush");
+    assert_eq!(error.fence_reason(), Some(FenceReason::PeerClaimedEpoch));
+    assert!(error.to_string().contains("Writer fenced"));
+
+    writer_b.close().await.unwrap();
+}

--- a/rust/lance/tests/mem_wal/mod.rs
+++ b/rust/lance/tests/mem_wal/mod.rs
@@ -6,11 +6,54 @@
 
 use std::time::Duration;
 
+use arrow_array::cast::AsArray;
 use arrow_array::record_batch;
+use arrow_array::types::Int32Type;
 use lance::dataset::mem_wal::{ShardWriter, ShardWriterConfig};
 use lance_core::FenceReason;
 use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
+
+fn durable_writer_config(shard_id: Uuid) -> ShardWriterConfig {
+    ShardWriterConfig {
+        shard_id,
+        durable_write: true,
+        max_wal_buffer_size: 64 * 1024 * 1024,
+        max_wal_flush_interval: Some(Duration::from_millis(10)),
+        max_memtable_size: 64 * 1024 * 1024,
+        manifest_scan_batch_size: 2,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn durable_put_is_readable_through_public_scan() {
+    let base_uri = "memory://".to_string();
+    let (store, base_path) = ObjectStore::from_uri(&base_uri).await.unwrap();
+    let batch = record_batch!(("id", Int32, [1, 2, 3])).unwrap();
+    let writer = ShardWriter::open(
+        store,
+        base_path,
+        base_uri,
+        durable_writer_config(Uuid::new_v4()),
+        batch.schema(),
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    writer.put(vec![batch]).await.unwrap();
+
+    let scanned = writer.scan().await.unwrap().try_into_batch().await.unwrap();
+    let scanned_ids = scanned["id"].as_primitive::<Int32Type>();
+    assert_eq!(
+        scanned_ids.values(),
+        &[1, 2, 3],
+        "a durable put must be readable through the public scan API"
+    );
+
+    writer.close().await.unwrap();
+}
 
 /// A durable put into a post-rotation MemTable must be acknowledged only by
 /// its own WAL flush, never by a flush from an older generation.
@@ -24,21 +67,12 @@ use uuid::Uuid;
 /// that fence instead of reporting durability.
 #[tokio::test]
 async fn durable_put_does_not_alias_across_memtable_generations() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let base_uri = format!("file://{}", temp_dir.path().display());
+    let base_uri = "memory://".to_string();
     let (store, base_path) = ObjectStore::from_uri(&base_uri).await.unwrap();
     let shard_id = Uuid::new_v4();
     let first_batch = record_batch!(("id", Int32, [1])).unwrap();
     let schema = first_batch.schema();
-    let config = ShardWriterConfig {
-        shard_id,
-        durable_write: true,
-        max_wal_buffer_size: 64 * 1024 * 1024,
-        max_wal_flush_interval: Some(Duration::from_millis(10)),
-        max_memtable_size: 64 * 1024 * 1024,
-        manifest_scan_batch_size: 2,
-        ..Default::default()
-    };
+    let config = durable_writer_config(shard_id);
 
     let writer_a = ShardWriter::open(
         store.clone(),
@@ -56,16 +90,23 @@ async fn durable_put_does_not_alias_across_memtable_generations() {
     let first_generation = writer_a.memtable_stats().await.unwrap().generation;
     writer_a.force_seal_active().await.unwrap();
     writer_a.wait_for_flush_drain().await.unwrap();
+    let current_generation = writer_a.memtable_stats().await.unwrap().generation;
     assert_eq!(
-        writer_a.memtable_stats().await.unwrap().generation,
-        first_generation + 1
+        current_generation,
+        first_generation + 1,
+        "expected rotation from generation {first_generation}, got {current_generation}"
     );
 
     // A peer claims a higher epoch, fencing writer A's next WAL append.
     let writer_b = ShardWriter::open(store, base_path, base_uri, config, schema, vec![])
         .await
         .unwrap();
-    assert!(writer_b.epoch() > writer_a.epoch());
+    assert!(
+        writer_b.epoch() > writer_a.epoch(),
+        "expected peer epoch to increase: writer_a={}, writer_b={}",
+        writer_a.epoch(),
+        writer_b.epoch()
+    );
 
     // Generation N+1's first durable put lands at the same local batch
     // position (0..1) that generation N already flushed. It must wait for its
@@ -76,8 +117,15 @@ async fn durable_put_does_not_alias_across_memtable_generations() {
         .put(vec![second_batch])
         .await
         .expect_err("generation-2 durable put must wait for its own WAL flush");
-    assert_eq!(error.fence_reason(), Some(FenceReason::PeerClaimedEpoch));
-    assert!(error.to_string().contains("Writer fenced"));
+    assert_eq!(
+        error.fence_reason(),
+        Some(FenceReason::PeerClaimedEpoch),
+        "expected a peer-claimed-epoch fence, got: {error}"
+    );
+    assert!(
+        error.to_string().contains("Writer fenced"),
+        "expected the writer-fenced error prefix, got: {error}"
+    );
 
     writer_b.close().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Ports the public-surface regression test from the closed #7759 onto the post-#7888 design.

- Add an end-to-end MemWAL test through the public `ShardWriter` API: after a MemTable rotation, a peer writer claims a higher epoch, and the first durable put into the new generation must wait for its own WAL flush and surface the `PeerClaimedEpoch` fence — not ack from the stale generation's durability state.
- Organize the integration coverage under `rust/lance/tests/mem_wal/` and add a durable public `put` → `scan` round-trip test for the primary write/read path.
- This is the integration-level counterpart to the lib-level `test_durable_ack_after_rotation_requires_its_own_wal_append` added in #7888, which covers the false acknowledgement (#7760) via internal stats; this test exercises the same failure sequence purely through the public API (`open` / `put` / `force_seal_active` / `wait_for_flush_drain`) and asserts the typed `FenceReason`.

## Background

Batch positions restart at 0 in every MemTable generation. Before the writer-global durability cursor (#7888), a durability watch keyed on the generation-local position could be satisfied by the previous generation's flush at the same position — the first durable put after a rotation returned success before its own WAL append completed. The sequence here (rotate → peer claims epoch → durable put at the same local position) makes that false success observable as a missing `PeerClaimedEpoch` error.

## Pre-#7888 failure sequence (what the test must never allow again)

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant G0 as Writer A / generation N
    participant M as Shared durability watermark
    participant G1 as Writer A / generation N+1
    participant B as Writer B
    participant W as WAL

    C->>G0: durable put, local range 0..1
    G0->>W: flush generation N
    W-->>G0: success
    G0->>M: publish watermark 1
    Note over G0,G1: MemTable rotates and local positions restart at 0
    B->>W: claim a higher writer epoch
    C->>G1: durable put, local range 0..1
    G1->>M: wait for watermark >= 1
    M-->>G1: already satisfied by generation N
    G1-->>C: incorrect success
    G1->>W: flush generation N+1
    W-->>G1: PeerClaimedEpoch
```

Steps 1–4 map to the first `put` plus `force_seal_active` + `wait_for_flush_drain`, step 6 to opening writer B, and steps 7–13 to the second `put`.

## Post-#7888 behavior (what the test asserts)

The durability cursor is writer-global and the put's target is lifted through `BatchStore::global_offset()`, so the wait can only be satisfied by an append covering this generation's own range — and the peer fence arrives *before* any success can be reported:

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant G1 as Writer A / generation N+1
    participant Cur as WriterCursors (writer-global)
    participant H as WalFlushHandler
    participant W as WAL

    C->>G1: durable put, local range 0..1
    G1->>G1: durable target = global_offset(1) + 1 = 2
    G1->>H: trigger flush of generation N+1
    G1->>Cur: wait until durable() >= 2 (cursor at 1)
    H->>W: append generation N+1 range
    W-->>H: PeerClaimedEpoch (writer B claimed the epoch)
    H->>Cur: latch terminal error, wake waiters
    Cur-->>C: Error::Fenced(PeerClaimedEpoch)
```

The test asserts exactly step 8: `error.fence_reason() == Some(FenceReason::PeerClaimedEpoch)`.

## Validation

- `cargo test -p lance --test integration_tests mem_wal:: -- --nocapture` — passed (2/2)
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all --tests --benches -- -D warnings` — passed
- pre-commit hooks (fmt, typos, lock-sync) — passed

## Compatibility

Test-only change; no API, format, or dependency changes.
