### PR TITLE
fix: persist finalized external manifest metadata

### DIFF
--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -134,20 +134,18 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
             info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
         }
 
-        // Get final e_tag (may change after copy for large files)
-        let e_tag = if copied && size < 5 * 1024 * 1024 {
-            e_tag
-        } else {
-            let meta = object_store.head(&final_path).await?;
-            meta.e_tag
-        };
+        // A copy creates a new object whose metadata may differ from the source.
+        // Read the destination metadata before publishing the final path.
+        let final_meta = object_store.head(&final_path).await?;
+        let final_size = final_meta.size;
+        let final_e_tag = final_meta.e_tag;
 
         let location = ManifestLocation {
             version,
             path: final_path.clone(),
-            size: Some(size),
+            size: Some(final_size),
             naming_scheme,
-            e_tag: e_tag.clone(),
+            e_tag: final_e_tag.clone(),
         };
 
         if !copied {
@@ -159,8 +157,8 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
             base_path.as_ref(),
             version,
             final_path.as_ref(),
-            size,
-            e_tag,
+            final_size,
+            final_e_tag,
         )
         .await?;
 
@@ -426,7 +424,6 @@ impl ExternalManifestCommitHandler {
         staging_manifest_path: &Path,
         version: u64,
         size: u64,
-        e_tag: Option<String>,
         store: &dyn OSObjectStore,
         naming_scheme: ManifestNamingScheme,
     ) -> std::result::Result<ManifestLocation, Error> {
@@ -443,25 +440,18 @@ impl ExternalManifestCommitHandler {
             info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_manifest_path.as_ref());
         }
 
