### PR TITLE
feat(mem_wal): return the sealed generation from force_seal_active

### DIFF
--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -101,6 +101,7 @@ pub use sharding::{
     evaluate_sharding_spec_with_source_columns,
 };
 pub use wal::{BatchDurableWatcher, WalAppendResult, WalAppender, WalReadEntry, WalTailer};
+pub use write::SealedGeneration;
 pub use write::ShardWriter;
 pub use write::ShardWriterConfig;
 pub use write::WriteResult;

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -101,7 +101,7 @@ pub use sharding::{
     evaluate_sharding_spec_with_source_columns,
 };
 pub use wal::{BatchDurableWatcher, WalAppendResult, WalAppender, WalReadEntry, WalTailer};
-pub use write::SealedGeneration;
+pub use write::SealFence;
 pub use write::ShardWriter;
 pub use write::ShardWriterConfig;
 pub use write::WriteResult;

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -415,6 +415,32 @@ impl MemIndexConfig {
     }
 }
 
+/// Which kind of in-memory index an [`MemIndexDescriptor`] names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemIndexKind {
+    BTree,
+    Hnsw,
+    Fts,
+}
+
+impl MemIndexKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::BTree => "btree",
+            Self::Hnsw => "hnsw",
+            Self::Fts => "fts",
+        }
+    }
+}
+
+/// One in-memory index, as reported by [`IndexStore::describe`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemIndexDescriptor {
+    pub name: String,
+    pub kind: MemIndexKind,
+    pub column: String,
+}
+
 /// Registry managing all in-memory indexes for a MemTable.
 ///
 /// Indexes are keyed by index name. Each index stores its field_id for
@@ -1127,6 +1153,44 @@ impl IndexStore {
     /// Check if the registry has any indexes.
     pub fn is_empty(&self) -> bool {
         self.btree_indexes.is_empty() && self.hnsw_indexes.is_empty() && self.fts_indexes.is_empty()
+    }
+
+    /// Describe every index this memtable carries, for diagnostics.
+    ///
+    /// Answers "is my fresh-tier vector search brute-force" — an absent
+    /// HNSW entry is the whole explanation, and there is no other way to
+    /// see it from outside. Ordered by kind then name so repeated calls
+    /// compare cleanly; `HashMap` iteration order alone would not.
+    pub fn describe(&self) -> Vec<MemIndexDescriptor> {
+        let mut out: Vec<MemIndexDescriptor> = self
+            .btree_indexes
+            .iter()
+            .map(|(name, idx)| MemIndexDescriptor {
+                name: name.clone(),
+                kind: MemIndexKind::BTree,
+                column: idx.column_name().to_string(),
+            })
+            .chain(
+                self.hnsw_indexes
+                    .iter()
+                    .map(|(name, idx)| MemIndexDescriptor {
+                        name: name.clone(),
+                        kind: MemIndexKind::Hnsw,
+                        column: idx.column_name().to_string(),
+                    }),
+            )
+            .chain(
+                self.fts_indexes
+                    .iter()
+                    .map(|(name, idx)| MemIndexDescriptor {
+                        name: name.clone(),
+                        kind: MemIndexKind::Fts,
+                        column: idx.column_name().to_string(),
+                    }),
+            )
+            .collect();
+        out.sort_by(|a, b| (a.kind, &a.name).cmp(&(b.kind, &b.name)));
+        out
     }
 
     /// Get the total number of indexes.

--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -415,32 +415,6 @@ impl MemIndexConfig {
     }
 }
 
-/// Which kind of in-memory index an [`MemIndexDescriptor`] names.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MemIndexKind {
-    BTree,
-    Hnsw,
-    Fts,
-}
-
-impl MemIndexKind {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::BTree => "btree",
-            Self::Hnsw => "hnsw",
-            Self::Fts => "fts",
-        }
-    }
-}
-
-/// One in-memory index, as reported by [`IndexStore::describe`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MemIndexDescriptor {
-    pub name: String,
-    pub kind: MemIndexKind,
-    pub column: String,
-}
-
 /// Registry managing all in-memory indexes for a MemTable.
 ///
 /// Indexes are keyed by index name. Each index stores its field_id for
@@ -1155,41 +1129,21 @@ impl IndexStore {
         self.btree_indexes.is_empty() && self.hnsw_indexes.is_empty() && self.fts_indexes.is_empty()
     }
 
-    /// Describe every index this memtable carries, for diagnostics.
+    /// Name every index this memtable carries, for diagnostics.
     ///
     /// Answers "is my fresh-tier vector search brute-force" — an absent
