### PR TITLE
fix(blob)!: preserve null selections across blob APIs

### DIFF
--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -175,6 +175,7 @@ Choose the read API based on the payload shape you want:
 | API | Returns | Use When |
 |---|---|---|
 | `read_blobs` | `List[Tuple[int, Optional[bytes]]]` | You need complete blob payloads in memory, such as training loaders or batch preprocessing. |
+| `read_blob_ranges` | `List[Tuple[int, int, Optional[bytes]]]` | You need selected byte ranges from multiple rows without materializing complete blobs. |
 | `take_blobs` | `List[Optional[BlobFile]]` | You need file-like objects for streaming, seeking, or partial reads. |
 | `scanner(..., blob_handling="all_binary")` | Arrow binary columns | You want blob columns in a scan result or `pyarrow.Table`. |
 
@@ -183,7 +184,8 @@ Do not wrap `take_blobs` in your own thread pool just to call `read()` or
 batched blob reads through Lance's scheduler.
 
 Exactly one selector must be provided to `read_blobs` or `take_blobs`: `ids`,
-`indices`, or `addresses`.
+`indices`, or `addresses`. `read_blob_ranges` accepts the same selector kinds
+through its required `selector` argument.
 
 | Selector | Typical Use | Stability |
 |---|---|---|
@@ -223,10 +225,47 @@ row_addrs = ds.to_table(columns=[], with_row_address=True).column("_rowaddr").to
 rows = ds.read_blobs("blob", addresses=row_addrs[:2])
 ```
 
-Blob selection APIs preserve caller identity. `read_blobs()` and
+Blob selection APIs preserve logical result cardinality. `read_blobs()` and
 `take_blobs()` return one element per selected row, and `read_blob_ranges()`
 returns one element per request. A null blob is returned as `None`; a valid
 empty blob remains a non-null empty payload or zero-length `BlobFile`.
+
+### Read row-specific byte ranges
+
+Use `read_blob_ranges` to read multiple blob-local ranges with one planned API
+call. Each request is a `(row, offset, length)` tuple, and `selector` determines
+whether every `row` is interpreted as a row ID, row address, or dataset index.
+
+```python
+import lance
+
+ds = lance.dataset("./blobs_v22.lance")
+results = ds.read_blob_ranges(
+    "blob",
+    requests=[
+        (7, 0, 1024),
+        (7, 4096, 1024),
+        (12, 0, 0),
+    ],
+    selector="indices",
+)
+
+for request_index, row_address, data in results:
+    if data is None:
+        # The selected blob is null.
+        continue
+    print(request_index, row_address, len(data))
+```
+
+Each result contains the zero-based `request_index`, the resolved physical row
+address, and the requested bytes. `request_index` identifies the original
+request when the same row appears more than once.
+
+A request on a null blob returns `None`, including when its range is empty. An
+empty range on a non-null blob returns `b""` without payload I/O. For every
+request, `offset + length` must fit in an unsigned 64-bit integer. A range on a
+non-null blob must not extend beyond its logical size; blob-local bounds are not
+evaluated for null blobs because they have no logical payload length.
 
 ### Read blob columns as Arrow binary
 
@@ -356,7 +395,7 @@ lance.write_dataset(
 
 Not every binary column needs to be a blob column. Plain Arrow `binary`/`large_binary` stores bytes *inline*, interleaved with your other columns, which is simplest and fastest for really small blobs (e.g., thumbnail images). Using a blob column to store the binary payload makes sense when either of these holds:
 
-- **You need partial or streaming reads.** Inline binary is always read in full; there is no way to fetch a byte range without materializing the entire value. Blob columns expose `take_blobs` → `BlobFile` handles that seek and range-read, so you pay only for the bytes you touch.
+- **You need partial or streaming reads.** Inline binary is always read in full; there is no way to fetch a byte range without materializing the entire value. Blob columns expose `read_blob_ranges` for planned row-specific range reads and `take_blobs` → `BlobFile` handles for caller-driven seeks, so you pay only for the bytes you touch.
 - **Your values are large (roughly 1 MB or more on average).** Operations that rewrite entire rows, such as compaction or some updates, must copy the large inline payloads forward into the new version — even when those bytes never changed. The bigger the payload, the more bytes you rewrite per logical change (write amplification). A blob column keeps large payloads in separate `.blob` files that are referenced rather than re-copied, so these operations don't rewrite the heavy bytes.
 
 !!! tip

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -174,8 +174,8 @@ Choose the read API based on the payload shape you want:
 
 | API | Returns | Use When |
 |---|---|---|
-| `read_blobs` | `List[Tuple[int, bytes]]` | You need complete blob payloads in memory, such as training loaders or batch preprocessing. |
-| `take_blobs` | `List[BlobFile]` | You need file-like objects for streaming, seeking, or partial reads. |
+| `read_blobs` | `List[Tuple[int, Optional[bytes]]]` | You need complete blob payloads in memory, such as training loaders or batch preprocessing. |
+| `take_blobs` | `List[Optional[BlobFile]]` | You need file-like objects for streaming, seeking, or partial reads. |
 | `scanner(..., blob_handling="all_binary")` | Arrow binary columns | You want blob columns in a scan result or `pyarrow.Table`. |
 
 Do not wrap `take_blobs` in your own thread pool just to call `read()` or
@@ -246,8 +246,10 @@ import lance
 ds = lance.dataset("./blobs_v22.lance")
 blobs = ds.take_blobs("blob", indices=[0, 1])
 
-with blobs[0] as f:
-    header = f.read(1024)
+blob = blobs[0]
+if blob is not None:
+    with blob as f:
+        header = f.read(1024)
 ```
 
 ### Example: decode video frames lazily
@@ -258,6 +260,8 @@ import lance
 
 ds = lance.dataset("./videos_v22.lance")
 blob = ds.take_blobs("video", indices=[0])[0]
+if blob is None:
+    raise ValueError("video blob is null")
 
 start_ms, end_ms = 500, 1000
 

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -223,6 +223,11 @@ row_addrs = ds.to_table(columns=[], with_row_address=True).column("_rowaddr").to
 rows = ds.read_blobs("blob", addresses=row_addrs[:2])
 ```
 
+Blob selection APIs preserve caller identity. `read_blobs()` and
+`take_blobs()` return one element per selected row, and `read_blob_ranges()`
+returns one element per request. A null blob is returned as `None`; a valid
+empty blob remains a non-null empty payload or zero-length `BlobFile`.
+
 ### Read blob columns as Arrow binary
 
 ```python

--- a/java/lance-jni/src/blocking_blob.rs
+++ b/java/lance-jni/src/blocking_blob.rs
@@ -63,19 +63,22 @@ fn inner_take_blobs<'local>(
     };
     let j_blobs = blobs
         .into_iter()
-        .map(BlockingBlobFile::from)
-        .collect::<Vec<BlockingBlobFile>>();
+        .map(|blob| blob.map(BlockingBlobFile::from))
+        .collect::<Vec<_>>();
     transform_vec(env, j_blobs)
 }
 
 fn transform_vec<'local>(
     env: &mut JNIEnv<'local>,
