### PR TITLE
fix(index): replace scalar cache entries on store rotation

### DIFF
--- a/rust/lance-index-core/src/scalar.rs
+++ b/rust/lance-index-core/src/scalar.rs
@@ -246,6 +246,29 @@ pub trait IndexStore: std::fmt::Debug + Send + Sync + DeepSizeOf {
     fn as_any(&self) -> &dyn Any;
     fn clone_arc(&self) -> Arc<dyn IndexStore>;
 
+    /// Return whether this store has the same live storage binding as `other`.
+    ///
+    /// `true` means cached indices holding [`IndexReader`]s created through `other` are safe to
+    /// reuse through this store. `false` means they must be reopened through
+    /// [`IndexStore::open_index_file`]. Implementations should return `true` only when readers,
+    /// credentials, and connection handles are interchangeable between both stores. The
+    /// conservative default prevents custom stores from accidentally reusing a store-bound
+    /// index.
+    ///
+    /// ```
+    /// use lance_index_core::scalar::IndexStore;
+    ///
+    /// fn can_reuse_cached_index(
+    ///     current_store: &dyn IndexStore,
+    ///     cached_store: &dyn IndexStore,
+    /// ) -> bool {
+    ///     current_store.is_same_storage_binding(cached_store)
+    /// }
+    /// ```
+    fn is_same_storage_binding(&self, _other: &dyn IndexStore) -> bool {
+        false
+    }
+
     /// Suggested I/O parallelism for the store
     fn io_parallelism(&self) -> usize;
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -1874,7 +1874,12 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
-    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+    async fn put_in_cache(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        cache: &LanceCache,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
         let state = BitmapIndexState::from_scalar_index(index.as_ref())?;
         cache
             .insert_with_key(&BitmapIndexStateKey, Arc::new(state))
@@ -2325,7 +2330,10 @@ mod tests {
 
         let plugin = BitmapIndexPlugin;
         let index_arc: Arc<dyn ScalarIndex> = index.clone() as Arc<dyn ScalarIndex>;
-        plugin.put_in_cache(&cache, index_arc).await.unwrap();
+        plugin
+            .put_in_cache(store.clone(), &cache, index_arc)
+            .await
+            .unwrap();
 
         // get_from_cache must return Some, and the BitmapIndexState's OnceLock
         // must have been populated by put_in_cache so no parse_lookup_batch occurs.

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -3377,7 +3377,12 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
         )?))
     }
 
