### PR TITLE
feat: support optional binary view decoding

### DIFF
--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -20,7 +20,8 @@ use std::{
 };
 
 use arrow_array::{
-    Array, ArrayRef, OffsetSizeTrait, UInt64Array,
+    Array, ArrayRef, BinaryArray, BinaryViewArray, LargeBinaryArray, LargeStringArray,
+    OffsetSizeTrait, StringArray, StringViewArray, UInt64Array,
     cast::AsArray,
     new_empty_array, new_null_array,
     types::{ArrowDictionaryKeyType, UInt8Type, UInt16Type, UInt32Type, UInt64Type},
@@ -590,18 +591,69 @@ pub struct VariableWidthBlock {
 
 impl VariableWidthBlock {
     fn into_arrow(self, data_type: DataType, validate: bool) -> Result<ArrayData> {
+        if !matches!(data_type, DataType::Utf8View | DataType::BinaryView) {
+            let data_buffer = self.data.into_buffer();
+            let offsets_buffer = self.offsets.into_buffer();
+            let builder = ArrayDataBuilder::new(data_type)
+                .add_buffer(offsets_buffer)
+                .add_buffer(data_buffer)
+                .len(self.num_values as usize)
+                .null_count(0);
+            return if validate {
+                Ok(builder.build()?)
+            } else {
+                Ok(unsafe { builder.build_unchecked() })
+            };
+        }
+
+        let base_data_type = match (&data_type, self.bits_per_offset) {
+            (DataType::Utf8View, 32) => DataType::Utf8,
+            (DataType::Utf8View, 64) => DataType::LargeUtf8,
+            (DataType::BinaryView, 32) => DataType::Binary,
+            (DataType::BinaryView, 64) => DataType::LargeBinary,
+            (_, bits_per_offset) => {
+                return Err(Error::invalid_input(format!(
+                    "Cannot convert VariableWidthBlock to {data_type} with \
+                     bits_per_offset={bits_per_offset}; expected 32 or 64"
+                )));
+            }
+        };
+
         let data_buffer = self.data.into_buffer();
         let offsets_buffer = self.offsets.into_buffer();
-        let builder = ArrayDataBuilder::new(data_type)
+        let builder = ArrayDataBuilder::new(base_data_type)
             .add_buffer(offsets_buffer)
             .add_buffer(data_buffer)
             .len(self.num_values as usize)
             .null_count(0);
-        if validate {
-            Ok(builder.build()?)
+        let base_data = if validate {
+            builder.build()?
         } else {
-            Ok(unsafe { builder.build_unchecked() })
-        }
+            unsafe { builder.build_unchecked() }
+        };
+
+        let view_data = match (data_type, self.bits_per_offset) {
+            (DataType::Utf8View, 32) => {
+                StringViewArray::from(&StringArray::from(base_data)).into_data()
+            }
+            (DataType::Utf8View, 64) => {
+                StringViewArray::from(&LargeStringArray::from(base_data)).into_data()
+            }
+            (DataType::BinaryView, 32) => {
+                BinaryViewArray::from(&BinaryArray::from(base_data)).into_data()
+            }
+            (DataType::BinaryView, 64) => {
+                BinaryViewArray::from(&LargeBinaryArray::from(base_data)).into_data()
+            }
+            (data_type, bits_per_offset) => {
+                return Err(Error::invalid_input(format!(
+                    "Cannot convert VariableWidthBlock to {data_type} with \
+                     bits_per_offset={bits_per_offset}; expected Utf8View or BinaryView with \
+                     32 or 64 bit offsets"
+                )));
+            }
+        };
+        Ok(view_data)
     }
 
     fn into_buffers(self) -> Vec<LanceBuffer> {
@@ -1661,10 +1713,11 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields};
     use lance_datagen::{ArrayGeneratorExt, DEFAULT_SEED, RowCount, array};
     use rand::SeedableRng;
+    use rstest::rstest;
 
     use crate::buffer::LanceBuffer;
 
-    use super::{AllNullDataBlock, DataBlock};
+    use super::{AllNullDataBlock, BlockInfo, DataBlock, NullableDataBlock, VariableWidthBlock};
 
     use arrow_array::Array;
 
@@ -1782,6 +1835,135 @@ mod tests {
         let block = block.as_nullable().unwrap();
         let data = block.data.as_variable_width().unwrap();
         assert_eq!(data.data, LanceBuffer::copy_slice(b"foobar"));
+    }
+
+    fn variable_width_block(data: &[u8], offsets: &[i64], bits_per_offset: u8) -> DataBlock {
+        let num_values = offsets.len() - 1;
+        let offsets_buffer = match bits_per_offset {
+            32 => LanceBuffer::reinterpret_vec(
+                offsets
+                    .iter()
+                    .map(|offset| i32::try_from(*offset).unwrap())
+                    .collect(),
+            ),
+            64 => LanceBuffer::reinterpret_vec(offsets.to_vec()),
+            _ => LanceBuffer::empty(),
+        };
+        DataBlock::VariableWidth(VariableWidthBlock {
+            data: LanceBuffer::copy_slice(data),
+            offsets: offsets_buffer,
+            bits_per_offset,
+            num_values: num_values as u64,
+            block_info: BlockInfo::new(),
+        })
+    }
+
+    #[rstest]
+    #[case(32)]
+    #[case(64)]
+    fn test_variable_width_to_view(#[case] bits_per_offset: u8) {
+        let values = b"abcdefghijklmnopqrstuvwxy";
+        let offsets = [0, 0, 12, 25];
+
+        let string_block = variable_width_block(values, &offsets, bits_per_offset);
+        let values_ptr = string_block.as_variable_width_ref().unwrap().data.as_ptr();
+        let string_data = string_block.into_arrow(DataType::Utf8View, true).unwrap();
+        let string_array = make_array(string_data);
+        let string_array = string_array
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .unwrap();
+        assert_eq!(
+            string_array.iter().collect::<Vec<_>>(),
+            vec![Some(""), Some("abcdefghijkl"), Some("mnopqrstuvwxy")]
+        );
+        assert_eq!(string_array.data_buffers()[0].as_ptr(), values_ptr);
+
+        let inline_view = string_array.views()[1].to_le_bytes();
+        assert_eq!(u32::from_le_bytes(inline_view[..4].try_into().unwrap()), 12);
+        assert_eq!(&inline_view[4..], b"abcdefghijkl");
+
+        let referenced_view = string_array.views()[2].to_le_bytes();
+        assert_eq!(
+            u32::from_le_bytes(referenced_view[..4].try_into().unwrap()),
+            13
+        );
+        assert_eq!(
+            u32::from_le_bytes(referenced_view[8..12].try_into().unwrap()),
+            0
+        );
+        assert_eq!(
+            u32::from_le_bytes(referenced_view[12..].try_into().unwrap()),
+            12
+        );
+
+        let binary_block = variable_width_block(values, &offsets, bits_per_offset);
+        let values_ptr = binary_block.as_variable_width_ref().unwrap().data.as_ptr();
+        let binary_data = binary_block.into_arrow(DataType::BinaryView, true).unwrap();
+        let binary_array = make_array(binary_data);
+        let binary_array = binary_array
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .unwrap();
+        assert_eq!(
+            binary_array.iter().collect::<Vec<_>>(),
+            vec![
+                Some(b"".as_slice()),
+                Some(b"abcdefghijkl".as_slice()),
+                Some(b"mnopqrstuvwxy".as_slice()),
+            ]
+        );
+        assert_eq!(binary_array.data_buffers()[0].as_ptr(), values_ptr);
+    }
+
+    #[rstest]
+    #[case(32)]
+    #[case(64)]
+    fn test_nullable_variable_width_to_view(#[case] bits_per_offset: u8) {
+        let data = variable_width_block(b"hellomaskedworld", &[0, 5, 11, 16], bits_per_offset);
+        let block = DataBlock::Nullable(NullableDataBlock {
+            data: Box::new(data),
+            nulls: LanceBuffer::from(vec![0b00000101]),
+            block_info: BlockInfo::new(),
+        });
+
+        let array = make_array(block.into_arrow(DataType::Utf8View, true).unwrap());
+        let array = array.as_any().downcast_ref::<StringViewArray>().unwrap();
+        assert_eq!(array.len(), 3);
+        assert_eq!(array.null_count(), 1);
+        assert_eq!(array.value(0), "hello");
+        assert!(array.is_null(1));
+        assert_eq!(array.value(2), "world");
+    }
+
+    #[test]
+    fn test_variable_width_to_view_validation() {
+        let error = variable_width_block(&[0xff], &[0, 1], 32)
+            .into_arrow(DataType::Utf8View, true)
+            .unwrap_err();
+        assert!(matches!(error, lance_core::Error::Arrow { .. }));
+        assert!(error.to_string().contains("Invalid UTF8 sequence"));
+
+        let data = variable_width_block(&[0xff], &[0, 1], 32)
+            .into_arrow(DataType::BinaryView, true)
+            .unwrap();
+        let array = make_array(data);
+        let array = array.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+        assert_eq!(array.value(0), &[0xff]);
+    }
+
+    #[rstest]
+    #[case(DataType::Utf8View)]
+    #[case(DataType::BinaryView)]
+    fn test_variable_width_to_view_rejects_unsupported_offsets(#[case] data_type: DataType) {
+        let error = variable_width_block(b"", &[0], 16)
+            .into_arrow(data_type.clone(), true)
+            .unwrap_err();
+        assert!(matches!(error, lance_core::Error::InvalidInput { .. }));
+        let message = error.to_string();
+        assert!(message.contains(&data_type.to_string()));
+        assert!(message.contains("bits_per_offset=16"));
+        assert!(message.contains("expected 32 or 64"));
     }
 
     #[test]

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -595,6 +595,7 @@ impl CoreFieldDecoderStrategy {
     fn create_primitive_scheduler(
         &self,
         field: &Field,
+        requested_data_type: &DataType,
         column: &ColumnInfo,
         buffers: FileBuffers,
     ) -> Result<Box<dyn crate::previous::decoder::FieldScheduler>> {
@@ -606,7 +607,7 @@ impl CoreFieldDecoderStrategy {
         };
         Ok(Box::new(PrimitiveFieldScheduler::new(
             column.index,
-            field.data_type(),
+            requested_data_type.clone(),
             column.page_infos.clone(),
             column_buffers,
             self.validate_data,
@@ -637,6 +638,7 @@ impl CoreFieldDecoderStrategy {
     fn create_list_scheduler(
         &self,
         list_field: &Field,
+        requested_list_field: &ArrowField,
         column_infos: &mut ColumnInfoIter,
         buffers: FileBuffers,
         offsets_column: &ColumnInfo,
@@ -646,8 +648,22 @@ impl CoreFieldDecoderStrategy {
             file_buffers: buffers,
             positions_and_sizes: &offsets_column.buffer_offsets_and_sizes,
         };
-        let items_scheduler =
-            self.create_legacy_field_scheduler(&list_field.children[0], column_infos, buffers)?;
+        let requested_items_field = match requested_list_field.data_type() {
+            DataType::List(inner) | DataType::LargeList(inner) => inner,
+            requested_type => {
+                return Err(Error::invalid_input(format!(
+                    "requested field {} has type {}, expected List or LargeList",
+                    requested_list_field.name(),
+                    requested_type
+                )));
+            }
+        };
+        let items_scheduler = self.create_legacy_field_scheduler(
+            &list_field.children[0],
+            requested_items_field,
+            column_infos,
+            buffers,
+        )?;
 
         let (inner_infos, null_offset_adjustments): (Vec<_>, Vec<_>) = offsets_column
             .page_infos
@@ -686,7 +702,7 @@ impl CoreFieldDecoderStrategy {
             offsets_column_buffers,
             self.validate_data,
         )) as Arc<dyn crate::previous::decoder::FieldScheduler>;
-        let items_field = match list_field.data_type() {
+        let items_field = match requested_list_field.data_type() {
             DataType::List(inner) => inner,
             DataType::LargeList(inner) => inner,
             _ => unreachable!(),
@@ -699,7 +715,7 @@ impl CoreFieldDecoderStrategy {
         Ok(Box::new(ListFieldScheduler::new(
             inner,
             items_scheduler.into(),
-            items_field,
+            items_field.clone(),
             offset_type,
             null_offset_adjustments,
         )))
@@ -720,6 +736,7 @@ impl CoreFieldDecoderStrategy {
     fn create_structural_field_scheduler(
         &self,
         field: &Field,
+        requested_field: &ArrowField,
         column_infos: &mut ColumnInfoIter,
     ) -> Result<Box<dyn StructuralFieldScheduler>> {
         let data_type = field.data_type();
@@ -729,7 +746,8 @@ impl CoreFieldDecoderStrategy {
                 column_info.as_ref(),
                 self.decompressor_strategy.as_ref(),
                 self.cache_repetition_index,
-                field,
+                &field.data_type(),
+                requested_field.data_type(),
             )?);
 
             // advance to the next top level column
@@ -738,7 +756,7 @@ impl CoreFieldDecoderStrategy {
             return Ok(scheduler);
         }
         match &data_type {
-            DataType::Struct(fields) => {
+            DataType::Struct(_) => {
                 if field.is_packed_struct() {
                     // Packed struct
                     let column_info = column_infos.expect_next()?;
@@ -746,7 +764,8 @@ impl CoreFieldDecoderStrategy {
                         column_info.as_ref(),
                         self.decompressor_strategy.as_ref(),
                         self.cache_repetition_index,
-                        field,
+                        &field.data_type(),
+                        requested_field.data_type(),
                     )?);
 
                     // advance to the next top level column
@@ -770,21 +789,43 @@ impl CoreFieldDecoderStrategy {
                             column_info.as_ref(),
                             self.decompressor_strategy.as_ref(),
                             self.cache_repetition_index,
-                            field,
+                            &field.data_type(),
+                            requested_field.data_type(),
                         )?);
                         column_infos.next_top_level();
                         return Ok(scheduler);
                     }
                 }
 
+                let requested_fields = match requested_field.data_type() {
+                    DataType::Struct(fields) => fields,
+                    requested_type => {
+                        return Err(Error::invalid_input(format!(
+                            "requested field {} has type {}, expected Struct",
+                            requested_field.name(),
+                            requested_type
+                        )));
+                    }
+                };
+                if requested_fields.len() != field.children.len() {
+                    return Err(Error::invalid_input(format!(
+                        "requested struct field {} has {} children but stored field has {}",
+                        requested_field.name(),
+                        requested_fields.len(),
+                        field.children.len()
+                    )));
+                }
                 let mut child_schedulers = Vec::with_capacity(field.children.len());
-                for field in field.children.iter() {
-                    let field_scheduler =
-                        self.create_structural_field_scheduler(field, column_infos)?;
+                for (field, requested_field) in field.children.iter().zip(requested_fields.iter()) {
+                    let field_scheduler = self.create_structural_field_scheduler(
+                        field,
+                        requested_field,
+                        column_infos,
+                    )?;
                     child_schedulers.push(field_scheduler);
                 }
 
-                let fields = fields.clone();
+                let fields = requested_fields.clone();
                 Ok(
                     Box::new(StructuralStructScheduler::new(child_schedulers, fields))
                         as Box<dyn StructuralFieldScheduler>,
@@ -792,8 +833,18 @@ impl CoreFieldDecoderStrategy {
             }
             DataType::List(_) | DataType::LargeList(_) => {
                 let child = field.children.first().expect_ok()?;
+                let requested_child = match requested_field.data_type() {
+                    DataType::List(child) | DataType::LargeList(child) => child,
+                    requested_type => {
+                        return Err(Error::invalid_input(format!(
+                            "requested field {} has type {}, expected List or LargeList",
+                            requested_field.name(),
+                            requested_type
+                        )));
+                    }
+                };
                 let child_scheduler =
-                    self.create_structural_field_scheduler(child, column_infos)?;
+                    self.create_structural_field_scheduler(child, requested_child, column_infos)?;
                 Ok(Box::new(StructuralListScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
             }
@@ -801,8 +852,23 @@ impl CoreFieldDecoderStrategy {
                 if matches!(inner.data_type(), DataType::Struct(_)) =>
             {
                 let child = field.children.first().expect_ok()?;
+                let requested_child = match requested_field.data_type() {
+                    DataType::FixedSizeList(child, requested_dimension)
+                        if requested_dimension == dimension =>
+                    {
+                        child
+                    }
+                    requested_type => {
+                        return Err(Error::invalid_input(format!(
+                            "requested field {} has type {}, expected FixedSizeList with dimension {}",
+                            requested_field.name(),
+                            requested_type,
+                            dimension
+                        )));
+                    }
+                };
                 let child_scheduler =
-                    self.create_structural_field_scheduler(child, column_infos)?;
+                    self.create_structural_field_scheduler(child, requested_child, column_infos)?;
                 Ok(Box::new(StructuralFixedSizeListScheduler::new(
                     child_scheduler,
                     *dimension,
@@ -816,8 +882,25 @@ impl CoreFieldDecoderStrategy {
                     return Err(Error::not_supported_source(format!("Map data type is not supported with keys_sorted=true now, current value is {}", *keys_sorted).into()));
                 }
                 let entries_child = field.children.first().expect_ok()?;
-                let child_scheduler =
-                    self.create_structural_field_scheduler(entries_child, column_infos)?;
+                let requested_entries = match requested_field.data_type() {
+                    DataType::Map(entries, requested_keys_sorted)
+                        if requested_keys_sorted == keys_sorted =>
+                    {
+                        entries
+                    }
+                    requested_type => {
+                        return Err(Error::invalid_input(format!(
+                            "requested field {} has type {}, expected Map",
+                            requested_field.name(),
+                            requested_type
+                        )));
+                    }
+                };
+                let child_scheduler = self.create_structural_field_scheduler(
+                    entries_child,
+                    requested_entries,
+                    column_infos,
+                )?;
                 Ok(Box::new(StructuralMapScheduler::new(child_scheduler))
                     as Box<dyn StructuralFieldScheduler>)
             }
@@ -828,20 +911,30 @@ impl CoreFieldDecoderStrategy {
     fn create_legacy_field_scheduler(
         &self,
         field: &Field,
+        requested_field: &ArrowField,
         column_infos: &mut ColumnInfoIter,
         buffers: FileBuffers,
     ) -> Result<Box<dyn crate::previous::decoder::FieldScheduler>> {
         let data_type = field.data_type();
         if Self::is_primitive_legacy(&data_type) {
             let column_info = column_infos.expect_next()?;
-            let scheduler = self.create_primitive_scheduler(field, column_info, buffers)?;
+            let scheduler = self.create_primitive_scheduler(
+                field,
+                requested_field.data_type(),
+                column_info,
+                buffers,
+            )?;
             return Ok(scheduler);
         } else if data_type.is_binary_like() {
             let column_info = column_infos.expect_next()?.clone();
             // Column is blob and user is asking for binary data
             if let Some(blob_col) = Self::unwrap_blob(column_info.as_ref()) {
-                let desc_scheduler =
-                    self.create_primitive_scheduler(&BLOB_DESC_LANCE_FIELD, &blob_col, buffers)?;
+                let desc_scheduler = self.create_primitive_scheduler(
+                    &BLOB_DESC_LANCE_FIELD,
+                    &BLOB_DESC_LANCE_FIELD.data_type(),
+                    &blob_col,
+                    buffers,
+                )?;
                 let blob_scheduler = Box::new(BlobFieldScheduler::new(desc_scheduler.into()));
                 return Ok(blob_scheduler);
             }
@@ -869,22 +962,36 @@ impl CoreFieldDecoderStrategy {
                     .unwrap();
                     let list_scheduler = self.create_list_scheduler(
                         &list_field,
+                        &ArrowField::new(
+                            field.name.clone(),
+                            list_field.data_type(),
+                            field.nullable,
+                        ),
                         column_infos,
                         buffers,
                         &column_info,
                     )?;
                     let binary_scheduler = Box::new(BinaryFieldScheduler::new(
                         list_scheduler.into(),
-                        field.data_type(),
+                        requested_field.data_type().clone(),
                     ));
                     return Ok(binary_scheduler);
                 } else {
-                    let scheduler =
-                        self.create_primitive_scheduler(field, &column_info, buffers)?;
+                    let scheduler = self.create_primitive_scheduler(
+                        field,
+                        requested_field.data_type(),
+                        &column_info,
+                        buffers,
+                    )?;
                     return Ok(scheduler);
                 }
             } else {
-                return self.create_primitive_scheduler(field, &column_info, buffers);
+                return self.create_primitive_scheduler(
+                    field,
+                    requested_field.data_type(),
+                    &column_info,
+                    buffers,
+                );
             }
         }
         match &data_type {
@@ -893,8 +1000,12 @@ impl CoreFieldDecoderStrategy {
                 // depending on the child data type.
                 if Self::is_primitive_legacy(inner.data_type()) {
                     let primitive_col = column_infos.expect_next()?;
-                    let scheduler =
-                        self.create_primitive_scheduler(field, primitive_col, buffers)?;
+                    let scheduler = self.create_primitive_scheduler(
+                        field,
+                        requested_field.data_type(),
+                        primitive_col,
+                        buffers,
+                    )?;
                     Ok(scheduler)
                 } else {
                     todo!()
@@ -903,8 +1014,12 @@ impl CoreFieldDecoderStrategy {
             DataType::Dictionary(_key_type, value_type) => {
                 if Self::is_primitive_legacy(value_type) || value_type.is_binary_like() {
                     let primitive_col = column_infos.expect_next()?;
-                    let scheduler =
-                        self.create_primitive_scheduler(field, primitive_col, buffers)?;
+                    let scheduler = self.create_primitive_scheduler(
+                        field,
+                        requested_field.data_type(),
+                        primitive_col,
+                        buffers,
+                    )?;
                     Ok(scheduler)
                 } else {
                     Err(Error::not_supported_source(
@@ -919,20 +1034,36 @@ impl CoreFieldDecoderStrategy {
             DataType::List(_) | DataType::LargeList(_) => {
                 let offsets_column = column_infos.expect_next()?.clone();
                 column_infos.next_top_level();
-                self.create_list_scheduler(field, column_infos, buffers, &offsets_column)
+                self.create_list_scheduler(
+                    field,
+                    requested_field,
+                    column_infos,
+                    buffers,
+                    &offsets_column,
+                )
             }
-            DataType::Struct(fields) => {
+            DataType::Struct(_) => {
                 let column_info = column_infos.expect_next()?;
 
                 // Column is blob and user is asking for descriptions
                 if let Some(blob_col) = Self::unwrap_blob(column_info.as_ref()) {
                     // Can use primitive scheduler here since descriptions are always packed struct
-                    return self.create_primitive_scheduler(field, &blob_col, buffers);
+                    return self.create_primitive_scheduler(
+                        field,
+                        requested_field.data_type(),
+                        &blob_col,
+                        buffers,
+                    );
                 }
 
                 if Self::check_packed_struct(column_info) {
                     // use packed struct encoding
-                    self.create_primitive_scheduler(field, column_info, buffers)
+                    self.create_primitive_scheduler(
+                        field,
+                        requested_field.data_type(),
+                        column_info,
+                        buffers,
+                    )
                 } else {
                     // use default struct encoding
                     Self::check_simple_struct(column_info, &field.name).unwrap();
@@ -941,18 +1072,41 @@ impl CoreFieldDecoderStrategy {
                         .iter()
                         .map(|page| page.num_rows)
                         .sum();
+                    let requested_fields = match requested_field.data_type() {
+                        DataType::Struct(fields) => fields,
+                        requested_type => {
+                            return Err(Error::invalid_input(format!(
+                                "requested field {} has type {}, expected Struct",
+                                requested_field.name(),
+                                requested_type
+                            )));
+                        }
+                    };
+                    if requested_fields.len() != field.children.len() {
+                        return Err(Error::invalid_input(format!(
+                            "requested struct field {} has {} children but stored field has {}",
+                            requested_field.name(),
+                            requested_fields.len(),
+                            field.children.len()
+                        )));
+                    }
                     let mut child_schedulers = Vec::with_capacity(field.children.len());
-                    for field in &field.children {
+                    for (field, requested_field) in
+                        field.children.iter().zip(requested_fields.iter())
+                    {
                         column_infos.next_top_level();
-                        let field_scheduler =
-                            self.create_legacy_field_scheduler(field, column_infos, buffers)?;
+                        let field_scheduler = self.create_legacy_field_scheduler(
+                            field,
+                            requested_field,
+                            column_infos,
+                            buffers,
+                        )?;
                         child_schedulers.push(Arc::from(field_scheduler));
                     }
 
-                    let fields = fields.clone();
                     Ok(Box::new(SimpleStructScheduler::new(
                         child_schedulers,
-                        fields,
+                        requested_fields.clone(),
                         num_rows,
                     )))
                 }
@@ -1030,13 +1184,49 @@ impl DecodeBatchScheduler {
         filter: &FilterExpression,
         decoder_config: &DecoderConfig,
     ) -> Result<Self> {
+        let output_schema = ArrowSchema::from(schema);
+        Self::try_new_with_output_schema(
+            schema,
+            &output_schema,
+            column_indices,
+            column_infos,
+            file_buffer_positions_and_sizes,
+            num_rows,
+            _decoder_plugins,
+            io,
+            cache,
+            filter,
+            decoder_config,
+        )
+        .await
+    }
+
+    /// Creates a new decode scheduler using a separate Arrow output schema.
+    ///
+    /// The Lance schema describes the stored fields and drives physical
+    /// traversal. The Arrow schema describes the in-memory types produced by
+    /// the decoders.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn try_new_with_output_schema<'a>(
+        schema: &'a Schema,
+        output_schema: &'a ArrowSchema,
+        column_indices: &[u32],
+        column_infos: &[Arc<ColumnInfo>],
+        file_buffer_positions_and_sizes: &'a Vec<(u64, u64)>,
+        num_rows: u64,
+        _decoder_plugins: Arc<DecoderPlugins>,
+        io: Arc<dyn EncodingsIo>,
+        cache: Arc<LanceCache>,
+        filter: &FilterExpression,
+        decoder_config: &DecoderConfig,
+    ) -> Result<Self> {
         assert!(num_rows > 0);
         let buffers = FileBuffers {
             positions_and_sizes: file_buffer_positions_and_sizes,
         };
-        let arrow_schema = ArrowSchema::from(schema);
-        let root_fields = arrow_schema.fields().clone();
-        let root_type = DataType::Struct(root_fields.clone());
+        let storage_arrow_schema = ArrowSchema::from(schema);
+        let root_fields = output_schema.fields().clone();
+        let root_type = DataType::Struct(storage_arrow_schema.fields().clone());
         let mut root_field = Field::try_from(&ArrowField::new("root", root_type, false))?;
         // root_field.children and schema.fields should be identical at this point but the latter
         // has field ids and the former does not.  This line restores that.
@@ -1045,13 +1235,18 @@ impl DecodeBatchScheduler {
         root_field
             .metadata
             .insert("__lance_decoder_root".to_string(), "true".to_string());
+        let requested_root_field =
+            ArrowField::new("root", DataType::Struct(root_fields.clone()), false);
 
         if column_infos.is_empty() || column_infos[0].is_structural() {
             let mut column_iter = ColumnInfoIter::new(column_infos.to_vec(), column_indices);
 
             let strategy = CoreFieldDecoderStrategy::from_decoder_config(decoder_config);
-            let mut root_scheduler =
-                strategy.create_structural_field_scheduler(&root_field, &mut column_iter)?;
+            let mut root_scheduler = strategy.create_structural_field_scheduler(
+                &root_field,
+                &requested_root_field,
+                &mut column_iter,
+            )?;
 
             let context = SchedulerContext::new(io, cache.clone());
             root_scheduler.initialize(filter, &context).await?;
@@ -1074,8 +1269,12 @@ impl DecodeBatchScheduler {
                 .collect::<Vec<_>>();
             let mut column_iter = ColumnInfoIter::new(columns, &adjusted_column_indices);
             let strategy = CoreFieldDecoderStrategy::from_decoder_config(decoder_config);
-            let root_scheduler =
-                strategy.create_legacy_field_scheduler(&root_field, &mut column_iter, buffers)?;
+            let root_scheduler = strategy.create_legacy_field_scheduler(
+                &root_field,
+                &requested_root_field,
+                &mut column_iter,
+                buffers,
+            )?;
 
             let context = SchedulerContext::new(io, cache.clone());
             root_scheduler.initialize(filter, &context).await?;
@@ -2060,10 +2259,33 @@ pub fn create_decode_stream(
     rx: mpsc::UnboundedReceiver<Result<DecoderMessage>>,
     batch_size_bytes: Option<u64>,
 ) -> Result<BoxStream<'static, ReadBatchTask>> {
+    let output_schema = ArrowSchema::from(schema);
+    create_decode_stream_with_output_schema(
+        &output_schema,
+        num_rows,
+        batch_size,
+        is_structural,
+        should_validate,
+        spawn_structural_batch_decode_tasks,
+        rx,
+        batch_size_bytes,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_decode_stream_with_output_schema(
+    output_schema: &ArrowSchema,
+    num_rows: u64,
+    batch_size: u32,
+    is_structural: bool,
+    should_validate: bool,
+    spawn_structural_batch_decode_tasks: bool,
+    rx: mpsc::UnboundedReceiver<Result<DecoderMessage>>,
+    batch_size_bytes: Option<u64>,
+) -> Result<BoxStream<'static, ReadBatchTask>> {
     if is_structural {
-        let arrow_schema = ArrowSchema::from(schema);
         let structural_decoder = StructuralStructDecoder::new(
-            arrow_schema.fields,
+            output_schema.fields().clone(),
             should_validate,
             /*is_root=*/ true,
         )?;
@@ -2080,8 +2302,7 @@ pub fn create_decode_stream(
         if batch_size_bytes.is_some() {
             warn!("batch_size_bytes is not supported for v2.0 files and will be ignored");
         }
-        let arrow_schema = ArrowSchema::from(schema);
-        let root_fields = arrow_schema.fields;
+        let root_fields = output_schema.fields().clone();
 
         let simple_struct_decoder = SimpleStructDecoder::new(root_fields, num_rows);
         Ok(BatchDecodeStream::new(rx, batch_size, num_rows, simple_struct_decoder).into_stream())
@@ -2099,8 +2320,26 @@ pub fn create_decode_iterator(
     is_structural: bool,
     messages: VecDeque<Result<DecoderMessage>>,
 ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
-    let arrow_schema = Arc::new(ArrowSchema::from(schema));
-    let root_fields = arrow_schema.fields.clone();
+    let output_schema = Arc::new(ArrowSchema::from(schema));
+    create_decode_iterator_with_output_schema(
+        output_schema,
+        num_rows,
+        batch_size,
+        should_validate,
+        is_structural,
+        messages,
+    )
+}
+
+pub fn create_decode_iterator_with_output_schema(
+    output_schema: Arc<ArrowSchema>,
+    num_rows: u64,
+    batch_size: u32,
+    should_validate: bool,
+    is_structural: bool,
+    messages: VecDeque<Result<DecoderMessage>>,
+) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
+    let root_fields = output_schema.fields.clone();
     if is_structural {
         let simple_struct_decoder =
             StructuralStructDecoder::new(root_fields, should_validate, /*is_root=*/ true)?;
@@ -2109,7 +2348,7 @@ pub fn create_decode_iterator(
             batch_size,
             num_rows,
             simple_struct_decoder,
-            arrow_schema,
+            output_schema,
         )))
     } else {
         let root_decoder = SimpleStructDecoder::new(root_fields, num_rows);
@@ -2118,7 +2357,7 @@ pub fn create_decode_iterator(
             batch_size,
             num_rows,
             root_decoder,
-            arrow_schema,
+            output_schema,
         )))
     }
 }
@@ -2129,6 +2368,7 @@ async fn create_scheduler_decoder(
     filter: FilterExpression,
     column_indices: Vec<u32>,
     target_schema: Arc<Schema>,
+    output_schema: Arc<ArrowSchema>,
     config: SchedulerDecoderConfig,
 ) -> Result<BoxStream<'static, ReadBatchTask>> {
     let num_rows = requested_rows.num_rows();
@@ -2143,8 +2383,8 @@ async fn create_scheduler_decoder(
 
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let decode_stream = create_decode_stream(
-        &target_schema,
+    let decode_stream = create_decode_stream_with_output_schema(
+        output_schema.as_ref(),
         num_rows,
         config.batch_size,
         is_structural,
@@ -2158,8 +2398,9 @@ async fn create_scheduler_decoder(
     // unless that metadata is already in the cache.  This metadata loading
     // happens as part of this call and should be parallelized if reading
     // multiple files.
-    let mut decode_scheduler = DecodeBatchScheduler::try_new(
+    let mut decode_scheduler = DecodeBatchScheduler::try_new_with_output_schema(
         target_schema.as_ref(),
+        output_schema.as_ref(),
         &column_indices,
         &column_infos,
         &vec![],
@@ -2233,6 +2474,29 @@ pub async fn schedule_and_decode(
     target_schema: Arc<Schema>,
     config: SchedulerDecoderConfig,
 ) -> Result<BoxStream<'static, ReadBatchTask>> {
+    let output_schema = Arc::new(ArrowSchema::from(target_schema.as_ref()));
+    schedule_and_decode_with_output_schema(
+        column_infos,
+        requested_rows,
+        filter,
+        column_indices,
+        target_schema,
+        output_schema,
+        config,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn schedule_and_decode_with_output_schema(
+    column_infos: Vec<Arc<ColumnInfo>>,
+    requested_rows: RequestedRows,
+    filter: FilterExpression,
+    column_indices: Vec<u32>,
+    target_schema: Arc<Schema>,
+    output_schema: Arc<ArrowSchema>,
+    config: SchedulerDecoderConfig,
+) -> Result<BoxStream<'static, ReadBatchTask>> {
     if requested_rows.num_rows() == 0 {
         return Ok(stream::empty().boxed());
     }
@@ -2249,6 +2513,7 @@ pub async fn schedule_and_decode(
         filter,
         column_indices,
         target_schema,
+        output_schema,
         config,
     )
     .await?;
@@ -2286,9 +2551,30 @@ pub fn schedule_and_decode_blocking(
     target_schema: Arc<Schema>,
     config: SchedulerDecoderConfig,
 ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
+    let output_schema = Arc::new(ArrowSchema::from(target_schema.as_ref()));
+    schedule_and_decode_blocking_with_output_schema(
+        column_infos,
+        requested_rows,
+        filter,
+        column_indices,
+        target_schema,
+        output_schema,
+        config,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn schedule_and_decode_blocking_with_output_schema(
+    column_infos: Vec<Arc<ColumnInfo>>,
+    requested_rows: RequestedRows,
+    filter: FilterExpression,
+    column_indices: Vec<u32>,
+    target_schema: Arc<Schema>,
+    output_schema: Arc<ArrowSchema>,
+    config: SchedulerDecoderConfig,
+) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
     if requested_rows.num_rows() == 0 {
-        let arrow_schema = Arc::new(ArrowSchema::from(target_schema.as_ref()));
-        return Ok(Box::new(RecordBatchIterator::new(vec![], arrow_schema)));
+        return Ok(Box::new(RecordBatchIterator::new(vec![], output_schema)));
     }
 
     let num_rows = requested_rows.num_rows();
@@ -2298,18 +2584,20 @@ pub fn schedule_and_decode_blocking(
 
     // Initialize the scheduler.  This is still "asynchronous" but we run it with a current-thread
     // runtime.
-    let mut decode_scheduler = WAITER_RT.block_on(DecodeBatchScheduler::try_new(
-        target_schema.as_ref(),
-        &column_indices,
-        &column_infos,
-        &vec![],
-        num_rows,
-        config.decoder_plugins,
-        config.io.clone(),
-        config.cache,
-        &filter,
-        &config.decoder_config,
-    ))?;
+    let mut decode_scheduler =
+        WAITER_RT.block_on(DecodeBatchScheduler::try_new_with_output_schema(
+            target_schema.as_ref(),
+            output_schema.as_ref(),
+            &column_indices,
+            &column_infos,
+            &vec![],
+            num_rows,
+            config.decoder_plugins,
+            config.io.clone(),
+            config.cache,
+            &filter,
+            &config.decoder_config,
+        ))?;
 
     // Schedule the requested rows
     match requested_rows {
@@ -2331,8 +2619,8 @@ pub fn schedule_and_decode_blocking(
     {}
 
     // Create a decoder to decode the messages
-    let decode_iterator = create_decode_iterator(
-        &target_schema,
+    let decode_iterator = create_decode_iterator_with_output_schema(
+        output_schema,
         num_rows,
         config.batch_size,
         config.decoder_config.validate_on_decode,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3310,7 +3310,8 @@ impl StructuralPrimitiveFieldScheduler {
         column_info: &ColumnInfo,
         decompressors: &dyn DecompressionStrategy,
         cache_repetition_index: bool,
-        target_field: &Field,
+        storage_data_type: &DataType,
+        requested_data_type: &DataType,
     ) -> Result<Self> {
         let page_schedulers = column_info
             .page_infos
@@ -3322,14 +3323,15 @@ impl StructuralPrimitiveFieldScheduler {
                     page_index,
                     decompressors,
                     cache_repetition_index,
-                    target_field,
+                    storage_data_type,
+                    requested_data_type,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
             page_schedulers,
             column_index: column_info.index,
-            view_tag: format!("{:?}", target_field.data_type()),
+            view_tag: format!("{requested_data_type:?}"),
         })
     }
 
@@ -3338,7 +3340,8 @@ impl StructuralPrimitiveFieldScheduler {
         page_layout: &PageLayout,
         decompressors: &dyn DecompressionStrategy,
         cache_repetition_index: bool,
-        target_field: &Field,
+        storage_data_type: &DataType,
+        requested_data_type: &DataType,
     ) -> Result<Box<dyn StructuralPageScheduler>> {
         use pb21::page_layout::Layout;
         Ok(match page_layout.layout.as_ref().expect_ok()? {
@@ -3373,7 +3376,8 @@ impl StructuralPrimitiveFieldScheduler {
                     Box::new(constant::ConstantPageScheduler::try_new(
                         page_info.buffer_offsets_and_sizes.clone(),
                         constant_layout.inline_value.clone(),
-                        target_field.data_type(),
+                        storage_data_type.clone(),
+                        requested_data_type.clone(),
                         def_meaning.into(),
                     )?) as Box<dyn StructuralPageScheduler>
                 } else if def_meaning.len() == 1
@@ -3411,14 +3415,15 @@ impl StructuralPrimitiveFieldScheduler {
                     blob.inner_layout.as_ref().expect_ok()?.as_ref(),
                     decompressors,
                     cache_repetition_index,
-                    target_field,
+                    storage_data_type,
+                    requested_data_type,
                 )?;
                 let def_meaning = blob
                     .layers
                     .iter()
                     .map(|l| ProtobufUtils21::repdef_layer_to_def_interp(*l))
                     .collect::<Vec<_>>();
-                if matches!(target_field.data_type(), DataType::Struct(_)) {
+                if matches!(requested_data_type, DataType::Struct(_)) {
                     // User wants to decode blob into struct
                     Box::new(BlobDescriptionPageScheduler::new(
                         inner_scheduler,
@@ -3442,7 +3447,8 @@ impl StructuralPrimitiveFieldScheduler {
         page_index: usize,
         decompressors: &dyn DecompressionStrategy,
         cache_repetition_index: bool,
-        target_field: &Field,
+        storage_data_type: &DataType,
+        requested_data_type: &DataType,
     ) -> Result<PageInfoAndScheduler> {
         let page_layout = page_info.encoding.as_structural();
         let scheduler = Self::page_layout_to_scheduler(
@@ -3450,7 +3456,8 @@ impl StructuralPrimitiveFieldScheduler {
             page_layout,
             decompressors,
             cache_repetition_index,
-            target_field,
+            storage_data_type,
+            requested_data_type,
         )?;
         Ok(PageInfoAndScheduler {
             page_index,

--- a/rust/lance-encoding/src/encodings/logical/primitive/constant.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/constant.rs
@@ -5,6 +5,7 @@ use std::{any::Any, collections::VecDeque, ops::Range, sync::Arc};
 
 use arrow_array::{Array, ArrayRef, new_empty_array};
 use arrow_buffer::ScalarBuffer;
+use arrow_cast::cast;
 use arrow_schema::DataType;
 use bytes::Bytes;
 use futures::FutureExt;
@@ -108,6 +109,7 @@ pub struct ConstantPageScheduler {
     rep_buf_idx: Option<usize>,
     def_buf_idx: Option<usize>,
     data_type: DataType,
+    requested_data_type: DataType,
     def_meaning: Arc<[DefinitionInterpretation]>,
     max_rep: u16,
     max_visible_def: u16,
@@ -119,6 +121,7 @@ impl ConstantPageScheduler {
         buffer_offsets_and_sizes: Arc<[(u64, u64)]>,
         inline_value: Option<Bytes>,
         data_type: DataType,
+        requested_data_type: DataType,
         def_meaning: Arc<[DefinitionInterpretation]>,
     ) -> Result<Self> {
         let max_rep = def_meaning.iter().filter(|d| d.is_list()).count() as u16;
@@ -175,6 +178,7 @@ impl ConstantPageScheduler {
             rep_buf_idx,
             def_buf_idx,
             data_type,
+            requested_data_type,
             def_meaning,
             max_rep,
             max_visible_def,
@@ -231,7 +235,10 @@ impl crate::encodings::logical::primitive::StructuralPageScheduler for ConstantP
                 &self.data_type,
                 inline.as_slice(),
             ) {
-                Ok(s) => s,
+                Ok(s) => match cast(&s, &self.requested_data_type) {
+                    Ok(s) => s,
+                    Err(e) => return std::future::ready(Err(e.into())).boxed(),
+                },
                 Err(e) => return std::future::ready(Err(e.into())).boxed(),
             };
             let cached = Arc::new(CachedConstantState {
@@ -246,6 +253,7 @@ impl crate::encodings::logical::primitive::StructuralPageScheduler for ConstantP
         let data = io.submit_request(reads, 0);
         let scalar_source = self.scalar_source.clone();
         let data_type = self.data_type.clone();
+        let requested_data_type = self.requested_data_type.clone();
         async move {
             let mut data_iter = data.await?.into_iter();
 
@@ -259,6 +267,7 @@ impl crate::encodings::logical::primitive::StructuralPageScheduler for ConstantP
                     lance_arrow::scalar::decode_scalar_from_value_buffer(&data_type, buf.as_ref())?
                 }
             };
+            let scalar = cast(&scalar, &requested_data_type)?;
 
             let rep = rep_range.map(|_| {
                 let rep = data_iter.next().unwrap();

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    Array, ArrayRef, GenericByteArray, GenericListArray,
+    Array, ArrayRef, BinaryViewArray, GenericByteArray, GenericListArray, StringViewArray,
     cast::AsArray,
     types::{BinaryType, ByteArrayType, LargeBinaryType, LargeUtf8Type, UInt8Type, Utf8Type},
 };
@@ -152,7 +152,9 @@ pub struct BinaryArrayDecoder {
 }
 
 impl BinaryArrayDecoder {
-    fn from_list_array<T: ByteArrayType>(array: &GenericListArray<T::Offset>) -> ArrayRef {
+    fn from_list_array<T: ByteArrayType>(
+        array: &GenericListArray<T::Offset>,
+    ) -> GenericByteArray<T> {
         let values = array
             .values()
             .as_primitive::<UInt8Type>()
@@ -160,11 +162,7 @@ impl BinaryArrayDecoder {
             .inner()
             .clone();
         let offsets = array.offsets().clone();
-        Arc::new(GenericByteArray::<T>::new(
-            offsets,
-            values,
-            array.nulls().cloned(),
-        ))
+        GenericByteArray::<T>::new(offsets, values, array.nulls().cloned())
     }
 }
 
@@ -173,10 +171,26 @@ impl DecodeArrayTask for BinaryArrayDecoder {
         let data_type = self.data_type;
         let (arr, _) = self.inner.decode()?;
         let result = match data_type {
-            DataType::Binary => Self::from_list_array::<BinaryType>(arr.as_list::<i32>()),
-            DataType::LargeBinary => Self::from_list_array::<LargeBinaryType>(arr.as_list::<i64>()),
-            DataType::Utf8 => Self::from_list_array::<Utf8Type>(arr.as_list::<i32>()),
-            DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
+            DataType::Binary => {
+                Arc::new(Self::from_list_array::<BinaryType>(arr.as_list::<i32>())) as ArrayRef
+            }
+            DataType::LargeBinary => Arc::new(Self::from_list_array::<LargeBinaryType>(
+                arr.as_list::<i64>(),
+            )) as ArrayRef,
+            DataType::Utf8 => {
+                Arc::new(Self::from_list_array::<Utf8Type>(arr.as_list::<i32>())) as ArrayRef
+            }
+            DataType::LargeUtf8 => {
+                Arc::new(Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>())) as ArrayRef
+            }
+            DataType::BinaryView => {
+                Arc::new(BinaryViewArray::from(&Self::from_list_array::<BinaryType>(
+                    arr.as_list::<i32>(),
+                )))
+            }
+            DataType::Utf8View => Arc::new(StringViewArray::from(
+                &Self::from_list_array::<Utf8Type>(arr.as_list::<i32>()),
+            )),
             _ => panic!("Binary decoder does not support this data type"),
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use arrow_array::RecordBatchReader;
-use arrow_schema::Schema as ArrowSchema;
+use arrow_schema::{DataType, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt, stream::BoxStream};
@@ -19,8 +19,8 @@ use lance_encoding::{
     EncodingsIo,
     decoder::{
         ColumnInfo, DecoderConfig, DecoderPlugins, FilterExpression, PageEncoding, PageInfo,
-        ReadBatchTask, RequestedRows, SchedulerDecoderConfig, schedule_and_decode,
-        schedule_and_decode_blocking,
+        ReadBatchTask, RequestedRows, SchedulerDecoderConfig,
+        schedule_and_decode_blocking_with_output_schema, schedule_and_decode_with_output_schema,
     },
     encoder::EncodedBatch,
     version::LanceFileVersion,
@@ -210,20 +210,11 @@ impl CachedFileMetadata {
     }
 }
 
-/// Selecting columns from a lance file requires specifying both the
-/// index of the column and the data type of the column
+/// Selecting columns from a Lance file requires specifying both the
+/// index of the column and the stored semantic type of the column.
 ///
-/// Partly, this is because it is not strictly required that columns
-/// be read into the same type.  For example, a string column may be
-/// read as a string, large_string or string_view type.
-///
-/// A read will only succeed if the decoder for a column is capable
-/// of decoding into the requested type.
-///
-/// Note that this should generally be limited to different in-memory
-/// representations of the same semantic type.  An encoding could
-/// theoretically support "casting" (e.g. int to string, etc.) but
-/// there is little advantage in doing so here.
+/// Use [`ReaderRequest`] when a different supported in-memory Arrow
+/// representation is desired.
 ///
 /// Note: in order to specify a projection the user will need some way
 /// to figure out the column indices.  In the table format we do this
@@ -399,6 +390,109 @@ impl ReaderProjection {
             schema: Arc::new(projected),
             column_indices,
         })
+    }
+}
+
+/// A file read request with separate storage and Arrow output schemas.
+///
+/// The projection identifies stored columns and their Lance types. The output
+/// schema controls the in-memory Arrow representation. Exact type matches are
+/// supported, along with top-level `Utf8` to `Utf8View` and `Binary` to
+/// `BinaryView` aliases.
+#[derive(Debug, Clone)]
+pub struct ReaderRequest {
+    projection: ReaderProjection,
+    output_schema: ArrowSchemaRef,
+}
+
+impl ReaderRequest {
+    /// Creates a request that preserves the projection's default Arrow types.
+    pub fn from_projection(projection: ReaderProjection) -> Self {
+        let output_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
+        Self {
+            projection,
+            output_schema,
+        }
+    }
+
+    /// Creates a request with an explicit Arrow output schema.
+    ///
+    /// Field order, names, nullability, and metadata must match the projection.
+    /// Only top-level `Utf8` to `Utf8View` and `Binary` to `BinaryView` type
+    /// aliases are accepted.
+    pub fn try_new(projection: ReaderProjection, output_schema: ArrowSchemaRef) -> Result<Self> {
+        let projected_schema = ArrowSchema::from(projection.schema.as_ref());
+        if projected_schema.metadata() != output_schema.metadata() {
+            return Err(Error::invalid_input(
+                "The requested output schema metadata does not match the projection schema metadata",
+            ));
+        }
+        if projected_schema.fields().len() != output_schema.fields().len() {
+            return Err(Error::invalid_input(format!(
+                "The requested output schema has {} fields but the projection schema has {}",
+                output_schema.fields().len(),
+                projected_schema.fields().len()
+            )));
+        }
+        for (index, (projected_field, output_field)) in projected_schema
+            .fields()
+            .iter()
+            .zip(output_schema.fields())
+            .enumerate()
+        {
+            if projected_field.name() != output_field.name() {
+                return Err(Error::invalid_input(format!(
+                    "The requested output field at index {index} is named '{}' but the projection field is named '{}'",
+                    output_field.name(),
+                    projected_field.name()
+                )));
+            }
+            if projected_field.is_nullable() != output_field.is_nullable() {
+                return Err(Error::invalid_input(format!(
+                    "The requested output field '{}' has nullable={} but the projection field has nullable={}",
+                    output_field.name(),
+                    output_field.is_nullable(),
+                    projected_field.is_nullable()
+                )));
+            }
+            if projected_field.metadata() != output_field.metadata() {
+                return Err(Error::invalid_input(format!(
+                    "The requested output field '{}' metadata does not match the projection field metadata",
+                    output_field.name()
+                )));
+            }
+            let is_supported_type = projected_field.data_type() == output_field.data_type()
+                || matches!(
+                    (projected_field.data_type(), output_field.data_type()),
+                    (DataType::Utf8, DataType::Utf8View) | (DataType::Binary, DataType::BinaryView)
+                );
+            if !is_supported_type {
+                return Err(Error::invalid_input(format!(
+                    "The requested output field '{}' has type {} but the projection field has type {}; only exact matches, Utf8 to Utf8View, and Binary to BinaryView are supported",
+                    output_field.name(),
+                    output_field.data_type(),
+                    projected_field.data_type()
+                )));
+            }
+        }
+        Ok(Self {
+            projection,
+            output_schema,
+        })
+    }
+
+    /// Returns the stored-column projection for this request.
+    pub fn projection(&self) -> &ReaderProjection {
+        &self.projection
+    }
+
+    /// Returns the requested in-memory Arrow schema.
+    pub fn output_schema(&self) -> &ArrowSchemaRef {
+        &self.output_schema
+    }
+
+    fn into_parts(self) -> (ReaderProjection, ArrowSchemaRef) {
+        (self.projection, self.output_schema)
     }
 }
 
@@ -996,6 +1090,7 @@ impl FileReader {
         range: Range<u64>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
         batch_size_bytes: Option<u64>,
@@ -1020,12 +1115,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(vec![range]);
 
-        schedule_and_decode(
+        schedule_and_decode_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
         .await
@@ -1035,9 +1131,10 @@ impl FileReader {
         &self,
         range: Range<u64>,
         batch_size: u32,
-        projection: ReaderProjection,
+        request: ReaderRequest,
         filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
+        let (projection, output_schema) = request.into_parts();
         // Create and initialize the stream
         Self::do_read_range(
             self.collect_columns_from_projection(&projection)?,
@@ -1048,6 +1145,7 @@ impl FileReader {
             range,
             batch_size,
             projection,
+            output_schema,
             filter,
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
@@ -1064,6 +1162,7 @@ impl FileReader {
         indices: Vec<u64>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
         batch_size_bytes: Option<u64>,
@@ -1088,12 +1187,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Indices(indices);
 
-        schedule_and_decode(
+        schedule_and_decode_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
         .await
@@ -1103,8 +1203,9 @@ impl FileReader {
         &self,
         indices: Vec<u64>,
         batch_size: u32,
-        projection: ReaderProjection,
+        request: ReaderRequest,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
+        let (projection, output_schema) = request.into_parts();
         // Create and initialize the stream
         Self::do_take_rows(
             self.collect_columns_from_projection(&projection)?,
@@ -1114,6 +1215,7 @@ impl FileReader {
             indices,
             batch_size,
             projection,
+            output_schema,
             FilterExpression::no_filter(),
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
@@ -1130,6 +1232,7 @@ impl FileReader {
         ranges: Vec<Range<u64>>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
         batch_size_bytes: Option<u64>,
@@ -1156,12 +1259,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(ranges);
 
-        schedule_and_decode(
+        schedule_and_decode_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
         .await
@@ -1171,9 +1275,10 @@ impl FileReader {
         &self,
         ranges: Vec<Range<u64>>,
         batch_size: u32,
-        projection: ReaderProjection,
+        request: ReaderRequest,
         filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
+        let (projection, output_schema) = request.into_parts();
         Self::do_read_ranges(
             self.collect_columns_from_projection(&projection)?,
             self.scheduler.clone(),
@@ -1182,6 +1287,7 @@ impl FileReader {
             ranges,
             batch_size,
             projection,
+            output_schema,
             filter,
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
@@ -1220,7 +1326,24 @@ impl FileReader {
         filter: FilterExpression,
     ) -> Result<Pin<Box<dyn Stream<Item = ReadBatchTask> + Send>>> {
         let projection = projection.unwrap_or_else(|| self.base_projection.clone());
-        Self::validate_projection(&projection, &self.metadata)?;
+        self.read_tasks_with_request(
+            params,
+            batch_size,
+            ReaderRequest::from_projection(projection),
+            filter,
+        )
+        .await
+    }
+
+    /// Creates decode tasks using an explicit Arrow output schema.
+    pub async fn read_tasks_with_request(
+        &self,
+        params: ReadBatchParams,
+        batch_size: u32,
+        request: ReaderRequest,
+        filter: FilterExpression,
+    ) -> Result<Pin<Box<dyn Stream<Item = ReadBatchTask> + Send>>> {
+        Self::validate_projection(request.projection(), &self.metadata)?;
         let verify_bound = |params: &ReadBatchParams, bound: u64, inclusive: bool| {
             if bound > self.num_rows || bound == self.num_rows && inclusive {
                 Err(Error::invalid_input(format!(
@@ -1244,14 +1367,14 @@ impl FileReader {
                     }
                 }
                 let indices = indices.iter().map(|idx| idx.unwrap() as u64).collect();
-                self.take_rows(indices, batch_size, projection).await
+                self.take_rows(indices, batch_size, request).await
             }
             ReadBatchParams::Range(range) => {
                 verify_bound(&params, range.end as u64, false)?;
                 self.read_range(
                     range.start as u64..range.end as u64,
                     batch_size,
-                    projection,
+                    request,
                     filter,
                 )
                 .await
@@ -1262,7 +1385,7 @@ impl FileReader {
                     verify_bound(&params, range.end, false)?;
                     ranges_u64.push(range.start..range.end);
                 }
-                self.read_ranges(ranges_u64, batch_size, projection, filter)
+                self.read_ranges(ranges_u64, batch_size, request, filter)
                     .await
             }
             ReadBatchParams::RangeFrom(range) => {
@@ -1270,18 +1393,18 @@ impl FileReader {
                 self.read_range(
                     range.start as u64..self.num_rows,
                     batch_size,
-                    projection,
+                    request,
                     filter,
                 )
                 .await
             }
             ReadBatchParams::RangeTo(range) => {
                 verify_bound(&params, range.end as u64, false)?;
-                self.read_range(0..range.end as u64, batch_size, projection, filter)
+                self.read_range(0..range.end as u64, batch_size, request, filter)
                     .await
             }
             ReadBatchParams::RangeFull => {
-                self.read_range(0..self.num_rows, batch_size, projection, filter)
+                self.read_range(0..self.num_rows, batch_size, request, filter)
                     .await
             }
         }
@@ -1324,16 +1447,35 @@ impl FileReader {
         projection: ReaderProjection,
         filter: FilterExpression,
     ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
-        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
+        self.read_stream_projected_with_request(
+            params,
+            batch_size,
+            batch_readahead,
+            ReaderRequest::from_projection(projection),
+            filter,
+        )
+        .await
+    }
+
+    /// Reads projected data using an explicit Arrow output schema.
+    pub async fn read_stream_projected_with_request(
+        &self,
+        params: ReadBatchParams,
+        batch_size: u32,
+        batch_readahead: u32,
+        request: ReaderRequest,
+        filter: FilterExpression,
+    ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
+        let output_schema = request.output_schema().clone();
         let tasks_stream = self
-            .read_tasks(params, batch_size, Some(projection), filter)
+            .read_tasks_with_request(params, batch_size, request, filter)
             .await?;
         let batch_stream = tasks_stream
             .map(|task| task.task)
             .buffered(batch_readahead as usize)
             .boxed();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            arrow_schema,
+            output_schema,
             batch_stream,
         )))
     }
@@ -1343,6 +1485,7 @@ impl FileReader {
         indices: Vec<u64>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
     ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         let column_infos = self.collect_columns_from_projection(&projection)?;
@@ -1366,12 +1509,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Indices(indices);
 
-        schedule_and_decode_blocking(
+        schedule_and_decode_blocking_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
     }
@@ -1381,6 +1525,7 @@ impl FileReader {
         ranges: Vec<Range<u64>>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
     ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         let column_infos = self.collect_columns_from_projection(&projection)?;
@@ -1406,12 +1551,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(ranges);
 
-        schedule_and_decode_blocking(
+        schedule_and_decode_blocking_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
     }
@@ -1421,6 +1567,7 @@ impl FileReader {
         range: Range<u64>,
         batch_size: u32,
         projection: ReaderProjection,
+        output_schema: ArrowSchemaRef,
         filter: FilterExpression,
     ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         let column_infos = self.collect_columns_from_projection(&projection)?;
@@ -1446,12 +1593,13 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(vec![range]);
 
-        schedule_and_decode_blocking(
+        schedule_and_decode_blocking_with_output_schema(
             column_infos,
             requested_rows,
             filter,
             projection.column_indices,
             projection.schema,
+            output_schema,
             config,
         )
     }
@@ -1475,7 +1623,24 @@ impl FileReader {
         filter: FilterExpression,
     ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         let projection = projection.unwrap_or_else(|| self.base_projection.clone());
-        Self::validate_projection(&projection, &self.metadata)?;
+        self.read_stream_projected_blocking_with_request(
+            params,
+            batch_size,
+            ReaderRequest::from_projection(projection),
+            filter,
+        )
+    }
+
+    /// Blocking read using an explicit Arrow output schema.
+    pub fn read_stream_projected_blocking_with_request(
+        &self,
+        params: ReadBatchParams,
+        batch_size: u32,
+        request: ReaderRequest,
+        filter: FilterExpression,
+    ) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
+        Self::validate_projection(request.projection(), &self.metadata)?;
+        let (projection, output_schema) = request.into_parts();
         let verify_bound = |params: &ReadBatchParams, bound: u64, inclusive: bool| {
             if bound > self.num_rows || bound == self.num_rows && inclusive {
                 Err(Error::invalid_input(format!(
@@ -1499,7 +1664,7 @@ impl FileReader {
                     }
                 }
                 let indices = indices.iter().map(|idx| idx.unwrap() as u64).collect();
-                self.take_rows_blocking(indices, batch_size, projection, filter)
+                self.take_rows_blocking(indices, batch_size, projection, output_schema, filter)
             }
             ReadBatchParams::Range(range) => {
                 verify_bound(&params, range.end as u64, false)?;
@@ -1507,6 +1672,7 @@ impl FileReader {
                     range.start as u64..range.end as u64,
                     batch_size,
                     projection,
+                    output_schema,
                     filter,
                 )
             }
@@ -1516,7 +1682,7 @@ impl FileReader {
                     verify_bound(&params, range.end, false)?;
                     ranges_u64.push(range.start..range.end);
                 }
-                self.read_ranges_blocking(ranges_u64, batch_size, projection, filter)
+                self.read_ranges_blocking(ranges_u64, batch_size, projection, output_schema, filter)
             }
             ReadBatchParams::RangeFrom(range) => {
                 verify_bound(&params, range.start as u64, true)?;
@@ -1524,16 +1690,27 @@ impl FileReader {
                     range.start as u64..self.num_rows,
                     batch_size,
                     projection,
+                    output_schema,
                     filter,
                 )
             }
             ReadBatchParams::RangeTo(range) => {
                 verify_bound(&params, range.end as u64, false)?;
-                self.read_range_blocking(0..range.end as u64, batch_size, projection, filter)
+                self.read_range_blocking(
+                    0..range.end as u64,
+                    batch_size,
+                    projection,
+                    output_schema,
+                    filter,
+                )
             }
-            ReadBatchParams::RangeFull => {
-                self.read_range_blocking(0..self.num_rows, batch_size, projection, filter)
-            }
+            ReadBatchParams::RangeFull => self.read_range_blocking(
+                0..self.num_rows,
+                batch_size,
+                projection,
+                output_schema,
+                filter,
+            ),
         }
     }
 
@@ -1723,10 +1900,15 @@ impl EncodedBatchReaderExt for EncodedBatch {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, pin::Pin, sync::Arc};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        pin::Pin,
+        sync::Arc,
+    };
 
     use arrow_array::{
-        RecordBatch, UInt32Array,
+        BinaryViewArray, RecordBatch, StringViewArray, UInt32Array,
+        cast::AsArray,
         types::{Float64Type, Int32Type},
     };
     use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
@@ -1740,12 +1922,14 @@ mod tests {
         encoder::{EncodedBatch, EncodingOptions, default_encoding_strategy, encode_batch},
         version::LanceFileVersion,
     };
-    use lance_io::{stream::RecordBatchStream, utils::CachedFileSize};
+    use lance_io::{ReadBatchParams, stream::RecordBatchStream, utils::CachedFileSize};
     use log::debug;
     use rstest::rstest;
     use tokio::sync::mpsc;
 
-    use crate::reader::{EncodedBatchReaderExt, FileReader, FileReaderOptions, ReaderProjection};
+    use crate::reader::{
+        EncodedBatchReaderExt, FileReader, FileReaderOptions, ReaderProjection, ReaderRequest,
+    };
     use crate::testing::{FsFixture, WrittenFile, test_cache, write_lance_file};
     use crate::writer::{EncodedBatchWriteExt, FileWriter, FileWriterOptions};
     use lance_encoding::decoder::DecoderConfig;
@@ -1776,6 +1960,208 @@ mod tests {
             },
         )
         .await
+    }
+
+    async fn create_view_file(fs: &FsFixture, version: LanceFileVersion) -> WrittenFile {
+        let reader = gen_batch()
+            .col("text", array::rand_type(&DataType::Utf8))
+            .col("bytes", array::rand_type(&DataType::Binary))
+            .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+        write_lance_file(
+            reader,
+            fs,
+            FileWriterOptions {
+                format_version: Some(version),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    fn request_projection() -> ReaderProjection {
+        let arrow_schema = ArrowSchema::new(vec![
+            Field::new("text", DataType::Utf8, true),
+            Field::new("bytes", DataType::Binary, false),
+        ]);
+        ReaderProjection {
+            schema: Arc::new(Schema::try_from(&arrow_schema).unwrap()),
+            column_indices: vec![0, 1],
+        }
+    }
+
+    #[test]
+    fn test_reader_request_validation() {
+        let projection = request_projection();
+        let valid_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("text", DataType::Utf8View, true),
+            Field::new("bytes", DataType::BinaryView, false),
+        ]));
+        let request = ReaderRequest::try_new(projection.clone(), valid_schema.clone()).unwrap();
+        assert_eq!(request.output_schema(), &valid_schema);
+
+        let invalid_schemas = [
+            (
+                ArrowSchema::new(vec![Field::new("text", DataType::Utf8View, true)]),
+                "has 1 fields",
+            ),
+            (
+                ArrowSchema::new(vec![
+                    Field::new("renamed", DataType::Utf8View, true),
+                    Field::new("bytes", DataType::BinaryView, false),
+                ]),
+                "named 'renamed'",
+            ),
+            (
+                ArrowSchema::new(vec![
+                    Field::new("text", DataType::Utf8View, false),
+                    Field::new("bytes", DataType::BinaryView, false),
+                ]),
+                "nullable=false",
+            ),
+            (
+                ArrowSchema::new(vec![
+                    Field::new("text", DataType::LargeUtf8, true),
+                    Field::new("bytes", DataType::BinaryView, false),
+                ]),
+                "only exact matches",
+            ),
+            (
+                ArrowSchema::new(vec![
+                    Field::new(
+                        "text",
+                        DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true))),
+                        true,
+                    ),
+                    Field::new("bytes", DataType::BinaryView, false),
+                ]),
+                "only exact matches",
+            ),
+        ];
+        for (output_schema, expected_message) in invalid_schemas {
+            let error =
+                ReaderRequest::try_new(projection.clone(), Arc::new(output_schema)).unwrap_err();
+            assert!(matches!(error, lance_core::Error::InvalidInput { .. }));
+            assert!(error.to_string().contains(expected_message));
+        }
+
+        let field_metadata_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("text", DataType::Utf8View, true)
+                .with_metadata(HashMap::from([("key".to_string(), "value".to_string())])),
+            Field::new("bytes", DataType::BinaryView, false),
+        ]));
+        let error = ReaderRequest::try_new(projection.clone(), field_metadata_schema).unwrap_err();
+        assert!(matches!(error, lance_core::Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("metadata does not match"));
+
+        let schema_metadata = Arc::new(ArrowSchema::new_with_metadata(
+            valid_schema.fields().clone(),
+            HashMap::from([("key".to_string(), "value".to_string())]),
+        ));
+        let error = ReaderRequest::try_new(projection, schema_metadata).unwrap_err();
+        assert!(matches!(error, lance_core::Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("schema metadata"));
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_requested_view_decode(
+        #[values(
+            LanceFileVersion::V2_0,
+            LanceFileVersion::V2_1,
+            LanceFileVersion::V2_2,
+            LanceFileVersion::V2_3
+        )]
+        version: LanceFileVersion,
+    ) {
+        let fs = FsFixture::default();
+        let written = create_view_file(&fs, version).await;
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &test_cache(),
+            FileReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+        let projection = ReaderProjection::from_whole_schema(&written.schema, version);
+        let projected_arrow = ArrowSchema::from(projection.schema.as_ref());
+        let output_schema = Arc::new(ArrowSchema::new_with_metadata(
+            projected_arrow
+                .fields()
+                .iter()
+                .map(|field| {
+                    let data_type = match field.data_type() {
+                        DataType::Utf8 => DataType::Utf8View,
+                        DataType::Binary => DataType::BinaryView,
+                        data_type => data_type.clone(),
+                    };
+                    Arc::new(field.as_ref().clone().with_data_type(data_type))
+                })
+                .collect::<Vec<_>>(),
+            projected_arrow.metadata().clone(),
+        ));
+        let request = ReaderRequest::try_new(projection.clone(), output_schema.clone()).unwrap();
+
+        let batches = file_reader
+            .read_stream_projected_with_request(
+                ReadBatchParams::RangeFull,
+                1024,
+                1,
+                request,
+                FilterExpression::no_filter(),
+            )
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].schema_ref(), &output_schema);
+
+        let actual_text = batches[0]
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .unwrap();
+        let expected_text = written.data[0]["text"].as_string::<i32>();
+        assert_eq!(
+            actual_text.iter().collect::<Vec<_>>(),
+            expected_text.iter().collect::<Vec<_>>()
+        );
+        let actual_bytes = batches[0]
+            .column_by_name("bytes")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .unwrap();
+        let expected_bytes = written.data[0]["bytes"].as_binary::<i32>();
+        assert_eq!(
+            actual_bytes.iter().collect::<Vec<_>>(),
+            expected_bytes.iter().collect::<Vec<_>>()
+        );
+
+        let default_batches = file_reader
+            .read_stream_projected(
+                ReadBatchParams::RangeFull,
+                1024,
+                1,
+                projection,
+                FilterExpression::no_filter(),
+            )
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(default_batches[0]["text"].data_type(), &DataType::Utf8);
+        assert_eq!(default_batches[0]["bytes"].data_type(), &DataType::Binary);
     }
 
     type Transformer = Box<dyn Fn(&RecordBatch) -> RecordBatch>;

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -17,7 +17,7 @@ use arrow_array::types::UInt64Type;
 use arrow_array::{
     Array, RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array, new_null_array,
 };
-use arrow_schema::Schema as ArrowSchema;
+use arrow_schema::{DataType, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use futures::future::{BoxFuture, try_join_all};
@@ -37,7 +37,7 @@ use lance_encoding::decoder::DecoderPlugins;
 use lance_file::previous::reader::{
     FileReader as PreviousFileReader, read_batch as previous_read_batch,
 };
-use lance_file::reader::{CachedFileMetadata, FileReaderOptions, ReaderProjection};
+use lance_file::reader::{CachedFileMetadata, FileReaderOptions, ReaderProjection, ReaderRequest};
 use lance_file::version::LanceFileVersion;
 use lance_file::{LanceEncodingsIo, determine_file_version};
 use lance_io::ReadBatchParams;
@@ -321,6 +321,32 @@ impl GenericFileReader for V1Reader {
     }
 }
 
+fn project_output_schema(
+    output_schema: &ArrowSchema,
+    projection: &Schema,
+) -> Result<ArrowSchemaRef> {
+    let projected_schema = ArrowSchema::from(projection);
+    let fields = projected_schema
+        .fields()
+        .iter()
+        .map(|projected_field| {
+            let output_field = output_schema.field_with_name(projected_field.name())?;
+            if matches!(
+                (projected_field.data_type(), output_field.data_type()),
+                (DataType::Utf8, DataType::Utf8View) | (DataType::Binary, DataType::BinaryView)
+            ) {
+                Ok(Arc::new(output_field.clone()))
+            } else {
+                Ok(projected_field.clone())
+            }
+        })
+        .collect::<std::result::Result<Vec<_>, arrow_schema::ArrowError>>()?;
+    Ok(Arc::new(ArrowSchema::new_with_metadata(
+        fields,
+        projected_schema.metadata().clone(),
+    )))
+}
+
 mod v2_adapter {
     use lance_encoding::decoder::FilterExpression;
 
@@ -330,6 +356,7 @@ mod v2_adapter {
     pub struct Reader {
         reader: Arc<lance_file::reader::FileReader>,
         projection: Arc<Schema>,
+        output_schema: ArrowSchemaRef,
         field_id_to_column_idx: Arc<BTreeMap<u32, u32>>,
         default_priority: u32,
         file_scheduler: FileScheduler,
@@ -339,6 +366,7 @@ mod v2_adapter {
         pub fn new(
             reader: Arc<lance_file::reader::FileReader>,
             projection: Arc<Schema>,
+            output_schema: ArrowSchemaRef,
             field_id_to_column_idx: Arc<BTreeMap<u32, u32>>,
             default_priority: u32,
             file_scheduler: FileScheduler,
@@ -346,6 +374,7 @@ mod v2_adapter {
             Self {
                 reader,
                 projection,
+                output_schema,
                 field_id_to_column_idx,
                 default_priority,
                 file_scheduler,
@@ -362,17 +391,20 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
             async move {
+                let output_schema =
+                    project_output_schema(self.output_schema.as_ref(), projection.as_ref())?;
                 let projection = ReaderProjection::from_field_ids(
                     self.reader.metadata().version(),
                     projection.as_ref(),
                     self.field_id_to_column_idx.as_ref(),
                 )?;
+                let request = ReaderRequest::try_new(projection, output_schema)?;
                 Ok(self
                     .reader
-                    .read_tasks(
+                    .read_tasks_with_request(
                         ReadBatchParams::Range(range.start as usize..range.end as usize),
                         batch_size,
-                        Some(projection),
+                        request,
                         FilterExpression::no_filter(),
                     )
                     .await?
@@ -392,17 +424,20 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
             async move {
+                let output_schema =
+                    project_output_schema(self.output_schema.as_ref(), projection.as_ref())?;
                 let projection = ReaderProjection::from_field_ids(
                     self.reader.metadata().version(),
                     projection.as_ref(),
                     self.field_id_to_column_idx.as_ref(),
                 )?;
+                let request = ReaderRequest::try_new(projection, output_schema)?;
                 Ok(self
                     .reader
-                    .read_tasks(
+                    .read_tasks_with_request(
                         ReadBatchParams::Ranges(ranges),
                         batch_size,
-                        Some(projection),
+                        request,
                         FilterExpression::no_filter(),
                     )
                     .await?
@@ -421,17 +456,20 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
             async move {
+                let output_schema =
+                    project_output_schema(self.output_schema.as_ref(), projection.as_ref())?;
                 let projection = ReaderProjection::from_field_ids(
                     self.reader.metadata().version(),
                     projection.as_ref(),
                     self.field_id_to_column_idx.as_ref(),
                 )?;
+                let request = ReaderRequest::try_new(projection, output_schema)?;
                 Ok(self
                     .reader
-                    .read_tasks(
+                    .read_tasks_with_request(
                         ReadBatchParams::RangeFull,
                         batch_size,
-                        Some(projection),
+                        request,
                         FilterExpression::no_filter(),
                     )
                     .await?
@@ -453,11 +491,14 @@ mod v2_adapter {
         ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
             let indices = UInt32Array::from(indices.to_vec());
             async move {
+                let output_schema =
+                    project_output_schema(self.output_schema.as_ref(), projection.as_ref())?;
                 let projection = ReaderProjection::from_field_ids(
                     self.reader.metadata().version(),
                     projection.as_ref(),
                     self.field_id_to_column_idx.as_ref(),
                 )?;
+                let request = ReaderRequest::try_new(projection, output_schema)?;
 
                 let reader = if let Some(take_priority) = take_priority {
                     let op_priority = ((take_priority as u64) << 32) | self.default_priority as u64;
@@ -471,10 +512,10 @@ mod v2_adapter {
                 };
 
                 Ok(reader
-                    .read_tasks(
+                    .read_tasks_with_request(
                         ReadBatchParams::Indices(indices),
                         batch_size,
-                        Some(projection),
+                        request,
                         FilterExpression::no_filter(),
                     )
                     .await?
@@ -540,12 +581,17 @@ mod v2_adapter {
 #[derive(Debug, Clone)]
 struct NullReader {
     schema: Arc<Schema>,
+    output_schema: ArrowSchemaRef,
     num_rows: u32,
 }
 
 impl NullReader {
-    fn new(schema: Arc<Schema>, num_rows: u32) -> Self {
-        Self { schema, num_rows }
+    fn new(schema: Arc<Schema>, output_schema: ArrowSchemaRef, num_rows: u32) -> Self {
+        Self {
+            schema,
+            output_schema,
+            num_rows,
+        }
     }
 
     fn batch(projection: Arc<ArrowSchema>, num_rows: usize) -> RecordBatch {
@@ -574,25 +620,26 @@ impl GenericFileReader for NullReader {
         batch_size: u32,
         projection: Arc<Schema>,
     ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
-        let mut remaining_rows = ranges.iter().map(|r| r.end - r.start).sum::<u64>();
-        let projection: Arc<ArrowSchema> = Arc::new(projection.as_ref().into());
+        async move {
+            let mut remaining_rows = ranges.iter().map(|r| r.end - r.start).sum::<u64>();
+            let projection =
+                project_output_schema(self.output_schema.as_ref(), projection.as_ref())?;
+            let task_iter = std::iter::from_fn(move || {
+                if remaining_rows == 0 {
+                    return None;
+                }
 
-        let task_iter = std::iter::from_fn(move || {
-            if remaining_rows == 0 {
-                return None;
-            }
-
-            let num_rows = remaining_rows.min(batch_size as u64) as usize;
-            remaining_rows -= num_rows as u64;
-            let batch = Self::batch(projection.clone(), num_rows);
-            let task = ReadBatchTask {
-                task: futures::future::ready(Ok(batch)).boxed(),
-                num_rows: num_rows as u32,
-            };
-            Some(task)
-        });
-
-        async move { Ok(futures::stream::iter(task_iter).boxed()) }.boxed()
+                let num_rows = remaining_rows.min(batch_size as u64) as usize;
+                remaining_rows -= num_rows as u64;
+                let batch = Self::batch(projection.clone(), num_rows);
+                Some(ReadBatchTask {
+                    task: futures::future::ready(Ok(batch)).boxed(),
+                    num_rows: num_rows as u32,
+                })
+            });
+            Ok(futures::stream::iter(task_iter).boxed())
+        }
+        .boxed()
     }
 
     fn read_all_tasks(
@@ -838,9 +885,11 @@ impl FileFragment {
         scan_scheduler: Arc<ScanScheduler>,
     ) -> Result<Vec<(u32, u64)>> {
         let mut stats = Vec::new();
+        let output_schema = Arc::new(ArrowSchema::from(dataset_schema));
         for reader in self
             .open_readers(
                 dataset_schema,
+                &output_schema,
                 &FragReadConfig::default().with_scan_scheduler(scan_scheduler),
             )
             .await?
@@ -900,7 +949,28 @@ impl FileFragment {
         projection: &Schema,
         read_config: FragReadConfig,
     ) -> Result<FragmentReader> {
-        let open_files = self.open_readers(projection, &read_config);
+        self.open_with_output_schema(
+            projection,
+            Arc::new(ArrowSchema::from(projection)),
+            read_config,
+        )
+        .await
+    }
+
+    /// Opens a fragment while requesting a different Arrow representation for
+    /// the projected storage fields.
+    pub(crate) async fn open_with_output_schema(
+        &self,
+        projection: &Schema,
+        output_schema: ArrowSchemaRef,
+        read_config: FragReadConfig,
+    ) -> Result<FragmentReader> {
+        let output_schema = if self.metadata.files.iter().any(DataFile::is_legacy_file) {
+            Arc::new(ArrowSchema::from(projection))
+        } else {
+            output_schema
+        };
+        let open_files = self.open_readers(projection, &output_schema, &read_config);
         let deletion_vec_load = self.get_deletion_vector();
 
         let row_id_load = if self.dataset.manifest.uses_stable_row_ids() {
@@ -926,13 +996,12 @@ impl FileFragment {
         }
 
         let num_physical_rows = self.physical_rows().await?;
-
         let mut reader = FragmentReader::try_new(
             self.id(),
             deletion_vec,
             row_id_sequence,
             opened_files,
-            ArrowSchema::from(projection),
+            output_schema.as_ref().clone(),
             self.count_rows(None).await?,
             num_physical_rows,
             Arc::new(self.metadata.clone()),
@@ -962,6 +1031,7 @@ impl FileFragment {
         &self,
         data_file: &DataFile,
         projection: Option<&Schema>,
+        output_schema: Option<&ArrowSchema>,
         read_config: &FragReadConfig,
     ) -> Result<Option<Box<dyn GenericFileReader>>> {
         let full_schema = self.dataset.schema();
@@ -970,6 +1040,11 @@ impl FileFragment {
         let projection = projection.unwrap_or(full_schema);
         // Also remove any fields that are not part of the user's provided projection
         let schema_per_file = Arc::new(projection.intersection_ignore_types(&data_file_schema)?);
+        let output_schema_per_file = if let Some(output_schema) = output_schema {
+            project_output_schema(output_schema, schema_per_file.as_ref())?
+        } else {
+            Arc::new(ArrowSchema::from(schema_per_file.as_ref()))
+        };
 
         if data_file.is_legacy_file() {
             let max_field_id = data_file.fields.iter().max().unwrap();
@@ -1069,6 +1144,7 @@ impl FileFragment {
             let reader = v2_adapter::Reader::new(
                 reader,
                 schema_per_file,
+                output_schema_per_file,
                 field_id_to_column_idx,
                 reader_priority,
                 file_scheduler,
@@ -1080,12 +1156,18 @@ impl FileFragment {
     async fn open_readers(
         &self,
         projection: &Schema,
+        output_schema: &ArrowSchemaRef,
         read_config: &FragReadConfig,
     ) -> Result<Vec<Box<dyn GenericFileReader>>> {
         let mut opened_files = vec![];
         for data_file in &self.metadata.files {
             if let Some(reader) = self
-                .open_reader(data_file, Some(projection), read_config)
+                .open_reader(
+                    data_file,
+                    Some(projection),
+                    Some(output_schema.as_ref()),
+                    read_config,
+                )
                 .await?
             {
                 opened_files.push(reader);
@@ -1106,7 +1188,13 @@ impl FileFragment {
         missing_fields.retain(|f| !field_ids_in_files.contains(f) && *f >= 0);
         if !missing_fields.is_empty() {
             let missing_projection = projection.project_by_ids(&missing_fields, true);
-            let null_reader = NullReader::new(Arc::new(missing_projection), num_rows as u32);
+            let missing_output_schema =
+                project_output_schema(output_schema.as_ref(), &missing_projection)?;
+            let null_reader = NullReader::new(
+                Arc::new(missing_projection),
+                missing_output_schema,
+                num_rows as u32,
+            );
             opened_files.push(Box::new(null_reader));
         }
 
@@ -1230,7 +1318,7 @@ impl FileFragment {
         // Just open any file. All of them should have same size.
         let some_file = &self.metadata.files[0];
         let reader = self
-            .open_reader(some_file, None, &FragReadConfig::default())
+            .open_reader(some_file, None, None, &FragReadConfig::default())
             .await?
             .ok_or_else(|| {
                 Error::internal(format!(
@@ -1301,7 +1389,7 @@ impl FileFragment {
         let get_lengths = self.metadata.files.iter().map(|data_file| async move {
             let data_file_dir = self.dataset.data_file_dir(data_file)?;
             let reader = self
-                .open_reader(data_file, None, &FragReadConfig::default())
+                .open_reader(data_file, None, None, &FragReadConfig::default())
                 .await?
                 .ok_or_else(|| {
                     Error::corrupt_file(
@@ -2095,6 +2183,10 @@ fn merge_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
 }
 
 impl FragmentReader {
+    pub(crate) fn output_schema(&self) -> &ArrowSchema {
+        &self.output_schema
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn try_new(
         fragment_id: usize,
@@ -2772,6 +2864,38 @@ mod tests {
         session::Session,
         utils::test::TestDatasetGenerator,
     };
+
+    #[tokio::test]
+    async fn test_null_reader_uses_requested_output_schema() {
+        let storage_arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("text", DataType::Utf8, true),
+            ArrowField::new("bytes", DataType::Binary, true),
+        ]);
+        let storage_schema = Arc::new(Schema::try_from(&storage_arrow_schema).unwrap());
+        let output_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("text", DataType::Utf8View, true),
+            ArrowField::new("bytes", DataType::BinaryView, true),
+        ]));
+        let reader = NullReader::new(storage_schema.clone(), output_schema.clone(), 3);
+        let bytes_projection = Arc::new(
+            storage_schema
+                .project_by_schema(
+                    &ArrowSchema::new(vec![ArrowField::new("bytes", DataType::Binary, true)]),
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )
+                .unwrap(),
+        );
+
+        let mut tasks = reader.read_all_tasks(10, bytes_projection).await.unwrap();
+        let batch = tasks.next().await.unwrap().task.await.unwrap();
+
+        assert_eq!(batch.schema().fields().len(), 1);
+        assert_eq!(batch.schema().field(0), output_schema.field(1));
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.column(0).data_type(), &DataType::BinaryView);
+        assert_eq!(batch.column(0).null_count(), 3);
+    }
 
     async fn create_dataset(test_uri: &str, data_storage_version: LanceFileVersion) -> Dataset {
         let schema = Arc::new(ArrowSchema::new(vec![

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{ops::Range, sync::Arc};
 
 use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, Schema as ArrowSchema, SchemaRef};
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
@@ -117,6 +117,34 @@ impl ScopedFragmentRead {
         }
         config
     }
+}
+
+fn use_view_types_for_predicate_columns(
+    read_schema: &ArrowSchema,
+    output_schema: &ArrowSchema,
+    filter_columns: &[String],
+) -> ArrowSchema {
+    let fields = read_schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let is_predicate_only = filter_columns.contains(field.name())
+                && output_schema.field_with_name(field.name()).is_err();
+            let data_type = if is_predicate_only {
+                match field.data_type() {
+                    DataType::Utf8 => Some(DataType::Utf8View),
+                    DataType::Binary => Some(DataType::BinaryView),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            data_type
+                .map(|data_type| Arc::new(field.as_ref().clone().with_data_type(data_type)))
+                .unwrap_or_else(|| field.clone())
+        })
+        .collect::<Vec<_>>();
+    ArrowSchema::new_with_metadata(fields, read_schema.metadata().clone())
 }
 
 /// A fragment with all of its metadata loaded
@@ -1082,24 +1110,37 @@ impl FilteredReadStream {
     ) -> Result<impl Stream<Item = Result<ReadBatchFut>>> {
         let output_schema = Arc::new(fragment_read_task.projection.to_arrow_schema());
 
-        if let Some(filter) = &fragment_read_task.filter {
-            let filter_cols = Planner::column_names_in_expr(filter);
-            if !filter_cols.is_empty() {
+        let filter_columns = if let Some(filter) = &fragment_read_task.filter {
+            let filter_columns = Planner::column_names_in_expr(filter);
+            if !filter_columns.is_empty() {
                 fragment_read_task.projection = Arc::new(
                     fragment_read_task
                         .projection
                         .as_ref()
                         .clone()
-                        .union_columns(filter_cols, OnMissing::Error)?,
+                        .union_columns(filter_columns.iter(), OnMissing::Error)?,
                 );
             }
-        }
+            filter_columns
+        } else {
+            Vec::new()
+        };
 
         let read_schema = fragment_read_task.projection.to_bare_schema();
+        let internal_data_schema = Arc::new(use_view_types_for_predicate_columns(
+            &ArrowSchema::from(&read_schema),
+            output_schema.as_ref(),
+            &filter_columns,
+        ));
         let mut fragment_reader = fragment_read_task
             .fragment
-            .open(&read_schema, fragment_read_task.frag_read_config())
+            .open_with_output_schema(
+                &read_schema,
+                internal_data_schema,
+                fragment_read_task.frag_read_config(),
+            )
             .await?;
+        let internal_schema = Arc::new(fragment_reader.output_schema().clone());
 
         if fragment_read_task.with_deleted_rows {
             fragment_reader.with_make_deletions_null();
@@ -1111,11 +1152,7 @@ impl FilteredReadStream {
 
         let physical_filter = fragment_read_task
             .filter
-            .map(|filter| {
-                let planner =
-                    Planner::new(Arc::new(fragment_read_task.projection.to_arrow_schema()));
-                planner.create_physical_expr(&filter)
-            })
+            .map(|filter| Planner::new(internal_schema).create_physical_expr(&filter))
             .transpose()?;
 
         // We are going to count the fragment as scanned on the first batch we
@@ -2376,6 +2413,48 @@ mod tests {
         ))
     }
 
+    #[test]
+    fn test_use_view_types_for_predicate_columns() {
+        let read_schema = ArrowSchema::new_with_metadata(
+            vec![
+                arrow_schema::Field::new("output_text", DataType::Utf8, true).with_metadata(
+                    HashMap::from([("field".to_string(), "metadata".to_string())]),
+                ),
+                arrow_schema::Field::new("predicate_text", DataType::Utf8, true),
+                arrow_schema::Field::new("predicate_binary", DataType::Binary, true),
+                arrow_schema::Field::new("large_text", DataType::LargeUtf8, true),
+                arrow_schema::Field::new("other", DataType::Int32, true),
+            ],
+            HashMap::from([("schema".to_string(), "metadata".to_string())]),
+        );
+        let output_schema = ArrowSchema::new(vec![arrow_schema::Field::new(
+            "output_text",
+            DataType::Utf8,
+            true,
+        )]);
+        let filter_columns = vec![
+            "output_text".to_string(),
+            "predicate_text".to_string(),
+            "predicate_binary".to_string(),
+            "large_text".to_string(),
+            "other".to_string(),
+        ];
+
+        let view_schema =
+            use_view_types_for_predicate_columns(&read_schema, &output_schema, &filter_columns);
+
+        assert_eq!(view_schema.field(0).data_type(), &DataType::Utf8);
+        assert_eq!(view_schema.field(1).data_type(), &DataType::Utf8View);
+        assert_eq!(view_schema.field(2).data_type(), &DataType::BinaryView);
+        assert_eq!(view_schema.field(3).data_type(), &DataType::LargeUtf8);
+        assert_eq!(view_schema.field(4).data_type(), &DataType::Int32);
+        assert_eq!(view_schema.metadata(), read_schema.metadata());
+        assert_eq!(
+            view_schema.field(0).metadata(),
+            read_schema.field(0).metadata()
+        );
+    }
+
     /// Round-trip every interval shape through the arrow wire format and
     /// confirm the endpoints survive. Exercises both
     /// `IndexExprResult::serialize` and `EvaluatedIndex::try_from_arrow`
@@ -2540,6 +2619,25 @@ mod tests {
         let batches = stream.try_collect::<Vec<_>>().await.unwrap();
         let batch_sizes = batches.iter().map(|b| b.num_rows()).collect::<Vec<_>>();
         assert_eq!(batch_sizes, vec![67]);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_predicate_only_utf8_column() {
+        let fixture = TestFixture::new().await;
+        let filter_plan = fixture
+            .filter_plan("contains(recheck_idx, 'cat')", false)
+            .await;
+        let projection = fixture
+            .dataset
+            .empty_projection()
+            .union_column("not_indexed", OnMissing::Error)
+            .unwrap();
+        let options = FilteredReadOptions::basic_full_read(&fixture.dataset)
+            .with_projection(projection)
+            .with_filter_plan(filter_plan);
+        let expected = UInt32Array::from_iter_values((0..100).filter(|value| value % 3 != 2));
+
+        fixture.test_plan(options, &expected).await;
     }
 
     #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Summary

- add requested Arrow output schemas to the file reader API
- decode stored `Utf8` / `Binary` columns as `Utf8View` / `BinaryView` when explicitly requested
- use view types for predicate-only columns in Lance's filtered-read path while preserving base types for external/default reads
- preserve legacy reader behavior and support V2.0 through V2.3

## Tests

- `cargo test -p lance-encoding --features protoc data::tests`
- `cargo test -p lance-encoding --features protoc test_simple_blob`
- `cargo test -p lance-file --features lance-file/protoc,lance-encoding/protoc test_requested_view_decode`
- `cargo test -p lance-file --features lance-file/protoc,lance-encoding/protoc test_reader_request_validation`
- `cargo test -p lance --features protoc test_predicate_only_utf8_column`
- `cargo check --workspace --tests --benches --features lance/protoc,lance-datafusion/protoc,lance-file/protoc,lance-encoding/protoc,lance-index/protoc,lance-table/protoc`
- `cargo clippy -p lance-encoding -p lance-file -p lance --all-targets --features lance/protoc,lance-datafusion/protoc -- -D warnings`

Part of #7069 (Task 2).
