### PR TITLE
feat: support incremental data storage format upgrades via Append

### DIFF
--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -596,12 +596,13 @@ pub(crate) fn convert_to_java_schema<'local>(
 
 fn parse_storage_format(name: &str) -> Result<LanceFileVersion> {
     match name.to_lowercase().as_str() {
-        "legacy" => Ok(LanceFileVersion::Legacy),
-        "v2_0" | "v2.0" => Ok(LanceFileVersion::V2_0),
+        "legacy" | "0.1" => Ok(LanceFileVersion::Legacy),
+        "v2_0" | "v2.0" | "2.0" => Ok(LanceFileVersion::V2_0),
         "stable" => Ok(LanceFileVersion::Stable),
-        "v2_1" | "v2.1" => Ok(LanceFileVersion::V2_1),
+        "v2_1" | "v2.1" | "2.1" => Ok(LanceFileVersion::V2_1),
         "next" => Ok(LanceFileVersion::Next),
-        "v2_2" | "v2.2" => Ok(LanceFileVersion::V2_2),
+        "v2_2" | "v2.2" | "2.2" => Ok(LanceFileVersion::V2_2),
+        "v2_3" | "v2.3" | "2.3" => Ok(LanceFileVersion::V2_3),
         _ => Err(Error::input_error(format!(
             "Unknown storage format: {}",
             name

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -321,10 +321,11 @@ def test_mixed_fragment_versions(tmp_path):
         lance.LanceFragment.create(ds.uri, data, data_storage_version="stable")
     )
 
-    # Attempt to commit
+    # Commit succeeds — mixed fragment versions are permitted when the manifest
+    # version is >= all fragment versions (incremental format upgrade).
     operation = lance.LanceOperation.Overwrite(ds.schema, fragments)
-    with pytest.raises(OSError, match="All data files must have the same version"):
-        lance.LanceDataset.commit(ds.uri, operation)
+    ds = lance.LanceDataset.commit(ds.uri, operation)
+    assert ds.count_rows() == 1600
 
 
 def test_create_from_file(tmp_path):

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -669,6 +669,27 @@ impl Fragment {
         }
         Ok(Some(file_version))
     }
+
+    /// Returns the maximum file version across all data files in the given fragments.
+    ///
+    /// Returns `None` if there are no data files.
+    pub fn max_file_version(fragments: &[Self]) -> Result<Option<LanceFileVersion>> {
+        let mut max_version: Option<LanceFileVersion> = None;
+        for frag in fragments {
+            for file in &frag.files {
+                let v = LanceFileVersion::try_from_major_minor(
+                    file.file_major_version,
+                    file.file_minor_version,
+                )?;
+                max_version = Some(match max_version {
+                    Some(current) if v > current => v,
+                    Some(current) => current,
+                    None => v,
+                });
+            }
+        }
+        Ok(max_version)
+    }
 }
 
 impl TryFrom<pb::DataFragment> for Fragment {

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2576,3 +2576,329 @@ async fn test_open_dataset_non_not_found_error_is_not_masked() {
         err,
     );
 }
+
+// ── Incremental format upgrade tests ─────────────────────────────────────
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_append_upgrades_format_version() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ds.manifest
+            .data_storage_format
+            .lance_file_version()
+            .unwrap(),
+        LanceFileVersion::V2_1
+    );
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ds.manifest
+            .data_storage_format
+            .lance_file_version()
+            .unwrap(),
+        LanceFileVersion::V2_2,
+        "Manifest should be upgraded to v2.2 after appending v2.2 fragments"
+    );
+    assert_eq!(ds.count_rows(None).await.unwrap(), 6);
+}
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_append_without_version_inherits_manifest() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))]).unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ds.manifest
+            .data_storage_format
+            .lance_file_version()
+            .unwrap(),
+        LanceFileVersion::V2_2,
+        "Manifest should remain v2.2 when appending without explicit version"
+    );
+    assert_eq!(ds.count_rows(None).await.unwrap(), 4);
+}
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_append_ignores_lower_format_version() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))]).unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ds.manifest
+            .data_storage_format
+            .lance_file_version()
+            .unwrap(),
+        LanceFileVersion::V2_2,
+        "Manifest should remain at v2.2 — downgrade requests are ignored"
+    );
+    assert_eq!(ds.count_rows(None).await.unwrap(), 2);
+}
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_overwrite_changes_format_version() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: Overwrite,
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ds.manifest
+            .data_storage_format
+            .lance_file_version()
+            .unwrap(),
+        LanceFileVersion::V2_2
+    );
+    assert_eq!(ds.count_rows(None).await.unwrap(), 3);
+}
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_mixed_version_fragments_readable() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+
+    let batch_v21 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![10, 20]))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch_v21)], schema.clone());
+    Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let batch_v22 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![30, 40]))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch_v22)], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let batches: Vec<RecordBatch> = ds
+        .scan()
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let combined = concat_batches(&schema, &batches).unwrap();
+    let values = combined
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let mut actual: Vec<i32> = values.iter().map(|v| v.unwrap()).collect();
+    actual.sort();
+    assert_eq!(actual, vec![10, 20, 30, 40]);
+}
+
+#[lance_test_macros::test(tokio::test)]
+async fn test_delete_on_mixed_version_table() {
+    let test_uri = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "x",
+        DataType::Int32,
+        false,
+    )]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![4, 5]))]).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let ds = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(ds.count_rows(None).await.unwrap(), 5);
+
+    let mut ds = Dataset::open(&test_uri).await.unwrap();
+    ds.delete("x = 2 OR x = 4").await.unwrap();
+
+    let ds = Dataset::open(&test_uri).await.unwrap();
+    assert_eq!(ds.count_rows(None).await.unwrap(), 3);
+    let batches: Vec<RecordBatch> = ds
+        .scan()
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let combined = concat_batches(&schema, &batches).unwrap();
+    let values = combined
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let mut actual: Vec<i32> = values.iter().map(|v| v.unwrap()).collect();
+    actual.sort();
+    assert_eq!(actual, vec![1, 3, 5]);
+}

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2452,13 +2452,27 @@ impl Transaction {
             let mut prev_manifest =
                 Manifest::new_from_previous(current_manifest, schema, Arc::new(final_fragments));
 
-            if let (Some(user_requested_version), Operation::Overwrite { .. }) =
-                (user_requested_version, &self.operation)
-            {
-                // If this is an overwrite operation and the user has requested a specific version
-                // then overwrite with that version.  Otherwise, if the user didn't request a specific
-                // version, then overwrite with whatever version we had before.
-                prev_manifest.data_storage_format = DataStorageFormat::new(user_requested_version);
+            if let Some(user_requested_version) = user_requested_version {
+                let existing_version = prev_manifest.data_storage_format.lance_file_version()?;
+                match &self.operation {
+                    Operation::Overwrite { .. } => {
+                        // Overwrite always applies the requested version.
+                        prev_manifest.data_storage_format =
+                            DataStorageFormat::new(user_requested_version);
+                    }
+                    _ => {
+                        // For all other operations (Append, Update, etc.): allow
+                        // upgrading the manifest to a higher format version. This
+                        // enables incremental format adoption — new fragments use
+                        // the newer encoding while existing fragments remain at
+                        // their original version. The reader dispatches per-file
+                        // based on DataFile.file_major_version/file_minor_version.
+                        if user_requested_version > existing_version {
+                            prev_manifest.data_storage_format =
+                                DataStorageFormat::new(user_requested_version);
+                        }
+                    }
+                }
             }
 
             prev_manifest

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -362,7 +362,9 @@ impl<'a> CommitBuilder<'a> {
         } else {
             self.use_stable_row_ids.unwrap_or(false)
         };
-        // Validate storage format matches existing dataset
+        // Validate storage format against existing dataset.
+        // Overwrite can set any version. Other operations (Append, Update, etc.)
+        // may upgrade to a higher version but cannot downgrade.
         if let Some(ds) = dest.dataset()
             && let Some(storage_format) = self.storage_format
         {
@@ -370,11 +372,15 @@ impl<'a> CommitBuilder<'a> {
             if ds.manifest.data_storage_format != passed_storage_format
                 && !matches!(transaction.operation, Operation::Overwrite { .. })
             {
-                return Err(Error::invalid_input_source(format!(
-                    "Storage format mismatch. Existing dataset uses {:?}, but new data uses {:?}",
-                    ds.manifest.data_storage_format,
-                    passed_storage_format
-                ).into()));
+                let existing_version = ds.manifest.data_storage_format.lance_file_version()?;
+                if storage_format <= existing_version {
+                    return Err(Error::invalid_input_source(format!(
+                        "Storage format mismatch. Existing dataset uses {:?}, but requested {:?}. \
+                         Only forward upgrades are permitted for non-overwrite operations.",
+                        ds.manifest.data_storage_format,
+                        passed_storage_format
+                    ).into()));
+                }
             }
         }
 

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -422,9 +422,12 @@ impl<'a> InsertBuilder<'a> {
                 })?
             }
             (_, WriteDestination::Dataset(dataset)) => {
-                // If appending to an existing dataset, always use the dataset version
                 let m = dataset.manifest.as_ref();
-                m.data_storage_format.lance_file_version()?
+                let existing = m.data_storage_format.lance_file_version()?;
+                match params.data_storage_version {
+                    Some(requested) if requested > existing => requested,
+                    _ => existing,
+                }
             }
             // Otherwise (no existing dataset) fallback to the default if the user didn't specify
             (_, WriteDestination::Uri(_)) => params.storage_version_or_default(),

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -394,14 +394,15 @@ fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
                     manifest.data_storage_format = DataStorageFormat::new(actual_file_version);
                 }
     } else {
-        // Otherwise, if we are on 2.0 or greater, we should ensure that the file versions
-        // match the data storage version.  This is a sanity assertion to prevent data corruption.
-        if let Some(actual_file_version) = Fragment::try_infer_version(&manifest.fragments)?
-            && actual_file_version != data_storage_version
+        // For v2.0+: verify that no fragment contains files encoded at a version
+        // higher than the manifest's declared data_storage_format. Mixed versions
+        // at or below the manifest version are valid (incremental format upgrade).
+        if let Some(max_file_version) = Fragment::max_file_version(&manifest.fragments)?
+            && max_file_version > data_storage_version
         {
             return Err(Error::internal(format!(
                 "The operation added files with version {}.  However, the data storage version is {}.",
-                actual_file_version, data_storage_version
+                max_file_version, data_storage_version
             )));
         }
     }