-    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+    async fn put_in_cache(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        cache: &LanceCache,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
         let state = BTreeIndexState::from_index(index.as_ref())?;
         cache
             .insert_with_key(&BTreeIndexStateKey, Arc::new(state))
@@ -6369,7 +6374,10 @@ mod tests {
         // The plugin's put/get hooks round-trip through a real cache + the codec.
         let cache = LanceCache::with_capacity(64 * 1024 * 1024);
         let plugin = BTreeIndexPlugin;
-        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
+        plugin
+            .put_in_cache(test_store.clone(), &cache, index.clone())
+            .await
+            .unwrap();
         let from_cache = plugin
             .get_from_cache(test_store.clone(), None, &cache)
             .await
@@ -6574,7 +6582,10 @@ mod tests {
 
         let cache = LanceCache::with_capacity(64 * 1024 * 1024);
         let plugin = BTreeIndexPlugin;
-        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
+        plugin
+            .put_in_cache(store.clone(), &cache, index.clone())
+            .await
+            .unwrap();
         let from_cache = plugin
             .get_from_cache(store.clone(), None, &cache)
             .await

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -285,8 +285,8 @@ use crate::scalar::{
     CreatedIndex, RowIdRemapper, ScalarIndex,
     expression::{FtsQueryParser, ScalarQueryParser},
     registry::{
-        BasicTrainer, ScalarIndexCacheKey, ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria,
-        TrainingOrdering, TrainingRequest,
+        BasicTrainer, ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+        TrainingRequest, single_flight_store_bound_open,
     },
 };
 
@@ -487,14 +487,12 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
 
     async fn get_or_insert_in_cache(
         &self,
-        _index_store: Arc<dyn IndexStore>,
+        index_store: Arc<dyn IndexStore>,
         _frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         cache: &LanceCache,
         load: ScalarIndexLoad<'_>,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        cache
-            .get_or_insert_unsized_with_key(ScalarIndexCacheKey, || load)
-            .await
+        single_flight_store_bound_open(index_store, cache, load).await
     }
 
     fn details_as_json(&self, details: &prost_types::Any) -> Result<serde_json::Value> {

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -826,7 +826,12 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
-    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+    async fn put_in_cache(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        cache: &LanceCache,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
         let state = LabelListIndexState::from_scalar_index(index.as_ref())?;
         cache
             .insert_with_key(&LabelListIndexStateKey, Arc::new(state))

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -406,6 +406,13 @@ impl IndexStore for LanceIndexStore {
         Arc::new(self.clone())
     }
 
+    fn is_same_storage_binding(&self, other: &dyn IndexStore) -> bool {
+        other.as_any().downcast_ref::<Self>().is_some_and(|other| {
+            Arc::ptr_eq(&self.object_store, &other.object_store)
+                && self.index_dir == other.index_dir
+        })
+    }
+
     fn io_parallelism(&self) -> usize {
         self.object_store.io_parallelism()
     }

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -4,6 +4,7 @@
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
+use arc_swap::ArcSwap;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
@@ -11,7 +12,7 @@ use futures::future::BoxFuture;
 use lance_core::{
     Result,
     cache::{CacheKey, CacheKeySchema, KeyBuilder, LanceCache, UnsizedCacheKey},
-    deepsize::DeepSizeOf,
+    deepsize::{Context, DeepSizeOf},
 };
 
 use crate::progress::IndexBuildProgress;
@@ -184,9 +185,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         let Some(entry) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await else {
             return Ok(None);
         };
-        Ok(index_store
-            .is_same_storage_binding(entry.index_store.as_ref())
-            .then(|| entry.index.clone()))
+        Ok(entry.index_for_store(&index_store))
     }
 
     /// Store a freshly-opened index in the cache.
@@ -372,8 +371,15 @@ pub(crate) async fn single_flight_store_bound_open(
         })
         .await?;
 
-    if index_store.is_same_storage_binding(entry.index_store.as_ref()) {
-        return Ok(entry.index());
+    if let Some(index) = entry.index_for_store(&index_store) {
+        return Ok(index);
+    }
+
+    // The cache slot stays stable across rotations. Serialize replacements and
+    // recheck after locking so same-binding waiters reuse the first reload.
+    let _replacement_guard = entry.replacement_guard.lock().await;
+    if let Some(index) = entry.index_for_store(&index_store) {
+        return Ok(index);
     }
 
     let Some(load) = take_scalar_index_load(&pending_load)? else {
@@ -383,15 +389,7 @@ pub(crate) async fn single_flight_store_bound_open(
         return Ok(entry.index());
     };
     let index = load.await?;
-    cache
-        .insert_unsized_with_key(
-            &ScalarIndexCacheKey,
-            Arc::new(StoreBoundScalarIndexCacheEntry::new(
-                index_store,
-                index.clone(),
-            )),
-        )
-        .await;
+    entry.replace(index_store, index.clone());
     Ok(index)
 }
 
@@ -408,19 +406,48 @@ fn take_scalar_index_load<'a>(
 
 /// A live scalar index together with the store binding used to open it.
 #[derive(DeepSizeOf)]
-pub struct StoreBoundScalarIndexCacheEntry {
+struct StoreBoundScalarIndexBinding {
     index_store: Arc<dyn IndexStore>,
     index: Arc<dyn ScalarIndex>,
 }
 
+/// A stable cache slot for one live, store-bound scalar index.
+pub struct StoreBoundScalarIndexCacheEntry {
+    binding: ArcSwap<StoreBoundScalarIndexBinding>,
+    replacement_guard: tokio::sync::Mutex<()>,
+}
+
+impl DeepSizeOf for StoreBoundScalarIndexCacheEntry {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.binding.load_full().deep_size_of_children(context)
+    }
+}
+
 impl StoreBoundScalarIndexCacheEntry {
     fn new(index_store: Arc<dyn IndexStore>, index: Arc<dyn ScalarIndex>) -> Self {
-        Self { index_store, index }
+        Self {
+            binding: ArcSwap::from_pointee(StoreBoundScalarIndexBinding { index_store, index }),
+            replacement_guard: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    fn index_for_store(&self, index_store: &Arc<dyn IndexStore>) -> Option<Arc<dyn ScalarIndex>> {
+        let binding = self.binding.load();
+        index_store
+            .is_same_storage_binding(binding.index_store.as_ref())
+            .then(|| binding.index.clone())
+    }
+
+    fn replace(&self, index_store: Arc<dyn IndexStore>, index: Arc<dyn ScalarIndex>) {
+        self.binding.store(Arc::new(StoreBoundScalarIndexBinding {
+            index_store,
+            index,
+        }));
     }
 
     /// Return a shared handle to the cached scalar index.
     pub fn index(&self) -> Arc<dyn ScalarIndex> {
-        self.index.clone()
+        self.binding.load().index.clone()
     }
 }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::borrow::Cow;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
@@ -177,11 +177,16 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// without re-reading metadata.
     async fn get_from_cache(
         &self,
-        _index_store: Arc<dyn IndexStore>,
+        index_store: Arc<dyn IndexStore>,
         _frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         cache: &LanceCache,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
-        Ok(cache.get_unsized_with_key(&ScalarIndexCacheKey).await)
+        let Some(entry) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await else {
+            return Ok(None);
+        };
+        Ok(index_store
+            .is_same_storage_binding(entry.index_store.as_ref())
+            .then(|| entry.index.clone()))
     }
 
     /// Store a freshly-opened index in the cache.
@@ -190,9 +195,17 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// [`get_from_cache`](Self::get_from_cache).
     ///
     /// The default implementation stores the `Arc<dyn ScalarIndex>` in-memory.
-    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+    async fn put_in_cache(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        cache: &LanceCache,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
         cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey, index)
+            .insert_unsized_with_key(
+                &ScalarIndexCacheKey,
+                Arc::new(StoreBoundScalarIndexCacheEntry::new(index_store, index)),
+            )
             .await;
         Ok(())
     }
@@ -212,13 +225,13 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         load: ScalarIndexLoad<'_>,
     ) -> Result<Arc<dyn ScalarIndex>> {
         if let Some(index) = self
-            .get_from_cache(index_store, frag_reuse_index, cache)
+            .get_from_cache(index_store.clone(), frag_reuse_index, cache)
             .await?
         {
             return Ok(index);
         }
         let index = load.await?;
-        self.put_in_cache(cache, index.clone()).await?;
+        self.put_in_cache(index_store, cache, index.clone()).await?;
         Ok(index)
     }
 
@@ -336,18 +349,93 @@ where
     from_state(state)
 }
 
-/// In-memory cache key for a whole `Arc<dyn ScalarIndex>`.
+pub(crate) async fn single_flight_store_bound_open(
+    index_store: Arc<dyn IndexStore>,
+    cache: &LanceCache,
+    load: ScalarIndexLoad<'_>,
+) -> Result<Arc<dyn ScalarIndex>> {
+    let pending_load = Arc::new(Mutex::new(Some(load)));
+    let cache_load = pending_load.clone();
+    let cache_index_store = index_store.clone();
+    let entry = cache
+        .get_or_insert_unsized_with_key(ScalarIndexCacheKey, move || async move {
+            let load = take_scalar_index_load(&cache_load)?.ok_or_else(|| {
+                lance_core::Error::internal(
+                    "store-bound scalar index cache loader was already consumed",
+                )
+            })?;
+            let index = load.await?;
+            Ok(Arc::new(StoreBoundScalarIndexCacheEntry::new(
+                cache_index_store,
+                index,
+            )))
+        })
+        .await?;
+
+    if index_store.is_same_storage_binding(entry.index_store.as_ref()) {
+        return Ok(entry.index());
+    }
+
+    let Some(load) = take_scalar_index_load(&pending_load)? else {
+        // The cache loader ran, so this entry was opened through `index_store`.
+        // A custom store may conservatively report no binding equivalence even
+        // when compared with the same instance.
+        return Ok(entry.index());
+    };
+    let index = load.await?;
+    cache
+        .insert_unsized_with_key(
+            &ScalarIndexCacheKey,
+            Arc::new(StoreBoundScalarIndexCacheEntry::new(
+                index_store,
+                index.clone(),
+            )),
+        )
+        .await;
+    Ok(index)
+}
+
+fn take_scalar_index_load<'a>(
+    pending_load: &Arc<Mutex<Option<ScalarIndexLoad<'a>>>>,
+) -> Result<Option<ScalarIndexLoad<'a>>> {
+    pending_load
+        .lock()
+        .map_err(|_| {
+            lance_core::Error::internal("store-bound scalar index cache loader mutex was poisoned")
+        })
+        .map(|mut pending_load| pending_load.take())
+}
+
+/// A live scalar index together with the store binding used to open it.
+#[derive(DeepSizeOf)]
+pub struct StoreBoundScalarIndexCacheEntry {
+    index_store: Arc<dyn IndexStore>,
+    index: Arc<dyn ScalarIndex>,
+}
+
+impl StoreBoundScalarIndexCacheEntry {
+    fn new(index_store: Arc<dyn IndexStore>, index: Arc<dyn ScalarIndex>) -> Self {
+        Self { index_store, index }
+    }
+
+    /// Return a shared handle to the cached scalar index.
+    pub fn index(&self) -> Arc<dyn ScalarIndex> {
+        self.index.clone()
+    }
+}
+
+/// In-memory cache key for a live, store-bound scalar index.
 ///
 /// Used by the default [`ScalarIndexPlugin::get_from_cache`] /
 /// [`ScalarIndexPlugin::put_in_cache`] implementations. The cache is already
-/// per-index namespaced by the caller, so a constant key suffices. Trait objects
+/// per-index namespaced by the caller, so a constant key suffices. The entry
 /// cannot be serialized, so this is an [`UnsizedCacheKey`] with no codec —
 /// plugins that want a persistable cache entry override those methods with a
 /// sized key.
 pub struct ScalarIndexCacheKey;
 
 impl UnsizedCacheKey for ScalarIndexCacheKey {
-    type ValueType = dyn ScalarIndex;
+    type ValueType = StoreBoundScalarIndexCacheEntry;
 
     fn key(&self) -> Cow<'_, str> {
         Cow::Borrowed("scalar_index")
@@ -358,7 +446,7 @@ impl UnsizedCacheKey for ScalarIndexCacheKey {
     }
 
     fn schema() -> CacheKeySchema {
-        CacheKeySchema::new("lance.scalar.registry.scalar-index-key", 1)
+        CacheKeySchema::new("lance.scalar.registry.scalar-index-key", 2)
     }
 
     fn write_key(&self, builder: &mut KeyBuilder) {

--- a/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
@@ -410,9 +410,11 @@ async fn open_pk_index(
     let details = prost_types::Any::from_msg(&lance_index::pbold::BTreeIndexDetails::default())
         .map_err(|e| Error::io(e.to_string()))?;
     let index = plugin
-        .load_index(store, &details, None, &index_cache)
+        .load_index(store.clone(), &details, None, &index_cache)
         .await?;
-    plugin.put_in_cache(&index_cache, index.clone()).await?;
+    plugin
+        .put_in_cache(store, &index_cache, index.clone())
+        .await?;
     Ok(index)
 }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -50,6 +50,7 @@ use lance_index::scalar::inverted::{
     query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
+use lance_index::scalar::registry::StoreBoundScalarIndexCacheEntry;
 use lance_index::scalar::{FullTextSearchQuery, ScalarIndex};
 use lance_index::{FtsPrewarmOptions, PrewarmOptions};
 use lance_index::{IndexType, scalar::ScalarIndexParams, vector::DIST_COL};
@@ -5310,7 +5311,11 @@ impl SingleScalarContainerCacheBackend {
     }
 
     fn rejects_scalar_container(entry: &CacheEntry, codec: Option<&CacheCodec>) -> bool {
-        codec.is_none() && entry.as_ref().is::<Arc<dyn ScalarIndex>>()
+        // Whole-container entries are stored as Arc<dyn ScalarIndex> by custom plugin
+        // paths and as StoreBoundScalarIndexCacheEntry by the default cache path.
+        codec.is_none()
+            && (entry.as_ref().is::<Arc<dyn ScalarIndex>>()
+                || entry.as_ref().is::<Arc<StoreBoundScalarIndexCacheEntry>>())
     }
 }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -3751,11 +3751,12 @@ mod tests {
         FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, StringArray,
     };
     use arrow_schema::{DataType, Field, Schema};
-    use futures::stream::TryStreamExt;
+    use futures::{future::try_join_all, stream::TryStreamExt};
     use lance_arrow::*;
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_datagen::{BatchCount, ByteCount, Dimension, RowCount, array};
+    use lance_index::metrics::LocalMetricsCollector;
     use lance_index::pbold::{BTreeIndexDetails, InvertedIndexDetails};
     use lance_index::scalar::bitmap::BITMAP_LOOKUP_NAME;
     use lance_index::scalar::inverted::query::{FtsQuery, PhraseQuery};
@@ -3781,7 +3782,10 @@ mod tests {
     use lance_testing::datagen::generate_random_array;
     use object_store::ObjectStoreExt;
     use rstest::rstest;
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::atomic::Ordering,
+    };
 
     async fn write_vector_segment_metadata(
         dataset: &Dataset,
@@ -3962,6 +3966,20 @@ mod tests {
                 .iter()
                 .any(|request| request.path.as_ref().contains(&index_path_fragment)),
             "the same store binding should reuse the live scalar index: {warm_store_stats:#?}"
+        );
+
+        let rotation_metrics = LocalMetricsCollector::default();
+        let opened = try_join_all(
+            (0..8)
+                .map(|_| dataset_b.open_scalar_index("text", &index_meta.uuid, &rotation_metrics)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(opened.len(), 8);
+        assert_eq!(
+            rotation_metrics.index_loads.load(Ordering::Relaxed),
+            1,
+            "concurrent opens after rotation should coalesce onto one store-B load"
         );
 
         assert_eq!(search_ids(&dataset_b, "beta").await, vec![1, 4, 7]);

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -3762,6 +3762,7 @@ mod tests {
     use lance_index::scalar::inverted::{
         INVERTED_INDEX_VERSION_V1, INVERTED_INDEX_VERSION_V2, INVERTED_INDEX_VERSION_V3,
     };
+    use lance_index::scalar::registry::ScalarIndexCacheKey;
     use lance_index::scalar::{
         BuiltinIndexType, FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams,
     };
@@ -3771,7 +3772,11 @@ mod tests {
         kmeans::{KMeansParams, train_kmeans},
         sq::builder::SQBuildParams,
     };
-    use lance_io::{assert_io_eq, assert_io_lt, utils::tracking_store::IoStats};
+    use lance_io::{
+        assert_io_eq, assert_io_lt,
+        object_store::{ObjectStore, ObjectStoreParams, StorageOptionsAccessor},
+        utils::tracking_store::IoStats,
+    };
     use lance_linalg::distance::{DistanceType, MetricType};
     use lance_testing::datagen::generate_random_array;
     use object_store::ObjectStoreExt;
@@ -3812,6 +3817,199 @@ mod tests {
                 size_bytes: payload.len() as u64,
             }]),
         }
+    }
+
+    #[tokio::test]
+    async fn test_scalar_cache_uses_current_object_store() {
+        async fn search_ids(dataset: &Dataset, term: &str) -> Vec<i32> {
+            let result = dataset
+                .scan()
+                .project(&["id"])
+                .unwrap()
+                .full_text_search(FullTextSearchQuery::new(term.to_owned()))
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let mut ids = result["id"].as_primitive::<Int32Type>().values().to_vec();
+            ids.sort_unstable();
+            ids
+        }
+
+        // Rotated credentials require distinct ObjectStore instances to read the same data.
+        // `memory://` creates an isolated in-memory backend for each instance, so this test needs
+        // a filesystem-backed URI.
+        let test_dir = TempStrDir::default();
+        let batches = vec![
+            arrow_array::record_batch!(
+                ("id", Int32, [0, 1, 2, 3]),
+                (
+                    "text",
+                    Utf8,
+                    [
+                        "alpha common",
+                        "beta common",
+                        "gamma common",
+                        "alpha common"
+                    ]
+                )
+            )
+            .unwrap(),
+            arrow_array::record_batch!(
+                ("id", Int32, [4, 5, 6, 7]),
+                (
+                    "text",
+                    Utf8,
+                    ["beta common", "gamma common", "alpha common", "beta common"]
+                )
+            )
+            .unwrap(),
+        ];
+        let schema = batches[0].schema();
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+        let mut dataset = Dataset::write(
+            reader,
+            test_dir.as_str(),
+            Some(WriteParams {
+                max_rows_per_group: 4,
+                max_rows_per_file: 4,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 2);
+        dataset
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("credential_rotation_fts".to_owned()),
+                &InvertedIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+        let index_meta = dataset
+            .load_indices_by_name("credential_rotation_fts")
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let session = Arc::new(Session::default());
+        let dataset = DatasetBuilder::from_uri(test_dir.as_str())
+            .with_session(session)
+            .load()
+            .await
+            .unwrap();
+
+        let store_params_a = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([(
+                    "credential_generation".to_owned(),
+                    "secret-generation-a".to_owned(),
+                )]),
+            ))),
+            ..Default::default()
+        };
+        let (store_a, _) = ObjectStore::from_uri_and_params(
+            dataset.session().store_registry(),
+            dataset.uri(),
+            &store_params_a,
+        )
+        .await
+        .unwrap();
+        let dataset_a = dataset.with_object_store(store_a.clone(), Some(store_params_a));
+
+        let store_params_b = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([(
+                    "credential_generation".to_owned(),
+                    "secret-generation-b".to_owned(),
+                )]),
+            ))),
+            ..Default::default()
+        };
+        let (store_b, _) = ObjectStore::from_uri_and_params(
+            dataset.session().store_registry(),
+            dataset.uri(),
+            &store_params_b,
+        )
+        .await
+        .unwrap();
+        assert!(!Arc::ptr_eq(&store_a, &store_b));
+        let dataset_b = dataset.with_object_store(store_b.clone(), Some(store_params_b));
+        let index_path_fragment = format!("_indices/{}", index_meta.uuid);
+
+        let _ = store_a.io_stats_incremental();
+        let _ = store_b.io_stats_incremental();
+        assert_eq!(search_ids(&dataset_a, "alpha").await, vec![0, 3, 6]);
+        let first_store_stats = store_a.io_stats_incremental();
+        assert!(
+            first_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "the first query should read the FTS index through store A: {first_store_stats:#?}"
+        );
+        let _ = store_b.io_stats_incremental();
+
+        assert_eq!(search_ids(&dataset_a, "alpha").await, vec![0, 3, 6]);
+        let warm_store_stats = store_a.io_stats_incremental();
+        assert!(
+            !warm_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "the same store binding should reuse the live scalar index: {warm_store_stats:#?}"
+        );
+
+        assert_eq!(search_ids(&dataset_b, "beta").await, vec![1, 4, 7]);
+        let old_store_stats = store_a.io_stats_incremental();
+        let new_store_stats = store_b.io_stats_incremental();
+        assert!(
+            !old_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "the second dataset must not use the scalar index bound to store A: {old_store_stats:#?}"
+        );
+        assert!(
+            new_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "the second dataset should read the scalar index through store B: {new_store_stats:#?}"
+        );
+
+        let scalar_cache = dataset.index_cache.for_index(&index_meta.uuid, None);
+        assert!(
+            scalar_cache
+                .get_unsized_with_key(&ScalarIndexCacheKey)
+                .await
+                .is_some(),
+            "the live scalar index should be cached with store B's binding"
+        );
+
+        let _ = store_a.io_stats_incremental();
+        let _ = store_b.io_stats_incremental();
+        assert_eq!(search_ids(&dataset_a, "gamma").await, vec![2, 5]);
+        let reopened_store_stats = store_a.io_stats_incremental();
+        let untouched_store_stats = store_b.io_stats_incremental();
+        assert!(
+            reopened_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "re-querying dataset A should replace store B's binding and read through store A: {reopened_store_stats:#?}"
+        );
+        assert!(
+            !untouched_store_stats
+                .requests
+                .iter()
+                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
+            "re-querying dataset A must not use store B: {untouched_store_stats:#?}"
+        );
     }
 
     fn list_io_stats(stats: &IoStats) -> IoStats {

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -617,7 +617,10 @@ pub(crate) async fn cached_scalar_index_container(
     let index_cache = dataset
         .index_cache
         .for_index(uuid, frag_reuse_uuid.as_ref());
-    index_cache.get_unsized_with_key(&ScalarIndexCacheKey).await
+    index_cache
+        .get_unsized_with_key(&ScalarIndexCacheKey)
+        .await
+        .map(|entry| entry.index())
 }
 
 pub(crate) async fn infer_scalar_index_details(


### PR DESCRIPTION
## Summary

- cache each default live scalar index together with the IndexStore binding that opened it
- let LanceIndexStore reuse a live index only when both stores share the same Arc<ObjectStore> and index directory; a rotation reloads the index and overwrites the single in-memory entry
- keep the existing portable BTree, Bitmap, and LabelList state caches unchanged and reusable across store bindings
- preserve normal scalar/FTS cache hits and the existing FTS prewarm zero-I/O contract without introducing serialized FTS runtime state
- cover a two-fragment A -> B -> A rotation, same-binding reuse, result correctness, and per-store index I/O ownership

## Scope

This PR fixes only store-bound live scalar cache entries. It does not add TTL/TTI, change vector or legacy-index behavior, or introduce a new portable FTS state format. #7958 described an intermediate #7944 design that was not merged and is being corrected separately.

Custom IndexStore implementations are conservative by default: they do not reuse a live index unless they explicitly establish storage-binding equivalence.

## Testing

- cargo fmt --all -- --check
- cargo clippy --all --tests --benches -- -D warnings
- cargo test -p lance-index --lib
- cargo test -p lance --lib test_scalar_cache_uses_current_object_store -- --nocapture
- cargo test -p lance --lib test_fts_prewarm_with_position_controls_phrase_query_cache -- --nocapture
- make build from python/
- uv run pytest python/tests/test_scalar_index.py::test_index_prewarm from python/

Closes #7959
