### PR TITLE
fix(io): prune empty local directories after their files are deleted

### DIFF
--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -25,7 +25,7 @@ use lance_core::{Error, Result};
 use object_store::path::Path;
 use tokio::io::AsyncSeekExt;
 use tokio::sync::OnceCell;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::object_reader::stream_local_range;
 use crate::object_store::DEFAULT_LOCAL_IO_PARALLELISM;
@@ -170,6 +170,31 @@ pub(crate) fn remove_empty_dirs(
         Err(error)
     } else {
         Ok(())
+    }
+}
+
+/// Remove `path`'s ancestor directories that are now empty, stopping at the first one
+/// that is not. Best effort.
+///
+/// `LocalFileSystem::with_automatic_cleanup` cannot do this: it derives its stop boundary
+/// from a rootless `file:///` URL, which `Url::to_file_path` rejects on Windows.
+pub fn prune_empty_parent_dirs(path: &Path) {
+    let local_path = to_local_path(path);
+    let mut parent = std::path::Path::new(&local_path).parent();
+    while let Some(dir) = parent {
+        if dir.as_os_str().is_empty() {
+            break;
+        }
+        if let Err(err) = std::fs::remove_dir(dir) {
+            if !matches!(
+                err.kind(),
+                ErrorKind::DirectoryNotEmpty | ErrorKind::NotFound
+            ) {
+                warn!("failed to prune empty directory {}: {}", dir.display(), err);
+            }
+            break;
+        }
+        parent = dir.parent();
     }
 }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -593,6 +593,11 @@ impl ObjectStore {
         self.scheme == "file" || self.scheme == "file+uring"
     }
 