-    /// HNSW entry is the whole explanation, and there is no other way to
-    /// see it from outside. Ordered by kind then name so repeated calls
-    /// compare cleanly; `HashMap` iteration order alone would not.
-    pub fn describe(&self) -> Vec<MemIndexDescriptor> {
-        let mut out: Vec<MemIndexDescriptor> = self
+    /// name is the whole explanation, and there is no other way to see it
+    /// from outside. Sorted so repeated calls compare cleanly; `HashMap`
+    /// iteration order alone would not.
+    pub fn index_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
             .btree_indexes
-            .iter()
-            .map(|(name, idx)| MemIndexDescriptor {
-                name: name.clone(),
-                kind: MemIndexKind::BTree,
-                column: idx.column_name().to_string(),
-            })
-            .chain(
-                self.hnsw_indexes
-                    .iter()
-                    .map(|(name, idx)| MemIndexDescriptor {
-                        name: name.clone(),
-                        kind: MemIndexKind::Hnsw,
-                        column: idx.column_name().to_string(),
-                    }),
-            )
-            .chain(
-                self.fts_indexes
-                    .iter()
-                    .map(|(name, idx)| MemIndexDescriptor {
-                        name: name.clone(),
-                        kind: MemIndexKind::Fts,
-                        column: idx.column_name().to_string(),
-                    }),
-            )
+            .keys()
+            .chain(self.hnsw_indexes.keys())
+            .chain(self.fts_indexes.keys())
+            .cloned()
             .collect();
-        out.sort_by(|a, b| (a.kind, &a.name).cmp(&(b.kind, &b.name)));
+        out.sort();
         out
     }
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -2501,17 +2501,16 @@ impl ShardWriter {
         }
     }
 
-    /// Seal the active memtable so it's queued for L0 flush. `None` when
-    /// the active memtable was empty (a no-op seal). Errors in WAL-only
-    /// mode or if this writer has been fenced by a successor.
+    /// Seal the active memtable so it's queued for L0 flush. Errors in
+    /// WAL-only mode or if this writer has been fenced by a successor.
     ///
-    /// The returned [`SealedGeneration`] is what makes a *bounded* wait
-    /// possible: a caller that needs "everything written before my seal is
-    /// in L0" can wait on this one generation
-    /// (`ShardManifest::current_generation` exceeding it) instead of
-    /// [`Self::wait_for_flush_drain`], which loops until the frozen set is
-    /// empty and therefore also waits on every memtable frozen *while it
-    /// waits*. Under sustained writes that set may never empty.
+    /// The returned [`SealFence`] is what makes a *bounded* wait possible:
+    /// a caller that needs "everything written before my seal is in L0"
+    /// awaits [`SealFence::wait`], which covers the flushes outstanding at
+    /// seal time and nothing else. [`Self::wait_for_flush_drain`] instead
+    /// loops until the frozen set is *empty*, re-collecting it each round,
+    /// so it also waits on every memtable frozen *while it waits*. Under
+    /// sustained writes that set may never empty.
     ///
     /// Beyond test setup where deterministic flush points are required,
     /// this is the primary lever for callers that need to drive flushes