-    vec: Vec<BlockingBlobFile>,
+    vec: Vec<Option<BlockingBlobFile>>,
 ) -> Result<JObject<'local>> {
     let array_list_class = env.find_class("java/util/ArrayList")?;
     let array_list = env.new_object(array_list_class, "()V", &[])?;
     for blob_file in vec {
-        let blob_file_obj = blob_file.into_java(env)?;
+        let blob_file_obj = match blob_file {
+            Some(blob_file) => blob_file.into_java(env)?,
+            None => JObject::null(),
+        };
         env.call_method(
             &array_list,
             "add",
@@ -117,8 +120,8 @@ fn inner_take_blobs_by_indices<'local>(
     };
     let j_blobs = blobs
         .into_iter()
-        .map(BlockingBlobFile::from)
-        .collect::<Vec<BlockingBlobFile>>();
+        .map(|blob| blob.map(BlockingBlobFile::from))
+        .collect::<Vec<_>>();
     transform_vec(env, j_blobs)
 }
 

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1625,7 +1625,7 @@ public class Dataset implements Closeable {
    *
    * @param rowIds stable row ids (row addresses)
    * @param column blob column name
-   * @return list of BlobFile objects
+   * @return one element per row id; null blob values are represented by null elements
    */
   public List<BlobFile> takeBlobs(List<Long> rowIds, String column) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
@@ -1643,7 +1643,7 @@ public class Dataset implements Closeable {
    *
    * @param rowIndices row offsets within dataset
    * @param column blob column name
-   * @return list of BlobFile objects
+   * @return one element per row index; null blob values are represented by null elements
    */
   public List<BlobFile> takeBlobsByIndices(List<Long> rowIndices, String column) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1621,10 +1621,14 @@ public class Dataset implements Closeable {
   private native List<BlobFile> nativeTakeBlobsByIndices(List<Long> rowIndices, String column);
 
   /**
-   * Open {@link BlobFile} handles for given row ids on a blob column. Names and semantics align
+   * Open {@link BlobFile} handles for given row IDs on a blob column. Names and semantics align
    * with Rust/Python.
    *
+   * <p>Pass logical row IDs read from {@code _rowid}, not physical row addresses from {@code
+   * _rowaddr}.
+   *
    * <pre>{@code
+   * long rowId = 42L; // Example value from the _rowid column.
    * List<BlobFile> blobs = dataset.takeBlobs(List.of(rowId), "images");
    * for (BlobFile blob : blobs) {
    *   if (blob != null) {
@@ -1635,9 +1639,9 @@ public class Dataset implements Closeable {
    * }
    * }</pre>
    *
-   * @param rowIds stable row ids (row addresses)
+   * @param rowIds logical row IDs from the {@code _rowid} column
    * @param column blob column name
-   * @return one {@link BlobFile} per row id; null blob values are represented by null elements
+   * @return one {@link BlobFile} per row ID; null blob values are represented by null elements
    */
   public List<BlobFile> takeBlobs(List<Long> rowIds, String column) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1621,11 +1621,23 @@ public class Dataset implements Closeable {
   private native List<BlobFile> nativeTakeBlobsByIndices(List<Long> rowIndices, String column);
 
   /**
-   * Open blob files for given row ids on a blob column. Names and semantics align with Rust/Python.
+   * Open {@link BlobFile} handles for given row ids on a blob column. Names and semantics align
+   * with Rust/Python.
+   *
+   * <pre>{@code
+   * List<BlobFile> blobs = dataset.takeBlobs(List.of(rowId), "images");
+   * for (BlobFile blob : blobs) {
+   *   if (blob != null) {
+   *     try (BlobFile file = blob) {
+   *       byte[] data = file.read();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param rowIds stable row ids (row addresses)
    * @param column blob column name
-   * @return one element per row id; null blob values are represented by null elements
+   * @return one {@link BlobFile} per row id; null blob values are represented by null elements
    */
   public List<BlobFile> takeBlobs(List<Long> rowIds, String column) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
@@ -1639,11 +1651,22 @@ public class Dataset implements Closeable {
   }
 
   /**
-   * Open blob files for given row indices on a blob column.
+   * Open {@link BlobFile} handles for given row indices on a blob column.
+   *
+   * <pre>{@code
+   * List<BlobFile> blobs = dataset.takeBlobsByIndices(List.of(0L), "images");
+   * for (BlobFile blob : blobs) {
+   *   if (blob != null) {
+   *     try (BlobFile file = blob) {
+   *       byte[] data = file.read();
+   *     }
+   *   }
+   * }
+   * }</pre>
    *
    * @param rowIndices row offsets within dataset
    * @param column blob column name
-   * @return one element per row index; null blob values are represented by null elements
+   * @return one {@link BlobFile} per row index; null blob values are represented by null elements
    */
   public List<BlobFile> takeBlobsByIndices(List<Long> rowIndices, String column) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -80,6 +80,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -2023,6 +2024,16 @@ public class DatasetTest {
       assertEquals(0L, blobFile.size());
       assertArrayEquals(new byte[0], blobFile.read());
       blobFile.close();
+    }
+  }
+
+  @Test
+  void testTakeNullBlobPreservesSelection(@TempDir Path tempDir) throws Exception {
+    String base = tempDir.resolve("testTakeNullBlobPreservesSelection").toString();
+    try (Dataset ds = TestUtils.createBlobDataset(base, 128, 8)) {
+      List<BlobFile> blobs = ds.takeBlobsByIndices(Collections.singletonList(15L), "blobs");
+      assertEquals(1, blobs.size());
+      assertNull(blobs.get(0));
     }
   }
 

--- a/java/src/test/java/org/lance/TestUtils.java
+++ b/java/src/test/java/org/lance/TestUtils.java
@@ -694,7 +694,8 @@ public class TestUtils {
     /**
      * Create a single fragment with given row count and return its metadata. The fragment contains
      * deterministic blob payloads: - Every 16th row starting at 0 has zero-length blob - Every 16th
-     * row starting at 1 has a ~1 MiB payload - Others have small variable blobs (128..383 bytes)
+     * row starting at 1 has a ~1 MiB payload - Every 16th row starting at 15 is null - Others have
+     * small variable blobs (128..383 bytes)
      */
     public FragmentMetadata createBlobFragment(int rowCount, int maxRowsPerFile) {
       Preconditions.checkArgument(rowCount >= 0, "rowCount must be non-negative");
@@ -716,6 +717,8 @@ public class TestUtils {
             byte[] big = new byte[1024 * 1024];
             Arrays.fill(big, (byte) 0xAB);
             blobsVec.setSafe(i, big);
+          } else if (i % 16 == 15) {
+            blobsVec.setNull(i);
           } else {
             // small variable blob
             int sz = 128 + (i % 256);

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2301,11 +2301,13 @@ class LanceDataset(pa.dataset.Dataset):
         request coalescing, and bounded I/O scheduling all happen in Rust; this
         method does not use a Python thread pool.
 
-        Every request produces one result. Null blob requests return ``None``.
-        Empty ranges on non-null blobs return empty bytes without issuing
-        payload I/O. Blob-local bounds are not evaluated for null values because
-        they have no logical payload length. By default results preserve the
-        input request order.
+        Every request produces one result. Requests on null blobs return ``None``,
+        including when the requested range is empty. Empty ranges on non-null
+        blobs return empty bytes without issuing payload I/O. For every request,
+        offset plus length must fit in an unsigned 64-bit integer. Ranges on
+        non-null blobs must not extend beyond the logical blob size. Blob-local
+        bounds are not evaluated for null values because they have no logical
+        payload length. By default results preserve the input request order.
 
         Parameters
         ----------

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2175,7 +2175,7 @@ class LanceDataset(pa.dataset.Dataset):
         ids: Optional[Union[List[int], pa.Array]] = None,
         addresses: Optional[Union[List[int], pa.Array]] = None,
         indices: Optional[Union[List[int], pa.Array]] = None,
-    ) -> List[BlobFile]:
+    ) -> List[Optional[BlobFile]]:
         """
         Select blobs by row IDs.
 
@@ -2202,7 +2202,9 @@ class LanceDataset(pa.dataset.Dataset):
 
         Returns
         -------
-        blob_files : List[BlobFile]
+        blob_files : List[Optional[BlobFile]]
+            One element per selected row. Null blob values return ``None``;
+            valid empty blobs return a ``BlobFile`` with size zero.
         """
         selection_kind, selection_values = _resolve_blob_selection(
             ids, addresses, indices
@@ -2218,7 +2220,10 @@ class LanceDataset(pa.dataset.Dataset):
             lance_blob_files = self._ds.take_blobs_by_indices(
                 selection_values, blob_column
             )
-        return [BlobFile(lance_blob_file) for lance_blob_file in lance_blob_files]
+        return [
+            BlobFile(lance_blob_file) if lance_blob_file is not None else None
+            for lance_blob_file in lance_blob_files
+        ]
 
     def read_blobs(
         self,
@@ -2229,7 +2234,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, bytes]]:
+    ) -> List[Tuple[int, Optional[bytes]]]:
         """
         Read blobs directly into memory using Lance's planned blob reader.
 
@@ -2257,8 +2262,9 @@ class LanceDataset(pa.dataset.Dataset):
 
         Returns
         -------
-        blobs : List[Tuple[int, bytes]]
-            A list of ``(row_address, blob_bytes)`` pairs.
+        blobs : List[Tuple[int, Optional[bytes]]]
+            One ``(row_address, blob_bytes)`` pair per selected row. Null blob
+            values return ``None``; valid empty blobs return ``b""``.
         """
         selection_kind, selection_values = _resolve_blob_selection(
             ids, addresses, indices
@@ -2284,7 +2290,7 @@ class LanceDataset(pa.dataset.Dataset):
         selector: Literal["ids", "addresses", "indices"],
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, int, bytes]]:
+    ) -> List[Tuple[int, int, Optional[bytes]]]:
         """
         Read row-specific blob-local byte ranges with one planned API call.
 
@@ -2295,9 +2301,11 @@ class LanceDataset(pa.dataset.Dataset):
         request coalescing, and bounded I/O scheduling all happen in Rust; this
         method does not use a Python thread pool.
 
-        Null blob requests produce no result. Empty ranges on non-null blobs
-        return empty bytes without issuing payload I/O. By default results
-        preserve the input order among non-null requests.
+        Every request produces one result. Null blob requests return ``None``.
+        Empty ranges on non-null blobs return empty bytes without issuing
+        payload I/O. Blob-local bounds are not evaluated for null values because
+        they have no logical payload length. By default results preserve the
+        input request order.
 
         Parameters
         ----------
@@ -2327,8 +2335,8 @@ class LanceDataset(pa.dataset.Dataset):
 
         Returns
         -------
-        results : List[Tuple[int, int, bytes]]
-            ``(request_index, row_address, data)`` for each non-null request.
+        results : List[Tuple[int, int, Optional[bytes]]]
+            One ``(request_index, row_address, data)`` tuple per request.
             The Python list retains all returned payload bytes in memory; peak
             result memory is therefore proportional to their total logical size.
         """

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -371,38 +371,38 @@ class _Dataset:
         self,
         row_ids: List[int],
         blob_column: str,
-    ) -> List[LanceBlobFile]: ...
+    ) -> List[Optional[LanceBlobFile]]: ...
     def take_blobs_by_addresses(
         self,
         row_addresses: List[int],
         blob_column: str,
-    ) -> List[LanceBlobFile]: ...
+    ) -> List[Optional[LanceBlobFile]]: ...
     def take_blobs_by_indices(
         self,
         row_indices: List[int],
         blob_column: str,
-    ) -> List[LanceBlobFile]: ...
+    ) -> List[Optional[LanceBlobFile]]: ...
     def read_blobs(
         self,
         row_ids: List[int],
         blob_column: str,
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, bytes]]: ...
+    ) -> List[Tuple[int, Optional[bytes]]]: ...
     def read_blobs_by_addresses(
         self,
         row_addresses: List[int],
         blob_column: str,
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, bytes]]: ...
+    ) -> List[Tuple[int, Optional[bytes]]]: ...
     def read_blobs_by_indices(
         self,
         row_indices: List[int],
         blob_column: str,
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, bytes]]: ...
+    ) -> List[Tuple[int, Optional[bytes]]]: ...
     def read_blob_ranges(
         self,
         requests: List[Tuple[int, int, int]],
@@ -410,7 +410,7 @@ class _Dataset:
         selector: Literal["ids", "addresses", "indices"],
         io_buffer_size: Optional[int] = None,
         preserve_order: Optional[bool] = None,
-    ) -> List[Tuple[int, int, bytes]]: ...
+    ) -> List[Tuple[int, int, Optional[bytes]]]: ...
     def take_scan(
         self,
         row_slices: Iterable[Tuple[int, int]],

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -556,6 +556,38 @@ def test_read_blobs_without_preserve_order_returns_same_rows(
 
 
 @pytest.mark.parametrize("selection_kind", ["ids", "addresses", "indices"])
+@pytest.mark.parametrize(
+    "selected_indices",
+    [
+        [0, 5],
+        [0, 5, 4],
+        [5],
+        [0, 5, 1],
+        [4, 4, 5],
+    ],
+)
+def test_blob_selection_apis_preserve_nulls_and_empty_values(
+    dataset_with_mixed_blob_v2, selection_kind, selected_indices
+):
+    dataset, payloads = dataset_with_mixed_blob_v2
+    if selection_kind == "ids":
+        all_selectors = _blob_row_ids(dataset)
+    elif selection_kind == "addresses":
+        all_selectors = _blob_row_addresses(dataset)
+    else:
+        all_selectors = list(range(len(payloads)))
+    selectors = [all_selectors[index] for index in selected_indices]
+    kwargs = {selection_kind: selectors}
+    expected = [payloads[index] for index in selected_indices]
+
+    blob_files = dataset.take_blobs("blobs", **kwargs)
+    assert [None if blob is None else blob.readall() for blob in blob_files] == expected
+
+    blobs = dataset.read_blobs("blobs", **kwargs, preserve_order=True)
+    assert [data for _, data in blobs] == expected
+
+
+@pytest.mark.parametrize("selection_kind", ["ids", "addresses", "indices"])
 def test_read_blob_ranges_mixed_sources_preserves_request_identity(
     dataset_with_mixed_blob_v2, selection_kind
 ):
@@ -587,18 +619,17 @@ def test_read_blob_ranges_mixed_sources_preserves_request_identity(
         zip(selected_indices, ranges)
     ):
         payload = payloads[row_index]
-        if payload is not None:
-            expected.append(
-                (
-                    request_index,
-                    addresses[row_index],
-                    payload[offset : offset + length],
-                )
+        expected.append(
+            (
+                request_index,
+                addresses[row_index],
+                None if payload is None else payload[offset : offset + length],
             )
+        )
     assert results == expected
 
 
-def test_read_blob_ranges_skips_blob_v1_nulls(tmp_path):
+def test_blob_selection_apis_preserve_blob_v1_nulls_and_empty_values(tmp_path):
     schema = pa.schema(
         [
             pa.field(
@@ -616,13 +647,28 @@ def test_read_blob_ranges_skips_blob_v1_nulls(tmp_path):
     )
     addresses = _blob_row_addresses(dataset)
 
+    blob_files = dataset.take_blobs("blobs", indices=[0, 1, 2])
+    assert [None if blob is None else blob.readall() for blob in blob_files] == [
+        None,
+        b"",
+        b"abc",
+    ]
+
+    blobs = dataset.read_blobs("blobs", indices=[0, 1, 2])
+    assert [data for _, data in blobs] == [None, b"", b"abc"]
+
     results = dataset.read_blob_ranges(
         "blobs",
         [(0, 0, 0), (0, 0, 1), (1, 0, 0), (2, 1, 1)],
         selector="indices",
     )
 
-    assert results == [(2, addresses[1], b""), (3, addresses[2], b"b")]
+    assert results == [
+        (0, addresses[0], None),
+        (1, addresses[0], None),
+        (2, addresses[1], b""),
+        (3, addresses[2], b"b"),
+    ]
 
 
 def test_read_blob_ranges_without_preserve_order_keeps_request_identity(
@@ -631,7 +677,7 @@ def test_read_blob_ranges_without_preserve_order_keeps_request_identity(
     dataset, _ = dataset_with_mixed_blob_v2
     results = dataset.read_blob_ranges(
         "blobs",
-        [(3, 0, 1), (1, 1, 2), (0, 0, 2)],
+        [(3, 0, 1), (4, 0, 1), (1, 1, 2), (0, 0, 2)],
         selector="indices",
         preserve_order=False,
     )
@@ -639,8 +685,9 @@ def test_read_blob_ranges_without_preserve_order_keeps_request_identity(
     assert sorted(results) == sorted(
         [
             (0, _blob_row_addresses(dataset)[3], b"e"),
-            (1, _blob_row_addresses(dataset)[1], b"ac"),
-            (2, _blob_row_addresses(dataset)[0], b"in"),
+            (1, _blob_row_addresses(dataset)[4], None),
+            (2, _blob_row_addresses(dataset)[1], b"ac"),
+            (3, _blob_row_addresses(dataset)[0], b"in"),
         ]
     )
 
@@ -704,8 +751,7 @@ def test_null_blobs(tmp_path):
     ds = lance.write_dataset(table, tmp_path / "test_ds")
 
     blobs = ds.take_blobs("blob", ids=range(100))
-    for blob in blobs:
-        assert blob.size() == 0
+    assert blobs == [None] * 100
 
     ds.insert(pa.table({"id": pa.array(range(100, 200), pa.uint64())}))
 
@@ -719,8 +765,7 @@ def test_null_blobs(tmp_path):
 
     for blob_col in ["blob", "more_blob"]:
         blobs = ds.take_blobs(blob_col, indices=range(100, 200))
-        for blob in blobs:
-            assert blob.size() == 0
+        assert blobs == [None] * 100
 
         blobs = ds.to_table(columns=[blob_col])
         for blob in blobs.column(blob_col):
@@ -1214,7 +1259,14 @@ def test_blob_extension_add_columns_all_nulls_blob_v2(tmp_path):
     ds.add_columns(lance.blob_field("blob"))
 
     assert ds.to_table(columns=["blob"]).column("blob").to_pylist() == [None] * 4
-    assert ds.take_blobs("blob", indices=range(4)) == []
+    assert ds.take_blobs("blob", indices=range(4)) == [None] * 4
+    assert [data for _, data in ds.read_blobs("blob", indices=range(4))] == [None] * 4
+    ranges = ds.read_blob_ranges(
+        "blob",
+        [(index, 0, 1) for index in range(4)],
+        selector="indices",
+    )
+    assert [data for _, _, data in ranges] == [None] * 4
 
 
 def test_blob_descriptor_array_builder_writes_prepared_packed_blob_for_data_replacement(
@@ -2123,7 +2175,7 @@ def test_write_nested_blob_v2_and_take_by_field_path(tmp_path):
     with blobs[1] as f:
         assert f.read() == packed
 
-    assert dataset.take_blobs("info.blob", indices=[2]) == []
+    assert dataset.take_blobs("info.blob", indices=[2]) == [None]
 
 
 def test_to_pandas_returns_blob_files_for_projected_nested_fields(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -125,27 +125,33 @@ const DEFAULT_NPROBES: usize = 1;
 const LANCE_COMMIT_MESSAGE_KEY: &str = "__lance_commit_message";
 const INDEX_PROGRESS_QUEUE_SIZE: usize = 1024;
 
-fn read_blobs_to_python(
-    py: Python<'_>,
-    blobs: Vec<lance::dataset::ReadBlob>,
-) -> Vec<(u64, Py<PyBytes>)> {
+type PyBlobBytes = Option<Py<PyBytes>>;
+type PyReadBlob = (u64, PyBlobBytes);
+type PyReadBlobRange = (usize, u64, PyBlobBytes);
+
+fn read_blobs_to_python(py: Python<'_>, blobs: Vec<lance::dataset::ReadBlob>) -> Vec<PyReadBlob> {
     blobs
         .into_iter()
-        .map(|blob| (blob.row_address, PyBytes::new(py, &blob.data).unbind()))
+        .map(|blob| {
+            (
+                blob.row_address,
+                blob.data.map(|data| PyBytes::new(py, &data).unbind()),
+            )
+        })
         .collect()
 }
 
 fn read_blob_ranges_to_python(
     py: Python<'_>,
     ranges: Vec<lance::dataset::ReadBlobRange>,
-) -> Vec<(usize, u64, Py<PyBytes>)> {
+) -> Vec<PyReadBlobRange> {
     ranges
         .into_iter()
         .map(|range| {
             (
                 range.request_index,
                 range.row_address,
-                PyBytes::new(py, &range.data).unbind(),
+                range.data.map(|data| PyBytes::new(py, &data).unbind()),
             )
         })
         .collect()
@@ -1618,18 +1624,21 @@ impl Dataset {
         self_: PyRef<'_, Self>,
         row_ids: Vec<u64>,
         blob_column: &str,
-    ) -> PyResult<Vec<LanceBlobFile>> {
+    ) -> PyResult<Vec<Option<LanceBlobFile>>> {
         let blobs = rt()
             .block_on(Some(self_.py()), self_.ds.take_blobs(&row_ids, blob_column))?
             .infer_error()?;
-        Ok(blobs.into_iter().map(LanceBlobFile::from).collect())
+        Ok(blobs
+            .into_iter()
+            .map(|blob| blob.map(LanceBlobFile::from))
+            .collect())
     }
 
     fn take_blobs_by_addresses(
         self_: PyRef<'_, Self>,
         row_addresses: Vec<u64>,
         blob_column: &str,
-    ) -> PyResult<Vec<LanceBlobFile>> {
+    ) -> PyResult<Vec<Option<LanceBlobFile>>> {
         let blobs = rt()
             .block_on(
                 Some(self_.py()),
@@ -1638,21 +1647,27 @@ impl Dataset {
                     .take_blobs_by_addresses(&row_addresses, blob_column),
             )?
             .infer_error()?;
-        Ok(blobs.into_iter().map(LanceBlobFile::from).collect())
+        Ok(blobs
+            .into_iter()
+            .map(|blob| blob.map(LanceBlobFile::from))
+            .collect())
     }
 
     fn take_blobs_by_indices(
         self_: PyRef<'_, Self>,
         row_indices: Vec<u64>,
         blob_column: &str,
-    ) -> PyResult<Vec<LanceBlobFile>> {
+    ) -> PyResult<Vec<Option<LanceBlobFile>>> {
         let blobs = rt()
             .block_on(
                 Some(self_.py()),
                 self_.ds.take_blobs_by_indices(&row_indices, blob_column),
             )?
             .infer_error()?;
-        Ok(blobs.into_iter().map(LanceBlobFile::from).collect())
+        Ok(blobs
+            .into_iter()
+            .map(|blob| blob.map(LanceBlobFile::from))
+            .collect())
     }
 
     #[pyo3(signature=(
@@ -1667,7 +1682,7 @@ impl Dataset {
         blob_column: &str,
         io_buffer_size: Option<u64>,
         preserve_order: Option<bool>,
-    ) -> PyResult<Vec<(u64, Py<PyBytes>)>> {
+    ) -> PyResult<Vec<PyReadBlob>> {
         let builder = configure_read_blobs_builder(
             self_
                 .ds
@@ -1695,7 +1710,7 @@ impl Dataset {
         blob_column: &str,
         io_buffer_size: Option<u64>,
         preserve_order: Option<bool>,
-    ) -> PyResult<Vec<(u64, Py<PyBytes>)>> {
+    ) -> PyResult<Vec<PyReadBlob>> {
         let builder = configure_read_blobs_builder(
             self_
                 .ds
@@ -1723,7 +1738,7 @@ impl Dataset {
         blob_column: &str,
         io_buffer_size: Option<u64>,
         preserve_order: Option<bool>,
-    ) -> PyResult<Vec<(u64, Py<PyBytes>)>> {
+    ) -> PyResult<Vec<PyReadBlob>> {
         let builder = configure_read_blobs_builder(
             self_
                 .ds
@@ -1753,7 +1768,7 @@ impl Dataset {
         selector: &str,
         io_buffer_size: Option<u64>,
         preserve_order: Option<bool>,
-    ) -> PyResult<Vec<(usize, u64, Py<PyBytes>)>> {
+    ) -> PyResult<Vec<PyReadBlobRange>> {
         let requests = blob_range_requests_from_tuples(requests);
         let builder = self_.ds.read_blob_ranges(blob_column).infer_error()?;
         let builder = match selector {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1734,11 +1734,15 @@ impl Dataset {
     }
 
     /// Take [BlobFile] by row IDs.
+    ///
+    /// The returned vector has one element per row ID. Null blob values are
+    /// represented as `None`; valid empty blobs return a `BlobFile` with size
+    /// zero.
     pub async fn take_blobs(
         self: &Arc<Self>,
         row_ids: &[u64],
         column: impl AsRef<str>,
-    ) -> Result<Vec<BlobFile>> {
+    ) -> Result<Vec<Option<BlobFile>>> {
         blob::take_blobs(self, row_ids, column.as_ref()).await
     }
 
@@ -1748,21 +1752,25 @@ impl Dataset {
     /// Use this method when you already have row addresses, for example from
     /// a scan with `with_row_address()`. For row IDs (stable identifiers), use
     /// [`Self::take_blobs`]. For row indices (offsets), use
-    /// [`Self::take_blobs_by_indices`].
+    /// [`Self::take_blobs_by_indices`]. The result has the same null and empty
+    /// blob representation as [`Self::take_blobs`].
     pub async fn take_blobs_by_addresses(
         self: &Arc<Self>,
         row_addrs: &[u64],
         column: impl AsRef<str>,
-    ) -> Result<Vec<BlobFile>> {
+    ) -> Result<Vec<Option<BlobFile>>> {
         blob::take_blobs_by_addresses(self, row_addrs, column.as_ref()).await
     }
 
     /// Take [BlobFile] by row indices (offsets in the dataset).
+    ///
+    /// The result has the same null and empty blob representation as
+    /// [`Self::take_blobs`].
     pub async fn take_blobs_by_indices(
         self: &Arc<Self>,
         row_indices: &[u64],
         column: impl AsRef<str>,
-    ) -> Result<Vec<BlobFile>> {
+    ) -> Result<Vec<Option<BlobFile>>> {
         let fragments = self.get_fragments();
         let row_addrs = row_offsets_to_row_addresses(&fragments, row_indices).await?;
         blob::take_blobs_by_addresses(self, &row_addrs, column.as_ref()).await
@@ -1773,7 +1781,9 @@ impl Dataset {
     /// This API complements [`Self::take_blobs`]. `take_blobs` returns
     /// [`BlobFile`] handles for caller-driven random access, while
     /// `read_blobs` builds a streaming read plan for sequential or batched blob
-    /// retrieval.
+    /// retrieval. Every selected row produces one result: null blob values have
+    /// `ReadBlob::data` set to `None`, while valid empty blobs contain an empty
+    /// buffer.
     ///
     /// ```rust
     /// # use std::sync::Arc;
@@ -1804,7 +1814,9 @@ impl Dataset {
     ///
     /// Each [`BlobRangeRequest`] contains both its row selector and byte range,
     /// so requests can be repeated or reordered without coordinating parallel
-    /// selector and range lists.
+    /// selector and range lists. Every request produces one result. A null blob
+    /// has `ReadBlobRange::data` set to `None`; an empty range on a non-null blob
+    /// contains an empty buffer.
     ///
     /// ```rust
     /// # use std::sync::Arc;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1738,6 +1738,21 @@ impl Dataset {
     /// The returned vector has one element per row ID. Null blob values are
     /// represented as `None`; valid empty blobs return a `BlobFile` with size
     /// zero.
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use lance::dataset::Dataset;
+    /// # use lance::Result;
+    /// # async fn example(dataset: Arc<Dataset>) -> Result<()> {
+    /// let blobs = dataset.take_blobs(&[42], "images").await?;
+    /// match &blobs[0] {
+    ///     None => { /* The selected blob is null. */ }
+    ///     Some(blob) if blob.size() == 0 => { /* The selected blob is valid but empty. */ }
+    ///     Some(blob) => { let _size = blob.size(); }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn take_blobs(
         self: &Arc<Self>,
         row_ids: &[u64],
@@ -1754,6 +1769,23 @@ impl Dataset {
     /// [`Self::take_blobs`]. For row indices (offsets), use
     /// [`Self::take_blobs_by_indices`]. The result has the same null and empty
     /// blob representation as [`Self::take_blobs`].
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use lance::dataset::Dataset;
+    /// # use lance::Result;
+    /// # async fn example(dataset: Arc<Dataset>, row_address: u64) -> Result<()> {
+    /// let blobs = dataset
+    ///     .take_blobs_by_addresses(&[row_address], "images")
+    ///     .await?;
+    /// match &blobs[0] {
+    ///     None => { /* The selected blob is null. */ }
+    ///     Some(blob) if blob.size() == 0 => { /* The selected blob is valid but empty. */ }
+    ///     Some(blob) => { let _size = blob.size(); }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn take_blobs_by_addresses(
         self: &Arc<Self>,
         row_addrs: &[u64],
@@ -1766,6 +1798,21 @@ impl Dataset {
     ///
     /// The result has the same null and empty blob representation as
     /// [`Self::take_blobs`].
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use lance::dataset::Dataset;
+    /// # use lance::Result;
+    /// # async fn example(dataset: Arc<Dataset>) -> Result<()> {
+    /// let blobs = dataset.take_blobs_by_indices(&[0], "images").await?;
+    /// match &blobs[0] {
+    ///     None => { /* The selected blob is null. */ }
+    ///     Some(blob) if blob.size() == 0 => { /* The selected blob is valid but empty. */ }
+    ///     Some(blob) => { let _size = blob.size(); }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn take_blobs_by_indices(
         self: &Arc<Self>,
         row_indices: &[u64],

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1575,8 +1575,10 @@ impl BlobFile {
 pub struct ReadBlob {
     /// Row address of the blob that was read.
     pub row_address: u64,
-    /// Blob payload bytes.
-    pub data: Bytes,
+    /// Blob payload bytes, or `None` when the selected blob value is null.
+    ///
+    /// A valid empty blob is represented as `Some(Bytes::new())`.
+    pub data: Option<Bytes>,
 }
 
 /// A byte range relative to the beginning of one logical blob value.
@@ -1634,8 +1636,11 @@ pub struct ReadBlobRange {
     pub row_address: u64,
     /// Blob-local range supplied for this request.
     pub range: BlobReadRange,
-    /// Bytes in `range`.
-    pub data: Bytes,
+    /// Bytes in `range`, or `None` when the selected blob value is null.
+    ///
+    /// An empty range on a non-null blob is represented as
+    /// `Some(Bytes::new())`.
+    pub data: Option<Bytes>,
 }
 
 /// Stream returned by [`ReadBlobsBuilder::try_into_stream`].
@@ -1728,29 +1733,41 @@ impl ReadBlobsBuilder {
 
     /// Execute the planned blob read and return a stream of blob payloads.
     ///
-    /// The stream yields one [`ReadBlob`] per selected non-null blob row.
+    /// The stream yields one [`ReadBlob`] per selected row. Null blob values
+    /// have `data` set to `None`; valid empty blobs contain an empty buffer.
     pub async fn try_into_stream(self) -> Result<ReadBlobsStream> {
         self.validate()?;
-        let entries = collect_blob_entries_for_selection(
+        let collected = collect_blob_selection_for_selection(
             &self.dataset,
             self.blob_field_id,
             &self.column,
             &self.selection,
         )
         .await?;
+        let (selection_count, null_blobs) =
+            collect_null_read_blobs(&collected.entries, collected.row_addresses)?;
         let physical_buffer_size = self.options.io_buffer_size_bytes.unwrap_or_else(|| {
             SchedulerConfig::max_bandwidth(self.dataset.object_store.as_ref()).io_buffer_size_bytes
         });
-        let batches = plan_blob_read_batches(entries, None, physical_buffer_size)?;
+        let batches = plan_blob_read_batches(collected.entries, None, physical_buffer_size)?;
         let execution = Arc::new(ReadBlobsExecution::new(self.options.io_buffer_size_bytes));
-        Ok(execute_blob_read_batches_stream(
+        let non_null_blobs = execute_blob_read_batches_stream(
             batches,
             execution,
             self.dataset.object_store.io_parallelism(),
             self.options.preserve_order,
         )
-        .map_ok(into_read_blob)
-        .boxed())
+        .map_ok(|blob| {
+            let selection_index = blob.selection_index;
+            (selection_index, into_read_blob(blob))
+        })
+        .boxed();
+        Ok(totalize_blob_selection_stream(
+            non_null_blobs,
+            null_blobs,
+            selection_count,
+            self.options.preserve_order,
+        ))
     }
 
     /// Execute the planned blob read and collect the full result in memory.
@@ -1820,37 +1837,55 @@ impl ReadBlobRangesBuilder {
         self
     }
 
-    /// Execute the planned range read and return a stream of non-null results.
+    /// Execute the planned range read and return one result per request.
     ///
-    /// Null blob requests do not produce a result. Empty ranges on non-null
-    /// blobs produce an empty buffer without issuing payload I/O. By default,
+    /// Null blob requests have `data` set to `None`. Empty ranges on non-null
+    /// blobs contain an empty buffer without issuing payload I/O. By default,
     /// results follow input order; `request_index` identifies the original
-    /// request even when ordering is disabled.
+    /// request even when ordering is disabled. Blob-local bounds are not
+    /// evaluated for null values because they have no logical payload length.
     pub async fn try_into_stream(self) -> Result<ReadBlobRangesStream> {
         self.validate()?;
-        let entries = collect_blob_entries_for_selection(
+        let collected = collect_blob_selection_for_selection(
             &self.inner.dataset,
             self.inner.blob_field_id,
             &self.inner.column,
             &self.inner.selection,
         )
         .await?;
+        let (selection_count, null_ranges) = collect_null_read_blob_ranges(
+            &collected.entries,
+            collected.row_addresses,
+            &self.ranges,
+        )?;
         let physical_buffer_size = self.inner.options.io_buffer_size_bytes.unwrap_or_else(|| {
             SchedulerConfig::max_bandwidth(self.inner.dataset.object_store.as_ref())
                 .io_buffer_size_bytes
         });
-        let batches = plan_blob_read_batches(entries, Some(&self.ranges), physical_buffer_size)?;
+        let batches =
+            plan_blob_read_batches(collected.entries, Some(&self.ranges), physical_buffer_size)?;
         let execution = Arc::new(ReadBlobsExecution::new(
             self.inner.options.io_buffer_size_bytes,
         ));
-        Ok(execute_blob_read_batches_stream(
+        let non_null_ranges = execute_blob_read_batches_stream(
             batches,
             execution,
             self.inner.dataset.object_store.io_parallelism(),
             self.inner.options.preserve_order,
         )
-        .map(|result| result.and_then(into_read_blob_range))
-        .boxed())
+        .map(|result| {
+            result.and_then(|blob| {
+                let selection_index = blob.selection_index;
+                into_read_blob_range(blob).map(|range| (selection_index, range))
+            })
+        })
+        .boxed();
+        Ok(totalize_blob_selection_stream(
+            non_null_ranges,
+            null_ranges,
+            selection_count,
+            self.inner.options.preserve_order,
+        ))
     }
 
     /// Execute the planned range read and collect all returned bytes in memory.
@@ -1903,6 +1938,13 @@ struct BlobEntry {
     selection_index: usize,
     row_address: u64,
     file: BlobFile,
+}
+
+/// Selected rows together with the subset that has a readable blob payload.
+#[derive(Debug)]
+struct CollectedBlobSelection {
+    entries: Vec<BlobEntry>,
+    row_addresses: Vec<u64>,
 }
 
 /// Physical read input derived from one [`BlobEntry`].
@@ -2111,8 +2153,124 @@ fn into_read_blob(blob: IndexedReadBlob) -> ReadBlob {
     );
     ReadBlob {
         row_address: blob.row_address,
-        data: blob.data,
+        data: Some(blob.data),
     }
+}
+
+fn collect_null_read_blobs(
+    entries: &[BlobEntry],
+    row_addresses: Vec<u64>,
+) -> Result<(usize, Vec<(usize, ReadBlob)>)> {
+    collect_null_selection_values(entries, row_addresses, |_, row_address| {
+        Ok(ReadBlob {
+            row_address,
+            data: None,
+        })
+    })
+}
+
+fn collect_null_read_blob_ranges(
+    entries: &[BlobEntry],
+    row_addresses: Vec<u64>,
+    ranges: &[BlobReadRange],
+) -> Result<(usize, Vec<(usize, ReadBlobRange)>)> {
+    collect_null_selection_values(entries, row_addresses, |request_index, row_address| {
+        let range = ranges.get(request_index).copied().ok_or_else(|| {
+            Error::internal(format!("Missing blob range for request {}", request_index))
+        })?;
+        Ok(ReadBlobRange {
+            request_index,
+            row_address,
+            range,
+            data: None,
+        })
+    })
+}
+
+fn collect_null_selection_values<T>(
+    entries: &[BlobEntry],
+    row_addresses: Vec<u64>,
+    mut make_value: impl FnMut(usize, u64) -> Result<T>,
+) -> Result<(usize, Vec<(usize, T)>)> {
+    let selection_count = row_addresses.len();
+    let mut non_null = vec![false; selection_count];
+    for entry in entries {
+        let is_non_null = non_null.get_mut(entry.selection_index).ok_or_else(|| {
+            Error::internal(format!(
+                "Blob selection index {} exceeded selected row count {}",
+                entry.selection_index, selection_count
+            ))
+        })?;
+        if *is_non_null {
+            return Err(Error::internal(format!(
+                "Blob selection index {} was collected more than once",
+                entry.selection_index
+            )));
+        }
+        *is_non_null = true;
+    }
+
+    let mut null_values = Vec::with_capacity(selection_count.saturating_sub(entries.len()));
+    for (selection_index, row_address) in row_addresses.into_iter().enumerate() {
+        if !non_null[selection_index] {
+            null_values.push((selection_index, make_value(selection_index, row_address)?));
+        }
+    }
+    Ok((selection_count, null_values))
+}
+
+fn totalize_blob_selection_stream<T: Send + 'static>(
+    non_null_values: BoxStream<'static, Result<(usize, T)>>,
+    null_values: Vec<(usize, T)>,
+    selection_count: usize,
+    preserve_order: bool,
+) -> BoxStream<'static, Result<T>> {
+    if !preserve_order {
+        let null_values = stream::iter(null_values.into_iter().map(|(_, value)| Ok(value)));
+        return stream::select(null_values, non_null_values.map_ok(|(_, value)| value)).boxed();
+    }
+
+    let mut non_null_values = non_null_values;
+    let mut next_selection_index = 0;
+    let mut ready = null_values.into_iter().collect::<BTreeMap<_, _>>();
+    stream::poll_fn(move |cx| {
+        loop {
+            if next_selection_index == selection_count {
+                return Poll::Ready(None);
+            }
+
+            if let Some(value) = ready.remove(&next_selection_index) {
+                next_selection_index += 1;
+                return Poll::Ready(Some(Ok(value)));
+            }
+
+            match non_null_values.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok((selection_index, value)))) => {
+                    if selection_index >= selection_count {
+                        return Poll::Ready(Some(Err(Error::internal(format!(
+                            "Blob selection index {} exceeded selected row count {}",
+                            selection_index, selection_count
+                        )))));
+                    }
+                    if ready.insert(selection_index, value).is_some() {
+                        return Poll::Ready(Some(Err(Error::internal(format!(
+                            "Blob selection index {} was produced more than once",
+                            selection_index
+                        )))));
+                    }
+                }
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
+                Poll::Ready(None) => {
+                    return Poll::Ready(Some(Err(Error::internal(format!(
+                        "planned blob read stream completed before selection index {} was produced",
+                        next_selection_index
+                    )))));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    })
+    .boxed()
 }
 
 fn into_read_blob_range(blob: IndexedReadBlob) -> Result<ReadBlobRange> {
@@ -2126,7 +2284,7 @@ fn into_read_blob_range(blob: IndexedReadBlob) -> Result<ReadBlobRange> {
         request_index: blob.selection_index,
         row_address: blob.row_address,
         range,
-        data: blob.data,
+        data: Some(blob.data),
     })
 }
 
@@ -2474,18 +2632,16 @@ pub(super) async fn take_blobs(
     dataset: &Arc<Dataset>,
     row_ids: &[u64],
     column: &str,
-) -> Result<Vec<BlobFile>> {
+) -> Result<Vec<Option<BlobFile>>> {
     let blob_field_id = validate_blob_column(dataset, column)?;
-    Ok(collect_blob_entries_for_selection(
+    let collected = collect_blob_selection_for_selection(
         dataset,
         blob_field_id,
         column,
         &ReadBlobsSelection::RowIds(row_ids.to_vec()),
     )
-    .await?
-    .into_iter()
-    .map(|entry| entry.file)
-    .collect())
+    .await?;
+    into_optional_blob_files(collected)
 }
 
 /// Take [BlobFile] by row addresses.
@@ -2499,18 +2655,38 @@ pub async fn take_blobs_by_addresses(
     dataset: &Arc<Dataset>,
     row_addrs: &[u64],
     column: &str,
-) -> Result<Vec<BlobFile>> {
+) -> Result<Vec<Option<BlobFile>>> {
     let blob_field_id = validate_blob_column(dataset, column)?;
-    Ok(collect_blob_entries_for_selection(
+    let collected = collect_blob_selection_for_selection(
         dataset,
         blob_field_id,
         column,
         &ReadBlobsSelection::RowAddresses(row_addrs.to_vec()),
     )
-    .await?
-    .into_iter()
-    .map(|entry| entry.file)
-    .collect())
+    .await?;
+    into_optional_blob_files(collected)
+}
+
+fn into_optional_blob_files(collected: CollectedBlobSelection) -> Result<Vec<Option<BlobFile>>> {
+    let selection_count = collected.row_addresses.len();
+    let mut files = std::iter::repeat_with(|| None)
+        .take(selection_count)
+        .collect::<Vec<_>>();
+    for entry in collected.entries {
+        let slot = files.get_mut(entry.selection_index).ok_or_else(|| {
+            Error::internal(format!(
+                "Blob selection index {} exceeded selected row count {}",
+                entry.selection_index, selection_count
+            ))
+        })?;
+        if slot.replace(entry.file).is_some() {
+            return Err(Error::internal(format!(
+                "Blob selection index {} was collected more than once",
+                entry.selection_index
+            )));
+        }
+    }
+    Ok(files)
 }
 
 /// Validate that `column` exists and is a blob column, returning its field id.
@@ -2556,14 +2732,13 @@ async fn take_blob_descriptions_by_row_addresses(
         .await
 }
 
-/// Resolve a caller selection into [`BlobEntry`] values that share `BlobSource`
-/// instances by physical backing object.
-async fn collect_blob_entries_for_selection(
+/// Resolve every selected row address and the non-null blob entries among them.
+async fn collect_blob_selection_for_selection(
     dataset: &Arc<Dataset>,
     blob_field_id: u32,
     column: &str,
     selection: &ReadBlobsSelection,
-) -> Result<Vec<BlobEntry>> {
+) -> Result<CollectedBlobSelection> {
     let description_and_addr = match selection {
         ReadBlobsSelection::None => {
             return Err(Error::invalid_input(
@@ -2585,18 +2760,26 @@ async fn collect_blob_entries_for_selection(
     };
 
     if description_and_addr.num_rows() == 0 {
-        return Ok(Vec::new());
+        return Ok(CollectedBlobSelection {
+            entries: Vec::new(),
+            row_addresses: Vec::new(),
+        });
     }
 
     let descriptions = leaf_descriptor_struct(&description_and_addr, column)?;
     let row_addrs = description_and_addr.column(1).as_primitive::<UInt64Type>();
+    let row_addresses = row_addrs.values().to_vec();
 
-    match blob_version_from_descriptions(descriptions)? {
+    let entries = match blob_version_from_descriptions(descriptions)? {
         BlobVersion::V1 => collect_blob_entries_v1(dataset, blob_field_id, descriptions, row_addrs),
         BlobVersion::V2 => {
             collect_blob_entries_v2(dataset, blob_field_id, descriptions, row_addrs).await
         }
-    }
+    }?;
+    Ok(CollectedBlobSelection {
+        entries,
+        row_addresses,
+    })
 }
 
 /// Walk into the descriptor `RecordBatch` at `column` and return the leaf
@@ -4061,7 +4244,7 @@ mod tests {
         for (actual_idx, (expected_batch_idx, expected_row_idx)) in
             [(5, 5), (6, 7), (8, 3)].iter().enumerate()
         {
-            let val = blobs[actual_idx].read().await.unwrap();
+            let val = blobs[actual_idx].as_ref().unwrap().read().await.unwrap();
             let expected = fixture.data[*expected_batch_idx]
                 .column(1)
                 .as_binary::<i64>()
@@ -4107,7 +4290,7 @@ mod tests {
                 .column(1)
                 .as_binary::<i64>()
                 .value(*expected_row_idx);
-            assert_eq!(blobs[actual_idx].data.as_ref(), expected);
+            assert_eq!(blobs[actual_idx].data.as_deref(), Some(expected));
         }
     }
 
@@ -4142,6 +4325,8 @@ mod tests {
         let blobs2 = fixture.dataset.take_blobs(&row_ids, "blobs").await.unwrap();
 
         for (blob1, blob2) in blobs.iter().zip(blobs2.iter()) {
+            let blob1 = blob1.as_ref().unwrap();
+            let blob2 = blob2.as_ref().unwrap();
             assert_eq!(blob1.position(), blob2.position());
             assert_eq!(blob1.size(), blob2.size());
             assert_eq!(blob1.data_path(), blob2.data_path());
@@ -4297,7 +4482,7 @@ mod tests {
 
         // Verify we can read the blob content
         for blob in &blobs {
-            let content = blob.read().await.unwrap();
+            let content = blob.as_ref().unwrap().read().await.unwrap();
             assert!(!content.is_empty(), "Blob content should not be empty");
         }
 
@@ -4310,7 +4495,7 @@ mod tests {
 
         // Verify we can read the blob content from second fragment
         for blob in &blobs {
-            let content = blob.read().await.unwrap();
+            let content = blob.as_ref().unwrap().read().await.unwrap();
             assert!(!content.is_empty(), "Blob content should not be empty");
         }
 
@@ -4498,7 +4683,10 @@ mod tests {
             .unwrap();
         assert_eq!(blob_files.len(), payloads.len());
         for (blob_file, expected) in blob_files.iter().zip(payloads) {
-            assert_eq!(blob_file.read().await.unwrap().as_ref(), expected);
+            assert_eq!(
+                blob_file.as_ref().unwrap().read().await.unwrap().as_ref(),
+                expected
+            );
         }
 
         let read_blobs = dataset
@@ -4510,7 +4698,7 @@ mod tests {
             .unwrap();
         assert_eq!(read_blobs.len(), payloads.len());
         for (read_blob, expected) in read_blobs.iter().zip(payloads) {
-            assert_eq!(read_blob.data.as_ref(), expected);
+            assert_eq!(read_blob.data.as_deref(), Some(expected));
         }
     }
 
@@ -4556,8 +4744,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(blobs.len(), 2);
-        let first = blobs[0].read().await.unwrap();
-        let second = blobs[1].read().await.unwrap();
+        let first = blobs[0].as_ref().unwrap().read().await.unwrap();
+        let second = blobs[1].as_ref().unwrap().read().await.unwrap();
         assert_eq!(first.as_ref(), b"hello");
         assert_eq!(second.as_ref(), b"world");
     }
@@ -4607,7 +4795,10 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"prepared-inline");
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"prepared-inline"
+        );
     }
 
     #[tokio::test]
@@ -4707,8 +4898,9 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"prepared-packed");
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.read().await.unwrap().as_ref(), b"prepared-packed");
+        assert_eq!(blob.kind(), BlobKind::Packed);
     }
 
     #[tokio::test]
@@ -4789,8 +4981,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(blobs.len(), 2);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"initial");
-        assert_eq!(blobs[1].read().await.unwrap().as_ref(), b"append");
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"initial"
+        );
+        assert_eq!(
+            blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"append"
+        );
     }
 
     #[tokio::test]
@@ -4890,10 +5088,10 @@ mod tests {
             .unwrap();
         assert_eq!(blobs.len(), 1);
         assert_eq!(
-            blobs[0].read().await.unwrap().as_ref(),
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
             b"nested-replacement"
         );
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
+        assert_eq!(blobs[0].as_ref().unwrap().kind(), BlobKind::Packed);
     }
 
     #[tokio::test]
@@ -5042,9 +5240,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(blobs.len(), 2);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"hello");
         assert_eq!(
-            blobs[1].read().await.unwrap().as_ref(),
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"hello"
+        );
+        assert_eq!(
+            blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
             packed_payload.as_slice()
         );
 
@@ -5052,7 +5253,8 @@ mod tests {
             .take_blobs_by_indices(&[2], "info.blob")
             .await
             .unwrap();
-        assert!(null_blobs.is_empty());
+        assert_eq!(null_blobs.len(), 1);
+        assert!(null_blobs[0].is_none());
 
         let filtered = dataset
             .scan()
@@ -5652,12 +5854,12 @@ mod tests {
             let end = start + range.length as usize;
             assert_eq!(result.request_index, request_index);
             assert_eq!(result.range, *range);
-            assert_eq!(result.data.as_ref(), &payload[start..end]);
+            assert_eq!(result.data.as_deref(), Some(&payload[start..end]));
         }
     }
 
     #[tokio::test]
-    async fn test_read_blob_ranges_skips_v1_nulls_and_preserves_empty_values() {
+    async fn test_blob_selection_apis_preserve_v1_nulls_and_empty_values() {
         let test_dir = TempStrDir::default();
         let blob_metadata = HashMap::from([(BLOB_META_KEY.to_string(), "true".to_string())]);
         let schema = Arc::new(Schema::new(vec![
@@ -5679,6 +5881,51 @@ mod tests {
             .unwrap(),
         );
 
+        let blob_files = dataset
+            .take_blobs_by_indices(&[2, 1, 0], "blob")
+            .await
+            .unwrap();
+        assert_eq!(blob_files.len(), 3);
+        assert_eq!(
+            blob_files[0]
+                .as_ref()
+                .unwrap()
+                .read()
+                .await
+                .unwrap()
+                .as_ref(),
+            b"abc"
+        );
+        assert!(
+            blob_files[1]
+                .as_ref()
+                .unwrap()
+                .read()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(blob_files[2].is_none());
+
+        let blobs = dataset
+            .read_blobs("blob")
+            .unwrap()
+            .with_row_indices([2, 1, 0])
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            blobs
+                .iter()
+                .map(|blob| (blob.row_address, blob.data.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                (2, Some(b"abc".as_slice())),
+                (1, Some(b"".as_slice())),
+                (0, None),
+            ]
+        );
+
         let results = dataset
             .read_blob_ranges("blob")
             .unwrap()
@@ -5695,9 +5942,14 @@ mod tests {
         assert_eq!(
             results
                 .iter()
-                .map(|result| (result.request_index, result.data.as_ref()))
+                .map(|result| (result.request_index, result.data.as_deref()))
                 .collect::<Vec<_>>(),
-            vec![(2, b"".as_slice()), (3, b"b".as_slice())]
+            vec![
+                (0, None),
+                (1, None),
+                (2, Some(b"".as_slice())),
+                (3, Some(b"b".as_slice())),
+            ]
         );
 
         let descriptions = StructArray::try_new(
@@ -5722,7 +5974,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_blob_ranges_skips_v2_nulls_and_preserves_empty_values() {
+    async fn test_blob_selection_apis_preserve_v2_nulls_and_empty_values() {
         let test_dir = TempStrDir::default();
         let mut blob_builder = BlobArrayBuilder::new(3);
         blob_builder.push_empty().unwrap();
@@ -5744,6 +5996,51 @@ mod tests {
             .unwrap(),
         );
 
+        let blob_files = dataset
+            .take_blobs_by_indices(&[2, 1, 0], "blob")
+            .await
+            .unwrap();
+        assert_eq!(blob_files.len(), 3);
+        assert_eq!(
+            blob_files[0]
+                .as_ref()
+                .unwrap()
+                .read()
+                .await
+                .unwrap()
+                .as_ref(),
+            b"abc"
+        );
+        assert!(blob_files[1].is_none());
+        assert!(
+            blob_files[2]
+                .as_ref()
+                .unwrap()
+                .read()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let blobs = dataset
+            .read_blobs("blob")
+            .unwrap()
+            .with_row_indices([2, 1, 0])
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            blobs
+                .iter()
+                .map(|blob| (blob.row_address, blob.data.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                (2, Some(b"abc".as_slice())),
+                (1, None),
+                (0, Some(b"".as_slice())),
+            ]
+        );
+
         let results = dataset
             .read_blob_ranges("blob")
             .unwrap()
@@ -5757,11 +6054,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(results.len(), 2);
+        assert_eq!(results.len(), 4);
         assert_eq!(results[0].request_index, 0);
-        assert!(results[0].data.is_empty());
-        assert_eq!(results[1].request_index, 3);
-        assert_eq!(results[1].data.as_ref(), b"b");
+        assert_eq!(results[0].data.as_deref(), Some(b"".as_slice()));
+        assert_eq!(results[1].request_index, 1);
+        assert!(results[1].data.is_none());
+        assert_eq!(results[2].request_index, 2);
+        assert!(results[2].data.is_none());
+        assert_eq!(results[3].request_index, 3);
+        assert_eq!(results[3].data.as_deref(), Some(b"b".as_slice()));
     }
 
     #[tokio::test]
@@ -5947,8 +6248,9 @@ mod tests {
         let stats = dataset.object_store.io_stats_incremental();
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].data.len(), WINDOW_SIZE as usize);
-        assert!(results[0].data.iter().all(|byte| *byte == 0xA5));
+        let data = results[0].data.as_ref().unwrap();
+        assert_eq!(data.len(), WINDOW_SIZE as usize);
+        assert!(data.iter().all(|byte| *byte == 0xA5));
         let blob_payload_ranges = stats
             .requests
             .iter()
@@ -6019,7 +6321,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(first.row_address, 11);
-        assert_eq!(first.data.as_ref(), b"uvw");
+        assert_eq!(first.data.as_deref(), Some(b"uvw".as_slice()));
 
         slow_gate.add_permits(1);
         let second = tokio::time::timeout(Duration::from_secs(1), stream.next())
@@ -6028,7 +6330,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(second.row_address, 10);
-        assert_eq!(second.data.as_ref(), b"abc");
+        assert_eq!(second.data.as_deref(), Some(b"abc".as_slice()));
     }
 
     #[tokio::test]
@@ -6042,9 +6344,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Inline);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Inline);
         assert_eq!(
-            blobs[0].read().await.unwrap().as_ref(),
+            blob.read().await.unwrap().as_ref(),
             fixture.expected.as_slice()
         );
     }
@@ -6062,9 +6365,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Packed);
         assert_eq!(
-            blobs[0].read().await.unwrap().as_ref(),
+            blob.read().await.unwrap().as_ref(),
             fixture.expected.as_slice()
         );
     }
@@ -6080,9 +6384,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Dedicated);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Dedicated);
         assert_eq!(
-            blobs[0].read().await.unwrap().as_ref(),
+            blob.read().await.unwrap().as_ref(),
             fixture.expected.as_slice()
         );
     }
@@ -6100,9 +6405,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Packed);
         assert_eq!(
-            blobs[0].read().await.unwrap().as_ref(),
+            blob.read().await.unwrap().as_ref(),
             fixture.expected.as_slice()
         );
     }
@@ -6223,7 +6529,10 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"outside");
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"outside"
+        );
     }
 
     #[tokio::test]
@@ -6286,7 +6595,10 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"mapped");
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"mapped"
+        );
     }
 
     #[tokio::test]
@@ -6371,8 +6683,9 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Inline);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), b"inline");
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Inline);
+        assert_eq!(blob.read().await.unwrap().as_ref(), b"inline");
     }
 
     #[tokio::test]
@@ -6425,8 +6738,9 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), payload.as_slice());
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Packed);
+        assert_eq!(blob.read().await.unwrap().as_ref(), payload.as_slice());
     }
 
     #[tokio::test]
@@ -6469,8 +6783,9 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Packed);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), payload.as_slice());
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Packed);
+        assert_eq!(blob.read().await.unwrap().as_ref(), payload.as_slice());
     }
 
     #[tokio::test]
@@ -6523,8 +6838,9 @@ mod tests {
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0].kind(), BlobKind::Dedicated);
-        assert_eq!(blobs[0].read().await.unwrap().as_ref(), payload.as_slice());
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Dedicated);
+        assert_eq!(blob.read().await.unwrap().as_ref(), payload.as_slice());
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1172,7 +1172,13 @@ async fn build_user_view_struct(
                 }
             }
             RowClass::DataBlob => {
-                let data = blob_files[blob_file_idx].read().await?;
+                let blob_file = blob_files[blob_file_idx].as_ref().ok_or_else(|| {
+                    Error::internal(format!(
+                        "Non-null blob row {} in column '{}' resolved to null",
+                        i, column_name
+                    ))
+                })?;
+                let data = blob_file.read().await?;
                 blob_file_idx += 1;
                 data_builder.append_value(data.as_ref());
                 uri_builder.append_null();
@@ -2586,7 +2592,7 @@ mod tests {
             .unwrap();
         assert_eq!(blobs.len(), expected_payload.len());
         for (blob, expected) in blobs.iter().zip(expected_payload.iter()) {
-            let bytes = blob.read().await.unwrap();
+            let bytes = blob.as_ref().unwrap().read().await.unwrap();
             assert_eq!(bytes.as_ref(), expected.as_slice());
         }
     }
@@ -7171,11 +7177,12 @@ mod tests {
             let row_id = row_ids.value(i);
             let id = ids.value(i);
             let blobs = dataset.take_blobs(&[row_id], column).await.unwrap();
-            if blobs.is_empty() {
-                result.push((id, None));
-            } else {
-                let data = blobs[0].read().await.unwrap();
-                result.push((id, Some(data.to_vec())));
+            match blobs.into_iter().next().flatten() {
+                Some(blob) => {
+                    let data = blob.read().await.unwrap();
+                    result.push((id, Some(data.to_vec())));
+                }
+                None => result.push((id, None)),
             }
         }
         result


### PR DESCRIPTION
## Why

Blob selection APIs currently expose an implementation detail of the physical read planner: null descriptors are omitted because they schedule no payload I/O. This makes result cardinality depend on descriptor contents, prevents callers from distinguishing null values from omitted rows, and leaves `read_blobs`, `read_blob_ranges`, and `take_blobs` with inconsistent contracts.

This is a follow-up to #7864 and resolves the remaining null behavior described in #7899.

## Contract

All blob selection APIs now return one logical result per selector or range request. Null blobs are represented explicitly, while valid empty blobs and empty ranges remain non-null empty values. The physical planner still avoids payload I/O for nulls; the logical result layer restores their selection positions.

## Breaking change

This intentionally changes public return types and observable result cardinality:

- Rust `take_blobs*` APIs return `Vec<Option<BlobFile>>`, and `ReadBlob::data` / `ReadBlobRange::data` are `Option<Bytes>`.
- Python blob APIs return `Optional` values for null blobs.
- Java `takeBlobs*` lists retain every requested position and may contain null elements.

Callers that relied on null selections being omitted must now handle explicit null results.

BREAKING CHANGE: Blob selection APIs now preserve every selector or request and represent null blob values explicitly instead of omitting them.
