### PR TITLE
feat(index): replace suffix array dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,6 @@ dependencies = [
  "lance-table",
  "lance-testing",
  "lance-tokenizer",
- "libsais-rs",
  "log",
  "ndarray",
  "num-traits",
@@ -5248,15 +5247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libsais-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe164dbd47ea0c20e78a121c980ef673326905f1d4fba55e3645a20ef6717f"
-dependencies = [
- "rayon",
 ]
 
 [[package]]

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4005,7 +4005,6 @@ dependencies = [
  "lance-select",
  "lance-table",
  "lance-tokenizer",
- "libsais-rs",
  "log",
  "ndarray",
  "num-traits",
@@ -4353,15 +4352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libsais-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe164dbd47ea0c20e78a121c980ef673326905f1d4fba55e3645a20ef6717f"
-dependencies = [
- "rayon",
 ]
 
 [[package]]

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4333,7 +4333,6 @@ dependencies = [
  "lance-select",
  "lance-table",
  "lance-tokenizer",
- "libsais-rs",
  "log",
  "ndarray",
  "num-traits",
@@ -4660,15 +4659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libsais-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe164dbd47ea0c20e78a121c980ef673326905f1d4fba55e3645a20ef6717f"
-dependencies = [
- "rayon",
 ]
 
 [[package]]

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -47,7 +47,6 @@ lance-file.workspace = true
 lance-geo = { workspace = true, optional = true }
 lance-io.workspace = true
 lance-bitpacking.workspace = true
-libsais-rs = "0.2"
 lance-linalg.workspace = true
 lance-select.workspace = true
 lance-tokenizer.workspace = true

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -50,6 +50,10 @@ use crate::scalar::{
 };
 use crate::{Index, IndexType};
 
+mod suffix_array;
+
+use suffix_array::build_suffix_array;
+
 const FMINDEX_INDEX_VERSION: u32 = 10;
 const BLOCK_WORDS: usize = 4096;
 const PARTITION_SIZE: usize = 10_000;
@@ -381,24 +385,6 @@ impl HuffmanWaveletTree {
                 .map(|c| c.node_path.len() * 8)
                 .sum::<usize>()
             + self.children.len() * 24
-    }
-}
-
-// ── Suffix Array ─────────────────────────────────────────────────────────────
-
-fn build_suffix_array(text: &[u8]) -> Vec<usize> {
-    let n = text.len();
-    if n == 0 {
-        return Vec::new();
-    }
-    if n > i32::MAX as usize {
-        let mut sa = vec![0i64; n];
-        assert_eq!(libsais_rs::libsais64(text, &mut sa, 0, None), 0);
-        sa.iter().map(|&x| x as usize).collect()
-    } else {
-        let mut sa = vec![0i32; n];
-        assert_eq!(libsais_rs::libsais(text, &mut sa, 0, None), 0);
-        sa.iter().map(|&x| x as usize).collect()
     }
 }
 

--- a/rust/lance-index/src/scalar/fmindex/suffix_array.rs
+++ b/rust/lance-index/src/scalar/fmindex/suffix_array.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Safe suffix-array construction using induced sorting.
+//!
+//! The implementation follows the SA-IS algorithm used by AtCoder Library,
+//! which is available under CC0-1.0.
+
+/// Builds the suffix array for `text` in linear time.
+pub(super) fn build_suffix_array(text: &[u8]) -> Vec<usize> {
+    sa_is(text, u8::MAX as usize)
+}
+
+trait Symbol: Copy + Ord {
+    fn rank(self) -> usize;
+}
+
+impl Symbol for u8 {
+    fn rank(self) -> usize {
+        self as usize
+    }
+}
+
+impl Symbol for usize {
+    fn rank(self) -> usize {
+        self
+    }
+}
+
+fn sa_naive<T: Symbol>(symbols: &[T]) -> Vec<usize> {
+    let mut suffix_array: Vec<_> = (0..symbols.len()).collect();
+    suffix_array.sort_unstable_by(|&left, &right| symbols[left..].cmp(&symbols[right..]));
+    suffix_array
+}
+
+fn sa_doubling<T: Symbol>(symbols: &[T]) -> Vec<usize> {
+    let len = symbols.len();
+    let mut suffix_array: Vec<_> = (0..len).collect();
+    let mut ranks: Vec<_> = symbols.iter().map(|symbol| symbol.rank()).collect();
+    let mut next_ranks = vec![0; len];
+    let mut width = 1;
+
+    while width < len {
+        let rank_pair = |suffix: usize| {
+            (
+                ranks[suffix],
+                suffix
+                    .checked_add(width)
+                    .filter(|&i| i < len)
+                    .map(|i| ranks[i]),
+            )
+        };
+        suffix_array.sort_unstable_by_key(|&suffix| rank_pair(suffix));
+        next_ranks[suffix_array[0]] = 0;
+        for pair in suffix_array.windows(2) {
+            next_ranks[pair[1]] =
+                next_ranks[pair[0]] + usize::from(rank_pair(pair[0]) < rank_pair(pair[1]));
+        }
+        std::mem::swap(&mut ranks, &mut next_ranks);
+        width = width.saturating_mul(2);
+    }
+    suffix_array
+}
+
+fn sa_is<T: Symbol>(symbols: &[T], alphabet_max: usize) -> Vec<usize> {
+    let len = symbols.len();
+    match len {
+        0 => return Vec::new(),
+        1 => return vec![0],
+        2 => {
+            return if symbols[0] < symbols[1] {
+                vec![0, 1]
+            } else {
+                vec![1, 0]
+            };
+        }
+        3..10 => return sa_naive(symbols),
+        10..40 => return sa_doubling(symbols),
+        _ => {}
+    }
+
+    let mut suffix_array = vec![0; len];
+    let mut is_s_type = vec![false; len];
+    for index in (0..len - 1).rev() {
+        is_s_type[index] = if symbols[index] == symbols[index + 1] {
+            is_s_type[index + 1]
+        } else {
+            symbols[index] < symbols[index + 1]
+        };
+    }
+
+    let mut bucket_l = vec![0; alphabet_max + 1];
+    let mut bucket_s = vec![0; alphabet_max + 1];
+    for index in 0..len {
+        let rank = symbols[index].rank();
+        if is_s_type[index] {
+            bucket_l[rank + 1] += 1;
+        } else {
+            bucket_s[rank] += 1;
+        }
+    }
+    for rank in 0..=alphabet_max {
+        bucket_s[rank] += bucket_l[rank];
+        if rank < alphabet_max {
+            bucket_l[rank + 1] += bucket_s[rank];
+        }
+    }
+
+    let induce = |suffix_array: &mut [usize], lms_suffixes: &[usize]| {
+        suffix_array.fill(0);
+        let mut buckets = bucket_s.clone();
+        for &suffix in lms_suffixes {
+            if suffix == len {
+                continue;
+            }
+            let rank = symbols[suffix].rank();
+            suffix_array[buckets[rank]] = suffix + 1;
+            buckets[rank] += 1;
+        }
+
+        buckets.copy_from_slice(&bucket_l);
+        let last_rank = symbols[len - 1].rank();
+        suffix_array[buckets[last_rank]] = len;
+        buckets[last_rank] += 1;
+        for index in 0..len {
+            let suffix = suffix_array[index];
+            if suffix >= 2 && !is_s_type[suffix - 2] {
+                let rank = symbols[suffix - 2].rank();
+                suffix_array[buckets[rank]] = suffix - 1;
+                buckets[rank] += 1;
+            }
+        }
+
+        buckets.copy_from_slice(&bucket_l);
+        for index in (0..len).rev() {
+            let suffix = suffix_array[index];
+            if suffix >= 2 && is_s_type[suffix - 2] {
+                let rank = symbols[suffix - 2].rank() + 1;
+                buckets[rank] -= 1;
+                suffix_array[buckets[rank]] = suffix - 1;
+            }
+        }
+    };
+
+    // Stored positions are offset by one so zero can represent an empty slot.
+    let mut lms_indices = vec![0; len + 1];
+    let mut lms_count = 0;
+    for index in 1..len {
+        if !is_s_type[index - 1] && is_s_type[index] {
+            lms_indices[index] = lms_count + 1;
+            lms_count += 1;
+        }
+    }
+    let lms_suffixes: Vec<_> = (1..len)
+        .filter(|&index| !is_s_type[index - 1] && is_s_type[index])
+        .collect();
+    induce(&mut suffix_array, &lms_suffixes);
+
+    if lms_count > 0 {
+        let mut sorted_lms = Vec::with_capacity(lms_count);
+        for &suffix in &suffix_array {
+            if suffix > 0 && lms_indices[suffix - 1] != 0 {
+                sorted_lms.push(suffix - 1);
+            }
+        }
+
+        let mut reduced_symbols = vec![0; lms_count];
+        let mut reduced_alphabet_max = 0;
+        reduced_symbols[lms_indices[sorted_lms[0]] - 1] = 0;
+        for index in 1..lms_count {
+            let mut left = sorted_lms[index - 1];
+            let mut right = sorted_lms[index];
+            let left_end = if lms_indices[left] < lms_count {
+                lms_suffixes[lms_indices[left]]
+            } else {
+                len
+            };
+            let right_end = if lms_indices[right] < lms_count {
+                lms_suffixes[lms_indices[right]]
+            } else {
+                len
+            };
+            let mut is_same = left_end - left == right_end - right;
+            while is_same && left < left_end {
+                if symbols[left] != symbols[right] {
+                    is_same = false;
+                    break;
+                }
+                left += 1;
+                right += 1;
+            }
+            if is_same && (left == len || symbols[left] != symbols[right]) {
+                is_same = false;
+            }
+            if !is_same {
+                reduced_alphabet_max += 1;
+            }
+            reduced_symbols[lms_indices[sorted_lms[index]] - 1] = reduced_alphabet_max;
+        }
+
+        let reduced_suffix_array = sa_is(&reduced_symbols, reduced_alphabet_max);
+        for index in 0..lms_count {
+            sorted_lms[index] = lms_suffixes[reduced_suffix_array[index]];
+        }
+        induce(&mut suffix_array, &sorted_lms);
+    }
+
+    for suffix in &mut suffix_array {
+        *suffix -= 1;
+    }
+    suffix_array
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expected_suffix_array(text: &[u8]) -> Vec<usize> {
+        let mut suffix_array: Vec<_> = (0..text.len()).collect();
+        suffix_array.sort_unstable_by(|&left, &right| text[left..].cmp(&text[right..]));
+        suffix_array
+    }
+
+    #[test]
+    fn test_suffix_array_edge_cases() {
+        for text in [
+            &b""[..],
+            &b"a"[..],
+            &b"banana"[..],
+            &b"mississippi"[..],
+            &b"aaaaaaaaaa"[..],
+            &[0, 255, 0, 255, 0, 0, 255],
+        ] {
+            assert_eq!(build_suffix_array(text), expected_suffix_array(text));
+        }
+    }
+
+    #[test]
+    fn test_suffix_array_varied_binary_inputs() {
+        let mut state = 0x9E37_79B9_u32;
+        for len in 0..256 {
+            let text: Vec<_> = (0..len)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 17;
+                    state ^= state << 5;
+                    state as u8
+                })
+                .collect();
+            assert_eq!(
+                build_suffix_array(&text),
+                expected_suffix_array(&text),
+                "suffix array mismatch for random input length {len}"
+            );
+
+            let repetitive_text: Vec<_> = text.iter().map(|byte| byte % 5).collect();
+            assert_eq!(
+                build_suffix_array(&repetitive_text),
+                expected_suffix_array(&repetitive_text),
+                "suffix array mismatch for repetitive input length {len}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
A security audit raised a concern about the dependency `libsais-rs` that was introduced in https://github.com/lance-format/lance/pull/7026

The audit specifically said:

> Brand-new (Apr 2026) FFI bindings to a C suffix-array library from an academic lab. 0 stars, no CI, single author. FFI means an unsafe surface in code nobody is reviewing.

I'd push back on the "code nobody is reviewing comment" but in general it seems worth some mitigation.

The usage of this dependency is limited in scope, so I had an agent implement the associated code based on the CC0 AtCoder Library algorithm. It is 100% rust with no `unsafe` operations.

## Performance trade-off

Replacing the highly-optimized `libsais` C implementation with the pure-Rust SA-IS is a known performance regression on suffix-array construction (index build only — query paths are unaffected).

**Benchmark**: suffix arrays built over a realistic FM-index corpus (vocabulary words, `0xFF` document separators, `0x00` terminator — matching the actual build path). Both implementations produced byte-identical suffix arrays. Criterion, 10 samples per case.

| Input size | safe SA-IS | libsais | Regression |
|------------|-----------:|--------:|-----------:|
| 64 KB | 1.69 ms (37 MiB/s) | 0.61 ms (102 MiB/s) | ~2.8× |
| 1 MB | 32.7 ms (31 MiB/s) | 11.0 ms (91 MiB/s) | ~3.0× |
| 8 MB | 431 ms (18 MiB/s) | 93 ms (86 MiB/s) | ~4.6× |

The gap widens with input size: `libsais` sustains ~86–102 MiB/s (cache-blocked + SIMD), while the safe SA-IS decays from ~37 to ~18 MiB/s due to scatter-heavy induced sorting. With the default 16 MB partition cap, worst-case per-partition SA build is ~5× slower. Partitions build in parallel via `spawn_cpu`, so multi-core wall-clock impact is softened.

This is an accepted trade: ~3–5× slower index build in exchange for removing an unaudited unsafe C FFI dependency. If build time becomes a bottleneck, options include parallelizing the induce phase or reducing partition size.
