### PR TITLE
fix(blob): preserve null and empty values during compaction

### DIFF
--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -55,6 +55,10 @@ impl EncodingsIo for LanceEncodingsIo {
     ) -> BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
         let mut split_ranges = Vec::new();
         let mut split_indices = Vec::new(); // Track which original range each split came from
+        // Large ranges (above read_chunk_size) will be split into
+        // multiple reads.  Empty ranges will skip the I/O layer
+        // entirely.  If we have either of these we will need to
+        // reassemble our results, inserting empties and merging parts
         let mut needs_reassembly = false;
 
         // Split large ranges into smaller chunks

--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -55,14 +55,23 @@ impl EncodingsIo for LanceEncodingsIo {
     ) -> BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
         let mut split_ranges = Vec::new();
         let mut split_indices = Vec::new(); // Track which original range each split came from
+        let mut needs_reassembly = false;
 
         // Split large ranges into smaller chunks
         //
         // TODO: consider read_chunk_size before submitting requests.
         for (idx, range) in ranges.iter().enumerate() {
+            if range.start == range.end {
+                // EncodingsIo requires one result per input range. Zero-length
+                // ranges schedule no I/O, so their empty results are restored
+                // after the non-empty requests complete.
+                needs_reassembly = true;
+                continue;
+            }
             let range_size = range.end - range.start;
 
             if range_size > self.read_chunk_size {
+                needs_reassembly = true;
                 let num_chunks = range_size.div_ceil(self.read_chunk_size);
                 let chunk_size = range_size / num_chunks;
 
@@ -87,34 +96,48 @@ impl EncodingsIo for LanceEncodingsIo {
         async move {
             let split_results = fut.await?;
 
-            // Fast path: if no splitting occurred, return results directly
-            if split_results.len() == ranges.len() {
+            if split_results.len() != split_indices.len() {
+                return Err(lance_core::Error::internal(format!(
+                    "Encoding I/O returned {} results for {} requested range chunks",
+                    split_results.len(),
+                    split_indices.len()
+                )));
+            }
+            if !needs_reassembly {
                 return Ok(split_results);
             }
 
-            // Slow path: reassemble split results
             let mut results = vec![Vec::new(); ranges.len()];
 
-            for (split_result, &orig_idx) in split_results.iter().zip(split_indices.iter()) {
-                results[orig_idx].push(split_result.clone());
+            for (split_result, orig_idx) in split_results.into_iter().zip(split_indices) {
+                results[orig_idx].push(split_result);
             }
 
-            Ok(results
-                .into_iter()
-                .map(|chunks| {
-                    if chunks.len() == 1 {
-                        chunks.into_iter().next().unwrap()
-                    } else {
-                        // Concatenate multiple chunks
-                        let total_size: usize = chunks.iter().map(|c| c.len()).sum();
-                        let mut combined = Vec::with_capacity(total_size);
-                        for chunk in chunks {
-                            combined.extend_from_slice(&chunk);
-                        }
-                        bytes::Bytes::from(combined)
+            let mut reassembled = Vec::with_capacity(ranges.len());
+            for (range, chunks) in ranges.iter().zip(results) {
+                if chunks.is_empty() {
+                    if range.start == range.end {
+                        reassembled.push(bytes::Bytes::new());
+                        continue;
                     }
-                })
-                .collect())
+                    return Err(lance_core::Error::internal(format!(
+                        "Encoding I/O returned no data for non-empty range {}..{}",
+                        range.start, range.end
+                    )));
+                }
+                if chunks.len() == 1 {
+                    reassembled.push(chunks[0].clone());
+                    continue;
+                }
+
+                let total_size: usize = chunks.iter().map(|c| c.len()).sum();
+                let mut combined = Vec::with_capacity(total_size);
+                for chunk in chunks {
+                    combined.extend_from_slice(&chunk);
+                }
+                reassembled.push(bytes::Bytes::from(combined));
+            }
+            Ok(reassembled)
         }
         .boxed()
     }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -971,32 +971,13 @@ impl CompactionPlan {
 
 /// Classification for one blob v2 row during compaction.
 ///
-/// - `Null`: NULL row or Inline blob with position=0 and size=0.
+/// - `Null`: NULL row.
 /// - `External`: External blob referenced by URI.
 /// - `DataBlob`: Inline/Packed/Dedicated blob stored in Lance files.
 enum RowClass {
     Null,
     External,
     DataBlob,
-}
-
-/// Check if a row is a null Inline blob.
-///
-/// This matches `BlobV2StructuralEncoder`'s behavior of encoding null rows as
-/// Inline with position=0 and size=0, and `collect_blob_entries_v2`'s behavior
-/// of skipping them.
-fn is_inline_null_blob(
-    kind: BlobKind,
-    position_col: &arrow::array::UInt64Array,
-    size_col: &arrow::array::UInt64Array,
-    index: usize,
-) -> bool {
-    if kind != BlobKind::Inline {
-        return false;
-    }
-    let position_is_empty = position_col.is_null(index) || position_col.value(index) == 0;
-    let size_is_empty = size_col.is_null(index) || size_col.value(index) == 0;
-    position_is_empty && size_is_empty
 }
 
 /// Column views for the 5 fields in a blob v2 descriptor struct.
@@ -1095,8 +1076,6 @@ fn classify_rows(
             })?;
             if kind == BlobKind::External {
                 row_classes.push(RowClass::External);
-            } else if is_inline_null_blob(kind, descriptor.position_col, descriptor.size_col, i) {
-                row_classes.push(RowClass::Null);
             } else {
                 row_classes.push(RowClass::DataBlob);
                 blob_read_addrs.push(row_addrs.value(i));
@@ -7263,6 +7242,119 @@ mod tests {
             }
         }
         result
+    }
+
+    fn mixed_blob_values() -> Vec<(i32, Option<Vec<u8>>)> {
+        vec![
+            (0, Some(vec![b'0'; 80])),
+            (1, None),
+            (2, Some(Vec::new())),
+            (3, Some(vec![b'3'; 80])),
+            (4, Some(vec![b'4'; 80])),
+            (5, Some(vec![b'5'; 80])),
+        ]
+    }
+
+    async fn assert_compaction_preserves_blob_values(
+        mut dataset: Dataset,
+        expected: &[(i32, Option<Vec<u8>>)],
+    ) {
+        assert_eq!(dataset.get_fragments().len(), 3);
+
+        let mut before = read_blob_bytes_by_index(&Arc::new(dataset.clone()), "blob").await;
+        before.sort_by_key(|(id, _)| *id);
+        assert_eq!(before, expected);
+
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 1024 * 1024,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(dataset.get_fragments().len(), 1);
+
+        let mut after = read_blob_bytes_by_index(&Arc::new(dataset), "blob").await;
+        after.sort_by_key(|(id, _)| *id);
+        assert_eq!(after, expected);
+    }
+
+    #[tokio::test]
+    async fn test_compact_blob_v1_preserves_null_empty_and_payload_order() {
+        let test_dir = TempStrDir::default();
+        let expected = mixed_blob_values();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("blob", DataType::LargeBinary, true)
+                .with_metadata([(BLOB_META_KEY.to_string(), "true".to_string())].into()),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..expected.len() as i32)),
+                Arc::new(LargeBinaryArray::from_iter(
+                    expected.iter().map(|(_, value)| value.as_deref()),
+                )),
+            ],
+        )
+        .unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &test_dir,
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_0),
+                max_rows_per_file: 2,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_compaction_preserves_blob_values(dataset, &expected).await;
+    }
+
+    #[tokio::test]
+    async fn test_compact_blob_v2_preserves_null_empty_and_payload_order() {
+        use crate::BlobArrayBuilder;
+
+        let test_dir = TempStrDir::default();
+        let expected = mixed_blob_values();
+        let mut blob_builder = BlobArrayBuilder::new(expected.len());
+        for (_, value) in &expected {
+            match value {
+                Some(value) => blob_builder.push_bytes(value).unwrap(),
+                None => blob_builder.push_null().unwrap(),
+            }
+        }
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            crate::blob_field("blob", true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..expected.len() as i32)),
+                blob_builder.finish().unwrap(),
+            ],
+        )
+        .unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &test_dir,
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                max_rows_per_file: 2,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_compaction_preserves_blob_values(dataset, &expected).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
`compact_files()` silently corrupts blob values when rewritten fragments contain null or empty values. In the v1 path, zero-length ranges were omitted by the I/O scheduler while returned payloads were still reassembled positionally, causing later payload descriptors to be zeroed. In the blob v2 path, compaction treated an inline `{position: 0, size: 0}` descriptor as null even though it also represents a valid empty value.

Preserve one result per requested encoding range and classify blob v2 nulls from Arrow validity instead of descriptor coordinates. This keeps payloads, nulls, and valid empty blobs stable across compaction for both storage formats.

Fixes #7955.
