### PR TITLE
fix(datagen): preserve timestamp time zones

### DIFF
--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -3268,6 +3268,18 @@ mod tests {
     }
 
     #[test]
+    fn test_fn_gen_propagates_array_data_build_error() {
+        // FnGen constructors are internal. Use an incompatible declared type to
+        // verify that ArrayDataBuilder validation failures are propagated.
+        let mut generator = FnGen::<i32, Int32Array, _>::new_unknown_size(DataType::Utf8, |_| 0, 1);
+
+        assert!(matches!(
+            generator.generate_default(RowCount::from(1)),
+            Err(ArrowError::InvalidArgumentError(_))
+        ));
+    }
+
+    #[test]
     fn test_step() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
         let mut genn = array::step::<Int32Type>();

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -569,7 +569,16 @@ where
         };
         self.leftover_count = ((self.leftover_count as u64 + length.0) % self.repeat as u64) as u32;
         self.leftover = values.last().copied().unwrap_or(T::default());
-        Ok(Arc::new(ArrayType::from(values)))
+        let array = ArrayType::from(values);
+        if array.data_type() == &self.data_type {
+            return Ok(Arc::new(array));
+        }
+        let data = array
+            .into_data()
+            .into_builder()
+            .data_type(self.data_type.clone())
+            .build()?;
+        Ok(make_array(data))
     }
 
     fn data_type(&self) -> &DataType {
@@ -3241,6 +3250,19 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_timestamp_timezone_is_preserved() {
+        let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()));
+        let mut generator = array::rand_type(&data_type);
+        let generated = generator.generate_default(RowCount::from(2)).unwrap();
+        assert_eq!(generated.data_type(), &data_type);
+
+        let fields = Fields::from(vec![Field::new("timestamp", data_type, true)]);
+        let mut generator = array::rand_struct(fields.clone());
+        let generated = generator.generate_default(RowCount::from(2)).unwrap();
+        assert_eq!(generated.data_type(), &DataType::Struct(fields));
+    }
 
     #[test]
     fn test_step() {

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -570,6 +570,9 @@ where
         self.leftover_count = ((self.leftover_count as u64 + length.0) % self.repeat as u64) as u32;
         self.leftover = values.last().copied().unwrap_or(T::default());
         let array = ArrayType::from(values);
+        // `ArrayType::from` uses the primitive type's default metadata. For
+        // timezone-aware timestamps this drops the timezone, so restore the
+        // generator's declared type when it differs.
         if array.data_type() == &self.data_type {
             return Ok(Arc::new(array));
         }


### PR DESCRIPTION
## Summary

- Preserve the requested timezone metadata when `lance-datagen` generates timestamp arrays.
- Prevent `rand_struct` from panicking when a struct contains a timezone-aware timestamp field.

## Root Cause

`FnGen` constructed the output with `PrimitiveArray::from(values)`, which restores the primitive type's default timestamp metadata. For timezone-aware timestamps, that dropped the timezone and made the generated child array type disagree with the struct field type.

## Changes

- Rebuild `ArrayData` with the generator's declared data type only when the generated type differs.
- Add regression coverage for both direct timestamp generation and timestamp fields generated through `rand_struct`.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p lance-datagen --lib` (14 passed)
- `cargo clippy -p lance-datagen --all-targets -- -D warnings`
- `cargo check --workspace --tests --benches`

## Related Issue

Fixes #7912