### PR TITLE
feat(index): stop HNSW greedy descent before level 0

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -340,8 +340,13 @@ impl HNSW {
         L: BorrowingGraph,
         B: BorrowingGraph,
     {
+        // Greedy descent stops at level 1 (HNSW paper, Algorithm 2): level 0
+        // is searched only by the ef-bounded beam below. Greedily descending
+        // into level 0 first collapses the entry point into a deep local
+        // minimum, which costs extra distance computations and measurably
+        // hurts recall at low ef (https://github.com/lance-format/lance/issues/5208).
         let mut ep = ep;
-        for level in (0..self.max_level()).rev() {
+        for level in (1..self.max_level()).rev() {
             let cur_level = make_level(level);
             ep = greedy_search_borrowed(
                 &cur_level,
@@ -508,8 +513,10 @@ impl HNSW {
         L: BorrowingGraph,
         B: BorrowingGraph,
     {
+        // Same level descent as [Self::run_search]: greedy stops at level 1
+        // (see the comment there); level 0 is left to the beam below.
         let mut ep = ep;
-        for level in (0..self.max_level()).rev() {
+        for level in (1..self.max_level()).rev() {
             let cur_level = make_level(level);
             ep = greedy_search_borrowed(
                 &cur_level,
@@ -1461,6 +1468,7 @@ impl IvfSubIndex for HNSW {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use arrow_array::{ArrayRef, FixedSizeListArray, RecordBatch, UInt8Array, UInt32Array};
     use arrow_schema::Schema;
@@ -1480,12 +1488,13 @@ mod tests {
     use object_store::path::Path;
     use rstest::rstest;
 
-    use super::HnswGraph;
+    use super::{HnswGraph, ImmutableHnswBottomView, ImmutableHnswLevelView};
+    use crate::vector::graph::builder::GraphBuilderNode;
     use crate::vector::storage::{DistCalculator, VectorStore};
     use crate::vector::v3::subindex::IvfSubIndex;
     use crate::vector::{
         flat::storage::{FlatBinStorage, FlatFloatStorage},
-        graph::{DISTS_FIELD, NEIGHBORS_FIELD, VisitedGenerator},
+        graph::{DISTS_FIELD, NEIGHBORS_FIELD, OrderedNode, VisitedGenerator},
         hnsw::{
             HNSW, VECTOR_ID_FIELD,
             builder::{HnswBuildParams, HnswQueryParams},
@@ -1685,6 +1694,143 @@ mod tests {
             .count();
         let recall = hits as f32 / k as f32;
         assert!(recall >= 0.5, "recall {recall} below 0.5 (k={k})");
+    }
+
+    /// A [`DistCalculator`] over fixed per-node distances that counts how
+    /// many distances it computes, so a test can assert exactly which search
+    /// phases ran.
+    struct CountingDistCalculator<'a> {
+        distances: &'a [f32],
+        calls: &'a AtomicUsize,
+    }
+
+    impl DistCalculator for CountingDistCalculator<'_> {
+        fn distance(&self, id: u32) -> f32 {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.distances[id as usize]
+        }
+
+        fn distance_all(&self, _k_hint: usize) -> Vec<f32> {
+            self.distances.to_vec()
+        }
+    }
+
+    /// Regression test for <https://github.com/lance-format/lance/issues/5208>:
+    /// the query-time greedy descent must stop at level 1 (HNSW paper,
+    /// Algorithm 2); level 0 must be searched only by the ef-bounded beam.
+    ///
+    /// Drives [`HNSW::run_search`] / [`HNSW::run_search_acorn`] directly over
+    /// a hand-built graph: node 0 is the entry point and the only node at
+    /// level 1 (with no level-1 neighbors), so the greedy descent over
+    /// levels >= 1 computes no distances, and with ef == N the bottom beam
+    /// visits every level-0 node exactly once. A greedy step at level 0
+    /// would show up as 10 extra distance computations: the level-0 degrees
+    /// along the path are 1,2,2,2,2,1 and the strictly decreasing distances
+    /// make greedy walk it end to end.
+    #[test]
+    fn test_greedy_descent_stops_before_level_0() {
+        const N: usize = 6;
+        // Strictly decreasing along the path; the true top-3 is nodes 5,4,3.
+        let distances: Vec<f32> = (0..N).map(|id| (N - id) as f32).collect();
+
+        // Level 0 is the path 0-1-...-5, mirrored into both the bottom view
+        // and the level-0 view (only the bottom view may be used at query
+        // time, which is what this test asserts).
+        let mut nodes: Vec<GraphBuilderNode> = (0..N as u32)
+            .map(|id| GraphBuilderNode::new(id, 2))
+            .collect();
+        for (id, node) in nodes.iter_mut().enumerate() {
+            let mut adjacency = Vec::new();
+            if id > 0 {
+                adjacency.push(id as u32 - 1);
+            }
+            if id + 1 < N {
+                adjacency.push(id as u32 + 1);
+            }
+            let adjacency = Arc::new(adjacency);
+            node.bottom_neighbors = adjacency.clone();
+            node.level_neighbors[0] = adjacency;
+        }
+
+        let build_params = HnswBuildParams {
+            max_level: 2,
+            m: 4,
+            ef_construction: 10,
+            prefetch_distance: None,
+        };
+        let hnsw = HNSW::from_parts(build_params, nodes.clone(), vec![N, 1], 0);
+        let query_params = HnswQueryParams {
+            ef: N,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+            use_acorn: false,
+        };
+
+        let calls = AtomicUsize::new(0);
+        let dist_calc = CountingDistCalculator {
+            distances: &distances,
+            calls: &calls,
+        };
+        // The entry-point distance (1 call) mirrors `search_inner`.
+        let ep = OrderedNode::new(0, dist_calc.distance(0).into());
+        let mut visited_generator = VisitedGenerator::new(N);
+
+        let results = hnsw.run_search(
+            ep.clone(),
+            3,
+            &query_params,
+            None,
+            &mut visited_generator,
+            N,
+            None,
+            &dist_calc,
+            |level| ImmutableHnswLevelView::new(level, &nodes),
+            ImmutableHnswBottomView::new(&nodes),
+        );
+        assert_eq!(
+            results.iter().map(|node| node.id).collect::<Vec<_>>(),
+            vec![5, 4, 3]
+        );
+        // Exactly 1 entry-point distance + 5 beam visits (one per remaining
+        // node); the pre-fix level-0 greedy step brought this to 16.
+        assert_eq!(calls.load(Ordering::Relaxed), N);
+
+        // The ACORN traversal shares the descent. Its beam additionally seeds
+        // mask-passing nodes with distance computations, so only bound the
+        // total: a level-0 greedy step would push it past one call per node.
+        let mut mask_generator = VisitedGenerator::new(N);
+        let mut mask = mask_generator.generate(N);
+        for id in 0..N as u32 {
+            mask.insert(id);
+        }
+        let mut expanded_generator = VisitedGenerator::new(N);
+        calls.store(0, Ordering::Relaxed);
+        let results = hnsw.run_search_acorn(
+            ep,
+            &query_params,
+            &mask,
+            &mut visited_generator,
+            &mut expanded_generator,
+            N,
+            None,
+            &dist_calc,
+            |level| ImmutableHnswLevelView::new(level, &nodes),
+            ImmutableHnswBottomView::new(&nodes),
+        );
+        assert_eq!(
+            results
+                .iter()
+                .take(3)
+                .map(|node| node.id)
+                .collect::<Vec<_>>(),
+            vec![5, 4, 3]
+        );
+        assert!(
+            calls.load(Ordering::Relaxed) <= N,
+            "level-0 greedy descent adds distance computations beyond the \
+             beam's one per node"
+        );
     }
 
     /// Brute-force top-`k` restricted to mask-passing ids.


### PR DESCRIPTION
## Summary

Fixes #5208.

Per the HNSW paper (Algorithm 2), the greedy (ef=1) descent should cover only levels `max_level-1` down to 1; level 0 must be searched solely by the ef-bounded beam search starting from the level-1 entry point. `HNSW::run_search` and `HNSW::run_search_acorn` were greedily descending through level 0 first, which collapsed the beam's entry point into a deep local minimum — extra distance computations and measurably lower recall at low ef.

The SIFT1M benchmark in the issue (3 independent graph builds, paired bootstrap intervals) shows stopping before level 0 is a repeatable Pareto improvement: **+3.7% recall@10 at ef=16**, +0.5% at ef=32, statistically equal recall at higher ef, and lower paired latency throughout the sweep. Note the online builder's query path (`OnlineHnswBuilder::search`) and both build-time `insert` paths already used the paper-correct range — only these two query paths were off.

## Test

New structural regression test `test_greedy_descent_stops_before_level_0` drives `run_search` / `run_search_acorn` over a hand-built 6-node, 2-level graph with a counting `DistCalculator`: the entry node is alone at level 1, so any greedy step at level 0 shows up as extra distance computations (6 expected, 16 pre-fix). I used a structural assertion rather than a recall threshold because on synthetic uniform data the recall delta is not sign-stable across graph sizes — the SIFT1M numbers in the issue are the recall evidence.

## Verification

- `cargo test -p lance-index --lib`: 887 passed
- `cargo test -p lance --lib -- vector index::`: 724 passed
- `cargo clippy --all --tests --benches -- -D warnings`: clean
- `cargo fmt --all`: clean