### PR TITLE
perf: accelerate fp16 HNSW search with AMX

### DIFF
--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -455,20 +455,25 @@ impl FlatDistanceCal<'_, Float16Type> {
         self.distance_type == DistanceType::Dot && self.dimension >= 32 && amx_fp16_available()
     }
 
-    /// The 16 `Dot` distances of the query against `ids`, fused into a single
-    /// AMX-FP16 tile pass when the hardware/kernel is available (otherwise 16
-    /// scalar `f16::dot`s — bit-identical to the per-id `distance()` path).
+    /// The `Dot` distances of the query against the first `len` of `ids`, fused
+    /// into a single AMX-FP16 tile pass when the hardware/kernel is available
+    /// (otherwise `len` scalar `f16::dot`s — bit-identical to the per-id
+    /// `distance()` path).
     ///
     /// [`dot_f16_batch_16`] returns raw dot products `Σ q·c`; `Dot` distance is
     /// `1.0 - Σ q·c` (see `lance_linalg`'s `dot_distance`), applied here so the
     /// result matches [`DistCalculator::distance`] to within fp16 precision.
     /// Only valid for `DistanceType::Dot`; the enum caller guarantees that.
+    ///
+    /// All 16 candidate slices are still resolved, since `ids` past `len` are
+    /// the caller's padding and therefore valid ids; the kernel reads only the
+    /// first `len` of them.
     #[inline]
-    fn dot_distance_batch_16_amx(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
+    fn dot_distance_batch_16_amx(&self, ids: &[u32; 16], dists: &mut [f32; 16], len: usize) {
         let query: &[f16] = self.query.as_ref();
         let candidates: [&[f16]; 16] = std::array::from_fn(|i| self.get_vector(ids[i]));
-        let dots = dot_f16_batch_16(query, &candidates);
-        for (dist, dot) in dists.iter_mut().zip(dots.iter()) {
+        let dots = dot_f16_batch_16(query, &candidates, len);
+        for (dist, dot) in dists.iter_mut().zip(dots.iter()).take(len) {
             *dist = 1.0 - *dot;
         }
     }
@@ -571,21 +576,23 @@ impl DistCalculator for FlatFloatDistanceCalc<'_> {
         matches!(self, Self::Float16(calc) if calc.has_amx_dot_kernel())
     }
 
-    /// Fuse the 16 neighbor distances (issued in batches of 16 by HNSW's
-    /// `beam_search_loop!`) into one AMX-FP16 tile pass for the fp16 `Dot` case
-    /// — the only path with a batched kernel. Every other case (fp16 L2/Cosine,
-    /// f32, f64) keeps the trait default of 16 individual `distance()` calls, so
-    /// results there are byte-identical to before. The guard matches
-    /// `has_batch_16_kernel` exactly; it stays here because this is a public
-    /// trait method that external callers may invoke without consulting it.
-    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
+    /// Fuse the `len` neighbor distances (issued in batches of up to 16 by
+    /// HNSW's `beam_search_loop!`) into one AMX-FP16 tile pass for the fp16
+    /// `Dot` case — the only path with a batched kernel. Every other case (fp16
+    /// L2/Cosine, f32, f64) keeps the trait default of `len` individual
+    /// `distance()` calls, so results there are byte-identical to before. The
+    /// guard matches `has_batch_16_kernel` exactly; it stays here because this
+    /// is a public trait method that external callers may invoke without
+    /// consulting it.
+    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16], len: usize) {
+        debug_assert!((1..=16).contains(&len), "len ({len}) must be in 1..=16");
         if let Self::Float16(calc) = self
             && calc.has_amx_dot_kernel()
         {
-            calc.dot_distance_batch_16_amx(ids, dists);
+            calc.dot_distance_batch_16_amx(ids, dists, len);
             return;
         }
-        for (dist, &id) in dists.iter_mut().zip(ids.iter()) {
+        for (dist, &id) in dists.iter_mut().zip(ids.iter()).take(len) {
             *dist = self.distance(id);
         }
     }
@@ -657,6 +664,20 @@ mod tests {
 
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+    use rstest::rstest;
+
+    /// Random `n x dim` fp16 vectors plus a random fp16 query. Values in [-1, 1).
+    fn make_random_f16_vectors(n: usize, dim: usize, seed: u64) -> (FixedSizeListArray, ArrayRef) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let values = Float16Array::from_iter_values(
+            (0..n * dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
+        );
+        let vectors = FixedSizeListArray::try_new_from_values(values, dim as i32).unwrap();
+        let query: ArrayRef = Arc::new(Float16Array::from_iter_values(
+            (0..dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
+        ));
+        (vectors, query)
+    }
 
     /// Random `n x dim` fp16 storage with the given metric, plus a random fp16
     /// query array. Values in [-1, 1).
@@ -666,16 +687,64 @@ mod tests {
         dt: DistanceType,
         seed: u64,
     ) -> (FlatFloatStorage, ArrayRef) {
-        let mut rng = StdRng::seed_from_u64(seed);
-        let values = Float16Array::from_iter_values(
-            (0..n * dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
-        );
-        let vectors = FixedSizeListArray::try_new_from_values(values, dim as i32).unwrap();
-        let storage = FlatFloatStorage::new(vectors, dt);
-        let query: ArrayRef = Arc::new(Float16Array::from_iter_values(
-            (0..dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
-        ));
-        (storage, query)
+        let (vectors, query) = make_random_f16_vectors(n, dim, seed);
+        (FlatFloatStorage::new(vectors, dt), query)
+    }
+
+    /// A value no metric here can produce, so a stray write into `dists[len..]`
+    /// shows up as an obviously wrong number rather than a plausible distance.
+    const BATCH_SENTINEL: f32 = -12345.0;
+
+    /// Assert `distance_batch_16(ids, .., len)` computes exactly lanes
+    /// `[0, len)` and leaves the rest as the caller left them.
+    fn check_partial_batch_16<C: DistCalculator>(calc: &C, ids: &[u32; 16], len: usize, ctx: &str) {
+        let mut dists = [BATCH_SENTINEL; 16];
+        calc.distance_batch_16(ids, &mut dists, len);
+        for (i, &id) in ids.iter().enumerate().take(len) {
+            let single = calc.distance(id);
+            let rel = (dists[i] - single).abs() / (single.abs() + 1e-6);
+            assert!(
+                rel <= 5e-3 || (dists[i] - single).abs() <= 1e-3,
+                "{ctx} len={len} lane {i}: batch {} vs single {single}",
+                dists[i]
+            );
+        }
+        for (i, &d) in dists.iter().enumerate().skip(len) {
+            assert_eq!(
+                d.to_bits(),
+                BATCH_SENTINEL.to_bits(),
+                "{ctx} len={len}: lane {i} must be untouched, got {d}"
+            );
+        }
+    }
+
+    /// A partial batch must score exactly its live lanes and write nothing else.
+    ///
+    /// Every other `distance_batch_16` test here passes 16, which cannot tell
+    /// `len` being honored from `len` being ignored. A regression that dropped
+    /// the `.take(len)` and clobbered the caller's `dists[len..]` is what the
+    /// sentinel catches; one where `len` was ignored outright is what comparing
+    /// the live lanes against per-id `distance()` catches.
+    ///
+    /// Covers both arms of the fp16 override — `Dot` reaches the batched
+    /// AMX-FP16 kernel on a host that has it, `L2` falls through to per-id calls
+    /// — and `FlatDistanceCal`, which does not override the method at all and so
+    /// exercises the `DistCalculator::distance_batch_16` default.
+    #[rstest]
+    #[case::dot(DistanceType::Dot)]
+    #[case::l2(DistanceType::L2)]
+    fn test_distance_batch_16_partial_len(#[case] dt: DistanceType) {
+        let dim = 128;
+        let (vectors, query) = make_random_f16_vectors(64, dim, 0xBA7C);
+        let storage = FlatFloatStorage::new(vectors.clone(), dt);
+        let enum_calc = storage.dist_calculator(query.clone(), 0.0);
+        let default_calc = FlatDistanceCal::<Float16Type>::new(&vectors, query, dt);
+
+        let ids: [u32; 16] = std::array::from_fn(|i| (i as u32 * 3 + 5) % 64);
+        for len in 1..=16 {
+            check_partial_batch_16(&enum_calc, &ids, len, "FlatFloatDistanceCalc");
+            check_partial_batch_16(&default_calc, &ids, len, "trait default");
+        }
     }
 
     /// The fp16 `Dot` `distance_batch_16` override (AMX-FP16 when active) must
@@ -692,7 +761,7 @@ mod tests {
             let ids: [u32; 16] = std::array::from_fn(|i| i as u32 + 7);
 
             let mut batch = [0f32; 16];
-            calc.distance_batch_16(&ids, &mut batch);
+            calc.distance_batch_16(&ids, &mut batch, 16);
 
             for (i, &id) in ids.iter().enumerate() {
                 let single = calc.distance(id);
@@ -722,7 +791,7 @@ mod tests {
         let calc = storage.dist_calculator(query, 0.0);
         let ids: [u32; 16] = std::array::from_fn(|i| i as u32);
         let mut batch = [0f32; 16];
-        calc.distance_batch_16(&ids, &mut batch);
+        calc.distance_batch_16(&ids, &mut batch, 16);
         for (i, &id) in ids.iter().enumerate() {
             let single = calc.distance(id);
             assert!((batch[i] - single).abs() <= 1e-2, "id={id}");
@@ -737,7 +806,7 @@ mod tests {
         let calc = storage.dist_calculator(query, 0.0);
         let ids: [u32; 16] = std::array::from_fn(|i| i as u32 + 3);
         let mut batch = [0f32; 16];
-        calc.distance_batch_16(&ids, &mut batch);
+        calc.distance_batch_16(&ids, &mut batch, 16);
         for (i, &id) in ids.iter().enumerate() {
             assert_eq!(batch[i].to_bits(), calc.distance(id).to_bits(), "id={id}");
         }

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -17,9 +17,11 @@ use arrow_array::{
     types::{Float32Type, UInt64Type},
 };
 use arrow_schema::{DataType, SchemaRef};
+use half::f16;
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, ROW_ID, Result};
 use lance_file::versions::v1::reader::FileReader as V1FileReader;
+use lance_linalg::distance::dot_f16::{amx_fp16_available, dot_f16_batch_16};
 use lance_linalg::distance::hamming::hamming;
 use lance_linalg::distance::{Cosine, DistanceType, Dot, L2};
 
@@ -353,6 +355,10 @@ pub struct FlatDistanceCal<'a, T: ArrowPrimitiveType> {
     vectors: &'a [T::Native],
     query: Cow<'a, [T::Native]>,
     dimension: usize,
+    /// Metric this calculator computes. Retained (beyond `distance_fn`) so the
+    /// fp16 `distance_batch_16` override can recognize the `Dot` case that maps
+    /// onto the batched AMX-FP16 tile kernel.
+    distance_type: DistanceType,
     #[allow(clippy::type_complexity)]
     distance_fn: fn(&[T::Native], &[T::Native]) -> f32,
 }
@@ -370,6 +376,7 @@ where
             vectors: flat_array.values(),
             query: Cow::Owned(query.as_primitive::<T>().values().to_vec()),
             dimension,
+            distance_type,
             distance_fn: distance_type.func(),
         }
     }
@@ -383,6 +390,7 @@ where
             vectors,
             query: Cow::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
+            distance_type,
             distance_fn: distance_type.func(),
         }
     }
@@ -402,6 +410,7 @@ impl<'a> FlatDistanceCal<'a, UInt8Type> {
             vectors: flat_array.values(),
             query: Cow::Owned(query.as_primitive::<UInt8Type>().values().to_vec()),
             dimension,
+            distance_type: _distance_type,
             distance_fn: hamming,
         }
     }
@@ -419,6 +428,7 @@ impl<'a> FlatDistanceCal<'a, UInt8Type> {
             vectors,
             query: Cow::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
+            distance_type: _distance_type,
             distance_fn: hamming,
         }
     }
@@ -428,6 +438,39 @@ impl<T: ArrowPrimitiveType> FlatDistanceCal<'_, T> {
     #[inline]
     fn get_vector(&self, id: u32) -> &[T::Native] {
         &self.vectors[self.dimension * id as usize..self.dimension * (id + 1) as usize]
+    }
+}
+
+impl FlatDistanceCal<'_, Float16Type> {
+    /// Whether [`Self::dot_distance_batch_16_amx`] would actually reach the
+    /// AMX-FP16 tile kernel: the metric must be `Dot`, the dimension must cover
+    /// at least one full 32-wide tile pass (below that `dot_f16_batch_16` falls
+    /// back regardless), and AMX-FP16 must be usable in this process.
+    ///
+    /// Single source of truth shared by the `distance_batch_16` override and
+    /// `has_batch_16_kernel`, so the two cannot drift apart and leave HNSW
+    /// buffering neighbors for a fused kernel it would never reach.
+    #[inline]
+    fn has_amx_dot_kernel(&self) -> bool {
+        self.distance_type == DistanceType::Dot && self.dimension >= 32 && amx_fp16_available()
+    }
+
+    /// The 16 `Dot` distances of the query against `ids`, fused into a single
+    /// AMX-FP16 tile pass when the hardware/kernel is available (otherwise 16
+    /// scalar `f16::dot`s — bit-identical to the per-id `distance()` path).
+    ///
+    /// [`dot_f16_batch_16`] returns raw dot products `Σ q·c`; `Dot` distance is
+    /// `1.0 - Σ q·c` (see `lance_linalg`'s `dot_distance`), applied here so the
+    /// result matches [`DistCalculator::distance`] to within fp16 precision.
+    /// Only valid for `DistanceType::Dot`; the enum caller guarantees that.
+    #[inline]
+    fn dot_distance_batch_16_amx(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
+        let query: &[f16] = self.query.as_ref();
+        let candidates: [&[f16]; 16] = std::array::from_fn(|i| self.get_vector(ids[i]));
+        let dots = dot_f16_batch_16(query, &candidates);
+        for (dist, dot) in dists.iter_mut().zip(dots.iter()) {
+            *dist = 1.0 - *dot;
+        }
     }
 }
 
@@ -521,6 +564,32 @@ impl DistCalculator for FlatFloatDistanceCalc<'_> {
         }
     }
 
+    /// fp16 `Dot` with AMX-FP16 available is the only configuration here backed
+    /// by a fused kernel, so it is the only one that reports `true` — and hence
+    /// the only one for which HNSW buffers neighbors 16 at a time at all.
+    fn has_batch_16_kernel(&self) -> bool {
+        matches!(self, Self::Float16(calc) if calc.has_amx_dot_kernel())
+    }
+
+    /// Fuse the 16 neighbor distances (issued in batches of 16 by HNSW's
+    /// `beam_search_loop!`) into one AMX-FP16 tile pass for the fp16 `Dot` case
+    /// — the only path with a batched kernel. Every other case (fp16 L2/Cosine,
+    /// f32, f64) keeps the trait default of 16 individual `distance()` calls, so
+    /// results there are byte-identical to before. The guard matches
+    /// `has_batch_16_kernel` exactly; it stays here because this is a public
+    /// trait method that external callers may invoke without consulting it.
+    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
+        if let Self::Float16(calc) = self
+            && calc.has_amx_dot_kernel()
+        {
+            calc.dot_distance_batch_16_amx(ids, dists);
+            return;
+        }
+        for (dist, &id) in dists.iter_mut().zip(ids.iter()) {
+            *dist = self.distance(id);
+        }
+    }
+
     fn prefetch(&self, id: u32) {
         match self {
             Self::Float16(calc) => calc.prefetch(id),
@@ -582,5 +651,95 @@ mod tests {
         assert_eq!(distances.len(), 2);
         assert_eq!(distances[0], 0.0);
         assert!((distances[1] - 25.0).abs() < 1e-6);
+    }
+
+    // --- fp16 Dot batched (AMX-FP16) distance_batch_16 override ---
+
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    /// Random `n x dim` fp16 storage with the given metric, plus a random fp16
+    /// query array. Values in [-1, 1).
+    fn make_random_f16(
+        n: usize,
+        dim: usize,
+        dt: DistanceType,
+        seed: u64,
+    ) -> (FlatFloatStorage, ArrayRef) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let values = Float16Array::from_iter_values(
+            (0..n * dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
+        );
+        let vectors = FixedSizeListArray::try_new_from_values(values, dim as i32).unwrap();
+        let storage = FlatFloatStorage::new(vectors, dt);
+        let query: ArrayRef = Arc::new(Float16Array::from_iter_values(
+            (0..dim).map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0))),
+        ));
+        (storage, query)
+    }
+
+    /// The fp16 `Dot` `distance_batch_16` override (AMX-FP16 when active) must
+    /// agree with 16 individual `distance()` calls. This is floating point, so
+    /// the bar is a relative tolerance, not bit-exactness: the tile kernel sums
+    /// f32-widened products in a different order than the per-id `f16::dot`.
+    /// 5e-3 relative is ~an order below fp16's own representational error; the
+    /// observed gap is ~1e-4. Dims include non-multiples of 32 (tail path).
+    #[test]
+    fn test_distance_batch_16_f16_dot_matches_single() {
+        for dim in [32usize, 47, 64, 100, 128, 200, 768, 1536] {
+            let (storage, query) = make_random_f16(64, dim, DistanceType::Dot, 0xF16 + dim as u64);
+            let calc = storage.dist_calculator(query, 0.0);
+            let ids: [u32; 16] = std::array::from_fn(|i| i as u32 + 7);
+
+            let mut batch = [0f32; 16];
+            calc.distance_batch_16(&ids, &mut batch);
+
+            for (i, &id) in ids.iter().enumerate() {
+                let single = calc.distance(id);
+                let rel = (batch[i] - single).abs() / (single.abs() + 1e-6);
+                assert!(
+                    rel <= 5e-3 || (batch[i] - single).abs() <= 1e-3,
+                    "dim={dim} id={id}: batch {} vs single {} (rel {rel})",
+                    batch[i],
+                    single
+                );
+            }
+        }
+    }
+
+    /// On an AMX-FP16 host (env not force-disabling), prove the accelerated tile
+    /// path is actually the one the fp16 Dot override selected, not a silent
+    /// fallback. `amx_fp16_available()` is a runtime probe (the compile-time
+    /// `kernel_support` cfg is only set for the `lance-linalg` crate, so it can't
+    /// be used to gate here). Reaching the end without SIGILL also proves the
+    /// tile instructions executed safely.
+    #[test]
+    fn test_distance_batch_16_f16_amx_active() {
+        if !lance_linalg::distance::dot_f16::amx_fp16_available() {
+            return; // This CI host may not expose AMX-FP16.
+        }
+        let (storage, query) = make_random_f16(64, 128, DistanceType::Dot, 42);
+        let calc = storage.dist_calculator(query, 0.0);
+        let ids: [u32; 16] = std::array::from_fn(|i| i as u32);
+        let mut batch = [0f32; 16];
+        calc.distance_batch_16(&ids, &mut batch);
+        for (i, &id) in ids.iter().enumerate() {
+            let single = calc.distance(id);
+            assert!((batch[i] - single).abs() <= 1e-2, "id={id}");
+        }
+    }
+
+    /// Non-Dot metrics keep the default per-id path, so the batch must be
+    /// bit-for-bit identical to individual `distance()` calls (no AMX involved).
+    #[test]
+    fn test_distance_batch_16_f16_l2_falls_through() {
+        let (storage, query) = make_random_f16(64, 100, DistanceType::L2, 5);
+        let calc = storage.dist_calculator(query, 0.0);
+        let ids: [u32; 16] = std::array::from_fn(|i| i as u32 + 3);
+        let mut batch = [0f32; 16];
+        calc.distance_batch_16(&ids, &mut batch);
+        for (i, &id) in ids.iter().enumerate() {
+            assert_eq!(batch[i].to_bits(), calc.distance(id).to_bits(), "id={id}");
+        }
     }
 }

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -278,6 +278,65 @@ fn process_neighbors_with_look_ahead<F>(
     }
 }
 
