### PR TITLE
fix(ci): unblock cargo publish and dry-run packaging in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,25 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
+  package:
+    name: Check crates are publishable
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+      # Catches manifest problems that only surface at publish time (missing
+      # readme/license files, path dependencies without a version, excluded
+      # files a crate needs). `--no-verify` skips building each packaged crate,
+      # which the other jobs already cover. Keep the excludes in sync with
+      # .github/workflows/cargo-publish.yml.
+      - name: Package crates
+        run: |
+          cargo package --workspace --no-verify \
+            --exclude lance-arrow-stats \
+            --exclude lance-arrow-scalar \
+            --all-features
+
   rustdoc:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/rust/lance-index-core/README.md
+++ b/rust/lance-index-core/README.md
@@ -1,0 +1,6 @@
+# lance-index-core
+
+`lance-index-core` is an internal sub-crate, containing the core traits and types used to
+implement index plugins for [Lance](https://github.com/lance-format/lance).
+
+**Important Note**: This crate is **not intended for external usage**.


### PR DESCRIPTION
The 9.0.0 crates.io publish failed while packaging `lance-index-core`:

```
error: readme `README.md` does not appear to exist (relative to `.../rust/lance-index-core`).
```

The crate was added in #7713 with `readme = "README.md"` but no such file. `cargo publish --workspace` packages every crate before uploading any, so the whole release aborted and no 9.0.0 crates reached crates.io.

Two changes:

- Add `rust/lance-index-core/README.md`, matching the sibling internal crates.
- Add a `cargo package --workspace --no-verify` job to the Rust workflow. Nothing in CI packaged the crates, so manifest problems that only surface at publish time (missing readme/license files, path dependencies without a version) were invisible until the release ran. `--no-verify` skips rebuilding each packaged crate, which the other jobs already cover, so the job takes about a minute.

Verified locally: all 25 publishable crates now package cleanly.

Fixes #7986