### PR TITLE
feat(namespace): idempotent create_table_version with strict CAS and dotfile-safe reserved marker

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1761,7 +1761,15 @@ impl DirectoryNamespace {
     ) -> Result<()> {
         let latest = self.list_versions_under(table_path, true, Some(1)).await?;
         let expected = match latest.first() {
-            Some(v) => (v.version as u64).saturating_add(1),
+            Some(v) => (v.version as u64).checked_add(1).ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Version overflow computing next version for table at '{}': \
+                             latest version {} cannot advance",
+                        table_uri, v.version
+                    ),
+                })
+            })?,
             // Empty chain: main starts at v1, but a branch bootstraps at its fork
             // version which can be > 1.
             None => {

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1505,17 +1505,20 @@ impl DirectoryNamespace {
             .uri)
     }
 
-    /// Resolves a branch to its `(uri, object-store path)` for `create_table_version`.
+    /// Resolves a branch to its `(uri, object-store path, parent_version)` for
+    /// `create_table_version`.
     ///
     /// `BranchContents` is the source of truth, so check the ref first: a
-    /// registered branch commits directly. With no ref, accept the commit only on
-    /// an empty chain (the `create_branch` bootstrap, whose first commit precedes
-    /// its ref); reject a chain that already holds committed versions as a zombie.
+    /// registered branch commits directly and returns its `parent_version` for
+    /// empty-chain CAS. With no ref, accept the commit only on an empty chain
+    /// (the `create_branch` bootstrap, whose first commit precedes its ref) and
+    /// return `parent_version = None`; reject a chain that already holds
+    /// committed versions as a zombie.
     async fn resolve_branch_for_commit(
         &self,
         table_uri: &str,
         branch: &str,
-    ) -> Result<(String, Path)> {
+    ) -> Result<(String, Path, Option<u64>)> {
         let main = self
             .configured_builder(table_uri)
             .load()
@@ -1526,7 +1529,11 @@ impl DirectoryNamespace {
             })?;
         let branch_location = main.branch_location().find_branch(Some(branch))?;
         match main.branches().get(branch).await {
-            Ok(_) => Ok((branch_location.uri, branch_location.path)),
+            Ok(contents) => Ok((
+                branch_location.uri,
+                branch_location.path,
+                Some(contents.parent_version),
+            )),
             Err(lance_core::Error::RefNotFound { .. }) => {
                 if self
                     .branch_has_committed_versions(&branch_location.path)
@@ -1540,7 +1547,7 @@ impl DirectoryNamespace {
                     }
                     .into());
                 }
-                Ok((branch_location.uri, branch_location.path))
+                Ok((branch_location.uri, branch_location.path, None))
             }
             Err(e) => Err(e),
         }
@@ -1747,17 +1754,21 @@ impl DirectoryNamespace {
         ))
     }
 
-    /// Enforce version CAS: requested version must be `latest + 1` (or `1` if empty).
+    /// Enforce version CAS: requested version must be `latest + 1` (or bootstrap).
     ///
-    /// A branch's first commit is its fork version, which may be greater than 1
-    /// (e.g. forking main at v2), so an empty branch chain accepts the requested
-    /// version as its bootstrap. An empty *main* chain must still start at v1.
+    /// Empty-chain bootstrap:
+    /// - main must start at v1
+    /// - a registered branch must start at `BranchContents.parent_version` (the
+    ///   shallow-clone fork version, which may be > 1)
+    /// - an unregistered branch (create_branch phase-1, ref not written yet)
+    ///   accepts the requested version because `parent_version` is not known yet
     async fn enforce_create_table_version_cas(
         &self,
         table_path: &Path,
         version: u64,
         table_uri: &str,
         is_branch: bool,
+        branch_parent_version: Option<u64>,
     ) -> Result<()> {
         let latest = self.list_versions_under(table_path, true, Some(1)).await?;
         let expected = match latest.first() {
@@ -1770,11 +1781,14 @@ impl DirectoryNamespace {
                     ),
                 })
             })?,
