### PR TITLE
docs: fix nested agent guide loading and trim root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,32 +4,6 @@ Lance is a modern columnar data format optimized for ML workflows and datasets, 
 
 Also see directory-specific guidelines: [rust/](rust/AGENTS.md) | [python/](python/AGENTS.md) | [java/](java/AGENTS.md) | [protos/](protos/AGENTS.md) | [docs/src/format/](docs/src/format/AGENTS.md)
 
-## Architecture
-
-Rust workspace with Python and Java bindings:
-
-- `rust/lance/` - Main library implementing the columnar format
-- `rust/lance-core/` - Core types, traits, and utilities
-- `rust/lance-arrow/` - Apache Arrow integration layer
-- `rust/lance-encoding/` - Data encoding and compression algorithms
-- `rust/lance-file/` - File format reading/writing
-- `rust/lance-index/` - Vector and scalar indexing
-- `rust/lance-io/` - I/O operations and object store integration
-- `rust/lance-linalg/` - Linear algebra for vector search
-- `rust/lance-table/` - Table format and operations
-- `rust/lance-geo/` - Geospatial data support
-- `rust/lance-datagen/` - Data generation for tests and benchmarks
-- `rust/lance-namespace/` / `rust/lance-namespace-impls/` - Namespace/catalog interfaces
-- `rust/lance-test-macros/` / `rust/lance-testing/` - Test infrastructure
-- `rust/lance-tools/` - CLI and developer tooling
-- `rust/examples/` - Sample binaries and demonstrations
-- `rust/compression/bitpacking/` / `rust/compression/fsst/` - Compression codecs
-- `rust/lance-datafusion/` - DataFusion integration (built separately)
-- `python/` - Python bindings (PyO3/maturin)
-- `java/` - Java bindings (JNI)
-
-Key technical traits: async-first (tokio), Arrow-native, versioned writes with manifest tracking, custom ML-optimized encodings, unified object store interface (local/S3/Azure/GCS).
-
 ## File Format Stability and Compatibility
 
 - Treat every file format marked stable as a durable compatibility contract. All changes to a stable format must preserve both backward and forward compatibility.

--- a/docs/src/format/CLAUDE.md
+++ b/docs/src/format/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
`rust/AGENTS.md` and `docs/src/format/AGENTS.md` were never reaching coding agents. Nested guides are discovered through a `CLAUDE.md` entry point in the directory — `protos/`, `python/`, and `java/` each have one, but those two directories did not. The Rust guide is the largest and most safety-relevant of the set, carrying the `spawn_cpu()` non-blocking contract, the `RowAddr`/`RowId` type separation, and the lance-encoding hot-path rules, so agents editing `rust/` had none of it in context.

The root `AGENTS.md` also carried a hand-maintained crate list that duplicates what `ls rust/` and each crate's `Cargo.toml` description already state, and it had drifted: `arrow-scalar`, `arrow-stats`, `lance-derive`, `lance-index-core`, `lance-namespace-datafusion`, `lance-select`, and `lance-tokenizer` were all missing. A stale map is worse than no map, and every session that loads the file pays for it. The directory-guide pointer above the list is unchanged, so navigation is unaffected.

The format vote reminder will fire on this PR because it adds a path under `docs/src/format/`. That path is a symlink to the agent guide already in that directory; the format specification itself is untouched.
