### PR TITLE
fix(mem-wal): refill scans after shadow filtering

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -739,9 +739,6 @@ impl LsmScanner {
         if let Some(warmer) = &self.warmer {
             planner = planner.with_warmer(warmer.clone());
         }
-        if let Some(factor) = self.overfetch_factor {
-            planner = planner.with_overfetch_factor(factor);
-        }
 
         planner
             .plan_scan(
@@ -1003,44 +1000,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_overfetch_factor_is_rejected() {
-        let shard = Uuid::new_v4();
-        let scanner = LsmScanner::without_base_table(
+    async fn overfetch_factor_only_applies_to_searches() {
+        // Plain scans refill exactly via LocalLimitExec, so overfetch_factor is
+        // search-only and must not affect scan planning.
+        let scan = LsmScanner::without_base_table(
             pk_schema(),
-            "memory://t",
+            "memory://scan",
             vec![],
             vec!["id".to_string()],
         )
-        .with_in_memory_memtables(
-            shard,
-            InMemoryMemTables {
-                active: mk_pk_memtable(&[1, 2], 2),
-                frozen: vec![],
-            },
-        )
-        .with_overfetch_factor(0.5);
+        .with_overfetch_factor(0.5)
+        .try_into_batch()
+        .await
+        .unwrap();
+        assert_eq!(scan.num_rows(), 0);
 
-        let Err(err) = scanner.try_into_stream().await else {
-            panic!("invalid overfetch factor should fail planning");
+        let vector_schema = pk_schema_with(arrow_schema::Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(arrow_schema::Field::new("item", DataType::Float32, true)),
+                4,
+            ),
+            false,
+        ));
+        let vector_search = LsmScanner::without_base_table(
+            vector_schema,
+            "memory://vector",
+            vec![],
+            vec!["id".to_string()],
+        )
+        .nearest(
+            "vector",
+            &arrow_array::Float32Array::from(vec![0.0f32, 0.0, 0.0, 0.0]),
+            1,
+        )
+        .unwrap()
+        .with_overfetch_factor(0.5);
+        let Err(err) = vector_search.try_into_stream().await else {
+            panic!("invalid overfetch factor should fail vector search planning");
         };
         assert!(
             err.to_string().contains("overfetch_factor"),
             "unexpected error for invalid overfetch factor: {err}"
         );
 
-        let empty_scanner = LsmScanner::without_base_table(
-            pk_schema(),
-            "memory://empty",
+        let fts_search = LsmScanner::without_base_table(
+            pk_schema_with(arrow_schema::Field::new("text", DataType::Utf8, true)),
+            "memory://fts",
             vec![],
             vec!["id".to_string()],
         )
+        .full_text_search(
+            FullTextSearchQuery::new("lance".to_string())
+                .with_column("text".to_string())
+                .unwrap(),
+        )
+        .unwrap()
         .with_overfetch_factor(0.5);
-        let Err(err) = empty_scanner.try_into_stream().await else {
-            panic!("invalid overfetch factor should fail even when there are no sources");
+        let Err(err) = fts_search.try_into_stream().await else {
+            panic!("invalid overfetch factor should fail full-text search planning");
         };
         assert!(
             err.to_string().contains("overfetch_factor"),
-            "unexpected error for invalid empty-source overfetch factor: {err}"
+            "unexpected error for invalid overfetch factor: {err}"
         );
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -53,18 +53,10 @@ pub struct LsmScanPlanner {
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
     warmer: Option<Arc<dyn GenerationWarmer>>,
-    /// Over-fetch multiple for the per-source limit pushdown: block-listed
-    /// sources scan `(offset + limit) * factor` rows so cross-gen dedup drops
-    /// still leave enough live rows. Clamped to `>= 1.0`.
-    ///
-    /// This headroom must also absorb deletes: a tombstone shadows the older
-    /// real row without emitting a replacement (shadow-without-replace), so it
-    /// is pure subtraction from a block-listed source. If delete density inside
-    /// a source's fetch window exceeds `factor - 1`, that source can deliver
-    /// `< k` live rows (a recall shortfall, not wrong content — see the
-    /// under-fetch `warn!` in `PkBlockFilterExec`). Steady-state this is
-    /// self-limiting because L0→base compaction drains tombstones from the
-    /// fresh tier; the exposure is a delete-heavy burst between compactions.
+    /// Configured search over-fetch factor. Plain scans validate it for
+    /// consistent [`LsmScanner`](super::LsmScanner) builder semantics but do
+    /// not use it: block-filtered scans refill exactly instead of relying on a
+    /// finite heuristic.
     overfetch_factor: f64,
 }
 
@@ -112,9 +104,9 @@ impl LsmScanPlanner {
         self
     }
 
-    /// Set the over-fetch multiple for the per-source limit pushdown
-    /// (see the field docs). Values below `1.0` are rejected by
-    /// [`Self::plan_scan`].
+    /// Set the search over-fetch factor to validate when planning a scan.
+    /// Values below `1.0` are rejected by [`Self::plan_scan`], consistently
+    /// with the vector and full-text planners.
     pub fn with_overfetch_factor(mut self, factor: f64) -> Self {
         self.overfetch_factor = factor;
         self
@@ -163,7 +155,7 @@ impl LsmScanPlanner {
 
         // 1. Collect all data sources
         let sources = self.collector.collect()?;
-        let overfetch = super::validate_overfetch_factor(self.overfetch_factor)?;
+        super::validate_overfetch_factor(self.overfetch_factor)?;
 
         if sources.is_empty() {
             // Return empty plan
@@ -187,14 +179,13 @@ impl LsmScanPlanner {
         let sources: Vec<_> = sources.into_iter().rev().collect();
 
         // Per-source limit pushdown: an unordered LIMIT needs only
-        // `offset + limit` live rows from EACH source to fill the global
-        // limit after dedup (any-N semantics), so cap every on-disk source
-        // instead of scanning whole generations and trimming above the
-        // union. Block-listed sources over-fetch by `overfetch_factor` so
-        // cross-gen dedup drops still leave `n_needed` live rows; the
-        // PkBlockFilter warns when that was not enough. The active memtable
-        // is in-memory and within-gen append duplicates are resolved by its
-        // own dedup, so it is never capped here.
+        // `offset + limit` live rows from each source to fill the global limit
+        // (any-N semantics). However, a source with a cross-generation block
+        // list can lose any number of rows after its scan, so a finite fetch
+        // before that filter is not safe. Leave those scans unbounded and let
+        // the LocalLimitExec below pull until it sees `n_needed` live rows or
+        // reaches EOF. Sources without a block filter can still push the limit
+        // down safely. The active memtable is in-memory and is never capped.
         let n_needed = limit.map(|l| l.saturating_add(offset.unwrap_or(0)));
 
         let mut source_plans = Vec::new();
@@ -204,12 +195,9 @@ impl LsmScanPlanner {
             let blocked = block_lists
                 .get(&(source.shard_id(), source.generation()))
                 .cloned();
-            let fetch = match (n_needed, is_active) {
-                (Some(n), false) => Some(if blocked.is_some() && !self.pk_columns.is_empty() {
-                    ((n as f64) * overfetch).ceil() as usize
-                } else {
-                    n
-                }),
+            let has_block_filter = blocked.is_some() && !self.pk_columns.is_empty();
+            let fetch = match (n_needed, is_active, has_block_filter) {
+                (Some(n), false, false) => Some(n),
                 _ => None,
             };
             let scan = self
@@ -217,14 +205,14 @@ impl LsmScanPlanner {
                 .await?;
 
             // Drop cross-generation stale rows (PKs superseded by a newer gen).
-            // With a limit, `k = n_needed` arms the under-fetch warning; with
-            // no limit `k = 0` keeps it silent.
+            // Plain scans refill exactly, so keep the approximate-search
+            // under-fetch warning disabled with k = 0.
             let scan = match blocked {
                 Some(set) if !self.pk_columns.is_empty() => Arc::new(PkBlockFilterExec::new(
                     scan,
                     self.pk_columns.clone(),
                     set,
-                    n_needed.unwrap_or(0),
+                    0,
                 ))
                     as Arc<dyn ExecutionPlan>,
                 _ => scan,
@@ -1005,6 +993,68 @@ mod integration_tests {
         // Count total rows
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 3, "Should have 3 rows due to limit");
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_limit_offset_refills_after_update_shadow_across_fragments() {
+        let schema = create_pk_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let base_batch = create_test_batch(&schema, &[1, 2, 3, 4], "base");
+        let reader = RecordBatchIterator::new([Ok(base_batch)], schema.clone());
+        let base = Arc::new(
+            Dataset::write(
+                reader,
+                &base_uri,
+                Some(WriteParams {
+                    max_rows_per_file: 2,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(
+            base.get_fragments().len(),
+            2,
+            "the stale prefix and live rows must occupy separate fragments"
+        );
+
+        // The newest values for ids 1 and 2 no longer match the predicate, so
+        // their matching base values are shadowed.  The second base fragment
+        // still contains the live matches that must fill offset + limit.
+        let (batch_store, index_store) =
+            pk_indexed(&[create_test_batch(&schema, &[1, 2], "active")]);
+        let scanner = LsmScanner::new(base, vec![], vec!["id".to_string()])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store,
+                        schema,
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            )
+            .filter("name LIKE 'base%'")
+            .unwrap()
+            .limit(Some(1), Some(1))
+            .unwrap();
+
+        let batch = scanner.try_into_batch().await.unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(
+            ids.iter().collect::<Vec<_>>(),
+            vec![Some(4)],
+            "offset=1, limit=1 must skip id=3 after shadow filtering"
+        );
     }
 
     #[tokio::test]
@@ -2089,6 +2139,46 @@ mod integration_tests {
             collect_sorted_ids(&batches),
             vec![1, 3, 4],
             "id=2 deleted; tombstone row not surfaced"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_limit_refills_after_active_tombstone_shadows_base() {
+        let base_schema = create_pk_schema();
+        let mem_schema = ts_pk_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let base = Arc::new(
+            create_dataset(
+                &base_uri,
+                vec![create_test_batch(&base_schema, &[1, 2, 3], "base")],
+            )
+            .await,
+        );
+
+        let active_batch = ts_batch(&mem_schema, &[(1, None, true)]);
+        let (batch_store, index_store) = pk_indexed(&[active_batch]);
+        let scanner = LsmScanner::new(base, vec![], vec!["id".to_string()])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store,
+                        schema: mem_schema,
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            )
+            .limit(Some(2), None)
+            .unwrap();
+
+        let batch = scanner.try_into_batch().await.unwrap();
+        assert_eq!(
+            collect_sorted_ids(&[batch]),
+            vec![2, 3],
+            "the base scan must continue past the shadowed row to fill the limit"
         );
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -1091,7 +1091,7 @@ mod integration_tests {
         let (base_dataset, _, _, pk_columns, _temp_path) = setup_multi_level_lsm().await;
 
         // Create scanner with only base table (no shard snapshots or active memtable)
-        let scanner = LsmScanner::new(base_dataset, vec![], pk_columns);
+        let scanner = LsmScanner::new(base_dataset.clone(), vec![], pk_columns.clone());
 
         let plan = scanner.create_plan().await.unwrap();
 
@@ -1101,6 +1101,22 @@ mod integration_tests {
             plan,
             "ProjectionExec:...
   LanceRead:...base/data...refine_filter=--",
+        )
+        .await
+        .unwrap();
+
+        // A base-only source has no cross-generation block filter, so its
+        // finite limit remains safe to push into the physical Lance read.
+        let scanner = LsmScanner::new(base_dataset, vec![], pk_columns)
+            .limit(Some(3), None)
+            .unwrap();
+        let plan = scanner.create_plan().await.unwrap();
+        assert_plan_node_equals(
+            plan,
+            "GlobalLimitExec: skip=0, fetch=3
+  ProjectionExec:...
+    LocalLimitExec: fetch=3
+      LanceRead:...base/data...range_before=Some(0..3)...refine_filter=--",
         )
         .await
         .unwrap();

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -53,11 +53,6 @@ pub struct LsmScanPlanner {
     flushed_cache: Option<Arc<dyn DatasetCache>>,
     /// Optional warmer fired on first open of a flushed generation.
     warmer: Option<Arc<dyn GenerationWarmer>>,
-    /// Configured search over-fetch factor. Plain scans validate it for
-    /// consistent [`LsmScanner`](super::LsmScanner) builder semantics but do
-    /// not use it: block-filtered scans refill exactly instead of relying on a
-    /// finite heuristic.
-    overfetch_factor: f64,
 }
 
 impl LsmScanPlanner {
@@ -75,7 +70,6 @@ impl LsmScanPlanner {
             store_params: None,
             flushed_cache: None,
             warmer: None,
-            overfetch_factor: 1.0,
         }
     }
 
@@ -101,14 +95,6 @@ impl LsmScanPlanner {
     /// Inject the warmer fired on first open of a flushed generation.
     pub fn with_warmer(mut self, warmer: Arc<dyn GenerationWarmer>) -> Self {
         self.warmer = Some(warmer);
-        self
-    }
-
-    /// Set the search over-fetch factor to validate when planning a scan.
-    /// Values below `1.0` are rejected by [`Self::plan_scan`], consistently
-    /// with the vector and full-text planners.
-    pub fn with_overfetch_factor(mut self, factor: f64) -> Self {
-        self.overfetch_factor = factor;
         self
     }
 
@@ -155,7 +141,6 @@ impl LsmScanPlanner {
 
         // 1. Collect all data sources
         let sources = self.collector.collect()?;
-        super::validate_overfetch_factor(self.overfetch_factor)?;
 
         if sources.is_empty() {
             // Return empty plan


### PR DESCRIPTION
## Summary

- stop pushing a finite source limit below cross-generation `PkBlockFilterExec`
- let the existing post-filter `LocalLimitExec` pull until it has `offset + limit` live rows or reaches EOF
- retain limit pushdown for sources without a block filter
- add regressions for update/filter predicate crossing, active tombstones, multiple base fragments, and offset/limit semantics

Closes #7916

## Why

A stale prefix could consume an on-disk source's finite limit before cross-generation shadow filtering removed it. The scan then returned fewer rows than requested even though later live rows existed. A finite over-fetch factor cannot make that exact.

Block-filtered scans now use the existing execution tree as a streaming refill: `LocalLimitExec` stays above `PkBlockFilterExec`, continues pulling until enough rows survive, and cancels the child once the source contribution is full. Sources without a block filter keep the physical limit pushdown.

## Testing

- `cargo test -p lance --lib test_lsm_scan_limit_`
- `cargo test -p lance --lib dataset::mem_wal::scanner::`
- `cargo test -p lance --lib dataset::mem_wal::`
- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- pre-commit hooks: fmt, typos, and Cargo lock sync

## Compatibility

No public API, file format, or dependency changes.

## Classification

This fixes silently incomplete query results and should be labeled `critical-fix`. The linked issue uses the required `bug:` title prefix, but GitHub rejected label mutation for the contributor account.