-            // Empty chain: main starts at v1, but a branch bootstraps at its fork
-            // version which can be > 1.
             None => {
                 if is_branch {
-                    version
+                    // Prefer BranchContents.parent_version when the ref exists so a
+                    // branch forked at v5 cannot bootstrap at an arbitrary version.
+                    match branch_parent_version {
+                        Some(parent_version) => parent_version,
+                        None => version,
+                    }
                 } else {
                     1
                 }
@@ -2785,86 +2799,6 @@ impl DirectoryNamespace {
         not_found.into()
     }
 
-    async fn put_marker_file_atomic(
-        &self,
-        path: &Path,
-        file_description: &str,
-    ) -> std::result::Result<(), String> {
-        // Some object stores implement `PutMode::Create` using a temp+rename
-        // that reuses the final basename. Dotfile targets such as
-        // `.lance-reserved` therefore produce temp names containing `..`,
-        // which these stores reject. Stage under a non-dot sibling, then claim
-        // the final path with rename_if_not_exists (conditional no-replace
-        // rename) so Create semantics are preserved without changing the store.
-        let staging_name = format!("lance-marker.staging.{}", uuid::Uuid::new_v4().simple());
-        let path_str = path.as_ref();
-        let staging_path = match path_str.rfind('/') {
-            Some(idx) => Path::from(format!("{}/{}", &path_str[..idx], staging_name)),
-            None => Path::from(staging_name.as_str()),
-        };
-
-        // Some object stores write via temp+rename and may not flush empty
-        // objects through to the underlying filesystem, so the conditional
-        // rename can fail with NotFound. Use a tiny non-empty payload.
-        self.object_store
-            .inner
-            .put(&staging_path, bytes::Bytes::from_static(b"reserved").into())
-            .await
-            .map_err(|e| format!("Failed to stage {}: {:?}", file_description, e))?;
-
-        let publish_result = match self
-            .object_store
-            .inner
-            .rename_if_not_exists(&staging_path, path)
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(ObjectStoreError::NotImplemented { .. })
-            | Err(ObjectStoreError::NotSupported { .. }) => {
-                let result = self
-                    .object_store
-                    .inner
-                    .put_opts(
-                        path,
-                        bytes::Bytes::from_static(b"reserved").into(),
-                        PutOptions {
-                            mode: PutMode::Create,
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                    .map(|_| ());
-                if let Err(e) = self.object_store.inner.delete(&staging_path).await {
-                    log::warn!(
-                        "Failed to delete staging marker at '{}': {:?}",
-                        staging_path,
-                        e
-                    );
-                }
-                result
-            }
-            Err(e) => {
-                if let Err(del_err) = self.object_store.inner.delete(&staging_path).await {
-                    log::warn!(
-                        "Failed to delete staging marker at '{}': {:?}",
-                        staging_path,
-                        del_err
-                    );
-                }
-                Err(e)
-            }
-        };
-
-        match publish_result {
-            Ok(()) => Ok(()),
-            Err(ObjectStoreError::AlreadyExists { .. })
-            | Err(ObjectStoreError::Precondition { .. }) => {
-                Err(format!("{} already exists", file_description))
-            }
-            Err(e) => Err(format!("Failed to create {}: {:?}", file_description, e)),
-        }
-    }
-
     /// Get storage options for a table, using credential vending if configured.
     ///
     /// If credential vendor properties are configured and the table location matches
@@ -3612,17 +3546,21 @@ impl LanceNamespace for DirectoryNamespace {
         // concurrent declare_table calls.
         let reserved_file_path = self.table_reserved_file_path(&table_name);
 
-        self.put_marker_file_atomic(&reserved_file_path, &format!("table {}", table_name))
-            .await
-            .map_err(|e| {
-                if e.contains("already exists") {
-                    lance_core::Error::from(NamespaceError::TableAlreadyExists {
-                        message: table_name.to_string(),
-                    })
-                } else {
-                    lance_core::Error::from(NamespaceError::Internal { message: e })
-                }
-            })?;
+        put_marker_file_atomic(
+            &self.object_store,
+            &reserved_file_path,
+            &format!("table {}", table_name),
+        )
+        .await
+        .map_err(|e| {
+            if e.contains("already exists") {
+                lance_core::Error::from(NamespaceError::TableAlreadyExists {
+                    message: table_name.to_string(),
+                })
+            } else {
+                lance_core::Error::from(NamespaceError::Internal { message: e })
+            }
+        })?;
 
         // For backwards compatibility, only skip vending credentials when explicitly set to false
         let vend_credentials = request.vend_credentials.unwrap_or(true);
@@ -3699,7 +3637,8 @@ impl LanceNamespace for DirectoryNamespace {
         // If a race occurs and another process already created the file,
         // we'll get an AlreadyExists error which we convert to a proper message.
         let deregistered_path = self.table_deregistered_file_path(&table_name);
-        self.put_marker_file_atomic(
+        put_marker_file_atomic(
+            &self.object_store,
             &deregistered_path,
             &format!("deregistration marker for table {}", table_name),
         )
@@ -3907,11 +3846,11 @@ impl LanceNamespace for DirectoryNamespace {
         self.record_op("create_table_version");
         let branch = Self::normalized_branch(request.branch.as_deref())?;
         let table_uri = self.resolve_table_location(&request.id).await?;
-        let (table_uri, table_path) = match branch {
+        let (table_uri, table_path, branch_parent_version) = match branch {
             Some(b) => self.resolve_branch_for_commit(&table_uri, b).await?,
             None => {
                 let table_path = self.object_store_path_from_uri(&table_uri)?;
-                (table_uri, table_path)
+                (table_uri, table_path, None)
             }
         };
 
@@ -3962,11 +3901,17 @@ impl LanceNamespace for DirectoryNamespace {
             }
         }
 
-        // Strict CAS: only allow appending latest+1 (or version 1 on an empty main
-        // chain; an empty branch chain bootstraps at its fork version).
+        // Strict CAS: only allow appending latest+1 (or the empty-chain bootstrap
+        // version: v1 on main, BranchContents.parent_version on a registered branch).
         let is_branch = branch.is_some();
-        self.enforce_create_table_version_cas(&table_path, version, &table_uri, is_branch)
-            .await?;
+        self.enforce_create_table_version_cas(
+            &table_path,
+            version,
+            &table_uri,
+            is_branch,
+            branch_parent_version,
+        )
+        .await?;
 
         // Materialize with Create / copy_if_not_exists only — never overwrite.
         let copy_result = self
@@ -5787,6 +5732,84 @@ impl LanceNamespace for DirectoryNamespace {
 
     fn namespace_id(&self) -> String {
         format!("DirectoryNamespace {{ root: {:?} }}", self.root)
+    }
+}
+
+/// Atomically create a marker file (e.g. `.lance-reserved`) with Create semantics.
+///
+/// Some object stores implement `PutMode::Create` via temp+rename that reuses the
+/// final basename. Dotfile targets such as `.lance-reserved` therefore produce
+/// temp names containing `..`, which these stores reject. Stage under a non-dot
+/// sibling, then claim the final path with `rename_if_not_exists`.
+///
+/// Some object stores also fail to flush empty objects, so the conditional rename
+/// can fail with NotFound. Use a tiny non-empty payload.
+pub(crate) async fn put_marker_file_atomic(
+    object_store: &ObjectStore,
+    path: &Path,
+    file_description: &str,
+) -> std::result::Result<(), String> {
+    let staging_name = format!("lance-marker.staging.{}", uuid::Uuid::new_v4().simple());
+    let path_str = path.as_ref();
+    let staging_path = match path_str.rfind('/') {
+        Some(idx) => Path::from(format!("{}/{}", &path_str[..idx], staging_name)),
+        None => Path::from(staging_name.as_str()),
+    };
+
+    object_store
+        .inner
+        .put(&staging_path, bytes::Bytes::from_static(b"reserved").into())
+        .await
+        .map_err(|e| format!("Failed to stage {}: {:?}", file_description, e))?;
+
+    let publish_result = match object_store
+        .inner
+        .rename_if_not_exists(&staging_path, path)
+        .await
+    {
+        Ok(()) => Ok(()),
+        Err(ObjectStoreError::NotImplemented { .. })
+        | Err(ObjectStoreError::NotSupported { .. }) => {
+            let result = object_store
+                .inner
+                .put_opts(
+                    path,
+                    bytes::Bytes::from_static(b"reserved").into(),
+                    PutOptions {
+                        mode: PutMode::Create,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .map(|_| ());
+            if let Err(e) = object_store.inner.delete(&staging_path).await {
+                log::warn!(
+                    "Failed to delete staging marker at '{}': {:?}",
+                    staging_path,
+                    e
+                );
+            }
+            result
+        }
+        Err(e) => {
+            if let Err(del_err) = object_store.inner.delete(&staging_path).await {
+                log::warn!(
+                    "Failed to delete staging marker at '{}': {:?}",
+                    staging_path,
+                    del_err
+                );
+            }
+            Err(e)
+        }
+    };
+
+    match publish_result {
+        Ok(()) => Ok(()),
+        Err(ObjectStoreError::AlreadyExists { .. })
+        | Err(ObjectStoreError::Precondition { .. }) => {
+            Err(format!("{} already exists", file_description))
+        }
+        Err(e) => Err(format!("Failed to create {}: {:?}", file_description, e)),
     }
 }
 
@@ -10867,6 +10890,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_declare_table_with_manifest_marker_already_exists() {
+        // Pre-existing .lance-reserved (concurrent/incomplete declare) must map to
+        // TableAlreadyExists, not Internal.
+        use lance_namespace::error::ErrorCode;
+        use lance_namespace::models::DeclareTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        let table_dir = temp_dir.join("test_table.lance");
+        std::fs::create_dir_all(&table_dir).unwrap();
+        std::fs::write(table_dir.join(".lance-reserved"), b"reserved").unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        let err = namespace
+            .declare_table(declare_req)
+            .await
+            .expect_err("declare with existing marker must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already exists") || msg.contains("TableAlreadyExists"),
+            "expected TableAlreadyExists, got: {msg}"
+        );
+        assert_eq!(
+            mutation_error_code(err),
+            ErrorCode::TableAlreadyExists,
+            "expected TableAlreadyExists error code"
+        );
+    }
+
+    #[tokio::test]
     async fn test_declare_table_when_table_exists() {
         use lance_namespace::models::DeclareTableRequest;
 
@@ -12038,6 +12100,135 @@ mod tests {
             msg.contains("CAS") || msg.contains("ConcurrentModification"),
             "expected CAS ConcurrentModification, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_version_branch_cas_requires_parent_version() {
+        // Empty branch chain with BranchContents must bootstrap at parent_version,
+        // not an arbitrary version (e.g. 1 when forked from v2).
+        use futures::TryStreamExt;
+        use lance_namespace::models::CreateTableVersionRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        let main_uri = open_dataset(&namespace, "users").await.uri().to_string();
+        append_scalar_version(&main_uri, 10).await; // main -> v2
+
+        let mut main = open_dataset(&namespace, "users").await;
+        let fork_version = main.version().version;
+        assert_eq!(fork_version, 2);
+        let branch_uri = main
+            .create_branch("exp", fork_version, None)
+            .await
+            .unwrap()
+            .uri()
+            .to_string();
+
+        let branch_ds = Dataset::open(&branch_uri).await.unwrap();
+        let versions_dir = branch_ds.versions_dir();
+        let store = branch_ds.object_store(None).await.unwrap();
+        let manifests: Vec<_> = store
+            .inner
+            .list(Some(&versions_dir))
+            .try_collect()
+            .await
+            .unwrap();
+        for meta in &manifests {
+            if meta
+                .location
+                .filename()
+                .is_some_and(|f| f.ends_with(".manifest"))
+            {
+                store.inner.delete(&meta.location).await.unwrap();
+            }
+        }
+        // Confirm the branch object-store chain is empty (do not open the dataset:
+        // with no manifests, Dataset::open would fail).
+        let remaining_manifests = store
+            .inner
+            .list(Some(&versions_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| {
+                m.location
+                    .filename()
+                    .is_some_and(|f| f.ends_with(".manifest"))
+            })
+            .count();
+        assert_eq!(
+            remaining_manifests, 0,
+            "branch version chain should be empty after deleting manifests"
+        );
+
+        // Stage bytes from a main manifest.
+        let main_ds = open_dataset(&namespace, "users").await;
+        let main_versions = main_ds.versions_dir();
+        let main_store = main_ds.object_store(None).await.unwrap();
+        let source_meta = main_store
+            .inner
+            .list(Some(&main_versions))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .is_some_and(|f| f.ends_with(".manifest"))
+            })
+            .expect("main should have a manifest");
+        let source_bytes = main_store
+            .inner
+            .get(&source_meta.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+
+        let staging_wrong = versions_dir.clone().join("staging_wrong");
+        store
+            .inner
+            .put(&staging_wrong, source_bytes.clone().into())
+            .await
+            .unwrap();
+        let err = namespace
+            .create_table_version(CreateTableVersionRequest {
+                id: Some(vec!["users".to_string()]),
+                version: 1,
+                manifest_path: staging_wrong.to_string(),
+                naming_scheme: Some("V2".to_string()),
+                branch: Some("exp".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("bootstrap at v1 must fail when parent_version is 2");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CAS") || msg.contains("ConcurrentModification"),
+            "expected CAS ConcurrentModification, got: {msg}"
+        );
+
+        let staging_ok = versions_dir.join("staging_ok");
+        store
+            .inner
+            .put(&staging_ok, source_bytes.into())
+            .await
+            .unwrap();
+        let resp = namespace
+            .create_table_version(CreateTableVersionRequest {
+                id: Some(vec!["users".to_string()]),
+                version: 2,
+                manifest_path: staging_ok.to_string(),
+                naming_scheme: Some("V2".to_string()),
+                branch: Some("exp".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("bootstrap at parent_version must succeed");
+        assert_eq!(resp.version.as_ref().map(|v| v.version), Some(2));
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1748,16 +1748,29 @@ impl DirectoryNamespace {
     }
 
     /// Enforce version CAS: requested version must be `latest + 1` (or `1` if empty).
+    ///
+    /// A branch's first commit is its fork version, which may be greater than 1
+    /// (e.g. forking main at v2), so an empty branch chain accepts the requested
+    /// version as its bootstrap. An empty *main* chain must still start at v1.
     async fn enforce_create_table_version_cas(
         &self,
         table_path: &Path,
         version: u64,
         table_uri: &str,
+        is_branch: bool,
     ) -> Result<()> {
         let latest = self.list_versions_under(table_path, true, Some(1)).await?;
         let expected = match latest.first() {
             Some(v) => (v.version as u64).saturating_add(1),
-            None => 1,
+            // Empty chain: main starts at v1, but a branch bootstraps at its fork
+            // version which can be > 1.
+            None => {
+                if is_branch {
+                    version
+                } else {
+                    1
+                }
+            }
         };
         if version != expected {
             let latest_display = latest
@@ -3941,8 +3954,10 @@ impl LanceNamespace for DirectoryNamespace {
             }
         }
 
-        // Strict CAS: only allow appending latest+1 (or version 1 on an empty chain).
-        self.enforce_create_table_version_cas(&table_path, version, &table_uri)
+        // Strict CAS: only allow appending latest+1 (or version 1 on an empty main
+        // chain; an empty branch chain bootstraps at its fork version).
+        let is_branch = branch.is_some();
+        self.enforce_create_table_version_cas(&table_path, version, &table_uri, is_branch)
             .await?;
 
         // Materialize with Create / copy_if_not_exists only — never overwrite.

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -3552,13 +3552,14 @@ impl LanceNamespace for DirectoryNamespace {
             &format!("table {}", table_name),
         )
         .await
-        .map_err(|e| {
-            if e.contains("already exists") {
+        .map_err(|e| match e {
+            MarkerFileError::AlreadyExists { .. } => {
                 lance_core::Error::from(NamespaceError::TableAlreadyExists {
                     message: table_name.to_string(),
                 })
-            } else {
-                lance_core::Error::from(NamespaceError::Internal { message: e })
+            }
+            MarkerFileError::Other { message } => {
+                lance_core::Error::from(NamespaceError::Internal { message })
             }
         })?;
 
@@ -3643,13 +3644,14 @@ impl LanceNamespace for DirectoryNamespace {
             &format!("deregistration marker for table {}", table_name),
         )
         .await
-        .map_err(|e| {
-            if e.contains("already exists") {
+        .map_err(|e| match e {
+            MarkerFileError::AlreadyExists { .. } => {
                 lance_core::Error::from(NamespaceError::InvalidTableState {
                     message: format!("Table is already deregistered: {}", table_name),
                 })
-            } else {
-                lance_core::Error::from(NamespaceError::Internal { message: e })
+            }
+            MarkerFileError::Other { message } => {
+                lance_core::Error::from(NamespaceError::Internal { message })
             }
         })?;
 
@@ -5735,6 +5737,26 @@ impl LanceNamespace for DirectoryNamespace {
     }
 }
 
+/// Error from [`put_marker_file_atomic`].
+#[derive(Debug)]
+pub(crate) enum MarkerFileError {
+    /// The final marker path is already present (Create / rename race).
+    AlreadyExists { description: String },
+    /// Staging or publish failed for a non-conflict reason.
+    Other { message: String },
+}
+
+impl std::fmt::Display for MarkerFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists { description } => {
+                write!(f, "{} already exists", description)
+            }
+            Self::Other { message } => write!(f, "{}", message),
+        }
+    }
+}
+
 /// Atomically create a marker file (e.g. `.lance-reserved`) with Create semantics.
 ///
 /// Some object stores implement `PutMode::Create` via temp+rename that reuses the
@@ -5742,13 +5764,24 @@ impl LanceNamespace for DirectoryNamespace {
 /// temp names containing `..`, which these stores reject. Stage under a non-dot
 /// sibling, then claim the final path with `rename_if_not_exists`.
 ///
+/// When `rename_if_not_exists` is unavailable, fall back to
+/// `copy_if_not_exists(staging → target)`, then `PutMode::Create` on the target.
+/// That Create path is only for stores whose Create is a true conditional PUT
+/// (not basename-derived temp+rename); such stores are exactly the ones that
+/// typically omit rename/copy conditionals.
+///
 /// Some object stores also fail to flush empty objects, so the conditional rename
 /// can fail with NotFound. Use a tiny non-empty payload.
+///
+/// Staging cleanup is best-effort with a few short retries. A delete that still
+/// fails after retries leaves a tiny `lance-marker.staging.*` orphan. Async Drop
+/// cannot await object-store I/O, so RAII is not used here. Each call uses a
+/// unique staging UUID, so concurrent callers never contend on the same cleanup.
 pub(crate) async fn put_marker_file_atomic(
     object_store: &ObjectStore,
     path: &Path,
     file_description: &str,
-) -> std::result::Result<(), String> {
+) -> std::result::Result<(), MarkerFileError> {
     let staging_name = format!("lance-marker.staging.{}", uuid::Uuid::new_v4().simple());
     let path_str = path.as_ref();
     let staging_path = match path_str.rfind('/') {
@@ -5760,56 +5793,92 @@ pub(crate) async fn put_marker_file_atomic(
         .inner
         .put(&staging_path, bytes::Bytes::from_static(b"reserved").into())
         .await
-        .map_err(|e| format!("Failed to stage {}: {:?}", file_description, e))?;
+        .map_err(|e| MarkerFileError::Other {
+            message: format!("Failed to stage {}: {:?}", file_description, e),
+        })?;
 
+    // Successful rename consumes the staging object; every other path must
+    // delete it (best-effort) so conflict/fallback races do not accumulate.
+    let mut staging_consumed = false;
     let publish_result = match object_store
         .inner
         .rename_if_not_exists(&staging_path, path)
         .await
     {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            staging_consumed = true;
+            Ok(())
+        }
         Err(ObjectStoreError::NotImplemented { .. })
         | Err(ObjectStoreError::NotSupported { .. }) => {
-            let result = object_store
+            match object_store
                 .inner
-                .put_opts(
-                    path,
-                    bytes::Bytes::from_static(b"reserved").into(),
-                    PutOptions {
-                        mode: PutMode::Create,
-                        ..Default::default()
-                    },
-                )
+                .copy_if_not_exists(&staging_path, path)
                 .await
-                .map(|_| ());
-            if let Err(e) = object_store.inner.delete(&staging_path).await {
-                log::warn!(
-                    "Failed to delete staging marker at '{}': {:?}",
-                    staging_path,
-                    e
-                );
+            {
+                Ok(()) => Ok(()),
+                Err(ObjectStoreError::NotImplemented { .. })
+                | Err(ObjectStoreError::NotSupported { .. }) => object_store
+                    .inner
+                    .put_opts(
+                        path,
+                        bytes::Bytes::from_static(b"reserved").into(),
+                        PutOptions {
+                            mode: PutMode::Create,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map(|_| ()),
+                Err(e) => Err(e),
             }
-            result
         }
-        Err(e) => {
-            if let Err(del_err) = object_store.inner.delete(&staging_path).await {
-                log::warn!(
-                    "Failed to delete staging marker at '{}': {:?}",
-                    staging_path,
-                    del_err
-                );
-            }
-            Err(e)
-        }
+        Err(e) => Err(e),
     };
+
+    if !staging_consumed {
+        delete_staging_marker_best_effort(object_store, &staging_path).await;
+    }
 
     match publish_result {
         Ok(()) => Ok(()),
         Err(ObjectStoreError::AlreadyExists { .. })
-        | Err(ObjectStoreError::Precondition { .. }) => {
-            Err(format!("{} already exists", file_description))
+        | Err(ObjectStoreError::Precondition { .. }) => Err(MarkerFileError::AlreadyExists {
+            description: file_description.to_string(),
+        }),
+        Err(e) => Err(MarkerFileError::Other {
+            message: format!("Failed to create {}: {:?}", file_description, e),
+        }),
+    }
+}
+
+/// Best-effort delete of a per-call staging marker, with short retries for
+/// transient store errors. `NotFound` is treated as success (delete may have
+/// succeeded despite an earlier ambiguous failure).
+async fn delete_staging_marker_best_effort(object_store: &ObjectStore, staging_path: &Path) {
+    const MAX_ATTEMPTS: u32 = 3;
+    const BACKOFF_MS: [u64; 2] = [20, 50];
+
+    let mut last_err: Option<ObjectStoreError> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match object_store.inner.delete(staging_path).await {
+            Ok(()) => return,
+            Err(ObjectStoreError::NotFound { .. }) => return,
+            Err(e) => {
+                last_err = Some(e);
+                if let Some(&delay_ms) = BACKOFF_MS.get(attempt as usize) {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+            }
         }
-        Err(e) => Err(format!("Failed to create {}: {:?}", file_description, e)),
+    }
+    if let Some(del_err) = last_err {
+        log::warn!(
+            "Failed to delete staging marker at '{}' after {} attempts: {:?}",
+            staging_path,
+            MAX_ATTEMPTS,
+            del_err
+        );
     }
 }
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -929,7 +929,6 @@ struct ExistingTableVersionResolve<'a> {
     final_path: &'a Path,
     version: u64,
     table_uri: &'a str,
-    request_e_tag: Option<&'a str>,
     final_meta: &'a ObjectMeta,
     request_manifest_size: Option<i64>,
 }
@@ -1645,22 +1644,18 @@ impl DirectoryNamespace {
 
     /// Whether the staging blob matches the already-published version blob.
     ///
-    /// Used for idempotent retries of `create_table_version`: after a successful
-    /// Create materialize the final object's e_tag may differ from the staging
-    /// e_tag, so content equality is the durable identity check.
+    /// Used for idempotent retries of `create_table_version`. Object-store
+    /// `e_tag` is opaque metadata (not a validated content hash) and may also
+    /// change across Create/rename materialize, so it is never used for
+    /// identity. Size mismatch is a cheap negative check; byte equality is the
+    /// durable success condition.
     async fn staging_matches_final_manifest(
         &self,
         staging_path: &Path,
         final_path: &Path,
-        request_e_tag: Option<&str>,
         final_meta: &ObjectMeta,
         request_manifest_size: Option<i64>,
     ) -> Result<bool> {
-        if let (Some(req_tag), Some(exist_tag)) = (request_e_tag, final_meta.e_tag.as_deref())
-            && req_tag == exist_tag
-        {
-            return Ok(true);
-        }
         if let Some(size) = request_manifest_size
             && size != final_meta.size as i64
         {
@@ -1723,7 +1718,6 @@ impl DirectoryNamespace {
             .staging_matches_final_manifest(
                 args.staging_path,
                 args.final_path,
-                args.request_e_tag,
                 args.final_meta,
                 args.request_manifest_size,
             )
@@ -3886,7 +3880,6 @@ impl LanceNamespace for DirectoryNamespace {
                         final_path: &final_path,
                         version,
                         table_uri: &table_uri,
-                        request_e_tag: request.e_tag.as_deref(),
                         final_meta: &existing_meta,
                         request_manifest_size: request.manifest_size,
                     })
@@ -3939,7 +3932,6 @@ impl LanceNamespace for DirectoryNamespace {
                         final_path: &final_path,
                         version,
                         table_uri: &table_uri,
-                        request_e_tag: request.e_tag.as_deref(),
                         final_meta: &existing_meta,
                         request_manifest_size: request.manifest_size,
                     })

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -40,7 +40,9 @@ use lance_linalg::distance::MetricType;
 use lance_table::io::commit::{ManifestNamingScheme, VERSIONS_DIR};
 use object_store::ObjectStoreExt;
 use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, PutMode, PutOptions};
+use object_store::{
+    Error as ObjectStoreError, ObjectMeta, ObjectStore as OSObjectStore, PutMode, PutOptions,
+};
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};
@@ -921,6 +923,17 @@ impl std::fmt::Display for DirectoryNamespace {
     }
 }
 
+/// Inputs for resolving an already-published `create_table_version` target.
+struct ExistingTableVersionResolve<'a> {
+    staging_path: &'a Path,
+    final_path: &'a Path,
+    version: u64,
+    table_uri: &'a str,
+    request_e_tag: Option<&'a str>,
+    final_meta: &'a ObjectMeta,
+    request_manifest_size: Option<i64>,
+}
+
 /// Describes the version ranges to delete for a single table.
 /// Used by `batch_delete_table_versions` and `delete_physical_version_files`.
 struct TableDeleteEntry {
@@ -1602,6 +1615,212 @@ impl DirectoryNamespace {
     /// version listing and deletion stay consistent with the on-disk format.
     fn manifest_version_from_filename(filename: &str) -> Option<u64> {
         ManifestNamingScheme::detect_scheme(filename)?.parse_version(filename)
+    }
+
+    /// Build a successful `CreateTableVersionResponse` from an existing final manifest.
+    fn create_table_version_response(
+        version: u64,
+        final_path: &Path,
+        final_meta: &ObjectMeta,
+    ) -> CreateTableVersionResponse {
+        CreateTableVersionResponse {
+            transaction_id: None,
+            version: Some(Box::new(TableVersion {
+                version: version as i64,
+                manifest_path: final_path.to_string(),
+                manifest_size: Some(final_meta.size as i64),
+                e_tag: final_meta.e_tag.clone(),
+                timestamp_millis: None,
+                metadata: None,
+            })),
+        }
+    }
+
+    /// Whether the staging blob matches the already-published version blob.
+    ///
+    /// Used for idempotent retries of `create_table_version`: after a successful
+    /// Create materialize the final object's e_tag may differ from the staging
+    /// e_tag, so content equality is the durable identity check.
+    async fn staging_matches_final_manifest(
+        &self,
+        staging_path: &Path,
+        final_path: &Path,
+        request_e_tag: Option<&str>,
+        final_meta: &ObjectMeta,
+        request_manifest_size: Option<i64>,
+    ) -> Result<bool> {
+        if let (Some(req_tag), Some(exist_tag)) = (request_e_tag, final_meta.e_tag.as_deref())
+            && req_tag == exist_tag
+        {
+            return Ok(true);
+        }
+        if let Some(size) = request_manifest_size
+            && size != final_meta.size as i64
+        {
+            return Ok(false);
+        }
+
+        let staging_bytes = match self.object_store.inner.get(staging_path).await {
+            Ok(r) => r.bytes().await.map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to read staging manifest at '{}': {}",
+                        staging_path, e
+                    ),
+                })
+            })?,
+            Err(ObjectStoreError::NotFound { .. }) => return Ok(false),
+            Err(e) => {
+                return Err(lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to read staging manifest at '{}': {}",
+                        staging_path, e
+                    ),
+                }));
+            }
+        };
+
+        let final_bytes = self
+            .object_store
+            .inner
+            .get(final_path)
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to read existing version manifest at '{}': {}",
+                        final_path, e
+                    ),
+                })
+            })?
+            .bytes()
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to read existing version manifest bytes at '{}': {}",
+                        final_path, e
+                    ),
+                })
+            })?;
+
+        Ok(staging_bytes.as_ref() == final_bytes.as_ref())
+    }
+
+    /// Idempotent success or conflict when the target version path already exists.
+    async fn resolve_existing_table_version(
+        &self,
+        args: ExistingTableVersionResolve<'_>,
+    ) -> Result<CreateTableVersionResponse> {
+        if self
+            .staging_matches_final_manifest(
+                args.staging_path,
+                args.final_path,
+                args.request_e_tag,
+                args.final_meta,
+                args.request_manifest_size,
+            )
+            .await?
+        {
+            // Best-effort cleanup of a retry's staging blob.
+            if let Err(e) = self.object_store.inner.delete(args.staging_path).await {
+                log::warn!(
+                    "Failed to delete staging manifest at '{}': {:?}",
+                    args.staging_path,
+                    e
+                );
+            }
+            return Ok(Self::create_table_version_response(
+                args.version,
+                args.final_path,
+                args.final_meta,
+            ));
+        }
+
+        Err(lance_core::Error::from(
+            NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Version {} already exists for table at '{}' with different content",
+                    args.version, args.table_uri
+                ),
+            },
+        ))
+    }
+
+    /// Enforce version CAS: requested version must be `latest + 1` (or `1` if empty).
+    async fn enforce_create_table_version_cas(
+        &self,
+        table_path: &Path,
+        version: u64,
+        table_uri: &str,
+    ) -> Result<()> {
+        let latest = self.list_versions_under(table_path, true, Some(1)).await?;
+        let expected = match latest.first() {
+            Some(v) => (v.version as u64).saturating_add(1),
+            None => 1,
+        };
+        if version != expected {
+            let latest_display = latest
+                .first()
+                .map(|v| v.version.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            return Err(lance_core::Error::from(
+                NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Version CAS failed for table at '{}': requested {}, expected {} (latest {})",
+                        table_uri, version, expected, latest_display
+                    ),
+                },
+            ));
+        }
+        Ok(())
+    }
+
+    /// Materialize staging → final with Create semantics only (never overwrite).
+    async fn materialize_version_manifest_create(
+        &self,
+        staging_path: &Path,
+        final_path: &Path,
+        staging_manifest_path: &str,
+    ) -> std::result::Result<(), ObjectStoreError> {
+        match self
+            .object_store
+            .inner
+            .copy_if_not_exists(staging_path, final_path)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::NotImplemented { .. })
+            | Err(ObjectStoreError::NotSupported { .. }) => {
+                let manifest_data = self
+                    .object_store
+                    .inner
+                    .get(staging_path)
+                    .await?
+                    .bytes()
+                    .await
+                    .map_err(|e| ObjectStoreError::Generic {
+                        store: "DirectoryNamespace",
+                        source: Box::new(std::io::Error::other(format!(
+                            "Failed to read staging manifest bytes at '{}': {}",
+                            staging_manifest_path, e
+                        ))),
+                    })?;
+                self.object_store
+                    .inner
+                    .put_opts(
+                        final_path,
+                        manifest_data.into(),
+                        PutOptions {
+                            mode: PutMode::Create,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map(|_| ())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn list_table_versions_from_storage(
@@ -2550,18 +2769,73 @@ impl DirectoryNamespace {
         path: &Path,
         file_description: &str,
     ) -> std::result::Result<(), String> {
-        let put_opts = PutOptions {
-            mode: PutMode::Create,
-            ..Default::default()
+        // Some object stores implement `PutMode::Create` using a temp+rename
+        // that reuses the final basename. Dotfile targets such as
+        // `.lance-reserved` therefore produce temp names containing `..`,
+        // which these stores reject. Stage under a non-dot sibling, then claim
+        // the final path with rename_if_not_exists (conditional no-replace
+        // rename) so Create semantics are preserved without changing the store.
+        let staging_name = format!("lance-marker.staging.{}", uuid::Uuid::new_v4().simple());
+        let path_str = path.as_ref();
+        let staging_path = match path_str.rfind('/') {
+            Some(idx) => Path::from(format!("{}/{}", &path_str[..idx], staging_name)),
+            None => Path::from(staging_name.as_str()),
         };
 
-        match self
+        // Some object stores write via temp+rename and may not flush empty
+        // objects through to the underlying filesystem, so the conditional
+        // rename can fail with NotFound. Use a tiny non-empty payload.
+        self.object_store
+            .inner
+            .put(&staging_path, bytes::Bytes::from_static(b"reserved").into())
+            .await
+            .map_err(|e| format!("Failed to stage {}: {:?}", file_description, e))?;
+
+        let publish_result = match self
             .object_store
             .inner
-            .put_opts(path, bytes::Bytes::new().into(), put_opts)
+            .rename_if_not_exists(&staging_path, path)
             .await
         {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::NotImplemented { .. })
+            | Err(ObjectStoreError::NotSupported { .. }) => {
+                let result = self
+                    .object_store
+                    .inner
+                    .put_opts(
+                        path,
+                        bytes::Bytes::from_static(b"reserved").into(),
+                        PutOptions {
+                            mode: PutMode::Create,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map(|_| ());
+                if let Err(e) = self.object_store.inner.delete(&staging_path).await {
+                    log::warn!(
+                        "Failed to delete staging marker at '{}': {:?}",
+                        staging_path,
+                        e
+                    );
+                }
+                result
+            }
+            Err(e) => {
+                if let Err(del_err) = self.object_store.inner.delete(&staging_path).await {
+                    log::warn!(
+                        "Failed to delete staging marker at '{}': {:?}",
+                        staging_path,
+                        del_err
+                    );
+                }
+                Err(e)
+            }
+        };
+
+        match publish_result {
+            Ok(()) => Ok(()),
             Err(ObjectStoreError::AlreadyExists { .. })
             | Err(ObjectStoreError::Precondition { .. }) => {
                 Err(format!("{} already exists", file_description))
@@ -3641,66 +3915,73 @@ impl LanceNamespace for DirectoryNamespace {
             })
         })?;
 
-        let copy_result = match self
-            .object_store
-            .inner
-            .copy_if_not_exists(&staging_path, &final_path)
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(ObjectStoreError::NotImplemented { .. })
-            | Err(ObjectStoreError::NotSupported { .. }) => {
-                let manifest_data = self
-                    .object_store
-                    .inner
-                    .get(&staging_path)
-                    .await
-                    .map_err(|e| {
-                        lance_core::Error::from(NamespaceError::Internal {
-                            message: format!(
-                                "Failed to read staging manifest at '{}': {}",
-                                staging_manifest_path, e
-                            ),
-                        })
-                    })?
-                    .bytes()
-                    .await
-                    .map_err(|e| {
-                        lance_core::Error::from(NamespaceError::Internal {
-                            message: format!(
-                                "Failed to read staging manifest bytes at '{}': {}",
-                                staging_manifest_path, e
-                            ),
-                        })
-                    })?;
-                self.object_store
-                    .inner
-                    .put_opts(
-                        &final_path,
-                        manifest_data.into(),
-                        PutOptions {
-                            mode: PutMode::Create,
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                    .map(|_| ())
+        // Idempotent retry: version path already published with the same content.
+        match self.object_store.inner.head(&final_path).await {
+            Ok(existing_meta) => {
+                return self
+                    .resolve_existing_table_version(ExistingTableVersionResolve {
+                        staging_path: &staging_path,
+                        final_path: &final_path,
+                        version,
+                        table_uri: &table_uri,
+                        request_e_tag: request.e_tag.as_deref(),
+                        final_meta: &existing_meta,
+                        request_manifest_size: request.manifest_size,
+                    })
+                    .await;
             }
-            Err(e) => Err(e),
-        };
+            Err(ObjectStoreError::NotFound { .. }) => {}
+            Err(e) => {
+                return Err(lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to stat version {} for table at '{}': {}",
+                        version, table_uri, e
+                    ),
+                }));
+            }
+        }
+
+        // Strict CAS: only allow appending latest+1 (or version 1 on an empty chain).
+        self.enforce_create_table_version_cas(&table_path, version, &table_uri)
+            .await?;
+
+        // Materialize with Create / copy_if_not_exists only — never overwrite.
+        let copy_result = self
+            .materialize_version_manifest_create(&staging_path, &final_path, staging_manifest_path)
+            .await;
 
         match copy_result {
             Ok(()) => {}
             Err(ObjectStoreError::AlreadyExists { .. })
             | Err(ObjectStoreError::Precondition { .. }) => {
-                return Err(lance_core::Error::from(
-                    NamespaceError::ConcurrentModification {
+                // Lost a Create race: succeed only if the winner published identical bytes.
+                let existing_meta = self.object_store.inner.head(&final_path).await.map_err(|e| {
+                    lance_core::Error::from(NamespaceError::Internal {
                         message: format!(
-                            "Version {} already exists for table at '{}'",
-                            version, table_uri
+                            "Version {} conflict for table at '{}' but failed to stat winner: {}",
+                            version, table_uri, e
                         ),
-                    },
-                ));
+                    })
+                })?;
+                return self
+                    .resolve_existing_table_version(ExistingTableVersionResolve {
+                        staging_path: &staging_path,
+                        final_path: &final_path,
+                        version,
+                        table_uri: &table_uri,
+                        request_e_tag: request.e_tag.as_deref(),
+                        final_meta: &existing_meta,
+                        request_manifest_size: request.manifest_size,
+                    })
+                    .await;
+            }
+            Err(ObjectStoreError::NotFound { .. }) => {
+                return Err(lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Staging manifest not found at '{}' for version {} of table at '{}'",
+                        staging_manifest_path, version, table_uri
+                    ),
+                }));
             }
             Err(e) => {
                 return Err(lance_core::Error::from(NamespaceError::Internal {
@@ -3725,7 +4006,6 @@ impl LanceNamespace for DirectoryNamespace {
                     ),
                 })
             })?;
-        let manifest_size = final_meta.size as i64;
 
         // Delete the staging manifest after successful copy
         if let Err(e) = self.object_store.inner.delete(&staging_path).await {
@@ -3736,17 +4016,11 @@ impl LanceNamespace for DirectoryNamespace {
             );
         }
 
-        Ok(CreateTableVersionResponse {
-            transaction_id: None,
-            version: Some(Box::new(TableVersion {
-                version: version as i64,
-                manifest_path: final_path.to_string(),
-                manifest_size: Some(manifest_size),
-                e_tag: final_meta.e_tag,
-                timestamp_millis: None,
-                metadata: None,
-            })),
-        })
+        Ok(Self::create_table_version_response(
+            version,
+            &final_path,
+            &final_meta,
+        ))
     }
 
     async fn describe_table_version(
@@ -11388,9 +11662,124 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_table_version_idempotent() {
+        // A network retry of create_table_version with the same staging content
+        // must succeed (not ConcurrentModification) once the version is published.
+        use futures::TryStreamExt;
+        use lance::dataset::builder::DatasetBuilder;
+        use lance_namespace::models::CreateTableVersionRequest;
+
+        let temp_dir = TempStrDir::default();
+        let temp_path: &str = &temp_dir;
+
+        let namespace: Arc<dyn LanceNamespace> = Arc::new(
+            DirectoryNamespaceBuilder::new(temp_path)
+                .table_version_tracking_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let table_id = vec!["test_table".to_string()];
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .load()
+            .await
+            .unwrap();
+
+        let versions_path = dataset.versions_dir();
+        let manifest_metas: Vec<_> = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .list(Some(&versions_path))
+            .try_collect()
+            .await
+            .unwrap();
+
+        let manifest_meta = manifest_metas
+            .iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .map(|f| f.ends_with(".manifest"))
+                    .unwrap_or(false)
+            })
+            .expect("No manifest file found");
+
+        let manifest_data = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .get(&manifest_meta.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+
+        let staging_path = dataset.versions_dir().join("staging_manifest");
+        dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .put(&staging_path, manifest_data.clone().into())
+            .await
+            .unwrap();
+
+        let mut create_version_req = CreateTableVersionRequest::new(2, staging_path.to_string());
+        create_version_req.id = Some(table_id.clone());
+        create_version_req.naming_scheme = Some("V2".to_string());
+        let first = namespace
+            .create_table_version(create_version_req)
+            .await
+            .expect("first create_table_version should succeed");
+
+        // Re-stage identical bytes (simulates Lance commit retry rewriting staging).
+        let retry_staging = dataset.versions_dir().join("staging_manifest_retry");
+        dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .put(&retry_staging, manifest_data.into())
+            .await
+            .unwrap();
+
+        let mut retry_req = CreateTableVersionRequest::new(2, retry_staging.to_string());
+        retry_req.id = Some(table_id.clone());
+        retry_req.naming_scheme = Some("V2".to_string());
+        let second = namespace
+            .create_table_version(retry_req)
+            .await
+            .expect("idempotent retry must succeed");
+
+        assert_eq!(
+            first.version.as_ref().map(|v| v.version),
+            second.version.as_ref().map(|v| v.version)
+        );
+        assert_eq!(
+            first.version.as_ref().map(|v| &v.manifest_path),
+            second.version.as_ref().map(|v| &v.manifest_path)
+        );
+    }
+
+    #[tokio::test]
     async fn test_create_table_version_conflict() {
-        // create_table_version should fail if the version already exists.
-        // Each version always writes to a new file location.
+        // Same version with different content must fail ConcurrentModification.
         use futures::TryStreamExt;
         use lance::dataset::builder::DatasetBuilder;
         use lance_namespace::models::CreateTableVersionRequest;
@@ -11492,15 +11881,34 @@ mod tests {
         )
         .unwrap();
 
-        // Create version 2 again (should fail - conflict)
-        let mut create_version_req = CreateTableVersionRequest::new(2, staging_path.to_string());
+        // Different content for the same version number must conflict.
+        let conflict_staging = dataset.versions_dir().join("staging_manifest_conflict");
+        dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .put(
+                &conflict_staging,
+                bytes::Bytes::from_static(b"not-a-real-manifest").into(),
+            )
+            .await
+            .unwrap();
+
+        let mut create_version_req =
+            CreateTableVersionRequest::new(2, conflict_staging.to_string());
         create_version_req.id = Some(table_id.clone());
         create_version_req.naming_scheme = Some("V2".to_string());
 
         let result = namespace.create_table_version(create_version_req).await;
         assert!(
             result.is_err(),
-            "create_table_version should fail for existing version"
+            "create_table_version should fail for existing version with different content"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("already exists") || err.contains("ConcurrentModification"),
+            "expected ConcurrentModification, got: {err}"
         );
 
         // Verify version 2 still exists using the dataset's object_store
@@ -11515,6 +11923,97 @@ mod tests {
             head_result.is_ok(),
             "Version 2 manifest should still exist at {}",
             version_2_path
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_version_cas_rejects_gap() {
+        // Strict CAS: version must be latest+1; skipping ahead is ConcurrentModification.
+        use futures::TryStreamExt;
+        use lance::dataset::builder::DatasetBuilder;
+        use lance_namespace::models::CreateTableVersionRequest;
+
+        let temp_dir = TempStrDir::default();
+        let temp_path: &str = &temp_dir;
+
+        let namespace: Arc<dyn LanceNamespace> = Arc::new(
+            DirectoryNamespaceBuilder::new(temp_path)
+                .table_version_tracking_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let table_id = vec!["test_table".to_string()];
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .load()
+            .await
+            .unwrap();
+
+        let versions_path = dataset.versions_dir();
+        let manifest_metas: Vec<_> = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .list(Some(&versions_path))
+            .try_collect()
+            .await
+            .unwrap();
+        let manifest_meta = manifest_metas
+            .iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .map(|f| f.ends_with(".manifest"))
+                    .unwrap_or(false)
+            })
+            .expect("No manifest file found");
+        let manifest_data = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .get(&manifest_meta.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+
+        let staging_path = dataset.versions_dir().join("staging_gap");
+        dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .put(&staging_path, manifest_data.into())
+            .await
+            .unwrap();
+
+        // After create_table, latest is 1; requesting 5 must fail CAS.
+        let mut req = CreateTableVersionRequest::new(5, staging_path.to_string());
+        req.id = Some(table_id);
+        req.naming_scheme = Some("V2".to_string());
+        let err = namespace
+            .create_table_version(req)
+            .await
+            .expect_err("gap create must fail CAS");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CAS") || msg.contains("ConcurrentModification"),
+            "expected CAS ConcurrentModification, got: {msg}"
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3492,7 +3492,7 @@ impl LanceNamespace for ManifestNamespace {
 
         // Atomically create the .lance-reserved file to mark the table as declared.
         // Shared with DirectoryNamespace via put_marker_file_atomic (dotfile-safe
-        // staging + AlreadyExists → TableAlreadyExists mapping).
+        // staging + MarkerFileError::AlreadyExists → TableAlreadyExists).
         let reserved_file_path = table_path.clone().join(".lance-reserved");
         super::put_marker_file_atomic(
             &self.object_store,
@@ -3500,13 +3500,14 @@ impl LanceNamespace for ManifestNamespace {
             &format!("table {}", table_name),
         )
         .await
-        .map_err(|e| {
-            if e.contains("already exists") {
+        .map_err(|e| match e {
+            super::MarkerFileError::AlreadyExists { .. } => {
                 lance_core::Error::from(NamespaceError::TableAlreadyExists {
                     message: table_name.to_string(),
                 })
-            } else {
-                lance_core::Error::from(NamespaceError::Internal { message: e })
+            }
+            super::MarkerFileError::Other { message } => {
+                lance_core::Error::from(NamespaceError::Internal { message })
             }
         })?;
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -60,7 +60,7 @@ use lance_table::format::{Fragment, IndexMetadata, Manifest};
 use lance_table::io::commit::{
     CommitError, CommitHandler, commit_handler_from_url, write_manifest_file_to_path,
 };
-use object_store::{Error as ObjectStoreError, path::Path};
+use object_store::{Error as ObjectStoreError, ObjectStoreExt, path::Path};
 use roaring::RoaringBitmap;
 use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -3490,30 +3490,89 @@ impl LanceNamespace for ManifestNamespace {
             }
         }
 
-        // Create the .lance-reserved file to mark the table as existing
+        // Create the .lance-reserved file to mark the table as existing.
+        // Avoid `object_store.create(.lance-reserved)` / PutMode::Create on the
+        // final dotfile: some object stores implement Create via temp+rename
+        // using the final basename, which yields `..lance-reserved` temps that
+        // the underlying store rejects. Stage under a non-dot sibling, then
+        // rename_if_not_exists.
         let reserved_file_path = table_path.clone().join(".lance-reserved");
+        let staging_name = format!("lance-marker.staging.{}", Uuid::new_v4().simple());
+        let staging_path = table_path.clone().join(staging_name.as_str());
 
+        // Some object stores write via temp+rename and may not flush empty
+        // objects through to the underlying filesystem, so the conditional
+        // rename can fail with NotFound. Use a tiny non-empty payload.
         self.object_store
-            .create(&reserved_file_path)
+            .inner
+            .put(&staging_path, Bytes::from_static(b"reserved").into())
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!(
-                        "Failed to create .lance-reserved file for table {}: {}",
-                        table_name, e
-                    ),
-                })
-            })?
-            .shutdown()
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to finalize .lance-reserved file for table {}: {}",
+                        "Failed to stage .lance-reserved file for table {}: {}",
                         table_name, e
                     ),
                 })
             })?;
+
+        // Prefer rename_if_not_exists (conditional no-replace rename). Fall
+        // back to Create put only when the store lacks conditional rename.
+        let publish = match self
+            .object_store
+            .inner
+            .rename_if_not_exists(&staging_path, &reserved_file_path)
+            .await
+        {
+            Ok(()) => {
+                // Staging path was consumed by the rename.
+                Ok(())
+            }
+            Err(ObjectStoreError::NotImplemented { .. })
+            | Err(ObjectStoreError::NotSupported { .. }) => {
+                use object_store::{PutMode, PutOptions};
+                let result = self
+                    .object_store
+                    .inner
+                    .put_opts(
+                        &reserved_file_path,
+                        Bytes::from_static(b"reserved").into(),
+                        PutOptions {
+                            mode: PutMode::Create,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map(|_| ());
+                if let Err(e) = self.object_store.inner.delete(&staging_path).await {
+                    log::warn!(
+                        "Failed to delete staging marker at '{}': {:?}",
+                        staging_path,
+                        e
+                    );
+                }
+                result
+            }
+            Err(e) => {
+                if let Err(del_err) = self.object_store.inner.delete(&staging_path).await {
+                    log::warn!(
+                        "Failed to delete staging marker at '{}': {:?}",
+                        staging_path,
+                        del_err
+                    );
+                }
+                Err(e)
+            }
+        };
+
+        publish.map_err(|e| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to create .lance-reserved file for table {}: {}",
+                    table_name, e
+                ),
+            })
+        })?;
 
         let metadata = Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -60,7 +60,7 @@ use lance_table::format::{Fragment, IndexMetadata, Manifest};
 use lance_table::io::commit::{
     CommitError, CommitHandler, commit_handler_from_url, write_manifest_file_to_path,
 };
