### PR TITLE
docs: define legacy compatibility boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ Also see directory-specific guidelines: [rust/](rust/AGENTS.md) | [python/](pyth
 - Treat every file format marked unstable as disposable. It may change freely; do not add compatibility code, migrations, fallbacks, or tests for files written by earlier unstable revisions.
 - Evaluate compatibility against the latest released stable version while continuing to honor all stable format contracts. Changes that exist only on the current branch or `main` are not compatibility constraints; do not compromise a cleaner or more complete design to preserve those intermediate states.
 
+### Legacy Compatibility Boundaries
+
+- Treat formats and code paths that current writers no longer emit as frozen compatibility surfaces. Preserve their existing read behavior, but exclude them from new feature design unless legacy support is explicitly required.
+- Implement new features in the current format and write paths. Do not extend legacy writers, retrofit new capabilities into legacy readers, or reuse legacy implementations as the foundation for new code.
+- Avoid refactoring or otherwise modifying legacy code during feature work. If a shared boundary makes a legacy change unavoidable, isolate the change, preserve existing behavior, and add targeted regression coverage using released historical fixtures.
+
 ## Development Commands
 
 ### Rust


### PR DESCRIPTION
Legacy format paths are retained to preserve compatibility with existing data, but current writers no longer emit them in normal operation. Without an explicit boundary, new feature work can accidentally extend or refactor these paths and increase the risk of breaking historical reads.

This establishes legacy code as a frozen compatibility surface. New features should target current format and write paths, while any unavoidable legacy change must stay isolated and be covered by released historical fixtures.
