### PR TITLE
perf(encoding): compact chunk index for sparse cached page state

### DIFF
--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -83,5 +83,13 @@ harness = false
 name = "buffer"
 harness = false
 
+[[bench]]
+name = "sparse_decode"
+harness = false
+
+[[bench]]
+name = "sparse_footprint"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance-encoding/benches/sparse/README.md
+++ b/rust/lance-encoding/benches/sparse/README.md
@@ -1,0 +1,103 @@
+# Sparse structural read-path benchmarks
+
+Measures the cost of reading pages written with `Layout::SparseLayout`, split into the two
+things a change to the sparse chunk index can move independently:
+
+| target                    | harness    | measures                                                     |
+| ------------------------- | ---------- | ------------------------------------------------------------ |
+| `bench sparse_footprint`  | plain main | exact resident bytes and allocation volume, no statistics    |
+| `bench sparse_decode`     | Criterion  | initialize, full scan and scattered take latency             |
+
+Memory is deliberately not a Criterion benchmark. The quantities are exact byte counts, so
+reporting them as a distribution with confidence intervals would add noise and hide the
+signal.
+
+## Running
+
+```bash
+# exact memory report
+cargo bench -p lance-encoding --bench sparse_footprint
+
+# timings; use -- <filter> to narrow, e.g. -- sparse_take
+cargo bench -p lance-encoding --bench sparse_decode
+
+# check the inputs still land on the sparse layout (also runs in CI)
+cargo test -p lance-encoding --test sparse_bench_layouts
+```
+
+## Comparing two revisions
+
+`run_ab.sh` is the reproducible path. It builds two refs, runs identical benchmark code
+against both, and reports a paired comparison.
+
+```bash
+CPUS=0,2,4,6,8,10,12,14 ./run_ab.sh <before-ref> <after-ref> 8
+```
+
+It handles the three things that most often make a hand-rolled A/B wrong:
+
+1. **Identical benchmark code on both arms.** The bench sources from the invoking tree are
+   copied into both worktrees, so the comparison cannot silently become "old bench versus
+   new bench".
+2. **Separate target directories per arm.** Cargo's unit hash covers package name, version,
+   profile and features but not the source directory. Two worktrees at the same crate
+   version share a hash, so with a shared `CARGO_TARGET_DIR` cargo reports the first arm's
+   stale artifact as fresh and both arms measure the same binary. Verify with `md5sum` on
+   the two bench executables if you are ever unsure.
+3. **Interleaved, rotated arms.** Arm order alternates each round so thermal drift and
+   background load bias both arms equally rather than whichever arm runs first.
+
+Timing comparisons need at least 6 rounds. `compare.py` uses an exact two-sided sign-flip
+permutation test over per-round paired deltas, whose smallest attainable p-value is
+`2/2**rounds`; at 5 rounds that floor is 0.0625, so no effect of any size could clear
+p<0.05.
+
+Pin to physical cores for timing. Find them with `lscpu -p=CPU,CORE` and take one CPU per
+`CORE` value; sibling hyperthreads share execution resources and inflate variance.
+
+## Reading the output
+
+`sparse_footprint` reports three numbers per case:
+
+- **`cache_bytes`** — what `LanceCache::size_bytes()` holds after `DecodeBatchScheduler::try_new`
+  has initialized every field scheduler. This is the headline: the state is retained for as
+  long as the dataset is open, once per page per column, so it sets the cost of holding a
+  wide 2.3 table open.
+- **`init_bytes`** — bytes passed to the global allocator during initialize. Catches
+  transient allocations that never reach the cache, which `cache_bytes` cannot see.
+- **`init_allocs`** — allocation count over the same region. Separates "allocates less" from
+  "allocates fewer times"; a change can do either without the other.
+
+`cache_bytes` is derived from `DeepSizeOf`. When comparing two revisions, check that neither
+revision changed how the cached types report their own size, or the comparison measures
+accounting rather than memory.
+
+## Input matrix
+
+`cases.rs` holds the matrix. Every case declares the layout it expects and
+`sparse_bench_layouts.rs` asserts it, because layout selection is a **writer-side**
+heuristic: a page is read by the sparse scheduler only because it was written with
+`SparseLayout`. Without that assertion a change to the rep/def budget or to automatic sparse
+selection would quietly move cases onto the dense mini-block path, leaving the benches green
+while measuring nothing.
+
+Note that an all-null page resolves to `ConstantLayout` rather than `SparseLayout`, as do
+zero-row and all-empty-list pages: the writer recognises that the page holds no distinct leaf
+values and emits a constant page, which stores no chunk index at all. `all_null_lists` is
+kept in the matrix to pin that behaviour down, so a future writer change that starts routing
+it through the sparse layout surfaces as an assertion failure rather than as a silent
+regression.
+
+`Case::columns` rather than page count is the knob for multiplying resident state.
+`encode_batch` emits one page per column here regardless of the page budget, because
+`AccumulationQueue` flushes whole arrays and never splits one.
+
+## What these benches do not cover
+
+- **The encode path.** Nothing here measures writing. That is deliberate for changes scoped
+  to the reader, where encode timings serve only as a neutrality check.
+- **Real IO.** Pages are served from memory via `BufferScheduler`, so results isolate CPU and
+  allocation cost and exclude storage latency.
+- **Whole-dataset reads.** These benches live in `lance-encoding`, which cannot depend on
+  `lance-file` or `lance`. Multi-fragment and full-table scan behaviour belongs in the
+  benches in `rust/lance/benches/`.

