### PR TITLE
docs: include lance-context in the full website build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           repository: lance-format/lance-trino
           path: lance-trino
+      - name: Checkout lance-context
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: lance-format/lance-context
+          path: lance-context
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -83,6 +88,7 @@ jobs:
           LANCE_TRINO_REPO: ${{ github.workspace }}/lance-trino
           LANCE_DUCKDB_REPO: ${{ github.workspace }}/lance-duckdb
           LANCE_HUGGINGFACE_REPO: ${{ github.workspace }}/lance-huggingface
+          LANCE_CONTEXT_REPO: ${{ github.workspace }}/lance-context
         run: |
           docs/make-full-website.sh
       - name: Deploy

--- a/docs/clean-full-website.sh
+++ b/docs/clean-full-website.sh
@@ -15,6 +15,7 @@ rm -rf "$docs_src/integrations/duckdb"
 rm -rf "$docs_src/integrations/spark"
 rm -rf "$docs_src/integrations/ray"
 rm -rf "$docs_src/integrations/trino"
+rm -rf "$docs_src/integrations/context"
 rm -f "$docs_src/community/project-specific/.pages"
 rm -rf "$docs_src/community/project-specific/lance"
 rm -f "$docs_src/community/project-specific/namespace.md"
@@ -22,6 +23,7 @@ rm -f "$docs_src/community/project-specific/namespace-impls.md"
 rm -f "$docs_src/community/project-specific/ray.md"
 rm -f "$docs_src/community/project-specific/spark.md"
 rm -f "$docs_src/community/project-specific/trino.md"
+rm -f "$docs_src/community/project-specific/context.md"
 
 cat > "$docs_src/format/.pages" <<'EOF'
 nav:

--- a/docs/make-full-website.sh
+++ b/docs/make-full-website.sh
@@ -13,6 +13,7 @@ Override any repo path with the matching environment variable:
   LANCE_TRINO_REPO
   LANCE_DUCKDB_REPO
   LANCE_HUGGINGFACE_REPO
+  LANCE_CONTEXT_REPO
 Defaults:
   LANCE_NAMESPACE_REPO=$HOME/oss/lance-namespace
   LANCE_NAMESPACE_IMPLS_REPO=$HOME/oss/lance-namespace-impls
@@ -21,6 +22,7 @@ Defaults:
   LANCE_TRINO_REPO=$HOME/oss/lance-trino
   LANCE_DUCKDB_REPO=$HOME/oss/lance-duckdb
   LANCE_HUGGINGFACE_REPO=$HOME/oss/lance-huggingface
+  LANCE_CONTEXT_REPO=$HOME/oss/lance-context
 EOF
 }
 
@@ -60,6 +62,7 @@ ray_repo_input=${LANCE_RAY_REPO:-$HOME/oss/lance-ray}
 trino_repo_input=${LANCE_TRINO_REPO:-$HOME/oss/lance-trino}
 duckdb_repo_input=${LANCE_DUCKDB_REPO:-$HOME/oss/lance-duckdb}
 huggingface_repo_input=${LANCE_HUGGINGFACE_REPO:-$HOME/oss/lance-huggingface}
+context_repo_input=${LANCE_CONTEXT_REPO:-$HOME/oss/lance-context}
 
 copy_docs_dir() {
     local source_dir="$1"
@@ -134,6 +137,7 @@ ray_repo=$(resolve_repo_dir "$ray_repo_input")
 trino_repo=$(resolve_repo_dir "$trino_repo_input")
 duckdb_repo=$(resolve_repo_dir "$duckdb_repo_input")
 huggingface_repo=$(resolve_repo_dir "$huggingface_repo_input")
+context_repo=$(resolve_repo_dir "$context_repo_input")
 
 "$script_dir/clean-full-website.sh"
 
@@ -265,6 +269,12 @@ else
     warn_missing_repo "Lance Trino docs" "$trino_repo/docs/src"
 fi
 
+if copy_docs_dir "$context_repo/docs/src" "$docs_src/integrations/context"; then
+    integration_entries+=("  - Lance Context: context")
+else
+    warn_missing_repo "Lance Context docs" "$context_repo/docs/src"
+fi
+
 {
     echo "nav:"
     for entry in "${integration_entries[@]}"; do
@@ -303,6 +313,10 @@ fi
 
 if copy_file_if_exists "$trino_repo/CONTRIBUTING.md" "$docs_src/community/project-specific/trino.md"; then
     project_entries+=("  - Lance Trino: trino.md")
+fi
+
+if copy_file_if_exists "$context_repo/CONTRIBUTING.md" "$docs_src/community/project-specific/context.md"; then
+    project_entries+=("  - Lance Context: context.md")
 fi
 
 {


### PR DESCRIPTION
## Summary

`lance-context` has a `docs/src` tree in the same shape as the other subprojects, but nothing pulls it into lance.org. This wires it in alongside spark/ray/trino so its docs publish the same way they do.

Context: I originally set up a standalone GitHub Pages site on the lance-context repo, and @jackye1995 pointed out that the org deliberately doesn't enable per-subproject Pages — public docs should build into lance.org instead. This is that change; the matching lance-context-side PR is lance-format/lance-context#212.

## Changes

Follows the existing pattern exactly, in both scripts:

- `LANCE_CONTEXT_REPO` (default `$HOME/oss/lance-context`), documented in the usage block like the others
- `docs/src` → `docs/src/integrations/context`, adding the nav entry only when the checkout is present, so a partial local build still works and just warns
- `CONTRIBUTING.md` → `community/project-specific/context.md`
- `clean-full-website.sh` removes both, keeping make/clean symmetric

## Verification

Ran the real thing rather than eyeballing the diff:

- `make-full-website.sh` against an actual lance-context checkout — all 12 pages copied, `integrations/.pages` nav entry generated, no warning for context
- `mkdocs build` succeeds; pages render under `site/integrations/context/` with correct nav nesting (`context/guide/quickstart/` etc. are linked from the integrations index)
- `clean-full-website.sh` removes everything it added

## Note on placement

I put it under **Integrations** since that's where the other subprojects live and it needs no new top-level section. It's arguably not an "integration" in the same sense as Spark or Trino — it's a storage engine built on Lance — so if you'd prefer a different home, say the word and I'll move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)