### PR TITLE
fix(arrow): preserve all-null struct validity during merge

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -1017,34 +1017,25 @@ fn merge_list_struct(left: &dyn Array, right: &dyn Array) -> Arc<dyn Array> {
     }
 }
 
-/// Helper function to normalize validity buffers
-/// Returns None for all-null validity (placeholder structs)
-fn normalize_validity(
-    validity: Option<&arrow_buffer::NullBuffer>,
-) -> Option<&arrow_buffer::NullBuffer> {
-    validity.filter(|v| v.null_count() != v.len())
-}
-
-/// Helper function to merge validity buffers from two struct arrays
-/// Returns None only if both arrays are null at the same position
+/// Helper function to merge validity buffers from two struct arrays.
 ///
-/// Special handling for placeholder structs (all-null validity)
+/// A row is valid if it is valid in either input.
+/// An absent validity buffer means all rows are valid, an all-null buffer acts as the identity for this merge.
 fn merge_struct_validity(
     left_validity: Option<&arrow_buffer::NullBuffer>,
     right_validity: Option<&arrow_buffer::NullBuffer>,
 ) -> Option<arrow_buffer::NullBuffer> {
-    // Normalize both validity buffers (convert all-null to None)
-    let left_normalized = normalize_validity(left_validity);
-    let right_normalized = normalize_validity(right_validity);
-
-    match (left_normalized, right_normalized) {
+    match (left_validity, right_validity) {
         // Fast paths: no computation needed
-        (None, None) => None,
-        (Some(left), None) => Some(left.clone()),
-        (None, Some(right)) => Some(right.clone()),
+        (None, _) | (_, None) => None,
         (Some(left), Some(right)) => {
-            // Fast path: if both have no nulls, can return either one
-            if left.null_count() == 0 && right.null_count() == 0 {
+            if left.null_count() == 0 || right.null_count() == 0 {
+                return None;
+            }
+            if left.null_count() == left.len() {
+                return Some(right.clone());
+            }
+            if right.null_count() == right.len() {
                 return Some(left.clone());
             }
 
@@ -2051,6 +2042,41 @@ mod tests {
         assert_eq!(width_values.value(0), 300);
         assert_eq!(width_values.value(1), 200);
         assert!(width_values.is_null(2)); // width is null when right struct was null
+
+        // An all-null validity buffer is data, not a placeholder meaning "this side has no
+        // validity": merging two of them keeps the rows null.
+        let all_null_left = StructArray::new(
+            Fields::from(vec![Field::new("height", DataType::Int32, true)]),
+            vec![Arc::new(Int32Array::from(vec![None, None])) as ArrayRef],
+            Some(vec![false, false].into()),
+        );
+        let all_null_right = StructArray::new(
+            Fields::from(vec![Field::new("width", DataType::Int32, true)]),
+            vec![Arc::new(Int32Array::from(vec![None, None])) as ArrayRef],
+            Some(vec![false, false].into()),
+        );
+
+        let merged = merge(&all_null_left, &all_null_right);
+        assert_eq!(merged.null_count(), 2);
+
+        // An all-null side is the identity of the merge, so the other side decides each row.
+        let partial_left = StructArray::new(
+            Fields::from(vec![Field::new("height", DataType::Int32, true)]),
+            vec![Arc::new(Int32Array::from(vec![Some(1), None])) as ArrayRef],
+            Some(vec![true, false].into()),
+        );
+        let merged = merge(&partial_left, &all_null_right);
+        assert!(!merged.is_null(0));
+        assert!(merged.is_null(1));
+
+        // A missing validity buffer means all rows are valid, which absorbs an all-null side.
+        let all_valid_left = StructArray::new(
+            Fields::from(vec![Field::new("height", DataType::Int32, true)]),
+            vec![Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef],
+            None,
+        );
+        let merged = merge(&all_valid_left, &all_null_right);
+        assert_eq!(merged.null_count(), 0);
     }
 
     #[test]

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -2077,6 +2077,12 @@ mod tests {
         );
         let merged = merge(&all_valid_left, &all_null_right);
         assert_eq!(merged.null_count(), 0);
+
+        // An explicit all-valid buffer has the same semantics as a missing buffer.
+        let all_valid: arrow_buffer::NullBuffer = vec![true, true].into();
+        let partial: arrow_buffer::NullBuffer = vec![true, false].into();
+        assert!(merge_struct_validity(Some(&all_valid), Some(&partial)).is_none());
+        assert!(merge_struct_validity(Some(&partial), Some(&all_valid)).is_none());
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_scanner.rs
+++ b/rust/lance/src/dataset/tests/dataset_scanner.rs
@@ -11,11 +11,11 @@ use lance_arrow::{ARROW_EXT_NAME_KEY, FixedSizeListArrayExt};
 
 use crate::index::DatasetIndexExt;
 use arrow::compute::concat_batches;
-use arrow_array::UInt64Array;
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, FixedSizeListArray, ListArray, StructArray};
 use arrow_array::{Float32Array, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
-use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+use arrow_array::{Int64Array, UInt64Array};
+use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema, SchemaRef};
 use futures::TryStreamExt;
 use lance_arrow::SchemaExt;
@@ -34,6 +34,7 @@ use lance_linalg::distance::MetricType;
 use uuid::Uuid;
 
 use crate::Dataset;
+use crate::dataset::NewColumnTransform;
 use crate::dataset::scanner::{DatasetRecordBatchStream, QueryFilter};
 use crate::dataset::write::WriteParams;
 use lance_index::scalar::inverted::query::FtsQuery;
@@ -41,6 +42,146 @@ use lance_index::vector::ivf::IvfBuildParams;
 use lance_index::vector::pq::PQBuildParams;
 use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
 use pretty_assertions::assert_eq;
+
+/// A null struct must not read back as a valid struct with null children.
+///
+/// A scan merges the per-column batches with `lance_arrow::merge`, which used to read an all-null
+/// validity buffer as "this side carries no validity" and drop it. A filter that selects only null
+/// rows leaves exactly that shape, so the scan reported those rows as valid while `IS NULL`
+/// counted them as null. The dataset is created empty and then appended to because that is the
+/// path this was found on, and the version is pinned because 2.0 does not encode struct validity.
+#[tokio::test]
+async fn test_filtered_scan_preserves_nullable_struct_validity() {
+    let struct_fields = Fields::from(vec![
+        ArrowField::new("a", DataType::Int64, true),
+        ArrowField::new("b", DataType::Utf8, true),
+    ]);
+    let item_field = Arc::new(ArrowField::new(
+        "item",
+        DataType::Struct(struct_fields.clone()),
+        true,
+    ));
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::UInt64, false),
+        ArrowField::new("s", DataType::Struct(struct_fields.clone()), true),
+        ArrowField::new("l", DataType::List(item_field.clone()), true),
+    ]));
+
+    let empty = RecordBatch::new_empty(schema.clone());
+    let reader = RecordBatchIterator::new([Ok(empty)], schema.clone());
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..WriteParams::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Rows 100 and 177 are null in both nested columns while their children still carry values,
+    // so losing the top-level validity turns them into valid values instead of null ones.
+    let validity = NullBuffer::from(vec![false, true, false]);
+    let structs = StructArray::new(
+        struct_fields.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![Some(10), Some(11), Some(12)])),
+            Arc::new(StringArray::from(vec![Some("x"), Some("y"), Some("z")])),
+        ],
+        Some(validity.clone()),
+    );
+    let items = StructArray::new(
+        struct_fields.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![Some(20), Some(21), Some(22)])),
+            Arc::new(StringArray::from(vec![Some("p"), Some("q"), Some("r")])),
+        ],
+        None,
+    );
+    let lists = ListArray::new(
+        item_field,
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 2, 3])),
+        Arc::new(items),
+        Some(validity),
+    );
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt64Array::from(vec![100, 116, 177])),
+            Arc::new(structs),
+            Arc::new(lists),
+        ],
+    )
+    .unwrap();
+    dataset
+        .append(
+            Box::new(RecordBatchIterator::new([Ok(batch)], schema)),
+            None,
+        )
+        .await
+        .unwrap();
+
+    for (id, expected_is_null) in [(100, true), (116, false), (177, true)] {
+        let mut scan = dataset.scan();
+        scan.filter(&format!("id = {id}")).unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        let structs = batch["s"].as_struct();
+        assert_eq!(structs.is_null(0), expected_is_null, "s, row id {id}");
+        // A null struct masks its children, so both levels have to agree.
+        assert_eq!(
+            structs.column(0).is_null(0),
+            expected_is_null,
+            "s.a, row id {id}"
+        );
+        assert_eq!(
+            batch["l"].as_list::<i32>().is_null(0),
+            expected_is_null,
+            "l, row id {id}"
+        );
+    }
+
+    assert_eq!(
+        dataset
+            .count_rows(Some("s IS NULL".to_owned()))
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        dataset
+            .count_rows(Some("l IS NULL".to_owned()))
+            .await
+            .unwrap(),
+        2
+    );
+
+    // A struct column added as all-nulls reaches the same merge through schema evolution, where
+    // every row is null and there is no other side to recover the validity from.
+    dataset
+        .add_columns(
+            NewColumnTransform::AllNulls(Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "t",
+                DataType::Struct(struct_fields),
+                true,
+            )]))),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let mut scan = dataset.scan();
+    scan.filter("id = 116").unwrap();
+    let batch = scan.try_into_batch().await.unwrap();
+    assert!(batch["t"].as_struct().is_null(0));
+    assert_eq!(
+        dataset
+            .count_rows(Some("t IS NULL".to_owned()))
+            .await
+            .unwrap(),
+        3
+    );
+}
 
 #[tokio::test]
 async fn test_scan_wide_fixed_size_list_at_batch_boundary() {


### PR DESCRIPTION
## Problem

Arrow structs carry a parent validity bitmap in addition to child validity. Lance reconstructs separately stored struct fields with `lance_arrow::merge`, where parent validity is combined with OR: either input can make a row valid, and a missing bitmap means all-valid.

`merge_struct_validity` first discarded any all-null bitmap to handle all-null placeholders from schema evolution. This conflated an explicit all-null batch with absent validity. When both inputs were all-null — as in a filtered batch containing only a null row, or an `AllNulls`-added column — both bitmaps were dropped and the result became all-valid. The scan then returned a valid struct with null children even though `IS NULL`, which reads on-disk definition levels directly, correctly reported null.

## Fix

Merge the original bitmaps without normalization. An all-null bitmap is already the identity for OR, so it preserves filler behavior while allowing two all-null inputs to remain null. All-valid and all-null cases short-circuit to avoid unnecessary allocation.

No file-format change is needed; the encoded validity was already correct. Reverting only this function reproduces the failure, so the loss was purely in the in-memory reconstruction.

## Affected read paths

Measured with the fix reverted, on storage version 2.1:

| Path | before | after |
|---|---|---|
| filtered scan of a nullable struct | valid struct, null children | null struct |
| filtered scan of `List<Struct>` | all rows valid | validity preserved |
| `add_columns(AllNulls)` struct column | valid struct, null children | null struct |
| full scan, `take`, `count_rows(IS NULL)` | already correct | unchanged |

Only the both-inputs-all-null combination changes behavior; every other combination produces exactly what it did before.

Storage version 2.0 does not encode struct validity at all, so the test pins 2.1.

## Tests

* `merge_struct_validity` combinations, including all-null/all-null and an all-null input acting as the merge identity
* filtered scans preserve nullable `Struct` and `List<Struct>` validity, children agree with the parent, and both agree with `IS NULL`
* a struct column added with `AllNulls` reads back as null structs

```
cargo nextest run -p lance-arrow
cargo nextest run -p lance --lib test_filtered_scan_preserves
```

Each new assertion fails with the fix reverted.

Fixes #7908
