### PR TITLE
chore(ci): group Dependabot security updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,28 @@
 version: 2
 updates:
+  # Rust — one grouped version-bump PR per directory each week, and security
+  # advisories that land together in a directory batched into a single PR
+  # instead of one PR per advisory.
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/python"
+      - "/java/lance-jni"
     versioning-strategy: lockfile-only
     schedule:
       interval: "weekly"
       day: "wednesday"
     groups:
       cargo:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      cargo-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
-  - package-ecosystem: "cargo"
-    directory: "/python"
-    versioning-strategy: lockfile-only
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    groups:
-      cargo:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "/java/lance-jni"
-    versioning-strategy: lockfile-only
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    groups:
-      cargo:
-        patterns:
-          - "*"
-
+  # Python (uv) — same weekly-grouped + grouped-security treatment.
   - package-ecosystem: "uv"
     directory: "/python"
     versioning-strategy: lockfile-only
@@ -41,5 +31,56 @@ updates:
       day: "wednesday"
     groups:
       uv:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      uv-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Standalone Rust lockfiles for dev/test fixtures. Dependabot security updates
+  # scan these regardless of config, so we group them; open-pull-requests-limit: 0
+  # disables the (unwanted) weekly version bumps for these crates.
+  - package-ecosystem: "cargo"
+    directories:
+      - "/memtest"
+      - "/test_data/fri_straddle_pre_6610/datagen"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      cargo-fixtures-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Java (Maven). Security updates fire regardless of config; group them and
+  # skip version bumps (limit 0) — we bump Java deps manually.
+  - package-ecosystem: "maven"
+    directory: "/java"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      maven-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Python benchmark scripts (pip / requirements.txt). Group security updates
+  # and skip version bumps (limit 0).
+  - package-ecosystem: "pip"
+    directories:
+      - "/benchmarks/*"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      pip-security:
+        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
Dependabot security updates run independently of the version-update config in `.github/dependabot.yml`: they ignore the weekly schedule, were not grouped (groups default to `version-updates`), and scan every manifest — including ecosystems (`maven` in `/java`, `pip` in `/benchmarks/*`) and directories (`/memtest`, `/test_data/.../datagen`) the config never listed. The result was a stream of individual security-fix PRs (e.g. the same quinn-proto advisory opening four separate PRs).

This groups them:

- Add an `applies-to: security-updates` group to every ecosystem so advisories that land together in a directory batch into a single PR instead of one-per-advisory.
- Bring the previously unmanaged surfaces (`maven` `/java`, `pip` `/benchmarks/*`, and the standalone cargo lockfiles `/memtest` and `/test_data/fri_straddle_pre_6610/datagen`) under config with `open-pull-requests-limit: 0`, so their security fixes are grouped but no new weekly version bumps are opened.
- Consolidate the three cargo blocks into one `directories` entry (behavior-neutral for version updates — still one grouped PR per directory).

**Known limitations** (GitHub behavior, not config bugs):

- The same CVE across multiple lockfiles stays multiple PRs — cross-directory single-PR grouping (`group-by: dependency-name`) is version-updates only.
- Test-fixture lockfiles can't be excluded from security scanning via config (`exclude-paths` is version-updates only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)