-        // On S3, the etag can change if originally was MultipartUpload and later was Copy
-        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html#AmazonS3-Type-Object-ETag
-        // We only do MultipartUpload for > 5MB files, so we can skip this check
-        // if size < 5MB. However, we need to double check the final_manifest_path
-        // exists before we change the external store, otherwise we may point to a
-        // non-existing manifest.
-        let e_tag = if copied && size < 5 * 1024 * 1024 {
-            e_tag
-        } else {
-            let meta = store.head(&final_manifest_path).await?;
-            meta.e_tag
-        };
+        // A copy creates a new object whose metadata may differ from the source.
+        // Read the destination metadata before publishing the final path.
+        let final_meta = store.head(&final_manifest_path).await?;
+        let final_size = final_meta.size;
+        let final_e_tag = final_meta.e_tag;
 
         let location = ManifestLocation {
             version,
             path: final_manifest_path,
-            size: Some(size),
+            size: Some(final_size),
             naming_scheme,
-            e_tag,
+            e_tag: final_e_tag,
         };
 
         if !copied {
@@ -474,7 +464,7 @@ impl ExternalManifestCommitHandler {
                 base_path.as_ref(),
                 version,
                 location.path.as_ref(),
-                size,
+                final_size,
                 location.e_tag.clone(),
             )
             .await?;
@@ -520,14 +510,14 @@ impl CommitHandler for ExternalManifestCommitHandler {
                     path,
                     size,
                     naming_scheme,
-                    e_tag,
+                    e_tag: _,
                 } = location;
 
-                let (size, e_tag) = if let Some(size) = size {
-                    (size, e_tag)
+                let size = if let Some(size) = size {
+                    size
                 } else {
                     match object_store.inner.head(&path).await {
-                        Ok(meta) => (meta.size, meta.e_tag),
+                        Ok(meta) => meta.size,
                         Err(ObjectStoreError::NotFound { .. }) => {
                             // there may be other threads that have finished executing finalize_manifest.
                             let new_location = self
@@ -546,7 +536,6 @@ impl CommitHandler for ExternalManifestCommitHandler {
                         &path,
                         version,
                         size,
-                        e_tag.clone(),
                         &object_store.inner,
                         naming_scheme,
                     )
@@ -625,11 +614,11 @@ impl CommitHandler for ExternalManifestCommitHandler {
         let naming_scheme =
             ManifestNamingScheme::detect_scheme_staging(location.path.filename().unwrap());
 
-        let (size, e_tag) = if let Some(size) = location.size {
-            (size, location.e_tag.clone())
+        let size = if let Some(size) = location.size {
+            size
         } else {
             let meta = object_store.head(&location.path).await?;
-            (meta.size as u64, meta.e_tag)
+            meta.size
         };
 
         self.finalize_manifest(
@@ -637,7 +626,6 @@ impl CommitHandler for ExternalManifestCommitHandler {
             &location.path,
             version,
             size,
-            e_tag,
             object_store,
             naming_scheme,
         )

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -129,6 +129,7 @@ mod test {
     #[derive(Debug)]
     struct StaticExternalManifestStore {
         location: ManifestLocation,
+        verify_store: Option<Arc<dyn OSObjectStore>>,
     }
 
     #[async_trait]
@@ -182,10 +183,15 @@ mod test {
             &self,
             _uri: &str,
             _version: u64,
-            _path: &str,
-            _size: u64,
-            _e_tag: Option<String>,
+            path: &str,
+            size: u64,
+            e_tag: Option<String>,
         ) -> Result<()> {
+            if let Some(store) = &self.verify_store {
+                let final_meta = store.head(&Path::from(path)).await?;
+                assert_eq!(size, final_meta.size);
+                assert_eq!(e_tag, final_meta.e_tag);
+            }
             Ok(())
         }
     }
@@ -297,6 +303,7 @@ mod test {
                     naming_scheme: ManifestNamingScheme::V2,
                     e_tag: None,
                 },
+                verify_store: None,
             }),
         };
 
@@ -330,6 +337,7 @@ mod test {
                     naming_scheme: ManifestNamingScheme::V2,
                     e_tag: Some("stale-etag".to_string()),
                 },
+                verify_store: None,
             }),
         };
 
@@ -339,6 +347,103 @@ mod test {
             .expect_err("stale external manifest e_tag should be rejected");
         assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
         assert!(err.to_string().contains("Manifest e_tag mismatch"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn external_manifest_store_put_records_destination_metadata() {
+        let object_store: Arc<dyn OSObjectStore> = Arc::new(InMemory::new());
+        let base_path = Path::from("repro");
+        let staging_path = Path::from("repro/_versions/1.manifest.staging-abcd");
+        object_store
+            .put(&staging_path, PutPayload::from_static(b"manifest body"))
+            .await
+            .expect("seed staging manifest");
+        let staging_meta = object_store
+            .head(&staging_path)
+            .await
+            .expect("read staging metadata");
+
+        let external_store = StaticExternalManifestStore {
+            location: ManifestLocation {
+                version: 1,
+                path: staging_path.clone(),
+                size: Some(staging_meta.size),
+                naming_scheme: ManifestNamingScheme::V2,
+                e_tag: staging_meta.e_tag.clone(),
+            },
+            verify_store: Some(object_store.clone()),
+        };
+        let location = external_store
+            .put(
+                &base_path,
+                1,
+                &staging_path,
+                staging_meta.size,
+                staging_meta.e_tag.clone(),
+                object_store.as_ref(),
+                ManifestNamingScheme::V2,
+            )
+            .await
+            .expect("finalize manifest");
+        let final_meta = object_store
+            .head(&location.path)
+            .await
+            .expect("read finalized metadata");
+
+        assert_ne!(
+            staging_meta.e_tag, final_meta.e_tag,
+            "test store must assign a new ETag to the copied object"
+        );
+        assert_eq!(location.size, Some(final_meta.size));
+        assert_eq!(location.e_tag, final_meta.e_tag);
+    }
+
+    #[tokio::test]
+    async fn external_manifest_handler_finalize_records_destination_metadata() {
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("repro");
+        let version = 1;
+        let staging_path = Path::from("repro/_versions/1.manifest.staging-abcd");
+        object_store
+            .inner
+            .put(&staging_path, PutPayload::from_static(b"manifest body"))
+            .await
+            .expect("seed staging manifest");
+        let staging_meta = object_store
+            .inner
+            .head(&staging_path)
+            .await
+            .expect("read staging metadata");
+
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(StaticExternalManifestStore {
+                location: ManifestLocation {
+                    version,
+                    path: staging_path,
+                    size: Some(staging_meta.size),
+                    naming_scheme: ManifestNamingScheme::V2,
+                    e_tag: staging_meta.e_tag.clone(),
+                },
+                verify_store: Some(object_store.inner.clone()),
+            }),
+        };
+
+        let location = handler
+            .resolve_version_location(&base_path, version, object_store.inner.as_ref())
+            .await
+            .expect("finalize manifest");
+        let final_meta = object_store
+            .inner
+            .head(&location.path)
+            .await
+            .expect("read finalized metadata");
+
+        assert_ne!(
+            staging_meta.e_tag, final_meta.e_tag,
+            "test store must assign a new ETag to the copied object"
+        );
+        assert_eq!(location.size, Some(final_meta.size));
+        assert_eq!(location.e_tag, final_meta.e_tag);
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -304,9 +304,12 @@ async fn test_ddb_open_iops() {
     //    * write staged file
     //    * copy to final file
     //    * delete staged file
+    // Commit: 2 read IOPs:
+    // * list versions before creating the dataset
+    // * HEAD the finalized manifest to record destination metadata after copy
     let io_stats = committed_ds.object_store.as_ref().io_stats_incremental();
     assert_io_eq!(io_stats, write_iops, 4);
-    assert_io_eq!(io_stats, read_iops, 1);
+    assert_io_eq!(io_stats, read_iops, 2);
 
     let dataset = DatasetBuilder::from_uri(&uri)
         .with_read_params(ReadParams {

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -338,9 +338,11 @@ async fn test_ddb_open_iops() {
     let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     // Append: 5 IOPS: data file, transaction file, 3x manifest file
     assert_io_eq!(io_stats, write_iops, 5);
+    // Append reads once to list versions and once to HEAD the finalized manifest
+    // so the destination metadata can be recorded after copy.
     // TODO: we can reduce this by implementing a specialized CommitHandler::list_manifest_locations()
     // for the DDB commit handler.
-    assert_io_eq!(io_stats, read_iops, 1);
+    assert_io_eq!(io_stats, read_iops, 2);
 
     // Checkout original version
     dataset.checkout_version(1).await.unwrap();


### PR DESCRIPTION
## Problem

External manifest finalization reused staging object metadata for manifests smaller than 5 MiB. Object-store copies may assign different metadata to the destination object, so finalized-manifest validation can reject a valid table as corrupt when the stored ETag does not match the copied object.

## Fix

Always read the finalized object metadata after copy and persist its destination size and ETag. This applies to both the default external-store commit path and recovery finalization, so the external store and returned manifest location describe the same object.