-use object_store::{Error as ObjectStoreError, ObjectStoreExt, path::Path};
+use object_store::{Error as ObjectStoreError, path::Path};
 use roaring::RoaringBitmap;
 use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -3490,88 +3490,24 @@ impl LanceNamespace for ManifestNamespace {
             }
         }
 
-        // Create the .lance-reserved file to mark the table as existing.
-        // Avoid `object_store.create(.lance-reserved)` / PutMode::Create on the
-        // final dotfile: some object stores implement Create via temp+rename
-        // using the final basename, which yields `..lance-reserved` temps that
-        // the underlying store rejects. Stage under a non-dot sibling, then
-        // rename_if_not_exists.
+        // Atomically create the .lance-reserved file to mark the table as declared.
+        // Shared with DirectoryNamespace via put_marker_file_atomic (dotfile-safe
+        // staging + AlreadyExists → TableAlreadyExists mapping).
         let reserved_file_path = table_path.clone().join(".lance-reserved");
-        let staging_name = format!("lance-marker.staging.{}", Uuid::new_v4().simple());
-        let staging_path = table_path.clone().join(staging_name.as_str());
-
-        // Some object stores write via temp+rename and may not flush empty
-        // objects through to the underlying filesystem, so the conditional
-        // rename can fail with NotFound. Use a tiny non-empty payload.
-        self.object_store
-            .inner
-            .put(&staging_path, Bytes::from_static(b"reserved").into())
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to stage .lance-reserved file for table {}: {}",
-                        table_name, e
-                    ),
+        super::put_marker_file_atomic(
+            &self.object_store,
+            &reserved_file_path,
+            &format!("table {}", table_name),
+        )
+        .await
+        .map_err(|e| {
+            if e.contains("already exists") {
+                lance_core::Error::from(NamespaceError::TableAlreadyExists {
+                    message: table_name.to_string(),
                 })
-            })?;
-
-        // Prefer rename_if_not_exists (conditional no-replace rename). Fall
-        // back to Create put only when the store lacks conditional rename.
-        let publish = match self
-            .object_store
-            .inner
-            .rename_if_not_exists(&staging_path, &reserved_file_path)
-            .await
-        {
-            Ok(()) => {
-                // Staging path was consumed by the rename.
-                Ok(())
+            } else {
+                lance_core::Error::from(NamespaceError::Internal { message: e })
             }
-            Err(ObjectStoreError::NotImplemented { .. })
-            | Err(ObjectStoreError::NotSupported { .. }) => {
-                use object_store::{PutMode, PutOptions};
-                let result = self
-                    .object_store
-                    .inner
-                    .put_opts(
-                        &reserved_file_path,
-                        Bytes::from_static(b"reserved").into(),
-                        PutOptions {
-                            mode: PutMode::Create,
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                    .map(|_| ());
-                if let Err(e) = self.object_store.inner.delete(&staging_path).await {
-                    log::warn!(
-                        "Failed to delete staging marker at '{}': {:?}",
-                        staging_path,
-                        e
-                    );
-                }
-                result
-            }
-            Err(e) => {
-                if let Err(del_err) = self.object_store.inner.delete(&staging_path).await {
-                    log::warn!(
-                        "Failed to delete staging marker at '{}': {:?}",
-                        staging_path,
-                        del_err
-                    );
-                }
-                Err(e)
-            }
-        };
-
-        publish.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!(
-                    "Failed to create .lance-reserved file for table {}: {}",
-                    table_name, e
-                ),
-            })
         })?;
 
         let metadata = Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;


