### PR TITLE
ci: build Linux Python wheel once

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,7 +93,59 @@ jobs:
         run: |
           source venv/bin/activate
           pytest --doctest-modules python/lance
+  linux-wheel:
+    timeout-minutes: 45
+    name: Python Linux x86_64 wheel
+    runs-on: "ubuntu-24.04-4x"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: python
+          prefix-key: ${{ env.CACHE_PREFIX }}
+      # python/Cargo.toml enables abi3-py310, so this wheel is reusable by
+      # every CPython version in the Linux test matrix.
+      - name: Build cp310 ABI3 wheel
+        uses: ./.github/workflows/build_linux_wheel
+        with:
+          python-minor-version: "10"
+          args: "--profile ci"
+      - name: Upload wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linux-x86_64-wheel
+          path: python/target/wheels/pylance-*.whl
+          if-no-files-found: error
+
+  linux-memtest:
+    timeout-minutes: 15
+    name: Python Linux x86_64 memtest
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+      - name: Build memtest
+        working-directory: memtest
+        run: cargo build --release
+      - name: Upload memtest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linux-x86_64-memtest
+          path: memtest/target/release/libmemtest.so
+          if-no-files-found: error
+
   linux:
+    needs: [linux-wheel, linux-memtest]
     timeout-minutes: 45
     strategy:
       matrix:
@@ -113,25 +165,22 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.${{ matrix.python-minor-version }}
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+      - name: Download wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          workspaces: python
-          prefix-key: ${{ env.CACHE_PREFIX }}
-      - uses: ./.github/workflows/build_linux_wheel
+          name: linux-x86_64-wheel
+          path: python/target/wheels
+      - name: Download memtest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          args: "--profile ci"
+          name: linux-x86_64-memtest
+          path: memtest/python/memtest
       - uses: ./.github/workflows/run_tests
         with:
           memtest: true
-      - name: Upload wheels as artifacts
-        if: ${{ matrix.python-minor-version == '14' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: linux-wheels
-          path: python/target/wheels/pylance-*.whl
 
   compat:
-    needs: linux
+    needs: linux-wheel
     timeout-minutes: 60
     runs-on: ubuntu-24.04
     name: Compatibility Tests
@@ -148,14 +197,14 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.14
-      - name: Download wheels
+      - name: Download wheel
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: linux-wheels
-          path: python/wheels
+          name: linux-x86_64-wheel
+          path: python/target/wheels
       - name: Install dependencies
         run: |
-          pip install $(ls wheels/pylance-*.whl)[tests,ray]
+          pip install $(ls target/wheels/pylance-*.whl)[tests,ray]
       - name: Run compatibility tests
         run: |
           make compattest
@@ -242,6 +291,7 @@ jobs:
           args: "--profile ci"
       - uses: ./.github/workflows/run_tests
   aws-integtest:
+    needs: linux-wheel
     timeout-minutes: 45
     runs-on: "ubuntu-24.04-4x"
     defaults:
@@ -257,13 +307,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11" # TODO: upgrade when ray supports 3.12
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+      - name: Download wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          workspaces: python
-          prefix-key: ${{ env.CACHE_PREFIX }}
-      - uses: ./.github/workflows/build_linux_wheel
-        with:
-          args: "--profile ci"
+          name: linux-x86_64-wheel
+          path: python/target/wheels
       - name: Install dependencies
         run: |
           pip install ray[data]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -134,6 +134,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+        with:
+          cache: "false"
+          rustflags: ""
       - name: Build memtest
         working-directory: memtest
         run: cargo build --release

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: "false"
   memtest:
     required: false
-    description: "Run memtest"
+    description: "Install and preload the prebuilt memtest library"
     default: "false"
 runs:
   using: "composite"
@@ -36,8 +36,9 @@ runs:
       if: inputs.memtest == 'true'
       shell: bash
       run: |
-        make build-release
-        echo "LD_PRELOAD=$(lance-memtest)" >> $GITHUB_ENV
+        test -f python/memtest/libmemtest.so
+        pip install -e .
+        echo "LD_PRELOAD=$(lance-memtest)" >> "$GITHUB_ENV"
     - name: Run python tests
       shell: bash
       working-directory: python


### PR DESCRIPTION
## Why

The Python workflow rebuilt the same `cp310-abi3` Linux x86_64 wheel in the Python 3.10, 3.13, 3.14, and AWS jobs. Compatibility tests then waited for the entire Linux matrix before downloading one of those identical wheels, adding an unnecessary serial dependency to the workflow critical path.

This change introduces explicit wheel and memtest artifact producers. The Linux Python matrix, compatibility tests, and AWS integration tests reuse the immutable wheel artifact, while the Linux matrix reuses one prebuilt memtest library. ARM, macOS, and Windows coverage remains unchanged.

## Benchmark

Measured on PR head `15d816e28` with [Python workflow run 30424299228](https://github.com/lance-format/lance/actions/runs/30424299228). The same SHA was run once with a cold producer cache and rerun once after that cache was populated.

| Metric | Baseline | Cold producer cache | Warm producer cache |
| --- | ---: | ---: | ---: |
| Python time-to-green | P50 37.6 min / P90 39.6 min | 27.7 min (-26.2% vs P50) | 24.1 min (-35.9% vs P50) |
| Compatibility test start offset | median 19.9 min | 9.1 min | 5.4 min |
| Total runner-minutes | 147.0 min | 128.9 min | 123.5 min |
| Linux x86_64 Rust cache restored | ~9.6 GiB | none | ~1.2 GiB |

Time-to-green baseline uses the latest 64 successful PR runs before this PR (2026-07-27 through 2026-07-29). Runner-minute and cache baselines use [run 30291213427](https://github.com/lance-format/lance/actions/runs/30291213427), the run nearest that P50. Both PR attempts completed all 11 Python workflow jobs successfully.
