### PR TITLE
fix(ci): backport cargo publish fix to release/v9.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,25 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
+  package:
+    name: Check crates are publishable
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+      # Catches manifest problems that only surface at publish time (missing
+      # readme/license files, path dependencies without a version, excluded
+      # files a crate needs). `--no-verify` skips building each packaged crate,
+      # which the other jobs already cover. Keep the excludes in sync with
+      # .github/workflows/cargo-publish.yml.
+      - name: Package crates
+        run: |
+          cargo package --workspace --no-verify \
+            --exclude lance-arrow-stats \
+            --exclude lance-arrow-scalar \
+            --all-features
+
   rustdoc:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/rust/lance-index-core/README.md
+++ b/rust/lance-index-core/README.md
@@ -1,0 +1,6 @@
+# lance-index-core
+
+`lance-index-core` is an internal sub-crate, containing the core traits and types used to
+implement index plugins for [Lance](https://github.com/lance-format/lance).
+
+**Important Note**: This crate is **not intended for external usage**.


### PR DESCRIPTION
Backport of #7989 so the 9.0.x line can publish to crates.io.

`cargo publish --workspace` aborted on the 9.0.0 release because `lance-index-core` declared a readme that does not exist, and it packages every crate before uploading any, so nothing reached crates.io. Without this, 9.0.1 would fail the same way.

Fixes #7986