### PR TITLE
fix(index): prune stale index coverage during rebase

### DIFF
--- a/python/python/tests/test_geo.py
+++ b/python/python/tests/test_geo.py
@@ -273,11 +273,12 @@ def test_staged_rtree_after_rewrite_columns(tmp_path: Path):
     )
 
     assert _query_point_ids(updated, "POINT (10 10)") == [0]
-    committed = updated.commit_existing_index_segments(
+    committed = dataset.commit_existing_index_segments(
         "point_rtree",
         "point",
         [segment],
     )
+    assert committed.describe_indices()[0].segments[0].fragment_ids == set()
     assert _query_point_ids(committed, "POINT (10 10)") == [0]
 
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2741,7 +2741,7 @@ impl Transaction {
 
     /// If an operation modifies one or more fields in a fragment then we need to remove
     /// that fragment from any indices that cover one of the modified fields.
-    fn prune_updated_fields_from_indices(
+    pub(crate) fn prune_updated_fields_from_indices(
         indices: &mut [IndexMetadata],
         updated_fragments: &[Fragment],
         fields_modified: &[u32],

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -578,7 +578,7 @@ impl<'a> TransactionRebase<'a> {
             new_indices,
             removed_indices,
             ..
-        } = &self.transaction.operation
+        } = &mut self.transaction.operation
         {
             match &other_transaction.operation {
                 Operation::Append { .. }
@@ -625,7 +625,19 @@ impl<'a> TransactionRebase<'a> {
                 }
                 // Although some of the rows we indexed may have been deleted / moved,
                 // row ids are still valid, so we allow this optimistically.
-                Operation::Delete { .. } | Operation::Update { .. } => Ok(()),
+                Operation::Delete { .. } => Ok(()),
+                Operation::Update {
+                    updated_fragments,
+                    fields_modified,
+                    ..
+                } => {
+                    Transaction::prune_updated_fields_from_indices(
+                        new_indices,
+                        updated_fragments,
+                        fields_modified,
+                    );
+                    Ok(())
+                }
                 // Merge, reserve, and project don't change row ids, so this should be fine.
                 Operation::Merge { .. } => Ok(()),
                 Operation::ReserveFragments { .. } => Ok(()),
@@ -3567,6 +3579,68 @@ mod tests {
                 "overlay disjoint from the moved row should succeed, got {res:?}"
             );
         }
+    }
+
+    #[rstest::rstest]
+    #[test]
+    #[case::indexed_field_updated(0, vec![0])]
+    #[case::other_field_updated(1, vec![0, 1])]
+    fn test_create_index_rebase_prunes_updated_field_coverage(
+        #[case] field_modified: u32,
+        #[case] expected_fragment_ids: Vec<u32>,
+    ) {
+        let index = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "test".to_string(),
+            fields: vec![0],
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([0, 1])),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+        };
+        let mut rebase = TransactionRebase {
+            transaction: Transaction::new(
+                1,
+                Operation::CreateIndex {
+                    new_indices: vec![index],
+                    removed_indices: vec![],
+                },
+                None,
+            ),
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: HashSet::new(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_compacted_sstables: Vec::new(),
+        };
+        let update = Transaction::new(
+            1,
+            Operation::Update {
+                updated_fragments: vec![Fragment::new(1)],
+                removed_fragment_ids: vec![],
+                new_fragments: vec![],
+                fields_modified: vec![field_modified],
+                compacted_sstables: Vec::new(),
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_fragment_offsets: None,
+            },
+            None,
+        );
+
+        rebase.check_txn(&update, 2).unwrap();
+
+        let Operation::CreateIndex { new_indices, .. } = &rebase.transaction.operation else {
+            panic!("expected CreateIndex operation");
+        };
+        assert_eq!(
+            new_indices[0].fragment_bitmap.as_ref().unwrap(),
+            &RoaringBitmap::from_iter(expected_fragment_ids)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An index can be built from an old dataset handle. If the indexed column is rewritten before the index is committed, the old index may still claim that fragment and return wrong rows.

When the dataset has changed during the commit, this PR checks each new index against the latest data. Fragments whose indexed columns changed are removed from the index coverage, so queries scan those fragments instead.

The fix applies to all index types. RTree is only used for the end-to-end regression test.

## Tests

- Commit an RTree segment from a stale dataset handle after `RewriteColumns`.
- Verify only the index on the changed column loses coverage.
- Focused Rust and Python tests, Clippy, Rust format, and Ruff.

## Related

Follow-up to the stale index coverage problem found in the [review of #7884](https://github.com/lance-format/lance/pull/7884#pullrequestreview-4772712967).