### PR TITLE
fix(core): reject non-finite values in AimdConfig::validate

### DIFF
--- a/rust/lance-core/src/utils/aimd.rs
+++ b/rust/lance-core/src/utils/aimd.rs
@@ -25,7 +25,7 @@ use crate::Result;
 ///
 /// - initial_rate: 2000 req/s
 /// - min_rate: 1 req/s
-/// - max_rate: 5000 req/s (0.0 disables ceiling)
+/// - max_rate: 5000 req/s (0.0 disables the ceiling; must be finite otherwise)
 /// - decrease_factor: 0.5 (halve on throttle)
 /// - additive_increment: 300 req/s per success window
 /// - window_duration: 1 second
@@ -384,6 +384,10 @@ mod tests {
         #[case] expected_msg: &str,
     ) {
         let err = config.validate().unwrap_err();
+        assert!(
+            matches!(&err, crate::Error::InvalidInput { .. }),
+            "expected InvalidInput, got: {err:?}"
+        );
         let msg = err.to_string();
         assert!(
             msg.contains(expected_msg),

--- a/rust/lance-core/src/utils/aimd.rs
+++ b/rust/lance-core/src/utils/aimd.rs
@@ -101,6 +101,26 @@ impl AimdConfig {
 
     /// Validate that the configuration values are sensible.
     pub fn validate(&self) -> Result<()> {
+        // Reject NaN and infinity first. The sign and ordering checks below
+        // compare with `<`/`>`, which are `false` for NaN and for a `+inf` on
+        // a field with no opposing bound, so a non-finite rate would otherwise
+        // slip through and silently disable throttling (a NaN rate makes the
+        // token bucket refill to full on every acquire) or, with a zero burst
+        // capacity, panic in `Duration::from_secs_f64`.
+        for (name, value) in [
+            ("initial_rate", self.initial_rate),
+            ("min_rate", self.min_rate),
+            ("max_rate", self.max_rate),
+            ("decrease_factor", self.decrease_factor),
+            ("additive_increment", self.additive_increment),
+            ("throttle_threshold", self.throttle_threshold),
+        ] {
+            if !value.is_finite() {
+                return Err(crate::Error::invalid_input(format!(
+                    "{name} must be finite, got {value}"
+                )));
+            }
+        }
         if self.initial_rate <= 0.0 {
             return Err(crate::Error::invalid_input(format!(
                 "initial_rate must be positive, got {}",
@@ -326,6 +346,38 @@ mod tests {
     #[case::initial_below_min(
         AimdConfig::default().with_initial_rate(0.5).with_min_rate(1.0),
         "initial_rate (0.5) must not be below min_rate (1)"
+    )]
+    #[case::nan_initial_rate(
+        AimdConfig::default().with_initial_rate(f64::NAN),
+        "initial_rate must be finite"
+    )]
+    #[case::inf_initial_rate(
+        AimdConfig::default().with_initial_rate(f64::INFINITY),
+        "initial_rate must be finite"
+    )]
+    #[case::nan_min_rate(
+        AimdConfig::default().with_min_rate(f64::NAN),
+        "min_rate must be finite"
+    )]
+    #[case::nan_max_rate(
+        AimdConfig::default().with_max_rate(f64::NAN),
+        "max_rate must be finite"
+    )]
+    #[case::inf_max_rate(
+        AimdConfig::default().with_max_rate(f64::INFINITY),
+        "max_rate must be finite"
+    )]
+    #[case::nan_decrease_factor(
+        AimdConfig::default().with_decrease_factor(f64::NAN),
+        "decrease_factor must be finite"
+    )]
+    #[case::nan_additive_increment(
+        AimdConfig::default().with_additive_increment(f64::NAN),
+        "additive_increment must be finite"
+    )]
+    #[case::nan_throttle_threshold(
+        AimdConfig::default().with_throttle_threshold(f64::NAN),
+        "throttle_threshold must be finite"
     )]
     fn test_config_validation_rejects_invalid(
         #[case] config: AimdConfig,


### PR DESCRIPTION
## Summary

`AimdConfig::validate` checks its rate fields with sign and ordering comparisons (`initial_rate <= 0.0`, `min_rate > max_rate`, `decrease_factor >= 1.0`, and so on). Every one of those comparisons is `false` for `NaN`, so a `NaN` value passes validation untouched; `+inf` likewise slips through on any field that has no opposing bound (`max_rate`, `additive_increment`).

These configs are user-reachable. The `LANCE_AIMD_*` environment variables and the equivalent `storage_options` keys are parsed with `f64::parse`, which accepts `"nan"`, `"inf"`, and `"infinity"` case-insensitively, and the parsed value flows straight into `AimdConfig` and then `AimdController::new` → `validate`.

## Failure mode

A non-finite rate does not fail loudly, which is what makes it worth guarding. With the default burst capacity, a `NaN` rate makes the token bucket refill to full on every acquire — `(tokens + elapsed * NaN).min(burst)` returns `burst` because `f64::min` drops the NaN — so throttling is silently disabled and the only visible symptom is a `NaN` leaking into rate metrics and logs. Only when the burst capacity is zero does the code reach `Duration::from_secs_f64(NaN)` and panic.

## Change

Reject all six `f64` fields up front when they are not finite, with an error naming the offending field, before the existing range checks run. This is the common chokepoint for all three ingress paths (env vars, storage options, and direct construction of the public `AimdConfig`), so it is more complete than validating at the parse layer.

## Note for reviewers

This also rejects `max_rate = f64::INFINITY`, which previously passed validation and acted as an undocumented "no ceiling" alias. The documented sentinel for no ceiling is `max_rate = 0.0`, which is finite and unaffected. No code, test, or configuration in the repository sets any of these fields to a non-finite value.

## Test plan

Extended the `test_config_validation_rejects_invalid` table with a `NaN` case for each of the six fields plus `+inf` on `initial_rate` and `max_rate`. `cargo test -p lance-core --lib utils::aimd` and `cargo test -p lance-io --lib object_store::throttle` pass; `cargo fmt --all` and `cargo clippy -p lance-core --all-targets -- -D warnings` are clean.