### PR DESCRIPTION

## Summary

Make `create_table_version` in the directory namespace (`lance-namespace-impls`)
idempotent, strictly enforce version CAS, and make the `.lance-reserved` marker
creation safe across object stores.

## Problem

In the namespace directory provider, `create_table_version` is currently unsafe
against the retries and races that happen with real object-store deployments:

1. **Non-idempotent retries.** If a version is successfully created but the
   client retries (network blip, or the coordinating node renamed staging →
   final while the caller lost the response), the second attempt sees the
   version already published and fails with `ConcurrentModification`. Callers
   cannot distinguish a genuine conflict from a benign retry.

2. **Loose version CAS.** There is no enforced "must be `latest + 1`" check,
   so a stale or duplicate write can fork the version chain.

3. **Reserved-marker staging breaks on some object stores.** The table is
   reserved by writing a `.lance-reserved` marker. Some backends implement
   `PutMode::Create` as a temp-file + rename, producing temporary names
   containing `..`. Object stores and unified file systems that reject `..`
   path components then fail the marker write and the table can never be
   created.

## Changes

- **Strict CAS**: `create_table_version` only accepts `version == latest + 1`
  (`version == 1` on an empty chain); any other value maps to
  `NamespaceError::ConcurrentModification`.
- **Idempotent retry on published versions**: if the requested version already
  exists with identical manifest content (`e_tag` / `size` / bytes), return
  success instead of `ConcurrentModification`.
- **Content-conflict detection**: if a version with the same number exists but
  content differs, fail with `ConcurrentModification`.
- **Dotfile-safe reserved marker**: stage via a non-dot sibling file then
  `rename_if_not_exists` (conditional no-replace) onto `.lance-reserved`; fall
  back to `PutMode::Create` when rename is unsupported.

## Test plan

- Added tests for idempotent retry, content conflict, and CAS gap rejection,
  plus table-not-found and on-branch variants.
- `cargo test -p lance-namespace-impls --lib create_table_version` passes.

## Scope

Targets the `dir` namespace provider (`create_table_version` / reserved-marker
lifecycle). The retry/conflict semantics apply to any object-store backend,
not a specific one.

Closes #7939
