### PR TITLE
fix(io): publish object store metrics for local reads and writes

### DIFF
--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -68,6 +68,24 @@ pub fn copy_file(from: &Path, to: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Await a filesystem operation running on a blocking thread, flattening the
+/// join and IO errors into a single `object_store` error.
+///
+/// Deliberately not written as `handle.await?` at the call sites: a `JoinError`
+/// means the operation panicked, and short-circuiting on it would skip the
+/// caller's metrics recording for exactly the failure worth counting.
+pub(crate) async fn join_local_io<T>(
+    handle: tokio::task::JoinHandle<std::io::Result<T>>,
+) -> object_store::Result<T> {
+    match handle.await {
+        Ok(result) => result.map_err(|err| object_store::Error::Generic {
+            store: "LocalFileSystem",
+            source: err.into(),
+        }),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Object reader for local file system.
 #[derive(Debug)]
 pub struct LocalObjectReader {
@@ -168,17 +186,8 @@ impl Reader for LocalObjectReader {
                     // The metadata lookup is this reader's equivalent of the HEAD
                     // request a cloud reader makes to learn the object size.
                     let metrics = self.io_tracker.begin_io("head");
-                    let result = match tokio::task::spawn_blocking(move || {
-                        file.metadata().map_err(|err| object_store::Error::Generic {
-                            store: "LocalFileSystem",
-                            source: err.into(),
-                        })
-                    })
-                    .await
-                    {
-                        Ok(metadata) => metadata,
-                        Err(err) => Err(err.into()),
-                    };
+                    let result =
+                        join_local_io(tokio::task::spawn_blocking(move || file.metadata())).await;
                     metrics.record(&result, 0);
                     Ok(result?.len() as usize)
                 })
@@ -198,7 +207,7 @@ impl Reader for LocalObjectReader {
 
         Box::pin(async move {
             let metrics = io_tracker.begin_io("get");
-            let result = tokio::task::spawn_blocking(move || {
+            let result = join_local_io(tokio::task::spawn_blocking(move || {
                 let mut buf = BytesMut::with_capacity(range.len());
                 // Safety: `buf` is set with appropriate capacity above. It is
                 // written to below and we check all data is initialized at that point.
@@ -209,12 +218,8 @@ impl Reader for LocalObjectReader {
                 read_exact_at(file, buf.as_mut(), range.start as u64)?;
 
                 Ok(buf.freeze())
-            })
-            .await?
-            .map_err(|err: std::io::Error| object_store::Error::Generic {
-                store: "LocalFileSystem",
-                source: err.into(),
-            });
+            }))
+            .await;
 
             metrics.record(&result, num_bytes);
             if result.is_ok() {
@@ -234,16 +239,12 @@ impl Reader for LocalObjectReader {
             let path = self.path.clone();
 
             let metrics = io_tracker.begin_io("get");
-            let result = tokio::task::spawn_blocking(move || {
+            let result = join_local_io(tokio::task::spawn_blocking(move || {
                 let mut buf = Vec::new();
                 file.read_to_end(buf.as_mut())?;
                 Ok(Bytes::from(buf))
-            })
-            .await?
-            .map_err(|err: std::io::Error| object_store::Error::Generic {
-                store: "LocalFileSystem",
-                source: err.into(),
-            });
+            }))
+            .await;
 
             let num_bytes = result.as_ref().map_or(0, |bytes| bytes.len() as u64);
             metrics.record(&result, num_bytes);

--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -165,14 +165,22 @@ impl Reader for LocalObjectReader {
             let file = self.file.clone();
             self.size
                 .get_or_try_init(|| async move {
-                    let metadata = tokio::task::spawn_blocking(move || {
+                    // The metadata lookup is this reader's equivalent of the HEAD
+                    // request a cloud reader makes to learn the object size.
+                    let metrics = self.io_tracker.begin_io("head");
+                    let result = match tokio::task::spawn_blocking(move || {
                         file.metadata().map_err(|err| object_store::Error::Generic {
                             store: "LocalFileSystem",
                             source: err.into(),
                         })
                     })
-                    .await??;
-                    Ok(metadata.len() as usize)
+                    .await
+                    {
+                        Ok(metadata) => metadata,
+                        Err(err) => Err(err.into()),
+                    };
+                    metrics.record(&result, 0);
+                    Ok(result?.len() as usize)
                 })
                 .await
                 .cloned()
@@ -189,6 +197,7 @@ impl Reader for LocalObjectReader {
         let range_u64 = (range.start as u64)..(range.end as u64);
 
         Box::pin(async move {
+            let metrics = io_tracker.begin_io("get");
             let result = tokio::task::spawn_blocking(move || {
                 let mut buf = BytesMut::with_capacity(range.len());
                 // Safety: `buf` is set with appropriate capacity above. It is
@@ -207,6 +216,7 @@ impl Reader for LocalObjectReader {
                 source: err.into(),
             });
 
+            metrics.record(&result, num_bytes);
             if result.is_ok() {
                 io_tracker.record_read("get_range", path, num_bytes, Some(range_u64));
             }
@@ -223,6 +233,7 @@ impl Reader for LocalObjectReader {
             let io_tracker = self.io_tracker.clone();
             let path = self.path.clone();
 
+            let metrics = io_tracker.begin_io("get");
             let result = tokio::task::spawn_blocking(move || {
                 let mut buf = Vec::new();
                 file.read_to_end(buf.as_mut())?;
@@ -234,6 +245,8 @@ impl Reader for LocalObjectReader {
                 source: err.into(),
             });
 
+            let num_bytes = result.as_ref().map_or(0, |bytes| bytes.len() as u64);
+            metrics.record(&result, num_bytes);
             if let Ok(bytes) = &result {
                 io_tracker.record_read("get_all", path, bytes.len() as u64, None);
             }

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -419,7 +419,9 @@ pub(crate) fn stream_local_range(
             let next = (start + chunk_size).min(end);
             let file_clone = file.clone();
             let path_clone = path.clone();
-            let bytes = tokio::task::spawn_blocking(move || {
+            let num_bytes = (next - start) as u64;
+            let metrics = io_tracker.begin_io("get");
+            let result = tokio::task::spawn_blocking(move || {
                 let mut buf = bytes::BytesMut::with_capacity(next - start);
                 // Safety: buffer capacity matches the exact number of bytes we read below.
                 unsafe { buf.set_len(next - start) };
@@ -433,12 +435,14 @@ pub(crate) fn stream_local_range(
             .map_err(|err: std::io::Error| object_store::Error::Generic {
                 store: "LocalFileSystem",
                 source: err.into(),
-            })?;
+            });
+            metrics.record(&result, num_bytes);
+            let bytes = result?;
 
             io_tracker.record_read(
                 "get_range_stream",
                 path_clone,
-                (next - start) as u64,
+                num_bytes,
                 Some(start as u64..next as u64),
             );
 

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::local::join_local_io;
 #[cfg(windows)]
 use crate::local::read_exact_at;
 #[cfg(unix)]
@@ -421,7 +422,7 @@ pub(crate) fn stream_local_range(
             let path_clone = path.clone();
             let num_bytes = (next - start) as u64;
             let metrics = io_tracker.begin_io("get");
-            let result = tokio::task::spawn_blocking(move || {
+            let result = join_local_io(tokio::task::spawn_blocking(move || {
                 let mut buf = bytes::BytesMut::with_capacity(next - start);
                 // Safety: buffer capacity matches the exact number of bytes we read below.
                 unsafe { buf.set_len(next - start) };
@@ -430,12 +431,8 @@ pub(crate) fn stream_local_range(
                 #[cfg(windows)]
                 read_exact_at(file_clone, buf.as_mut(), start as u64)?;
                 Ok::<_, std::io::Error>(buf.freeze())
-            })
-            .await?
-            .map_err(|err: std::io::Error| object_store::Error::Generic {
-                store: "LocalFileSystem",
-                source: err.into(),
-            });
+            }))
+            .await;
             metrics.record(&result, num_bytes);
             let bytes = result?;
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -488,6 +488,13 @@ impl ObjectStore {
             let mut inner = store.clone();
             let store_prefix =
                 registry.calculate_object_store_prefix(uri, params.storage_options())?;
+
+            #[cfg(feature = "metrics")]
+            {
+                use crate::object_store::metrics::ObjectStoreMetricsExt;
+                inner = inner.metered(store_prefix.clone());
+            }
+
             if let Some(wrapper) = params.object_store_wrapper.as_ref() {
                 inner = wrapper.wrap(&store_prefix, inner);
             }
@@ -643,6 +650,16 @@ impl ObjectStore {
         self.io_tracker.incremental_stats()
     }
 
+    /// A handle on this store's IO tracker for the readers, writers and
+    /// shortcuts that talk to the filesystem directly instead of going through
+    /// [`Self::inner`]. It carries the store prefix so the metrics they publish
+    /// land under the same `base` label as the store's metered operations.
+    fn local_io_tracker(&self) -> IOTracker {
+        self.io_tracker
+            .clone()
+            .with_metrics_base(&self.store_prefix)
+    }
+
     /// Open a file for path.
     ///
     /// Parameters
@@ -654,7 +671,7 @@ impl ObjectStore {
                     path,
                     self.block_size,
                     None,
-                    Arc::new(self.io_tracker.clone()),
+                    Arc::new(self.local_io_tracker()),
                 )
                 .await
             }
@@ -670,7 +687,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         None,
-                        Arc::new(self.io_tracker.clone()),
+                        Arc::new(self.local_io_tracker()),
                     )
                     .await
                 } else {
@@ -678,7 +695,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         None,
-                        Arc::new(self.io_tracker.clone()),
+                        Arc::new(self.local_io_tracker()),
                     )
                     .await
                 }
@@ -716,7 +733,7 @@ impl ObjectStore {
                     path,
                     self.block_size,
                     Some(known_size),
-                    Arc::new(self.io_tracker.clone()),
+                    Arc::new(self.local_io_tracker()),
                 )
                 .await
             }
@@ -732,7 +749,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         Some(known_size),
-                        Arc::new(self.io_tracker.clone()),
+                        Arc::new(self.local_io_tracker()),
                     )
                     .await
                 } else {
@@ -740,7 +757,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         Some(known_size),
-                        Arc::new(self.io_tracker.clone()),
+                        Arc::new(self.local_io_tracker()),
                     )
                     .await
                 }
@@ -794,7 +811,7 @@ impl ObjectStore {
                     file,
                     path.clone(),
                     temp_path,
-                    Arc::new(self.io_tracker.clone()),
+                    Arc::new(self.local_io_tracker()),
                 )))
             }
             _ => Ok(Box::new(ObjectWriter::new(self, path).await?)),
@@ -847,7 +864,10 @@ impl ObjectStore {
     ) -> Result<()> {
         if self.is_local() {
             // Use std::fs::copy for local filesystem to support cross-filesystem copies
-            return super::local::copy_file(from, to);
+            let metrics = self.local_io_tracker().begin_io("copy");
+            let result = super::local::copy_file(from, to);
+            metrics.record(&result, 0);
+            return result;
         }
         if multipart_copy_fallback {
             // Reuse the reader for both the size lookup (a single cached HEAD)
@@ -911,7 +931,12 @@ impl ObjectStore {
 
         if self.is_local() {
             // The local file system provider needs to delete both files and directories.
-            return super::local::remove_dir_all(&path);
+            // Counted as a single delete request, matching how `delete_stream`
+            // counts one batched request regardless of how many paths it removes.
+            let metrics = self.local_io_tracker().begin_io("delete");
+            let result = super::local::remove_dir_all(&path);
+            metrics.record(&result, 0);
+            return result;
         }
         let sub_entries = self
             .inner

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -489,18 +489,14 @@ impl ObjectStore {
             let store_prefix =
                 registry.calculate_object_store_prefix(uri, params.storage_options())?;
 
-            #[cfg(feature = "metrics")]
-            {
-                use crate::object_store::metrics::ObjectStoreMetricsExt;
-                inner = inner.metered(store_prefix.clone());
-            }
+            let mut io_tracker = IOTracker::default();
+            meter_store(&mut inner, &mut io_tracker, &store_prefix);
 
             if let Some(wrapper) = params.object_store_wrapper.as_ref() {
                 inner = wrapper.wrap(&store_prefix, inner);
             }
 
             // Always wrap with IO tracking
-            let io_tracker = IOTracker::default();
             let tracked_store = io_tracker.wrap("", inner);
 
             let store = Self {
@@ -650,16 +646,6 @@ impl ObjectStore {
         self.io_tracker.incremental_stats()
     }
 
-    /// A handle on this store's IO tracker for the readers, writers and
-    /// shortcuts that talk to the filesystem directly instead of going through
-    /// [`Self::inner`]. It carries the store prefix so the metrics they publish
-    /// land under the same `base` label as the store's metered operations.
-    fn local_io_tracker(&self) -> IOTracker {
-        self.io_tracker
-            .clone()
-            .with_metrics_base(&self.store_prefix)
-    }
-
     /// Open a file for path.
     ///
     /// Parameters
@@ -671,7 +657,7 @@ impl ObjectStore {
                     path,
                     self.block_size,
                     None,
-                    Arc::new(self.local_io_tracker()),
+                    Arc::new(self.io_tracker.clone()),
                 )
                 .await
             }
@@ -687,7 +673,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         None,
-                        Arc::new(self.local_io_tracker()),
+                        Arc::new(self.io_tracker.clone()),
                     )
                     .await
                 } else {
@@ -695,7 +681,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         None,
-                        Arc::new(self.local_io_tracker()),
+                        Arc::new(self.io_tracker.clone()),
                     )
                     .await
                 }
@@ -733,7 +719,7 @@ impl ObjectStore {
                     path,
                     self.block_size,
                     Some(known_size),
-                    Arc::new(self.local_io_tracker()),
+                    Arc::new(self.io_tracker.clone()),
                 )
                 .await
             }
@@ -749,7 +735,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         Some(known_size),
-                        Arc::new(self.local_io_tracker()),
+                        Arc::new(self.io_tracker.clone()),
                     )
                     .await
                 } else {
@@ -757,7 +743,7 @@ impl ObjectStore {
                         path,
                         self.block_size,
                         Some(known_size),
-                        Arc::new(self.local_io_tracker()),
+                        Arc::new(self.io_tracker.clone()),
                     )
                     .await
                 }
@@ -811,7 +797,7 @@ impl ObjectStore {
                     file,
                     path.clone(),
                     temp_path,
-                    Arc::new(self.local_io_tracker()),
+                    Arc::new(self.io_tracker.clone()),
                 )))
             }
             _ => Ok(Box::new(ObjectWriter::new(self, path).await?)),
@@ -864,7 +850,7 @@ impl ObjectStore {
     ) -> Result<()> {
         if self.is_local() {
             // Use std::fs::copy for local filesystem to support cross-filesystem copies
-            let metrics = self.local_io_tracker().begin_io("copy");
+            let metrics = self.io_tracker.begin_io("copy");
             let result = super::local::copy_file(from, to);
             metrics.record(&result, 0);
             return result;
@@ -933,7 +919,7 @@ impl ObjectStore {
             // The local file system provider needs to delete both files and directories.
             // Counted as a single delete request, matching how `delete_stream`
             // counts one batched request regardless of how many paths it removes.
-            let metrics = self.local_io_tracker().begin_io("delete");
+            let metrics = self.io_tracker.begin_io("delete");
             let result = super::local::remove_dir_all(&path);
             metrics.record(&result, 0);
             return result;
@@ -1134,7 +1120,7 @@ static DEFAULT_OBJECT_STORE_REGISTRY: std::sync::LazyLock<ObjectStoreRegistry> =
 impl ObjectStore {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        store: Arc<DynObjectStore>,
+        mut store: Arc<DynObjectStore>,
         location: Url,
         block_size: Option<usize>,
         wrapper: Option<Arc<dyn WrappingObjectStore>>,
@@ -1159,13 +1145,15 @@ impl ObjectStore {
                 store_prefix
             }
         };
+        let mut io_tracker = IOTracker::default();
+        meter_store(&mut store, &mut io_tracker, &store_prefix);
+
         let store = match wrapper {
             Some(wrapper) => wrapper.wrap(&store_prefix, store),
             None => store,
         };
 
         // Always wrap with IO tracking
-        let io_tracker = IOTracker::default();
         let tracked_store = io_tracker.wrap("", store);
 
         Self {
@@ -1181,6 +1169,29 @@ impl ObjectStore {
             store_prefix,
         }
     }
+}
+
+/// Wrap `inner` so its operations publish metrics labelled by `store_prefix`,
+/// and label `io_tracker` with the same prefix so the local reads and writes
+/// that bypass `inner` publish under it too.
+///
+/// The two go together on purpose: a store metered on one path but not the other
+/// would report a partial picture that reads like a complete one. Every
+/// constructor that hands an [`ObjectStore`] to a caller must route its `inner`
+/// through here, or through nothing at all.
+#[cfg(feature = "metrics")]
+fn meter_store(inner: &mut Arc<dyn OSObjectStore>, io_tracker: &mut IOTracker, store_prefix: &str) {
+    use crate::object_store::metrics::ObjectStoreMetricsExt;
+    io_tracker.set_metrics_base(store_prefix);
+    *inner = inner.clone().metered(store_prefix.to_owned());
+}
+
+#[cfg(not(feature = "metrics"))]
+fn meter_store(
+    _inner: &mut Arc<dyn OSObjectStore>,
+    _io_tracker: &mut IOTracker,
+    _store_prefix: &str,
+) {
 }
 
 fn infer_block_size(scheme: &str) -> usize {

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -21,6 +21,15 @@
 //! bypass `object_store`'s HTTP client, so there is no place to install the
 //! connector for them.
 //!
+//! Neither layer sees the optimized local reads and writes ([`LocalObjectReader`],
+//! [`LocalWriter`], the io_uring readers, and the local `copy` / recursive delete
+//! shortcuts), which go straight to the filesystem. Those publish the same
+//! request-level metrics themselves through
+//! [`IOTracker::begin_io`](crate::utils::tracking_store::IOTracker::begin_io).
+//!
+//! [`LocalObjectReader`]: crate::local::LocalObjectReader
+//! [`LocalWriter`]: crate::object_writer::LocalWriter
+//!
 //! Metrics carry a `base` label identifying the store. Its cardinality is
 //! controlled by the `LANCE_OBJECT_STORE_METRICS_LABEL` environment variable
 //! ([`BASE_LABEL_ENV_VAR`]):
@@ -777,9 +786,15 @@ pub use http::MeteringHttpConnector;
 mod tests {
     use super::*;
 
+    use lance_core::utils::tempfile::TempStdDir;
     use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
     use object_store::memory::InMemory;
     use object_store::{ObjectStoreExt, PutPayload};
+    use tokio::io::AsyncWriteExt;
+    use url::Url;
+
+    use crate::object_store::ObjectStore as LanceObjectStore;
+    use crate::traits::Writer;
 
     fn payload(data: &[u8]) -> PutPayload {
         PutPayload::from_bytes(Bytes::copy_from_slice(data))
@@ -1424,6 +1439,163 @@ mod tests {
         let list_labels = [("operation", "list"), ("base", "memory")];
         assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &list_labels), 1);
         assert_eq!(counter_value(&recorded, METRIC_ERRORS, &list_labels), 1);
+    }
+
+    /// The optimized local reads and writes talk to the filesystem directly, so
+    /// they never reach [`MeteredObjectStore`] and publish these metrics
+    /// themselves. They must land under the same `base` label as the store's
+    /// metered operations, which for a local store is its scheme.
+    #[test]
+    fn test_local_filesystem_io_is_metered() {
+        let tmp = TempStdDir::default();
+        let dir = tmp.join("sub");
+        let data = b"hello world";
+        let recorded = capture_metrics(|| async {
+            // Built through the registry, like any store opened from a URI.
+            let (store, path) = LanceObjectStore::from_uri(dir.join("a.bin").to_str().unwrap())
+                .await
+                .unwrap();
+            // Writes go through LocalWriter.
+            store.put(&path, data).await.unwrap();
+
+            // Reads go through LocalObjectReader.
+            let reader = store.open(&path).await.unwrap();
+            assert_eq!(reader.size().await.unwrap(), data.len());
+            assert_eq!(reader.get_range(0..5).await.unwrap().len(), 5);
+            assert_eq!(reader.get_all().await.unwrap().len(), data.len());
+            // The file is smaller than the block size, so it streams as one chunk.
+            let chunks: Vec<_> = reader.get_stream().await.unwrap().collect().await;
+            assert_eq!(chunks.len(), 1);
+
+            // Copy and recursive delete both shortcut to the filesystem too.
+            store
+                .copy(&path, &Path::from_absolute_path(dir.join("b.bin")).unwrap())
+                .await
+                .unwrap();
+            store
+                .remove_dir_all(Path::from_absolute_path(&dir).unwrap())
+                .await
+                .unwrap();
+        });
+
+        let put_labels = [("operation", "put"), ("base", "file")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &put_labels), 1);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &put_labels),
+            data.len() as u64
+        );
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &put_labels), 1);
+        assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &put_labels), 0.0);
+
+        // One request each for the range read, the full read and the single
+        // streamed chunk.
+        let get_labels = [("operation", "get"), ("base", "file")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &get_labels), 3);
+        assert_eq!(
+            counter_value(&recorded, METRIC_BYTES, &get_labels),
+            (5 + 2 * data.len()) as u64
+        );
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &get_labels), 3);
+        assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &get_labels), 0.0);
+
+        // The size lookup is the local equivalent of a HEAD, and transfers no
+        // payload bytes.
+        let head_labels = [("operation", "head"), ("base", "file")];
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &head_labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &head_labels), 0);
+
+        for operation in ["copy", "delete"] {
+            let labels = [("operation", operation), ("base", "file")];
+            assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+            assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
+        }
+
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &get_labels), 0);
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &put_labels), 0);
+    }
+
+    #[test]
+    fn test_local_read_error_is_counted() {
+        let tmp = TempStdDir::default();
+        let recorded = capture_metrics(|| async {
+            let store = LanceObjectStore::local();
+            let path = Path::from_absolute_path(tmp.join("a.bin")).unwrap();
+            store.put(&path, b"hello").await.unwrap();
+
+            let reader = store.open(&path).await.unwrap();
+            // Reading past the end of the file fails.
+            assert!(reader.get_range(0..100).await.is_err());
+        });
+
+        let labels = [("operation", "get"), ("base", "file")];
+        assert_eq!(counter_value(&recorded, METRIC_ERRORS, &labels), 1);
+        // A failed read is still counted as a request, with latency recorded.
+        assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+        assert_eq!(histogram_count(&recorded, METRIC_DURATION, &labels), 1);
+        assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 0);
+    }
+
+    /// A local write is reported as a single `put` covering the whole file, so it
+    /// stays in flight until the file is persisted under its final path.
+    #[test]
+    fn test_local_write_is_in_flight_until_persisted() {
+        let tmp = TempStdDir::default();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let labels = [("operation", "put"), ("base", "file")];
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let store = LanceObjectStore::local();
+                let path = Path::from_absolute_path(tmp.join("a.bin")).unwrap();
+                let mut writer = store.create(&path).await.unwrap();
+                writer.write_all(b"hello").await.unwrap();
+
+                let recorded = snapshot(&snapshotter);
+                assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &labels), 1.0);
+                assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 0);
+
+                Writer::shutdown(writer.as_mut()).await.unwrap();
+                let recorded = snapshot(&snapshotter);
+                assert_eq!(gauge_value(&recorded, METRIC_IN_FLIGHT, &labels), 0.0);
+                assert_eq!(counter_value(&recorded, METRIC_REQUESTS, &labels), 1);
+                assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), 5);
+            });
+        });
+    }
+
+    /// A store handed in by the caller is metered like one built by the registry.
+    #[test]
+    fn test_caller_supplied_store_is_metered() {
+        let recorded = capture_metrics(|| async {
+            #[allow(deprecated)]
+            let params = crate::object_store::ObjectStoreParams {
+                object_store: Some((
+                    Arc::new(InMemory::new()) as Arc<dyn object_store::ObjectStore>,
+                    Url::parse("memory:///").unwrap(),
+                )),
+                ..Default::default()
+            };
+            let (store, _) = LanceObjectStore::from_uri_and_params(
+                Arc::new(crate::object_store::ObjectStoreRegistry::default()),
+                "memory:///",
+                &params,
+            )
+            .await
+            .unwrap();
+            store.put(&Path::from("a"), b"hello").await.unwrap();
+        });
+
+        assert_eq!(
+            counter_value(
+                &recorded,
+                METRIC_REQUESTS,
+                &[("operation", "put"), ("base", "memory")]
+            ),
+            1
+        );
     }
 
     /// A store whose stream-producing operations always yield an error, used to