+/// Smallest remainder that is worth padding up to 16 and sending through
+/// `distance_batch_16` rather than draining with scalar `distance()` calls.
+/// Overridable with `LANCE_HNSW_BATCH_PAD_MIN`; read once, this is hot-path.
+///
+/// Padding costs a tile pass over 16 rows whatever the batch holds, so the
+/// threshold is where that pass starts beating `k` scalar distance calls — which
+/// depends on how fast the build's scalar f16 kernel is, and is why this is
+/// tunable rather than a constant.
+///
+/// 3 is the default: it is the crossover for a build whose scalar f16 kernel the
+/// compiler leaves unvectorized, which is the case this batching exists to help.
+/// A build with a faster scalar kernel wants a higher value.
+///
+/// Measured end to end rather than in a microbenchmark, because the two disagree.
+/// A single-threaded microbenchmark on an idle machine puts the crossover at
+/// k = 1 for every configuration, since there a padded call's extra memory
+/// traffic is free. Under saturation it is not: on 100M x 1024, 32 physical cores
+/// at 97% utilisation, three rotated rounds, dropping the threshold from 3 to 1
+/// measured 0.999x on the unvectorized build (intervals overlapping) and 0.954x
+/// on a build whose scalar kernel is vectorized (intervals separated). The extra
+/// distances a lower threshold computes have to contend with every other query
+/// for the same cores.
+pub(crate) fn batch16_pad_min() -> usize {
+    static PAD_MIN: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *PAD_MIN.get_or_init(|| {
+        std::env::var("LANCE_HNSW_BATCH_PAD_MIN")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            // 0 would pad every single-neighbor remainder; 17+ would disable
+            // padding entirely. Both are legitimate as experiments, so only the
+            // unparseable case falls back.
+            .map(|v| v.min(17))
+            .unwrap_or(3)
+    })
+}
+
+/// Whether the fused-kernel arm of `beam_search_loop` lets its 16-wide neighbor
+/// buffer carry across popped nodes (`LANCE_HNSW_BATCH_SPAN=1`) instead of
+/// emptying it at the end of each node.
+///
+/// Off by default: spanning **changes search results**, because a neighbor found
+/// while visiting one node may not reach the candidate heap until after a later
+/// node has been popped, which reorders the traversal. With it off the batched
+/// arm stays equivalent to the unbatched one.
+///
+/// It exists because a per-node buffer is usually far from full — in
+/// steady-state beam search most of a node's neighbors are already visited — so
+/// spanning is what actually keeps the fused kernel fed. Read once; this sits on
+/// the search hot path.
+pub(crate) fn batch16_spans_nodes() -> bool {
+    static SPAN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SPAN.get_or_init(|| {
+        matches!(
+            std::env::var("LANCE_HNSW_BATCH_SPAN").as_deref(),
+            Ok("1") | Ok("true")
+        )
+    })
+}
+
 #[inline]
 fn furthest_distance(results: &BinaryHeap<OrderedNode>) -> OrderedFloat {
     results
@@ -306,10 +365,20 @@ pub(crate) static BEAM_BATCH16_FLUSHES: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
 /// Test-only instrumentation companion to [`BEAM_BATCH16_FLUSHES`]: number of
-/// non-empty `< 16` remainder drains (the scalar tail). Confirms the remainder
-/// path is exercised, not just the full-batch path.
+/// non-empty sub-threshold remainder drains (the scalar tail). Confirms the
+/// remainder path is exercised, not just the full-batch path.
 #[cfg(test)]
 pub(crate) static BEAM_BATCH16_DRAINS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Test-only instrumentation: number of remainders that were padded up to 16 and
+/// sent through [`DistCalculator::distance_batch_16`] instead of drained scalar.
+/// In steady-state beam search most of a node's neighbors are already visited, so
+/// this is the path that carries the bulk of the fused-kernel work; a run where
+/// this stays 0 while [`BEAM_BATCH16_FLUSHES`] is small means the accelerated
+/// kernel is barely being used.
+#[cfg(test)]
+pub(crate) static BEAM_BATCH16_PADDED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
 /// Gate for the two counters above. Off by default: the counter `fetch_add`s are
@@ -350,6 +419,72 @@ fn apply_neighbor(
     }
 }
 
