### PR TITLE
feat(index): support segmented bloom filters

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3299,6 +3299,7 @@ class LanceDataset(pa.dataset.Dataset):
             "INVERTED",
             "FTS",
             "ZONEMAP",
+            "BLOOMFILTER",
         }
 
     @classmethod
@@ -3310,6 +3311,7 @@ class LanceDataset(pa.dataset.Dataset):
             "BTREE",
             "BITMAP",
             "ZONEMAP",
+            "BLOOMFILTER",
         }
 
     def create_scalar_index(
@@ -4265,8 +4267,8 @@ class LanceDataset(pa.dataset.Dataset):
         Create one segment without publishing it and return its metadata.
 
         This is the public distributed-build API for vector, BTREE scalar,
-        canonical bitmap scalar, INVERTED scalar, and ZONEMAP scalar index
-        construction. Unlike
+        canonical bitmap scalar, INVERTED scalar, ZONEMAP scalar, and
+        BLOOMFILTER scalar index construction. Unlike
         :meth:`create_index`, this method does not publish the index into the
         dataset manifest. Instead, it writes one segment under
         ``_indices/<segment_uuid>/`` and returns the resulting
@@ -4282,7 +4284,7 @@ class LanceDataset(pa.dataset.Dataset):
         4. commit the final segment list with
            :meth:`commit_existing_index_segments`
 
-        BTREE, BITMAP, INVERTED, and ZONEMAP segments may
+        BTREE, BITMAP, INVERTED, ZONEMAP, and BLOOMFILTER segments may
         be merged with :meth:`merge_existing_index_segments` before commit.
         Parameters are the same as :meth:`create_index`, with one additional
         requirement:

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -4742,6 +4742,54 @@ def test_zonemap_segment_merge_and_commit_from_python(tmp_path):
     )
 
 