### PR DESCRIPTION
## Summary

Allow upgrading a table's `data_storage_format` from an older version (e.g., v2.1) to a newer one (e.g., v2.2) without requiring a full Overwrite. This enables incremental adoption of newer format versions on large production tables.

Closes #8060

## Changes

- **`check_storage_version`**: use `Fragment::max_file_version` instead of `try_infer_version` for v2.0+ datasets. Validates no fragment exceeds the manifest version, but permits mixed versions at or below it.
- **`build_manifest`**: apply `user_requested_version` for any operation (not just Overwrite) when the requested version is higher than existing.
- **`CommitBuilder.execute_inner`**: allow forward format upgrades on non-Overwrite operations (reject only downgrades).
- **`InsertBuilder`**: honor `data_storage_version` when it exceeds the existing manifest version.
- **JNI `parse_storage_format`**: accept numeric format strings ("2.1", "2.2") matching `LanceFileVersion::from_str`.

## Safety

- No downgrades: lower version than existing manifest is ignored (not an error)
- No fragment may exceed the manifest's declared version
- Reader dispatches per-file based on `DataFile.file_major/minor_version`
- When `storageFormat` is not set, behavior is unchanged

## Test Plan

6 new integration tests covering: append upgrades format, append inherits manifest, lower version ignored, overwrite changes version, mixed-version reads, delete on mixed-version table.