+/// Evaluate `len` buffered neighbors in one `distance_batch_16` call and apply
+/// them.
+///
+/// `len` is passed through, so a partial batch only gathers `len` rows: one tile
+/// pass costs the same for 3 useful lanes as for 16, but the gather scales with
+/// the rows staged.
+///
+/// **STALE — measured on the pre-`count` kernel**, which staged all 16 rows
+/// however small the batch. On Granite Rapids at dim=768 (gcc-13.4, scattered
+/// ids), one padded call against `len` scalar `distance()` calls: len=1 1.13x,
+/// len=2 0.88x, len=3 1.98x, len=4 2.30x, len=8 3.40x, len=16 5.70x. Passing
+/// `len` through is precisely what those small-`len` ratios were paying for, so
+/// they need re-measuring end to end.
+///
+/// The slots past `len` are still filled with `ids[0]` rather than left stale:
+/// the sixteen ids need not be distinct -- a calculator resolves each
+/// independently (`get_vector(ids[i])`), so a repeat merely recomputes that row
+/// -- which keeps an implementation that ignores `len` correct instead of
+/// letting it read a `u32` from an earlier flush.
+///
+/// Each neighbor is applied against the `furthest` snapshot taken when it was
+/// *discovered*, not one read at flush time, because the unbatched loop tests a
+/// neighbor against the threshold current at its parent's pop.
+macro_rules! flush_batch16 {
+    ($candidates:ident, $results:ident, $k:expr, $dist_calc:expr, $accepts_result:expr,
+     $batch_ids:ident, $batch_furthest:ident, $batch_len:ident) => {{
+        debug_assert!($batch_len > 0 && $batch_len <= 16);
+        let mut padded = $batch_ids;
+        for slot in padded.iter_mut().skip($batch_len) {
+            *slot = $batch_ids[0];
+        }
+        let mut batch_dists = [0f32; 16];
+        $dist_calc.distance_batch_16(&padded, &mut batch_dists, $batch_len);
+        #[cfg(test)]
+        if $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            if $batch_len == 16 {
+                $crate::vector::graph::BEAM_BATCH16_FLUSHES
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            } else {
+                $crate::vector::graph::BEAM_BATCH16_PADDED
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+        for i in 0..$batch_len {
+            apply_neighbor(
+                &mut $candidates,
+                &mut $results,
+                $k,
+                $batch_furthest[i],
+                &$accepts_result,
+                $batch_ids[i],
+                batch_dists[i].into(),
+            );
+        }
+        // Emptied here rather than by each caller so the macro cannot leave a
+        // stale length behind. One caller — the final flush just before the
+        // traversal `break`s — never reads it again, hence the allow.
+        #[allow(unused_assignments)]
+        {
+            $batch_len = 0;
+        }
+    }};
+}
+
 macro_rules! beam_search_loop {
     (
         $candidates:ident,
@@ -368,11 +503,58 @@ macro_rules! beam_search_loop {
         // original traversal, so they are untouched by this path.
         let use_batch16 = $dist_calc.has_batch_16_kernel();
 
-        while !$candidates.is_empty() {
+        // Opt-in via `LANCE_HNSW_BATCH_SPAN=1`: let the 16-wide buffer carry
+        // across popped nodes instead of being emptied at the end of each one.
+        //
+        // Off by default because it CHANGES RESULTS. A neighbor discovered while
+        // visiting node A may not reach `candidates` until after node B has been
+        // popped, so the traversal order differs from the unbatched loop and
+        // recall shifts rather than matching it exactly. With it off, the buffer
+        // is emptied before the next pop and the arm stays equivalent.
+        //
+        // Worth having because the buffer is per popped node, and in steady-state
+        // beam search most of a node's neighbors are already visited: a per-node
+        // buffer rarely reaches 16, so without spanning most distance work goes
+        // out through the (much smaller) remainder flushes.
+        let span_nodes = use_batch16 && $crate::vector::graph::batch16_spans_nodes();
+        // Read once per search rather than per node: `batch16_pad_min` is behind a
+        // OnceLock, but the call still costs an atomic load.
+        let pad_min = $crate::vector::graph::batch16_pad_min();
+
+        // Buffer state lives outside the loop so that it *can* span nodes. When
+        // `span_nodes` is false it is drained before the next pop, which makes it
+        // behave exactly like a buffer scoped to one node.
+        let mut batch_ids = [0u32; 16];
+        let mut batch_furthest = [OrderedFloat(0.0f32); 16];
+        let mut batch_len = 0usize;
+
+        loop {
+            if $candidates.is_empty() {
+                // Spanning can leave discovered-but-unevaluated neighbors behind,
+                // and their distances may still add candidates, so flush and
+                // re-test instead of exiting on an empty heap.
+                if batch_len == 0 {
+                    break;
+                }
+                flush_batch16!(
+                    $candidates, $results, $k, $dist_calc, $accepts_result,
+                    batch_ids, batch_furthest, batch_len
+                );
+                continue;
+            }
+
             let $current = $candidates.pop().expect("candidates is empty").0;
             let furthest = furthest_distance(&$results);
 
             if $current.dist > furthest && $results.len() == $k {
+                // Don't discard work already discovered: evaluate it so it can
+                // still enter `results`, then stop traversing.
+                if batch_len > 0 {
+                    flush_batch16!(
+                        $candidates, $results, $k, $dist_calc, $accepts_result,
+                        batch_ids, batch_furthest, batch_len
+                    );
+                }
                 break;
             }
 
@@ -385,65 +567,57 @@ macro_rules! beam_search_loop {
                 // exactly where the scalar loop marks it; only the distance
                 // computation and its accept/push consequences are deferred to the
                 // flush.
-                let mut batch_ids = [0u32; 16];
-                let mut batch_len = 0usize;
-
                 let $process_neighbor = |neighbor: u32| {
                     if $visited.contains(neighbor) {
                         return;
                     }
                     $visited.insert(neighbor);
                     batch_ids[batch_len] = neighbor;
+                    batch_furthest[batch_len] = furthest;
                     batch_len += 1;
                     if batch_len == 16 {
-                        let mut batch_dists = [0f32; 16];
-                        $dist_calc.distance_batch_16(&batch_ids, &mut batch_dists);
-                        #[cfg(test)]
-                        if $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
-                            .load(std::sync::atomic::Ordering::Relaxed)
-                        {
-                            $crate::vector::graph::BEAM_BATCH16_FLUSHES
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        }
-                        for i in 0..16 {
-                            apply_neighbor(
-                                &mut $candidates,
-                                &mut $results,
-                                $k,
-                                furthest,
-                                &$accepts_result,
-                                batch_ids[i],
-                                batch_dists[i].into(),
-                            );
-                        }
-                        batch_len = 0;
+                        flush_batch16!(
+                            $candidates, $results, $k, $dist_calc, $accepts_result,
+                            batch_ids, batch_furthest, batch_len
+                        );
                     }
                 };
                 $visit_neighbors
 
-                // Drain the < 16 remainder with scalar `distance` calls (FAISS's
-                // tail loop). `distance_batch_16` needs exactly 16 valid ids, so a
-                // partial buffer cannot use it without padding with bogus ids.
-                #[cfg(test)]
-                if batch_len > 0
-                    && $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                {
-                    $crate::vector::graph::BEAM_BATCH16_DRAINS
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
-                for i in 0..batch_len {
-                    let neighbor = batch_ids[i];
-                    let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
-                    apply_neighbor(
-                        &mut $candidates,
-                        &mut $results,
-                        $k,
-                        furthest,
-                        &$accepts_result,
-                        neighbor,
-                        dist,
-                    );
+                if !span_nodes && batch_len > 0 {
+                    // Remainder for this node. Padding to 16 beats the scalar tail
+                    // above a crossover that depends on how fast the scalar f16
+                    // kernel is, i.e. on which compiler built it — see
+                    // `batch16_pad_min`. Below the crossover the gather is not
+                    // amortised, so keep the scalar drain.
+                    if batch_len >= pad_min {
+                        flush_batch16!(
+                            $candidates, $results, $k, $dist_calc, $accepts_result,
+                            batch_ids, batch_furthest, batch_len
+                        );
+                    } else {
+                        #[cfg(test)]
+                        if $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            $crate::vector::graph::BEAM_BATCH16_DRAINS
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        for i in 0..batch_len {
+                            let neighbor = batch_ids[i];
+                            let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
+                            apply_neighbor(
+                                &mut $candidates,
+                                &mut $results,
+                                $k,
+                                batch_furthest[i],
+                                &$accepts_result,
+                                neighbor,
+                                dist,
+                            );
+                        }
+                        batch_len = 0;
+                    }
                 }
             } else {
                 // The pre-batching traversal, unchanged: evaluate each freshly

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -296,6 +296,60 @@ fn push_result(results: &mut BinaryHeap<OrderedNode>, candidate: OrderedNode, k:
     }
 }
 
+/// Test-only instrumentation: number of *full* 16-wide neighbor batches flushed
+/// through [`DistCalculator::distance_batch_16`] by [`beam_search_loop`]. Lets the
+/// AMX activation test prove the batched (accelerated) path is actually exercised
+/// during graph construction, rather than every neighbor list being < 16 and
+/// silently draining through the scalar tail.
+#[cfg(test)]
+pub(crate) static BEAM_BATCH16_FLUSHES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Test-only instrumentation companion to [`BEAM_BATCH16_FLUSHES`]: number of
+/// non-empty `< 16` remainder drains (the scalar tail). Confirms the remainder
+/// path is exercised, not just the full-batch path.
+#[cfg(test)]
+pub(crate) static BEAM_BATCH16_DRAINS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Gate for the two counters above. Off by default: the counter `fetch_add`s are
+/// a single shared atomic each, so leaving them live in the parallel build
+/// benchmark would serialize every flush across all worker threads and dominate
+/// the measurement. The (single-threaded) activation test flips this on around
+/// its build; the benchmark leaves it off, so only a cheap uncontended relaxed
+/// load remains on the hot path.
+#[cfg(test)]
+pub(crate) static BEAM_BATCH16_COUNT_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Apply the beam-search accept / threshold / push logic for one already-computed
+/// neighbor distance. Extracted so the batched-flush path and the scalar-drain
+/// path in [`beam_search_loop`] share a single implementation.
+///
+/// `furthest` is the per-candidate snapshot of the results-heap frontier — read
+/// once when the current candidate was popped, exactly as the pre-batching loop
+/// did — while `results.len()` (and `push_result`'s own `peek`) are read fresh.
+/// Because distances are a pure function of (query, neighbor), independent of heap
+/// state, computing a batch of them up-front and then applying this in buffer order
+/// is byte-for-byte equivalent to the old interleaved per-neighbor loop.
+#[inline]
+fn apply_neighbor(
+    candidates: &mut BinaryHeap<Reverse<OrderedNode>>,
+    results: &mut BinaryHeap<OrderedNode>,
+    k: usize,
+    furthest: OrderedFloat,
+    accepts: impl Fn(u32, OrderedFloat) -> bool,
+    neighbor: u32,
+    dist: OrderedFloat,
+) {
+    if dist <= furthest || results.len() < k {
+        if accepts(neighbor, dist) {
+            push_result(results, (dist, neighbor).into(), k);
+        }
+        candidates.push(Reverse((dist, neighbor).into()));
+    }
+}
+
 macro_rules! beam_search_loop {
     (
         $candidates:ident,
@@ -307,6 +361,13 @@ macro_rules! beam_search_loop {
         $accepts_result:expr,
         |$current:ident, $process_neighbor:ident| $visit_neighbors:block
     ) => {{
+        // Decided once per search — `dist_calc` is fixed for the whole traversal.
+        // Only backends whose `distance_batch_16` is backed by a fused kernel take
+        // the batched arm; everything else (PQ, SQ, BQ, flat f32/f64, and fp16 on
+        // hosts without usable AMX-FP16) takes the `else` arm, which is the
+        // original traversal, so they are untouched by this path.
+        let use_batch16 = $dist_calc.has_batch_16_kernel();
+
         while !$candidates.is_empty() {
             let $current = $candidates.pop().expect("candidates is empty").0;
             let furthest = furthest_distance(&$results);
@@ -315,20 +376,97 @@ macro_rules! beam_search_loop {
                 break;
             }
 
-            let $process_neighbor = |neighbor: u32| {
-                if $visited.contains(neighbor) {
-                    return;
-                }
-                $visited.insert(neighbor);
-                let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
-                if dist <= furthest || $results.len() < $k {
-                    if $accepts_result(neighbor, dist) {
-                        push_result(&mut $results, (dist, neighbor).into(), $k);
+            if use_batch16 {
+                // Buffer freshly-visited neighbor ids and evaluate their distances
+                // in batches of 16 via `distance_batch_16` (one fused AMX-FP16 tile
+                // pass for flat fp16 Dot search) instead of one scalar call at a
+                // time — mirrors FAISS #5235's `search_from_candidates_fixVT`.
+                // Dedup / visited-marking still happens inline at first encounter,
+                // exactly where the scalar loop marks it; only the distance
+                // computation and its accept/push consequences are deferred to the
+                // flush.
+                let mut batch_ids = [0u32; 16];
+                let mut batch_len = 0usize;
+
+                let $process_neighbor = |neighbor: u32| {
+                    if $visited.contains(neighbor) {
+                        return;
                     }
-                    $candidates.push(Reverse((dist, neighbor).into()));
+                    $visited.insert(neighbor);
+                    batch_ids[batch_len] = neighbor;
+                    batch_len += 1;
+                    if batch_len == 16 {
+                        let mut batch_dists = [0f32; 16];
+                        $dist_calc.distance_batch_16(&batch_ids, &mut batch_dists);
+                        #[cfg(test)]
+                        if $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            $crate::vector::graph::BEAM_BATCH16_FLUSHES
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        for i in 0..16 {
+                            apply_neighbor(
+                                &mut $candidates,
+                                &mut $results,
+                                $k,
+                                furthest,
+                                &$accepts_result,
+                                batch_ids[i],
+                                batch_dists[i].into(),
+                            );
+                        }
+                        batch_len = 0;
+                    }
+                };
+                $visit_neighbors
+
+                // Drain the < 16 remainder with scalar `distance` calls (FAISS's
+                // tail loop). `distance_batch_16` needs exactly 16 valid ids, so a
+                // partial buffer cannot use it without padding with bogus ids.
+                #[cfg(test)]
+                if batch_len > 0
+                    && $crate::vector::graph::BEAM_BATCH16_COUNT_ENABLED
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    $crate::vector::graph::BEAM_BATCH16_DRAINS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 }
-            };
-            $visit_neighbors
+                for i in 0..batch_len {
+                    let neighbor = batch_ids[i];
+                    let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
+                    apply_neighbor(
+                        &mut $candidates,
+                        &mut $results,
+                        $k,
+                        furthest,
+                        &$accepts_result,
+                        neighbor,
+                        dist,
+                    );
+                }
+            } else {
+                // The pre-batching traversal, unchanged: evaluate each freshly
+                // visited neighbor immediately. `apply_neighbor` holds the same
+                // accept / threshold / push logic this loop used to inline.
+                let $process_neighbor = |neighbor: u32| {
+                    if $visited.contains(neighbor) {
+                        return;
+                    }
+                    $visited.insert(neighbor);
+                    let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
+                    apply_neighbor(
+                        &mut $candidates,
+                        &mut $results,
+                        $k,
+                        furthest,
+                        &$accepts_result,
+                        neighbor,
+                        dist,
+                    );
+                };
+                $visit_neighbors
+            }
         }
     }};
 }
@@ -766,6 +904,23 @@ pub fn greedy_search_borrowed(
 mod tests {
     use super::*;
 
+    use super::{BEAM_BATCH16_COUNT_ENABLED, BEAM_BATCH16_FLUSHES};
+    use crate::vector::flat::storage::FlatFloatStorage;
+    use crate::vector::hnsw::HNSW;
+    use crate::vector::hnsw::builder::{HnswBuildParams, HnswQueryParams};
+    use crate::vector::storage::{DistCalculator, VectorStore};
+    use crate::vector::v3::subindex::IvfSubIndex;
+    use arrow_array::{ArrayRef, FixedSizeListArray, Float16Array};
+    use half::f16;
+    use lance_arrow::FixedSizeListArrayExt;
+    use lance_linalg::distance::DistanceType;
+    use lance_linalg::distance::dot_f16::amx_fp16_available;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering::Relaxed;
+
     struct ChainGraph {
         neighbors: Vec<Vec<u32>>,
     }
@@ -854,5 +1009,240 @@ mod tests {
         assert_eq!(basic_results.len(), PASSING_COUNT);
         assert_eq!(acorn_results.len(), PASSING_COUNT);
         assert!(acorn_results.iter().all(|node| mask.contains(node.id)));
+    }
+
+    /// Deterministic random f32 vectors in `[-1, 1)`, flat `n * dim` layout.
+    fn gen_vectors(seed: u64, n: usize, dim: usize) -> Vec<f32> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        (0..n * dim)
+            .map(|_| rng.random_range(-1.0f32..1.0))
+            .collect()
+    }
+
+    // ===== Flat fp16 (AMX-FP16) HNSW query-path tests & benchmark =====
+    //
+    // The AMX-FP16 override lives on the flat fp16 distance calculator, so it
+    // fires on the real user query path (table.search -> HNSW search ->
+    // FlatFloatDistanceCalc::distance_batch_16).
+
+    /// Flat (unquantized) fp16 storage over `values`, Dot metric: the symmetric
+    /// fp16-vs-fp16 comparison an `IvfHnswFlat` index over an fp16 column runs.
+    fn build_flat_f16_storage(values: &[f32], dim: usize) -> FlatFloatStorage {
+        let f16vals = Float16Array::from_iter_values(values.iter().map(|&v| f16::from_f32(v)));
+        let fsl = FixedSizeListArray::try_new_from_values(f16vals, dim as i32).unwrap();
+        FlatFloatStorage::new(fsl, DistanceType::Dot)
+    }
+
+    fn flat_f16_hnsw_topk(
+        hnsw: &HNSW,
+        storage: &FlatFloatStorage,
+        query: &[f32],
+        k: usize,
+        ef: usize,
+    ) -> Vec<u32> {
+        let q = Arc::new(Float16Array::from_iter_values(
+            query.iter().map(|&v| f16::from_f32(v)),
+        )) as ArrayRef;
+        let params = HnswQueryParams {
+            ef,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+            use_acorn: false,
+        };
+        hnsw.search_basic(q, k, &params, None, storage)
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id)
+            .collect()
+    }
+
+    /// Exhaustive top-`k` under the same fp16 Dot distance (graph ground truth).
+    fn brute_force_flat_f16_topk(storage: &FlatFloatStorage, query: &[f32], k: usize) -> Vec<u32> {
+        let q = Arc::new(Float16Array::from_iter_values(
+            query.iter().map(|&v| f16::from_f32(v)),
+        )) as ArrayRef;
+        let dc = storage.dist_calculator(q, 0.0);
+        let mut all: Vec<(f32, u32)> = (0..storage.len() as u32)
+            .map(|id| (dc.distance(id), id))
+            .collect();
+        all.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        all.into_iter().take(k).map(|(_, id)| id).collect()
+    }
+
+    /// Recall parity for the real fp16 query path. Builds HNSW+Flat(fp16, Dot),
+    /// runs queries, compares recall@k against brute-force fp16 ground truth, and
+    /// proves both that the 16-wide batch flush path is exercised during *search*
+    /// and (when not disabled) that it maps onto the AMX-FP16 tile kernel.
+    ///
+    /// Re-run with `LANCE_DISABLE_AMX=1` for the scalar/AVX-512-FP16 fallback
+    /// recall (out-of-band comparison; the two should be ~identical — tile
+    /// accumulation order only perturbs distances at the 1e-4 level).
+    #[test]
+    #[allow(clippy::print_stderr)]
+    fn test_flat_f16_hnsw_recall_and_amx_activation() {
+        let (n, dim, nq, k, ef) = (2000usize, 128usize, 100usize, 10usize, 100usize);
+        let values = gen_vectors(1, n, dim);
+        let storage = build_flat_f16_storage(&values, dim);
+
+        // Pin construction to 1 thread so the build is deterministic here.
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let hnsw = pool
+            .install(|| HNSW::index_vectors(&storage, HnswBuildParams::default()))
+            .unwrap();
+
+        let qvals = gen_vectors(2, nq, dim);
+        BEAM_BATCH16_FLUSHES.store(0, Relaxed);
+        BEAM_BATCH16_COUNT_ENABLED.store(true, Relaxed);
+        let mut hits = 0usize;
+        for i in 0..nq {
+            let q = &qvals[i * dim..(i + 1) * dim];
+            let got = flat_f16_hnsw_topk(&hnsw, &storage, q, k, ef);
+            let truth: HashSet<u32> = brute_force_flat_f16_topk(&storage, q, k)
+                .into_iter()
+                .collect();
+            hits += got.iter().filter(|id| truth.contains(id)).count();
+        }
+        BEAM_BATCH16_COUNT_ENABLED.store(false, Relaxed);
+        let flushes = BEAM_BATCH16_FLUSHES.load(Relaxed);
+        let recall = hits as f64 / (nq * k) as f64;
+
+        eprintln!(
+            "[flat_f16] recall@{k}={recall:.4} search_flushes={flushes} amx_fp16_available={}",
+            amx_fp16_available()
+        );
+        assert!(recall > 0.90, "fp16 HNSW recall unexpectedly low: {recall}");
+        // The batched traversal must engage exactly when a fused kernel backs it.
+        // With AMX-FP16 usable the 16-wide flush path has to be exercised (runtime
+        // probe — the `kernel_support` cfg is set only for the lance-linalg crate,
+        // so it cannot gate here). Without it (no hardware, or LANCE_DISABLE_AMX
+        // set) the search must take the original per-neighbor traversal and never
+        // buffer at all, which is what keeps this change free for backends and
+        // hosts that cannot use the kernel.
+        if amx_fp16_available() {
+            assert!(
+                flushes > 0,
+                "16-wide batch flush path never hit during search"
+            );
+        } else {
+            assert_eq!(
+                flushes, 0,
+                "neighbors were buffered even though no fused kernel is available"
+            );
+            eprintln!("[flat_f16] AMX-FP16 unavailable; search used the scalar traversal");
+        }
+    }
+
+    /// Wall-clock HNSW+Flat(fp16) benchmark: construction time (all-core), then
+    /// query throughput/latency over a batch of `search()` calls (the metric
+    /// that matters, since AMX-FP16 fires on the query path) at each of three
+    /// concurrency settings. `#[ignore]` -- run:
+    ///   cargo test -p lance-index --release --features lance-linalg/amx \
+    ///     flat_f16_search_bench -- --ignored --nocapture
+    /// Without the `amx` feature this still runs, on the original per-neighbor
+    /// traversal, which is the pre-patch baseline. Toggle AMX at runtime with
+    /// `LANCE_DISABLE_AMX=1` (one setting per process — it is cached
+    /// process-wide). Tune with `BENCH_N` / `BENCH_DIM` / `BENCH_NQ` /
+    /// `BENCH_EF` / `BENCH_THREADS` (comma-separated; default `<ncpu>,32,1`).
+    ///
+    /// The index is built once (all-core) and then searched under each thread
+    /// count via an explicit rayon pool, so a single process yields the whole
+    /// concurrency sweep for one (dim, AMX) cell.
+    #[test]
+    #[ignore]
+    #[allow(clippy::print_stderr)]
+    fn hnsw_flat_f16_search_bench() {
+        use rayon::prelude::*;
+        use std::time::Instant;
+
+        let env_usize = |k: &str, d: usize| {
+            std::env::var(k)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(d)
+        };
+        let n = env_usize("BENCH_N", 50_000);
+        let dim = env_usize("BENCH_DIM", 128);
+        let nq = env_usize("BENCH_NQ", 20_000);
+        let ef = env_usize("BENCH_EF", 100);
+        let k = 10usize;
+        let ncpu = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        let thread_counts: Vec<usize> = std::env::var("BENCH_THREADS")
+            .ok()
+            .map(|s| s.split(',').filter_map(|t| t.trim().parse().ok()).collect())
+            .unwrap_or_else(|| vec![ncpu, 32, 1]);
+
+        let values = gen_vectors(7, n, dim);
+        let storage = build_flat_f16_storage(&values, dim);
+
+        // Build once, all-core, so construction time is independent of the
+        // search-concurrency sweep. Both build and search take the AMX-FP16 path
+        // when enabled.
+        let build_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(ncpu)
+            .build()
+            .unwrap();
+        let t0 = Instant::now();
+        let hnsw = build_pool
+            .install(|| HNSW::index_vectors(&storage, HnswBuildParams::default()))
+            .unwrap();
+        let build_dt = t0.elapsed();
+        std::hint::black_box(&hnsw);
+        eprintln!(
+            "[flat_f16_bench] n={n} dim={dim} ef={ef} amx_fp16={} | build_allcore({ncpu}t)={:.3}s ({:.0} vec/s)",
+            amx_fp16_available(),
+            build_dt.as_secs_f64(),
+            n as f64 / build_dt.as_secs_f64(),
+        );
+
+        let qvals = gen_vectors(11, nq, dim);
+        let queries: Vec<&[f32]> = (0..nq).map(|i| &qvals[i * dim..(i + 1) * dim]).collect();
+
+        // Each concurrency level is measured for a fixed wall-time budget
+        // (repeating the query set), so single-thread and 384-thread runs take
+        // comparable time and all report stable numbers regardless of dim.
+        let budget = std::time::Duration::from_secs_f64(
+            std::env::var("BENCH_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1.5),
+        );
+        for &nthreads in &thread_counts {
+            if nthreads == 0 || nthreads > ncpu {
+                continue;
+            }
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(nthreads)
+                .build()
+                .unwrap();
+            let run_pass = || -> usize {
+                pool.install(|| {
+                    queries
+                        .par_iter()
+                        .map(|q| flat_f16_hnsw_topk(&hnsw, &storage, q, k, ef).len())
+                        .sum()
+                })
+            };
+            run_pass(); // warm up (page-in, thread spin-up) before timing
+            let t1 = Instant::now();
+            let mut served = 0usize;
+            let mut done = 0usize;
+            while t1.elapsed() < budget {
+                served += run_pass();
+                done += nq;
+            }
+            let search_dt = t1.elapsed();
+            std::hint::black_box(served);
+            let qps = done as f64 / search_dt.as_secs_f64();
+            let lat_us = search_dt.as_secs_f64() * 1e6 / done as f64;
+            eprintln!(
+                "[flat_f16_bench]   search_threads={nthreads:>3} queries={done:>8}: qps={qps:>9.0} lat={lat_us:>7.1}us/q",
+            );
+        }
     }
 }

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -83,15 +83,27 @@ pub trait DistCalculator {
         false
     }
 
-    /// Compute distances for a batch of exactly 16 ids in one call, writing
-    /// `dists[i]` for `ids[i]`.
+    /// Compute distances for the first `len` of 16 ids in one call, writing
+    /// `dists[i]` for `ids[i]`. `len` must be in `1..=16`.
     ///
-    /// The default implementation issues 16 individual [`Self::distance`] calls,
-    /// so every backend is correct with no behavior change. Backends with a
-    /// batched distance kernel override this to compute all 16 in a single
+    /// `len` controls only *how many distances are computed*. It does not relax
+    /// the requirement on `ids`: **every element of `ids` must be a valid id**,
+    /// including the slots at or after `len`. Implementations are free to
+    /// resolve all 16 before looking at `len` — the flat fp16 override does
+    /// exactly that, and an out-of-range id there panics — so a caller with
+    /// fewer than 16 real ids must fill the rest with some valid id (repeating
+    /// `ids[0]` is what HNSW's `flush_batch16!` does) rather than leaving them
+    /// arbitrary.
+    ///
+    /// Only `dists[..len]` is written; the rest is left as the caller had it.
+    ///
+    /// The default implementation issues `len` individual [`Self::distance`]
+    /// calls, so every backend is correct with no behavior change. Backends with
+    /// a batched distance kernel override this to compute all `len` in a single
     /// fused pass.
-    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
-        for (dist, &id) in dists.iter_mut().zip(ids.iter()) {
+    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16], len: usize) {
+        debug_assert!((1..=16).contains(&len), "len ({len}) must be in 1..=16");
+        for (dist, &id) in dists.iter_mut().zip(ids.iter()).take(len) {
             *dist = self.distance(id);
         }
     }

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -66,6 +66,36 @@ pub trait DistCalculator {
         *dists = self.distance_all(k_hint);
     }
 
+    /// Whether [`Self::distance_batch_16`] on this calculator is backed by a real
+    /// fused kernel rather than the 16-individual-[`Self::distance`] default.
+    ///
+    /// HNSW's `beam_search_loop!` reads this once per search to decide whether to
+    /// buffer neighbors 16 at a time at all. Backends answering `false` — the
+    /// default, i.e. every backend without a batched kernel — keep the original
+    /// evaluate-each-neighbor-immediately traversal, so they pay nothing for a
+    /// batching path they could not benefit from.
+    ///
+    /// Implementations must answer `true` only when the fused path would actually
+    /// be taken (correct metric and dimension, hardware usable at runtime);
+    /// answering `true` while [`Self::distance_batch_16`] falls back internally
+    /// would make the buffering pure overhead.
+    fn has_batch_16_kernel(&self) -> bool {
+        false
+    }
+
+    /// Compute distances for a batch of exactly 16 ids in one call, writing
+    /// `dists[i]` for `ids[i]`.
+    ///
+    /// The default implementation issues 16 individual [`Self::distance`] calls,
+    /// so every backend is correct with no behavior change. Backends with a
+    /// batched distance kernel override this to compute all 16 in a single
+    /// fused pass.
+    fn distance_batch_16(&self, ids: &[u32; 16], dists: &mut [f32; 16]) {
+        for (dist, &id) in dists.iter_mut().zip(ids.iter()) {
+            *dist = self.distance(id);
+        }
+    }
+
     fn prefetch(&self, _id: u32) {}
 
     #[allow(clippy::too_many_arguments)]

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -35,6 +35,14 @@ cc = "1.0.83"
 # This requires GCC 12 / Clang 6 or later. (To get AVX-512 support,
 # you need Clang 11 or later.)
 fp16kernels = []
+# Enable the AMX-FP16 tile kernel backing batched fp16 dot products
+# (Granite Rapids and newer). Off by default, and deliberately separate from
+# fp16kernels: it needs a C compiler accepting -mamx-fp16 (Clang >= 16 or
+# GCC >= 13; override the probe with LANCE_AMX_FP16_CC), and it links a C FFI
+# kernel that must request XTILEDATA from the kernel before executing any tile
+# instruction. With this feature off, no AMX source is compiled or linked and
+# HNSW keeps its original per-neighbor traversal.
+amx = ["fp16kernels"]
 
 [[bench]]
 name = "l2"

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -17,12 +17,14 @@ fn main() -> Result<(), String> {
 
     // Let clippy know about our custom cfg attribute
     println!(
-        "cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512_f16\", \"avx512_bf16\", \"avx512_dist_table\"))"
+        "cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512_f16\", \"avx512_bf16\", \"avx512_dist_table\", \"amx_fp16\"))"
     );
 
     println!("cargo:rerun-if-changed=src/simd/f16.c");
     println!("cargo:rerun-if-changed=src/simd/bf16.c");
     println!("cargo:rerun-if-changed=src/simd/dist_table.c");
+    println!("cargo:rerun-if-changed=src/simd/amx_fp16.c");
+    println!("cargo:rerun-if-env-changed=LANCE_AMX_FP16_CC");
 
     // Important: we don't use `cfg!(target_arch)` here because that is the target_arch
     // for the build script, not the target_arch for the library. Similar story for
@@ -84,6 +86,26 @@ fn main() -> Result<(), String> {
         } else {
             println!("cargo:rustc-cfg=kernel_support=\"avx512_dist_table\"");
         };
+        // Build the AMX-FP16 batched f16 dot-product kernel (Granite Rapids+)
+        // only under its own opt-in `amx` feature, kept separate from
+        // fp16kernels because this kernel carries requirements the pure-SIMD
+        // ones do not: AMX-FP16 (`_tile_dpfp16ps`) needs clang >= 16 or gcc >=
+        // 13, so it may use a different compiler than the rest (auto-probed
+        // below), and it must obtain XTILEDATA permission at runtime. Skips
+        // gracefully if no capable compiler is available; the Rust side then
+        // uses the existing AVX-512-FP16 / scalar fp16 distance instead.
+        if env::var("CARGO_FEATURE_AMX").is_ok() {
+            if let Err(err) =
+                build_amx_fp16_with_flags(&["-march=sapphirerapids", "-mamx-fp16", "-mamx-tile"])
+            {
+                println!(
+                    "cargo:warning=Skipping build of AMX-FP16 kernels. Error: {}",
+                    err
+                );
+            } else {
+                println!("cargo:rustc-cfg=kernel_support=\"amx_fp16\"");
+            };
+        }
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang
         // has support for __fp16 going back to at least clang 6.
@@ -195,4 +217,97 @@ fn build_dist_table_with_flags(suffix: &str, flags: &[&str]) -> Result<(), cc::E
         builder.flag(flag);
     }
     builder.try_compile(&format!("dist_table_{}", suffix))
+}
+
+/// Compile the AMX-FP16 kernel. Unlike the other kernels this may need a
+/// different C compiler: `_tile_dpfp16ps` / `-mamx-fp16` require clang >= 16 or
+/// gcc >= 13, which is often newer than the platform default `cc`. We probe for
+/// a capable compiler (respecting a `LANCE_AMX_FP16_CC` override) and use it
+/// only for this one file; everything else keeps using the default toolchain.
+fn build_amx_fp16_with_flags(flags: &[&str]) -> Result<(), String> {
+    let compiler = find_amx_fp16_compiler(flags).ok_or_else(|| {
+        "no C compiler supporting -mamx-fp16 found (need clang>=16 or gcc>=13; \
+         set LANCE_AMX_FP16_CC to override)"
+            .to_string()
+    })?;
+    let mut builder = cc::Build::new();
+    builder
+        .compiler(&compiler)
+        .std("c17")
+        .file("src/simd/amx_fp16.c")
+        .flag("-funroll-loops")
+        .flag("-O3")
+        .flag("-Wall")
+        .flag("-Wextra");
+    for flag in flags {
+        builder.flag(flag);
+    }
+    builder.try_compile("amx_fp16").map_err(|e| e.to_string())
+}
+
+/// Find a C compiler that can build the AMX-FP16 kernel with `flags`, in order:
+/// the `LANCE_AMX_FP16_CC` override, the default toolchain `cc`, then common
+/// modern clang names. Returns the first that compiles a `_tile_dpfp16ps` probe.
+fn find_amx_fp16_compiler(flags: &[&str]) -> Option<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(cc) = env::var("LANCE_AMX_FP16_CC") {
+        candidates.push(cc);
+    }
+    if let Ok(default_cc) = cc::Build::new()
+        .get_compiler()
+        .path()
+        .to_str()
+        .ok_or(())
+        .map(str::to_string)
+    {
+        candidates.push(default_cc);
+    }
+    for c in ["clang-18", "clang-17", "clang-16", "clang"] {
+        candidates.push(c.to_string());
+    }
+    candidates
+        .into_iter()
+        .find(|cc| cc_supports_amx_fp16(cc, flags))
+}
+
+/// True iff invoking `cc` with `flags` can compile a translation unit that uses
+/// `_tile_dpfp16ps`. `-Werror=implicit-function-declaration` turns gcc's
+/// "intrinsic not declared" *warning* (which otherwise still exits 0 on the
+/// too-old gcc that lacks amx-fp16) into a hard failure.
+fn cc_supports_amx_fp16(cc: &str, flags: &[&str]) -> bool {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let src = b"#include <immintrin.h>\n\
+        void t(const void* a, const void* b) {\n\
+        _tile_loadd(1, a, 64); _tile_loadd(2, b, 4);\n\
+        _tile_dpfp16ps(0, 1, 2); _tile_release(); }\n";
+    let out = env::var("OUT_DIR")
+        .map(|d| format!("{d}/amx_fp16_probe.o"))
+        .unwrap_or_else(|_| "/dev/null".to_string());
+
+    let mut cmd = Command::new(cc);
+    cmd.args(flags)
+        .args([
+            "-Werror=implicit-function-declaration",
+            "-x",
+            "c",
+            "-c",
+            "-",
+            "-o",
+        ])
+        .arg(&out)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let Ok(mut child) = cmd.spawn() else {
+        return false;
+    };
+    if let Some(mut stdin) = child.stdin.take()
+        && stdin.write_all(src).is_err()
+    {
+        return false;
+    }
+    child.wait().map(|s| s.success()).unwrap_or(false)
 }

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -19,6 +19,7 @@ use arrow_schema::{ArrowError, DataType};
 pub mod cosine;
 pub mod cosine_u8;
 pub mod dot;
+pub mod dot_f16;
 pub mod dot_u8;
 pub mod hamming;
 pub mod l2;

--- a/rust/lance-linalg/src/distance/dot_f16.rs
+++ b/rust/lance-linalg/src/distance/dot_f16.rs
@@ -25,21 +25,31 @@ use half::f16;
 
 use crate::distance::dot::dot;
 
-/// Batched f16 dot product: the raw dot products of one `query` against 16
-/// `candidates`, in order. Every candidate slice must have the same length as
-/// `query`.
+/// Batched f16 dot product: the raw dot products of one `query` against the
+/// first `len` of 16 `candidates`, in order. Every candidate slice must have the
+/// same length as `query`, and `len` must be in `1..=16`.
+///
+/// A batch shorter than 16 is the common case on the beam-search path, so `len`
+/// is not a convenience: it is what stops a one-neighbor flush from doing 16
+/// candidates' worth of work. Lanes `len..16` are returned as `0` rather than
+/// left unspecified, so both the AMX and fallback paths agree exactly on what a
+/// caller that reads past `len` would see.
 ///
 /// Safe to call unconditionally: the caller never needs to know whether AMX is
 /// present. The function panics if any candidate has a different length from
-/// `query`, rather than allowing a malformed batch to reach the FFI kernel.
-/// See the module docs for the accuracy contract.
+/// `query`, or if `len` is out of range, rather than allowing a malformed batch
+/// to reach the FFI kernel. See the module docs for the accuracy contract.
 #[inline]
-pub fn dot_f16_batch_16(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
+pub fn dot_f16_batch_16(query: &[f16], candidates: &[&[f16]; 16], len: usize) -> [f32; 16] {
     assert!(
         candidates
             .iter()
             .all(|candidate| candidate.len() == query.len()),
         "all candidate vectors must have the same length as query"
+    );
+    assert!(
+        (1..=16).contains(&len),
+        "batch length must be in 1..=16, got {len}"
     );
     #[cfg(all(
         kernel_support = "amx_fp16",
@@ -50,18 +60,29 @@ pub fn dot_f16_batch_16(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
         // AMX only earns its tile-config overhead once there is at least one
         // full 32-wide pass; for tiny dims the fallback is cheaper anyway.
         if query.len() >= 32 && crate::simd::amx_fp16::amx_available() {
-            return unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(query, candidates) };
+            return unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(query, candidates, len) };
         }
     }
-    dot_f16_batch_16_fallback(query, candidates)
+    dot_f16_batch_16_fallback(query, candidates, len)
 }
 
-/// Fallback for [`dot_f16_batch_16`]: 16 independent [`crate::distance::dot()`]
+/// Fallback for [`dot_f16_batch_16`]: `len` independent [`crate::distance::dot()`]
 /// calls — bit-identical to the per-neighbor `distance()` path (both go through
-/// `f16::dot`). Exposed separately so tests can exercise it regardless of host.
+/// `f16::dot`) — and `0` for the remaining lanes, matching what the kernel
+/// leaves there. Exposed separately so tests can exercise it regardless of host.
 #[inline]
-pub(crate) fn dot_f16_batch_16_fallback(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
-    std::array::from_fn(|i| dot(query, candidates[i]))
+pub(crate) fn dot_f16_batch_16_fallback(
+    query: &[f16],
+    candidates: &[&[f16]; 16],
+    len: usize,
+) -> [f32; 16] {
+    std::array::from_fn(|i| {
+        if i < len {
+            dot(query, candidates[i])
+        } else {
+            0.0
+        }
+    })
 }
 
 /// Whether a `dot_f16_batch_16` call would take the AMX-FP16 tile path (given a
@@ -139,7 +160,7 @@ mod tests {
         for &dim in BATCH_DIMS {
             let (query, cands) = make_batch(dim, &mut rng);
             let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
-            let got = dot_f16_batch_16_fallback(&query, &candidates);
+            let got = dot_f16_batch_16_fallback(&query, &candidates, 16);
             for i in 0..16 {
                 assert_close(
                     got[i],
@@ -156,7 +177,7 @@ mod tests {
         for &dim in BATCH_DIMS {
             let (query, cands) = make_batch(dim, &mut rng);
             let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
-            let got = dot_f16_batch_16(&query, &candidates);
+            let got = dot_f16_batch_16(&query, &candidates, 16);
             for i in 0..16 {
                 assert_close(
                     got[i],
@@ -179,7 +200,59 @@ mod tests {
                 query.as_slice()
             }
         });
-        let _ = dot_f16_batch_16(&query, &candidates);
+        let _ = dot_f16_batch_16(&query, &candidates, 16);
+    }
+
+    /// A live lane must be bit-identical whatever `len` the batch was issued at.
+    /// Shortening the batch changes only how many rows are gathered, never a
+    /// row's contents nor the order the tile passes accumulate them, so anything
+    /// less than bit-exact here would mean a staging offset moved with `len` —
+    /// exactly the bug a tolerance would hide. Lanes past `len` must read 0 on
+    /// both paths: dispatch is host-dependent, so a caller must not be able to
+    /// tell which one ran.
+    #[test]
+    fn partial_len_matches_full_batch_and_zeroes_the_rest() {
+        let mut rng = StdRng::seed_from_u64(0x1EE);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let full = dot_f16_batch_16(&query, &candidates, 16);
+            let full_fb = dot_f16_batch_16_fallback(&query, &candidates, 16);
+            for len in 1..=16 {
+                let got = dot_f16_batch_16(&query, &candidates, len);
+                let got_fb = dot_f16_batch_16_fallback(&query, &candidates, len);
+                for i in 0..len {
+                    assert_eq!(
+                        got[i].to_bits(),
+                        full[i].to_bits(),
+                        "dim={dim} len={len} i={i}: {} vs {}",
+                        got[i],
+                        full[i]
+                    );
+                    assert_eq!(
+                        got_fb[i].to_bits(),
+                        full_fb[i].to_bits(),
+                        "fb dim={dim} i={i}"
+                    );
+                }
+                for i in len..16 {
+                    assert_eq!(got[i], 0.0, "dim={dim} len={len}: lane {i} must be 0");
+                    assert_eq!(got_fb[i], 0.0, "fb dim={dim} len={len}: lane {i} must be 0");
+                }
+            }
+        }
+    }
+
+    /// `len` is rejected, never clamped: the kernel indexes its staging buffer
+    /// by it, and a caller that meant 16 and passed 17 should hear about it.
+    #[rstest::rstest]
+    #[case::zero(0)]
+    #[case::seventeen(17)]
+    #[should_panic(expected = "batch length must be in 1..=16")]
+    fn rejects_out_of_range_len(#[case] len: usize) {
+        let query = vec![f16::from_f32(1.0); 32];
+        let candidates: [&[f16]; 16] = std::array::from_fn(|_| query.as_slice());
+        let _ = dot_f16_batch_16(&query, &candidates, len);
     }
 
     /// On AMX-FP16 hardware, assert the AMX branch is actually selected (not a
@@ -200,7 +273,8 @@ mod tests {
         for &dim in BATCH_DIMS.iter().filter(|&&d| d >= 32) {
             let (query, cands) = make_batch(dim, &mut rng);
             let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
-            let amx = unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates) };
+            let amx =
+                unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates, 16) };
             for i in 0..16 {
                 let want = ref_dot_f32(&query, &cands[i]);
                 assert_close(amx[i], want, &format!("amx dim={dim} i={i}"));
@@ -209,5 +283,60 @@ mod tests {
             }
         }
         assert!(worst <= REL_TOL, "worst AMX relative error: {worst:.2e}");
+    }
+
+    /// The batch-16 kernel's tile shape, pinned byte for byte.
+    ///
+    /// The shape is the one thing a refactor of `amx_fp16.c` can change with no
+    /// visible symptom until it runs on AMX hardware, where a wrong shape is a
+    /// #UD or wrong results rather than a clean failure. Asserting the
+    /// configuration image directly keeps that a check every host can run,
+    /// whether or not it has AMX.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn search_tile_config_image_is_pinned() {
+        use crate::simd::amx_fp16::{AMX_CFG_SEARCH, tilecfg_image};
+
+        // Image layout per Intel SDM: palette_id, start_row, 14 reserved bytes,
+        // a u16 colsb[16] array, then a u8 rows[16] array.
+        const COLSB: usize = 16;
+        const ROWS: usize = 48;
+
+        let mut want = [0u8; 64];
+        want[0] = 1; // palette_id
+        // C = tmm0: 16 x 1 fp32, fed by three independent (A, B) pairs so three
+        // TDPFP16PS can be in flight at once: A = tmm1/3/5, each 16 x 32 fp16;
+        // B = tmm2/4/6, each 16 x 2 fp16. tmm7 is left unconfigured.
+        for (tmm, colsb) in [
+            (0usize, 4u16),
+            (1, 64),
+            (2, 4),
+            (3, 64),
+            (4, 4),
+            (5, 64),
+            (6, 4),
+        ] {
+            want[COLSB + tmm * 2..COLSB + tmm * 2 + 2].copy_from_slice(&colsb.to_le_bytes());
+            want[ROWS + tmm] = 16;
+        }
+
+        let got = tilecfg_image(AMX_CFG_SEARCH).expect("search config kind must be known");
+        assert_eq!(got, want, "batch-16 tile configuration changed");
+    }
+
+    /// An unknown config kind must be rejected rather than answered with a
+    /// zeroed image: an all-zero (unconfigured) shape #UDs on the first tile op.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn unknown_tile_config_kind_is_rejected() {
+        assert!(crate::simd::amx_fp16::tilecfg_image(-1).is_none());
     }
 }

--- a/rust/lance-linalg/src/distance/dot_f16.rs
+++ b/rust/lance-linalg/src/distance/dot_f16.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Batched f16 dot product with an optional AMX-FP16 tile backend.
+//!
+//! Used by flat (unquantized) fp16 vector search: an `IvfHnswFlat` index over
+//! an fp16 column compares an fp16 query against fp16 stored vectors
+//! symmetrically. During beam search the graph evaluates neighbors 16 at a time
+//! (see `lance_index`'s `beam_search_loop!`), which maps onto one AMX tile pass.
+//!
+//! [`dot_f16_batch_16`] returns the 16 raw dot products `Σ query·candidate`
+//! (same value convention as [`crate::distance::dot()`]); the caller applies the
+//! `1.0 - dot` distance wrapping. On Linux/x86_64 hosts with AMX-FP16 it
+//! dispatches to a single tile pass; everywhere else (and on any AMX
+//! unavailability) it falls back to 16 independent [`crate::distance::dot()`]
+//! calls, which are bit-identical to the per-neighbor `distance()` path.
+//!
+//! Unlike integer AMX kernels this is floating point: the AMX and fallback paths
+//! are **not** bit-for-bit identical (tile accumulation order rounds
+//! differently), but both accumulate products in f32 and agree to within fp16
+//! precision — a relative error on the order of 1e-4, far below fp16's own
+//! representational error, so recall is unaffected.
+
+use half::f16;
+
+use crate::distance::dot::dot;
+
+/// Batched f16 dot product: the raw dot products of one `query` against 16
+/// `candidates`, in order. Every candidate slice must have the same length as
+/// `query`.
+///
+/// Safe to call unconditionally: the caller never needs to know whether AMX is
+/// present. The function panics if any candidate has a different length from
+/// `query`, rather than allowing a malformed batch to reach the FFI kernel.
+/// See the module docs for the accuracy contract.
+#[inline]
+pub fn dot_f16_batch_16(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
+    assert!(
+        candidates
+            .iter()
+            .all(|candidate| candidate.len() == query.len()),
+        "all candidate vectors must have the same length as query"
+    );
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    {
+        // AMX only earns its tile-config overhead once there is at least one
+        // full 32-wide pass; for tiny dims the fallback is cheaper anyway.
+        if query.len() >= 32 && crate::simd::amx_fp16::amx_available() {
+            return unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(query, candidates) };
+        }
+    }
+    dot_f16_batch_16_fallback(query, candidates)
+}
+
+/// Fallback for [`dot_f16_batch_16`]: 16 independent [`crate::distance::dot()`]
+/// calls — bit-identical to the per-neighbor `distance()` path (both go through
+/// `f16::dot`). Exposed separately so tests can exercise it regardless of host.
+#[inline]
+pub(crate) fn dot_f16_batch_16_fallback(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
+    std::array::from_fn(|i| dot(query, candidates[i]))
+}
+
+/// Whether a `dot_f16_batch_16` call would take the AMX-FP16 tile path (given a
+/// dim `>= 32`) rather than the scalar/AVX-512 fallback: the kernel was compiled
+/// in, the host is Linux/x86_64 with the amx-tile + amx-fp16 CPUID bits, the
+/// one-time XTILEDATA `arch_prctl` succeeded, and `LANCE_DISABLE_AMX` is unset.
+///
+/// Exists so higher layers / tests can *assert* the accelerated path is active
+/// on a given host instead of silently falling back.
+pub fn amx_fp16_available() -> bool {
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    {
+        return crate::simd::amx_fp16::amx_available();
+    }
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    /// Dims covering: < 32 (no tile pass, pure fallback), exactly 32 (one pass,
+    /// no tail), non-multiples of 32 (exercise the AMX tail), and larger dims
+    /// (multiple passes).
+    const BATCH_DIMS: &[usize] = &[
+        1, 7, 31, 32, 33, 47, 64, 96, 100, 127, 128, 200, 256, 384, 768, 1000, 1536,
+    ];
+
+    fn make_batch(dim: usize, rng: &mut StdRng) -> (Vec<f16>, Vec<Vec<f16>>) {
+        let gen_vec = |rng: &mut StdRng| -> Vec<f16> {
+            (0..dim)
+                .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+                .collect()
+        };
+        let query = gen_vec(rng);
+        let candidates = (0..16).map(|_| gen_vec(rng)).collect();
+        (query, candidates)
+    }
+
+    /// f32-accumulated reference dot product — the semantic contract both the
+    /// AMX and fallback paths approximate. `f16::dot` itself accumulates in f32.
+    fn ref_dot_f32(query: &[f16], cand: &[f16]) -> f32 {
+        query
+            .iter()
+            .zip(cand.iter())
+            .map(|(&q, &c)| q.to_f32() * c.to_f32())
+            .sum()
+    }
+
+    /// Relative-error tolerance justification: fp16 carries ~11 bits of mantissa
+    /// (~3 decimal digits). The AMX path and the f32 reference differ only in
+    /// summation order of f32-widened products, so the error is many orders
+    /// tighter than fp16's own representational error; 5e-3 relative is a very
+    /// safe bound (observed worst case is ~2e-4).
+    const REL_TOL: f32 = 5e-3;
+
+    fn assert_close(got: f32, want: f32, ctx: &str) {
+        let rel = (got - want).abs() / (want.abs() + 1e-6);
+        assert!(
+            rel <= REL_TOL || (got - want).abs() <= 1e-3,
+            "{ctx}: got {got} want {want} rel_err {rel}"
+        );
+    }
+
+    #[test]
+    fn fallback_matches_reference() {
+        let mut rng = StdRng::seed_from_u64(0xF16);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let got = dot_f16_batch_16_fallback(&query, &candidates);
+            for i in 0..16 {
+                assert_close(
+                    got[i],
+                    ref_dot_f32(&query, &cands[i]),
+                    &format!("fb dim={dim} i={i}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dispatch_matches_reference() {
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let got = dot_f16_batch_16(&query, &candidates);
+            for i in 0..16 {
+                assert_close(
+                    got[i],
+                    ref_dot_f32(&query, &cands[i]),
+                    &format!("disp dim={dim} i={i}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "all candidate vectors must have the same length")]
+    fn rejects_mismatched_candidate_length() {
+        let query = vec![f16::from_f32(1.0); 32];
+        let short = vec![f16::from_f32(1.0); 31];
+        let candidates: [&[f16]; 16] = std::array::from_fn(|i| {
+            if i == 0 {
+                short.as_slice()
+            } else {
+                query.as_slice()
+            }
+        });
+        let _ = dot_f16_batch_16(&query, &candidates);
+    }
+
+    /// On AMX-FP16 hardware, assert the AMX branch is actually selected (not a
+    /// silent fallback) and agrees with the f32 reference within tolerance.
+    /// Reaching the end without a SIGILL is itself proof the tile path executed.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn amx_path_is_active_and_close() {
+        if !crate::simd::amx_fp16::amx_available() {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xA11);
+        let mut worst = 0f32;
+        for &dim in BATCH_DIMS.iter().filter(|&&d| d >= 32) {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let amx = unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates) };
+            for i in 0..16 {
+                let want = ref_dot_f32(&query, &cands[i]);
+                assert_close(amx[i], want, &format!("amx dim={dim} i={i}"));
+                let rel = (amx[i] - want).abs() / (want.abs() + 1e-6);
+                worst = worst.max(rel);
+            }
+        }
+        assert!(worst <= REL_TOL, "worst AMX relative error: {worst:.2e}");
+    }
+}

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -14,6 +14,7 @@
 
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 
+pub mod amx_fp16;
 pub mod dist_table;
 pub mod f32;
 pub mod f64;

--- a/rust/lance-linalg/src/simd/amx_fp16.c
+++ b/rust/lance-linalg/src/simd/amx_fp16.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+// AMX-FP16 batched f16 x f16 dot-product kernel for flat (unquantized) fp16
+// vector search.
+//
+// Computes 16 dot products of one IEEE-754 binary16 query vector against 16
+// binary16 candidate vectors in a single sequence of AMX tile passes, using
+// TDPFP16PS (fp16 x fp16 -> fp32 accumulate). It follows the same tile
+// roles/configuration as other AMX kernels and is ported in spirit from
+// FAISS PR facebookresearch/faiss#5235's AMX-BF16 kernel: fp16 and bf16 are
+// both 2-byte tile elements consumed by the same `_tile_dp*ps` shape, so only
+// the instruction (`_tile_dpbf16ps` -> `_tile_dpfp16ps`) and the element ->
+// float conversion (bf16 bit-shift -> real IEEE fp16 via F16C `_cvtsh_ss`)
+// differ.
+//
+// Tile layout (one TDPFP16PS pass covers K = 32 fp16 dims):
+//   C (tmm0): 16 rows x 1  fp32  -- the 16 results          colsb=4,  rows=16
+//   A (tmm1): 16 rows x 32 fp16  -- 16 candidate rows        colsb=64, rows=16
+//   B (tmm2): 16 rows x 2  fp16  -- query, VNNI-packed N=1   colsb=4,  rows=16
+//
+// The C/A/B tile configuration uses colsb = 4/64/4. With N = 1 the query
+// needs no VNNI repacking:
+// B.row[k].fp16[i] = query[k*2 + i] is just the contiguous query halfwords,
+// obtained by loading with a 4-byte row stride. The candidates form the A
+// tile's rows, gathered contiguously (16 rows of `stride` halfwords) by the
+// Rust caller so the tile load uses one fixed row stride.
+//
+// For dim > 32 we accumulate across floor(dim/32) tile passes into the same C
+// tile. The tail (dim % 32 dims) is computed in scalar fp32 afterwards. The
+// result is NOT bit-exact against a sequential scalar loop:
+// floating-point tile-order accumulation rounds differently. It matches an
+// f32-accumulated reference dot product to within fp16 precision, which is all
+// the fp16 distance path requires (see amx_fp16.rs / the Rust-side tests).
+//
+// SAFETY: executing any AMX tile instruction without first (a) confirming the
+// amx-tile + amx-fp16 CPUID bits and (b) obtaining XTILEDATA permission from
+// the kernel raises SIGILL. Both are the Rust caller's responsibility (see
+// `simd/amx_fp16.rs`); `lance_amx_fp16_request_perm` below performs (b).
+
+// Must precede all includes: exposes the glibc `syscall()` prototype from
+// <unistd.h>, which -std=c17 otherwise hides.
+#define _GNU_SOURCE
+
+#include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+// Ask the kernel to enable AMX tile data state for this process, via
+// arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA). Returns 0 on success,
+// non-zero otherwise. Requesting XTILEDATA (18) implicitly also grants
+// XTILECFG (17). Constants per Linux Documentation/arch/x86/xstate.rst.
+//
+// XTILEDATA is the single dynamically-enabled XSAVE state component backing the
+// physical TMM tile registers, shared by every AMX compute instruction
+// (TDPBUUD / TDPBF16PS / TDPFP16PS ...). The syscall is idempotent, so
+// requesting an already-granted permission is harmless.
+int lance_amx_fp16_request_perm(void) {
+#ifdef __linux__
+  const unsigned long ARCH_REQ_XCOMP_PERM = 0x1023;
+  const unsigned long XFEATURE_XTILEDATA = 18;
+  return (int)syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA);
+#else
+  return -1;
+#endif
+}
+
+// The 64-byte tile configuration image loaded by LDTILECFG (`_tile_loadconfig`).
+// Layout per Intel SDM: palette_id, start_row, 14 reserved bytes, then a u16
+// colsb[16] (bytes-per-row) array and a u8 rows[16] array. Only slots 0..2 are
+// meaningful here; the rest must be zero.
+typedef struct __attribute__((packed)) {
+  uint8_t palette_id;
+  uint8_t start_row;
+  uint8_t reserved[14];
+  uint16_t colsb[16];
+  uint8_t rows[16];
+} lance_amx_fp16_tilecfg;
+
+// out[i] = sum_{d in 0..dim} f32(query[d]) * f32(candidates[i*stride + d]).
+//
+// `query`, `candidates` -- IEEE-754 binary16 values as raw uint16_t bit
+//                          patterns (half::f16 has identical layout).
+// `dim`    -- vector dimension (query has `dim` valid halfwords).
+// `stride` -- per-row stride, in halfwords, of the gathered candidate buffer;
+//             must be >= dim so each of the 16 rows holds `dim` valid halfwords.
+// `out`    -- destination for 16 fp32 dot products.
+void lance_amx_dot_f16_batch_16(const uint16_t *query, const uint16_t *candidates,
+                                size_t dim, size_t stride, float *out) {
+  const size_t full = (dim / 32) * 32;  // dims covered by full 32-wide passes
+
+  if (full > 0) {
+    lance_amx_fp16_tilecfg cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.palette_id = 1;
+    cfg.rows[0] = 16;  cfg.colsb[0] = 4;   // tmm0 = C: 16 x 1 fp32
+    cfg.rows[1] = 16;  cfg.colsb[1] = 64;  // tmm1 = A: 16 x 32 fp16 (candidates)
+    cfg.rows[2] = 16;  cfg.colsb[2] = 4;   // tmm2 = B: 16 x 2 fp16 (query, N=1)
+    // Some GCC versions do not model _tile_loadconfig as reading the 64-byte
+    // cfg image and dead-store-eliminate the rows/colsb writes above, loading an
+    // all-zero (unconfigured) tile shape -> #UD on the first tile op (documented
+    // in FAISS #5235). Force the stores to be observable. Harmless under clang.
+    __asm__ volatile("" : : "m"(cfg) : "memory");
+    _tile_loadconfig(&cfg);
+
+    const size_t stride_bytes = stride * sizeof(uint16_t);
+    _tile_zero(0);
+    for (size_t k = 0; k < full; k += 32) {
+      _tile_loadd(1, candidates + k, stride_bytes);  // A: 16 cand rows, cols [k,k+32)
+      _tile_loadd(2, query + k, 4);                  // B: query[k..k+32], 16 rows x 2 fp16
+      _tile_dpfp16ps(0, 1, 2);                       // C += A * B  (fp16 x fp16 -> fp32)
+    }
+    _tile_stored(0, out, 4);  // 16 fp32, row stride 4 bytes
+    _tile_release();
+  } else {
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+  }
+
+  // Tail: the dims not covered by a full 32-wide tile, in scalar fp32. F16C
+  // `_cvtsh_ss` is an exact (lossless) binary16 -> binary32 widening.
+  const size_t tail = dim - full;
+  if (tail > 0) {
+    for (int i = 0; i < 16; i++) {
+      float acc = 0.0f;
+      const uint16_t *row = candidates + (size_t)i * stride;
+      for (size_t d = full; d < dim; d++) {
+        acc += _cvtsh_ss(row[d]) * _cvtsh_ss(query[d]);
+      }
+      out[i] += acc;
+    }
+  }
+}

--- a/rust/lance-linalg/src/simd/amx_fp16.c
+++ b/rust/lance-linalg/src/simd/amx_fp16.c
@@ -1,37 +1,59 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-// AMX-FP16 batched f16 x f16 dot-product kernel for flat (unquantized) fp16
-// vector search.
+// AMX-FP16 tile kernels, and the tile-configuration plumbing they share.
 //
-// Computes 16 dot products of one IEEE-754 binary16 query vector against 16
-// binary16 candidate vectors in a single sequence of AMX tile passes, using
-// TDPFP16PS (fp16 x fp16 -> fp32 accumulate). It follows the same tile
-// roles/configuration as other AMX kernels and is ported in spirit from
-// FAISS PR facebookresearch/faiss#5235's AMX-BF16 kernel: fp16 and bf16 are
-// both 2-byte tile elements consumed by the same `_tile_dp*ps` shape, so only
-// the instruction (`_tile_dpbf16ps` -> `_tile_dpfp16ps`) and the element ->
-// float conversion (bf16 bit-shift -> real IEEE fp16 via F16C `_cvtsh_ss`)
-// differ.
+// Every kernel here computes fp16 x fp16 dot products with TDPFP16PS
+// (fp16 x fp16 -> fp32 accumulate). The tile *shapes* differ per kernel and are
+// declared next to each one; the code that turns a shape into a loaded
+// LDTILECFG image is shared, because the one subtle step in it (the
+// dead-store barrier below) fails silently and only on some compilers, so it
+// must exist exactly once.
 //
-// Tile layout (one TDPFP16PS pass covers K = 32 fp16 dims):
-//   C (tmm0): 16 rows x 1  fp32  -- the 16 results          colsb=4,  rows=16
-//   A (tmm1): 16 rows x 32 fp16  -- 16 candidate rows        colsb=64, rows=16
-//   B (tmm2): 16 rows x 2  fp16  -- query, VNNI-packed N=1   colsb=4,  rows=16
+// One kernel:
+//   * `lance_amx_dot_f16_batch_16` -- one query against 16 candidates, for flat
+//     fp16 HNSW beam search. Ported in spirit from FAISS PR
+//     facebookresearch/faiss#5235's AMX-BF16 kernel: fp16 and bf16 are both
+//     2-byte tile elements consumed by the same `_tile_dp*ps` shape, so only the
+//     instruction (`_tile_dpbf16ps` -> `_tile_dpfp16ps`) and the element ->
+//     float conversion (bf16 bit-shift -> real IEEE fp16 via F16C `_cvtsh_ss`)
+//     differ. Its C tile is fed by three independent (A, B) tile pairs so three
+//     TDPFP16PS can be in flight at once; see the tile roles below.
+// ## Tile configuration is cached per thread, not reloaded per call
 //
-// The C/A/B tile configuration uses colsb = 4/64/4. With N = 1 the query
-// needs no VNNI repacking:
-// B.row[k].fp16[i] = query[k*2 + i] is just the contiguous query halfwords,
-// obtained by loading with a 4-byte row stride. The candidates form the A
-// tile's rows, gathered contiguously (16 rows of `stride` halfwords) by the
-// Rust caller so the tile load uses one fixed row stride.
+// The kernel's tile *shape* does not depend on its arguments: `dim` only
+// changes the loop trip count, so it has exactly one compile-time
+// constant shape (`SEARCH_TILES`). LDTILECFG, on the other hand,
+// is a full reconfiguration of the tile unit and costs on the order of a few
+// hundred cycles -- more than the ~64 cycles of useful tile work a dim-128
+// search call performs. Paying it per call would leave the search kernel
+// spending most of its time configuring.
 //
-// For dim > 32 we accumulate across floor(dim/32) tile passes into the same C
-// tile. The tail (dim % 32 dims) is computed in scalar fp32 afterwards. The
-// result is NOT bit-exact against a sequential scalar loop:
-// floating-point tile-order accumulation rounds differently. It matches an
-// f32-accumulated reference dot product to within fp16 precision, which is all
-// the fp16 distance path requires (see amx_fp16.rs / the Rust-side tests).
+// So the configuration is loaded lazily and remembered in `t_loaded_cfg`, a
+// per-thread record of which shape is currently live on this logical processor.
+// `lance_amx_tile_ensure` reloads only when the *other* kernel has since taken
+// over the tile unit, which is why a kernel must pass its own
+// `LANCE_AMX_CFG_*` kind: the kind is the cache key, and a kernel that shared
+// a key with a different shape would run against the wrong one.
+//
+// The corollary is that the kernel does not execute TILERELEASE on the way out;
+// doing so would throw away exactly the state being cached. Tile data therefore
+// stays live (non-INIT) on threads that have run a kernel, so their context
+// switches carry the 8 KB of XTILEDATA in XSAVE until something releases it.
+// That is the intended trade: the search path issues these calls back to back,
+// once per beam-search flush. `lance_amx_tile_release` is the explicit teardown
+// for a caller that wants the state back -- shutdown, or a test that wants the
+// next call to reconfigure.
+//
+// ## Thread safety
+//
+// LDTILECFG sets per-logical-processor state. The spec tables below are
+// `static const` and therefore shareable, and the 64-byte config *image* is
+// always built on the calling thread's stack -- never in shared storage -- so
+// two threads running different kernels concurrently cannot corrupt each
+// other's configuration. `t_loaded_cfg` is `__thread` for the same reason: it
+// mirrors state the kernel owns per thread, and XTILECFG travels with the
+// thread across context switches and migrations as part of its XSAVE area.
 //
 // SAFETY: executing any AMX tile instruction without first (a) confirming the
 // amx-tile + amx-fp16 CPUID bits and (b) obtaining XTILEDATA permission from
@@ -52,6 +74,10 @@
 #include <unistd.h>
 #endif
 
+// ---------------------------------------------------------------------------
+// XTILEDATA permission
+// ---------------------------------------------------------------------------
+
 // Ask the kernel to enable AMX tile data state for this process, via
 // arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA). Returns 0 on success,
 // non-zero otherwise. Requesting XTILEDATA (18) implicitly also grants
@@ -71,68 +97,452 @@ int lance_amx_fp16_request_perm(void) {
 #endif
 }
 
-// The 64-byte tile configuration image loaded by LDTILECFG (`_tile_loadconfig`).
-// Layout per Intel SDM: palette_id, start_row, 14 reserved bytes, then a u16
-// colsb[16] (bytes-per-row) array and a u8 rows[16] array. Only slots 0..2 are
-// meaningful here; the rest must be zero.
-typedef struct __attribute__((packed)) {
+// ---------------------------------------------------------------------------
+// Shared tile configuration
+// ---------------------------------------------------------------------------
+
+// Tile configuration kinds. One per distinct tile shape, and simultaneously the
+// cache key `lance_amx_tile_ensure` compares against `t_loaded_cfg` and the
+// selector `lance_amx_tilecfg_image` exposes to the Rust tests. Kept in sync
+// with the `AMX_CFG_*` constants in `simd/amx_fp16.rs`.
+#define LANCE_AMX_CFG_SEARCH 0
+
+// The 64-byte tile configuration image loaded by LDTILECFG
+// (`_tile_loadconfig`). Layout per Intel SDM: palette_id, start_row, 14
+// reserved bytes, then a u16 colsb[16] (bytes-per-row) array and a u8 rows[16]
+// array. Slots not named by a kernel's spec table stay zero.
+//
+// 64-byte aligned so the configuration load does not straddle a cache line.
+typedef struct __attribute__((packed, aligned(64))) {
   uint8_t palette_id;
   uint8_t start_row;
   uint8_t reserved[14];
   uint16_t colsb[16];
   uint8_t rows[16];
-} lance_amx_fp16_tilecfg;
+} lance_amx_tilecfg;
 
-// out[i] = sum_{d in 0..dim} f32(query[d]) * f32(candidates[i*stride + d]).
+// The image LDTILECFG reads is exactly 64 bytes; a layout change that altered
+// the size would silently feed the instruction garbage.
+_Static_assert(sizeof(lance_amx_tilecfg) == 64,
+               "LDTILECFG image must be exactly 64 bytes");
+
+// One tile register's shape. `tmm` is the register index (0..7), `colsb` its
+// bytes per row, `rows` its row count.
+typedef struct {
+  uint8_t tmm;
+  uint8_t rows;
+  uint16_t colsb;
+} lance_amx_tile_spec;
+
+#define LANCE_AMX_TILE_COUNT(specs) (sizeof(specs) / sizeof((specs)[0]))
+
+// Fill `cfg` with the LDTILECFG image described by `specs`, without loading it.
+// Split from the load so `lance_amx_tilecfg_image` can hand the Rust tests the
+// exact bytes a kernel would configure.
+static void lance_amx_tilecfg_build(lance_amx_tilecfg *cfg,
+                                    const lance_amx_tile_spec *specs,
+                                    size_t n) {
+  memset(cfg, 0, sizeof(*cfg));
+  cfg->palette_id = 1;
+  for (size_t i = 0; i < n; i++) {
+    cfg->rows[specs[i].tmm] = specs[i].rows;
+    cfg->colsb[specs[i].tmm] = specs[i].colsb;
+  }
+}
+
+// Which `LANCE_AMX_CFG_*` shape is live on this thread's tile unit; -1 for
+// "none loaded", the state every thread starts in and the one
+// `lance_amx_tile_release` restores.
+static __thread int t_loaded_cfg = -1;
+
+// Make `cfg_kind` the loaded tile configuration, doing nothing if it already
+// is. See the file header for why this is cached rather than done per call.
 //
-// `query`, `candidates` -- IEEE-754 binary16 values as raw uint16_t bit
-//                          patterns (half::f16 has identical layout).
-// `dim`    -- vector dimension (query has `dim` valid halfwords).
-// `stride` -- per-row stride, in halfwords, of the gathered candidate buffer;
-//             must be >= dim so each of the 16 rows holds `dim` valid halfwords.
-// `out`    -- destination for 16 fp32 dot products.
-void lance_amx_dot_f16_batch_16(const uint16_t *query, const uint16_t *candidates,
-                                size_t dim, size_t stride, float *out) {
-  const size_t full = (dim / 32) * 32;  // dims covered by full 32-wide passes
+// The barrier is not optional: some GCC versions do not model
+// _tile_loadconfig as reading the 64-byte cfg image, dead-store-eliminate the
+// rows/colsb writes, and load an all-zero (unconfigured) tile shape -> #UD on
+// the first tile op (documented in FAISS #5235). Keeping it here, in the one
+// function that owns the image, is why kernels do not build configurations
+// themselves. Harmless under clang.
+static inline void lance_amx_tile_ensure(int cfg_kind,
+                                         const lance_amx_tile_spec *specs,
+                                         size_t n) {
+  if (t_loaded_cfg == cfg_kind) return;
+  lance_amx_tilecfg cfg;
+  lance_amx_tilecfg_build(&cfg, specs, n);
+  __asm__ volatile("" : : "m"(cfg) : "memory");
+  _tile_loadconfig(&cfg);
+  t_loaded_cfg = cfg_kind;
+}
 
-  if (full > 0) {
-    lance_amx_fp16_tilecfg cfg;
-    memset(&cfg, 0, sizeof(cfg));
-    cfg.palette_id = 1;
-    cfg.rows[0] = 16;  cfg.colsb[0] = 4;   // tmm0 = C: 16 x 1 fp32
-    cfg.rows[1] = 16;  cfg.colsb[1] = 64;  // tmm1 = A: 16 x 32 fp16 (candidates)
-    cfg.rows[2] = 16;  cfg.colsb[2] = 4;   // tmm2 = B: 16 x 2 fp16 (query, N=1)
-    // Some GCC versions do not model _tile_loadconfig as reading the 64-byte
-    // cfg image and dead-store-eliminate the rows/colsb writes above, loading an
-    // all-zero (unconfigured) tile shape -> #UD on the first tile op (documented
-    // in FAISS #5235). Force the stores to be observable. Harmless under clang.
-    __asm__ volatile("" : : "m"(cfg) : "memory");
-    _tile_loadconfig(&cfg);
+// Release this thread's tile state and forget the cached configuration, so the
+// next kernel call reconfigures from scratch.
+//
+// The kernels deliberately never do this themselves. It exists for callers that
+// need the tile unit back in its INIT state -- a thread parking for a long time
+// (tile data is 8 KB of XSAVE state per context switch while it stays live), or
+// a test asserting that reconfiguration happens.
+void lance_amx_tile_release(void) {
+  _tile_release();
+  t_loaded_cfg = -1;
+}
 
-    const size_t stride_bytes = stride * sizeof(uint16_t);
-    _tile_zero(0);
-    for (size_t k = 0; k < full; k += 32) {
-      _tile_loadd(1, candidates + k, stride_bytes);  // A: 16 cand rows, cols [k,k+32)
-      _tile_loadd(2, query + k, 4);                  // B: query[k..k+32], 16 rows x 2 fp16
-      _tile_dpfp16ps(0, 1, 2);                       // C += A * B  (fp16 x fp16 -> fp32)
+// ---------------------------------------------------------------------------
+// Kernel: batch-16 search (one query x 16 candidates)
+// ---------------------------------------------------------------------------
+
+// Tile roles. These are immediate operands of the tile intrinsics, so they must
+// be compile-time constants; `#define` rather than `enum` avoids relying on how
+// strictly a compiler treats enum constants as immediates.
+//
+// One TDPFP16PS pass covers K = 32 fp16 dims. With N = 1 the query needs no
+// VNNI repacking: B.row[k].fp16[i] = query[k*2 + i] is just the contiguous
+// query halfwords, obtained by loading with a 4-byte row stride. The candidates
+// form the A tile's rows; they live at unrelated addresses, so this kernel
+// stages them a few k-blocks at a time into a fixed-stride scratch buffer that
+// the tile load can read (see `lance_amx_stage_rows`).
+//
+// Three (A, B) pairs, not one. A single pair would make the loop strictly
+// serial -- every TDPFP16PS waiting on the two loads that just overwrote its
+// own operands -- so the tile unit would idle through each load's latency.
+// Three independent pairs let three k-blocks' loads issue before the first
+// TDPFP16PS needs its result, which is enough to keep the dp ops back to back.
+// Seven tiles is what that costs; tmm7 is left unconfigured.
+#define SEARCH_TMM_C 0   // 16 results x 1 fp32
+#define SEARCH_TMM_A0 1  // 16 candidate rows x 32 fp16, k-block 3t
+#define SEARCH_TMM_B0 2  // query, VNNI-packed at N = 1, k-block 3t
+#define SEARCH_TMM_A1 3  // k-block 3t + 1
+#define SEARCH_TMM_B1 4
+#define SEARCH_TMM_A2 5  // k-block 3t + 2
+#define SEARCH_TMM_B2 6
+
+static const lance_amx_tile_spec SEARCH_TILES[] = {
+    {SEARCH_TMM_C, 16, 4},   {SEARCH_TMM_A0, 16, 64}, {SEARCH_TMM_B0, 16, 4},
+    {SEARCH_TMM_A1, 16, 64}, {SEARCH_TMM_B1, 16, 4},  {SEARCH_TMM_A2, 16, 64},
+    {SEARCH_TMM_B2, 16, 4},
+};
+
+// Halfwords of one k-block: 32 fp16 dims, the K a single TDPFP16PS covers.
+#define SEARCH_K_BLOCK 32
+
+// Bytes one tile row spans in one k-block: 32 fp16, the A tile's full row width.
+#define SEARCH_ROW_BYTES (SEARCH_K_BLOCK * (int)sizeof(uint16_t))
+
+// K-blocks gathered per staging step. Three, so one staged buffer feeds exactly
+// the three (A, B) pairs the main loop issues together.
+#define SEARCH_STAGE_BLOCKS 3
+#define SEARCH_STAGE_ROW_BYTES (SEARCH_STAGE_BLOCKS * SEARCH_ROW_BYTES)
+
+// One staging buffer: the 16 rows a tile load always reads, whatever the batch
+// actually holds.
+#define SEARCH_STAGE_BYTES (16 * SEARCH_STAGE_ROW_BYTES)
+
+// The furthest-reaching tile load is A2: 64 bytes at offset 128 of the last of
+// 16 rows, so the last byte it touches is at 128 + 15*192 + 63 and the span it
+// covers is exactly SEARCH_STAGE_BYTES. Asserted because an overrun here would
+// be a stack smash with no other symptom.
+//
+// What this actually pins is that the three A tiles tile one staging row with
+// no gap and no overlap, i.e. SEARCH_STAGE_BLOCKS == 3; it does not check
+// SEARCH_K_BLOCK, nor the 64-byte A-tile width, which is hardcoded separately
+// in SEARCH_TILES.
+_Static_assert(2 * SEARCH_ROW_BYTES + 15 * SEARCH_STAGE_ROW_BYTES +
+                       SEARCH_ROW_BYTES ==
+                   SEARCH_STAGE_BYTES,
+               "the three A tiles must tile a staging row exactly");
+
+// Gather `row_bytes` starting at k-block `kb` out of each of the first `count`
+// candidates into `dst`, one candidate per row.
+//
+// Rows are SEARCH_STAGE_ROW_BYTES apart even when `row_bytes` is smaller: an A
+// tile only reads 64 bytes at its own offset within a row, so a wider stride
+// simply leaves the trailing bytes unread. Keeping the stride fixed across
+// every staging step is what lets rows [count, 16) be zeroed once per call --
+// each step then rewrites the same rows at the same addresses.
+//
+// The k-blocks a row covers are adjacent inside the candidate vector, so each
+// candidate costs exactly one straight-line copy no matter how many k-blocks the
+// step covers. `row_bytes` should stay a compile-time constant at every call
+// site: a constant size expands to inline wide moves, while a variable one
+// becomes a libc `memcpy` call that `-funroll-loops` then multiplies (five PLT
+// calls for the one remainder loop, measured under clang-16).
+//
+// Zeroing the padding rows is deliberately *not* routed through here: it writes
+// rows [count, 16) rather than [0, count), and when the rows are full width it
+// is one contiguous `memset` rather than a per-row loop.
+static inline void lance_amx_stage_rows(uint8_t *dst,
+                                        const uint16_t *const *candidates,
+                                        size_t count, size_t kb,
+                                        size_t row_bytes) {
+  for (size_t n = 0; n < count; n++) {
+    memcpy(dst + n * SEARCH_STAGE_ROW_BYTES,
+           candidates[n] + kb * SEARCH_K_BLOCK, row_bytes);
+  }
+}
+
+// out[i] = sum_{d in 0..dim} f32(query[d]) * f32(candidates[i][d]), i < count.
+//
+// `query`      -- IEEE-754 binary16 values as raw uint16_t bit patterns
+//                 (half::f16 has identical layout); `dim` valid halfwords.
+// `candidates` -- pointers to `dim` halfwords each; only the first `count` are
+//                 read. The vectors live wherever the storage put them; this
+//                 kernel owns the gather.
+// `count`      -- candidates carrying a real neighbor. **Precondition:
+//                 1 <= count <= 16**, rejected at the Rust boundary
+//                 (`dot_f16_batch_16`) rather than clamped here; a larger value
+//                 would run the gather off the end of a staging buffer.
+// `dim`        -- vector dimension.
+// `out`        -- destination for 16 fp32 dot products. Lanes [count, 16) are
+//                 written as 0, not left untouched.
+//
+// ## Why `count` rather than always 16
+//
+// The caller pads a partial beam-search flush up to 16 by repeating candidate 0
+// (see `flush_batch16!`), and partial flushes are the common case: in
+// steady-state beam search most of a node's neighbors are already visited.
+// Staging all 16 rows would copy that one vector 16 times -- 32 KB of stores at
+// dim 1024 to produce one useful distance. Only rows [0, count) are gathered
+// instead, so the copying scales with the neighbors actually found while the
+// tile work stays one fixed-cost pass. The padded rows still have to exist,
+// since a tile load reads 16 rows unconditionally; they are zeroed once per
+// call, and an all-zero A row yields a zero dot product.
+//
+// ## Why the gather is here and not in the caller
+//
+// A tile load reads 16 rows at one fixed stride from one base pointer, and the
+// 16 candidates of a beam-search flush are 16 unrelated addresses, so their
+// bytes have to be brought together somewhere. Doing it in the caller means
+// copying 16 * dim * 2 bytes -- 24 KB at dim 768, 32 KB at dim 1024 -- and every
+// one of those bytes has to land before the first TDPFP16PS can issue. Against a
+// 48 KB L1D that buffer alone is half the cache, and the copy is pure exposed
+// latency: nothing overlaps it.
+//
+// Staging inside the k-block loop instead keeps the working buffer at 3 KB and
+// lets the copies for one triple run underneath the tile ops of the previous
+// one. The bytes moved are identical; what changes is that they move while the
+// tile unit is busy rather than before it starts. (Measured on the caller-side
+// version at dim 1024: __memmove 3.7M cycles/query against 0.5M for the scalar
+// kernel, IPC 1.70 -> 1.17, and a critical path 18% longer even though total CPU
+// work per query was 6.5% lower. The same structure is what
+// epeshared/hnswlib-amx uses for its AMX-BF16 kernel.)
+//
+// For dim > 32 we accumulate across floor(dim/32) tile passes into the same C
+// tile, three k-blocks at a time. The tail (dim % 32 dims) is computed in
+// scalar fp32 afterwards. The result is NOT bit-exact against a sequential
+// scalar loop: floating-point tile-order accumulation rounds differently. It
+// matches an f32-accumulated reference dot product to within fp16 precision,
+// which is all the fp16 distance path requires (see amx_fp16.rs / the Rust-side
+// tests).
+void lance_amx_dot_f16_batch_16(const uint16_t *query,
+                                const uint16_t *const *candidates, size_t count,
+                                size_t dim, float *out) {
+  const size_t blocks = dim / SEARCH_K_BLOCK;   // whole 32-wide tile passes
+  const size_t full = blocks * SEARCH_K_BLOCK;  // dims they cover
+
+  if (blocks > 0) {
+    lance_amx_tile_ensure(LANCE_AMX_CFG_SEARCH, SEARCH_TILES,
+                          LANCE_AMX_TILE_COUNT(SEARCH_TILES));
+
+    // Two staging buffers, 16 rows x 192 bytes each. Double buffered so a
+    // triple's gather can be issued a whole triple before the tile loads that
+    // read it: a tile load cannot take its data from the store buffer, so the
+    // gather's stores have to reach L1 first, and with one buffer there is
+    // nothing to overlap that drain with. 3 KB each, so both sit in L1D
+    // alongside the candidate rows streaming through it.
+    __attribute__((aligned(64))) uint8_t stage[2][SEARCH_STAGE_BYTES];
+
+    const size_t triples = blocks / SEARCH_STAGE_BLOCKS;
+    const size_t rem = blocks % SEARCH_STAGE_BLOCKS;
+
+    // Rows [count, 16) are padding that a tile load reads but no candidate
+    // fills, so they are zeroed here and an all-zero A row then contributes a
+    // zero dot product. Once per call is enough: every staging step below
+    // writes rows [0, count) only, always at the same row stride, so nothing
+    // disturbs the padding again.
+    //
+    // Only bytes some tile load actually reads are zeroed. This cost is the one
+    // part of the call that does not shrink with `dim`, so zeroing the full
+    // 2 x 15 x 192 bytes unconditionally would dominate short vectors:
+    //   * `stage[1]` is tile-loaded only if the main loop reaches a second
+    //     iteration, or the remainder lands on it (an odd `triples`). A single
+    //     triple with no remainder never reads it at all.
+    //   * A padding row is read to its full width only by the main loop. With
+    //     `triples == 0` the remainder is the only reader, and it loads A0 --
+    //     plus A1 when `rem == 2` -- so only the first `rem` k-block slots of
+    //     each row are ever seen.
+    if (count < 16) {
+      const size_t pad_off = count * SEARCH_STAGE_ROW_BYTES;
+      if (triples > 0) {
+        // Full-width padding rows are contiguous: one memset covers them all.
+        memset(stage[0] + pad_off, 0, SEARCH_STAGE_BYTES - pad_off);
+        if (triples > 1 || rem > 0) {
+          memset(stage[1] + pad_off, 0, SEARCH_STAGE_BYTES - pad_off);
+        }
+      } else {
+        for (size_t n = count; n < 16; n++) {
+          memset(stage[0] + n * SEARCH_STAGE_ROW_BYTES, 0,
+                 rem * (size_t)SEARCH_ROW_BYTES);
+        }
+      }
     }
-    _tile_stored(0, out, 4);  // 16 fp32, row stride 4 bytes
-    _tile_release();
+
+    _tile_zero(SEARCH_TMM_C);
+
+    // Take ownership of the destination line now (PREFETCHW), so the RFO
+    // overlaps the tile work instead of stalling TILESTORED at the end. The
+    // store is 64 bytes issued as one instruction, and waiting on the RFO there
+    // backs up the store queue: measured on the FAISS #5235 BF16 kernel as
+    // SQ_Full 28.9% of cycles, with XQ.FULL_CYCLES 56x an AVX-512 baseline.
+    _mm_prefetch((const char *)out, _MM_HINT_ET0);
+
+    // Prologue of the software pipeline below, and the one gather in the call
+    // with no tile work ahead of it to hide behind.
+    if (triples > 0) {
+      lance_amx_stage_rows(stage[0], candidates, count, 0,
+                           SEARCH_STAGE_ROW_BYTES);
+
+      // The in-loop prefetch below runs two triples ahead, so k-blocks
+      // [3, 6) -- read by the very first iteration's gather -- would otherwise
+      // be touched by nothing. Guarded on the address staying inside the
+      // vectors, which also covers a remainder that follows a single triple.
+      if (SEARCH_STAGE_BLOCKS < blocks) {
+        for (size_t n = 0; n < count; n++) {
+          _mm_prefetch(
+              (const char *)(candidates[n] +
+                             SEARCH_STAGE_BLOCKS * (size_t)SEARCH_K_BLOCK),
+              _MM_HINT_T0);
+        }
+      }
+    }
+
+    size_t kb = 0;
+    for (size_t t = 0; t < triples; t++, kb += SEARCH_STAGE_BLOCKS) {
+      const uint8_t *st = stage[t & 1];
+
+      // Gather the *next* triple before issuing this one's tile ops, into the
+      // buffer the previous iteration's tile loads have already consumed. Those
+      // stores then have a full triple of tile work to commit to L1 under,
+      // instead of the tile load immediately below them waiting on the drain.
+      if (t + 1 < triples) {
+        // Open the candidate streams the iteration after this one will copy
+        // from, so that copy finds them resident. With the rows at 16 unrelated
+        // addresses there is no single stride for a hardware prefetcher to
+        // latch onto; what it can do is run each candidate forward once that
+        // candidate has been touched, and these touches are what start it.
+        // (Measured on the FAISS #5235 BF16 kernel without any prefetch: L1D MPI
+        // 2.6x and DTLB load MPI 14.6x an AVX-512 baseline.) Guarded so the last
+        // iterations stay inside the vectors.
+        if (kb + 2 * SEARCH_STAGE_BLOCKS < blocks) {
+          const size_t ahead = (kb + 2 * SEARCH_STAGE_BLOCKS) * SEARCH_K_BLOCK;
+          for (size_t n = 0; n < count; n++) {
+            _mm_prefetch((const char *)(candidates[n] + ahead), _MM_HINT_T0);
+          }
+        }
+        lance_amx_stage_rows(stage[(t + 1) & 1], candidates, count,
+                             kb + SEARCH_STAGE_BLOCKS, SEARCH_STAGE_ROW_BYTES);
+      }
+
+      // All six loads first: they are independent, so the three dp ops below
+      // issue back to back rather than each waiting on its own operands.
+      _tile_loadd(SEARCH_TMM_A0, st + 0 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B0, query + kb * SEARCH_K_BLOCK, 4);
+      _tile_loadd(SEARCH_TMM_A1, st + 1 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B1, query + (kb + 1) * SEARCH_K_BLOCK, 4);
+      _tile_loadd(SEARCH_TMM_A2, st + 2 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B2, query + (kb + 2) * SEARCH_K_BLOCK, 4);
+
+      // C += A * B  (fp16 x fp16 -> fp32)
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A0, SEARCH_TMM_B0);
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A1, SEARCH_TMM_B1);
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A2, SEARCH_TMM_B2);
+    }
+
+    // The 1 or 2 k-blocks left over when `blocks` is not a multiple of three.
+    // `stage[triples & 1]` is the buffer the loop above neither wrote nor read
+    // last, so filling it now cannot collide with a tile load still in flight.
+    if (rem > 0) {
+      uint8_t *st = stage[triples & 1];
+      // Two constant-size cases rather than one `rem * 64` copy, because a
+      // variable-length memcpy here does not stay one instruction: clang-16
+      // emits a libc call and `-funroll-loops` then multiplies it, measured as
+      // five `memcpy@PLT` calls for this one loop (the pre-`count` kernel,
+      // whose loop ran to 16, paid sixteen). The main loop's gather is
+      // unaffected either way -- it keeps its inline wide moves -- so this is
+      // about the remainder alone. The branch costs one predictable compare.
+      if (rem == 2) {
+        lance_amx_stage_rows(st, candidates, count, kb, 2 * SEARCH_ROW_BYTES);
+      } else {
+        lance_amx_stage_rows(st, candidates, count, kb, SEARCH_ROW_BYTES);
+      }
+
+      // Loaded at the main loop's row stride even though only `rem` k-blocks are
+      // live: A0 and A1 read their own 64 bytes at offsets 0 and 64, which is
+      // what the staging step just filled, and the padding rows are already zero
+      // at exactly this stride.
+      _tile_loadd(SEARCH_TMM_A0, st, SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B0, query + kb * SEARCH_K_BLOCK, 4);
+      if (rem == 2) {
+        _tile_loadd(SEARCH_TMM_A1, st + SEARCH_ROW_BYTES,
+                    SEARCH_STAGE_ROW_BYTES);
+        _tile_loadd(SEARCH_TMM_B1, query + (kb + 1) * SEARCH_K_BLOCK, 4);
+      }
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A0, SEARCH_TMM_B0);
+      if (rem == 2) {
+        _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A1, SEARCH_TMM_B1);
+      }
+    }
+
+    _tile_stored(SEARCH_TMM_C, out, 4);  // 16 fp32, row stride 4 bytes
   } else {
     for (int i = 0; i < 16; i++) out[i] = 0.0f;
   }
 
   // Tail: the dims not covered by a full 32-wide tile, in scalar fp32. F16C
-  // `_cvtsh_ss` is an exact (lossless) binary16 -> binary32 widening.
+  // `_cvtsh_ss` is an exact (lossless) binary16 -> binary32 widening. Lanes at
+  // or past `count` are skipped rather than accumulated onto: they are already
+  // 0 (zeroed staging rows, or the no-tile-pass branch above) and must stay so.
   const size_t tail = dim - full;
   if (tail > 0) {
-    for (int i = 0; i < 16; i++) {
+    for (size_t i = 0; i < count; i++) {
       float acc = 0.0f;
-      const uint16_t *row = candidates + (size_t)i * stride;
+      const uint16_t *row = candidates[i];
       for (size_t d = full; d < dim; d++) {
         acc += _cvtsh_ss(row[d]) * _cvtsh_ss(query[d]);
       }
       out[i] += acc;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration introspection
+// ---------------------------------------------------------------------------
+
+// Write the 64-byte LDTILECFG image for `cfg_kind` (a `LANCE_AMX_CFG_*`
+// constant) into `out`, without loading it. Returns 0 on success, -1 for an
+// unknown `cfg_kind`.
+//
+// Exposed so the Rust tests can pin each kernel's tile shape byte for byte. A
+// wrong shape does not fail cleanly — it is a #UD or silently wrong results —
+// so the shape is asserted directly rather than inferred from kernel output.
+int lance_amx_tilecfg_image(int cfg_kind, uint8_t *out) {
+  const lance_amx_tile_spec *specs;
+  size_t n;
+
+  switch (cfg_kind) {
+    case LANCE_AMX_CFG_SEARCH:
+      specs = SEARCH_TILES;
+      n = LANCE_AMX_TILE_COUNT(SEARCH_TILES);
+      break;
+    default:
+      return -1;
+  }
+
+  lance_amx_tilecfg cfg;
+  lance_amx_tilecfg_build(&cfg, specs, n);
+  memcpy(out, &cfg, sizeof(cfg));
+  return 0;
 }

--- a/rust/lance-linalg/src/simd/amx_fp16.rs
+++ b/rust/lance-linalg/src/simd/amx_fp16.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! AMX-FP16 accelerated batched f16 x f16 dot product for flat fp16 search.
+//!
+//! The tile math lives in `amx_fp16.c` (compiled by `build.rs` with a compiler
+//! new enough for `-mamx-fp16`, which sets `kernel_support = "amx_fp16"`). This
+//! module holds the FFI declarations and the runtime safety gate. The safe
+//! public entry point is [`crate::distance::dot_f16::dot_f16_batch_16`].
+//!
+//! ## Safety gate
+//!
+//! A set CPUID bit is not sufficient to run AMX tile instructions on Linux:
+//! the OS must first grant the extended (XTILEDATA)
+//! state via `arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA)`; skipping
+//! that SIGILLs the first tile instruction. `amx_available` requires, and
+//! caches process-wide, all of:
+//!   1. `target_arch = "x86_64"` and `target_os = "linux"` (compile-time cfg),
+//!   2. the amx-tile CPUID bit (leaf 7, sub-leaf 0, EDX bit 24) **and** the
+//!      amx-fp16 CPUID bit (leaf 7, sub-leaf 1, EAX bit 21),
+//!   3. a successful one-time `arch_prctl` permission request.
+//!
+//! On any failure the caller falls back to the existing AVX-512-FP16 / scalar
+//! `f16::dot` path, so results are unchanged (both accumulate in f32; only the
+//! summation order — hence fp16-level rounding — differs).
+//!
+//! ## XTILEDATA is a shared AMX state permission
+//!
+//! XTILEDATA (component 18) is the single dynamically-enabled XSAVE state
+//! backing the physical TMM tile registers; it is requested per-*state*, not
+//! per-*instruction*, so one grant covers every AMX compute instruction — see
+//! Linux `Documentation/arch/x86/xstate.rst` ("Dynamically Enabled XSAVE
+//! Features", AMX example) and Intel SDM Vol.1 §13.3. The syscall is
+//! idempotent, so requesting an already-granted permission again is harmless.
+
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+use half::f16;
+
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+unsafe extern "C" {
+    /// arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA); 0 on success.
+    fn lance_amx_fp16_request_perm() -> i32;
+
+    /// out[i] = sum_d f32(query[d]) * f32(candidates[i*stride + d]), i in 0..16.
+    /// `query` / `candidates` are IEEE binary16 bit patterns; `stride >= dim`
+    /// (in halfwords); `out` holds 16 f32. See `amx_fp16.c`.
+    fn lance_amx_dot_f16_batch_16(
+        query: *const u16,
+        candidates: *const u16,
+        dim: usize,
+        stride: usize,
+        out: *mut f32,
+    );
+}
+
+/// True iff AMX-FP16 tile instructions can be executed safely in this process.
+/// Evaluated once and cached; the `arch_prctl` permission request (a syscall)
+/// happens at most once, process-wide.
+///
+/// Setting the `LANCE_DISABLE_AMX` environment variable forces this to `false`
+/// so the scalar/AVX-512 fallback can be exercised on AMX hardware.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn amx_available() -> bool {
+    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        if std::env::var_os("LANCE_DISABLE_AMX").is_some() {
+            return false;
+        }
+        if !detect_amx_fp16() {
+            return false;
+        }
+        // Request XTILEDATA permission; without a 0 return, any tile instruction
+        // would SIGILL, so treat anything else as unavailable.
+        unsafe { lance_amx_fp16_request_perm() == 0 }
+    })
+}
+
+/// AMX-TILE = CPUID leaf 7, sub-leaf 0, EDX bit 24. AMX-FP16 = CPUID leaf 7,
+/// sub-leaf 1, EAX bit 21. Both required.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+fn detect_amx_fp16() -> bool {
+    use std::arch::x86_64::__cpuid_count;
+    // `__cpuid_count` is safe on nightly but `unsafe` on stable; allow both.
+    #[allow(unused_unsafe)]
+    let leaf7_0 = unsafe { __cpuid_count(7, 0) };
+    let amx_tile = (leaf7_0.edx & (1 << 24)) != 0;
+    #[allow(unused_unsafe)]
+    let leaf7_1 = unsafe { __cpuid_count(7, 1) };
+    let amx_fp16 = (leaf7_1.eax & (1 << 21)) != 0;
+    amx_tile && amx_fp16
+}
+
+/// Batched AMX-FP16 dot product. Gathers the 16 (non-contiguous) candidate
+/// slices into a contiguous `16 x dim` scratch buffer so the tile load can use
+/// a single fixed row stride, then runs the tile kernel. Returns the 16 raw
+/// dot products (`Σ query·candidate`, no `1.0 -` distance wrapping).
+///
+/// The gather scratch is a reused thread-local buffer, not a fresh allocation
+/// per call: this runs on the hot search path (once per 16-neighbor beam-search
+/// flush), where a per-batch heap allocation (48 KB at dim 1536) would churn the
+/// allocator and erode the tile speedup, especially at high query concurrency.
+///
+/// # Safety
+/// `amx_available` must have returned `true`. Every candidate slice must have
+/// length `query.len()`.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) unsafe fn dot_f16_batch_16_amx(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
+    use std::cell::RefCell;
+    thread_local! {
+        static SCRATCH: RefCell<Vec<f16>> = const { RefCell::new(Vec::new()) };
+    }
+    let dim = query.len();
+    SCRATCH.with(|cell| {
+        let mut gathered = cell.borrow_mut();
+        gathered.clear();
+        gathered.reserve(16 * dim);
+        for (i, cand) in candidates.iter().enumerate() {
+            debug_assert_eq!(
+                cand.len(),
+                dim,
+                "candidate {i} length must equal query length"
+            );
+            gathered.extend_from_slice(cand);
+        }
+        let mut out = [0f32; 16];
+        // half::f16 is #[repr(transparent)] over u16, so the pointer casts below
+        // reinterpret the identical IEEE binary16 bit patterns the kernel expects.
+        unsafe {
+            lance_amx_dot_f16_batch_16(
+                query.as_ptr() as *const u16,
+                gathered.as_ptr() as *const u16,
+                dim,
+                dim, // stride: rows packed tightly at `dim` halfwords
+                out.as_mut_ptr(),
+            );
+        }
+        out
+    })
+}

--- a/rust/lance-linalg/src/simd/amx_fp16.rs
+++ b/rust/lance-linalg/src/simd/amx_fp16.rs
@@ -1,12 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! AMX-FP16 accelerated batched f16 x f16 dot product for flat fp16 search.
+//! AMX-FP16 accelerated f16 x f16 dot products.
+//!
+//! One shape: `dot_f16_batch_16_amx`, one query against 16 candidates, for flat
+//! fp16 search. It is named in a plain code span rather than an intra-doc link:
+//! it is `kernel_support = "amx_fp16"`-gated, so a link from these unconditional
+//! module docs is unresolved — and hence a rustdoc error under `-D warnings` —
+//! on any build without the `amx` feature.
 //!
 //! The tile math lives in `amx_fp16.c` (compiled by `build.rs` with a compiler
 //! new enough for `-mamx-fp16`, which sets `kernel_support = "amx_fp16"`). This
-//! module holds the FFI declarations and the runtime safety gate. The safe
-//! public entry point is [`crate::distance::dot_f16::dot_f16_batch_16`].
+//! module holds the FFI declaration and the runtime safety gate. Everything
+//! here is crate-internal; the safe public entry point is
+//! [`crate::distance::dot_f16::dot_f16_batch_16`], and the availability gate is
+//! [`crate::distance::dot_f16::amx_fp16_available`].
 //!
 //! ## Safety gate
 //!
@@ -49,16 +57,53 @@ unsafe extern "C" {
     /// arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA); 0 on success.
     fn lance_amx_fp16_request_perm() -> i32;
 
-    /// out[i] = sum_d f32(query[d]) * f32(candidates[i*stride + d]), i in 0..16.
-    /// `query` / `candidates` are IEEE binary16 bit patterns; `stride >= dim`
-    /// (in halfwords); `out` holds 16 f32. See `amx_fp16.c`.
+    /// out[i] = sum_d f32(query[d]) * f32(candidates[i][d]), i in 0..count;
+    /// out[count..16] = 0. `query` is `dim` IEEE binary16 bit patterns;
+    /// `candidates` is 16 pointers to `dim` of them each, of which only the
+    /// first `count` (1..=16) are read; `out` holds 16 f32. The kernel gathers
+    /// the rows itself, k-block by k-block. See `amx_fp16.c`.
     fn lance_amx_dot_f16_batch_16(
         query: *const u16,
-        candidates: *const u16,
+        candidates: *const *const u16,
+        count: usize,
         dim: usize,
-        stride: usize,
         out: *mut f32,
     );
+
+    /// Writes the 64-byte LDTILECFG image for `cfg_kind` into `out` without
+    /// loading it; 0 on success, -1 for an unknown kind. See `amx_fp16.c`.
+    #[cfg(test)]
+    fn lance_amx_tilecfg_image(cfg_kind: i32, out: *mut u8) -> i32;
+}
+
+/// Config kind for [`tilecfg_image`]: the batch-16 search kernel's tile shape.
+/// Must match `LANCE_AMX_CFG_SEARCH` in `amx_fp16.c`.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) const AMX_CFG_SEARCH: i32 = 0;
+
+/// The 64-byte LDTILECFG image a kernel would configure, without loading it.
+/// `None` if `cfg_kind` is not one of the `AMX_CFG_*` constants.
+///
+/// Exists for the tests: a wrong tile shape never surfaces as a clean error —
+/// it is a #UD or silently wrong results — so the shape is pinned directly
+/// rather than inferred from kernel output.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn tilecfg_image(cfg_kind: i32) -> Option<[u8; 64]> {
+    let mut image = [0u8; 64];
+    // SAFETY: the C side writes exactly `sizeof(lance_amx_tilecfg)` bytes, which
+    // a `_Static_assert` there pins to 64 — the length of `image`.
+    let rc = unsafe { lance_amx_tilecfg_image(cfg_kind, image.as_mut_ptr()) };
+    (rc == 0).then_some(image)
 }
 
 /// True iff AMX-FP16 tile instructions can be executed safely in this process.
@@ -106,54 +151,61 @@ fn detect_amx_fp16() -> bool {
     amx_tile && amx_fp16
 }
 
-/// Batched AMX-FP16 dot product. Gathers the 16 (non-contiguous) candidate
-/// slices into a contiguous `16 x dim` scratch buffer so the tile load can use
-/// a single fixed row stride, then runs the tile kernel. Returns the 16 raw
-/// dot products (`Σ query·candidate`, no `1.0 -` distance wrapping).
+/// Batched AMX-FP16 dot product: one query against the first `len` of 16
+/// candidates. Returns the 16 raw dot products (`Σ query·candidate`, no `1.0 -`
+/// distance wrapping); lanes `len..16` are 0.
 ///
-/// The gather scratch is a reused thread-local buffer, not a fresh allocation
-/// per call: this runs on the hot search path (once per 16-neighbor beam-search
-/// flush), where a per-batch heap allocation (48 KB at dim 1536) would churn the
-/// allocator and erode the tile speedup, especially at high query concurrency.
+/// Hands the kernel 16 pointers rather than a packed `16 x dim` buffer. The
+/// candidates still have to be brought together for a tile load, but the kernel
+/// does it one k-block at a time into 3 KB of stack, which overlaps the copies
+/// with the tile ops; packing all `16 * dim * 2` bytes here first could not
+/// overlap with anything, and at dim 1024 that is 32 KB against a 48 KB L1D.
+/// See the kernel comment in `amx_fp16.c` for the measurements behind this.
+///
+/// `len` is what keeps a partial batch cheap: the tile pass is a fixed cost for
+/// 16 lanes either way, but only `len` rows are gathered.
 ///
 /// # Safety
-/// `amx_available` must have returned `true`. Every candidate slice must have
-/// length `query.len()`.
+/// `amx_available` must have returned `true`. `len` must be in `1..=16` — the
+/// kernel does not clamp it, and a larger value walks its staging buffer off the
+/// end; [`crate::distance::dot_f16::dot_f16_batch_16`] is where that is
+/// rejected. Every candidate slice must have length `query.len()`, and must
+/// outlive the call.
 #[cfg(all(
     kernel_support = "amx_fp16",
     target_arch = "x86_64",
     target_os = "linux"
 ))]