+def test_bloomfilter_segment_merge_and_commit_from_python(tmp_path):
+    ds = generate_multi_fragment_dataset(
+        tmp_path, num_fragments=3, rows_per_fragment=100
+    )
+
+    index_name = "id_bloomfilter_segments"
+    fragment_ids = [fragment.fragment_id for fragment in ds.get_fragments()]
+    staged_segments = [
+        ds.create_index_uncommitted(
+            column="id",
+            index_type="BLOOMFILTER",
+            name=index_name,
+            fragment_ids=[fragment_id],
+        )
+        for fragment_id in fragment_ids
+    ]
+
+    for segment, fragment_id in zip(staged_segments, fragment_ids):
+        assert segment.fragment_ids == {fragment_id}
+        assert any(file.path == "bloomfilter.lance" for file in segment.files)
+
+    merged_segment = ds.merge_existing_index_segments(staged_segments)
+    assert merged_segment.fragment_ids == set(fragment_ids)
+    assert any(file.path == "bloomfilter.lance" for file in merged_segment.files)
+
+    ds = ds.commit_existing_index_segments(index_name, "id", [merged_segment])
+    descriptions = {index.name: index for index in ds.describe_indices()}
+    assert descriptions[index_name].index_type == "BloomFilter"
+    assert len(descriptions[index_name].segments) == 1
+
+    filter_expr = "id = 117"
+    without_index = ds.scanner(
+        filter=filter_expr,
+        columns=["id", "text"],
+        use_scalar_index=False,
+    ).to_table()
+    with_index = ds.scanner(
+        filter=filter_expr,
+        columns=["id", "text"],
+        use_scalar_index=True,
+    ).to_table()
+    assert with_index.to_pydict() == without_index.to_pydict()
+    assert (
+        "ScalarIndexQuery"
+        in ds.scanner(filter=filter_expr, use_scalar_index=True).explain_plan()
+    )
+
+
 def test_merge_index_metadata_btree_soft_break(tmp_path):
     ds = generate_multi_fragment_dataset(
         tmp_path, num_fragments=2, rows_per_fragment=100

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -526,10 +526,9 @@ pub async fn merge_bloomfilter_indices(
     let first = source_indices
         .iter()
         .find(|(_, fragment_filter)| !fragment_filter.is_empty())
+        .or_else(|| source_indices.first())
         .ok_or_else(|| {
-            Error::invalid_input(
-                "merge_bloomfilter_indices requires at least one source with fragment coverage",
-            )
+            Error::invalid_input("merge_bloomfilter_indices requires at least one source index")
         })?;
     let params = BloomFilterIndexBuilderParams {
         number_of_items: first.0.number_of_items,
@@ -2527,6 +2526,24 @@ mod tests {
                 .await
                 .unwrap(),
             SearchResult::exact(expected_nulls)
+        );
+
+        let (_empty_tmpdir, empty_store) = create_store();
+        merge_bloomfilter_indices(
+            &[(&ignored_legacy, &RoaringBitmap::new())],
+            empty_store.as_ref(),
+        )
+        .await
+        .unwrap();
+        let empty = BloomFilterIndex::load(empty_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert_eq!(
+            empty
+                .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+                .await
+                .unwrap(),
+            SearchResult::exact(RowAddrTreeMap::new())
         );
     }
 }

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -523,9 +523,14 @@ pub async fn merge_bloomfilter_indices(
     source_indices: &[(&BloomFilterIndex, &RoaringBitmap)],
     dest_store: &dyn IndexStore,
 ) -> Result<CreatedIndex> {
-    let first = source_indices.first().ok_or_else(|| {
-        Error::invalid_input("merge_bloomfilter_indices requires at least one source index")
-    })?;
+    let first = source_indices
+        .iter()
+        .find(|(_, fragment_filter)| !fragment_filter.is_empty())
+        .ok_or_else(|| {
+            Error::invalid_input(
+                "merge_bloomfilter_indices requires at least one source with fragment coverage",
+            )
+        })?;
     let params = BloomFilterIndexBuilderParams {
         number_of_items: first.0.number_of_items,
         probability: first.0.probability,
@@ -535,6 +540,9 @@ pub async fn merge_bloomfilter_indices(
     let mut merged_null_rows = RowAddrTreeMap::new();
     let mut has_missing_null_bitmap = false;
     for (source, fragment_filter) in source_indices {
+        if fragment_filter.is_empty() {
+            continue;
+        }
         if source.number_of_items != params.number_of_items
             || source.probability != params.probability
         {
@@ -546,9 +554,6 @@ pub async fn merge_bloomfilter_indices(
                 source.number_of_items,
                 source.probability
             )));
-        }
-        if fragment_filter.is_empty() {
-            continue;
         }
         blocks.extend(
             source
@@ -2500,9 +2505,11 @@ mod tests {
         );
 
         let (_trimmed_tmpdir, trimmed_store) = create_store();
+        let mut ignored_legacy = legacy.as_ref().clone();
+        ignored_legacy.probability = 0.5;
         merge_bloomfilter_indices(
             &[
-                (legacy.as_ref(), &RoaringBitmap::new()),
+                (&ignored_legacy, &RoaringBitmap::new()),
                 (second.as_ref(), &RoaringBitmap::from_iter([1])),
             ],
             trimmed_store.as_ref(),

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -50,6 +50,7 @@ const BLOOMFILTER_ITEM_META_KEY: &str = "bloomfilter_item";
 const NULL_BITMAP_META_KEY: &str = "null_bitmap";
 const BLOOMFILTER_PROBABILITY_META_KEY: &str = "bloomfilter_probability";
 const BLOOMFILTER_INDEX_VERSION: u32 = 0;
+pub const MAX_BINARY_VALUE_BUFFER_LEN: u64 = i32::MAX as u64;
 
 #[derive(Debug, Clone)]
 struct BloomFilterStatistics {
@@ -86,6 +87,7 @@ pub struct BloomFilterIndex {
     probability: f64,
     // Exact set of null row addresses; None for older indices without this bitmap.
     null_rows: Option<RowAddrTreeMap>,
+    frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
 }
 
 impl DeepSizeOf for BloomFilterIndex {
@@ -97,7 +99,7 @@ impl DeepSizeOf for BloomFilterIndex {
 impl BloomFilterIndex {
     async fn load(
         store: Arc<dyn IndexStore>,
-        _fri: Option<Arc<dyn RowIdRemapper>>,
+        fri: Option<Arc<dyn RowIdRemapper>>,
         _index_cache: &LanceCache,
     ) -> Result<Arc<Self>> {
         let index_file = store.open_index_file(BLOOMFILTER_FILENAME).await?;
@@ -133,6 +135,7 @@ impl BloomFilterIndex {
             number_of_items,
             probability,
             null_rows,
+            fri,
         )?))
     }
 
@@ -141,6 +144,7 @@ impl BloomFilterIndex {
         number_of_items: u64,
         probability: f64,
         null_rows: Option<RowAddrTreeMap>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         if data.num_rows() == 0 {
             return Ok(Self {
@@ -148,6 +152,7 @@ impl BloomFilterIndex {
                 number_of_items,
                 probability,
                 null_rows,
+                frag_reuse_index,
             });
         }
 
@@ -229,6 +234,7 @@ impl BloomFilterIndex {
             number_of_items,
             probability,
             null_rows,
+            frag_reuse_index,
         })
     }
 
@@ -496,8 +502,7 @@ impl ScalarIndex for BloomFilterIndex {
         let files = builder.write_index(dest_store).await?;
 
         Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
-                .unwrap(),
+            index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())?,
             index_version: BLOOMFILTER_INDEX_VERSION,
             files,
         })
@@ -516,6 +521,65 @@ impl ScalarIndex for BloomFilterIndex {
         })?;
         Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::BloomFilter).with_params(&params))
     }
+}
+
+fn remap_zone(
+    zone: &BloomFilterStatistics,
+    remapper: &dyn RowIdRemapper,
+) -> Vec<BloomFilterStatistics> {
+    let zone_start = (zone.bound.fragment_id << 32).saturating_add(zone.bound.start);
+    let mut remapped = (0..zone.bound.length as u64)
+        .filter_map(|offset| remapper.remap_row_id(zone_start.saturating_add(offset)))
+        .collect::<Vec<_>>();
+    remapped.sort_unstable();
+    remapped.dedup();
+
+    let mut zones = Vec::new();
+    let mut run_start = None;
+    let mut previous = 0u64;
+    for row_id in remapped {
+        if run_start.is_none() {
+            run_start = Some(row_id);
+        } else if row_id != previous.saturating_add(1) || row_id >> 32 != previous >> 32 {
+            let start = run_start.take().unwrap();
+            zones.push(BloomFilterStatistics {
+                bound: ZoneBound {
+                    fragment_id: start >> 32,
+                    start: start & u64::from(u32::MAX),
+                    length: (previous - start + 1) as usize,
+                },
+                has_null: zone.has_null,
+                bloom_filter: zone.bloom_filter.clone(),
+            });
+            run_start = Some(row_id);
+        }
+        previous = row_id;
+    }
+    if let Some(start) = run_start {
+        zones.push(BloomFilterStatistics {
+            bound: ZoneBound {
+                fragment_id: start >> 32,
+                start: start & u64::from(u32::MAX),
+                length: (previous - start + 1) as usize,
+            },
+            has_null: zone.has_null,
+            bloom_filter: zone.bloom_filter.clone(),
+        });
+    }
+    zones
+}
+
+fn checked_merged_payload_size(current: u64, additional: usize) -> Result<u64> {
+    let total = current
+        .checked_add(additional as u64)
+        .ok_or_else(|| Error::invalid_input("merged BloomFilter payload size overflowed u64"))?;
+    if total > MAX_BINARY_VALUE_BUFFER_LEN {
+        return Err(Error::invalid_input(format!(
+            "merged BloomFilter payload is {total} bytes, exceeding the Arrow BinaryArray limit \
+             of {MAX_BINARY_VALUE_BUFFER_LEN} bytes; merge fewer segments at a time"
+        )));
+    }
+    Ok(total)
 }
 
 /// Merge caller-selected BloomFilter segments into one self-contained segment.
@@ -538,6 +602,7 @@ pub async fn merge_bloomfilter_indices(
     let mut blocks = Vec::new();
     let mut merged_null_rows = RowAddrTreeMap::new();
     let mut has_missing_null_bitmap = false;
+    let mut serialized_bytes = 0u64;
     for (source, fragment_filter) in source_indices {
         if fragment_filter.is_empty() {
             continue;
@@ -554,19 +619,26 @@ pub async fn merge_bloomfilter_indices(
                 source.probability
             )));
         }
-        blocks.extend(
-            source
-                .zones
-                .iter()
-                .filter(|block| {
-                    u32::try_from(block.bound.fragment_id)
-                        .is_ok_and(|fragment_id| fragment_filter.contains(fragment_id))
-                })
-                .cloned(),
-        );
+        let source_zones = source.zones.iter().flat_map(|block| {
+            source.frag_reuse_index.as_deref().map_or_else(
+                || vec![block.clone()],
+                |remapper| remap_zone(block, remapper),
+            )
+        });
+        for block in source_zones.filter(|block| {
+            u32::try_from(block.bound.fragment_id)
+                .is_ok_and(|fragment_id| fragment_filter.contains(fragment_id))
+        }) {
+            serialized_bytes =
+                checked_merged_payload_size(serialized_bytes, block.bloom_filter.to_bytes().len())?;
+            blocks.push(block);
+        }
         match &source.null_rows {
             Some(null_rows) => {
-                let mut filtered = null_rows.clone();
+                let mut filtered = source.frag_reuse_index.as_deref().map_or_else(
+                    || null_rows.clone(),
+                    |remapper| remapper.remap_row_addrs_tree_map(null_rows),
+                );
                 filtered.retain_fragments(fragment_filter.iter());
                 merged_null_rows |= &filtered;
             }
@@ -583,7 +655,7 @@ pub async fn merge_bloomfilter_indices(
     let files = builder.write_index(dest_store).await?;
 
     Ok(CreatedIndex {
-        index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default()).unwrap(),
+        index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())?,
         index_version: BLOOMFILTER_INDEX_VERSION,
         files,
     })
@@ -1282,7 +1354,9 @@ impl TrainingRequest for BloomFilterIndexTrainingRequest {
 
 #[cfg(test)]
 mod tests {
+    use crate::frag_reuse::{FragReuseIndex, FragReuseIndexDetails, FragReuseIndexHandle};
     use crate::scalar::registry::VALUE_COLUMN_NAME;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::scalar::bloomfilter::BloomFilterIndexPlugin;
@@ -1298,13 +1372,26 @@ mod tests {
 
     use crate::scalar::{
         BloomFilterQuery, IndexStore, ScalarIndex, SearchResult,
-        bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilderParams, merge_bloomfilter_indices},
+        bloomfilter::{
+            BloomFilterIndex, BloomFilterIndexBuilderParams, MAX_BINARY_VALUE_BUFFER_LEN,
+            checked_merged_payload_size, merge_bloomfilter_indices,
+        },
         lance_format::LanceIndexStore,
     };
 
     use crate::Index; // Import Index trait to access calculate_included_frags
     use crate::metrics::NoOpMetricsCollector;
     use roaring::RoaringBitmap; // Import RoaringBitmap for the test
+
+    #[test]
+    fn test_checked_merged_payload_size_rejects_binary_overflow() {
+        assert_eq!(
+            checked_merged_payload_size(MAX_BINARY_VALUE_BUFFER_LEN - 1, 1).unwrap(),
+            MAX_BINARY_VALUE_BUFFER_LEN
+        );
+        let err = checked_merged_payload_size(MAX_BINARY_VALUE_BUFFER_LEN, 1).unwrap_err();
+        assert!(err.to_string().contains("Arrow BinaryArray limit"));
+    }
 
     // Adds a _rowaddr column emulating each batch as a new fragment
     fn add_row_addr(stream: SendableRecordBatchStream) -> SendableRecordBatchStream {
@@ -2447,7 +2534,7 @@ mod tests {
             .unwrap();
         }
 
-        let first = BloomFilterIndex::load(first_store, None, &LanceCache::no_cache())
+        let first = BloomFilterIndex::load(first_store.clone(), None, &LanceCache::no_cache())
             .await
             .unwrap();
         let second = BloomFilterIndex::load(second_store, None, &LanceCache::no_cache())
@@ -2474,6 +2561,59 @@ mod tests {
                 .await
                 .unwrap(),
             SearchResult::exact(expected_nulls)
+        );
+
+        let remapped_base = 2_u64 << 32;
+        let remapper = FragReuseIndexHandle(Arc::new(FragReuseIndex::new(
+            uuid::Uuid::new_v4(),
+            vec![HashMap::from([
+                (0, Some(remapped_base)),
+                (1, Some(remapped_base + 1)),
+                (2, Some(remapped_base + 2)),
+            ])],
+            FragReuseIndexDetails { versions: vec![] },
+        )));
+        let remapped_first = BloomFilterIndex::load(
+            first_store,
+            Some(Arc::new(remapper)),
+            &LanceCache::no_cache(),
+        )
+        .await
+        .unwrap();
+        let (_remapped_tmpdir, remapped_store) = create_store();
+        merge_bloomfilter_indices(
+            &[(remapped_first.as_ref(), &RoaringBitmap::from_iter([2]))],
+            remapped_store.as_ref(),
+        )
+        .await
+        .unwrap();
+        let remapped = BloomFilterIndex::load(remapped_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let mut expected_remapped_nulls = RowAddrTreeMap::new();
+        expected_remapped_nulls.insert(remapped_base + 1);
+        assert_eq!(
+            remapped
+                .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+                .await
+                .unwrap(),
+            SearchResult::exact(expected_remapped_nulls)
+        );
+        let candidates = remapped
+            .search(
+                &BloomFilterQuery::Equals(ScalarValue::Int64(Some(10))),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        assert!(
+            candidates
+                .row_addrs()
+                .true_rows()
+                .row_addrs()
+                .unwrap()
+                .map(u64::from)
+                .any(|row_id| row_id == remapped_base)
         );
 
         let (_legacy_tmpdir, legacy_store) = create_store();

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -520,22 +520,21 @@ impl ScalarIndex for BloomFilterIndex {
 
 /// Merge caller-selected BloomFilter segments into one self-contained segment.
 pub async fn merge_bloomfilter_indices(
-    source_indices: &[&BloomFilterIndex],
+    source_indices: &[(&BloomFilterIndex, &RoaringBitmap)],
     dest_store: &dyn IndexStore,
-    fragment_filter: &RoaringBitmap,
 ) -> Result<CreatedIndex> {
     let first = source_indices.first().ok_or_else(|| {
         Error::invalid_input("merge_bloomfilter_indices requires at least one source index")
     })?;
     let params = BloomFilterIndexBuilderParams {
-        number_of_items: first.number_of_items,
-        probability: first.probability,
+        number_of_items: first.0.number_of_items,
+        probability: first.0.probability,
     };
 
     let mut blocks = Vec::new();
     let mut merged_null_rows = RowAddrTreeMap::new();
     let mut has_missing_null_bitmap = false;
-    for source in source_indices {
+    for (source, fragment_filter) in source_indices {
         if source.number_of_items != params.number_of_items
             || source.probability != params.probability
         {
@@ -547,6 +546,9 @@ pub async fn merge_bloomfilter_indices(
                 source.number_of_items,
                 source.probability
             )));
+        }
+        if fragment_filter.is_empty() {
+            continue;
         }
         blocks.extend(
             source
@@ -2448,9 +2450,11 @@ mod tests {
             .await
             .unwrap();
         merge_bloomfilter_indices(
-            &[first.as_ref(), second.as_ref()],
+            &[
+                (first.as_ref(), &RoaringBitmap::from_iter([0])),
+                (second.as_ref(), &RoaringBitmap::from_iter([1])),
+            ],
             merged_store.as_ref(),
-            &RoaringBitmap::from_iter([0, 1]),
         )
         .await
         .unwrap();
@@ -2475,9 +2479,11 @@ mod tests {
             .await
             .unwrap();
         merge_bloomfilter_indices(
-            &[legacy.as_ref(), second.as_ref()],
+            &[
+                (legacy.as_ref(), &RoaringBitmap::from_iter([0])),
+                (second.as_ref(), &RoaringBitmap::from_iter([1])),
+            ],
             legacy_merged_store.as_ref(),
-            &RoaringBitmap::from_iter([0, 1]),
         )
         .await
         .unwrap();
@@ -2491,6 +2497,29 @@ mod tests {
                 .await
                 .unwrap()
                 .is_exact()
+        );
+
+        let (_trimmed_tmpdir, trimmed_store) = create_store();
+        merge_bloomfilter_indices(
+            &[
+                (legacy.as_ref(), &RoaringBitmap::new()),
+                (second.as_ref(), &RoaringBitmap::from_iter([1])),
+            ],
+            trimmed_store.as_ref(),
+        )
+        .await
+        .unwrap();
+        let trimmed = BloomFilterIndex::load(trimmed_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let mut expected_nulls = RowAddrTreeMap::new();
+        expected_nulls.insert((1_u64 << 32) + 1);
+        assert_eq!(
+            trimmed
+                .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+                .await
+                .unwrap(),
+            SearchResult::exact(expected_nulls)
         );
     }
 }

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -518,6 +518,71 @@ impl ScalarIndex for BloomFilterIndex {
     }
 }
 
+/// Merge caller-selected BloomFilter segments into one self-contained segment.
+pub async fn merge_bloomfilter_indices(
+    source_indices: &[&BloomFilterIndex],
+    dest_store: &dyn IndexStore,
+    fragment_filter: &RoaringBitmap,
+) -> Result<CreatedIndex> {
+    let first = source_indices.first().ok_or_else(|| {
+        Error::invalid_input("merge_bloomfilter_indices requires at least one source index")
+    })?;
+    let params = BloomFilterIndexBuilderParams {
+        number_of_items: first.number_of_items,
+        probability: first.probability,
+    };
+
+    let mut blocks = Vec::new();
+    let mut merged_null_rows = RowAddrTreeMap::new();
+    let mut has_missing_null_bitmap = false;
+    for source in source_indices {
+        if source.number_of_items != params.number_of_items
+            || source.probability != params.probability
+        {
+            return Err(Error::invalid_input(format!(
+                "cannot merge BloomFilter segments with different parameters: \
+                 number_of_items={}, probability={} and number_of_items={}, probability={}",
+                params.number_of_items,
+                params.probability,
+                source.number_of_items,
+                source.probability
+            )));
+        }
+        blocks.extend(
+            source
+                .zones
+                .iter()
+                .filter(|block| {
+                    u32::try_from(block.bound.fragment_id)
+                        .is_ok_and(|fragment_id| fragment_filter.contains(fragment_id))
+                })
+                .cloned(),
+        );
+        match &source.null_rows {
+            Some(null_rows) => {
+                let mut filtered = null_rows.clone();
+                filtered.retain_fragments(fragment_filter.iter());
+                merged_null_rows |= &filtered;
+            }
+            None => has_missing_null_bitmap = true,
+        }
+    }
+    blocks.sort_by_key(|block| (block.bound.fragment_id, block.bound.start));
+
+    let mut builder = BloomFilterIndexBuilder::try_new(params)?;
+    builder.blocks = blocks;
+    if !has_missing_null_bitmap {
+        builder.null_rows = Some(merged_null_rows);
+    }
+    let files = builder.write_index(dest_store).await?;
+
+    Ok(CreatedIndex {
+        index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default()).unwrap(),
+        index_version: BLOOMFILTER_INDEX_VERSION,
+        files,
+    })
+}
+
 fn default_number_of_items() -> u64 {
     *DEFAULT_NUMBER_OF_ITEMS
 }
@@ -1112,15 +1177,9 @@ impl BasicTrainer for BloomFilterIndexPlugin {
         data: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         request: Box<dyn TrainingRequest>,
-        fragment_ids: Option<Vec<u32>>,
+        _fragment_ids: Option<Vec<u32>>,
         _progress: Arc<dyn crate::progress::IndexBuildProgress>,
     ) -> Result<CreatedIndex> {
-        if fragment_ids.is_some() {
-            return Err(Error::invalid_input_source(
-                "BloomFilter index does not support fragment training".into(),
-            ));
-        }
-
         let request = (request as Box<dyn std::any::Any>)
             .downcast::<BloomFilterIndexTrainingRequest>()
             .map_err(|_| {
@@ -1233,7 +1292,7 @@ mod tests {
 
     use crate::scalar::{
         BloomFilterQuery, IndexStore, ScalarIndex, SearchResult,
-        bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilderParams},
+        bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilderParams, merge_bloomfilter_indices},
         lance_format::LanceIndexStore,
     };
 
@@ -2342,6 +2401,96 @@ mod tests {
         assert!(
             !result.is_exact(),
             "IS NULL on a legacy index should not be exact"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_bloomfilter_indices_preserves_exact_and_legacy_nulls() {
+        fn create_store() -> (TempObjDir, Arc<LanceIndexStore>) {
+            let tmpdir = TempObjDir::default();
+            let store = Arc::new(LanceIndexStore::new(
+                Arc::new(ObjectStore::local()),
+                tmpdir.clone(),
+                Arc::new(LanceCache::no_cache()),
+            ));
+            (tmpdir, store)
+        }
+
+        let (_first_tmpdir, first_store) = create_store();
+        let (_second_tmpdir, second_store) = create_store();
+        let (_merged_tmpdir, merged_store) = create_store();
+        let params = BloomFilterIndexBuilderParams::new(1000, 0.01);
+        for (fragment_id, store) in [(0_u64, &first_store), (1_u64, &second_store)] {
+            let row_base = fragment_id << 32;
+            let batch = record_batch!(
+                (VALUE_COLUMN_NAME, Int64, [Some(10), None, Some(30)]),
+                (ROW_ADDR, UInt64, [row_base, row_base + 1, row_base + 2])
+            )
+            .unwrap();
+            let schema = batch.schema();
+            let stream = Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                stream::once(async move { Ok(batch) }),
+            ));
+            BloomFilterIndexPlugin::train_bloomfilter_index(
+                stream,
+                store.as_ref(),
+                Some(params.clone()),
+            )
+            .await
+            .unwrap();
+        }
+
+        let first = BloomFilterIndex::load(first_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let second = BloomFilterIndex::load(second_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        merge_bloomfilter_indices(
+            &[first.as_ref(), second.as_ref()],
+            merged_store.as_ref(),
+            &RoaringBitmap::from_iter([0, 1]),
+        )
+        .await
+        .unwrap();
+        let merged = BloomFilterIndex::load(merged_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let mut expected_nulls = RowAddrTreeMap::new();
+        expected_nulls.insert(1);
+        expected_nulls.insert((1_u64 << 32) + 1);
+        assert_eq!(
+            merged
+                .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+                .await
+                .unwrap(),
+            SearchResult::exact(expected_nulls)
+        );
+
+        let (_legacy_tmpdir, legacy_store) = create_store();
+        let (_legacy_merged_tmpdir, legacy_merged_store) = create_store();
+        write_legacy_bloomfilter(legacy_store.as_ref(), true).await;
+        let legacy = BloomFilterIndex::load(legacy_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        merge_bloomfilter_indices(
+            &[legacy.as_ref(), second.as_ref()],
+            legacy_merged_store.as_ref(),
+            &RoaringBitmap::from_iter([0, 1]),
+        )
+        .await
+        .unwrap();
+        let legacy_merged =
+            BloomFilterIndex::load(legacy_merged_store, None, &LanceCache::no_cache())
+                .await
+                .unwrap();
+        assert!(
+            !legacy_merged
+                .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+                .await
+                .unwrap()
+                .is_exact()
         );
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -164,6 +164,9 @@ pub(crate) async fn build_index_metadata_from_segments(
 
     let mut new_indices = Vec::with_capacity(segments.len());
     for segment in segments {
+        let dataset_version = segment
+            .dataset_version()
+            .unwrap_or(dataset.manifest.version);
         let (uuid, fragment_bitmap, index_details, index_version) = segment.into_parts();
         let is_inverted_index = index_details.type_url.ends_with("InvertedIndexDetails");
         if is_inverted_index {
@@ -171,7 +174,7 @@ pub(crate) async fn build_index_metadata_from_segments(
                 uuid,
                 name: index_name.to_string(),
                 fields: vec![field_id],
-                dataset_version: dataset.manifest.version,
+                dataset_version,
                 fragment_bitmap: Some(fragment_bitmap.clone()),
                 index_details: Some(index_details.clone()),
                 index_version,
@@ -191,7 +194,7 @@ pub(crate) async fn build_index_metadata_from_segments(
             uuid,
             name: index_name.to_string(),
             fields: vec![field_id],
-            dataset_version: dataset.manifest.version,
+            dataset_version,
             fragment_bitmap: Some(fragment_bitmap),
             index_details: Some(index_details),
             index_version,
@@ -1382,6 +1385,11 @@ impl DatasetIndexExt for Dataset {
         source_segments: Vec<IndexMetadata>,
     ) -> Result<IndexMetadata> {
         validate_segment_metadata("uncommitted", &source_segments)?;
+        let source_dataset_version = source_segments
+            .iter()
+            .map(|segment| segment.dataset_version)
+            .min()
+            .unwrap_or(self.manifest.version);
         let field_id = *source_segments[0].fields.first().ok_or_else(|| {
             Error::invalid_input(format!(
                 "CreateIndex: segment {} is missing field ids",
@@ -1441,7 +1449,7 @@ impl DatasetIndexExt for Dataset {
         } else {
             crate::index::scalar::btree::merge_segments(self, source_segments).await?
         };
-        merged_segment.dataset_version = self.manifest.version;
+        merged_segment.dataset_version = source_dataset_version;
         merged_segment.fields = vec![field_id];
         Ok(merged_segment)
     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -487,6 +487,13 @@ fn segment_has_bitmap_details(segment: &IndexMetadata) -> bool {
         .is_some_and(|details| details.type_url.ends_with("BitmapIndexDetails"))
 }
 
+fn segment_has_bloomfilter_details(segment: &IndexMetadata) -> bool {
+    segment
+        .index_details
+        .as_ref()
+        .is_some_and(|details| details.type_url.ends_with("BloomFilterIndexDetails"))
+}
+
 /// Detect BTree segments, preserving a legacy pre-details fallback.
 fn segment_has_btree_details(segment: &IndexMetadata) -> bool {
     segment.index_details.as_ref().map_or_else(
@@ -1392,6 +1399,7 @@ impl DatasetIndexExt for Dataset {
         let all_vector = source_segments.iter().all(segment_has_vector_details);
         let all_inverted = source_segments.iter().all(segment_has_inverted_details);
         let all_bitmap = source_segments.iter().all(segment_has_bitmap_details);
+        let all_bloomfilter = source_segments.iter().all(segment_has_bloomfilter_details);
         let all_btree = source_segments.iter().all(segment_has_btree_details);
         let all_fmindex = source_segments.iter().all(segment_has_fmindex_details);
         let all_zonemap = source_segments.iter().all(segment_has_zonemap_details);
@@ -1399,6 +1407,7 @@ impl DatasetIndexExt for Dataset {
         if !all_vector
             && !all_inverted
             && !all_bitmap
+            && !all_bloomfilter
             && !all_btree
             && !all_fmindex
             && !all_zonemap
@@ -1423,6 +1432,8 @@ impl DatasetIndexExt for Dataset {
             crate::index::scalar::fmindex::merge_segments(self, source_segments).await?
         } else if all_bitmap {
             crate::index::scalar::bitmap::merge_segments(self, source_segments).await?
+        } else if all_bloomfilter {
+            crate::index::scalar::bloomfilter::merge_segments(self, source_segments).await?
         } else if all_label_list {
             crate::index::scalar::label_list::merge_segments(self, source_segments).await?
         } else if all_zonemap {

--- a/rust/lance/src/index/api.rs
+++ b/rust/lance/src/index/api.rs
@@ -27,6 +27,8 @@ pub struct IndexSegment {
     index_details: Arc<prost_types::Any>,
     /// The on-disk index version for this segment.
     index_version: i32,
+    /// Dataset version at which this segment's physical contents were built.
+    dataset_version: Option<u64>,
 }
 
 impl IndexSegment {
@@ -46,6 +48,7 @@ impl IndexSegment {
             fragment_bitmap: fragment_bitmap.into_iter().collect(),
             index_details,
             index_version,
+            dataset_version: None,
         }
     }
 
@@ -67,6 +70,11 @@ impl IndexSegment {
     /// Return the on-disk index version for this segment.
     pub fn index_version(&self) -> i32 {
         self.index_version
+    }
+
+    /// Return the source dataset version when this segment came from index metadata.
+    pub fn dataset_version(&self) -> Option<u64> {
+        self.dataset_version
     }
 
     /// Consume the segment and return its component parts.
@@ -107,12 +115,14 @@ impl IntoIndexSegment for IndexMetadata {
             ))
         })?;
 
-        Ok(IndexSegment::new(
+        let mut segment = IndexSegment::new(
             self.uuid,
             fragment_bitmap.iter(),
             index_details,
             self.index_version,
-        ))
+        );
+        segment.dataset_version = Some(self.dataset_version);
+        Ok(segment)
     }
 }
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1914,7 +1914,13 @@ mod tests {
             "unexpected merge error: {err}"
         );
 
+        let expected_dataset_version = staged
+            .iter()
+            .map(|segment| segment.dataset_version)
+            .min()
+            .unwrap();
         let merged = dataset.merge_existing_index_segments(staged).await.unwrap();
+        assert_eq!(merged.dataset_version, expected_dataset_version);
         assert_eq!(
             merged.fragment_bitmap.as_ref().unwrap(),
             dataset.fragment_bitmap.as_ref()
@@ -1931,6 +1937,11 @@ mod tests {
             .commit_existing_index_segments("value_bloom_merged", "value", vec![merged])
             .await
             .unwrap();
+        let committed = dataset
+            .load_indices_by_name("value_bloom_merged")
+            .await
+            .unwrap();
+        assert_eq!(committed[0].dataset_version, expected_dataset_version);
         let merged_logical = crate::index::scalar_logical::open_named_scalar_index(
             &dataset,
             "value",

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -932,12 +932,14 @@ mod tests {
     use lance_index::optimize::OptimizeOptions;
     use lance_index::progress::IndexBuildProgress;
     use lance_index::scalar::{
-        FullTextSearchQuery, SargableQuery, SearchResult, inverted::tokenizer::InvertedIndexParams,
+        BloomFilterQuery, FullTextSearchQuery, SargableQuery, SearchResult,
+        inverted::tokenizer::InvertedIndexParams,
     };
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::ivf::IvfBuildParams;
     use lance_index::vector::kmeans::{KMeansParams, train_kmeans};
     use lance_linalg::distance::{DistanceType, MetricType};
+    use roaring::RoaringBitmap;
     use std::{collections::BTreeSet, ops::Bound, sync::Arc};
     use uuid::Uuid;
 
@@ -1821,6 +1823,148 @@ mod tests {
             files.iter().all(|file| !file.path.starts_with("part_")),
             "staged bitmap segment should only reference canonical files"
         );
+    }
+
+    #[tokio::test]
+    async fn test_bloomfilter_distributed_segments_merge_and_query() {
+        #[derive(serde::Serialize)]
+        struct BloomParams {
+            number_of_items: u64,
+            probability: f64,
+        }
+
+        let mut dataset = gen_batch()
+            .col("value", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(3), FragmentRowCount::from(8))
+            .await
+            .unwrap();
+
+        let params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::BloomFilter)
+                .with_params(&BloomParams {
+                    number_of_items: 4,
+                    probability: 0.000_001,
+                });
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 3);
+        let mut staged = Vec::with_capacity(fragments.len());
+        for fragment in &fragments {
+            staged.push(
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BloomFilter, &params)
+                    .name("value_bloom_segments".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        dataset
+            .commit_existing_index_segments("value_bloom_segments", "value", staged.clone())
+            .await
+            .unwrap();
+        let logical = crate::index::scalar_logical::open_named_scalar_index(
+            &dataset,
+            "value",
+            "value_bloom_segments",
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            logical.calculate_included_frags().await.unwrap(),
+            dataset.fragment_bitmap.as_ref().clone()
+        );
+
+        let mut trimmed = staged.clone();
+        trimmed[0].fragment_bitmap = Some(RoaringBitmap::new());
+        let trimmed_merged = dataset
+            .merge_existing_index_segments(trimmed)
+            .await
+            .unwrap();
+        assert_eq!(
+            trimmed_merged.fragment_bitmap.as_ref().unwrap(),
+            &RoaringBitmap::from_iter(fragments[1..].iter().map(|fragment| fragment.id() as u32))
+        );
+
+        let incompatible_params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::BloomFilter)
+                .with_params(&BloomParams {
+                    number_of_items: 8,
+                    probability: 0.01,
+                });
+        let incompatible = CreateIndexBuilder::new(
+            &mut dataset,
+            &["value"],
+            IndexType::BloomFilter,
+            &incompatible_params,
+        )
+        .name("value_bloom_incompatible".to_string())
+        .fragments(vec![fragments[1].id() as u32])
+        .execute_uncommitted()
+        .await
+        .unwrap();
+        let err = dataset
+            .merge_existing_index_segments(vec![staged[0].clone(), incompatible])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("different parameters: number_of_items=4"),
+            "unexpected merge error: {err}"
+        );
+
+        let merged = dataset.merge_existing_index_segments(staged).await.unwrap();
+        assert_eq!(
+            merged.fragment_bitmap.as_ref().unwrap(),
+            dataset.fragment_bitmap.as_ref()
+        );
+        assert!(
+            merged
+                .index_details
+                .as_ref()
+                .unwrap()
+                .type_url
+                .ends_with("BloomFilterIndexDetails")
+        );
+        dataset
+            .commit_existing_index_segments("value_bloom_merged", "value", vec![merged])
+            .await
+            .unwrap();
+        let merged_logical = crate::index::scalar_logical::open_named_scalar_index(
+            &dataset,
+            "value",
+            "value_bloom_merged",
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+        let candidates = merged_logical
+            .search(
+                &BloomFilterQuery::Equals(ScalarValue::Int32(Some(17))),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        assert!(
+            candidates
+                .row_addrs()
+                .true_rows()
+                .row_addrs()
+                .unwrap()
+                .map(u64::from)
+                .any(|row_addr| row_addr == (2_u64 << 32) + 1)
+        );
+
+        let result = dataset
+            .scan()
+            .filter("value = 17")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(result.num_rows(), 1);
+        assert_eq!(result["value"].as_primitive::<Int32Type>().value(0), 17);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -5,6 +5,7 @@
 //!
 
 pub(crate) mod bitmap;
+pub(crate) mod bloomfilter;
 pub(crate) mod btree;
 pub(crate) mod fmindex;
 pub(crate) mod inverted;

--- a/rust/lance/src/index/scalar/bloomfilter.rs
+++ b/rust/lance/src/index/scalar/bloomfilter.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use lance_index::metrics::NoOpMetricsCollector;
+use lance_index::scalar::bloomfilter::BloomFilterIndex;
+use lance_index::scalar::index_files_to_table;
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_table::format::IndexMetadata;
+use roaring::RoaringBitmap;
+use uuid::Uuid;
+
+use crate::{Dataset, Error, Result, dataset::index::LanceIndexStoreExt};
+
+/// Merge one caller-defined group of source BloomFilter segments into a single segment.
+pub(in crate::index) async fn merge_segments(
+    dataset: &Dataset,
+    segments: Vec<IndexMetadata>,
+) -> Result<IndexMetadata> {
+    if segments.is_empty() {
+        return Err(Error::index("No segment metadata was provided".to_string()));
+    }
+
+    let field_id = *segments[0].fields.first().ok_or_else(|| {
+        Error::invalid_input(format!(
+            "CreateIndex: segment {} is missing field ids",
+            segments[0].uuid
+        ))
+    })?;
+    let field_path = dataset.schema().field_path(field_id)?;
+
+    let mut scalar_indices = Vec::with_capacity(segments.len());
+    let mut fragment_bitmap = RoaringBitmap::new();
+    let dataset_fragments = dataset.fragment_bitmap.as_ref();
+    for segment in &segments {
+        let effective = segment
+            .effective_fragment_bitmap(dataset_fragments)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "CreateIndex: segment {} is missing fragment coverage",
+                    segment.uuid
+                ))
+            })?;
+        fragment_bitmap |= effective;
+        let scalar_index =
+            super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
+        scalar_indices.push((segment.uuid, scalar_index));
+    }
+
+    let mut source_indices = Vec::with_capacity(scalar_indices.len());
+    for (segment_uuid, scalar_index) in &scalar_indices {
+        let bloomfilter_index = scalar_index
+            .as_any()
+            .downcast_ref::<BloomFilterIndex>()
+            .ok_or_else(|| {
+                Error::index(format!(
+                    "merge_existing_index_segments: expected bloom filter segment {}, got {:?}",
+                    segment_uuid,
+                    scalar_index.index_type()
+                ))
+            })?;
+        source_indices.push(bloomfilter_index);
+    }
+
+    let new_uuid = Uuid::new_v4();
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
+    let created_index = lance_index::scalar::bloomfilter::merge_bloomfilter_indices(
+        &source_indices,
+        &new_store,
+        &fragment_bitmap,
+    )
+    .await?;
+
+    Ok(IndexMetadata {
+        uuid: new_uuid,
+        fields: vec![field_id],
+        dataset_version: dataset.manifest.version,
+        fragment_bitmap: Some(fragment_bitmap),
+        index_details: Some(Arc::new(created_index.index_details)),
+        index_version: created_index.index_version as i32,
+        created_at: Some(chrono::Utc::now()),
+        base_id: None,
+        files: Some(index_files_to_table(created_index.files)),
+        ..segments[0].clone()
+    })
+}

--- a/rust/lance/src/index/scalar/bloomfilter.rs
+++ b/rust/lance/src/index/scalar/bloomfilter.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use lance_index::metrics::NoOpMetricsCollector;
-use lance_index::scalar::bloomfilter::BloomFilterIndex;
+use lance_index::scalar::bloomfilter::{BloomFilterIndex, MAX_BINARY_VALUE_BUFFER_LEN};
 use lance_index::scalar::index_files_to_table;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_table::format::IndexMetadata;
@@ -29,6 +29,25 @@ pub(in crate::index) async fn merge_segments(
         ))
     })?;
     let field_path = dataset.schema().field_path(field_id)?;
+    let dataset_version = segments
+        .iter()
+        .map(|segment| segment.dataset_version)
+        .min()
+        .unwrap_or(dataset.manifest.version);
+    if segments.iter().all(|segment| segment.files.is_some()) {
+        let total_size = segments
+            .iter()
+            .filter_map(IndexMetadata::total_size_bytes)
+            .try_fold(0u64, u64::checked_add)
+            .ok_or_else(|| Error::invalid_input("BloomFilter segment sizes overflowed u64"))?;
+        if total_size > MAX_BINARY_VALUE_BUFFER_LEN {
+            return Err(Error::invalid_input(format!(
+                "BloomFilter segment files total {total_size} bytes, exceeding the Arrow \
+                 BinaryArray merge limit of {MAX_BINARY_VALUE_BUFFER_LEN} bytes; merge fewer \
+                 segments at a time"
+            )));
+        }
+    }
 
     let mut fragment_bitmap = RoaringBitmap::new();
     let dataset_fragments = dataset.fragment_bitmap.as_ref();
@@ -83,7 +102,7 @@ pub(in crate::index) async fn merge_segments(
     Ok(IndexMetadata {
         uuid: new_uuid,
         fields: vec![field_id],
-        dataset_version: dataset.manifest.version,
+        dataset_version,
         fragment_bitmap: Some(fragment_bitmap),
         index_details: Some(Arc::new(created_index.index_details)),
         index_version: created_index.index_version as i32,

--- a/rust/lance/src/index/scalar/bloomfilter.rs
+++ b/rust/lance/src/index/scalar/bloomfilter.rs
@@ -31,6 +31,7 @@ pub(in crate::index) async fn merge_segments(
     let field_path = dataset.schema().field_path(field_id)?;
 
     let mut scalar_indices = Vec::with_capacity(segments.len());
+    let mut fragment_filters = Vec::with_capacity(segments.len());
     let mut fragment_bitmap = RoaringBitmap::new();
     let dataset_fragments = dataset.fragment_bitmap.as_ref();
     for segment in &segments {
@@ -42,7 +43,8 @@ pub(in crate::index) async fn merge_segments(
                     segment.uuid
                 ))
             })?;
-        fragment_bitmap |= effective;
+        fragment_bitmap |= &effective;
+        fragment_filters.push(effective);
         let scalar_index =
             super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
         scalar_indices.push((segment.uuid, scalar_index));
@@ -62,15 +64,17 @@ pub(in crate::index) async fn merge_segments(
             })?;
         source_indices.push(bloomfilter_index);
     }
+    let filtered_sources = source_indices
+        .iter()
+        .zip(&fragment_filters)
+        .map(|(index, fragments)| (*index, fragments))
+        .collect::<Vec<_>>();
 
     let new_uuid = Uuid::new_v4();
     let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
-    let created_index = lance_index::scalar::bloomfilter::merge_bloomfilter_indices(
-        &source_indices,
-        &new_store,
-        &fragment_bitmap,
-    )
-    .await?;
+    let created_index =
+        lance_index::scalar::bloomfilter::merge_bloomfilter_indices(&filtered_sources, &new_store)
+            .await?;
 
     Ok(IndexMetadata {
         uuid: new_uuid,

--- a/rust/lance/src/index/scalar/bloomfilter.rs
+++ b/rust/lance/src/index/scalar/bloomfilter.rs
@@ -30,31 +30,37 @@ pub(in crate::index) async fn merge_segments(
     })?;
     let field_path = dataset.schema().field_path(field_id)?;
 
-    let mut scalar_indices = Vec::with_capacity(segments.len());
-    let mut fragment_filters = Vec::with_capacity(segments.len());
     let mut fragment_bitmap = RoaringBitmap::new();
     let dataset_fragments = dataset.fragment_bitmap.as_ref();
-    for segment in &segments {
-        let effective = segment
-            .effective_fragment_bitmap(dataset_fragments)
-            .ok_or_else(|| {
-                Error::invalid_input(format!(
-                    "CreateIndex: segment {} is missing fragment coverage",
-                    segment.uuid
-                ))
-            })?;
-        if effective.is_empty() {
+    let fragment_filters = segments
+        .iter()
+        .map(|segment| {
+            segment
+                .effective_fragment_bitmap(dataset_fragments)
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "CreateIndex: segment {} is missing fragment coverage",
+                        segment.uuid
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for effective in &fragment_filters {
+        fragment_bitmap |= effective;
+    }
+
+    let mut scalar_indices = Vec::with_capacity(segments.len());
+    for (position, (segment, effective)) in segments.iter().zip(&fragment_filters).enumerate() {
+        if effective.is_empty() && !(fragment_bitmap.is_empty() && position == 0) {
             continue;
         }
-        fragment_bitmap |= &effective;
-        fragment_filters.push(effective);
         let scalar_index =
             super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
-        scalar_indices.push((segment.uuid, scalar_index));
+        scalar_indices.push((segment.uuid, scalar_index, effective));
     }
 
     let mut source_indices = Vec::with_capacity(scalar_indices.len());
-    for (segment_uuid, scalar_index) in &scalar_indices {
+    for (segment_uuid, scalar_index, fragment_filter) in &scalar_indices {
         let bloomfilter_index = scalar_index
             .as_any()
             .downcast_ref::<BloomFilterIndex>()
@@ -65,18 +71,13 @@ pub(in crate::index) async fn merge_segments(
                     scalar_index.index_type()
                 ))
             })?;
-        source_indices.push(bloomfilter_index);
+        source_indices.push((bloomfilter_index, *fragment_filter));
     }
-    let filtered_sources = source_indices
-        .iter()
-        .zip(&fragment_filters)
-        .map(|(index, fragments)| (*index, fragments))
-        .collect::<Vec<_>>();
 
     let new_uuid = Uuid::new_v4();
     let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
     let created_index =
-        lance_index::scalar::bloomfilter::merge_bloomfilter_indices(&filtered_sources, &new_store)
+        lance_index::scalar::bloomfilter::merge_bloomfilter_indices(&source_indices, &new_store)
             .await?;
 
     Ok(IndexMetadata {

--- a/rust/lance/src/index/scalar/bloomfilter.rs
+++ b/rust/lance/src/index/scalar/bloomfilter.rs
@@ -43,6 +43,9 @@ pub(in crate::index) async fn merge_segments(
                     segment.uuid
                 ))
             })?;
+        if effective.is_empty() {
+            continue;
+        }
         fragment_bitmap |= &effective;
         fragment_filters.push(effective);
         let scalar_index =


### PR DESCRIPTION
## What changed

- add native BloomFilter segment merging with fragment filtering and conservative legacy null handling
- wire BloomFilter segment detection and merge dispatch into dataset index creation
- enable Python distributed segment creation and uncommitted index publication for BloomFilter indexes
- add Rust unit/integration coverage and a Python end-to-end test

## Why

Distributed index construction could create segmented scalar indexes for several index types, but BloomFilter still rejected fragment-scoped builds and could not consolidate segment metadata into a queryable index.

## Impact

BloomFilter scalar indexes can now be built per fragment group, queried as logical segments, merged while excluding retired fragments, and committed through the Python API.

