### PR TITLE
docs: correct approx_mode guidance for prefiltered HNSW search

### DIFF
--- a/java/src/main/java/org/lance/ipc/ApproxMode.java
+++ b/java/src/main/java/org/lance/ipc/ApproxMode.java
@@ -16,11 +16,15 @@ package org.lance.ipc;
 /**
  * Controls the speed / accuracy tradeoff for approximate vector search.
  *
- * <p>This setting currently only affects RQ-quantized vector indexes, such as IVF_RQ. Other index
- * types ignore this setting.
+ * <p>This setting currently affects RQ-quantized vector indexes (such as IVF_RQ) and prefiltered
+ * search on HNSW sub-indexes, where {@code FAST} enables the ACORN traversal. Other index types
+ * ignore this setting.
  */
 public enum ApproxMode {
-  /** Prefer faster approximate scoring when supported by the RQ index. */
+  /**
+   * Prefer faster approximate scoring when supported by the RQ index, and the ACORN traversal for
+   * prefiltered HNSW search.
+   */
   FAST("fast"),
 
   /** Use the index's default approximation behavior. */

--- a/java/src/main/java/org/lance/ipc/Query.java
+++ b/java/src/main/java/org/lance/ipc/Query.java
@@ -290,7 +290,8 @@ public class Query {
     /**
      * Sets the speed / accuracy tradeoff for approximate vector search.
      *
-     * <p>This setting currently only affects RQ-quantized vector indexes, such as IVF_RQ. Other
+     * <p>This setting currently affects RQ-quantized vector indexes (such as IVF_RQ) and
+     * prefiltered search on HNSW sub-indexes, where {@code FAST} enables the ACORN traversal. Other
      * index types ignore this setting.
      *
      * @param approxMode The approximate search mode to use for the query.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6610,11 +6610,12 @@ class ScannerBuilder:
             CPU pool size.
         approx_mode: {"fast", "normal", "accurate"}, default "normal"
             Controls the speed / accuracy tradeoff for approximate vector search
-            when supported by the selected index. This currently only affects
-            RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-            setting. ``fast`` favors lower latency and may reduce recall,
-            ``normal`` uses the default balance, and ``accurate`` favors higher
-            recall and may increase latency.
+            when supported by the selected index. This currently affects
+            RQ-quantized indexes (such as IVF_RQ) and prefiltered search on HNSW
+            sub-indexes, where ``fast`` enables the ACORN traversal. Other index
+            types ignore this setting. ``fast`` favors lower latency and may
+            reduce recall, ``normal`` uses the default balance, and ``accurate``
+            favors higher recall and may increase latency.
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -7811,11 +7812,12 @@ def _build_vector_search_query(
         the partition-parallel path and are clamped to the CPU pool size.
     approx_mode: {"fast", "normal", "accurate"}, default "normal"
         Controls the speed / accuracy tradeoff for approximate vector search
-        when supported by the selected index. This currently only affects
-        RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-        setting. ``fast`` favors lower latency and may reduce recall,
-        ``normal`` uses the default balance, and ``accurate`` favors higher
-        recall and may increase latency.
+        when supported by the selected index. This currently affects RQ-quantized
+        indexes (such as IVF_RQ) and prefiltered search on HNSW sub-indexes, where
+        ``fast`` enables the ACORN traversal. Other index types ignore this
+        setting. ``fast`` favors lower latency and may reduce recall, ``normal``
+        uses the default balance, and ``accurate`` favors higher recall and may
+        increase latency.
     distance_range: tuple[Optional[float], Optional[float]], optional
         A tuple of (lower_bound, upper_bound) to filter results by distance.
         Both bounds are optional. The lower bound is inclusive and the upper

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -163,8 +163,9 @@ pub struct Query {
 
     /// Controls the speed / accuracy tradeoff for approximate vector search.
     ///
-    /// This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
-    /// Other index types ignore this setting.
+    /// This currently affects RQ-quantized vector indexes (such as IVF_RQ) and
+    /// prefiltered search on HNSW sub-indexes, where `Fast` enables the ACORN
+    /// traversal. Other index types ignore this setting.
     pub approx_mode: ApproxMode,
 }
 


### PR DESCRIPTION
`ApproxMode::Fast` became meaningful for prefiltered HNSW sub-indexes in #7927, which is the only way to reach the ACORN traversal. That PR updated the doc on the `ApproxMode` enum but missed the other places the old claim appears, so the switch is still documented as a no-op for HNSW in every binding:

- `rust/lance-index/src/vector.rs` — the `Query::approx_mode` field, which contradicts the enum doc 80 lines above it
- `python/python/lance/dataset.py` — `ScannerBuilder.nearest` and `_build_vector_search_query`
- `java/.../ipc/ApproxMode.java` — the class doc, and the `FAST` constant ("when supported by the RQ index")
- `java/.../ipc/Query.java` — the `setApproxMode` javadoc

Wording is taken verbatim from what #7927 put on the enum, so all five sites now agree.

Docs only, no behavior change.

`ACCURATE` still refers only to the RQ index. That stays accurate, since ACORN has no accurate-mode behavior, but happy to touch it for consistency if preferred.

One note for CI: I could not run `spotless:check` locally (no JRE), so the Java javadoc rewrapping is unverified against google-java-format. Lines are within 100 columns and follow the surrounding style.