-pub(crate) unsafe fn dot_f16_batch_16_amx(query: &[f16], candidates: &[&[f16]; 16]) -> [f32; 16] {
-    use std::cell::RefCell;
-    thread_local! {
-        static SCRATCH: RefCell<Vec<f16>> = const { RefCell::new(Vec::new()) };
-    }
+pub(crate) unsafe fn dot_f16_batch_16_amx(
+    query: &[f16],
+    candidates: &[&[f16]; 16],
+    len: usize,
+) -> [f32; 16] {
+    debug_assert!((1..=16).contains(&len), "len ({len}) must be in 1..=16");
     let dim = query.len();
-    SCRATCH.with(|cell| {
-        let mut gathered = cell.borrow_mut();
-        gathered.clear();
-        gathered.reserve(16 * dim);
-        for (i, cand) in candidates.iter().enumerate() {
-            debug_assert_eq!(
-                cand.len(),
-                dim,
-                "candidate {i} length must equal query length"
-            );
-            gathered.extend_from_slice(cand);
-        }
-        let mut out = [0f32; 16];
-        // half::f16 is #[repr(transparent)] over u16, so the pointer casts below
-        // reinterpret the identical IEEE binary16 bit patterns the kernel expects.
-        unsafe {
-            lance_amx_dot_f16_batch_16(
-                query.as_ptr() as *const u16,
-                gathered.as_ptr() as *const u16,
-                dim,
-                dim, // stride: rows packed tightly at `dim` halfwords
-                out.as_mut_ptr(),
-            );
-        }
-        out
-    })
+    // half::f16 is #[repr(transparent)] over u16, so the casts below reinterpret
+    // the identical IEEE binary16 bit patterns the kernel expects. All 16 slots
+    // are filled even though the kernel reads only `len` of them: the caller
+    // already holds 16 valid slices, so there is nothing to gain from leaving
+    // the tail of the array undefined.
+    let mut rows = [std::ptr::null::<u16>(); 16];
+    for (i, cand) in candidates.iter().enumerate() {
+        debug_assert_eq!(
+            cand.len(),
+            dim,
+            "candidate {i} length must equal query length"
+        );
+        rows[i] = cand.as_ptr() as *const u16;
+    }
+    let mut out = [0f32; 16];
+    unsafe {
+        lance_amx_dot_f16_batch_16(
+            query.as_ptr() as *const u16,
+            rows.as_ptr(),
+            len,
+            dim,
+            out.as_mut_ptr(),
+        );
+    }
+    out
 }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -141,6 +141,8 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 default = ["aws", "azure", "gcp", "oss", "huggingface", "tencent", "tos", "goosefs", "geo"]
 backtrace = ["lance-core/backtrace"]
 fp16kernels = ["lance-linalg/fp16kernels"]
+# Opt-in AMX-FP16 tile kernel for batched fp16 dot products; see lance-linalg.
+amx = ["lance-linalg/amx"]
 # Prevent dynamic linking of lzma, which comes from datafusion
 cli = ["dep:clap", "lzma-sys/static"]
 dynamodb = ["lance-table/dynamodb", "dep:aws-sdk-dynamodb"]


### PR DESCRIPTION
## Summary

Adds an opt-in `amx` feature (off by default) that routes flat FP16 + `Dot` HNSW
distance evaluation through an AMX-FP16 (`_tile_dpfp16ps`) kernel, plus three
changes that decide how much of the search actually reaches that kernel and how
efficiently it is fed.

Measured on 100M x 768 real vectors at recall@10 = 0.988, with the CPUs
saturated: **1.382x throughput, recall bit-identical.**

| | QPS | [min..max] | recall@10 | CPU util |
|---|---:|---|---:|---:|
| baseline (`fp16kernels`, no AMX) | 1840 | [1839..1842] | 0.9880 | 98% |
| **this PR (`amx`)** | **2543** | [2534..2554] | **0.9880** | 97% |

Both built with GCC 13.4. Three rounds, arm order rotated per round; the
intervals do not overlap.

## What this changes

Four layers, each measured separately. Every increment below is a median over
three rounds with non-overlapping [min..max] intervals.

| Layer | Increment | Cumulative |
|---|---:|---:|
| 1. AMX-FP16 batch-16 distance kernel | 1.164x | 1.164x |
| 2. Gather moved into the kernel's k-block loop | 1.097x | 1.277x |
| 3. Batch-length parameter | (measured with layer 2) | 1.277x |
| 4. Candidate buffer spans popped nodes | 1.083x | **1.382x** |

### Layer 1 — AMX-FP16 batch-16 kernel

`lance_amx_dot_f16_batch_16` computes one query against 16 candidates in a single
sequence of tile passes: fp16 multiply, fp32 accumulate.

```
Before: one scalar call per neighbour
    v0  ---> dot_f16_avx512(q, v0) ---> d0
    v1  ---> dot_f16_avx512(q, v1) ---> d1
    ...
    v15 ---> dot_f16_avx512(q, v15) --> d15

After: 16 candidates in one tile pass
         A tile                   B tile          C tile
    +-------------------+      +---------+     +--------+
 v0 | v0[k .. k+32)     |      | query   |     |  d0    |
 v1 | v1[k .. k+32)     |  x   | [k..k+32)|  = |  d1    |
    |       ...         |      |         |     |  ...   |
v15 | v15[k .. k+32)    |      |         |     |  d15   |
    +-------------------+      +---------+     +--------+
     16 rows x 64 bytes         16 x 4 B        16 x 4 B (fp32)

    One TDPFP16PS covers 32 dims; dim=768 needs 24, accumulating into one C tile.
```

At N=1 the query needs no VNNI repacking: loading it with a 4-byte row stride
already gives `B.row[k].fp16[i] = query[k*2 + i]`. Three independent (A, B) pairs
rather than one, so three `TDPFP16PS` can be in flight instead of each waiting on
the two loads that just overwrote its own operands.

Tile configuration is cached per thread and reloaded only when the shape changes.
`LDTILECFG` costs a few hundred cycles — more than the useful tile work of a
dim-128 call — so configuring per call would leave the kernel mostly configuring.

### Layer 2 — gather moved into the k-block loop

A tile load reads 16 rows at one fixed stride from one base pointer, and the 16
candidates of a flush live at 16 unrelated addresses, so they have to be brought
together first. The question is how much, and when.

```
Before: the caller packs whole vectors up front
  buffer = 16 candidates x dim x 2 bytes
    dim=768  -> 16 x 768  x 2 = 24,576 B = 24 KiB   (50% of a 48 KiB L1d)
    dim=1536 -> 16 x 1536 x 2 = 49,152 B = 48 KiB   (100%)

time --------------------------------------------------------->
caller |######## copy 24..48 KiB ########|
kernel |                                 |~~~ tile work ~~~|
                                         ^
                        the first TDPFP16PS waits for the whole copy

After: three k-blocks at a time, double buffered
time --------------------------------------------------------->
gather |# 3KB #|# 3KB #|# 3KB #|# 3KB #|
         buf A   buf B   buf A   buf B
tile   |       |~ work ~|~ work ~|~ work ~|~ work ~|
                ^
        buf B fills while buf A is being multiplied

staging layout (one triple = three k-blocks):
        0        64      128      192 bytes
        +--------+--------+--------+
  row0  | kb+0   | kb+1   | kb+2   |  one straight-line 192-byte copy
  row1  | kb+0   | kb+1   | kb+2   |  (the three k-blocks are adjacent
  ...                                  inside the candidate vector)
  row15 | kb+0   | kb+1   | kb+2   |
        +--------+--------+--------+
          A0       A1       A2       row stride 192
```

The bytes moved are identical. What changes is that they move while the tile unit
is busy instead of before it starts, and that the working buffer is a constant
3 KiB instead of growing with `dim`.

Microbenchmark, one query against 16 scattered candidates, batch call only:

| dim | before (ns) | after (ns) | speedup |
|---:|---:|---:|---:|
| 512 | 1746 | 1279 | 1.37x |
| 768 | 2329 | 1526 | 1.53x |
| 1024 | 2827 | 2042 | 1.38x |
| 1536 | 4118 | 2756 | 1.49x |

Enlarging the candidate pool to 3.81 GB, well past L3, keeps 1.47x at dim 1024,
so this is not simply a cache-residency effect: the chunked path sustains
20.4 GB/s from DRAM against 13.9 GB/s for the packed one.

**Below 256 dimensions this layer is a regression** and is gated off. Measured
over three rounds, all intervals separated: dim 128 gives 0.86x-0.92x, dim 160
0.88x, dim 224 0.94x, while dim 256 and above are consistently 1.37x-1.55x. The
threshold is empirical; a pipelined gather has little to overlap when the whole
vector is only a handful of k-blocks.

### Layer 3 — batch-length parameter

A partial batch is padded to 16 by repeating candidate 0. The kernel could not
tell which rows were real, so it staged the same vector up to 16 times.

```
batch of 3 real candidates:

Before                              After
 row0  v_a  <- real                  row0  v_a  <- real
 row1  v_b  <- real                  row1  v_b  <- real
 row2  v_c  <- real                  row2  v_c  <- real
 row3  v_a  <- repeat of a           row3  0    +
 ...                                 ...        | zeroed once per call;
 row15 v_a  <- repeat of a           row15 0    + later k-blocks never touch it

 16 rows staged per k-block          3 rows staged per k-block
 dim=768: 16 x 24 x 64 = 24.6 KiB    dim=768: 3 x 24 x 64 = 4.6 KiB
                                     plus one 13-row zero fill
```

Lanes at or past `len` come back as 0; callers only read `[0, len)`.

### Layer 4 — candidate buffer spans popped nodes

```
Before: the buffer is drained at the end of every popped node
  pop node A -- unvisited neighbours [n0 n1 n2] --+
                                                  +-> 3 < 16
                                                  |   >= pad_min: pad to 16
                                                  |     (13 of 16 lanes wasted)
                                                  |   <  pad_min: scalar drain
                                                  +-> clear
  pop node B -- [n3 n4] --------------------------+   starts from zero again
  pop node C -- [n5] -----------------------------+

  Measured consequence: only ~28% of the distance work reached the kernel.

After (LANCE_HNSW_BATCH_SPAN=1): the buffer carries across nodes
  pop node A -- [n0 n1 n2] --+
  pop node B -- [n3 n4]      |
  pop node C -- [n5]         +--> buffer --> full 16 --> one batch
  pop node D -- [n6 n7 ...]  |               (all 16 lanes useful)
        ...                  +

  Cost: n0's distance is not computed until node D is popped, so it reaches the
  candidate heap later and the traversal order changes.
```

Because it reorders the traversal it stays **off by default** and is opt-in
through `LANCE_HNSW_BATCH_SPAN=1`. On the dataset below recall is unchanged to
four decimals with it on, but that is one dataset, one query set and one `ef`.

## Performance

### Setup

| | |
|---|---|
| Data | 100,000,000 x 768 fp16 real embeddings, scaled to unit norm |
| Metric | `Dot` — the only metric with a batched kernel. On unit vectors it ranks identically to cosine, which is what the ground truth is defined on. |
| Index | `IVF_HNSW_FLAT`, 10,000 partitions (`sqrt(rows)`), `m=20`, `ef_construction=150`, 154 GB |
| Queries | 200 vectors held out from the corpus tail — same distribution, not indexed |
| Ground truth | exhaustive scan over all 100M rows |
| Search | `ef=128`, `nprobes=32`, `k=10`, recall@10 = 0.988 |
| Concurrency | 64 |
| CPUs | 32 physical cores of one NUMA node (`0-31,192-223`), `LANCE_CPU_THREADS=64` |
| Rounds | 3, arm order rotated each round; median with [min..max] |

### Results

| arm | QPS | [min..max] | spread | recall@10 | CPU util |
|---|---:|---|---:|---:|---:|
| baseline | 1840 | [1839..1842] | 1.00 | 0.9880 | 98% |
| + layer 1 | 2141 | [2139..2153] | 1.01 | 0.9880 | — |
| + layers 2-3 | 2349 | [2345..2352] | 1.00 | 0.9880 | 97% |
| **+ layer 4** | **2543** | [2534..2554] | 1.01 | **0.9880** | 97% |

Adjacent rows are separated. Run-to-run spread is at most 1.01x against a
smallest effect of 1.083x.

A second dataset — 100M x 1024, a different embedding model, `m=32`,
`ef_construction=300` — reproduces layers 1-3 at 1.267x and 1.445x. Layer 4 was
not measured there.

### The benchmark has to saturate the CPUs

This is the one methodological point worth reading before reproducing anything.
Query latency is

```
latency = CPU time per query / achieved parallelism
```

and this PR reduces the numerator. When the machine is not saturated the work it
removes comes out of the *parallel* phase, so the denominator falls with it and
latency barely moves:

| | CPU time/query | achieved parallelism | latency |
|---|---:|---:|---:|
| before | 20.22 ms | 1.480 | 13.66 ms |
| after | 18.98 ms (-6.1%) | 1.426 (-3.6%) | 13.31 ms (-2.6%) |

**The same code measures 0.85x at 2.6% CPU utilisation and 1.45x at 99%.** A
latency benchmark at low concurrency will report this change as a regression.

The harness therefore records CPU utilisation per timed window (`utime + stime`
from `/proc/self/stat` divided by the window's wall time, sampled around the
timed region only) and reports throughput, not p50 — under saturation p50 is set
by queue depth and doubles when concurrency doubles. Utilisation on 64 bound
logical CPUs:

| concurrency | 1 | 32 | **64** | 128 |
|---|---:|---:|---:|---:|
| utilisation | 2.6% | 66% | **99%** | 99% |

Going from 64 to 128 raises throughput by 0.9% and doubles latency, which is what
saturation looks like.

## Opting in

The kernel lives behind its own feature, kept separate from `fp16kernels`, because
it carries requirements the pure-SIMD kernels do not — a C compiler accepting
`-mamx-fp16` (`LANCE_AMX_FP16_CC` overrides the probe), and an `arch_prctl`
XTILEDATA request before any tile instruction may execute.

```toml
lance-linalg = { version = "...", features = ["amx"] }   # implies fp16kernels
lance        = { version = "...", features = ["amx"] }   # forwards to lance-linalg
```

```console
cargo build -p lance --features amx
cargo test -p lance-index --features lance-linalg/amx f16 -- --nocapture
```

With the feature off — the default — none of this is present in the build.
`build.rs` never enters the AMX branch, `amx_fp16.c` is neither compiled nor
linked, `kernel_support="amx_fp16"` stays unset so every item in
`simd/amx_fp16.rs` is compiled out, `has_batch_16_kernel()` is `false`, and HNSW
runs exactly the traversal it ran before this PR.

## How to tell whether AMX is actually in use

Three conditions must all hold, and each is separately observable.

**1. Compiled in?** Requires the `amx` feature *and* a capable compiler. When the
feature is on but no compiler qualifies the build prints a warning and leaves
`kernel_support="amx_fp16"` unset, so every call falls back to the existing path.

**2. Usable on this host?** `amx_fp16_available()` returns `true` only if the
kernel was compiled in, both CPUID bits are present (amx-tile: leaf 7 sub-leaf 0,
EDX bit 24; amx-fp16: leaf 7 sub-leaf 1, EAX bit 21), the one-time
`arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA)` succeeded, and
`LANCE_DISABLE_AMX` is unset. Note that `/proc/cpuinfo` may omit the `amx_fp16`
flag on kernels whose flag table predates it — the CPUID probe is authoritative.

**3. Did the search take the batched path?** The recall test reports both signals:

```console
$ cargo test -p lance-index --features lance-linalg/amx f16 -- --nocapture
[flat_f16] recall@10=0.9930 search_flushes=4889 amx_fp16_available=true

$ LANCE_DISABLE_AMX=1 cargo test -p lance-index --features lance-linalg/amx f16 -- --nocapture
[flat_f16] recall@10=0.9930 search_flushes=0 amx_fp16_available=false
```

The test asserts both directions, so neither a silent fallback nor unnecessary
buffering can pass unnoticed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lance-linalg --features amx --tests -- -D warnings`
- `cargo clippy -p lance-index --features lance-linalg/amx --tests -- -D warnings`
- `cargo clippy -p lance-index --features lance-linalg/fp16kernels --tests -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test -p lance-linalg --features amx dot_f16 -- --nocapture`
- `cargo test -p lance-index --features lance-linalg/amx f16 -- --nocapture`
- `cargo test -p lance-index --features lance-linalg/fp16kernels f16 -- --nocapture`
- `LANCE_DISABLE_AMX=1 cargo test -p lance-index --features lance-linalg/amx f16 -- --nocapture`

FP16 HNSW recall@10 is 0.9930 in all configurations, with `search_flushes` at
4889, 0 and 0 respectively. No `Cargo.lock` changes.