+    /// Wider than [`Self::is_local`]: `file-object-store` also stores real directories.
+    fn backed_by_local_fs(&self) -> bool {
+        self.is_local() || self.scheme == "file-object-store"
+    }
+
     pub fn is_cloud(&self) -> bool {
         if self.is_local() || self.scheme == "memory" || self.scheme == "shared-memory" {
             return false;
@@ -825,6 +830,9 @@ impl ObjectStore {
 
     pub async fn delete(&self, path: &Path) -> Result<()> {
         self.inner.delete(path).await?;
+        if self.backed_by_local_fs() {
+            super::local::prune_empty_parent_dirs(path);
+        }
         Ok(())
     }
 
@@ -1005,11 +1013,15 @@ impl ObjectStore {
         locations: BoxStream<'a, Result<Path>>,
     ) -> BoxStream<'a, Result<Path>> {
         let store = Arc::clone(&self.inner);
+        let prune_empty_dirs = self.backed_by_local_fs();
         locations
             .and_then(move |location| {
                 let store = Arc::clone(&store);
                 async move {
                     store.delete(&location).await?;
+                    if prune_empty_dirs {
+                        super::local::prune_empty_parent_dirs(&location);
+                    }
                     Ok(location)
                 }
             })
@@ -1512,15 +1524,7 @@ mod tests {
             "delete",
         )
         .unwrap();
-        let file_url = Url::from_directory_path(&path).unwrap();
-        let url = if scheme.is_empty() {
-            file_url
-        } else {
-            let mut url = Url::parse(&format!("{scheme}:///")).unwrap();
-            // Use the file:// URL's normalized path so this works on Windows too.
-            url.set_path(file_url.path());
-            url
-        };
+        let url = dir_url(&path, scheme);
         let (store, base) = ObjectStore::from_uri(url.as_ref()).await.unwrap();
         store
             .remove_dir_all(base.clone().join("foo"))
@@ -1552,9 +1556,7 @@ mod tests {
         .unwrap();
         create_dir_all(path.join("file_bearing").join("empty_child")).unwrap();
 
-        let file_url = Url::from_directory_path(&path).unwrap();
-        let mut url = Url::parse(&format!("{scheme}:///")).unwrap();
-        url.set_path(file_url.path());
+        let url = dir_url(&path, scheme);
         let (store, base) = ObjectStore::from_uri(url.as_ref()).await.unwrap();
 
         #[cfg(unix)]
@@ -1606,6 +1608,86 @@ mod tests {
 
         assert!(path.join("fresh").exists());
         assert!(!path.join("verified").exists());
+    }
+
+    fn dir_url(path: impl AsRef<std::path::Path>, scheme: &str) -> Url {
+        let file_url = Url::from_directory_path(path).unwrap();
+        if scheme.is_empty() {
+            return file_url;
+        }
+        let mut url = Url::parse(&format!("{scheme}:///")).unwrap();
+        // Use the file:// URL's normalized path so this works on Windows too.
+        url.set_path(file_url.path());
+        url
+    }
+
+    #[tokio::test]
+    async fn test_delete_prunes_empty_dirs_local_store() {
+        test_delete_prunes_empty_dirs("").await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_prunes_empty_dirs_file_object_store() {
+        test_delete_prunes_empty_dirs("file-object-store").await;
+    }
+
+    async fn test_delete_prunes_empty_dirs(scheme: &str) {
+        let (path, store, file) = prune_fixture(scheme).await;
+        store.delete(&file).await.unwrap();
+        assert_pruned(&path);
+    }
+
+    #[tokio::test]
+    async fn test_remove_stream_prunes_empty_dirs_local_store() {
+        test_remove_stream_prunes_empty_dirs("").await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_stream_prunes_empty_dirs_file_object_store() {
+        test_remove_stream_prunes_empty_dirs("file-object-store").await;
+    }
+
+    async fn test_remove_stream_prunes_empty_dirs(scheme: &str) {
+        let (path, store, file) = prune_fixture(scheme).await;
+        store
+            .remove_stream(futures::stream::once(async { Ok(file) }).boxed())
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_pruned(&path);
+    }
+
+    /// A `foo/bar/nested/test_file` to delete, next to a `foo/zoo/keep_file` that must
+    /// stop the upward walk at `foo/`.
+    async fn prune_fixture(scheme: &str) -> (TempStdDir, Arc<ObjectStore>, Path) {
+        let path = TempStdDir::default();
+        let nested = path.join("foo").join("bar").join("nested");
+        create_dir_all(&nested).unwrap();
+        create_dir_all(path.join("foo").join("zoo")).unwrap();
+        write_to_file(nested.join("test_file").to_str().unwrap(), "delete").unwrap();
+        write_to_file(
+            path.join("foo")
+                .join("zoo")
+                .join("keep_file")
+                .to_str()
+                .unwrap(),
+            "keep",
+        )
+        .unwrap();
+
+        let url = dir_url(&path, scheme);
+        let (store, base) = ObjectStore::from_uri(url.as_ref()).await.unwrap();
+        let file = base
+            .join("foo")
+            .join("bar")
+            .join("nested")
+            .join("test_file");
+        (path, store, file)
+    }
+
+    fn assert_pruned(path: &TempStdDir) {
+        assert!(!path.join("foo").join("bar").exists());
+        assert!(path.join("foo").join("zoo").join("keep_file").exists());
     }
 
     #[derive(Debug)]

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -3120,6 +3120,8 @@ mod tests {
                 .await
                 .unwrap()
         );
+        assert!(fixture.local_index_dir(seg_b).exists());
+        assert!(fixture.local_index_dir(seg_c).exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #7937

## Problem

After `cleanup_old_versions` removes an obsolete index, its files under `_indices/<uuid>/` are deleted one at a time, but on a local filesystem the now-empty `_indices/<uuid>/` directory is left behind. Cleanup deletes files only and never removes directories. On object stores (S3/GCS/Azure) directories are virtual prefixes that vanish with their last object, so this only affects local filesystems.

## Fix

`ObjectStore::delete` and `ObjectStore::remove_stream` walk up from the deleted file and remove the parent directories that became empty, stopping at the first one that is not.

The gate is wider than `is_local()`: it also covers `file-object-store`, which stores real directories that have no remote equivalent.

## Why not `LocalFileSystem::with_automatic_cleanup`

arrow has this built in and the first revision of this PR used it, but it is broken on Windows. `LocalFileSystem::new()` roots the store at `file:///`, and `delete_location` bounds its upward walk by resolving that root through `Url::to_file_path()`, which on Windows requires a drive letter and so returns `Err`. Every delete then removed the file and reported `InvalidUrl`; since `RenameCommitHandler` is copy + delete, 1055 of 2531 `lance` tests failed on `windows-build`.

## Tests

`test_delete_prunes_empty_dirs_local_store` / `..._file_object_store` in `lance-io` delete a file nested three levels deep and assert the emptied directories are gone while a non-empty sibling survives.

Two existing cleanup tests are extended to assert the directory itself is gone, not just its files, via a filesystem check the object-store `exists()` cannot observe: `cleanup_old_replaced_segment_keeps_still_referenced_segments` (flat layout; still-referenced dirs preserved) and `cleanup_old_uncommitted_index_artifacts` (nested layout).

All four fail without the fix. The full `lance-io`, `lance-table` and `lance` unit suites pass.