@@ -2521,7 +2520,7 @@ impl ShardWriter {
     /// the next epoch starts with no replayable entries from the old
     /// layout.
     #[instrument(name = "sw_force_seal_active", level = "info", skip_all, fields(shard_id = %self.config.shard_id, epoch = self.epoch))]
-    pub async fn force_seal_active(&self) -> Result<Option<SealedGeneration>> {
+    pub async fn force_seal_active(&self) -> Result<SealFence> {
         match &self.mode {
             WriterMode::MemTable {
                 state,
@@ -2531,15 +2530,28 @@ impl ShardWriter {
                 self.check_fenced().await?;
                 self.wal_flusher.check_poisoned()?;
                 let mut state = state.write().await;
-                if state.memtable.batch_count() == 0 {
-                    return Ok(None);
-                }
-                let sealed = SealedGeneration {
-                    generation: state.memtable.generation(),
-                    rows: state.memtable.row_count(),
+                let sealed_generation = if state.memtable.batch_count() == 0 {
+                    None
+                } else {
+                    let generation = state.memtable.generation();
+                    writer_state.freeze_memtable(&mut state)?;
+                    Some(generation)
                 };
-                writer_state.freeze_memtable(&mut state)?;
-                Ok(Some(sealed))
+                // Capture the outstanding set under the same lock that froze,
+                // so no freeze can slip between the two and widen the fence.
+                // It covers more than the generation just sealed: a
+                // size/interval trigger freezes generations asynchronously, so
+                // an empty active memtable does *not* mean every pre-call write
+                // already reached L0. Watchers are popped as flushes settle, so
+                // whatever remains here is exactly what is still owed.
+                Ok(SealFence {
+                    sealed_generation,
+                    watchers: state
+                        .frozen_flush_watchers
+                        .iter()
+                        .map(|(_, w)| w.clone())
+                        .collect(),
+                })
             }
             WriterMode::WalOnly { .. } => Err(Error::invalid_input(
                 "force_seal_active not available in WAL-only mode (no MemTable)",
@@ -2553,12 +2565,10 @@ impl ShardWriter {
     /// want everything-on-disk. Errors in WAL-only mode, or if any
     /// awaited flush reports `DurabilityResult::Failed`.
     ///
-    /// Useful in tests for deterministic post-flush assertions, and in
-    /// production wherever a caller needs a synchronous fence after
-    /// [`Self::force_seal_active`] — e.g. trimming memtable residency
-    /// across shards in a multi-table WAL writer, or ensuring the WAL
-    /// is fully drained to Lance storage before rolling to a new
-    /// format/epoch.
+    /// Useful in tests for deterministic post-flush assertions. In
+    /// production prefer [`SealFence::wait`] from the seal itself: this
+    /// drains the queue to empty, including memtables frozen after the
+    /// call, so under sustained writes it may not return.
     #[instrument(name = "sw_wait_for_flush_drain", level = "info", skip_all, fields(shard_id = %self.config.shard_id, epoch = self.epoch))]
     pub async fn wait_for_flush_drain(&self) -> Result<()> {
         let state_lock = match &self.mode {
@@ -2846,15 +2856,50 @@ pub struct WalStats {
     pub next_wal_entry_position: u64,
 }
 
-/// What one [`ShardWriter::force_seal_active`] call sealed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SealedGeneration {
-    /// Generation number of the memtable that was frozen. The shard
-    /// manifest covers it once `current_generation` exceeds it — that is
-    /// the predicate a bounded post-seal wait should use.
-    pub generation: u64,
-    /// Rows the sealed memtable held.
-    pub rows: usize,
+/// The L0 flushes outstanding when [`ShardWriter::force_seal_active`]
+/// returned — the exact predicate for "everything written before that call
+/// is in L0".
+///
+/// The set is fixed at seal time, so [`Self::wait`] is bounded no matter how
+/// many memtables freeze while it waits, and each entry reports the outcome of
+/// its own flush. That is why the fence is a captured watcher set and not a
+/// generation number compared against `ShardManifest::current_generation`: the
+/// manifest advances to `generation + 1` on every committed flush without
+/// checking for a gap, so a later generation's success moves it past a
+/// generation that failed and never reached L0 — the watermark would report
+/// durability that does not exist.
+#[derive(Debug)]
+pub struct SealFence {
+    sealed_generation: Option<u64>,
+    watchers: Vec<DurabilityWatcher>,
+}
+
+impl SealFence {
+    /// The generation the seal froze, or `None` when the active memtable
+    /// was empty (a no-op seal). Independent of what the fence covers: an
+    /// empty active memtable says nothing about generations frozen earlier
+    /// and still awaiting flush, which the fence still waits on.
+    pub fn sealed_generation(&self) -> Option<u64> {
+        self.sealed_generation
+    }
+
+    /// Block until every flush this fence covers has landed in L0.
+    ///
+    /// Errors if any of them reports `DurabilityResult::Failed`, or if the
+    /// flush handler exited without reporting.
+    pub async fn wait(self) -> Result<()> {
+        for mut watcher in self.watchers {
+            match watcher.await_value().await {
+                Some(durability) => durability.into_result()?,
+                None => {
+                    return Err(Error::io(
+                        "MemTable flush handler exited before reporting completion",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 /// The oldest store that still owes the WAL an append, or `None` when everything
@@ -6922,8 +6967,9 @@ mod tests {
             .put(vec![create_test_batch(&schema, 0, 10)])
             .await
             .unwrap();
-        writer.force_seal_active().await.unwrap();
-        writer.wait_for_flush_drain().await.unwrap();
+        let fence = writer.force_seal_active().await.unwrap();
+        assert_eq!(fence.sealed_generation(), Some(initial_gen));
+        fence.wait().await.unwrap();
 
         let stats = writer.memtable_stats().await.unwrap();
         assert_eq!(stats.generation, initial_gen + 1);
@@ -6937,6 +6983,127 @@ mod tests {
         assert_eq!(manifest.sstables.len(), flushed_before + 1);
 
         writer.close().await.unwrap();
+    }
+
+    /// Durable writes so `put` returns only once the row is indexed and
+    /// WAL-durable. Both fence tests tear the background tasks down before
+    /// freezing, and a freeze still owing an index apply or a WAL append
+    /// would dispatch onto a closed channel and poison the writer.
+    fn seal_fence_test_config(shard_id: Uuid) -> ShardWriterConfig {
+        ShardWriterConfig {
+            shard_id,
+            shard_spec_id: 0,
+            durable_write: true,
+            max_wal_flush_interval: Some(Duration::from_millis(10)),
+            max_memtable_size: 64 * 1024 * 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        }
+    }
+
+    /// An empty active memtable does not mean every pre-call write is in
+    /// L0: a size/interval trigger swaps generation N for an empty N+1
+    /// while N's flush is still in flight. The seal must fence that
+    /// generation anyway — reporting "nothing sealed, nothing to wait for"
+    /// lets a caller acknowledge a flush that has not happened.
+    #[tokio::test]
+    async fn test_force_seal_active_fences_pending_generation_when_active_is_empty() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            seal_fence_test_config(Uuid::new_v4()),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer
+            .put(vec![create_test_batch(&schema, 0, 10)])
+            .await
+            .unwrap();
+
+        // Stop the flush tasks, then freeze by hand: this is the post-rotation
+        // state held still — generation N frozen and unflushed, N+1 active and
+        // empty.
+        writer.task_executor.shutdown_all().await.unwrap();
+        let pending_generation = match &writer.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                ..
+            } => {
+                let mut state = state.write().await;
+                writer_state.freeze_memtable(&mut state).unwrap() - 1
+            }
+            WriterMode::WalOnly { .. } => unreachable!("opened in memtable mode"),
+        };
+
+        let fence = writer.force_seal_active().await.unwrap();
+        assert_eq!(
+            fence.sealed_generation(),
+            None,
+            "the active memtable was empty, so this seal froze nothing"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), fence.wait())
+                .await
+                .is_err(),
+            "generation {pending_generation} is still awaiting flush; the fence must not be satisfied"
+        );
+    }
+
+    /// The fence is tied to each flush's own outcome, never to
+    /// `ShardManifest::current_generation`. The manifest advances to
+    /// `generation + 1` on every committed flush without checking for a gap,
+    /// so a later generation's success moves it past one that failed — a
+    /// watermark comparison would report durability that does not exist.
+    #[tokio::test]
+    async fn test_force_seal_active_fence_ignores_manifest_generation_advance() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            seal_fence_test_config(Uuid::new_v4()),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer
+            .put(vec![create_test_batch(&schema, 0, 10)])
+            .await
+            .unwrap();
+
+        // No flush task, so the sealed generation never reaches L0.
+        writer.task_executor.shutdown_all().await.unwrap();
+        let fence = writer.force_seal_active().await.unwrap();
+        let sealed = fence
+            .sealed_generation()
+            .expect("the active memtable held rows");
+
+        // Advance the manifest past the sealed generation, as a later
+        // generation's successful flush would.
+        writer
+            .manifest_store
+            .commit_update(writer.epoch(), |current| ShardManifest {
+                version: current.version + 1,
+                current_generation: sealed + 2,
+                ..current.clone()
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), fence.wait())
+                .await
+                .is_err(),
+            "generation {sealed} never reached L0; a manifest advance past it must not satisfy its fence"
+        );
     }
 
     /// `abort` tears down the background flush tasks WITHOUT flushing —

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -2501,10 +2501,17 @@ impl ShardWriter {
         }
     }
 
-    /// Seal the active memtable so it's queued for L0 flush. No-op when
-    /// the active memtable is empty. Errors in WAL-only mode or if this
-    /// writer has been fenced by a successor. Pair with
-    /// [`Self::wait_for_flush_drain`] to wait for the queued flush.
+    /// Seal the active memtable so it's queued for L0 flush. `None` when
+    /// the active memtable was empty (a no-op seal). Errors in WAL-only
+    /// mode or if this writer has been fenced by a successor.
+    ///
+    /// The returned [`SealedGeneration`] is what makes a *bounded* wait
+    /// possible: a caller that needs "everything written before my seal is
+    /// in L0" can wait on this one generation
+    /// (`ShardManifest::current_generation` exceeding it) instead of
+    /// [`Self::wait_for_flush_drain`], which loops until the frozen set is
+    /// empty and therefore also waits on every memtable frozen *while it
+    /// waits*. Under sustained writes that set may never empty.
     ///
     /// Beyond test setup where deterministic flush points are required,
     /// this is the primary lever for callers that need to drive flushes
@@ -2514,7 +2521,7 @@ impl ShardWriter {
     /// the next epoch starts with no replayable entries from the old
     /// layout.
     #[instrument(name = "sw_force_seal_active", level = "info", skip_all, fields(shard_id = %self.config.shard_id, epoch = self.epoch))]
-    pub async fn force_seal_active(&self) -> Result<()> {
+    pub async fn force_seal_active(&self) -> Result<Option<SealedGeneration>> {
         match &self.mode {
             WriterMode::MemTable {
                 state,
@@ -2525,10 +2532,14 @@ impl ShardWriter {
                 self.wal_flusher.check_poisoned()?;
                 let mut state = state.write().await;
                 if state.memtable.batch_count() == 0 {
-                    return Ok(());
+                    return Ok(None);
                 }
+                let sealed = SealedGeneration {
+                    generation: state.memtable.generation(),
+                    rows: state.memtable.row_count(),
+                };
                 writer_state.freeze_memtable(&mut state)?;
-                Ok(())
+                Ok(Some(sealed))
             }
             WriterMode::WalOnly { .. } => Err(Error::invalid_input(
                 "force_seal_active not available in WAL-only mode (no MemTable)",
@@ -2833,6 +2844,17 @@ pub struct MemTableStats {
 pub struct WalStats {
     /// Next WAL entry position to be used.
     pub next_wal_entry_position: u64,
+}
+
+/// What one [`ShardWriter::force_seal_active`] call sealed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SealedGeneration {
+    /// Generation number of the memtable that was frozen. The shard
+    /// manifest covers it once `current_generation` exceeds it — that is
+    /// the predicate a bounded post-seal wait should use.
+    pub generation: u64,
+    /// Rows the sealed memtable held.
+    pub rows: usize,
 }
 
 /// The oldest store that still owes the WAL an append, or `None` when everything


### PR DESCRIPTION
## Why

`wait_for_flush_drain` loops until the frozen-watcher set is *empty*, re-collecting the set on each round — so it also waits on every memtable frozen **while it waits**, including ones the size/interval trigger and backpressure freeze concurrently. On a table under sustained write load that set may never empty, which makes any post-seal ack unbounded on exactly the workload that asks for one.

The contract a caller actually needs is narrower: *everything written before my seal is in L0*. That is a predicate on a fixed set of outstanding flushes, not on the queue as it evolves.

## What

`force_seal_active` now returns a `SealFence`: the flush-completion watchers outstanding at seal time, captured under the same lock that performs the freeze. `SealFence::wait()` awaits exactly those — bounded by construction, and unaffected by concurrent freezes.

The set is deliberately wider than the generation the call froze. A size/interval trigger freezes generations asynchronously, so an empty active memtable does *not* mean every pre-call write reached L0; the fence covers those pending generations too. What this call sealed is reporting only (`SealFence::sealed_generation()`, `None` on a no-op seal) and is not the wait target.

An earlier revision returned that generation for the caller to compare against the manifest's `current_generation`. That predicate was unsound (thanks @lance-gatekeeper): `update_manifest` advances `current_generation` to `generation + 1` on every committed flush without checking for a gap, and the dispatcher logs a failed flush and keeps draining — so a later generation's success moves the watermark past one that failed and never reached L0. Waiting on per-generation flush outcomes avoids the manifest entirely. The durability hole underneath it is #8293.

Also reports the in-memory index set via `IndexStore::index_names`. An absent HNSW entry on a vector column is the whole explanation for a brute-force fresh-tier search, and there was no way to see it from outside the store.

## Compatibility

`force_seal_active`'s return type changes from `Result<()>` to `Result<SealFence>`. Existing `.await?;` call sites compile unchanged (the value is dropped); only code that binds or asserts on the unit value needs touching. No format or on-disk change.

## Consumer

Sophon's WAL uses this to make `POST /v1/table/{name}/flush` bounded — it currently calls `wait_for_flush_drain` and inherits the unbounded-latency problem above.

## Tests

- `test_force_seal_active_and_wait_for_flush_drain` — extended to assert the fence names the frozen generation and that `wait()` is a working flush fence.
- `test_force_seal_active_fences_pending_generation_when_active_is_empty` — an empty active memtable with a generation still awaiting flush must not produce a satisfied fence.
- `test_force_seal_active_fence_ignores_manifest_generation_advance` — advancing `current_generation` past the sealed generation, as a later success would, must not satisfy its fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)