--- a/rust/lance-encoding/benches/sparse/cases.rs
+++ b/rust/lance-encoding/benches/sparse/cases.rs
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+//! Shared input matrix for the sparse structural benchmarks.
+//!
+//! The sparse structural layout is chosen at write time, not read time: a page is
+//! scheduled by [`SparseStructuralScheduler`] whenever it was written with
+//! `Layout::SparseLayout`. That happens when a field asks for
+//! `lance-encoding:structural-encoding=sparse`, or automatically for a Lance 2.3+
+//! nested column whose rep/def levels overflow the dense mini-block budget.
+//!
+//! Every case therefore records which layout it *expects*, and the benches assert it.
+//! Without that check it is easy to benchmark the dense mini-block path by accident and
+//! conclude, wrongly, that a sparse change had no effect.
+
+// Shared by the `sparse_decode` and `sparse_footprint` bench targets, each of which uses a
+// subset of this module.
+#![allow(dead_code)]
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow_array::{Array, ArrayRef, Int32Array, ListArray, RecordBatch};
+use arrow_buffer::{NullBuffer, OffsetBuffer};
+use arrow_schema::{DataType, Field, Schema};
+use lance_encoding::{
+    constants::{STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_SPARSE},
+    decoder::PageEncoding,
+    encoder::{EncodedBatch, EncodingOptions, default_encoding_strategy, encode_batch},
+    format::pb21::page_layout::Layout,
+    version::LanceFileVersion,
+};
+
+/// Sparse structural encoding is only available from this version onwards.
+pub const SPARSE_VERSION: LanceFileVersion = LanceFileVersion::V2_3;
+
+const ITEM: &str = "item";
+const COLUMN: &str = "l";
+
+/// The structural layout a page was written with, as observed from the encoded batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservedLayout {
+    Sparse,
+    MiniBlock,
+    FullZip,
+    /// Every visible value is the same scalar or null, so the page stores no chunk index.
+    Constant,
+    Blob,
+    Legacy,
+    Other,
+}
+
+impl std::fmt::Display for ObservedLayout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Sparse => "sparse",
+            Self::MiniBlock => "miniblock",
+            Self::FullZip => "fullzip",
+            Self::Constant => "constant",
+            Self::Blob => "blob",
+            Self::Legacy => "legacy",
+            Self::Other => "other",
+        };
+        f.write_str(name)
+    }
+}
+
+/// The shape of the list column under test.
+///
+/// Shape controls both whether the writer picks the sparse layout and, within a sparse
+/// page, which chunk-index representation the reader ends up caching: uniform value
+/// counts map arithmetically, non-uniform counts need an explicit prefix array, and
+/// nested data carries per-chunk row metadata.
+#[derive(Debug, Clone, Copy)]
+pub enum Shape {
+    /// A single row holding a single value.
+    SingleValue,
+    /// Every row holds exactly `run` values, so all non-final chunks are the same size.
+    Uniform { rows: usize, run: usize },
+    /// Uniform except for a final oversized row, which breaks uniform chunk sizing.
+    UniformWithBigTail {
+        rows: usize,
+        run: usize,
+        tail: usize,
+    },
+    /// Every `stride`-th row holds `run` values; the rest are empty. Many rep/def levels
+    /// per leaf value, which is what pushes the dense mini-block budget over its limit.
+    Skewed {
+        rows: usize,
+        stride: usize,
+        run: usize,
+    },
+    /// Every row is null.
+    AllNull { rows: usize },
+    /// `List<List<Int32>>`, which forces the nested per-chunk row mapping.
+    Nested {
+        rows: usize,
+        outer: usize,
+        inner: usize,
+    },
+}
+
+impl Shape {
+    fn build(&self) -> ArrayRef {
+        match *self {
+            Self::SingleValue => Arc::new(lists(&[1])),
+            Self::Uniform { rows, run } => Arc::new(lists(&vec![run; rows])),
+            Self::UniformWithBigTail { rows, run, tail } => {
+                let mut counts = vec![run; rows];
+                *counts.last_mut().expect("non-empty") = tail;
+                Arc::new(lists(&counts))
+            }
+            Self::Skewed { rows, stride, run } => {
+                let counts: Vec<usize> = (0..rows)
+                    .map(|row| if row % stride == 0 { run } else { 0 })
+                    .collect();
+                Arc::new(lists(&counts))
+            }
+            Self::AllNull { rows } => Arc::new(null_lists(rows)),
+            Self::Nested { rows, outer, inner } => Arc::new(nested_lists(rows, outer, inner)),
+        }
+    }
+}
+
+/// A `List<Int32>` array whose row `i` holds `counts[i]` values.
+fn lists(counts: &[usize]) -> ListArray {
+    let total: usize = counts.iter().sum();
+    let mut offsets = Vec::with_capacity(counts.len() + 1);
+    offsets.push(0i32);
+    let mut end = 0i32;
+    for count in counts {
+        end += *count as i32;
+        offsets.push(end);
+    }
+    ListArray::new(
+        Arc::new(Field::new(ITEM, DataType::Int32, true)),
+        OffsetBuffer::new(offsets.into()),
+        Arc::new(Int32Array::from_iter_values((0..total).map(|v| v as i32))),
+        None,
+    )
+}
+
+/// A `List<Int32>` array where every row is null.
+fn null_lists(rows: usize) -> ListArray {
+    ListArray::new(
+        Arc::new(Field::new(ITEM, DataType::Int32, true)),
+        OffsetBuffer::new(vec![0i32; rows + 1].into()),
+        Arc::new(Int32Array::from(Vec::<i32>::new())),
+        Some(NullBuffer::new_null(rows)),
+    )
+}
+
+/// A `List<List<Int32>>` array: `rows` rows, each holding `outer` inner lists of `inner`
+/// values.
+fn nested_lists(rows: usize, outer: usize, inner: usize) -> ListArray {
+    let inner_array = lists(&vec![inner; rows * outer]);
+    let mut offsets = Vec::with_capacity(rows + 1);
+    offsets.push(0i32);
+    for row in 0..rows {
+        offsets.push(((row + 1) * outer) as i32);
+    }
+    ListArray::new(
+        Arc::new(Field::new(
+            ITEM,
+            DataType::List(Arc::new(Field::new(ITEM, DataType::Int32, true))),
+            true,
+        )),
+        OffsetBuffer::new(offsets.into()),
+        Arc::new(inner_array),
+        None,
+    )
+}
+
+/// One benchmark input.
+#[derive(Debug, Clone, Copy)]
+pub struct Case {
+    pub name: &'static str,
+    /// Why this case is in the matrix; printed by the footprint report.
+    pub note: &'static str,
+    pub shape: Shape,
+    /// Request the sparse layout explicitly rather than relying on the writer's automatic
+    /// selection. Cases that exercise automatic selection deliberately leave this false.
+    pub force_sparse: bool,
+    /// How many identical columns to encode.
+    ///
+    /// The scheduler caches its per-page state once per page per column, and
+    /// `encode_batch` emits one page per column here (the accumulation queue never splits a
+    /// single array), so column count is the knob that multiplies resident state. A wide
+    /// table is also the realistic shape for the memory pressure this measures.
+    pub columns: usize,
+    /// The layout this case is expected to produce.
+    pub expect: ObservedLayout,
+}
+
+/// Large enough that no case in the matrix is split by the writer's page budget, so page
+/// count is determined solely by `Case::columns`.
+const PAGE_BUDGET: u64 = 8 * 1024 * 1024;
+
+/// The full input matrix.
+///
+/// Ordered from degenerate to large so that a failure in the cheap cases surfaces first.
+pub fn cases() -> Vec<Case> {
+    vec![
+        // -- Degenerate shapes ------------------------------------------------------
+        // An all-null page never reaches the sparse layout: the writer recognises that it
+        // carries no distinct leaf values and emits a constant page, which stores no chunk
+        // index. It is kept in the matrix to pin that down, so a future writer change that
+        // starts routing it through the sparse layout shows up as a layout assertion failure
+        // rather than as a silent memory regression.
+        Case {
+            name: "degenerate/all_null_lists",
+            note: "every row null; writer emits a constant page",
+            shape: Shape::AllNull { rows: 200_000 },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Constant,
+        },
+        Case {
+            name: "degenerate/single_value",
+            note: "one row, one value, one chunk; the smallest real sparse index",
+            shape: Shape::SingleValue,
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        Case {
+            name: "degenerate/many_tiny_pages",
+            note: "64 single-value pages; isolates the per-page floor",
+            shape: Shape::SingleValue,
+            force_sparse: true,
+            columns: 64,
+            expect: ObservedLayout::Sparse,
+        },
+        // -- Sweep over page size ---------------------------------------------------
+        // A compact chunk index trades a fixed per-page cost against a per-chunk saving, so
+        // the interesting question is where that trade turns positive. These three points
+        // plus `degenerate/single_value` and `uniform/many_chunks` give the curve.
+        Case {
+            name: "sweep/16k_values",
+            note: "16k leaf values in one page",
+            shape: Shape::Uniform {
+                rows: 2_048,
+                run: 8,
+            },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        Case {
+            name: "sweep/256k_values",
+            note: "256k leaf values in one page",
+            shape: Shape::Uniform {
+                rows: 32_768,
+                run: 8,
+            },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        // -- Chunk-index representations -------------------------------------------
+        Case {
+            name: "uniform/many_chunks",
+            note: "equal value counts; chunk lookups reduce to arithmetic",
+            shape: Shape::Uniform {
+                rows: 400_000,
+                run: 8,
+            },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        Case {
+            name: "non_uniform/many_chunks",
+            note: "one row of a different length; forces per-row count materialization",
+            shape: Shape::UniformWithBigTail {
+                rows: 400_000,
+                run: 8,
+                tail: 500_000,
+            },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        Case {
+            name: "nested/list_of_list",
+            note: "List<List<Int32>>; per-chunk row metadata is boxed",
+            shape: Shape::Nested {
+                rows: 100_000,
+                outer: 4,
+                inner: 4,
+            },
+            force_sparse: true,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+        // -- Wide, which is what multiplies the resident state ----------------------
+        Case {
+            name: "wide/32_columns",
+            note: "32 sparse columns held open at once",
+            shape: Shape::Uniform {
+                rows: 50_000,
+                run: 8,
+            },
+            force_sparse: true,
+            columns: 32,
+            expect: ObservedLayout::Sparse,
+        },
+        // -- Automatic selection, i.e. what real 2.3 files will do -----------------
+        Case {
+            name: "automatic/skewed_lists",
+            note: "no metadata hint; writer picks sparse from the rep/def budget",
+            shape: Shape::Skewed {
+                rows: 500_000,
+                stride: 64,
+                run: 8,
+            },
+            force_sparse: false,
+            columns: 1,
+            expect: ObservedLayout::Sparse,
+        },
+    ]
+}
+
+impl Case {
+    pub fn batch(&self) -> RecordBatch {
+        let array = self.shape.build();
+        let mut metadata = HashMap::new();
+        if self.force_sparse {
+            metadata.insert(
+                STRUCTURAL_ENCODING_META_KEY.to_string(),
+                STRUCTURAL_ENCODING_SPARSE.to_string(),
+            );
+        }
+        let fields: Vec<Field> = (0..self.columns.max(1))
+            .map(|i| {
+                Field::new(format!("{COLUMN}{i}"), array.data_type().clone(), true)
+                    .with_metadata(metadata.clone())
+            })
+            .collect();
+        let columns: Vec<ArrayRef> = vec![array; self.columns.max(1)];
+        let schema = Arc::new(Schema::new(fields));
+        RecordBatch::try_new(schema, columns).expect("valid batch")
+    }
+
+    pub fn encoding_options(&self) -> EncodingOptions {
+        EncodingOptions {
+            cache_bytes_per_column: PAGE_BUDGET,
+            max_page_bytes: PAGE_BUDGET,
+            version: SPARSE_VERSION,
+            ..Default::default()
+        }
+    }
+}
+
+/// Encode a case without checking which layout the writer chose.
+pub fn encode_unchecked(case: &Case) -> EncodedBatch {
+    let batch = case.batch();
+    let lance_schema =
+        Arc::new(lance_core::datatypes::Schema::try_from(batch.schema().as_ref()).unwrap());
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("runtime");
+    rt.block_on(encode_batch(
+        &batch,
+        lance_schema,
+        default_encoding_strategy(SPARSE_VERSION).as_ref(),
+        &case.encoding_options(),
+    ))
+    .unwrap_or_else(|e| panic!("case {} failed to encode: {e}", case.name))
+}
+
+/// Encode a case and verify it produced the layout the case claims.
+///
+/// Panics on a layout mismatch: silently measuring the dense path would invalidate the
+/// whole comparison.
+pub fn encode(case: &Case) -> EncodedBatch {
+    let encoded = encode_unchecked(case);
+    let observed = layouts(&encoded);
+    assert!(
+        observed.iter().all(|l| *l == case.expect),
+        "case {} expected every page to be {} but observed {:?}",
+        case.name,
+        case.expect,
+        observed
+    );
+    encoded
+}
+
+/// The layout of every page in the encoded batch.
+pub fn layouts(encoded: &EncodedBatch) -> Vec<ObservedLayout> {
+    encoded
+        .page_table
+        .iter()
+        .flat_map(|col| col.page_infos.iter())
+        .map(|page| match &page.encoding {
+            PageEncoding::Legacy(_) => ObservedLayout::Legacy,
+            PageEncoding::Structural(layout) => match &layout.layout {
+                Some(Layout::SparseLayout(_)) => ObservedLayout::Sparse,
+                Some(Layout::MiniBlockLayout(_)) => ObservedLayout::MiniBlock,
+                Some(Layout::FullZipLayout(_)) => ObservedLayout::FullZip,
+                Some(Layout::ConstantLayout(_)) => ObservedLayout::Constant,
+                Some(Layout::BlobLayout(_)) => ObservedLayout::Blob,
+                _ => ObservedLayout::Other,
+            },
+        })
+        .collect()
+}
+
+/// Number of leaf value slots across every sparse page, used to normalise footprint.
+pub fn visible_items(encoded: &EncodedBatch) -> u64 {
+    encoded
+        .page_table
+        .iter()
+        .flat_map(|col| col.page_infos.iter())
+        .filter_map(|page| match &page.encoding {
+            PageEncoding::Structural(layout) => match &layout.layout {
+                Some(Layout::SparseLayout(sparse)) => Some(sparse.num_visible_items),
+                _ => None,
+            },
+            PageEncoding::Legacy(_) => None,
+        })
+        .sum()
+}
+
+/// Evenly spaced ascending row indices, which is the shape that drives the per-chunk
+/// lookups on the scheduling and decode paths hardest.
+pub fn scattered_indices(num_rows: u64, count: u64) -> Vec<u64> {
+    if num_rows == 0 || count == 0 {
+        return Vec::new();
+    }
+    let stride = (num_rows / count).max(1);
+    (0..num_rows)
+        .step_by(stride as usize)
+        .take(count as usize)
+        .collect()
+}

--- a/rust/lance-encoding/benches/sparse/compare.py
+++ b/rust/lance-encoding/benches/sparse/compare.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+"""Compare two arms of the sparse structural benchmarks.
+
+Two subcommands, because the two measurements need different statistics:
+
+  footprint <before.json> <after.json>
+      Exact byte counts, so a plain per-case diff is the whole story.
+
+  timing <criterion-root>
+      Criterion means collected over several interleaved rounds. Reported as a paired
+      comparison: each round contributes one before/after pair, and the p-value comes from
+      a permutation test over the per-round deltas. That is the right test here because the
+      rounds are matched in time, so it controls for the drift that makes a naive
+      before-then-after comparison unreliable.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# Below this, a timing difference is not distinguishable from run-to-run noise on a typical
+# developer machine even with pinning, so it is reported as "noise" regardless of p-value.
+NOISE_FLOOR_PCT = 3.0
+
+
+def load_footprint(path: Path) -> dict[str, dict]:
+    rows = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            row = json.loads(line)
+            rows[row["case"]] = row
+    return rows
+
+
+def fmt_bytes(n: float) -> str:
+    for unit, scale in (("GiB", 1 << 30), ("MiB", 1 << 20), ("KiB", 1 << 10)):
+        if abs(n) >= scale:
+            return f"{n / scale:,.2f} {unit}"
+    return f"{n:,.0f} B"
+
+
+def pct(before: float, after: float) -> str:
+    if before == 0:
+        return "n/a" if after == 0 else "+inf"
+    return f"{100.0 * (after - before) / before:+.1f}%"
+
+
+def footprint(before_path: Path, after_path: Path) -> None:
+    before = load_footprint(before_path)
+    after = load_footprint(after_path)
+
+    shared = [c for c in before if c in after]
+    if not shared:
+        sys.exit("no cases in common between the two arms")
+
+    missing = sorted(set(before) ^ set(after))
+    if missing:
+        print(f"warning: cases present in only one arm, skipped: {', '.join(missing)}\n")
+
+    for metric, label in (
+        ("cache_bytes", "resident scheduler state (LanceCache)"),
+        ("init_bytes", "bytes allocated during initialize"),
+        ("init_allocs", "allocation count during initialize"),
+    ):
+        print(f"\n{label}")
+        print(
+            f"  {'case':<30} {'layout':>9} {'pages':>6} {'before':>14} {'after':>14} {'delta':>10}"
+        )
+        print("  " + "-" * 88)
+        total_before = total_after = 0
+        for case in shared:
+            b, a = before[case][metric], after[case][metric]
+            total_before += b
+            total_after += a
+            show = fmt_bytes if metric != "init_allocs" else lambda n: f"{n:,.0f}"
+            print(
+                f"  {case:<30} {before[case]['layout']:>9} {before[case]['pages']:>6} "
+                f"{show(b):>14} {show(a):>14} {pct(b, a):>10}"
+            )
+        show = fmt_bytes if metric != "init_allocs" else lambda n: f"{n:,.0f}"
+        print("  " + "-" * 88)
+        print(
+            f"  {'total':<30} {'':>9} {'':>6} {show(total_before):>14} "
+            f"{show(total_after):>14} {pct(total_before, total_after):>10}"
+        )
+
+    print(
+        "\nA negative delta on resident scheduler state is the headline: that state is held"
+        "\nfor as long as the dataset is open, once per page per column."
+    )
+
+
+def load_timing(root: Path) -> dict[str, dict[str, dict[int, float]]]:
+    """-> {group/bench: {arm: {round: mean_seconds}}}"""
+    out: dict[str, dict[str, dict[int, float]]] = {}
+    for estimates in root.glob("r*/*/**/new/estimates.json"):
+        parts = estimates.relative_to(root).parts
+        rnd = int(parts[0][1:])
+        arm = parts[1]
+        bench = "/".join(parts[2:-2])
+        try:
+            mean = json.loads(estimates.read_text())["mean"]["point_estimate"]
+        except (json.JSONDecodeError, KeyError):
+            continue
+        out.setdefault(bench, {}).setdefault(arm, {})[rnd] = mean / 1e9
+    return out
+
+
+def permutation_p(deltas: list[float]) -> float:
+    """Exact two-sided sign-flip permutation test on paired deltas.
+
+    With n rounds there are only 2**n sign assignments, so for the round counts used here
+    the test enumerates them all rather than sampling. Note the consequence: the smallest
+    p-value attainable is 2/2**n, so fewer than 6 rounds can never clear p<0.05.
+    """
+    n = len(deltas)
+    if n == 0:
+        return 1.0
+    observed = abs(statistics.fmean(deltas))
+    if n > 20:  # keep it exact but bounded
+        deltas = deltas[:20]
+        n = 20
+    extreme = 0
+    total = 0
+    for signs in itertools.product((1, -1), repeat=n):
+        total += 1
+        flipped = statistics.fmean(s * d for s, d in zip(signs, deltas))
+        if abs(flipped) >= observed:
+            extreme += 1
+    return extreme / total
+
+
+def timing(root: Path) -> None:
+    data = load_timing(root)
+    if not data:
+        sys.exit(f"no criterion estimates found under {root}")
+
+    print(
+        f"  {'benchmark':<40} {'before':>10} {'after':>10} {'delta':>9} {'rounds':>7} {'p':>7}  verdict"
+    )
+    print("  " + "-" * 100)
+
+    for bench in sorted(data):
+        arms = data[bench]
+        if "before" not in arms or "after" not in arms:
+            continue
+        rounds = sorted(set(arms["before"]) & set(arms["after"]))
+        if not rounds:
+            continue
+        pairs = [(arms["before"][r], arms["after"][r]) for r in rounds]
+        deltas = [a - b for b, a in pairs]
+        mean_before = statistics.fmean(b for b, _ in pairs)
+        mean_after = statistics.fmean(a for _, a in pairs)
+        change = 100.0 * statistics.fmean(deltas) / mean_before if mean_before else 0.0
+        p = permutation_p(deltas)
+
+        if abs(change) < NOISE_FLOOR_PCT:
+            verdict = "noise"
+        elif p >= 0.05:
+            verdict = "not significant"
+        else:
+            verdict = "SLOWER" if change > 0 else "faster"
+
+        print(
+            f"  {bench:<40} {mean_before * 1e3:>9.3f}ms {mean_after * 1e3:>9.3f}ms "
+            f"{change:>+8.1f}% {len(rounds):>7} {p:>7.3f}  {verdict}"
+        )
+
+    print(
+        f"\n  Deltas below {NOISE_FLOOR_PCT}% are reported as noise regardless of p-value."
+        "\n  p is an exact sign-flip permutation test over per-round paired deltas."
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    mode = sys.argv[1]
+    if mode == "footprint":
+        footprint(Path(sys.argv[2]), Path(sys.argv[3]))
+    elif mode == "timing":
+        timing(Path(sys.argv[2]))
+    else:
+        sys.exit(f"unknown mode {mode!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/lance-encoding/benches/sparse/run_ab.sh
+++ b/rust/lance-encoding/benches/sparse/run_ab.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Interleaved A/B comparison of the sparse structural read path across two git refs.
+#
+#   ./run_ab.sh <before-ref> <after-ref> [rounds]
+#   ./run_ab.sh d8030a364 HEAD 8
+#
+# Use at least 6 rounds. The paired test in compare.py is an exact two-sided sign-flip
+# permutation test, whose smallest attainable p-value is 2/2**rounds; at 5 rounds that
+# floor is 0.0625, so no result could ever clear p<0.05 no matter how large the effect.
+#
+# What it does, and why each step matters:
+#
+#  1. Checks out both refs into throwaway worktrees.
+#  2. Copies *this* tree's bench sources into both worktrees, so identical benchmark code
+#     runs against two different library versions. Without this the comparison silently
+#     becomes "old bench vs new bench".
+#  3. Builds each worktree into its OWN target dir. A shared CARGO_TARGET_DIR is unusable:
+#     cargo's unit hash covers package name, version, profile and features but not the
+#     source directory, so two worktrees at the same crate version collide and cargo
+#     reports the stale artifact as fresh.
+#  4. Runs the footprint report on both and diffs it. These numbers are exact, so one run
+#     is enough.
+#  5. Runs the Criterion benches with the arms interleaved and rotated per round, so
+#     thermal drift and background load bias both arms equally instead of whichever arm
+#     happens to run first.
+#
+# Timing results are only meaningful pinned to physical cores on an otherwise idle
+# machine. Set CPUS to a list of physical core ids for your host; the default is a
+# reasonable guess and will be skipped if taskset is unavailable.
+set -euo pipefail
+
+BEFORE=${1:?usage: run_ab.sh <before-ref> <after-ref> [rounds]}
+AFTER=${2:?usage: run_ab.sh <before-ref> <after-ref> [rounds]}
+ROUNDS=${3:-8}
+if ((ROUNDS < 6)); then
+    echo "warning: $ROUNDS rounds cannot reach p<0.05 (floor is 2/2**$ROUNDS); use 6 or more" >&2
+fi
+
+REPO=$(git rev-parse --show-toplevel)
+BENCH_DIR=rust/lance-encoding/benches
+WORK=${SPARSE_AB_WORKDIR:-/tmp/sparse-ab}
+CPUS=${CPUS:-}
+
+mkdir -p "$WORK"
+echo "workdir: $WORK"
+
+# --- 1. worktrees -----------------------------------------------------------------
+for arm in before after; do
+    ref=$([[ $arm == before ]] && echo "$BEFORE" || echo "$AFTER")
+    dir=$WORK/$arm
+    if [[ ! -d $dir ]]; then
+        git -C "$REPO" worktree add --detach "$dir" "$ref" >/dev/null
+    fi
+    echo "$arm -> $ref ($(git -C "$dir" rev-parse --short HEAD))"
+done
+
+# --- 2. pin the benchmark sources ------------------------------------------------
+# Both arms must run byte-identical bench code for the comparison to mean anything.
+# A no-op when an arm's worktree is the tree this script was invoked from.
+sync_file() {
+    [[ $(realpath "$1") == $(realpath -m "$2") ]] || cp "$1" "$2"
+}
+
+for arm in before after; do
+    dir=$WORK/$arm
+    mkdir -p "$dir/$BENCH_DIR/sparse" "$dir/rust/lance-encoding/tests"
+    sync_file "$REPO/$BENCH_DIR/sparse/cases.rs" "$dir/$BENCH_DIR/sparse/cases.rs"
+    sync_file "$REPO/$BENCH_DIR/sparse_footprint.rs" "$dir/$BENCH_DIR/sparse_footprint.rs"
+    sync_file "$REPO/$BENCH_DIR/sparse_decode.rs" "$dir/$BENCH_DIR/sparse_decode.rs"
+    sync_file "$REPO/rust/lance-encoding/tests/sparse_bench_layouts.rs" \
+        "$dir/rust/lance-encoding/tests/sparse_bench_layouts.rs"
+
+    # Register the bench targets if this ref predates them.
+    python3 - "$dir/rust/lance-encoding/Cargo.toml" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+src = path.read_text()
+for name in ("sparse_decode", "sparse_footprint"):
+    entry = f'[[bench]]\nname = "{name}"\nharness = false\n'
+    if entry not in src:
+        src = src.replace("[lints]", entry + "\n[lints]", 1)
+path.write_text(src)
+PY
+done
+
+# --- 3. build --------------------------------------------------------------------
+for arm in before after; do
+    echo "=== building $arm ==="
+    CARGO_TARGET_DIR=$WORK/target-$arm cargo build --manifest-path "$WORK/$arm/Cargo.toml" \
+        --profile bench -p lance-encoding --benches >"$WORK/$arm.build.log" 2>&1 || {
+        echo "build failed for $arm; see $WORK/$arm.build.log" >&2
+        tail -30 "$WORK/$arm.build.log" >&2
+        exit 1
+    }
+done
+
+# bin <bench-name> <arm> -> path to the most recently built bench executable.
+# The `bench` profile emits into release/deps alongside stale hashes from earlier builds,
+# so pick the newest rather than the first match.
+bin() {
+    find "$WORK/target-$2/release/deps" -maxdepth 1 -name "$1-*" -type f -perm -u+x \
+        -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2
+}
+
+# --- 4. exact memory comparison --------------------------------------------------
+echo
+echo "=== layout guard (both arms must agree the inputs are still sparse) ==="
+for arm in before after; do
+    CARGO_TARGET_DIR=$WORK/target-$arm cargo test --manifest-path "$WORK/$arm/Cargo.toml" \
+        -p lance-encoding --test sparse_bench_layouts >"$WORK/$arm.layout.log" 2>&1 &&
+        echo "  $arm: ok" ||
+        {
+            echo "  $arm: FAILED - inputs no longer hit the sparse layout" >&2
+            tail -20 "$WORK/$arm.layout.log" >&2
+            exit 1
+        }
+done
+
+echo
+echo "=== footprint ==="
+for arm in before after; do
+    exe=$(bin sparse_footprint "$arm")
+    "$exe" --json >"$WORK/$arm.footprint.json"
+done
+python3 "$REPO/$BENCH_DIR/sparse/compare.py" footprint \
+    "$WORK/before.footprint.json" "$WORK/after.footprint.json"
+
+# --- 5. interleaved timing -------------------------------------------------------
+echo
+echo "=== timing ($ROUNDS rounds, arms rotated) ==="
+pin=()
+if [[ -n $CPUS ]] && command -v taskset >/dev/null; then
+    pin=(taskset -c "$CPUS")
+    echo "pinned to cpus $CPUS"
+else
+    echo "not pinned; set CPUS=<physical core ids> for lower variance"
+fi
+
+for ((r = 1; r <= ROUNDS; r++)); do
+    # Rotate which arm runs first so neither is systematically favoured.
+    order=(before after)
+    if ((r % 2 == 0)); then order=(after before); fi
+    for arm in "${order[@]}"; do
+        home=$WORK/crit/r$r/$arm
+        mkdir -p "$home"
+        exe=$(bin sparse_decode "$arm")
+        CRITERION_HOME=$home "${pin[@]}" "$exe" --bench >"$home/stdout.txt" 2>&1 ||
+            echo "  round $r $arm: bench exited nonzero, see $home/stdout.txt" >&2
+        echo "  round $r $arm: done"
+    done
+done
+
+python3 "$REPO/$BENCH_DIR/sparse/compare.py" timing "$WORK/crit"

--- a/rust/lance-encoding/benches/sparse_decode.rs
+++ b/rust/lance-encoding/benches/sparse_decode.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+//! Timing benchmarks for the sparse structural read path.
+//!
+//! Three groups, because a change to the cached chunk index can move them independently:
+//!
+//! * `sparse_init` — scheduler construction against a cold cache. This is the metadata
+//!   parse plus chunk-index build, paid once per page per open dataset.
+//! * `sparse_scan` — full sequential decode with a warm cache, the throughput case.
+//! * `sparse_take` — scattered ascending row take with a warm cache. Each index lands in a
+//!   different chunk, so this is the path that does the most per-chunk lookups and is
+//!   where a more compact chunk index could plausibly cost time.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo bench -p lance-encoding --bench sparse_decode
+//! cargo bench -p lance-encoding --bench sparse_decode -- sparse_take
+//! ```
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use futures::StreamExt;
+use lance_core::cache::LanceCache;
+use lance_encoding::{
+    decoder::{
+        DecodeBatchScheduler, DecoderConfig, DecoderPlugins, FilterExpression, create_decode_stream,
+    },
+    encoder::EncodedBatch,
+};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[path = "sparse/cases.rs"]
+mod cases;
+
+use cases::{Case, cases, encode, scattered_indices};
+
+const BATCH_SIZE: u32 = 8192;
+/// Enough scattered indices to spread across many chunks without the take degenerating
+/// into a full scan.
+const TAKE_COUNT: u64 = 4096;
+
+/// Build a scheduler over an already-encoded batch.
+///
+/// The cache is supplied by the caller so that the init benchmark can pass a cold cache
+/// per iteration while the scan and take benchmarks reuse a warm one.
+async fn scheduler(
+    encoded: &EncodedBatch,
+    cache: Arc<LanceCache>,
+    io: Arc<dyn lance_encoding::EncodingsIo>,
+) -> DecodeBatchScheduler {
+    DecodeBatchScheduler::try_new(
+        encoded.schema.as_ref(),
+        &encoded.top_level_columns,
+        &encoded.page_table,
+        &vec![],
+        encoded.num_rows,
+        Arc::<DecoderPlugins>::default(),
+        io,
+        cache,
+        &FilterExpression::no_filter(),
+        &DecoderConfig::default(),
+    )
+    .await
+    .expect("scheduler")
+}
+
+/// Drive the decoder to completion, returning the row count so the work cannot be
+/// optimised away.
+async fn drain(encoded: &EncodedBatch, cache: Arc<LanceCache>, indices: Option<&[u64]>) -> usize {
+    let io = Arc::new(lance_encoding::BufferScheduler::new(encoded.data.clone()))
+        as Arc<dyn lance_encoding::EncodingsIo>;
+    let filter = FilterExpression::no_filter();
+    let mut sched = scheduler(encoded, cache, io.clone()).await;
+
+    let (tx, rx) = unbounded_channel();
+    let expected = match indices {
+        Some(indices) => {
+            sched.schedule_take(indices, &filter, tx, io);
+            indices.len() as u64
+        }
+        None => {
+            sched.schedule_range(0..encoded.num_rows, &filter, tx, io);
+            encoded.num_rows
+        }
+    };
+
+    let stream = create_decode_stream(
+        &encoded.schema,
+        expected,
+        BATCH_SIZE,
+        /*is_structural=*/ true,
+        /*should_validate=*/ false,
+        /*spawn_structural_batch_decode_tasks=*/ false,
+        rx,
+        None,
+    )
+    .expect("decode stream");
+
+    let mut rows = 0;
+    let mut stream = stream.map(|task| task.task).buffered(1);
+    while let Some(batch) = stream.next().await {
+        rows += batch.expect("decoded batch").num_rows();
+    }
+    rows
+}
+
+/// Cases worth timing. The degenerate shapes are covered by the footprint report; timing
+/// them adds Criterion runtime without adding signal, except for the two that actually
+/// stress chunk lookups.
+fn timed_cases() -> Vec<Case> {
+    cases()
+        .into_iter()
+        .filter(|c| {
+            matches!(
+                c.name,
+                "degenerate/single_value"
+                    | "uniform/many_chunks"
+                    | "non_uniform/many_chunks"
+                    | "nested/list_of_list"
+                    | "wide/32_columns"
+                    | "automatic/skewed_lists"
+            )
+        })
+        .collect()
+}
+
+/// Criterion ids use `_` where the case name uses `/`, so that `uniform/many_chunks` and
+/// `non_uniform/many_chunks` stay distinct within a group.
+fn bench_id(name: &str) -> String {
+    name.replace('/', "_")
+}
+
+fn bench_sparse(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    for case in timed_cases() {
+        let encoded = Arc::new(encode(&case));
+        if encoded.num_rows == 0 {
+            continue;
+        }
+        let indices = scattered_indices(encoded.num_rows, TAKE_COUNT);
+        let id = bench_id(case.name);
+
+        // A cold cache per iteration: this is the once-per-page cost, so a warm cache
+        // would measure nothing.
+        let mut group = c.benchmark_group("sparse_init");
+        group.bench_function(&id, |b| {
+            b.iter(|| {
+                let cache = Arc::new(LanceCache::with_capacity(1024 * 1024 * 1024));
+                let io = Arc::new(lance_encoding::BufferScheduler::new(encoded.data.clone()))
+                    as Arc<dyn lance_encoding::EncodingsIo>;
+                rt.block_on(scheduler(&encoded, cache, io));
+            })
+        });
+        group.finish();
+
+        // Warm cache, shared across iterations, so the scan measures decode rather than
+        // repeated metadata parsing.
+        let warm = Arc::new(LanceCache::with_capacity(1024 * 1024 * 1024));
+        rt.block_on(drain(&encoded, warm.clone(), None));
+
+        let mut group = c.benchmark_group("sparse_scan");
+        group.throughput(criterion::Throughput::Elements(encoded.num_rows));
+        group.bench_function(&id, |b| {
+            b.iter(|| {
+                let rows = rt.block_on(drain(&encoded, warm.clone(), None));
+                assert_eq!(rows as u64, encoded.num_rows);
+            })
+        });
+        group.finish();
+
+        if indices.is_empty() {
+            continue;
+        }
+        let mut group = c.benchmark_group("sparse_take");
+        group.throughput(criterion::Throughput::Elements(indices.len() as u64));
+        group.bench_function(&id, |b| {
+            b.iter(|| {
+                let rows = rt.block_on(drain(&encoded, warm.clone(), Some(&indices)));
+                assert_eq!(rows, indices.len());
+            })
+        });
+        group.finish();
+    }
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10)
+        .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
+    targets = bench_sparse
+);
+
+// Non-linux version does not support pprof.
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = bench_sparse
+);
+
+criterion_main!(benches);

--- a/rust/lance-encoding/benches/sparse_footprint.rs
+++ b/rust/lance-encoding/benches/sparse_footprint.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+// This bench's output *is* its result, so it prints rather than logs.
+#![allow(clippy::print_stdout)]
+//! Reports the resident cost of scheduling sparse structural pages.
+//!
+//! This is a measurement harness, not a timing benchmark, so it does not use Criterion:
+//! the quantities of interest are exact rather than statistical.
+//!
+//! Two numbers are reported per input:
+//!
+//! * `cache_bytes` — what [`LanceCache::size_bytes`] holds after the scheduler has
+//!   initialized. This is the state that stays resident for the lifetime of an open
+//!   dataset, once per page per column, so it is the number that decides how much memory
+//!   a wide 2.3 table costs to keep open.
+//! * `init_bytes` — total bytes passed to the global allocator while initializing. This
+//!   catches transient allocations that never reach the cache, which `cache_bytes` cannot
+//!   see by construction.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo bench -p lance-encoding --bench sparse_footprint
+//! cargo bench -p lance-encoding --bench sparse_footprint -- --json
+//! ```
+//!
+//! `--json` emits one object per line for `ci/sparse_ab.py` to diff across two builds.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
+
+use lance_core::cache::LanceCache;
+use lance_encoding::{
+    decoder::{DecodeBatchScheduler, DecoderConfig, DecoderPlugins, FilterExpression},
+    encoder::EncodedBatch,
+};
+
+#[path = "sparse/cases.rs"]
+mod cases;
+
+use cases::{Case, cases, encode, layouts, visible_items};
+
+/// Counting allocator. Recording is opt-in so that only the region under test is counted;
+/// otherwise input construction and encoding would dominate the totals.
+struct Counting;
+
+static RECORDING: AtomicBool = AtomicBool::new(false);
+static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if RECORDING.load(Ordering::Relaxed) {
+            ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if RECORDING.load(Ordering::Relaxed) && new_size > layout.size() {
+            ALLOC_BYTES.fetch_add((new_size - layout.size()) as u64, Ordering::Relaxed);
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Run `f` with allocation recording on, returning `(bytes, count)`.
+///
+/// Single-threaded by construction: the scheduler runs on a current-thread runtime so no
+/// other thread's allocations can leak into the totals.
+fn measure_allocations<T>(f: impl FnOnce() -> T) -> (T, u64, u64) {
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+    ALLOC_COUNT.store(0, Ordering::Relaxed);
+    RECORDING.store(true, Ordering::Relaxed);
+    let out = f();
+    RECORDING.store(false, Ordering::Relaxed);
+    (
+        out,
+        ALLOC_BYTES.load(Ordering::Relaxed),
+        ALLOC_COUNT.load(Ordering::Relaxed),
+    )
+}
+
+/// Initialize a scheduler against a cold cache and report what the cache retains.
+///
+/// `DecodeBatchScheduler::try_new` is what calls `initialize` on the field schedulers, so
+/// this measures exactly the work an open dataset does once per page.
+fn cache_footprint(encoded: &EncodedBatch) -> Footprint {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("runtime");
+    // Capacity well above anything the matrix produces, so nothing is evicted and
+    // `size_bytes` reflects the full retained state rather than a capacity ceiling.
+    let cache = Arc::new(LanceCache::with_capacity(4 * 1024 * 1024 * 1024));
+    let io = Arc::new(lance_encoding::BufferScheduler::new(encoded.data.clone()))
+        as Arc<dyn lance_encoding::EncodingsIo>;
+    let filter = FilterExpression::no_filter();
+
+    let (scheduler, alloc_bytes, alloc_count) = measure_allocations(|| {
+        rt.block_on(DecodeBatchScheduler::try_new(
+            encoded.schema.as_ref(),
+            &encoded.top_level_columns,
+            &encoded.page_table,
+            &vec![],
+            encoded.num_rows,
+            Arc::<DecoderPlugins>::default(),
+            io,
+            cache.clone(),
+            &filter,
+            &DecoderConfig::default(),
+        ))
+        .expect("scheduler")
+    });
+    drop(scheduler);
+
+    Footprint {
+        cache_bytes: rt.block_on(cache.size_bytes()) as u64,
+        init_bytes: alloc_bytes,
+        init_allocs: alloc_count,
+    }
+}
+
+struct Footprint {
+    cache_bytes: u64,
+    init_bytes: u64,
+    init_allocs: u64,
+}
+
+struct Row {
+    case: &'static str,
+    note: &'static str,
+    layout: String,
+    pages: usize,
+    rows: u64,
+    items: u64,
+    /// `None` for an empty page: `DecodeBatchScheduler::try_new` requires at least one row,
+    /// so there is no scheduler state to measure.
+    footprint: Option<Footprint>,
+}
+
+fn run(case: &Case) -> Row {
+    let encoded = encode(case);
+    let observed = layouts(&encoded);
+    let layout = observed
+        .first()
+        .map(|l| l.to_string())
+        .unwrap_or_else(|| "none".to_string());
+    Row {
+        case: case.name,
+        note: case.note,
+        layout,
+        pages: observed.len(),
+        rows: encoded.num_rows,
+        items: visible_items(&encoded),
+        footprint: (encoded.num_rows > 0).then(|| cache_footprint(&encoded)),
+    }
+}
+
+fn main() {
+    let json = std::env::args().any(|a| a == "--json");
+
+    let rows: Vec<Row> = cases().iter().map(run).collect();
+
+    if json {
+        for row in &rows {
+            let Some(footprint) = &row.footprint else {
+                continue;
+            };
+            println!(
+                r#"{{"case":"{}","layout":"{}","pages":{},"rows":{},"items":{},"cache_bytes":{},"init_bytes":{},"init_allocs":{}}}"#,
+                row.case,
+                row.layout,
+                row.pages,
+                row.rows,
+                row.items,
+                footprint.cache_bytes,
+                footprint.init_bytes,
+                footprint.init_allocs,
+            );
+        }
+        return;
+    }
+
+    println!("sparse structural scheduler: resident cost of an initialized scheduler\n");
+    println!(
+        "{:<30} {:>9} {:>6} {:>10} {:>12} {:>12} {:>11} {:>10}",
+        "case",
+        "layout",
+        "pages",
+        "items",
+        "cache_bytes",
+        "bytes/page",
+        "init_bytes",
+        "init_allocs"
+    );
+    println!("{}", "-".repeat(107));
+    for row in &rows {
+        let Some(footprint) = &row.footprint else {
+            println!(
+                "{:<30} {:>9} {:>6} {:>10} {:>12} {:>12} {:>11} {:>10}",
+                row.case, row.layout, row.pages, row.items, "-", "-", "-", "-"
+            );
+            continue;
+        };
+        let per_page = footprint.cache_bytes / row.pages.max(1) as u64;
+        println!(
+            "{:<30} {:>9} {:>6} {:>10} {:>12} {:>12} {:>11} {:>10}",
+            row.case,
+            row.layout,
+            row.pages,
+            row.items,
+            footprint.cache_bytes,
+            per_page,
+            footprint.init_bytes,
+            footprint.init_allocs,
+        );
+    }
+
+    println!("\nnotes");
+    for row in &rows {
+        println!("  {:<30} {} ({} rows)", row.case, row.note, row.rows);
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -135,14 +135,6 @@ trait StructuralPageScheduler: std::fmt::Debug + Send {
     ) -> Result<Vec<PageLoadTask>>;
 }
 
-/// Metadata describing the decoded size of a mini-block
-#[derive(Debug)]
-struct ChunkMeta {
-    num_values: u64,
-    chunk_size_bytes: u64,
-    offset_bytes: u64,
-}
-
 /// A mini-block chunk that has been decoded and decompressed
 #[derive(Debug, Clone)]
 struct DecodedMiniBlockChunk {

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1819,18 +1819,13 @@ fn build_chunk_index(
                 last_chunk_values: value_counts.last_chunk_values,
             }
         };
-        RowMapping::Nested {
-            row_starts,
-            has_trailer,
-            item_counts,
-        }
+        RowMapping::nested(row_starts, has_trailer, item_counts)
     } else {
         let value_counts = analyze_value_counts(words, items_in_page);
         if value_counts.uniform {
             RowMapping::UniformFlat {
                 values_per_chunk: value_counts.values_per_chunk,
                 last_chunk_values: value_counts.last_chunk_values,
-                num_chunks,
             }
         } else {
             let value_starts = PrefixSums::from_deltas(
@@ -6716,7 +6711,7 @@ mod tests {
     use super::chunk_index::{PrefixSums, RowMapping};
     use super::{MINIBLOCK_ALIGNMENT, Words, build_chunk_index};
     use bytes::Bytes;
-    use lance_core::cache::{Context, DeepSizeOf};
+    use lance_core::cache::DeepSizeOf;
     use rstest::rstest;
 
     /// Builds a `Words` metadata buffer (u16 words) from `(log_num_values, num_bytes)`
@@ -6864,28 +6859,34 @@ mod tests {
     #[test]
     fn test_deep_size_per_variant_below_legacy() {
         // The previous representation cached 48 bytes per chunk (24 for ChunkMeta plus
-        // 24 for a rep-index block); every variant's heap must be well below that.
+        // 24 for a rep-index block), plus two inline Vec headers.
         const LEGACY_PER_CHUNK: usize = 48;
+        const LEGACY_FIXED_SIZE: usize = 2 * std::mem::size_of::<Vec<[u64; 3]>>();
         let num_chunks = 3;
-        let heap = |index: &MiniBlockChunkIndex| index.deep_size_of_children(&mut Context::new());
+        let legacy_size = LEGACY_FIXED_SIZE + LEGACY_PER_CHUNK * num_chunks;
+        let size = |index: &MiniBlockChunkIndex| index.deep_size_of();
 
         let (uniform_words, uniform_dbs) = words_from(&[(2, 8), (2, 8), (0, 8)]);
         let uniform = build_chunk_index(&uniform_words, 10, 0, uniform_dbs, None, 0);
         assert_eq!(uniform.row_mapping_debug(), "uniform_flat");
-        assert!(heap(&uniform) < LEGACY_PER_CHUNK * num_chunks);
+        assert!(size(&uniform) < legacy_size);
 
         let (flat_words, flat_dbs) = words_from(&[(3, 8), (1, 8), (0, 8)]);
         let flat = build_chunk_index(&flat_words, 11, 0, flat_dbs, None, 0);
         assert_eq!(flat.row_mapping_debug(), "flat");
-        assert!(heap(&flat) < LEGACY_PER_CHUNK * num_chunks);
+        assert!(size(&flat) < legacy_size);
         // Flat carries a value-starts array that UniformFlat derives arithmetically.
-        assert!(heap(&flat) > heap(&uniform));
+        assert!(size(&flat) > size(&uniform));
 
         let rep = rep_bytes_from(&[4, 0, 3, 0, 3, 0]);
         let (nested_words, nested_dbs) = words_from(&[(2, 8), (2, 8), (0, 8)]);
         let nested = build_chunk_index(&nested_words, 10, 0, nested_dbs, Some(&rep), 1);
         assert_eq!(nested.row_mapping_debug(), "nested");
-        assert!(heap(&nested) < LEGACY_PER_CHUNK * num_chunks);
+        let nested_size = size(&nested);
+        assert!(
+            nested_size < legacy_size,
+            "nested index uses {nested_size} bytes, legacy uses {legacy_size}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-encoding/src/encodings/logical/primitive/chunk_index.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/chunk_index.rs
@@ -17,12 +17,12 @@
 //! `- rows: RowMapping
 //!    |- UniformFlat { .. }          flat page, uniform leaf chunking (arithmetic)
 //!    |- Flat { value_starts }       flat page, non-uniform leaf chunking
-//!    `- Nested { row_starts, .. }   repetition present; rows tracked as prefix sums
+//!    `- Nested(_)                    repetition present; rows tracked as prefix sums
 //! ```
 
 use std::ops::Range;
 
-use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
+use arrow_buffer::bit_util;
 use lance_core::cache::{Context, DeepSizeOf};
 
 /// Cumulative (prefix-sum) array of length `num_chunks + 1` (entry `0` is `0`,
@@ -183,19 +183,35 @@ impl ItemCounts {
     }
 }
 
+/// Nested-page-only row metadata, boxed by [`RowMapping`] so flat page indices
+/// do not carry its inline footprint.
+#[derive(Debug)]
+pub struct NestedRowMapping {
+    row_starts: PrefixSums,
+    has_trailer: Box<[u8]>,
+    item_counts: ItemCounts,
+}
+
+impl DeepSizeOf for NestedRowMapping {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.row_starts.deep_size_of_children(context)
+            + self.has_trailer.len()
+            + self.item_counts.deep_size_of_children(context)
+    }
+}
+
 /// How row ranges map onto chunks.
 ///
 /// Flat pages have row == value index and no preamble/trailer.  Nested pages
 /// track rows separately from leaf items and store a trailer bit per chunk; a
 /// chunk's preamble is the previous chunk's trailer.
-#[derive(Debug)]
+#[derive(Debug, DeepSizeOf)]
 pub enum RowMapping {
     /// Flat page whose non-last chunks all hold `values_per_chunk` values, so
     /// row->chunk is pure arithmetic.
     UniformFlat {
         values_per_chunk: u64,
         last_chunk_values: u64,
-        num_chunks: usize,
     },
     /// Flat page with non-uniform chunk sizes; `value_starts` are the cumulative
     /// value counts (final entry == number of items in the page).
@@ -203,34 +219,23 @@ pub enum RowMapping {
     /// Nested page.  `row_starts` are cumulative row counts (final entry ==
     /// number of rows in the page); `has_trailer[i]` is set when chunk `i` ends
     /// with a partial list.
-    Nested {
-        row_starts: PrefixSums,
-        has_trailer: BooleanBuffer,
-        item_counts: ItemCounts,
-    },
+    Nested(Box<NestedRowMapping>),
 }
 
-impl DeepSizeOf for RowMapping {
-    fn deep_size_of_children(&self, context: &mut Context) -> usize {
-        match self {
-            Self::UniformFlat { .. } => 0,
-            Self::Flat { value_starts } => value_starts.deep_size_of_children(context),
-            Self::Nested {
-                row_starts,
-                has_trailer,
-                item_counts,
-            } => {
-                row_starts.deep_size_of_children(context)
-                    + has_trailer.len().div_ceil(8)
-                    + item_counts.deep_size_of_children(context)
-            }
-        }
+impl RowMapping {
+    /// Builds a nested row mapping without inflating the flat enum variants.
+    pub fn nested(row_starts: PrefixSums, has_trailer: Box<[u8]>, item_counts: ItemCounts) -> Self {
+        Self::Nested(Box::new(NestedRowMapping {
+            row_starts,
+            has_trailer,
+            item_counts,
+        }))
     }
 }
 
 /// Compact per-page chunk index that avoids fully materializing the repetition
 /// index into u64's to save RAM.  See the module docs for the layout.
-#[derive(Debug)]
+#[derive(Debug, DeepSizeOf)]
 pub struct MiniBlockChunkIndex {
     base: u64,
     byte_starts: PrefixSums,
@@ -264,7 +269,6 @@ impl MiniBlockChunkIndex {
             RowMapping::UniformFlat {
                 values_per_chunk,
                 last_chunk_values,
-                ..
             } => {
                 if i == num_chunks - 1 {
                     *last_chunk_values
@@ -273,7 +277,7 @@ impl MiniBlockChunkIndex {
                 }
             }
             RowMapping::Flat { value_starts } => value_starts.delta(i),
-            RowMapping::Nested { item_counts, .. } => item_counts.get(i, num_chunks),
+            RowMapping::Nested(mapping) => mapping.item_counts.get(i, num_chunks),
         }
     }
 
@@ -281,12 +285,10 @@ impl MiniBlockChunkIndex {
     pub fn find_chunk(&self, row: u64) -> usize {
         match &self.rows {
             RowMapping::UniformFlat {
-                values_per_chunk,
-                num_chunks,
-                ..
-            } => ((row / values_per_chunk) as usize).min(num_chunks - 1),
+                values_per_chunk, ..
+            } => ((row / values_per_chunk) as usize).min(self.num_chunks() - 1),
             RowMapping::Flat { value_starts } => value_starts.find(row),
-            RowMapping::Nested { row_starts, .. } => row_starts.find(row),
+            RowMapping::Nested(mapping) => mapping.row_starts.find(row),
         }
     }
 
@@ -297,7 +299,7 @@ impl MiniBlockChunkIndex {
                 values_per_chunk, ..
             } => i as u64 * values_per_chunk,
             RowMapping::Flat { value_starts } => value_starts.get(i),
-            RowMapping::Nested { row_starts, .. } => row_starts.get(i),
+            RowMapping::Nested(mapping) => mapping.row_starts.get(i),
         }
     }
 
@@ -309,7 +311,6 @@ impl MiniBlockChunkIndex {
             RowMapping::UniformFlat {
                 values_per_chunk,
                 last_chunk_values,
-                ..
             } => {
                 if i == num_chunks - 1 {
                     *last_chunk_values
@@ -318,7 +319,7 @@ impl MiniBlockChunkIndex {
                 }
             }
             RowMapping::Flat { value_starts } => value_starts.delta(i),
-            RowMapping::Nested { row_starts, .. } => row_starts.delta(i),
+            RowMapping::Nested(mapping) => mapping.row_starts.delta(i),
         }
     }
 
@@ -327,7 +328,9 @@ impl MiniBlockChunkIndex {
     /// previous chunk's trailer.
     pub fn has_preamble(&self, i: usize) -> bool {
         match &self.rows {
-            RowMapping::Nested { has_trailer, .. } => i > 0 && has_trailer.value(i - 1),
+            RowMapping::Nested(mapping) => {
+                i > 0 && bit_util::get_bit(mapping.has_trailer.as_ref(), i - 1)
+            }
             _ => false,
         }
     }
@@ -336,7 +339,7 @@ impl MiniBlockChunkIndex {
     /// next chunk).  Always false for flat pages.
     pub fn has_trailer(&self, i: usize) -> bool {
         match &self.rows {
-            RowMapping::Nested { has_trailer, .. } => has_trailer.value(i),
+            RowMapping::Nested(mapping) => bit_util::get_bit(mapping.has_trailer.as_ref(), i),
             _ => false,
         }
     }
@@ -347,7 +350,7 @@ impl MiniBlockChunkIndex {
         match &self.rows {
             RowMapping::UniformFlat { .. } => "uniform_flat",
             RowMapping::Flat { .. } => "flat",
-            RowMapping::Nested { .. } => "nested",
+            RowMapping::Nested(_) => "nested",
         }
     }
 
@@ -366,21 +369,15 @@ impl MiniBlockChunkIndex {
         Self {
             base: 0,
             byte_starts,
-            rows: RowMapping::Nested {
+            rows: RowMapping::nested(
                 row_starts,
                 has_trailer,
-                item_counts: ItemCounts::Uniform {
+                ItemCounts::Uniform {
                     values_per_chunk: 1,
                     last_chunk_values: 1,
                 },
-            },
+            ),
         }
-    }
-}
-
-impl DeepSizeOf for MiniBlockChunkIndex {
-    fn deep_size_of_children(&self, context: &mut Context) -> usize {
-        self.byte_starts.deep_size_of_children(context) + self.rows.deep_size_of_children(context)
     }
 }
 
@@ -390,7 +387,7 @@ impl DeepSizeOf for MiniBlockChunkIndex {
 /// finishing in the chunk) and `partial` (leftover items).  Only cumulative row
 /// starts and a trailer bit are kept: `has_preamble[i] = has_trailer[i-1]` and
 /// `starts_including_trailer = ends + has_trailer - has_preamble`.
-pub fn parse_nested_rep(rep_bytes: &[u8], stride: usize) -> (PrefixSums, BooleanBuffer) {
+pub fn parse_nested_rep(rep_bytes: &[u8], stride: usize) -> (PrefixSums, Box<[u8]>) {
     // Read the two `u64`s per group straight from the little-endian bytes rather
     // than copying the buffer to reinterpret it.  The caller guarantees
     // `rep_bytes.len() % 8 == 0`, so the 8-byte windows stay in bounds.
@@ -401,7 +398,7 @@ pub fn parse_nested_rep(rep_bytes: &[u8], stride: usize) -> (PrefixSums, Boolean
     };
     let num_chunks = (rep_bytes.len() / WORD) / stride;
 
-    let mut has_trailer_builder = BooleanBufferBuilder::new(num_chunks);
+    let mut has_trailer_bits = vec![0u8; num_chunks.div_ceil(8)];
     // Accumulate the cumulative row starts in a single pass (entry 0 is 0, the
     // trailing entry is the total) so there is no separate deltas buffer.
     let mut row_starts = Vec::with_capacity(num_chunks + 1);
@@ -417,7 +414,9 @@ pub fn parse_nested_rep(rep_bytes: &[u8], stride: usize) -> (PrefixSums, Boolean
         let has_trailer = partial > 0;
         let starts_including_trailer = ends + (has_trailer as u64) - (chunk_has_preamble as u64);
 
-        has_trailer_builder.append(has_trailer);
+        if has_trailer {
+            bit_util::set_bit(&mut has_trailer_bits, i);
+        }
         acc += starts_including_trailer;
         row_starts.push(acc);
 
@@ -426,7 +425,7 @@ pub fn parse_nested_rep(rep_bytes: &[u8], stride: usize) -> (PrefixSums, Boolean
 
     (
         PrefixSums::from_prefix(row_starts),
-        has_trailer_builder.finish(),
+        has_trailer_bits.into_boxed_slice(),
     )
 }
 
@@ -527,8 +526,12 @@ mod tests {
                     block.starts_including_trailer,
                     "starts_including_trailer[{i}]"
                 );
-                assert_eq!(has_trailer.value(i), block.has_trailer, "has_trailer[{i}]");
-                let derived_preamble = i > 0 && has_trailer.value(i - 1);
+                assert_eq!(
+                    bit_util::get_bit(has_trailer.as_ref(), i),
+                    block.has_trailer,
+                    "has_trailer[{i}]"
+                );
+                let derived_preamble = i > 0 && bit_util::get_bit(has_trailer.as_ref(), i - 1);
                 assert_eq!(derived_preamble, block.has_preamble, "has_preamble[{i}]");
             }
         }

--- a/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
@@ -27,18 +27,45 @@ fn usize_from_u64(value: u64, label: &str) -> Result<usize> {
     })
 }
 
+/// Decodes one 8-byte sparse value-chunk metadata entry.
+///
+/// Callers pass entries from `chunks_exact(8)` after validating the metadata
+/// buffer length. The fallback keeps this helper total if that invariant changes.
+fn sparse_value_chunk_metadata(entry: &[u8]) -> (u64, u64) {
+    let &[
+        byte_0,
+        byte_1,
+        byte_2,
+        byte_3,
+        value_0,
+        value_1,
+        value_2,
+        value_3,
+    ] = entry
+    else {
+        debug_assert_eq!(entry.len(), 8);
+        return (0, 0);
+    };
+    let divided_bytes_minus_one = u32::from_le_bytes([byte_0, byte_1, byte_2, byte_3]);
+    let num_values = u32::from_le_bytes([value_0, value_1, value_2, value_3]);
+    (
+        (u64::from(divided_bytes_minus_one) + 1) * MINIBLOCK_ALIGNMENT as u64,
+        u64::from(num_values),
+    )
+}
+
 /// Native sparse structural representation used by the 2.3 sparse layout.
 ///
 /// Layers are stored from outer-most to inner-most, matching the order Arrow structural
 /// encoders record offsets and validity.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub struct SparseStructuralPlan {
     pub(crate) layers: Vec<SparseStructuralLayerPlan>,
     pub(crate) num_items: u64,
     pub(crate) num_visible_items: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub enum SparsePositionSet {
     Empty,
     All { len: u64 },
@@ -130,13 +157,6 @@ impl SparsePositionSet {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    pub(crate) fn deep_size(&self) -> usize {
-        match self {
-            Self::Explicit(positions) => positions.len() * std::mem::size_of::<u64>(),
-            Self::Empty | Self::All { .. } | Self::Range { .. } => 0,
-        }
     }
 
     pub(crate) fn materialize(&self) -> Result<Vec<u64>> {
@@ -241,23 +261,19 @@ impl SparsePositionSet {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, DeepSizeOf, PartialEq, Eq)]
 pub enum SparseValidityMeaning {
     NullPositions,
     ValidPositions,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub struct SparseValiditySet {
     pub(crate) meaning: SparseValidityMeaning,
     pub(crate) positions: SparsePositionSet,
 }
 
 impl SparseValiditySet {
-    pub(crate) fn deep_size(&self) -> usize {
-        self.positions.deep_size()
-    }
-
     fn contains_only_valid_positions(
         &self,
         positions: &SparsePositionSet,
@@ -468,7 +484,7 @@ impl<'a> SparseValidityCursor<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub enum SparseCountSet {
     Empty,
     Constant {
@@ -514,16 +530,6 @@ impl SparseCountSet {
             Self::Empty => 0,
             Self::Constant { len, .. } => *len,
             Self::Explicit { counts, .. } => counts.len() as u64,
-        }
-    }
-
-    pub(crate) fn deep_size(&self) -> usize {
-        match self {
-            Self::Explicit { counts, offsets } => {
-                counts.len() * std::mem::size_of::<u64>()
-                    + offsets.len() * std::mem::size_of::<u64>()
-            }
-            Self::Empty | Self::Constant { .. } => 0,
         }
     }
 
@@ -577,7 +583,7 @@ impl SparseCountSet {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub enum SparseStructuralLayerPlan {
     Validity {
         num_slots: u64,
@@ -1120,29 +1126,13 @@ struct SparseValiditySetDecoder {
 #[derive(Debug)]
 struct SparseStructuralCacheableState {
     value_index: MiniBlockChunkIndex,
-    num_visible_items: u64,
     plan: SparseStructuralPlan,
     row_domain: u64,
 }
 
 impl DeepSizeOf for SparseStructuralCacheableState {
     fn deep_size_of_children(&self, context: &mut Context) -> usize {
-        let structural_size = self
-            .plan
-            .layers
-            .iter()
-            .map(|layer| match layer {
-                SparseStructuralLayerPlan::Validity { validity, .. } => validity.deep_size(),
-                SparseStructuralLayerPlan::List {
-                    non_empty_positions,
-                    counts,
-                    validity,
-                    ..
-                } => non_empty_positions.deep_size() + counts.deep_size() + validity.deep_size(),
-                SparseStructuralLayerPlan::FixedSizeList { validity, .. } => validity.deep_size(),
-            })
-            .sum::<usize>();
-        self.value_index.deep_size_of_children(context) + structural_size
+        self.value_index.deep_size_of_children(context) + self.plan.deep_size_of_children(context)
     }
 }
 
@@ -2426,36 +2416,13 @@ impl SparseStructuralScheduler {
                 Error::invalid_input_source("Sparse layout value buffer range overflows".into())
             })?;
         let num_chunks = meta_bytes.len() / 8;
-        let mut byte_deltas = Vec::with_capacity(num_chunks);
-        let mut value_counts = Vec::with_capacity(num_chunks);
-        let mut rows_counter = 0_u64;
-        let mut bytes_counter = 0_u64;
-        for chunk in meta_bytes.chunks_exact(8) {
-            let entry: [u8; 8] = chunk.try_into().map_err(|_| {
-                Error::invalid_input_source(
-                    "Sparse layout chunk metadata entry is not 8 bytes".into(),
-                )
-            })?;
-            let divided_bytes_minus_one = u32::from_le_bytes(
-                entry
-                    .get(..4)
-                    .and_then(|bytes| bytes.try_into().ok())
-                    .ok_or_else(|| {
-                        Error::invalid_input_source(
-                            "Sparse layout chunk byte-size field is malformed".into(),
-                        )
-                    })?,
-            );
-            let num_values = u64::from(u32::from_le_bytes(
-                entry
-                    .get(4..)
-                    .and_then(|bytes| bytes.try_into().ok())
-                    .ok_or_else(|| {
-                        Error::invalid_input_source(
-                            "Sparse layout chunk value-count field is malformed".into(),
-                        )
-                    })?,
-            ));
+        let mut total_values = 0_u64;
+        let mut total_bytes = 0_u64;
+        let mut values_per_chunk = 1_u64;
+        let mut last_chunk_values = 0_u64;
+        let mut has_uniform_non_last_counts = num_chunks > 0;
+        for (chunk_idx, chunk) in meta_bytes.chunks_exact(8).enumerate() {
+            let (num_bytes, num_values) = sparse_value_chunk_metadata(chunk);
             if num_values == 0 {
                 return Err(Error::invalid_input_source(
                     "Sparse layout contains an empty value chunk".into(),
@@ -2471,70 +2438,69 @@ impl SparseStructuralScheduler {
                     .into(),
                 ));
             }
-            let num_bytes = u64::from(divided_bytes_minus_one)
-                .checked_add(1)
-                .and_then(|units| units.checked_mul(MINIBLOCK_ALIGNMENT as u64))
-                .ok_or_else(|| {
-                    Error::invalid_input_source(
-                        "Sparse layout value chunk byte size overflows".into(),
-                    )
-                })?;
-            rows_counter = rows_counter.checked_add(num_values).ok_or_else(|| {
+            total_values = total_values.checked_add(num_values).ok_or_else(|| {
                 Error::invalid_input_source("Sparse layout visible item count overflows".into())
             })?;
-            bytes_counter = bytes_counter.checked_add(num_bytes).ok_or_else(|| {
+            total_bytes = total_bytes.checked_add(num_bytes).ok_or_else(|| {
                 Error::invalid_input_source("Sparse layout value chunk byte range overflows".into())
             })?;
-            byte_deltas.push(num_bytes);
-            value_counts.push(num_values);
+            if chunk_idx == 0 {
+                values_per_chunk = num_values;
+            } else {
+                // `last_chunk_values` is the previous chunk here, so the final
+                // chunk is deliberately excluded from the uniformity check.
+                has_uniform_non_last_counts &= last_chunk_values == values_per_chunk;
+            }
+            last_chunk_values = num_values;
         }
-        if rows_counter != self.num_visible_items {
+        if total_values != self.num_visible_items {
             return Err(Error::invalid_input_source(
                 format!(
                     "Sparse layout visible item count mismatch: metadata has {}, layout has {}",
-                    rows_counter, self.num_visible_items
+                    total_values, self.num_visible_items
                 )
                 .into(),
             ));
         }
         // The chunk byte sizes must exactly fill the declared value buffer.
-        let described_end = value_buf_position
-            .checked_add(bytes_counter)
-            .ok_or_else(|| {
-                Error::invalid_input_source("Sparse layout value chunk byte range overflows".into())
-            })?;
+        let described_end = value_buf_position.checked_add(total_bytes).ok_or_else(|| {
+            Error::invalid_input_source("Sparse layout value chunk byte range overflows".into())
+        })?;
         if described_end != value_buf_end {
             return Err(Error::invalid_input_source(
                 format!(
                     "Sparse layout chunk metadata describes {} value bytes, but value buffer has {} bytes",
-                    bytes_counter, value_buf_size
+                    total_bytes, value_buf_size
                 )
                 .into(),
             ));
         }
 
-        let byte_starts =
-            PrefixSums::from_deltas(byte_deltas.into_iter(), num_chunks, bytes_counter);
+        // Rescan the already-validated metadata to build only the final prefix
+        // sums, avoiding temporary per-chunk byte and value vectors.
+        let byte_starts = PrefixSums::from_deltas(
+            meta_bytes
+                .chunks_exact(8)
+                .map(|chunk| sparse_value_chunk_metadata(chunk).0),
+            num_chunks,
+            total_bytes,
+        );
         // Sparse value chunks have row == value index (no repetition), so the row
         // mapping is flat; use the arithmetic `UniformFlat` shape when every
         // non-last chunk holds the same number of values, else an explicit array.
-        let values_per_chunk = value_counts.first().copied().unwrap_or(0);
-        let uniform = num_chunks > 0
-            && value_counts[..num_chunks - 1]
-                .iter()
-                .all(|&count| count == values_per_chunk);
-        let rows = if uniform {
+        let rows = if has_uniform_non_last_counts {
             RowMapping::UniformFlat {
                 values_per_chunk,
-                last_chunk_values: value_counts[num_chunks - 1],
-                num_chunks,
+                last_chunk_values,
             }
         } else {
             RowMapping::Flat {
                 value_starts: PrefixSums::from_deltas(
-                    value_counts.iter().copied(),
+                    meta_bytes
+                        .chunks_exact(8)
+                        .map(|chunk| sparse_value_chunk_metadata(chunk).1),
                     num_chunks,
-                    rows_counter,
+                    total_values,
                 ),
             }
         };
@@ -3074,7 +3040,6 @@ impl StructuralPageScheduler for SparseStructuralScheduler {
 
             let page_meta = Arc::new(SparseStructuralCacheableState {
                 value_index,
-                num_visible_items: self.num_visible_items,
                 plan,
                 row_domain: self.row_domain,
             });
@@ -3130,7 +3095,7 @@ impl StructuralPageScheduler for SparseStructuralScheduler {
         for value_range in &selection.leaf_ranges {
             chunks_needed.extend(Self::value_chunk_range(
                 &page_meta.value_index,
-                page_meta.num_visible_items,
+                page_meta.plan.num_visible_items,
                 value_range.clone(),
             )?);
         }
@@ -3952,7 +3917,7 @@ impl DecodeSparseStructuralTask {
         while value_start < value_range.end {
             let chunk_idx = SparseStructuralScheduler::value_chunk_index(
                 &self.page_meta.value_index,
-                self.page_meta.num_visible_items,
+                self.page_meta.plan.num_visible_items,
                 value_start,
             )?;
             let chunk_value_start = self.page_meta.value_index.first_row(chunk_idx);
@@ -5524,13 +5489,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn selective_read_requests_only_intersecting_value_chunk() {
+    async fn selective_read_requests_only_intersecting_value_chunks() {
         let mut layout = sparse_layout();
         layout.num_items = 4;
         layout.num_visible_items = 4;
         let decompressors = DefaultDecompressionStrategy::default();
         let mut scheduler = SparseStructuralScheduler::try_new(
-            &[(0, 16), (16, 32)],
+            &[(0, 24), (24, 48)],
             0,
             4,
             DataType::Int32,
@@ -5540,30 +5505,42 @@ mod tests {
         .unwrap();
 
         let mut data = Vec::new();
-        for _ in 0..2 {
+        for num_values in [1_u32, 2, 1] {
             data.extend_from_slice(&1_u32.to_le_bytes());
-            data.extend_from_slice(&2_u32.to_le_bytes());
+            data.extend_from_slice(&num_values.to_le_bytes());
         }
-        for values in [[10_i32, 20], [30, 40]] {
+        for values in [&[10_i32][..], &[20, 30], &[40]] {
+            let chunk_start = data.len();
             data.extend_from_slice(&0_u16.to_le_bytes());
-            data.extend_from_slice(&8_u16.to_le_bytes());
+            data.extend_from_slice(&u16::try_from(values.len() * 4).unwrap().to_le_bytes());
             data.extend_from_slice(&[0; 4]);
             for value in values {
                 data.extend_from_slice(&value.to_le_bytes());
             }
+            data.resize(chunk_start + 16, 0);
         }
 
         let io = Arc::new(RecordingIo::new(Bytes::from(data)));
         let trait_io: Arc<dyn EncodingsIo> = io.clone();
         scheduler.initialize(&trait_io).await.unwrap();
-        let mut page_tasks = scheduler.schedule_ranges(&[2..3], &trait_io).unwrap();
+        assert_eq!(
+            scheduler
+                .page_meta
+                .as_ref()
+                .unwrap()
+                .value_index
+                .row_mapping_debug(),
+            "flat"
+        );
+        let mut page_tasks = scheduler.schedule_ranges(&[2..4], &trait_io).unwrap();
         let page_task = page_tasks.pop().unwrap();
         let mut decoder = page_task.decoder_fut.await.unwrap();
-        let decoded = decoder.drain(1).unwrap().decode().unwrap();
-        assert_eq!(decoded.data.num_values(), 1);
+        let decoded = decoder.drain(2).unwrap().decode().unwrap();
+        let fixed = decoded.data.as_fixed_width().unwrap();
+        assert_eq!(fixed.data.borrow_to_typed_slice::<i32>(), &[30, 40]);
 
         let calls = io.calls.lock().unwrap();
-        assert_eq!(calls.as_slice(), &[vec![0..16], vec![32..48]]);
+        assert_eq!(calls.as_slice(), &[vec![0..24], vec![40..56, 56..72]]);
     }
 
     #[tokio::test]
@@ -5607,9 +5584,8 @@ mod tests {
     }
 
     /// Initializes a sparse scheduler over a value buffer described by `chunks`
-    /// (each `(divided_bytes_minus_one, num_values)`), returning the cached value
-    /// index's row-mapping variant, heap size, and chunk count.
-    async fn init_value_index(chunks: &[(u32, u32)]) -> (&'static str, usize, usize) {
+    /// (each `(divided_bytes_minus_one, num_values)`) and returns its cached state.
+    async fn init_value_index(chunks: &[(u32, u32)]) -> Arc<SparseStructuralCacheableState> {
         let num_visible_items: u64 = chunks.iter().map(|&(_, values)| u64::from(values)).sum();
         let value_size: u64 = chunks
             .iter()
@@ -5642,30 +5618,94 @@ mod tests {
         let io: Arc<dyn EncodingsIo> = Arc::new(SimulatedScheduler::new(Bytes::from(metadata)));
         scheduler.initialize(&io).await.unwrap();
 
-        let value_index = &scheduler.page_meta.as_ref().unwrap().value_index;
-        (
-            value_index.row_mapping_debug(),
-            value_index.deep_size_of_children(&mut Context::new()),
-            value_index.num_chunks(),
-        )
+        scheduler.page_meta.unwrap()
+    }
+
+    fn legacy_value_index_size(num_chunks: usize) -> usize {
+        std::mem::size_of::<Vec<[u64; 3]>>()
+            + num_chunks * std::mem::size_of::<[u64; 3]>()
+            + std::mem::size_of::<Arc<[u64]>>()
+            + (num_chunks + 1) * std::mem::size_of::<u64>()
     }
 
     #[tokio::test]
     async fn value_chunk_index_stays_compact_across_row_mappings() {
         // Uniform non-last chunks collapse the row axis to arithmetic (no per-chunk array).
-        let (uniform_variant, uniform_heap, num_chunks) =
-            init_value_index(&[(1, 2), (1, 2), (1, 2)]).await;
-        assert_eq!(uniform_variant, "uniform_flat");
+        let uniform_page = init_value_index(&[(1, 2), (1, 2), (1, 2)]).await;
+        let uniform = &uniform_page.value_index;
+        assert_eq!(uniform.row_mapping_debug(), "uniform_flat");
         // A differing non-last chunk forces an explicit value-starts array.
-        let (flat_variant, flat_heap, _) = init_value_index(&[(1, 2), (1, 3), (1, 1)]).await;
-        assert_eq!(flat_variant, "flat");
+        let flat_page = init_value_index(&[(1, 2), (1, 3), (1, 1)]).await;
+        let flat = &flat_page.value_index;
+        assert_eq!(flat.row_mapping_debug(), "flat");
 
-        // The layout used to cache a 24-byte `ChunkMeta` plus an 8-byte value
-        // offset per chunk; both compact mappings must stay well under that.
-        const LEGACY_PER_CHUNK: usize = 32;
-        assert!(uniform_heap < LEGACY_PER_CHUNK * num_chunks);
-        assert!(flat_heap < LEGACY_PER_CHUNK * num_chunks);
+        // Include both inline and heap memory: cache weighting uses `deep_size_of`,
+        // not just the allocations reported by `deep_size_of_children`.
+        let uniform_size = uniform.deep_size_of();
+        let flat_size = flat.deep_size_of();
+        let legacy_size = legacy_value_index_size(3);
+        assert!(
+            uniform_size < legacy_size,
+            "uniform index uses {uniform_size} bytes, legacy uses {legacy_size}"
+        );
+        assert!(
+            flat_size < legacy_size,
+            "flat index uses {flat_size} bytes, legacy uses {legacy_size}"
+        );
         // Dropping the redundant value offsets keeps uniform cheaper than flat.
-        assert!(uniform_heap < flat_heap);
+        assert!(uniform_size < flat_size);
+
+        // A larger final chunk remains uniform: clamping maps all of its values
+        // back to the last chunk instead of inventing additional chunks.
+        let enlarged_last_page = init_value_index(&[(1, 2), (1, 4)]).await;
+        let enlarged_last = &enlarged_last_page.value_index;
+        assert_eq!(enlarged_last.row_mapping_debug(), "uniform_flat");
+        assert_eq!(
+            SparseStructuralScheduler::value_chunk_index(enlarged_last, 6, 5).unwrap(),
+            1
+        );
+        assert_eq!(enlarged_last.first_row(1), 2);
+        assert_eq!(enlarged_last.items_in_chunk(1), 4);
+
+        let single_page = init_value_index(&[(1, 6)]).await;
+        let single_size = single_page.value_index.deep_size_of();
+        let legacy_single_size = legacy_value_index_size(1);
+        assert!(
+            single_size <= legacy_single_size,
+            "single-chunk index uses {single_size} bytes, legacy uses {legacy_single_size}"
+        );
+
+        // simplified: Empty pages retain one fixed index header. Avoiding it would require
+        // boxing every non-empty index, adding an allocation and indirection to
+        // the hot path; cap this deliberate empty-only overhead at 32 bytes.
+        let empty_page = init_value_index(&[]).await;
+        let empty_size = empty_page.value_index.deep_size_of();
+        let legacy_empty_size = legacy_value_index_size(0);
+        let max_empty_overhead = 4 * std::mem::size_of::<u64>();
+        assert_eq!(empty_page.value_index.num_chunks(), 0);
+        assert!(
+            empty_size <= legacy_empty_size + max_empty_overhead,
+            "empty index uses {empty_size} bytes, legacy uses {legacy_empty_size}"
+        );
+    }
+
+    #[test]
+    fn cached_plan_deep_size_counts_layer_storage() {
+        let plan = SparseStructuralPlan {
+            layers: vec![SparseStructuralLayerPlan::Validity {
+                num_slots: 4,
+                validity: SparseValiditySet {
+                    meaning: SparseValidityMeaning::NullPositions,
+                    positions: SparsePositionSet::Explicit(vec![1, 3]),
+                },
+            }],
+            num_items: 4,
+            num_visible_items: 4,
+        };
+        let layer_storage = std::mem::size_of::<SparseStructuralLayerPlan>();
+        let position_storage = 2 * std::mem::size_of::<u64>();
+        assert!(
+            plan.deep_size_of_children(&mut Context::new()) >= layer_storage + position_storage
+        );
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use super::chunk_index::{MiniBlockChunkIndex, PrefixSums, RowMapping};
 use super::*;
 use arrow_array::new_empty_array;
 use arrow_buffer::ArrowNativeType;
@@ -1118,14 +1119,14 @@ struct SparseValiditySetDecoder {
 
 #[derive(Debug)]
 struct SparseStructuralCacheableState {
-    chunk_meta: Vec<ChunkMeta>,
-    chunk_value_offsets: Arc<[u64]>,
+    value_index: MiniBlockChunkIndex,
+    num_visible_items: u64,
     plan: SparseStructuralPlan,
     row_domain: u64,
 }
 
 impl DeepSizeOf for SparseStructuralCacheableState {
-    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
         let structural_size = self
             .plan
             .layers
@@ -1141,9 +1142,7 @@ impl DeepSizeOf for SparseStructuralCacheableState {
                 SparseStructuralLayerPlan::FixedSizeList { validity, .. } => validity.deep_size(),
             })
             .sum::<usize>();
-        self.chunk_meta.len() * std::mem::size_of::<ChunkMeta>()
-            + self.chunk_value_offsets.len() * std::mem::size_of::<u64>()
-            + structural_size
+        self.value_index.deep_size_of_children(context) + structural_size
     }
 }
 
@@ -2403,7 +2402,13 @@ impl SparseStructuralScheduler {
         })
     }
 
-    fn parse_chunk_meta(&self, meta_bytes: Bytes) -> Result<Vec<ChunkMeta>> {
+    /// Parses the sparse layout's per-chunk value metadata into the compact
+    /// [`MiniBlockChunkIndex`], validating chunk sizes and the total item/byte
+    /// counts.  Sparse value chunks are themselves mini-blocks, so this reuses
+    /// the same prefix-sum index the mini-block path builds, avoiding the
+    /// redundant per-chunk byte offsets and value offsets the layout used to
+    /// cache separately.
+    fn build_value_chunk_index(&self, meta_bytes: Bytes) -> Result<MiniBlockChunkIndex> {
         if !meta_bytes.len().is_multiple_of(8) {
             return Err(Error::invalid_input_source(
                 format!(
@@ -2420,9 +2425,11 @@ impl SparseStructuralScheduler {
             .ok_or_else(|| {
                 Error::invalid_input_source("Sparse layout value buffer range overflows".into())
             })?;
+        let num_chunks = meta_bytes.len() / 8;
+        let mut byte_deltas = Vec::with_capacity(num_chunks);
+        let mut value_counts = Vec::with_capacity(num_chunks);
         let mut rows_counter = 0_u64;
-        let mut offset_bytes = value_buf_position;
-        let mut chunk_meta = Vec::with_capacity(meta_bytes.len() / 8);
+        let mut bytes_counter = 0_u64;
         for chunk in meta_bytes.chunks_exact(8) {
             let entry: [u8; 8] = chunk.try_into().map_err(|_| {
                 Error::invalid_input_source(
@@ -2475,14 +2482,11 @@ impl SparseStructuralScheduler {
             rows_counter = rows_counter.checked_add(num_values).ok_or_else(|| {
                 Error::invalid_input_source("Sparse layout visible item count overflows".into())
             })?;
-            chunk_meta.push(ChunkMeta {
-                num_values,
-                chunk_size_bytes: num_bytes,
-                offset_bytes,
-            });
-            offset_bytes = offset_bytes.checked_add(num_bytes).ok_or_else(|| {
+            bytes_counter = bytes_counter.checked_add(num_bytes).ok_or_else(|| {
                 Error::invalid_input_source("Sparse layout value chunk byte range overflows".into())
             })?;
+            byte_deltas.push(num_bytes);
+            value_counts.push(num_values);
         }
         if rows_counter != self.num_visible_items {
             return Err(Error::invalid_input_source(
@@ -2493,17 +2497,52 @@ impl SparseStructuralScheduler {
                 .into(),
             ));
         }
-        if offset_bytes != value_buf_end {
+        // The chunk byte sizes must exactly fill the declared value buffer.
+        let described_end = value_buf_position
+            .checked_add(bytes_counter)
+            .ok_or_else(|| {
+                Error::invalid_input_source("Sparse layout value chunk byte range overflows".into())
+            })?;
+        if described_end != value_buf_end {
             return Err(Error::invalid_input_source(
                 format!(
                     "Sparse layout chunk metadata describes {} value bytes, but value buffer has {} bytes",
-                    offset_bytes - value_buf_position,
-                    value_buf_size
+                    bytes_counter, value_buf_size
                 )
                 .into(),
             ));
         }
-        Ok(chunk_meta)
+
+        let byte_starts =
+            PrefixSums::from_deltas(byte_deltas.into_iter(), num_chunks, bytes_counter);
+        // Sparse value chunks have row == value index (no repetition), so the row
+        // mapping is flat; use the arithmetic `UniformFlat` shape when every
+        // non-last chunk holds the same number of values, else an explicit array.
+        let values_per_chunk = value_counts.first().copied().unwrap_or(0);
+        let uniform = num_chunks > 0
+            && value_counts[..num_chunks - 1]
+                .iter()
+                .all(|&count| count == values_per_chunk);
+        let rows = if uniform {
+            RowMapping::UniformFlat {
+                values_per_chunk,
+                last_chunk_values: value_counts[num_chunks - 1],
+                num_chunks,
+            }
+        } else {
+            RowMapping::Flat {
+                value_starts: PrefixSums::from_deltas(
+                    value_counts.iter().copied(),
+                    num_chunks,
+                    rows_counter,
+                ),
+            }
+        };
+        Ok(MiniBlockChunkIndex::new(
+            value_buf_position,
+            byte_starts,
+            rows,
+        ))
     }
 
     fn validate_general_buffer_header(
@@ -2920,30 +2959,19 @@ impl SparseStructuralScheduler {
         let page_meta = self.page_meta.as_ref().ok_or_else(|| {
             Error::internal("Sparse page scheduler has not been initialized".to_string())
         })?;
+        let num_chunks = page_meta.value_index.num_chunks();
         chunk_indices
             .iter()
             .map(|&chunk_idx| {
-                let chunk_meta = page_meta.chunk_meta.get(chunk_idx).ok_or_else(|| {
-                    Error::invalid_input_source(
+                if chunk_idx >= num_chunks {
+                    return Err(Error::invalid_input_source(
                         format!("Sparse layout missing value chunk metadata for chunk {chunk_idx}")
                             .into(),
-                    )
-                })?;
-                let bytes_start = chunk_meta.offset_bytes;
-                let bytes_end = bytes_start
-                    .checked_add(chunk_meta.chunk_size_bytes)
-                    .ok_or_else(|| {
-                        Error::invalid_input_source(
-                            format!(
-                                "Sparse layout value chunk {} byte range overflows",
-                                chunk_idx
-                            )
-                            .into(),
-                        )
-                    })?;
+                    ));
+                }
                 Ok(LoadedChunk {
-                    byte_range: bytes_start..bytes_end,
-                    items_in_chunk: chunk_meta.num_values,
+                    byte_range: page_meta.value_index.byte_range(chunk_idx),
+                    items_in_chunk: page_meta.value_index.items_in_chunk(chunk_idx),
                     chunk_idx,
                     data: LanceBuffer::empty(),
                 })
@@ -2951,52 +2979,44 @@ impl SparseStructuralScheduler {
             .collect()
     }
 
-    fn value_chunk_index(chunk_value_offsets: &[u64], value: u64) -> Result<usize> {
-        let total_values = chunk_value_offsets.last().copied().ok_or_else(|| {
-            Error::invalid_input_source("Sparse layout has no value chunk offsets".into())
-        })?;
-        if chunk_value_offsets.len() < 2 || value >= total_values {
+    fn value_chunk_index(
+        value_index: &MiniBlockChunkIndex,
+        num_visible_items: u64,
+        value: u64,
+    ) -> Result<usize> {
+        if value >= num_visible_items {
             return Err(Error::invalid_input_source(
                 format!(
                     "Sparse layout value index {} is outside {} visible items",
-                    value, total_values
+                    value, num_visible_items
                 )
                 .into(),
             ));
         }
-        chunk_value_offsets
-            .partition_point(|&offset| offset <= value)
-            .checked_sub(1)
-            .ok_or_else(|| {
-                Error::invalid_input_source(
-                    format!("Sparse layout value index {value} is before the first chunk").into(),
-                )
-            })
+        Ok(value_index.find_chunk(value))
     }
 
     fn value_chunk_range(
-        chunk_value_offsets: &[u64],
+        value_index: &MiniBlockChunkIndex,
+        num_visible_items: u64,
         value_range: Range<u64>,
     ) -> Result<Range<usize>> {
         if value_range.is_empty() {
             return Ok(0..0);
         }
-        let total_values = chunk_value_offsets.last().copied().ok_or_else(|| {
-            Error::invalid_input_source("Sparse layout has no value chunk offsets".into())
-        })?;
-        if value_range.start > value_range.end || value_range.end > total_values {
+        if value_range.start > value_range.end || value_range.end > num_visible_items {
             return Err(Error::invalid_input_source(
                 format!(
                     "Sparse layout value range {}..{} is outside {} visible items",
-                    value_range.start, value_range.end, total_values
+                    value_range.start, value_range.end, num_visible_items
                 )
                 .into(),
             ));
         }
-        let start = Self::value_chunk_index(chunk_value_offsets, value_range.start)?;
-        let end = chunk_value_offsets
-            .partition_point(|&offset| offset < value_range.end)
-            .max(start + 1);
+        let start = Self::value_chunk_index(value_index, num_visible_items, value_range.start)?;
+        // The range is non-empty, so `end - 1` is a valid item; the chunk holding
+        // it is the last overlapped chunk, giving an exclusive end of `+ 1`.
+        let end = (value_index.find_chunk(value_range.end - 1) + 1).max(start + 1);
         Ok(start..end)
     }
 }
@@ -3033,18 +3053,7 @@ impl StructuralPageScheduler for SparseStructuralScheduler {
                 Error::invalid_input_source("Sparse layout is missing chunk metadata buffer".into())
             })?;
 
-            let chunk_meta = self.parse_chunk_meta(meta_bytes)?;
-            let mut chunk_value_offsets = Vec::with_capacity(chunk_meta.len() + 1);
-            let mut value_offset = 0_u64;
-            chunk_value_offsets.push(value_offset);
-            for chunk in &chunk_meta {
-                value_offset = value_offset.checked_add(chunk.num_values).ok_or_else(|| {
-                    Error::invalid_input_source(
-                        "Sparse layout visible item offset overflows".into(),
-                    )
-                })?;
-                chunk_value_offsets.push(value_offset);
-            }
+            let value_index = self.build_value_chunk_index(meta_bytes)?;
 
             let layers = self
                 .layer_decompressors
@@ -3064,8 +3073,8 @@ impl StructuralPageScheduler for SparseStructuralScheduler {
             }
 
             let page_meta = Arc::new(SparseStructuralCacheableState {
-                chunk_meta,
-                chunk_value_offsets: chunk_value_offsets.into(),
+                value_index,
+                num_visible_items: self.num_visible_items,
                 plan,
                 row_domain: self.row_domain,
             });
@@ -3120,7 +3129,8 @@ impl StructuralPageScheduler for SparseStructuralScheduler {
         let selection = slice_sparse_plan(&page_meta.plan, &ranges, page_meta.row_domain)?;
         for value_range in &selection.leaf_ranges {
             chunks_needed.extend(Self::value_chunk_range(
-                &page_meta.chunk_value_offsets,
+                &page_meta.value_index,
+                page_meta.num_visible_items,
                 value_range.clone(),
             )?);
         }
@@ -3941,29 +3951,13 @@ impl DecodeSparseStructuralTask {
         let mut value_start = value_range.start;
         while value_start < value_range.end {
             let chunk_idx = SparseStructuralScheduler::value_chunk_index(
-                &self.page_meta.chunk_value_offsets,
+                &self.page_meta.value_index,
+                self.page_meta.num_visible_items,
                 value_start,
             )?;
-            let chunk_value_start = *self
-                .page_meta
-                .chunk_value_offsets
-                .get(chunk_idx)
-                .ok_or_else(|| {
-                    Error::invalid_input_source(
-                        format!("Sparse value chunk {} has no start offset", chunk_idx).into(),
-                    )
-                })?;
-            let chunk_value_end = *self
-                .page_meta
-                .chunk_value_offsets
-                .get(chunk_idx.checked_add(1).ok_or_else(|| {
-                    Error::invalid_input_source("Sparse value chunk index overflows".into())
-                })?)
-                .ok_or_else(|| {
-                    Error::invalid_input_source(
-                        format!("Sparse value chunk {} has no end offset", chunk_idx).into(),
-                    )
-                })?;
+            let chunk_value_start = self.page_meta.value_index.first_row(chunk_idx);
+            let chunk_value_end =
+                chunk_value_start + self.page_meta.value_index.items_in_chunk(chunk_idx);
             let take_end = value_range.end.min(chunk_value_end);
             if value_start < chunk_value_start || take_end <= value_start {
                 return Err(Error::invalid_input_source(
@@ -5610,5 +5604,68 @@ mod tests {
         let calls = io.calls.lock().unwrap();
         assert_eq!(calls.len(), 2);
         assert!(calls[1].is_empty(), "value payload must not be requested");
+    }
+
+    /// Initializes a sparse scheduler over a value buffer described by `chunks`
+    /// (each `(divided_bytes_minus_one, num_values)`), returning the cached value
+    /// index's row-mapping variant, heap size, and chunk count.
+    async fn init_value_index(chunks: &[(u32, u32)]) -> (&'static str, usize, usize) {
+        let num_visible_items: u64 = chunks.iter().map(|&(_, values)| u64::from(values)).sum();
+        let value_size: u64 = chunks
+            .iter()
+            .map(|&(divided_minus_one, _)| {
+                (u64::from(divided_minus_one) + 1) * MINIBLOCK_ALIGNMENT as u64
+            })
+            .sum();
+        let mut metadata = Vec::new();
+        for &(divided_minus_one, num_values) in chunks {
+            metadata.extend_from_slice(&divided_minus_one.to_le_bytes());
+            metadata.extend_from_slice(&num_values.to_le_bytes());
+        }
+        let metadata_size = metadata.len() as u64;
+
+        let mut layout = sparse_layout();
+        layout.num_items = num_visible_items;
+        layout.num_visible_items = num_visible_items;
+        let decompressors = DefaultDecompressionStrategy::default();
+        let mut scheduler = SparseStructuralScheduler::try_new(
+            &[(0, metadata_size), (metadata_size, value_size)],
+            0,
+            num_visible_items,
+            DataType::Int32,
+            &layout,
+            &decompressors,
+        )
+        .unwrap();
+
+        // `initialize` only reads the metadata buffer, so a metadata-only blob suffices.
+        let io: Arc<dyn EncodingsIo> = Arc::new(SimulatedScheduler::new(Bytes::from(metadata)));
+        scheduler.initialize(&io).await.unwrap();
+
+        let value_index = &scheduler.page_meta.as_ref().unwrap().value_index;
+        (
+            value_index.row_mapping_debug(),
+            value_index.deep_size_of_children(&mut Context::new()),
+            value_index.num_chunks(),
+        )
+    }
+
+    #[tokio::test]
+    async fn value_chunk_index_stays_compact_across_row_mappings() {
+        // Uniform non-last chunks collapse the row axis to arithmetic (no per-chunk array).
+        let (uniform_variant, uniform_heap, num_chunks) =
+            init_value_index(&[(1, 2), (1, 2), (1, 2)]).await;
+        assert_eq!(uniform_variant, "uniform_flat");
+        // A differing non-last chunk forces an explicit value-starts array.
+        let (flat_variant, flat_heap, _) = init_value_index(&[(1, 2), (1, 3), (1, 1)]).await;
+        assert_eq!(flat_variant, "flat");
+
+        // The layout used to cache a 24-byte `ChunkMeta` plus an 8-byte value
+        // offset per chunk; both compact mappings must stay well under that.
+        const LEGACY_PER_CHUNK: usize = 32;
+        assert!(uniform_heap < LEGACY_PER_CHUNK * num_chunks);
+        assert!(flat_heap < LEGACY_PER_CHUNK * num_chunks);
+        // Dropping the redundant value offsets keeps uniform cheaper than flat.
+        assert!(uniform_heap < flat_heap);
     }
 }

--- a/rust/lance-encoding/tests/sparse_bench_layouts.rs
+++ b/rust/lance-encoding/tests/sparse_bench_layouts.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+// The reporting helper below prints its findings for a human to read.
+#![allow(clippy::print_stdout)]
+//! Guards the sparse benchmark inputs against writer heuristic drift.
+//!
+//! The benches in `benches/sparse_decode.rs` and `benches/sparse_footprint.rs` are only
+//! meaningful if their inputs actually land on the sparse structural layout. Layout
+//! selection is a writer-side heuristic, so a change to the rep/def budget or to automatic
+//! sparse selection could quietly move a case onto the dense mini-block path, leaving the
+//! benches green while measuring nothing. This test fails instead.
+
+#[path = "../benches/sparse/cases.rs"]
+mod cases;
+
+use cases::{cases, encode_unchecked, layouts};
+
+#[test]
+fn bench_cases_produce_declared_layout() {
+    for case in cases() {
+        let encoded = encode_unchecked(&case);
+        let observed = layouts(&encoded);
+        assert!(!observed.is_empty(), "case {} produced no pages", case.name);
+        for layout in &observed {
+            assert_eq!(
+                *layout, case.expect,
+                "case {} expected {} but observed {:?}",
+                case.name, case.expect, observed
+            );
+        }
+    }
+}
+
+/// Prints the observed layout for every case, so the matrix can be re-derived after a
+/// writer change without editing code:
+/// `cargo test -p lance-encoding --test sparse_bench_layouts -- --ignored --nocapture`
+#[test]
+#[ignore = "reporting helper, not an assertion"]
+fn report_bench_case_layouts() {
+    for case in cases() {
+        let encoded = encode_unchecked(&case);
+        let observed = layouts(&encoded);
+        println!(
+            "{:<30} declared={:<10} observed={:<10} pages={} rows={}",
+            case.name,
+            case.expect.to_string(),
+            observed
+                .first()
+                .map(|l| l.to_string())
+                .unwrap_or_else(|| "none".into()),
+            observed.len(),
+            encoded.num_rows,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #7651. The sparse structural scheduler cached a `Vec<ChunkMeta>` (value count, byte size, byte offset) plus a separate cumulative-value-offset array — about 32 bytes per chunk, with most fields derivable.

Sparse value chunks are mini-blocks, so this replaces that state with the compact `MiniBlockChunkIndex` introduced in #7651:

- byte ranges come from width-adaptive `PrefixSums` (`u32` when the value buffer fits);
- uniform non-last value counts use arithmetic `UniformFlat` mapping;
- non-uniform counts use a compact `Flat` value-prefix array;
- nested-only row metadata is boxed, so its large representation does not inflate every flat/sparse index;
- nested trailer flags use a raw bit-packed `Box<[u8]>`, avoiding an unnecessary Arrow buffer header.

Metadata is validated once and then rescanned to build only the final prefix sums, avoiding two temporary `Vec<u64>` allocations per page. The cached state also no longer duplicates `num_visible_items`, and `DeepSizeOf` now includes the sparse plan's layer-vector storage and nested allocations.

## Memory behavior

The tests now use `deep_size_of()` (the same total inline + heap accounting used by the cache), rather than checking heap children alone:

- one-chunk pages do not regress;
- multi-chunk `UniformFlat` and `Flat` pages are smaller than the legacy representation;
- asymptotic metadata falls from ~32 bytes/chunk to ~4 bytes/chunk (uniform) or ~8 bytes/chunk (non-uniform);
- zero-value pages intentionally retain at most a 32-byte fixed index-header overhead. Avoiding that would require boxing every non-empty index, adding an allocation and pointer indirection to the hot path.

## Testing

- `cargo test -p lance-encoding --lib sparse` — 55 passed
- total-memory coverage for empty, single, uniform, non-uniform, enlarged-final, and nested mappings
- end-to-end non-uniform scheduling and cross-chunk decode coverage
- malformed metadata and existing sparse roundtrip/validation tests pass unchanged
- `cargo clippy -p lance-encoding --tests --benches -- -D warnings`
- `cargo fmt --all --check`

Made with [Cursor](https://cursor.com)