### PR TITLE
fix(fts): validate complete parameters across segments

### DIFF
--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -4249,3 +4249,142 @@ async fn test_load_segment_params_full_fidelity() {
         .expect("inverted index");
     assert_eq!(&read, opened.params());
 }
+
+#[tokio::test]
+async fn test_full_text_search_loads_segment_params_from_shallow_clone_base() {
+    let test_uri = TempStrDir::default();
+    let clone_uri = format!("{test_uri}/clone");
+    let batch = RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "text",
+            DataType::Utf8,
+            false,
+        )])),
+        vec![Arc::new(StringArray::from(vec!["the alpha", "the beta"]))],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let mut source = Dataset::write(reader, &test_uri, None).await.unwrap();
+    source
+        .create_index(
+            &["text"],
+            IndexType::Inverted,
+            Some("fts_idx".to_string()),
+            &InvertedIndexParams::default().custom_stop_words(Some(vec!["alpha".to_string()])),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let source_version = source.version().version;
+    let cloned = source
+        .shallow_clone(&clone_uri, source_version, None)
+        .await
+        .unwrap();
+    let segments = crate::index::scalar::load_segments(&cloned, "text")
+        .await
+        .unwrap()
+        .expect("cloned FTS segment");
+    assert_eq!(segments.len(), 1);
+    assert!(
+        segments[0].base_id.is_some(),
+        "shallow-cloned index must resolve through its source base"
+    );
+
+    let mut scanner = cloned.scan();
+    scanner
+        .full_text_search(FullTextSearchQuery::new("the".to_string()))
+        .unwrap();
+    let results = scanner.try_into_batch().await.unwrap();
+    assert_eq!(
+        results.num_rows(),
+        2,
+        "custom stop words replace built-ins after loading through the clone base"
+    );
+}
+
+#[rstest]
+#[case::none_vs_empty(None, Some(Vec::new()))]
+#[case::empty_vs_nonempty(
+    Some(Vec::new()),
+    Some(vec!["alpha".to_string()])
+)]
+#[tokio::test]
+async fn test_full_text_search_rejects_inconsistent_segment_params(
+    #[case] first_custom_stop_words: Option<Vec<String>>,
+    #[case] second_custom_stop_words: Option<Vec<String>>,
+) {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "text",
+        DataType::Utf8,
+        false,
+    )]));
+    let batches = vec![
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["the alpha", "beta"]))],
+        )
+        .unwrap(),
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["the alpha", "gamma"]))],
+        )
+        .unwrap(),
+    ];
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            max_rows_per_group: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    let fragment_ids = dataset
+        .get_fragments()
+        .iter()
+        .map(|fragment| fragment.id() as u32)
+        .collect::<Vec<_>>();
+    assert_eq!(fragment_ids.len(), 2);
+
+    let params = [
+        InvertedIndexParams::default().custom_stop_words(first_custom_stop_words),
+        InvertedIndexParams::default().custom_stop_words(second_custom_stop_words),
+    ];
+    let mut segments = Vec::with_capacity(fragment_ids.len());
+    for (fragment_id, params) in fragment_ids.into_iter().zip(params.iter()) {
+        let mut builder = dataset
+            .create_index_builder(&["text"], IndexType::Inverted, params)
+            .name("fts_idx".to_string())
+            .fragments(vec![fragment_id]);
+        segments.push(builder.execute_uncommitted().await.unwrap());
+    }
+    assert_eq!(
+        segments[0].index_details, segments[1].index_details,
+        "manifest details intentionally omit custom stop words"
+    );
+    dataset
+        .commit_existing_index_segments("fts_idx", "text", segments)
+        .await
+        .unwrap();
+
+    let mut scanner = dataset.scan();
+    scanner
+        .full_text_search(FullTextSearchQuery::new("alpha".to_string()))
+        .unwrap();
+    let error = scanner.try_into_batch().await.unwrap_err();
+
+    assert!(
+        matches!(error, Error::InvalidInput { .. }),
+        "expected InvalidInput, got {error:?}"
+    );
+    assert_contains!(
+        error.to_string(),
+        "inconsistent inverted index parameters across segments"
+    );
+}

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -16,10 +16,15 @@ use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexParams};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_table::format::IndexMetadata;
+use prost::Message;
 use roaring::RoaringBitmap;
 use uuid::Uuid;
 
