### PR TITLE
feat(python): add LanceDataset.slice() method

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2367,6 +2367,52 @@ class LanceDataset(pa.dataset.Dataset):
         kwargs["limit"] = num_rows
         return self.scanner(**kwargs).to_table()
 
+    def slice(
+        self,
+        start: int,
+        end: int,
+        columns: Optional[Union[List[str], Dict[str, str]]] = None,
+    ) -> pa.Table:
+        """Select a contiguous range of rows by position.
+
+        Equivalent to ``dataset.take(list(range(start, end)))``, but pushed
+        down as an offset/limit scan instead of a materialized index list.
+
+        Parameters
+        ----------
+        start : int
+            The index of the first row to include (inclusive). Must be
+            non-negative.
+        end : int
+            The index to stop before (exclusive). Must be greater than or
+            equal to ``start``.
+        columns: list of str, or dict of str to str default None
+            List of column names to be fetched.
+            Or a dictionary of column names to SQL expressions.
+            All columns are fetched if None or unspecified.
+
+        Returns
+        -------
+        table : pyarrow.Table
+
+        Examples
+        --------
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> tbl = pa.table({"id": range(100)})
+        >>> dataset = lance.write_dataset(tbl, "memory://slice_dataset")
+        >>> dataset.slice(10, 20)
+        pyarrow.Table
+        id: int64
+        ----
+        id: [[10,11,12,13,14,15,16,17,18,19]]
+        """
+        if start < 0:
+            raise ValueError(f"start must be non-negative, got {start}")
+        if end < start:
+            raise ValueError(f"end ({end}) must be >= start ({start})")
+        return self.scanner(offset=start, limit=end - start, columns=columns).to_table()
+
     def count_rows(
         self, filter: Optional[Union[str, pa.compute.Expression]] = None, **kwargs
     ) -> int:

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -700,6 +700,51 @@ def test_take(tmp_path: Path):
     assert table2 == table1
 
 
+@pytest.mark.parametrize("data_storage_version", ["legacy", "stable"])
+def test_slice(tmp_path: Path, data_storage_version: str):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+    lance.write_dataset(
+        table, base_dir, data_storage_version=data_storage_version, max_rows_per_file=10
+    )
+    dataset = lance.dataset(base_dir)
+
+    # Equivalent to take(range(start, end))
+    assert dataset.slice(10, 20) == dataset.take(list(range(10, 20)))
+
+    # Basic range within a single fragment
+    assert dataset.slice(5, 8) == table.slice(5, 3)
+
+    # Range spanning multiple fragments
+    assert dataset.slice(5, 25) == table.slice(5, 20)
+
+    # Skipping entire fragments
+    assert dataset.slice(50, 75) == table.slice(50, 25)
+
+    # Full dataset
+    assert dataset.slice(0, 100) == table.slice(0, 100)
+
+    # Empty range (start == end)
+    assert dataset.slice(10, 10) == table.slice(10, 0)
+
+    # Range extending past the end of the dataset
+    assert dataset.slice(90, 1000) == table.slice(90, 10)
+
+    # Range entirely past the end of the dataset
+    assert dataset.slice(100, 110) == table.slice(100, 0)
+
+    # With column projection
+    assert dataset.slice(10, 20, columns=["a"]) == table.select(["a"]).slice(10, 10)
+
+    # Invalid start
+    with pytest.raises(ValueError, match="start must be non-negative"):
+        dataset.slice(-1, 10)
+
+    # end < start
+    with pytest.raises(ValueError, match="must be >= start"):
+        dataset.slice(10, 5)
+
+
 def test_take_rowid_rowaddr(tmp_path: Path):
     sample_size = 10
     table1 = pa.table({"a": range(1000), "b": range(1000)})


### PR DESCRIPTION
Adds a slice(start, end, columns=None) convenience method, equivalent to take(list(range(start, end))) but implemented as a thin wrapper over scanner(offset=start, limit=end-start), reusing the existing offset/limit scan pushdown instead of materializing an index list.

Fixes #1808