--- a/rust/lance-io/src/object_store/metrics.rs
+++ b/rust/lance-io/src/object_store/metrics.rs
@@ -26,6 +26,12 @@
 //! shortcuts), which go straight to the filesystem. Those publish the same
 //! request-level metrics themselves through
 //! [`IOTracker::begin_io`](crate::utils::tracking_store::IOTracker::begin_io).
+//! The two are installed together, so a store either publishes for all of its
+//! IO or for none of it. A store built by calling a provider's `new_store`
+//! directly, bypassing both `ObjectStore` constructors — as
+//! [`ObjectStore::local`](crate::object_store::ObjectStore::local) and
+//! [`ObjectStore::memory`](crate::object_store::ObjectStore::memory) do — is in
+//! the "none of it" case.
 //!
 //! [`LocalObjectReader`]: crate::local::LocalObjectReader
 //! [`LocalWriter`]: crate::object_writer::LocalWriter
@@ -1518,8 +1524,9 @@ mod tests {
     fn test_local_read_error_is_counted() {
         let tmp = TempStdDir::default();
         let recorded = capture_metrics(|| async {
-            let store = LanceObjectStore::local();
-            let path = Path::from_absolute_path(tmp.join("a.bin")).unwrap();
+            let (store, path) = LanceObjectStore::from_uri(tmp.join("a.bin").to_str().unwrap())
+                .await
+                .unwrap();
             store.put(&path, b"hello").await.unwrap();
 
             let reader = store.open(&path).await.unwrap();
@@ -1548,8 +1555,9 @@ mod tests {
                 .build()
                 .unwrap();
             rt.block_on(async {
-                let store = LanceObjectStore::local();
-                let path = Path::from_absolute_path(tmp.join("a.bin")).unwrap();
+                let (store, path) = LanceObjectStore::from_uri(tmp.join("a.bin").to_str().unwrap())
+                    .await
+                    .unwrap();
                 let mut writer = store.create(&path).await.unwrap();
                 writer.write_all(b"hello").await.unwrap();
 
@@ -1596,6 +1604,45 @@ mod tests {
             ),
             1
         );
+    }
+
+    /// `ObjectStore::new` is how `DatasetBuilder` wraps a caller-supplied store,
+    /// so it must meter both halves of the store: the operations that go through
+    /// `inner`, and the local ones that bypass it. Metering only one half would
+    /// report a partial picture that reads like a complete one.
+    #[test]
+    fn test_store_built_from_new_is_metered() {
+        let tmp = TempStdDir::default();
+        let recorded = capture_metrics(|| async {
+            let store = LanceObjectStore::new(
+                Arc::new(object_store::local::LocalFileSystem::new()),
+                Url::parse("file:///").unwrap(),
+                None,
+                None,
+                false,
+                false,
+                1,
+                3,
+                None,
+            );
+            let path = Path::from_absolute_path(tmp.join("a.bin")).unwrap();
+            // put and open bypass `inner` and publish for themselves.
+            store.put(&path, b"hello").await.unwrap();
+            let reader = store.open(&path).await.unwrap();
+            assert_eq!(reader.get_all().await.unwrap().len(), 5);
+            // delete goes through `inner`, so only MeteredObjectStore can count it.
+            store.delete(&path).await.unwrap();
+        });
+
+        for (operation, bytes) in [("put", 5), ("get", 5), ("delete", 0)] {
+            let labels = [("operation", operation), ("base", "file")];
+            assert_eq!(
+                counter_value(&recorded, METRIC_REQUESTS, &labels),
+                1,
+                "expected one {operation} request"
+            );
+            assert_eq!(counter_value(&recorded, METRIC_BYTES, &labels), bytes);
+        }
     }
 
     /// A store whose stream-producing operations always yield an error, used to

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -265,13 +265,9 @@ impl ObjectStoreRegistry {
 
         store.inner = store.inner.traced();
 
-        #[cfg(feature = "metrics")]
-        {
-            // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
-            // `az$container@account`) so multiple stores on one cloud differ.
-            use crate::object_store::metrics::ObjectStoreMetricsExt;
-            store.inner = store.inner.metered(cache_path.clone());
-        }
+        // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
+        // `az$container@account`) so multiple stores on one cloud differ.
+        crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, &cache_path);
 
         if let Some(wrapper) = &params.object_store_wrapper {
             store.inner = wrapper.wrap(&cache_path, store.inner);

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -21,7 +21,7 @@ use lance_core::{Error, Result};
 use tracing::Instrument;
 
 use crate::traits::Writer;
-use crate::utils::tracking_store::IOTracker;
+use crate::utils::tracking_store::{IOTracker, IoMetricsGuard};
 use tokio::runtime::Handle;
 
 /// Start at 5MB.
@@ -522,7 +522,7 @@ pub struct LocalWriter {
 
 #[derive(Default)]
 enum LocalWriteState {
-    Writing(WritingState),
+    Writing(Box<WritingState>),
     Finishing {
         size: usize,
         future: BoxFuture<'static, Result<WriteResult>>,
@@ -538,6 +538,10 @@ struct WritingState {
     /// Temp path that auto-deletes on drop. Set to `None` after `persist()`.
     temp_path: tempfile::TempPath,
     io_tracker: Arc<IOTracker>,
+    /// The whole file is reported as a single `put`, so this covers everything
+    /// from opening the file to it being durable under its final path. A writer
+    /// dropped before `persist()` records nothing, like an aborted upload.
+    metrics: IoMetricsGuard,
 }
 
 impl LocalWriter {
@@ -549,12 +553,13 @@ impl LocalWriter {
     ) -> Self {
         Self {
             path,
-            state: LocalWriteState::Writing(WritingState {
+            state: LocalWriteState::Writing(Box::new(WritingState {
                 writer: tokio::io::BufWriter::new(file),
                 cursor: 0,
                 temp_path,
+                metrics: io_tracker.begin_io("put"),
                 io_tracker,
-            }),
+            })),
         }
     }
 
@@ -574,9 +579,10 @@ impl LocalWriter {
         final_path: Path,
         size: usize,
         io_tracker: Arc<IOTracker>,
+        metrics: IoMetricsGuard,
     ) -> Result<WriteResult> {
         let local_path = crate::local::to_local_path(&final_path);
-        let e_tag = tokio::task::spawn_blocking(move || -> Result<String> {
+        let persisted = tokio::task::spawn_blocking(move || -> Result<String> {
             temp_path.persist(&local_path).map_err(|e| {
                 Error::io(format!(
                     "failed to persist temp file to {}: {}",
@@ -590,7 +596,11 @@ impl LocalWriter {
             Ok(get_etag(&metadata))
         })
         .await
-        .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))??;
+        .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))
+        .and_then(|e_tag| e_tag);
+
+        metrics.record(&persisted, size as u64);
+        let e_tag = persisted?;
 
         io_tracker.record_write("put", final_path, size as u64);
 
@@ -655,6 +665,7 @@ impl AsyncWrite for LocalWriter {
                             mut_self.path.clone(),
                             size,
                             state.io_tracker,
+                            state.metrics,
                         )),
                     };
                 }

--- a/rust/lance-io/src/uring/current_thread.rs
+++ b/rust/lance-io/src/uring/current_thread.rs
@@ -14,8 +14,8 @@ use crate::traits::Reader;
 use crate::uring::DEFAULT_URING_QUEUE_DEPTH;
 use crate::utils::tracking_store::IOTracker;
 use bytes::{Bytes, BytesMut};
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, TryFutureExt};
 use io_uring::{IoUring, opcode, types};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
@@ -396,10 +396,14 @@ impl Reader for UringCurrentThreadReader {
         let num_bytes = range.len() as u64;
         let range_u64 = (range.start as u64)..(range.end as u64);
 
+        let metrics = self.io_tracker.begin_io("get");
         self.submit_read(range.start as u64, range.len())
-            .map_ok(move |bytes| {
-                io_tracker.record_read("get_range", path, num_bytes, Some(range_u64));
-                bytes
+            .map(move |result| {
+                metrics.record(&result, num_bytes);
+                if result.is_ok() {
+                    io_tracker.record_read("get_range", path, num_bytes, Some(range_u64));
+                }
+                result
             })
             .boxed()
     }
@@ -411,10 +415,15 @@ impl Reader for UringCurrentThreadReader {
         let io_tracker = self.io_tracker.clone();
         let path = self.handle.path.clone();
 
+        let metrics = self.io_tracker.begin_io("get");
         self.submit_read(0, size)
-            .map_ok(move |bytes| {
-                io_tracker.record_read("get_all", path, bytes.len() as u64, None);
-                bytes
+            .map(move |result| {
+                let num_bytes = result.as_ref().map_or(0, |bytes| bytes.len() as u64);
+                metrics.record(&result, num_bytes);
+                if result.is_ok() {
+                    io_tracker.record_read("get_all", path, num_bytes, None);
+                }
+                result
             })
             .boxed()
     }

--- a/rust/lance-io/src/uring/reader.rs
+++ b/rust/lance-io/src/uring/reader.rs
@@ -12,8 +12,8 @@ use crate::traits::Reader;
 use crate::uring::requests::RequestState;
 use crate::utils::tracking_store::IOTracker;
 use bytes::{Bytes, BytesMut};
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, TryFutureExt};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use object_store::path::Path;
@@ -267,10 +267,14 @@ impl Reader for UringReader {
         let num_bytes = range.len() as u64;
         let range_u64 = (range.start as u64)..(range.end as u64);
 
+        let metrics = self.io_tracker.begin_io("get");
         self.submit_read(range.start as u64, range.len())
-            .map_ok(move |bytes| {
-                io_tracker.record_read("get_range", path, num_bytes, Some(range_u64));
-                bytes
+            .map(move |result| {
+                metrics.record(&result, num_bytes);
+                if result.is_ok() {
+                    io_tracker.record_read("get_range", path, num_bytes, Some(range_u64));
+                }
+                result
             })
             .boxed()
     }
@@ -282,10 +286,15 @@ impl Reader for UringReader {
         let io_tracker = self.io_tracker.clone();
         let path = self.handle.path.clone();
 
+        let metrics = self.io_tracker.begin_io("get");
         self.submit_read(0, size)
-            .map_ok(move |bytes| {
-                io_tracker.record_read("get_all", path, bytes.len() as u64, None);
-                bytes
+            .map(move |result| {
+                let num_bytes = result.as_ref().map_or(0, |bytes| bytes.len() as u64);
+                metrics.record(&result, num_bytes);
+                if result.is_ok() {
+                    io_tracker.record_read("get_all", path, num_bytes, None);
+                }
+                result
             })
             .boxed()
     }

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -13,6 +13,8 @@ use std::ops::Range;
 #[cfg(feature = "test-util")]
 use std::sync::atomic::AtomicU16;
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "metrics")]
+use std::time::Instant;
 
 use bytes::Bytes;
 use futures::StreamExt;
@@ -26,9 +28,19 @@ use object_store::{
 };
 
 use crate::object_store::WrappingObjectStore;
+#[cfg(feature = "metrics")]
+use crate::object_store::metrics::{InFlightGuard, record_outcome};
 
 #[derive(Debug, Default, Clone)]
-pub struct IOTracker(Arc<Mutex<IoStats>>);
+pub struct IOTracker {
+    stats: Arc<Mutex<IoStats>>,
+    /// The `base` label for the object store metrics published by IO that
+    /// bypasses the `object_store` layer (see [`Self::begin_io`]). `None` when
+    /// the IO cannot be attributed to a store, in which case no metrics are
+    /// published.
+    #[cfg(feature = "metrics")]
+    metrics_base: Option<Arc<str>>,
+}
 
 impl IOTracker {
     /// Get IO statistics and reset the counters (incremental pattern).
@@ -36,7 +48,7 @@ impl IOTracker {
     /// This returns the accumulated statistics since the last call and resets
     /// the internal counters to zero.
     pub fn incremental_stats(&self) -> IoStats {
-        std::mem::take(&mut *self.0.lock().unwrap())
+        std::mem::take(&mut *self.stats.lock().unwrap())
     }
 
     /// Get a snapshot of current IO statistics without resetting counters.
@@ -44,7 +56,7 @@ impl IOTracker {
     /// This returns a clone of the current statistics without modifying the
     /// internal state. Use this when you need to check stats without resetting.
     pub fn stats(&self) -> IoStats {
-        self.0.lock().unwrap().clone()
+        self.stats.lock().unwrap().clone()
     }
 
     /// Record a read operation for tracking.
@@ -58,7 +70,7 @@ impl IOTracker {
         num_bytes: u64,
         #[allow(unused_variables)] range: Option<Range<u64>>,
     ) {
-        let mut stats = self.0.lock().unwrap();
+        let mut stats = self.stats.lock().unwrap();
         stats.read_iops += 1;
         stats.read_bytes += num_bytes;
         #[cfg(feature = "test-util")]
@@ -79,7 +91,7 @@ impl IOTracker {
         #[allow(unused_variables)] path: Path,
         num_bytes: u64,
     ) {
-        let mut stats = self.0.lock().unwrap();
+        let mut stats = self.stats.lock().unwrap();
         stats.write_iops += 1;
         stats.written_bytes += num_bytes;
         #[cfg(feature = "test-util")]
@@ -89,11 +101,91 @@ impl IOTracker {
             range: None,
         });
     }
+
+    /// Label the metrics published through [`Self::begin_io`] with the prefix of
+    /// the store this tracker belongs to, so IO that bypasses the `object_store`
+    /// layer carries the same `base` label as the store's metered operations.
+    #[cfg(feature = "metrics")]
+    pub fn with_metrics_base(mut self, base: &str) -> Self {
+        self.metrics_base = Some(base.into());
+        self
+    }
+
+    /// Without the `metrics` feature there is nothing to label.
+    #[cfg(not(feature = "metrics"))]
+    pub fn with_metrics_base(self, _base: &str) -> Self {
+        self
+    }
+
+    /// Begin an operation that talks to storage without going through the
+    /// `object_store` layer, and so is invisible to the `MeteredObjectStore`
+    /// wrapper: the optimized local reads and writes go straight to the
+    /// filesystem. `operation` must be one of the labels that wrapper uses
+    /// (`get`, `put`, `head`, ...) so this IO aggregates with the rest.
+    ///
+    /// The returned guard keeps the in-flight gauge raised until it is dropped.
+    #[cfg(feature = "metrics")]
+    pub fn begin_io(&self, operation: &'static str) -> IoMetricsGuard {
+        IoMetricsGuard {
+            state: self.metrics_base.as_ref().map(|base| IoMetricsState {
+                _in_flight: InFlightGuard::new(base, operation),
+                base: base.clone(),
+                operation,
+                start: Instant::now(),
+            }),
+        }
+    }
+
+    /// Without the `metrics` feature there is nothing to publish.
+    #[cfg(not(feature = "metrics"))]
+    pub fn begin_io(&self, _operation: &'static str) -> IoMetricsGuard {
+        IoMetricsGuard {}
+    }
+}
+
+/// Publishes the object store metrics for a single operation that bypassed the
+/// `object_store` layer (see [`IOTracker::begin_io`]).
+///
+/// The operation is only counted by [`Self::record`]; one dropped before that —
+/// a cancelled read, an abandoned write — counts as neither a success nor a
+/// failure, and only lowers the in-flight gauge.
+#[must_use = "the operation is not recorded until `record` is called"]
+pub struct IoMetricsGuard {
+    #[cfg(feature = "metrics")]
+    state: Option<IoMetricsState>,
+}
+
+#[cfg(feature = "metrics")]
+struct IoMetricsState {
+    base: Arc<str>,
+    operation: &'static str,
+    start: Instant,
+    /// Lowers the in-flight gauge when the guard is dropped.
+    _in_flight: InFlightGuard,
+}
+
+impl IoMetricsGuard {
+    /// Record the operation's count and latency, along with `num_bytes`
+    /// transferred if `result` is `Ok` or an error if it is not.
+    pub fn record<T, E>(self, result: &std::result::Result<T, E>, num_bytes: u64) {
+        #[cfg(feature = "metrics")]
+        if let Some(state) = self.state {
+            record_outcome(
+                &state.base,
+                state.operation,
+                state.start,
+                num_bytes,
+                result.is_err(),
+            );
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = (result, num_bytes);
+    }
 }
 
 impl WrappingObjectStore for IOTracker {
     fn wrap(&self, _store_prefix: &str, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
-        Arc::new(IoTrackingStore::new(target, self.0.clone()))
+        Arc::new(IoTrackingStore::new(target, self.stats.clone()))
     }
 }
 

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -105,16 +105,12 @@ impl IOTracker {
     /// Label the metrics published through [`Self::begin_io`] with the prefix of
     /// the store this tracker belongs to, so IO that bypasses the `object_store`
     /// layer carries the same `base` label as the store's metered operations.
+    ///
+    /// Only `meter_store` should call this, so that labelling the tracker and
+    /// wrapping the store stay inseparable — see the rationale there.
     #[cfg(feature = "metrics")]
-    pub fn with_metrics_base(mut self, base: &str) -> Self {
+    pub(crate) fn set_metrics_base(&mut self, base: &str) {
         self.metrics_base = Some(base.into());
-        self
-    }
-
-    /// Without the `metrics` feature there is nothing to label.
-    #[cfg(not(feature = "metrics"))]
-    pub fn with_metrics_base(self, _base: &str) -> Self {
-        self
     }
 
     /// Begin an operation that talks to storage without going through the


### PR DESCRIPTION
The optimized local paths — `LocalWriter`, `LocalObjectReader`, the io_uring readers, and the local `copy` / recursive-delete shortcuts — go straight to the filesystem, so they never reach `MeteredObjectStore` and published no metrics at all. Writing a dataset to a local path produced zero object store metrics even though the IO tracker recorded it.

`IOTracker` now carries the metrics `base` label of the store it belongs to (its store prefix, the same value `MeteredObjectStore` is given) and hands out an `IoMetricsGuard` for IO that bypasses the `object_store` layer. Each bypassing path now records requests, bytes, latency, errors and the in-flight gauge under the same labels, so local IO aggregates with cloud IO:

| path | operation |
| --- | --- |
| `LocalWriter` (one `put` per file, from open to durable at its final path) | `put` |
| `LocalObjectReader::get_range` / `get_all` / streamed chunks | `get` |
| `LocalObjectReader::size` (the local equivalent of a HEAD) | `head` |
| `UringReader` / `UringCurrentThreadReader` `get_range` / `get_all` | `get` |
| local `ObjectStore::copy` | `copy` |
| local `ObjectStore::remove_dir_all` (one request, like `delete_stream`) | `delete` |

Two things worth a second opinion:

- Metering a store's `inner` and labelling its `IOTracker` now happen together in `meter_store`, called from all three constructors — the registry, `from_uri_and_params`, and `ObjectStore::new`. Previously only the first two metered `inner`, so a caller-supplied store routed through `ObjectStore::new` (which is what `DatasetBuilder::build_object_store` does) would have published local reads and writes but nothing for `list` / `delete` / `rename`. A store now publishes for all of its IO or none of it; stores built by calling a provider's `new_store` directly (`ObjectStore::local` / `memory`) are the "none" case. This would still double-count if a caller passed in a store Lance had already metered.
- `IoStats` is left alone. The local `copy`, recursive delete and size lookup were never counted there and still aren't, so existing IO assertions are unaffected; adding them would shift IO counts across the test suite.

The io_uring readers have no coverage here — they need Linux plus a working ring, so the new tests exercise the non-uring local paths only.

Fixes #7993