-use crate::{Dataset, Error, Result, dataset::index::LanceIndexStoreExt, index::DatasetIndexExt};
+use crate::{
+    Dataset, Error, Result,
+    dataset::index::LanceIndexStoreExt,
+    index::{DatasetIndexExt, scalar::fetch_index_details},
+};
 
 /// Build an empty update stream for the inverted merge API.
 ///
@@ -175,41 +180,53 @@ pub async fn load_segments(dataset: &Dataset, column: &str) -> Result<Option<Vec
     Ok(Some(indices))
 }
 
-/// Load and validate the shared [`InvertedIndexParams`] across committed
-/// segments returned by [`load_segments`], then derive their manifest-facing
-/// [`InvertedIndexDetails`].
+/// Load and validate the shared [`InvertedIndexDetails`] across committed
+/// segments returned by [`load_segments`].
 ///
-/// The persisted params are the authoritative query contract because
-/// `InvertedIndexDetails` is intentionally lossy (for example, it omits custom
-/// stop words). All segments must agree on the complete persisted params before
-/// a query may select one segment's tokenizer. Legacy segments remain
-/// compatible because [`InvertedIndex::load_params`] reads their tokenizer
-/// config from the legacy tokens file and applies defaults for missing fields.
+/// All segments are required to agree on their semantic `InvertedIndexDetails`
+/// payload (tokenizer, position settings, etc.); inconsistent
+/// segments return an error. Details are canonicalized before comparison so
+/// legacy segments that omit default fields remain compatible with newly
+/// written text FTS segments. Returns the canonical details that may be used
+/// when constructing a tokenizer or running a query against the index.
 pub async fn load_segment_details(
     dataset: &Dataset,
     column: &str,
     segments: &[IndexMetadata],
 ) -> Result<InvertedIndexDetails> {
-    let mut expected_params: Option<(Uuid, InvertedIndexParams)> = None;
+    let mut expected_details: Option<InvertedIndexDetails> = None;
     for meta in segments {
-        let params = load_segment_params(dataset, meta).await?;
-        match &expected_params {
-            Some((expected_uuid, expected)) if expected != &params => {
+        let details_any = fetch_index_details(dataset, column, meta).await?;
+        let details =
+            InvertedIndexDetails::decode(details_any.value.as_slice()).map_err(|err| {
+                Error::io(format!(
+                    "failed to decode InvertedIndexDetails payload: {err}"
+                ))
+            })?;
+        let details = canonicalize_inverted_index_details(details)?;
+        match &expected_details {
+            Some(expected) if expected != &details => {
                 return Err(Error::invalid_input(format!(
-                    "FTS index {} has inconsistent inverted index parameters across segments {} and {}",
-                    meta.name, expected_uuid, meta.uuid
+                    "FTS index {} has inconsistent inverted index details across segments",
+                    meta.name
                 )));
             }
             Some(_) => {}
-            None => expected_params = Some((meta.uuid, params)),
+            None => expected_details = Some(details),
         }
     }
-    let (_, params) = expected_params.ok_or_else(|| {
+    expected_details.ok_or_else(|| {
         Error::invalid_input(format!(
             "FTS index for column {} requires at least one segment",
             column
         ))
-    })?;
+    })
+}
+
+fn canonicalize_inverted_index_details(
+    details: InvertedIndexDetails,
+) -> Result<InvertedIndexDetails> {
+    let params = InvertedIndexParams::try_from(&details)?;
     InvertedIndexDetails::try_from(&params)
 }
 
@@ -223,17 +240,7 @@ pub async fn load_segment_params(
 }
 
 #[cfg(test)]
-fn canonicalize_inverted_index_details(
-    details: InvertedIndexDetails,
-) -> Result<InvertedIndexDetails> {
-    let params = InvertedIndexParams::try_from(&details)?;
-    InvertedIndexDetails::try_from(&params)
-}
-
-#[cfg(test)]
 mod tests {
-    use prost::Message;
-
     use super::*;
 
     #[test]

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -16,15 +16,10 @@ use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexParams};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_table::format::IndexMetadata;
-use prost::Message;
 use roaring::RoaringBitmap;
 use uuid::Uuid;
 
-use crate::{
-    Dataset, Error, Result,
-    dataset::index::LanceIndexStoreExt,
-    index::{DatasetIndexExt, scalar::fetch_index_details},
-};
+use crate::{Dataset, Error, Result, dataset::index::LanceIndexStoreExt, index::DatasetIndexExt};
 
 /// Build an empty update stream for the inverted merge API.
 ///
@@ -180,53 +175,41 @@ pub async fn load_segments(dataset: &Dataset, column: &str) -> Result<Option<Vec
     Ok(Some(indices))
 }
 
-/// Load and validate the shared [`InvertedIndexDetails`] across committed
-/// segments returned by [`load_segments`].
+/// Load and validate the shared [`InvertedIndexParams`] across committed
+/// segments returned by [`load_segments`], then derive their manifest-facing
+/// [`InvertedIndexDetails`].
 ///
-/// All segments are required to agree on their semantic `InvertedIndexDetails`
-/// payload (tokenizer, position settings, etc.); inconsistent
-/// segments return an error. Details are canonicalized before comparison so
-/// legacy segments that omit default fields remain compatible with newly
-/// written text FTS segments. Returns the canonical details that may be used
-/// when constructing a tokenizer or running a query against the index.
+/// The persisted params are the authoritative query contract because
+/// `InvertedIndexDetails` is intentionally lossy (for example, it omits custom
+/// stop words). All segments must agree on the complete persisted params before
+/// a query may select one segment's tokenizer. Legacy segments remain
+/// compatible because [`InvertedIndex::load_params`] reads their tokenizer
+/// config from the legacy tokens file and applies defaults for missing fields.
 pub async fn load_segment_details(
     dataset: &Dataset,
     column: &str,
     segments: &[IndexMetadata],
 ) -> Result<InvertedIndexDetails> {
-    let mut expected_details: Option<InvertedIndexDetails> = None;
+    let mut expected_params: Option<(Uuid, InvertedIndexParams)> = None;
     for meta in segments {
-        let details_any = fetch_index_details(dataset, column, meta).await?;
-        let details =
-            InvertedIndexDetails::decode(details_any.value.as_slice()).map_err(|err| {
-                Error::io(format!(
-                    "failed to decode InvertedIndexDetails payload: {err}"
-                ))
-            })?;
-        let details = canonicalize_inverted_index_details(details)?;
-        match &expected_details {
-            Some(expected) if expected != &details => {
+        let params = load_segment_params(dataset, meta).await?;
+        match &expected_params {
+            Some((expected_uuid, expected)) if expected != &params => {
                 return Err(Error::invalid_input(format!(
-                    "FTS index {} has inconsistent inverted index details across segments",
-                    meta.name
+                    "FTS index {} has inconsistent inverted index parameters across segments {} and {}",
+                    meta.name, expected_uuid, meta.uuid
                 )));
             }
             Some(_) => {}
-            None => expected_details = Some(details),
+            None => expected_params = Some((meta.uuid, params)),
         }
     }
-    expected_details.ok_or_else(|| {
+    let (_, params) = expected_params.ok_or_else(|| {
         Error::invalid_input(format!(
             "FTS index for column {} requires at least one segment",
             column
         ))
-    })
-}
-
-fn canonicalize_inverted_index_details(
-    details: InvertedIndexDetails,
-) -> Result<InvertedIndexDetails> {
-    let params = InvertedIndexParams::try_from(&details)?;
+    })?;
     InvertedIndexDetails::try_from(&params)
 }
 
@@ -240,7 +223,17 @@ pub async fn load_segment_params(
 }
 
 #[cfg(test)]
+fn canonicalize_inverted_index_details(
+    details: InvertedIndexDetails,
+) -> Result<InvertedIndexDetails> {
+    let params = InvertedIndexParams::try_from(&details)?;
+    InvertedIndexDetails::try_from(&params)
+}
+
+#[cfg(test)]
 mod tests {
+    use prost::Message;
+
     use super::*;
 
     #[test]

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -35,7 +35,7 @@ use lance_table::format::IndexMetadata;
 
 use super::PreFilterSource;
 use super::utils::{IndexMetrics, build_prefilter};
-use crate::index::scalar::inverted::{load_segment_details, load_segments};
+use crate::index::scalar::inverted::load_segments;
 use crate::{Dataset, index::DatasetIndexInternalExt};
 use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
@@ -90,12 +90,50 @@ async fn open_fts_segments(
     segments: &[IndexMetadata],
     metrics: &IndexMetrics,
 ) -> Result<Vec<Arc<InvertedIndex>>> {
-    try_join_all(
+    let indices = try_join_all(
         segments
             .iter()
             .map(|segment| open_fts_segment(dataset, column, segment, metrics)),
     )
-    .await
+    .await?;
+    validate_fts_segment_params(column, segments, &indices)?;
+    Ok(indices)
+}
+
+/// Validate complete persisted FTS parameters after opening all segments.
+///
+/// The opened indices are authoritative for query semantics and already carry
+/// their persisted params. Comparing them here includes fields omitted from
+/// manifest details, such as custom stop words, without reading index metadata
+/// separately from the scalar-index cache.
+fn validate_fts_segment_params(
+    column: &str,
+    segments: &[IndexMetadata],
+    indices: &[Arc<InvertedIndex>],
+) -> Result<()> {
+    if segments.len() != indices.len() {
+        return Err(Error::invalid_input(format!(
+            "FTS index for column {} resolved {} segments but opened {} indices",
+            column,
+            segments.len(),
+            indices.len()
+        )));
+    }
+    let Some((expected_segment, expected_index)) = segments.first().zip(indices.first()) else {
+        return Err(Error::invalid_input(format!(
+            "FTS index for column {} requires at least one segment",
+            column
+        )));
+    };
+    for (segment, index) in segments.iter().zip(indices).skip(1) {
+        if index.params() != expected_index.params() {
+            return Err(Error::invalid_input(format!(
+                "FTS index {} has inconsistent inverted index parameters across segments {} and {}",
+                segment.name, expected_segment.uuid, segment.uuid
+            )));
+        }
+    }
+    Ok(())
 }
 
 async fn search_segments(
@@ -630,7 +668,6 @@ impl ExecutionPlan for MatchQueryExec {
             let segments = segment_selection
                 .resolve(&ds, &column, &metrics.segment_bind_duration)
                 .await?;
-            let _details = load_segment_details(&ds, &column, &segments).await?;
             let indices =
                 open_fts_segments(&ds, &column, &segments, &metrics.index_metrics).await?;
 
@@ -745,9 +782,9 @@ pub struct FlatMatchFilterExec {
     query: MatchQuery,
     params: FtsSearchParams,
     /// Optional pre-resolved segment list. See
-    /// [`MatchQueryExec::new_with_segments`]. `FlatMatchFilterExec` only
-    /// uses the first segment's tokenizer, but the full list is preserved so
-    /// the field round-trips through `with_new_children`.
+    /// [`MatchQueryExec::new_with_segments`]. All segments are opened to
+    /// validate their complete persisted params before using the first
+    /// segment's tokenizer.
     preset_segments: Option<Vec<IndexMetadata>>,
 
     metrics: ExecutionPlanMetricsSet,
@@ -783,15 +820,14 @@ impl FlatMatchFilterExec {
         metrics: &IndexMetrics,
     ) -> DataFusionResult<Box<dyn LanceTokenizer>> {
         if let Some(segments) = load_segments(dataset, column).await? {
-            let index_meta = segments.first().ok_or_else(|| {
+            let indices = open_fts_segments(dataset, column, &segments, metrics).await?;
+            let index = indices.first().ok_or_else(|| {
                 DataFusionError::Execution(format!(
                     "FTS index for column {} has no segments",
                     column
                 ))
             })?;
-            return Ok(open_fts_segment(dataset, column, index_meta, metrics)
-                .await?
-                .tokenizer());
+            return Ok(index.tokenizer());
         }
         Ok(default_text_tokenizer())
     }
@@ -802,12 +838,11 @@ impl FlatMatchFilterExec {
         segments: &[IndexMetadata],
         metrics: &IndexMetrics,
     ) -> DataFusionResult<Box<dyn LanceTokenizer>> {
-        let index_meta = segments.first().ok_or_else(|| {
+        let indices = open_fts_segments(dataset, column, segments, metrics).await?;
+        let index = indices.first().ok_or_else(|| {
             DataFusionError::Execution(format!("FTS index for column {} has no segments", column))
         })?;
-        Ok(open_fts_segment(dataset, column, index_meta, metrics)
-            .await?
-            .tokenizer())
+        Ok(index.tokenizer())
     }
 
     pub fn new(
@@ -826,9 +861,9 @@ impl FlatMatchFilterExec {
         }
     }
 
-    /// See [`MatchQueryExec::new_with_segments`]. `FlatMatchFilterExec`
-    /// uses the first segment's tokenizer; the rest are kept for caller-side
-    /// bookkeeping.
+    /// See [`MatchQueryExec::new_with_segments`]. The first segment supplies
+    /// the tokenizer after every segment's complete params have been
+    /// validated.
     pub fn new_with_segments(
         input: Arc<dyn ExecutionPlan>,
         dataset: Arc<Dataset>,
@@ -1214,7 +1249,6 @@ impl ExecutionPlan for FlatMatchQueryExec {
             };
             let (tokenizer, base_scorer) = match segments {
                 Some(segments) => {
-                    let _details = load_segment_details(&ds, &column, &segments).await?;
                     let indices =
                         open_fts_segments(&ds, &column, &segments, &metrics.index_metrics).await?;
                     metrics.record_parts_searched(
@@ -1552,7 +1586,6 @@ impl ExecutionPlan for PhraseQueryExec {
             let segments = segment_selection
                 .resolve(&ds, &column, &metrics.segment_bind_duration)
                 .await?;
-            let _details = load_segment_details(&ds, &column, &segments).await?;
             let indices =
                 open_fts_segments(&ds, &column, &segments, &metrics.index_metrics).await?;
 


### PR DESCRIPTION
## What is the bug?

Segmented FTS query planning compared `InvertedIndexDetails` from each index manifest. That representation is intentionally lossy and omits tokenizer state such as `custom_stop_words`, so segments with different persisted tokenizer configurations could be combined and queried with inconsistent semantics.

## What incorrect behavior does the bug cause?

A segmented index could silently collapse distinct states such as omitted custom stop words, an explicit empty list, and a non-empty replacement list. A first implementation fixed correctness by reading every segment's metadata before execution, but that bypassed the scalar-index cache and added two I/O operations to both cold and fully prewarmed queries.

## How does this PR fix the problem?

- Keep manifest `InvertedIndexDetails` validation in planning for capability checks such as positions.
- Open every selected FTS segment through the existing scalar-index cache before choosing a tokenizer.
- Compare the complete persisted `InvertedIndexParams` from the opened indexes, including `custom_stop_words`.
- Fail closed with both segment IDs when any complete parameter set differs.
- Cover Match, FlatMatch, Phrase, and FlatMatchFilter paths through the same validation boundary.
- Preserve shallow-clone `base_id` behavior through the public index-store path.
- Add actual multi-segment query coverage for `None` versus `[]`, `[]` versus non-empty lists, legacy details, and shallow clones.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- Prewarmed FTS query I/O regression: 1 passed, 0 reads after prewarm
- Cold inverted-index I/O regression: 1 passed, below the existing 18-read bound
- `cargo test -p lance segment_params -- --nocapture` (4 passed)
- `cargo test -p lance canonicalize_inverted_details_accepts_legacy_empty_details -- --nocapture` (1 passed)
- `cargo test -p lance-index params_legacy -- --nocapture` (2 passed)
- FlatMatchFilter persisted-tokenizer regression: 1 passed

## Coordination

This is the canonical latest-`main` fix. Sophon currently pins Lance `v10.0.0-beta.5`, so its parent PR uses the same patch backported onto that exact pin instead of upgrading the full Lance dependency set.

- LanceDB SDK/source contract: https://github.com/lancedb/lancedb/pull/3734
- Sophon end-to-end support: https://github.com/lancedb/sophon/pull/6932
