### PR TITLE
feat(overlay): gate overlay writes on an explicit dataset setting

### DIFF
--- a/docs/src/format/table/data_overlay_file.md
+++ b/docs/src/format/table/data_overlay_file.md
@@ -9,8 +9,13 @@
     The flag describes the current manifest, not the dataset's history. The commit
     that attaches the first overlay sets it, and the commit that removes the last
     overlay — whether by [compacting](#compaction) the overlays into base data or by
-    deleting the overlaid fragments — clears it. A dataset that no longer carries
-    overlays is therefore readable by pre-overlay readers again.
+    deleting the overlaid fragments — clears it, so the dataset is readable by
+    pre-overlay readers again.
+
+    That describes the moment, not a guarantee. Whether a writer *may* create a new
+    overlay is a separate setting, [`lance.overlays.enabled`](#enabling-overlays); a
+    dataset stays open to pre-overlay readers only if its overlays are both removed
+    and disabled.
 
 Overlay files supply new values for a subset of `(row offset, field)` cells
 within a fragment **without rewriting the fragment's base data files**. They make
@@ -22,6 +27,36 @@ This is Lance's third mechanism for changing data in place, alongside
 [deletion files](index.md#deletion-files) (which remove rows) and
 [data evolution](index.md#data-evolution) (which adds or rewrites whole columns).
 An overlay changes individual cells.
+
+## Enabling overlays
+
+A dataset records whether writers may create overlays in the table config key
+`lance.overlays.enabled`, whose value is the string `true` or `false`. This is
+distinct from feature flag 64: the flag reports that overlays **are present**,
+while the config key states that they **are permitted**. Keeping the two apart is
+what lets a dataset be overlay-enabled while holding no overlays, so a writer can
+choose the overlay representation for the next update without the dataset being
+closed to pre-overlay readers in the meantime.
+
+The key is resolved as follows:
+
+1. If it is set to a recognized boolean, that value wins.
+2. Otherwise, if any fragment already carries an overlay, overlays are enabled.
+   This keeps datasets written before the key existed writable.
+3. Otherwise the implementation's default applies. The default is currently
+   *disabled* and is expected to become *enabled* in a future release.
+
+Because absence resolves to a default that is expected to change, a dataset that
+must not accumulate overlays should set the key to `false` explicitly rather than
+relying on it being unset.
+
+Disabling is permitted only when no fragment carries an overlay, since a disabled
+dataset must be resolvable without overlay support. A writer that has overlays to
+clear must [compact](#compaction) them into base data first. Writers must reject
+both a commit that disables overlays while any remain and a commit that adds an
+overlay while they are disabled; both checks have to be re-evaluated when a
+transaction is rebased onto a newer version, or a disable can race an overlay
+write.
 
 ## Concepts
 

--- a/docs/src/format/table/index.md
+++ b/docs/src/format/table/index.md
@@ -174,7 +174,8 @@ However, this invalidates row addresses and requires rebuilding indices, which c
 
     The flag is set by the commit that attaches the first overlay and cleared by
     the commit that removes the last one, so it tracks the current manifest rather
-    than the dataset's history.
+    than the dataset's history. Whether a writer may *create* overlays is a
+    separate setting, `lance.overlays.enabled`.
 
 Overlay files supply new values for a subset of cells within
 a fragment without rewriting the base data files. They make updates cheap when only

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -118,7 +118,9 @@ message Manifest {
   // * 1 << 6: data overlay files are present (see DataOverlayFile). Readers that do
   //   not understand overlays must refuse the dataset, since ignoring an overlay
   //   would silently return stale base values. Writers set this flag when a commit
-  //   attaches the first overlay and clear it when a commit removes the last one.
+  //   attaches the first overlay and clear it when a commit removes the last one,
+  //   so it reports that overlays are present, not that they are permitted. Whether
+  //   a writer may create one is the separate "lance.overlays.enabled" config key.
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -180,6 +182,13 @@ message Manifest {
   // Keys with the prefix "lance." are reserved for the Lance library. Other
   // libraries may wish to similarly prefix their configuration keys
   // appropriately.
+  //
+  // Reserved keys that affect how a writer may change the table:
+  // * "lance.overlays.enabled": "true" or "false". Whether a writer may store new
+  //   values as data overlay files (see DataOverlayFile). When unset, a dataset
+  //   that already carries overlays is treated as enabled and one that does not
+  //   falls back to the implementation default. It may only be set to "false"
+  //   while no fragment carries an overlay.
   map<string, string> config = 16;
 
   // Metadata associated with the table.

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -30,6 +30,13 @@ pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
 /// that removes the last one (compaction folding overlays into base data, or the
 /// overlaid fragments being deleted). A dataset that no longer carries overlays is
 /// therefore readable by writers and readers that predate the feature.
+///
+/// So this reports that overlays are *present*. Whether a writer may create one is
+/// the separate [`LANCE_OVERLAYS_ENABLED`] setting, which persists across the flag
+/// being cleared -- a dataset only stays open to pre-overlay readers if its overlays
+/// are both removed and disabled.
+///
+/// [`LANCE_OVERLAYS_ENABLED`]: crate::format::LANCE_OVERLAYS_ENABLED
 pub const FLAG_DATA_OVERLAY_FILES: u64 = 64;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 128;

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -17,8 +17,9 @@ pub use fragment::*;
 pub use index::{IndexFile, IndexMetadata, index_metadata_codec, list_index_files_with_sizes};
 
 pub use manifest::{
-    BasePath, DETACHED_VERSION_MASK, DataStorageFormat, Manifest, SelfDescribingFileReader,
-    WriterVersion, is_detached_version,
+    BasePath, DETACHED_VERSION_MASK, DataStorageFormat, LANCE_OVERLAYS_ENABLED, Manifest,
+    SelfDescribingFileReader, WriterVersion, is_detached_version, overlays_enabled_with,
+    parse_overlays_enabled,
 };
 pub use transaction::Transaction;
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -110,6 +110,50 @@ pub fn is_detached_version(version: u64) -> bool {
     version & DETACHED_VERSION_MASK != 0
 }
 
+/// Dataset config key controlling whether writers may store new values as data
+/// overlay files. See [`Manifest::overlays_enabled`].
+pub const LANCE_OVERLAYS_ENABLED: &str = "lance.overlays.enabled";
+
+/// What [`LANCE_OVERLAYS_ENABLED`] resolves to when a dataset has not set it.
+///
+/// Flipping this to `true` opts every dataset that never configured the setting
+/// into overlay writes, including datasets created long before the feature. That
+/// is intended, but it is a behavior change for existing tables: the first overlay
+/// written to such a table sets `FLAG_DATA_OVERLAY_FILES`, which pre-overlay
+/// readers refuse. A table can always get back by compacting its overlays away and
+/// setting the key to `false`.
+// TODO: flip to `true` once overlay-capable readers have been GA long enough that
+// writing overlays into an existing table is safe by default, and once a
+// session-level default exists so a deployment can opt out fleet-wide first.
+const DEFAULT_OVERLAYS_ENABLED: bool = false;
+
+/// Resolve [`LANCE_OVERLAYS_ENABLED`] from a config map and whether the dataset
+/// already carries overlays.
+///
+/// Split out from [`Manifest::overlays_enabled`] so a commit can resolve enablement
+/// against the *pre-commit* fragment list. Resolving it against the post-commit
+/// fragments would let a `DataOverlay` commit authorize itself: the overlays it is
+/// adding would satisfy the `has_overlays` fallback.
+pub fn overlays_enabled_with(config: &HashMap<String, String>, has_overlays: bool) -> bool {
+    config
+        .get(LANCE_OVERLAYS_ENABLED)
+        .and_then(|value| parse_overlays_enabled(value))
+        // Unconfigured. Datasets written before this setting existed carry
+        // overlays without it, so presence implies enablement; once
+        // DEFAULT_OVERLAYS_ENABLED flips, that clause is subsumed.
+        .unwrap_or(DEFAULT_OVERLAYS_ENABLED || has_overlays)
+}
+
+/// Parse a [`LANCE_OVERLAYS_ENABLED`] value, returning `None` if it is not a
+/// recognized boolean.
+pub fn parse_overlays_enabled(value: &str) -> Option<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
 fn compute_fragment_offsets(fragments: &[Fragment]) -> Vec<usize> {
     fragments
         .iter()
@@ -492,6 +536,31 @@ impl Manifest {
     /// Whether the dataset uses stable row ids.
     pub fn uses_stable_row_ids(&self) -> bool {
         self.reader_feature_flags & FLAG_STABLE_ROW_IDS != 0
+    }
+
+    /// Whether any fragment currently carries data overlay files. This is the
+    /// condition that drives [`FLAG_DATA_OVERLAY_FILES`], and is distinct from
+    /// [`Self::overlays_enabled`], which says whether new overlays may be written.
+    ///
+    /// [`FLAG_DATA_OVERLAY_FILES`]: crate::feature_flags::FLAG_DATA_OVERLAY_FILES
+    pub fn has_overlays(&self) -> bool {
+        self.fragments.iter().any(|frag| !frag.overlays.is_empty())
+    }
+
+    /// Whether writers may store new values as data overlay files for this dataset.
+    ///
+    /// Enablement is a dataset setting held in [`LANCE_OVERLAYS_ENABLED`], not a
+    /// feature flag, so it survives writers that predate overlays (config round-trips
+    /// untouched) without locking pre-overlay readers out of a dataset that has no
+    /// overlays in it yet.
+    ///
+    /// An unparsable value is treated as unset rather than rejected here, so a bad
+    /// value cannot wedge every subsequent commit; writes of the key are validated at
+    /// commit time instead.
+    // TODO: when a session-level default lands, resolution becomes
+    // explicit config -> session default -> DEFAULT_OVERLAYS_ENABLED.
+    pub fn overlays_enabled(&self) -> bool {
+        overlays_enabled_with(&self.config, self.has_overlays())
     }
 
     /// Creates a serialized copy of the manifest, suitable for IPC or temp storage
@@ -1378,6 +1447,40 @@ mod tests {
         config.remove("other-key");
         manifest.config_mut().remove("other-key");
         assert_eq!(manifest.config, config);
+    }
+
+    #[rstest::rstest]
+    // An explicit value always wins, whether or not overlays are present.
+    #[case::explicit_true(Some("true"), false, true)]
+    #[case::explicit_false(Some("false"), false, false)]
+    #[case::explicit_true_with_overlays(Some("true"), true, true)]
+    #[case::case_insensitive(Some("TRUE"), false, true)]
+    // Unset falls back to the library default, except that a dataset already
+    // carrying overlays counts as enabled -- that is what keeps datasets written
+    // before this setting existed writable.
+    #[case::unset_without_overlays(None, false, DEFAULT_OVERLAYS_ENABLED)]
+    #[case::unset_with_overlays(None, true, true)]
+    // An unparsable value is treated as unset rather than as `false`, so a bad
+    // value cannot strand a dataset that already has overlays in it.
+    #[case::unparsable_with_overlays(Some("yes"), true, true)]
+    #[case::unparsable_without_overlays(Some(""), false, DEFAULT_OVERLAYS_ENABLED)]
+    fn test_overlays_enabled_resolution(
+        #[case] configured: Option<&str>,
+        #[case] has_overlays: bool,
+        #[case] expected: bool,
+    ) {
+        let config = configured
+            .map(|value| HashMap::from([(LANCE_OVERLAYS_ENABLED.to_string(), value.to_string())]))
+            .unwrap_or_default();
+        assert_eq!(overlays_enabled_with(&config, has_overlays), expected);
+    }
+
+    #[test]
+    fn test_parse_overlays_enabled() {
+        assert_eq!(parse_overlays_enabled("true"), Some(true));
+        assert_eq!(parse_overlays_enabled("False"), Some(false));
+        assert_eq!(parse_overlays_enabled("1"), None);
+        assert_eq!(parse_overlays_enabled(""), None);
     }
 
     #[test]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -129,7 +129,9 @@ use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
 use lance_table::feature_flags::{apply_feature_flags, can_read_dataset};
+use lance_table::format::LANCE_OVERLAYS_ENABLED;
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
+use optimize::{CompactionMetrics, CompactionOptions, compact_files};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
 };
@@ -3829,6 +3831,55 @@ impl Dataset {
         values: impl IntoIterator<Item = impl Into<UpdateMapEntry>>,
     ) -> metadata::UpdateMetadataBuilder<'_> {
         metadata::UpdateMetadataBuilder::new(self, values, metadata::MetadataType::Config)
+    }
+
+    /// Whether writers may store new values as data overlay files for this dataset.
+    ///
+    /// See [`Manifest::overlays_enabled`] for how an unconfigured dataset resolves.
+    pub fn overlays_enabled(&self) -> bool {
+        self.manifest.overlays_enabled()
+    }
+
+    /// Enable or disable data overlay files for this dataset.
+    ///
+    /// Unlike stable row ids this is a two-way door, but only in one direction at a
+    /// time: disabling requires that no fragment still carries an overlay, since a
+    /// disabled dataset must be readable without overlay support. Call
+    /// [`Self::remove_overlays`] first if any remain.
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # async fn example(dataset: &mut Dataset) -> Result<()> {
+    /// dataset.remove_overlays().await?;
+    /// dataset.set_overlays_enabled(false).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_overlays_enabled(&mut self, enabled: bool) -> Result<()> {
+        self.update_config([(LANCE_OVERLAYS_ENABLED.to_string(), enabled.to_string())])
+            .await?;
+        Ok(())
+    }
+
+    /// Compact every fragment carrying data overlay files, folding the overlaid
+    /// cells into fresh base data files, and leave every other fragment alone.
+    ///
+    /// This is the prerequisite for [`Self::set_overlays_enabled(false)`], and is
+    /// also how a dataset drops `FLAG_DATA_OVERLAY_FILES` so pre-overlay readers can
+    /// open it again.
+    ///
+    /// [`Self::set_overlays_enabled(false)`]: Self::set_overlays_enabled
+    pub async fn remove_overlays(&mut self) -> Result<CompactionMetrics> {
+        // `overlays_only` keeps the size and deletion triggers out of it, so this
+        // rewrites overlaid fragments and nothing else. The default
+        // `target_rows_per_fragment` still applies as the rewritten files' row
+        // limit, so an overlaid fragment is not split.
+        let options = CompactionOptions {
+            max_overlays_per_fragment: Some(0),
+            overlays_only: true,
+            ..Default::default()
+        };
+        compact_files(self, options, None).await
     }
 
     /// Update schema metadata.

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -3271,6 +3271,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -3515,6 +3516,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -3653,6 +3655,7 @@ mod tests {
                 max_rows_per_file: N,
                 max_rows_per_group: N,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(base)], schema.clone());
@@ -4008,6 +4011,7 @@ mod tests {
                 max_rows_per_file: 100,
                 max_rows_per_group: 100,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4110,6 +4114,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4234,6 +4239,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4314,6 +4320,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4392,6 +4399,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4465,6 +4473,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -4668,6 +4677,7 @@ mod tests {
                 max_rows_per_file: 6,
                 max_rows_per_group: 6,
                 data_storage_version: Some(version),
+                enable_overlays: Some(true),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -271,6 +271,13 @@ pub struct CompactionOptions {
     /// carries any overlay, or `None` to disable the overlay-count trigger
     /// entirely.
     pub max_overlays_per_fragment: Option<usize>,
+    /// Restrict compaction to fragments selected by `max_overlays_per_fragment`,
+    /// skipping the size and deletion triggers entirely.
+    ///
+    /// Without this, removing overlays from a table of small fragments also bins
+    /// those fragments together, which is a much larger rewrite than the caller
+    /// asked for. Defaults to `false`.
+    pub overlays_only: bool,
     /// Transaction properties to store with this commit.
     ///
     /// These key-value pairs are stored in the transaction file
@@ -301,6 +308,7 @@ impl Default for CompactionOptions {
             binary_copy_read_batch_bytes: Some(16 * 1024 * 1024),
             max_source_fragments: None,
             max_overlays_per_fragment: Some(10),
+            overlays_only: false,
             transaction_properties: None,
         }
     }
@@ -328,6 +336,7 @@ impl CompactionOptions {
     /// - `lance.compaction.binary_copy_read_batch_bytes`
     /// - `lance.compaction.max_source_fragments`
     /// - `lance.compaction.max_overlays_per_fragment`
+    /// - `lance.compaction.overlays_only`
     pub fn from_dataset_config(config: &HashMap<String, String>) -> Result<Self> {
         let mut opts = Self::default();
         opts.apply_dataset_config(config)?;
@@ -450,6 +459,14 @@ impl CompactionOptions {
                             ))
                         })?),
                     };
+                }
+                "overlays_only" => {
+                    self.overlays_only = value.parse().map_err(|_| {
+                        Error::invalid_input(format!(
+                            "Invalid value for {}: '{}' (expected a boolean)",
+                            key, value
+                        ))
+                    })?;
                 }
                 _ => {
                     warn!("Ignoring unknown compaction config key: {}", key);
@@ -747,6 +764,8 @@ impl CompactionPlanner for DefaultCompactionPlanner {
                 // Too many overlays: fully compact this fragment on its own,
                 // regardless of its size or deletion count.
                 Some(CompactionCandidacy::CompactItself)
+            } else if self.options.overlays_only {
+                None
             } else if self.options.materialize_deletions
                 && metrics.deletion_percentage() > self.options.materialize_deletions_threshold
             {
@@ -6613,6 +6632,25 @@ mod tests {
     }
 
     #[test]
+    fn test_from_dataset_config_overlays_only() {
+        let key = "lance.compaction.overlays_only".to_string();
+
+        let config = HashMap::from([(key.clone(), "true".to_string())]);
+        assert!(
+            CompactionOptions::from_dataset_config(&config)
+                .unwrap()
+                .overlays_only
+        );
+
+        let config = HashMap::from([(key, "sometimes".to_string())]);
+        let err_msg = CompactionOptions::from_dataset_config(&config)
+            .unwrap_err()
+            .to_string();
+        assert!(err_msg.contains("overlays_only"));
+        assert!(err_msg.contains("sometimes"));
+    }
+
+    #[test]
     fn test_apply_dataset_config_overrides() {
         let config = HashMap::from([(
             "lance.compaction.target_rows_per_fragment".to_string(),
@@ -8375,6 +8413,7 @@ mod tests {
             max_rows_per_file: 6,
             max_rows_per_group: 6,
             data_storage_version: Some(LanceFileVersion::Stable),
+            enable_overlays: Some(true),
             ..Default::default()
         };
         let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -8549,6 +8588,44 @@ mod tests {
             })
             .collect();
         assert_eq!(values, expected);
+    }
+
+    #[tokio::test]
+    async fn test_overlays_only_skips_the_size_trigger() {
+        // Both fragments hold 6 rows, far below the default 1M-row target, so
+        // the size trigger alone would bin them together.
+        let dataset = create_base_dataset("memory://").await;
+        let mut dataset = commit_n_overlays(dataset, 1).await;
+
+        let options = CompactionOptions {
+            max_overlays_per_fragment: Some(0),
+            overlays_only: true,
+            ..Default::default()
+        };
+        let metrics = compact_files(&mut dataset, options, None).await.unwrap();
+
+        // Only the overlaid fragment was rewritten; fragment 1 was left alone.
+        assert_eq!(metrics.fragments_removed, 1);
+        assert_eq!(metrics.fragments_added, 1);
+        assert!(dataset.get_fragment(1).is_some());
+        assert_eq!(dataset.get_fragments().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_without_overlays_only_the_size_trigger_still_applies() {
+        // Same setup, but leaving `overlays_only` off folds the untouched
+        // neighbor in as well -- the behavior `remove_overlays` avoids.
+        let dataset = create_base_dataset("memory://").await;
+        let mut dataset = commit_n_overlays(dataset, 1).await;
+
+        let options = CompactionOptions {
+            max_overlays_per_fragment: Some(0),
+            ..Default::default()
+        };
+        let metrics = compact_files(&mut dataset, options, None).await.unwrap();
+
+        assert_eq!(metrics.fragments_removed, 2);
+        assert_eq!(metrics.fragments_added, 1);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_overlay_feature_flag.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_feature_flag.rs
@@ -1,34 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! End-to-end tests for the data overlay feature flag lifecycle: the manifest advertises
-//! [`FLAG_DATA_OVERLAY_FILES`] exactly while some fragment carries an overlay. The commit
-//! that attaches the first overlay sets it, and the commit that removes the last one --
-//! by deleting the overlaid fragments or by compacting the overlays into base data --
-//! clears it again, so the dataset becomes readable by pre-overlay readers once more.
+//! End-to-end tests for the two facts a dataset records about data overlay files.
+//!
+//! [`FLAG_DATA_OVERLAY_FILES`] says overlays are *present*: the manifest advertises it
+//! exactly while some fragment carries an overlay. The commit that attaches the first
+//! overlay sets it, and the commit that removes the last one -- by deleting the overlaid
+//! fragments or by compacting the overlays into base data -- clears it again, so the
+//! dataset becomes readable by pre-overlay readers once more.
+//!
+//! `lance.overlays.enabled` says overlays are *permitted*, and is what a writer consults
+//! before choosing to store an update as an overlay. It is a two-way door: it can be
+//! turned off again, but only once no overlay remains, since a disabled dataset must be
+//! resolvable without overlay support.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, record_batch};
 use lance_file::writer::{FileWriter, FileWriterOptions};
 use lance_io::utils::CachedFileSize;
 use lance_table::feature_flags::FLAG_DATA_OVERLAY_FILES;
-use lance_table::format::DataFile;
 use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+use lance_table::format::{DataFile, LANCE_OVERLAYS_ENABLED};
 use roaring::RoaringBitmap;
 use tempfile::{TempDir, tempdir};
 use uuid::Uuid;
 
-use crate::Dataset;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
-use crate::dataset::transaction::{DataOverlayGroup, Operation};
+use crate::dataset::transaction::{DataOverlayGroup, Operation, UpdateMap, UpdateMapEntry};
 use crate::dataset::{DATA_DIR, WriteDestination, WriteParams};
+use crate::{Dataset, Result};
 
 /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `val` (field 1) = id * 10,
-/// six rows per fragment (fragments 0 and 1). Backed by a temp dir rather than
-/// `memory://` so tests can reopen the dataset and check the persisted manifest.
+/// six rows per fragment (fragments 0 and 1), with overlay writes enabled. Backed by a
+/// temp dir rather than `memory://` so tests can reopen the dataset and check the
+/// persisted manifest.
 async fn create_base_dataset() -> (TempDir, Dataset) {
+    create_base_dataset_with(Some(true)).await
+}
+
+async fn create_base_dataset_with(enable_overlays: Option<bool>) -> (TempDir, Dataset) {
     let test_dir = tempdir().unwrap();
     let uri = test_dir.path().to_str().unwrap().to_string();
     let batch = record_batch!(
@@ -40,6 +52,7 @@ async fn create_base_dataset() -> (TempDir, Dataset) {
     let write_params = WriteParams {
         max_rows_per_file: 6,
         max_rows_per_group: 6,
+        enable_overlays,
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
@@ -70,7 +83,21 @@ async fn reopen(dataset: &Dataset) -> Dataset {
 
 /// Commit a dense overlay setting `val` at `offset` of `fragment_id` to `value`.
 async fn commit_overlay(dataset: Dataset, fragment_id: u64, offset: u32, value: i32) -> Dataset {
-    let read_version = dataset.version().version;
+    try_commit_overlay(dataset, fragment_id, offset, value, None)
+        .await
+        .unwrap()
+}
+
+/// Like [`commit_overlay`] but surfaces the commit error, and lets a test commit
+/// against a stale `read_version` to exercise conflict rebase.
+async fn try_commit_overlay(
+    dataset: Dataset,
+    fragment_id: u64,
+    offset: u32,
+    value: i32,
+    read_version: Option<u64>,
+) -> Result<Dataset> {
+    let read_version = read_version.unwrap_or_else(|| dataset.version().version);
     let overlay_schema = dataset.schema().project_by_ids(&[1], true);
     let filename = format!("{}.lance", Uuid::new_v4());
     let path = dataset.base.clone().join(DATA_DIR).join(filename.as_str());
@@ -116,7 +143,36 @@ async fn commit_overlay(dataset: Dataset, fragment_id: u64, offset: u32, value: 
         false,
     )
     .await
-    .unwrap()
+}
+
+/// Commit a `lance.overlays.enabled` change against an explicit read version, so a test
+/// can issue a disable that was planned before a concurrent overlay landed.
+async fn commit_overlays_enabled_at(
+    dataset: Dataset,
+    enabled: bool,
+    read_version: u64,
+) -> Result<Dataset> {
+    Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::UpdateConfig {
+            config_updates: Some(UpdateMap {
+                update_entries: vec![UpdateMapEntry {
+                    key: LANCE_OVERLAYS_ENABLED.to_string(),
+                    value: Some(enabled.to_string()),
+                }],
+                replace: false,
+            }),
+            table_metadata_updates: None,
+            schema_metadata_updates: None,
+            field_metadata_updates: HashMap::new(),
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
 }
 
 /// Scan `id` and `val` and return an `id -> val` map (order-independent).
@@ -207,4 +263,147 @@ async fn test_compacting_overlays_clears_feature_flag() {
     assert_eq!(values[&0], 1000);
     assert_eq!(values[&1], 1001);
     assert_eq!(values[&2], 20);
+}
+
+#[tokio::test]
+async fn test_overlays_disabled_unless_enabled() {
+    // A dataset that says nothing follows the library default, which is currently
+    // off, so an overlay commit is refused rather than silently allowed.
+    let (_test_dir, dataset) = create_base_dataset_with(None).await;
+    assert!(!dataset.overlays_enabled());
+    let error = try_commit_overlay(dataset, 0, 0, 1000, None)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("while they are disabled"),
+        "unexpected error: {error}"
+    );
+
+    // The same dataset created with the setting on accepts the commit.
+    let (_test_dir, dataset) = create_base_dataset_with(Some(true)).await;
+    assert!(dataset.overlays_enabled());
+    let dataset = commit_overlay(dataset, 0, 0, 1000).await;
+    assert!(advertises_overlays(&dataset));
+}
+
+#[tokio::test]
+async fn test_enablement_survives_the_flag_clearing() {
+    // The two facts are independent: compacting the overlays away clears the
+    // feature flag but must leave the dataset free to write overlays again.
+    let (_test_dir, dataset) = create_base_dataset().await;
+    let mut dataset = commit_overlay(dataset, 0, 0, 1000).await;
+    dataset.remove_overlays().await.unwrap();
+
+    assert!(!advertises_overlays(&dataset));
+    assert!(dataset.overlays_enabled());
+    assert!(reopen(&dataset).await.overlays_enabled());
+    commit_overlay(dataset, 1, 0, 2000).await;
+}
+
+#[tokio::test]
+async fn test_cannot_disable_while_overlays_remain() {
+    let (_test_dir, dataset) = create_base_dataset().await;
+    let mut dataset = commit_overlay(dataset, 0, 0, 1000).await;
+
+    let error = dataset.set_overlays_enabled(false).await.unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("still carry overlays"), "{message}");
+    // The offending fragment is named so the caller knows what to compact.
+    assert!(message.contains('0'), "{message}");
+    assert!(dataset.overlays_enabled());
+}
+
+#[tokio::test]
+async fn test_remove_overlays_then_disable() {
+    let (_test_dir, dataset) = create_base_dataset().await;
+    let dataset = commit_overlay(dataset, 0, 0, 1000).await;
+    let mut dataset = commit_overlay(dataset, 0, 1, 1001).await;
+
+    let metrics = dataset.remove_overlays().await.unwrap();
+    // Only the overlaid fragment is rewritten. Fragment 1 is well under the
+    // default row target, so a plain compaction would have swept it up too.
+    assert_eq!(metrics.fragments_removed, 1);
+    assert_eq!(metrics.fragments_added, 1);
+    assert!(dataset.get_fragment(1).is_some());
+    assert!(!advertises_overlays(&dataset));
+
+    dataset.set_overlays_enabled(false).await.unwrap();
+    assert!(!dataset.overlays_enabled());
+    assert!(!reopen(&dataset).await.overlays_enabled());
+
+    // Disabling did not cost any data.
+    let values = id_val_map(&dataset).await;
+    assert_eq!(values[&0], 1000);
+    assert_eq!(values[&1], 1001);
+    assert_eq!(values[&2], 20);
+
+    // And it is a real gate, not just a label. Fragment 1 was never overlaid, so
+    // compaction left it in place.
+    let error = try_commit_overlay(dataset, 1, 0, 2000, None)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("while they are disabled"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_disable_racing_a_concurrent_overlay_is_rejected() {
+    // The disable is planned against a version with no overlays, so it is valid
+    // when issued. A concurrent writer then adds one. The check lives in
+    // build_manifest, which re-runs when the transaction is rebased onto the
+    // newer version, so the race is caught rather than silently committed.
+    let (_test_dir, dataset) = create_base_dataset().await;
+    let stale_version = dataset.version().version;
+    let dataset = commit_overlay(dataset, 0, 0, 1000).await;
+    assert!(dataset.version().version > stale_version);
+    let uri = dataset.uri().to_string();
+
+    let error = commit_overlays_enabled_at(dataset, false, stale_version)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("still carry overlays"),
+        "unexpected error: {error}"
+    );
+
+    // The dataset is untouched: still enabled, still carrying its overlay.
+    let dataset = Dataset::open(&uri).await.unwrap();
+    assert!(dataset.overlays_enabled());
+    assert!(advertises_overlays(&dataset));
+}
+
+#[tokio::test]
+async fn test_unparsable_setting_is_rejected_at_write() {
+    let (_test_dir, mut dataset) = create_base_dataset().await;
+    let error = dataset
+        .update_config([(LANCE_OVERLAYS_ENABLED.to_string(), "yes".to_string())])
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("must be \"true\" or \"false\""),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_dataset_with_overlays_but_no_setting_stays_writable() {
+    // Datasets written while overlays were experimental carry overlays without
+    // the setting. Removing the key reproduces that shape: the dataset must stay
+    // overlay-writable rather than becoming un-updatable.
+    let (_test_dir, dataset) = create_base_dataset().await;
+    let mut dataset = commit_overlay(dataset, 0, 0, 1000).await;
+    dataset
+        .update_config([(LANCE_OVERLAYS_ENABLED.to_string(), None)])
+        .await
+        .unwrap();
+    assert!(!dataset.config().contains_key(LANCE_OVERLAYS_ENABLED));
+
+    assert!(dataset.overlays_enabled());
+    let dataset = commit_overlay(dataset, 0, 1, 1001).await;
+    assert_eq!(
+        dataset.get_fragment(0).unwrap().metadata().overlays.len(),
+        2
+    );
 }

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -58,6 +58,7 @@ async fn create_base_dataset_with(stable_row_ids: bool) -> Dataset {
     let write_params = WriteParams {
         max_rows_per_file: 6,
         enable_stable_row_ids: stable_row_ids,
+        enable_overlays: Some(true),
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -509,6 +510,7 @@ async fn create_vector_overlay_dataset(stable_row_ids: bool) -> Dataset {
     let write_params = WriteParams {
         max_rows_per_file: 32,
         enable_stable_row_ids: stable_row_ids,
+        enable_overlays: Some(true),
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -672,6 +674,7 @@ async fn create_text_dataset() -> Dataset {
     .unwrap();
     let write_params = WriteParams {
         max_rows_per_file: 6,
+        enable_overlays: Some(true),
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
@@ -1092,6 +1095,7 @@ async fn bench_index_query_overlay_overhead() {
 
     let write_params = WriteParams {
         max_rows_per_file: ROWS_PER_FRAG as usize,
+        enable_overlays: Some(true),
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -31,9 +31,10 @@ use lance_table::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
 use lance_table::rowids::read_row_ids;
 use lance_table::{
     format::{
-        BasePath, DataFile, DataStorageFormat, Fragment, IndexFile, IndexMetadata, Manifest,
-        RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence, RowIdMeta,
-        overlay::DataOverlayFile, pb,
+        BasePath, DataFile, DataStorageFormat, Fragment, IndexFile, IndexMetadata,
+        LANCE_OVERLAYS_ENABLED, Manifest, RowDatasetVersionMeta, RowDatasetVersionRun,
+        RowDatasetVersionSequence, RowIdMeta, overlay::DataOverlayFile, overlays_enabled_with,
+        parse_overlays_enabled, pb,
     },
     io::{
         commit::CommitHandler,
@@ -2496,6 +2497,20 @@ impl Transaction {
                 field_metadata_updates,
             } => {
                 if let Some(config_updates) = config_updates {
+                    // Reject an unparsable overlay setting at the point it is
+                    // written. Validating the resolved config on every commit
+                    // instead would let one bad value wedge all later writes.
+                    if let Some(entry) = config_updates
+                        .update_entries
+                        .iter()
+                        .find(|entry| entry.key == LANCE_OVERLAYS_ENABLED)
+                        && let Some(value) = &entry.value
+                        && parse_overlays_enabled(value).is_none()
+                    {
+                        return Err(Error::invalid_input(format!(
+                            "{LANCE_OVERLAYS_ENABLED} must be \"true\" or \"false\", got {value:?}"
+                        )));
+                    }
                     let mut config = manifest.config.clone();
                     apply_update_map(&mut config, config_updates);
                     manifest.config = config;
@@ -2617,6 +2632,39 @@ impl Transaction {
                 }
             }
             _ => {}
+        }
+
+        // "Overlays disabled" and "overlays in the manifest" are mutually
+        // exclusive: a disabled dataset must be resolvable without overlay
+        // support. One invariant covers both ways to violate it -- disabling
+        // while overlays remain, and writing an overlay while disabled.
+        //
+        // This lives in build_manifest rather than at the API boundary because
+        // build_manifest re-runs on conflict rebase, so it also rejects a
+        // disable that races a concurrent DataOverlay commit.
+        //
+        // Enablement resolves against the pre-commit fragments so a DataOverlay
+        // cannot authorize itself through the overlays it is adding.
+        let was_overlaid = current_manifest.is_some_and(|current| current.has_overlays());
+        if !overlays_enabled_with(&manifest.config, was_overlaid) {
+            let overlaid = manifest
+                .fragments
+                .iter()
+                .filter(|fragment| !fragment.overlays.is_empty())
+                .map(|fragment| fragment.id)
+                .collect::<Vec<_>>();
+            if !overlaid.is_empty() {
+                return Err(Error::invalid_input(match &self.operation {
+                    Operation::DataOverlay { .. } => format!(
+                        "cannot write data overlay files while they are disabled for this \
+                         dataset; set {LANCE_OVERLAYS_ENABLED} to \"true\" first"
+                    ),
+                    _ => format!(
+                        "cannot disable data overlay files while fragments {overlaid:?} still \
+                         carry overlays; remove them first (see Dataset::remove_overlays)"
+                    ),
+                }));
+            }
         }
 
         // Handle UpdateBases operation to update manifest base_paths
@@ -4115,6 +4163,17 @@ mod tests {
             DataStorageFormat::new(LanceFileVersion::V2_0),
             HashMap::new(),
         )
+    }
+
+    /// A [`sample_manifest`] that permits overlay writes. Without the setting a
+    /// `DataOverlay` commit is rejected, since a dataset with no overlays yet
+    /// resolves to the (currently disabled) library default.
+    fn overlay_enabled_manifest() -> Manifest {
+        let mut manifest = sample_manifest();
+        manifest
+            .config
+            .insert(LANCE_OVERLAYS_ENABLED.to_string(), "true".to_string());
+        manifest
     }
 
     fn sample_index_metadata(name: &str) -> IndexMetadata {
@@ -6655,7 +6714,7 @@ mod tests {
     fn test_data_overlay_build_manifest_merges_duplicate_groups() {
         // Two groups targeting the same fragment must both survive (a HashMap
         // collapse would have dropped the first).
-        let manifest = sample_manifest();
+        let manifest = overlay_enabled_manifest();
         let txn = Transaction::new(
             manifest.version,
             Operation::DataOverlay {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -333,6 +333,20 @@ pub struct WriteParams {
     /// secondary indices need to be updated to point to new row ids.
     pub enable_stable_row_ids: bool,
 
+    /// Whether writers may store new values as data overlay files for this dataset,
+    /// recorded as the `lance.overlays.enabled` dataset config key.
+    ///
+    /// `None` leaves the dataset unconfigured, so it follows the library default.
+    /// This is deliberately an `Option<bool>` rather than a `bool`: the default is
+    /// expected to become "enabled", and a bare `enable_*: bool` could not tell
+    /// "the caller asked for off" from "the caller said nothing".
+    ///
+    /// Only honored for `Create` and `Overwrite`; an append leaves the existing
+    /// setting alone. Use [`Dataset::set_overlays_enabled`] to change it later.
+    ///
+    /// [`Dataset::set_overlays_enabled`]: crate::Dataset::set_overlays_enabled
+    pub enable_overlays: Option<bool>,
+
     /// If set to true, and this is a new dataset, uses the new v2 manifest paths.
     /// These allow constant-time lookups for the latest manifest on object storage.
     /// This parameter has no effect on existing datasets. To migrate an existing
@@ -427,6 +441,7 @@ impl Default for WriteParams {
             commit_handler: None,
             data_storage_version: None,
             enable_stable_row_ids: false,
+            enable_overlays: None,
             enable_v2_manifest_paths: true,
             session: None,
             auto_cleanup: None,

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -14,7 +14,7 @@ use lance_datafusion::utils::StreamingWriteSource;
 use lance_file::version::LanceFileVersion;
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::can_write_dataset;
-use lance_table::format::Fragment;
+use lance_table::format::{Fragment, LANCE_OVERLAYS_ENABLED};
 use lance_table::io::commit::CommitHandler;
 use object_store::path::Path;
 
@@ -229,6 +229,19 @@ impl<'a> InsertBuilder<'a> {
         Ok((transaction, context))
     }
 
+    /// The `lance.overlays.enabled` config entry this write should stamp, if the
+    /// caller asked for one. Left unset otherwise so the dataset follows the
+    /// library default rather than freezing today's default into the manifest.
+    fn overlays_enabled_upsert(
+        context: &WriteContext<'_>,
+    ) -> impl Iterator<Item = (String, String)> {
+        context
+            .params
+            .enable_overlays
+            .map(|enabled| (LANCE_OVERLAYS_ENABLED.to_string(), enabled.to_string()))
+            .into_iter()
+    }
+
     fn build_transaction(
         schema: Schema,
         fragments: Vec<Fragment>,
@@ -252,6 +265,7 @@ impl<'a> InsertBuilder<'a> {
                         format_duration(duration).to_string(),
                     );
                 }
+                upsert_values.extend(Self::overlays_enabled_upsert(context));
                 let config_upsert_values = if upsert_values.is_empty() {
                     None
                 } else {
@@ -265,12 +279,15 @@ impl<'a> InsertBuilder<'a> {
                     initial_bases: context.params.initial_bases.clone(),
                 }
             }
-            WriteMode::Overwrite => Operation::Overwrite {
-                schema,
-                fragments,
-                config_upsert_values: None,
-                initial_bases: context.params.initial_bases.clone(),
-            },
+            WriteMode::Overwrite => {
+                let upsert_values: HashMap<_, _> = Self::overlays_enabled_upsert(context).collect();
+                Operation::Overwrite {
+                    schema,
+                    fragments,
+                    config_upsert_values: (!upsert_values.is_empty()).then_some(upsert_values),
+                    initial_bases: context.params.initial_bases.clone(),
+                }
+            }
             WriteMode::Append => Operation::Append { fragments },
         };
 


### PR DESCRIPTION
Stacked on #8016 — review the last commit only.

Overlays were permitted on any dataset, so there was nowhere to record that a table *wants* overlays before its first one exists. That's the fact a high-level writer (`update`, `merge_insert`) needs to consult when deciding whether to store an update as an overlay.

## Where enablement lives

`lance.overlays.enabled`, a table config key — **not** feature flag 64. Two reasons:

- **It survives legacy writers.** A pre-overlay writer recomputes reader/writer flags from what it knows and would drop bit 64, silently disabling the feature. `Manifest::new_from_previous` clones `config` verbatim, so a config key round-trips through writers that have never heard of it.
- **It doesn't lock out readers early.** `reader_feature_flags` is a hard refusal gate. An enabled-but-overlay-free dataset is byte-for-byte readable by a pre-overlay reader, and setting bit 64 on it would exclude them for no correctness reason. This matters more once the default flips: enablement-as-flag would set bit 64 on every newly created table at creation.

Flag 64 keeps its existing meaning — overlays are *present*.

## Resolution, and the coming default flip

1. An explicit `true`/`false` wins.
2. Otherwise, a dataset already carrying overlays counts as enabled. This is what keeps datasets written while overlays were experimental writable, with no migration.
3. Otherwise `DEFAULT_OVERLAYS_ENABLED`, currently `false`.

The plan is to flip step 3 to `true` in ~6 months so existing tables get the optimization, which is a one-line change plus deleting clause 2's rationale. Two consequences are baked in deliberately:

- `WriteParams::enable_overlays` is `Option<bool>`, not `bool`. `rust/CLAUDE.md` says to name booleans so `false`/`Default::default()` is the desired default, which makes `enable_*: bool` wrong once the default is on — and renaming a public field to `disable_*` later is a break.
- The docs tell readers that a dataset which must not accumulate overlays should set `false` explicitly rather than relying on absence, since absence is the thing designed to change.

**Not in this PR, and I'd treat it as a prerequisite for the flip:** a session-level default, so a deployment can opt out fleet-wide before upgrading rather than table-by-table after. Resolution order would become explicit config → session default → library default; `overlays_enabled_with` is the single place it slots into.

## The disable guard

One invariant — "disabled implies no overlays" — covers both directions: disabling while overlays remain, and committing a `DataOverlay` while disabled. It lives in `build_manifest` rather than at the API boundary because `build_manifest` re-runs on conflict rebase. `check_update_config_txn` puts `UpdateConfig` vs `DataOverlay` in the compatible bucket, so a disable racing an overlay write gets rebased and replayed against the newer manifest, and the check fires. `test_disable_racing_a_concurrent_overlay_is_rejected` covers exactly that path.

One subtlety worth a look: enablement is resolved against the **pre-commit** fragment list (`overlays_enabled_with(&manifest.config, was_overlaid)`). Resolving against post-commit fragments would let a `DataOverlay` authorize itself — the overlays it's adding would satisfy clause 2.

## API

- `WriteParams::enable_overlays: Option<bool>` — honored on Create and Overwrite; append leaves the setting alone.
- `Dataset::overlays_enabled()` / `Dataset::set_overlays_enabled(bool)`.
- `Dataset::remove_overlays()` — compacts overlaid fragments **and nothing else**. This needed a new `CompactionOptions::overlays_only`: `max_overlays_per_fragment: Some(0)` alone still bins small neighbors together and materializes deletions, and the obvious workaround of zeroing `target_rows_per_fragment` is unsafe because it doubles as `max_rows_per_file` for the rewrite. `test_without_overlays_only_the_size_trigger_still_applies` pins the contrast.

## Test churn

Every existing overlay test committed overlays against datasets that never enabled them, so ~80 now correctly fail without opting in. Fixed by setting `enable_overlays: Some(true)` in each module's base-dataset helper (`fragment.rs` overlay_read, `optimize.rs`, `dataset_overlay_index_masking.rs`) and adding `overlay_enabled_manifest()` for the one `transaction.rs` unit test. That churn is the feature working.

New tests: 8 resolution cases + `parse_overlays_enabled` in lance-table; 7 e2e in `dataset_overlay_feature_flag.rs` (default-off, enable-at-creation, enablement surviving flag clearing, disable rejected with overlays, remove-then-disable, the rebase race, unparsable value, and a dataset with overlays but no key staying writable); 3 in `optimize.rs` for `overlays_only`.

## Testing

`cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` clean. Full `cargo test -p lance --lib` green (2619 passed) and `cargo test -p lance-table --lib` green (135). `cargo check` clean for the python and java crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)