### PR TITLE
feat: select index segments for optimization

### DIFF
--- a/rust/lance-index/src/optimize.rs
+++ b/rust/lance-index/src/optimize.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use uuid::Uuid;
+
 use crate::progress::{IndexBuildProgress, noop_progress};
 
 /// Options for optimizing all indices.
@@ -25,6 +27,12 @@ pub struct OptimizeOptions {
 
     /// the index names to optimize. If None, all indices will be optimized.
     pub index_names: Option<Vec<String>>,
+
+    /// Physical index segment IDs to optimize.
+    ///
+    /// This can only be set when exactly one index name is specified. All
+    /// selected segments must belong to that logical index.
+    pub index_segment_ids: Option<Vec<Uuid>>,
 
     /// whether to retrain the whole index. Default: false.
     ///
@@ -55,6 +63,7 @@ impl Default for OptimizeOptions {
         Self {
             num_indices_to_merge: None,
             index_names: None,
+            index_segment_ids: None,
             retrain: false,
             transaction_properties: None,
             progress: noop_progress(),
@@ -99,6 +108,12 @@ impl OptimizeOptions {
 
     pub fn index_names(mut self, names: Vec<String>) -> Self {
         self.index_names = Some(names);
+        self
+    }
+
+    /// Select physical index segments to optimize.
+    pub fn with_index_segment_ids(mut self, segment_ids: Vec<Uuid>) -> Self {
+        self.index_segment_ids = Some(segment_ids);
         self
     }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1830,6 +1830,46 @@ impl DatasetIndexExt for Dataset {
     async fn optimize_indices(&mut self, options: &OptimizeOptions) -> Result<()> {
         let dataset = Arc::new(self.clone());
         let indices = self.load_indices().await?;
+        let selected_segment_ids = if let Some(segment_ids) = &options.index_segment_ids {
+            if segment_ids.is_empty() {
+                return Err(Error::invalid_input(
+                    "OptimizeIndices: index_segment_ids must not be empty",
+                ));
+            }
+            let Some(index_names) = &options.index_names else {
+                return Err(Error::invalid_input(
+                    "OptimizeIndices: index_segment_ids requires exactly one index name",
+                ));
+            };
+            if index_names.len() != 1 {
+                return Err(Error::invalid_input(
+                    "OptimizeIndices: index_segment_ids requires exactly one index name",
+                ));
+            }
+            if segment_ids.iter().collect::<HashSet<_>>().len() != segment_ids.len() {
+                return Err(Error::invalid_input(
+                    "OptimizeIndices: index_segment_ids must not contain duplicates",
+                ));
+            }
+
+            let index_name = &index_names[0];
+            for segment_id in segment_ids {
+                let Some(index) = indices.iter().find(|index| index.uuid == *segment_id) else {
+                    return Err(Error::invalid_input(format!(
+                        "OptimizeIndices: index segment {segment_id} does not exist"
+                    )));
+                };
+                if &index.name != index_name {
+                    return Err(Error::invalid_input(format!(
+                        "OptimizeIndices: index segment {segment_id} belongs to index '{}' instead of '{index_name}'",
+                        index.name
+                    )));
+                }
+            }
+            Some(segment_ids)
+        } else {
+            None
+        };
 
         let indices_to_optimize = options
             .index_names
@@ -1849,6 +1889,23 @@ impl DatasetIndexExt for Dataset {
         let mut new_indices = vec![];
         let mut removed_indices = vec![];
         for deltas in name_to_indices.values() {
+            let selected_deltas = if let Some(segment_ids) = selected_segment_ids {
+                segment_ids
+                    .iter()
+                    .filter_map(|segment_id| {
+                        deltas
+                            .iter()
+                            .find(|index| index.uuid == *segment_id)
+                            .copied()
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                deltas.clone()
+            };
+            if selected_deltas.is_empty() {
+                continue;
+            }
+
             // Scalar indices have no rebalance concept, so skip them entirely
             // when every fragment is already covered and the caller hasn't
             // asked for retrain or an explicit delta merge. Vector indices
@@ -1862,12 +1919,15 @@ impl DatasetIndexExt for Dataset {
                 continue;
             }
 
-            let Some(res) = merge_indices(dataset.clone(), deltas.as_slice(), options).await?
+            let Some(res) =
+                merge_indices(dataset.clone(), selected_deltas.as_slice(), options).await?
             else {
                 continue;
             };
 
-            let last_idx = deltas.last().expect("Delta indices should not be empty");
+            let last_idx = selected_deltas
+                .last()
+                .ok_or_else(|| Error::internal("Selected index segments should not be empty"))?;
             let new_idx = IndexMetadata {
                 uuid: res.new_uuid,
                 name: last_idx.name.clone(), // Keep the same name

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -1788,7 +1788,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_merge_indices_with_unindexed_frags_vector_subset() {
+    async fn test_optimize_indices_with_vector_segment_selection() {
         const DIM: usize = 64;
         const TOTAL: usize = 1000;
 
@@ -1823,7 +1823,120 @@ mod tests {
             .await
             .unwrap();
 
-        let next_batch = RecordBatch::try_new(
+        let make_batch = |start_id: u32| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(
+                        FixedSizeListArray::try_new_from_values(
+                            generate_random_array(TOTAL * DIM),
+                            DIM as i32,
+                        )
+                        .unwrap(),
+                    ),
+                    Arc::new(UInt32Array::from_iter_values(
+                        start_id..start_id + TOTAL as u32,
+                    )),
+                ],
+            )
+            .unwrap()
+        };
+        let next_batch = make_batch(TOTAL as u32);
+        let batches =
+            RecordBatchIterator::new(vec![next_batch].into_iter().map(Ok), schema.clone());
+        dataset.append(batches, None).await.unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        let indices_before = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(indices_before.len(), 2);
+        let selected_uuid = indices_before[0].uuid;
+        let preserved_uuid = indices_before[1].uuid;
+
+        let unindexed_batch = make_batch((TOTAL * 2) as u32);
+        let query = unindexed_batch["vector"].as_fixed_size_list().value(0);
+        let batches = RecordBatchIterator::new(vec![unindexed_batch].into_iter().map(Ok), schema);
+        dataset.append(batches, None).await.unwrap();
+        assert_eq!(
+            dataset
+                .unindexed_fragments("vector_idx")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        dataset
+            .optimize_indices(
+                &OptimizeOptions::merge(1)
+                    .index_names(vec!["vector_idx".to_string()])
+                    .with_index_segment_ids(vec![selected_uuid]),
+            )
+            .await
+            .unwrap();
+
+        let indices_after = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(indices_after.len(), 2);
+        assert!(
+            indices_after
+                .iter()
+                .all(|index| index.uuid != selected_uuid)
+        );
+        assert!(
+            indices_after
+                .iter()
+                .any(|index| index.uuid == preserved_uuid)
+        );
+        assert!(
+            dataset
+                .unindexed_fragments("vector_idx")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let covered_fragments = indices_after
+            .iter()
+            .flat_map(|index| index.fragment_bitmap.as_ref().unwrap().iter())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            covered_fragments,
+            std::collections::HashSet::from([0, 1, 2])
+        );
+
+        let results = dataset
+            .scan()
+            .nearest("vector", query.as_primitive::<Float32Type>(), 10)
+            .unwrap()
+            .nprobes(2)
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(results.num_rows(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_optimize_indices_rejects_invalid_segment_selection() {
+        const DIM: usize = 64;
+        const TOTAL: usize = 1000;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIM as i32,
+                ),
+                true,
+            ),
+            Field::new("id", DataType::UInt32, false),
+        ]));
+        let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
                 Arc::new(
@@ -1833,34 +1946,27 @@ mod tests {
                     )
                     .unwrap(),
                 ),
-                Arc::new(UInt32Array::from_iter_values(
-                    TOTAL as u32..(TOTAL * 2) as u32,
-                )),
+                Arc::new(UInt32Array::from_iter_values(0..TOTAL as u32)),
             ],
         )
         .unwrap();
-        let batches = RecordBatchIterator::new(vec![next_batch].into_iter().map(Ok), schema);
-        dataset.append(batches, None).await.unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let index_params = VectorIndexParams::ivf_pq(2, 8, 4, MetricType::L2, 2);
         dataset
-            .optimize_indices(&OptimizeOptions::append())
+            .create_index(&["vector"], IndexType::Vector, None, &index_params, true)
             .await
             .unwrap();
 
-        let indices = dataset.load_indices_by_name("vector_idx").await.unwrap();
-        assert_eq!(indices.len(), 2);
-        let subset = vec![&indices[1]];
-        let merge_result = merge_indices_with_unindexed_frags(
-            Arc::new(dataset),
-            &subset,
-            &[],
-            &OptimizeOptions::merge(1),
-        )
-        .await
-        .unwrap();
-
+        let segment_uuid = dataset.load_indices().await.unwrap()[0].uuid;
+        let error = dataset
+            .optimize_indices(&OptimizeOptions::merge(1).with_index_segment_ids(vec![segment_uuid]))
+            .await
+            .unwrap_err();
         assert!(
-            merge_result.is_some(),
-            "subset merges should respect the caller-provided indices"
+            error
+                .to_string()
+                .contains("index_segment_ids requires exactly one index name")
         );
     }
 


### PR DESCRIPTION
Adds optional physical-segment selection to `OptimizeOptions` so callers can merge unindexed data into a specific segment while preserving the other segments of the logical index.

Includes validation and coverage tests. Local validation was limited to Rust formatting and diff checks; compilation and tests are delegated to CI due workstation disk constraints.