### PR TITLE
feat(java): add OpenTelemetry metrics bridge

### DIFF
--- a/docs/src/guide/observability.md
+++ b/docs/src/guide/observability.md
@@ -11,8 +11,8 @@ documentation.
 
 Lance emits through the [`metrics`](https://docs.rs/metrics) crate facade, so it
 is not tied to a specific backend — you install a recorder/exporter and route
-the metrics wherever you like. Metrics are available from **both** the Rust and
-Python APIs.
+the metrics wherever you like. Metrics are available from the Rust, Python, and
+Java APIs.
 
 ### Rust
 
@@ -56,6 +56,37 @@ from lance.otel import instrument_lance_metrics
 # Uses the global MeterProvider; pass meter_provider=... to target a specific one.
 instrument_lance_metrics()
 ```
+
+### Java
+
+The Java SDK includes an OpenTelemetry bridge in `org.lance.otel`. Register it
+before opening datasets or performing Lance IO so the process-global Rust
+recorder sees every emitted metric:
+
+```java
+import org.lance.otel.LanceMetrics;
+
+LanceMetrics.instrument();
+```
+
+The OpenTelemetry API is a dependency of the Java SDK. The application must
+still configure an OpenTelemetry SDK, metric reader, and exporter for collection
+and delivery.
+
+The no-argument method uses OpenTelemetry's global `MeterProvider`. To register
+with an explicitly configured provider, pass it directly:
+
+```java
+SdkMeterProvider provider = SdkMeterProvider.builder()
+    .registerMetricReader(metricReader)
+    .build();
+LanceMetrics.instrument(provider);
+```
+
+Repeated calls with the same provider are idempotent. Passing a different
+provider unregisters the existing callback before registering the new one. Call
+`LanceMetrics.close()` to stop exporting while retaining the process-global Rust
+metric state.
 
 From there the metrics flow through whatever OpenTelemetry pipeline you have
 configured (OTLP, Prometheus, console, …). Because OpenTelemetry has no

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4120,6 +4120,7 @@ dependencies = [
  "lance-table",
  "log",
  "metrics",
+ "metrics-util",
  "object_store",
  "prost",
  "prost-types",
@@ -4523,6 +4524,21 @@ checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "rand 0.9.5",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -6707,6 +6723,12 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4077,6 +4077,7 @@ dependencies = [
  "lance-core",
  "lance-namespace",
  "log",
+ "metrics",
  "moka",
  "object_store",
  "object_store_opendal",
@@ -4118,6 +4119,7 @@ dependencies = [
  "lance-namespace-impls",
  "lance-table",
  "log",
+ "metrics",
  "object_store",
  "prost",
  "prost-types",
@@ -4512,6 +4514,16 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
 
 [[package]]
 name = "mime"
@@ -5720,6 +5732,15 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "rawpointer"

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -23,12 +23,12 @@ default = []
 backtrace = ["lance/backtrace", "lance-core/backtrace"]
 
 [dependencies]
-lance = { path = "../../rust/lance", features = ["substrait"] }
+lance = { path = "../../rust/lance", features = ["substrait", "metrics"] }
 lance-datafusion = { path = "../../rust/lance-datafusion" }
 lance-encoding = { path = "../../rust/lance-encoding" }
 lance-linalg = { path = "../../rust/lance-linalg" }
 lance-index = { path = "../../rust/lance-index" }
-lance-io = { path = "../../rust/lance-io" }
+lance-io = { path = "../../rust/lance-io", features = ["metrics"] }
 lance-namespace = { path = "../../rust/lance-namespace" }
 lance-namespace-impls = { path = "../../rust/lance-namespace-impls", features = ["rest", "rest-adapter", "dir-goosefs"] }
 lance-core = { path = "../../rust/lance-core" }
@@ -52,6 +52,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
 bytes = "1.11"
 log = "0.4"
+metrics = "0.24"
 env_logger = "0.11.7"
 uuid = { version = "1.17.0", features = ["v4"] }
 prost = "0.14.1"

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -53,6 +53,7 @@ serde_json = { version = "1" }
 bytes = "1.11"
 log = "0.4"
 metrics = "0.24"
+metrics-util = { version = "0.19", default-features = false, features = ["registry"] }
 env_logger = "0.11.7"
 uuid = { version = "1.17.0", features = ["v4"] }
 prost = "0.14.1"

--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -55,6 +55,7 @@ mod mem_wal;
 mod merge_insert;
 mod namespace;
 mod optimize;
+mod otel;
 mod schema;
 mod session;
 mod sql;

--- a/java/lance-jni/src/otel.rs
+++ b/java/lance-jni/src/otel.rs
@@ -66,6 +66,17 @@ fn bounds_for(name: &str) -> Arc<[f64]> {
         .unwrap_or_else(|| Arc::from(DEFAULT_BOUNDS))
 }
 
+fn atomic_add_f64(cell: &AtomicU64, value: f64) {
+    let mut current = cell.load(Ordering::Relaxed);
+    loop {
+        let updated = (f64::from_bits(current) + value).to_bits();
+        match cell.compare_exchange_weak(current, updated, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(actual) => current = actual,
+        }
+    }
+}
+
 struct BucketedHistogram {
     bounds: Arc<[f64]>,
     counts: Box<[AtomicU64]>,
@@ -75,10 +86,9 @@ struct BucketedHistogram {
 
 impl BucketedHistogram {
     fn new(bounds: Arc<[f64]>) -> Self {
-        let counts = (0..bounds.len() + 1)
+        let counts = (0..=bounds.len())
             .map(|_| AtomicU64::new(0))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+            .collect::<Box<[_]>>();
         Self {
             bounds,
             counts,
@@ -87,28 +97,12 @@ impl BucketedHistogram {
         }
     }
 
-    fn add_to_sum(&self, value: f64) {
-        let mut current = self.sum_bits.load(Ordering::Relaxed);
-        loop {
-            let updated = (f64::from_bits(current) + value).to_bits();
-            match self.sum_bits.compare_exchange_weak(
-                current,
-                updated,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current = actual,
-            }
-        }
-    }
-
     fn snapshot(&self) -> MetricValue {
         let mut cumulative = 0u64;
         let mut buckets = Vec::with_capacity(self.bounds.len() + 1);
         for (i, bound) in self.bounds.iter().enumerate() {
             cumulative += self.counts[i].load(Ordering::Relaxed);
-            buckets.push((format!("{}", bound), cumulative));
+            buckets.push((bound.to_string(), cumulative));
         }
         cumulative += self.counts[self.bounds.len()].load(Ordering::Relaxed);
         buckets.push(("+Inf".to_string(), cumulative));
@@ -125,7 +119,7 @@ impl metrics::HistogramFn for BucketedHistogram {
         let idx = self.bounds.partition_point(|&bound| bound < value);
         self.counts[idx].fetch_add(1, Ordering::Relaxed);
         self.count.fetch_add(1, Ordering::Relaxed);
-        self.add_to_sum(value);
+        atomic_add_f64(&self.sum_bits, value);
     }
 }
 
@@ -174,19 +168,7 @@ impl AtomicGauge {
     }
 
     fn add(&self, value: f64) {
-        let mut current = self.value_bits.load(Ordering::Relaxed);
-        loop {
-            let updated = (f64::from_bits(current) + value).to_bits();
-            match self.value_bits.compare_exchange_weak(
-                current,
-                updated,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current = actual,
-            }
-        }
+        atomic_add_f64(&self.value_bits, value);
     }
 }
 
@@ -561,4 +543,55 @@ pub extern "system" fn Java_org_lance_otel_LanceMetrics_snapshotLanceMetricsNati
         std::ptr::null_mut()
     )
     .into_raw()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics::{GaugeFn, HistogramFn};
+
+    fn bucket_count(buckets: &[(String, u64)], le: &str) -> u64 {
+        buckets
+            .iter()
+            .find(|(bound, _)| bound == le)
+            .map(|(_, count)| *count)
+            .unwrap_or_else(|| panic!("no bucket with le={le}"))
+    }
+
+    #[test]
+    fn test_bucketed_histogram_records_cumulative_buckets() {
+        let histogram = BucketedHistogram::new(Arc::from([0.1f64, 1.0, 10.0].as_slice()));
+        histogram.record(0.05);
+        histogram.record(0.1);
+        histogram.record(0.5);
+        histogram.record(1.0);
+        histogram.record(5.0);
+        histogram.record(50.0);
+
+        let MetricValue::Histogram {
+            buckets,
+            count,
+            sum,
+        } = histogram.snapshot()
+        else {
+            panic!("expected histogram");
+        };
+
+        assert_eq!(bucket_count(&buckets, "0.1"), 2);
+        assert_eq!(bucket_count(&buckets, "1"), 4);
+        assert_eq!(bucket_count(&buckets, "10"), 5);
+        assert_eq!(bucket_count(&buckets, "+Inf"), 6);
+        assert_eq!(bucket_count(&buckets, "+Inf"), count);
+        assert!((sum - 56.65).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_atomic_gauge_adds_and_subtracts_values() {
+        let gauge = AtomicGauge::new();
+
+        gauge.increment(3.5);
+        gauge.decrement(1.25);
+
+        assert!((f64::from_bits(gauge.value_bits.load(Ordering::Relaxed)) - 2.25).abs() < 1e-9);
+    }
 }

--- a/java/lance-jni/src/otel.rs
+++ b/java/lance-jni/src/otel.rs
@@ -405,6 +405,8 @@ fn attributes_to_java<'local>(
             "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
             &[JValue::Object(&java_key), JValue::Object(&java_value)],
         )?;
+        env.delete_local_ref(java_key)?;
+        env.delete_local_ref(java_value)?;
     }
     Ok(java_map)
 }
@@ -425,6 +427,8 @@ fn buckets_to_java<'local>(
             &[JValue::Object(&le), JValue::Long(*cumulative_count as i64)],
         )?;
         add_to_list(env, &list, &bucket)?;
+        env.delete_local_ref(le)?;
+        env.delete_local_ref(bucket)?;
     }
     Ok(list)
 }
@@ -514,8 +518,10 @@ fn snapshot_lance_metrics_native<'local>(env: &mut JNIEnv<'local>) -> Result<JOb
     let list = object_list(env)?;
     if let Some(registry) = REGISTRY.get() {
         for point in collect_points(registry) {
-            let item = metric_point_to_java(env, point)?;
-            add_to_list(env, &list, &item)?;
+            env.with_local_frame(64, |env| {
+                let item = metric_point_to_java(env, point)?;
+                add_to_list(env, &list, &item)
+            })?;
         }
     }
     Ok(list)

--- a/java/lance-jni/src/otel.rs
+++ b/java/lance-jni/src/otel.rs
@@ -15,10 +15,8 @@ use jni::JNIEnv;
 use jni::objects::{JClass, JObject, JValue};
 use jni::sys::{jboolean, jobject};
 use metrics::atomics::AtomicU64;
-use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, Key, KeyName, Metadata, Recorder, SharedString,
-    Unit,
-};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
+use metrics_util::registry::{Registry, Storage};
 
 use crate::error::Result;
 
@@ -55,7 +53,7 @@ static CATALOG: LazyLock<Mutex<HashMap<String, MetricDescription>>> =
 static HISTOGRAM_BOUNDS: LazyLock<RwLock<HashMap<String, Arc<[f64]>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-static REGISTRY: OnceLock<Arc<LanceRegistry>> = OnceLock::new();
+static REGISTRY: OnceLock<Arc<Registry<Key, LanceStorage>>> = OnceLock::new();
 
 fn bounds_for(name: &str) -> Arc<[f64]> {
     HISTOGRAM_BOUNDS
@@ -64,17 +62,6 @@ fn bounds_for(name: &str) -> Arc<[f64]> {
         .get(name)
         .cloned()
         .unwrap_or_else(|| Arc::from(DEFAULT_BOUNDS))
-}
-
-fn atomic_add_f64(cell: &AtomicU64, value: f64) {
-    let mut current = cell.load(Ordering::Relaxed);
-    loop {
-        let updated = (f64::from_bits(current) + value).to_bits();
-        match cell.compare_exchange_weak(current, updated, Ordering::Relaxed, Ordering::Relaxed) {
-            Ok(_) => break,
-            Err(actual) => current = actual,
-        }
-    }
 }
 
 struct BucketedHistogram {
@@ -94,6 +81,22 @@ impl BucketedHistogram {
             counts,
             count: AtomicU64::new(0),
             sum_bits: AtomicU64::new(0),
+        }
+    }
+
+    fn add_to_sum(&self, value: f64) {
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let updated = (f64::from_bits(current) + value).to_bits();
+            match self.sum_bits.compare_exchange_weak(
+                current,
+                updated,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
         }
     }
 
@@ -119,111 +122,32 @@ impl metrics::HistogramFn for BucketedHistogram {
         let idx = self.bounds.partition_point(|&bound| bound < value);
         self.counts[idx].fetch_add(1, Ordering::Relaxed);
         self.count.fetch_add(1, Ordering::Relaxed);
-        atomic_add_f64(&self.sum_bits, value);
+        self.add_to_sum(value);
     }
 }
 
-struct AtomicCounter {
-    value: AtomicU64,
-}
+struct LanceStorage;
 
-impl AtomicCounter {
-    fn new() -> Self {
-        Self {
-            value: AtomicU64::new(0),
-        }
-    }
-}
+impl Storage<Key> for LanceStorage {
+    type Counter = Arc<AtomicU64>;
+    type Gauge = Arc<AtomicU64>;
+    type Histogram = Arc<BucketedHistogram>;
 
-impl CounterFn for AtomicCounter {
-    fn increment(&self, value: u64) {
-        self.value.fetch_add(value, Ordering::Relaxed);
+    fn counter(&self, _key: &Key) -> Self::Counter {
+        Arc::new(AtomicU64::new(0))
     }
 
-    fn absolute(&self, value: u64) {
-        let mut current = self.value.load(Ordering::Relaxed);
-        while current < value {
-            match self.value.compare_exchange_weak(
-                current,
-                value,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current = actual,
-            }
-        }
-    }
-}
-
-struct AtomicGauge {
-    value_bits: AtomicU64,
-}
-
-impl AtomicGauge {
-    fn new() -> Self {
-        Self {
-            value_bits: AtomicU64::new(0),
-        }
+    fn gauge(&self, _key: &Key) -> Self::Gauge {
+        Arc::new(AtomicU64::new(0))
     }
 
-    fn add(&self, value: f64) {
-        atomic_add_f64(&self.value_bits, value);
-    }
-}
-
-impl GaugeFn for AtomicGauge {
-    fn increment(&self, value: f64) {
-        self.add(value);
-    }
-
-    fn decrement(&self, value: f64) {
-        self.add(-value);
-    }
-
-    fn set(&self, value: f64) {
-        self.value_bits.store(value.to_bits(), Ordering::Relaxed);
-    }
-}
-
-#[derive(Default)]
-struct LanceRegistry {
-    counters: Mutex<HashMap<Key, Arc<AtomicCounter>>>,
-    gauges: Mutex<HashMap<Key, Arc<AtomicGauge>>>,
-    histograms: Mutex<HashMap<Key, Arc<BucketedHistogram>>>,
-}
-
-impl LanceRegistry {
-    fn counter(&self, key: &Key) -> Arc<AtomicCounter> {
-        self.counters
-            .lock()
-            .unwrap()
-            .entry(key.clone())
-            .or_insert_with(|| Arc::new(AtomicCounter::new()))
-            .clone()
-    }
-
-    fn gauge(&self, key: &Key) -> Arc<AtomicGauge> {
-        self.gauges
-            .lock()
-            .unwrap()
-            .entry(key.clone())
-            .or_insert_with(|| Arc::new(AtomicGauge::new()))
-            .clone()
-    }
-
-    fn histogram(&self, key: &Key) -> Arc<BucketedHistogram> {
-        self.histograms
-            .lock()
-            .unwrap()
-            .entry(key.clone())
-            .or_insert_with(|| Arc::new(BucketedHistogram::new(bounds_for(key.name()))))
-            .clone()
+    fn histogram(&self, key: &Key) -> Self::Histogram {
+        Arc::new(BucketedHistogram::new(bounds_for(key.name())))
     }
 }
 
 struct LanceRecorder {
-    registry: Arc<LanceRegistry>,
+    registry: Arc<Registry<Key, LanceStorage>>,
 }
 
 impl LanceRecorder {
@@ -259,15 +183,18 @@ impl Recorder for LanceRecorder {
     }
 
     fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        Counter::from_arc(self.registry.counter(key))
+        self.registry
+            .get_or_create_counter(key, |counter| Counter::from_arc(counter.clone()))
     }
 
     fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
-        Gauge::from_arc(self.registry.gauge(key))
+        self.registry
+            .get_or_create_gauge(key, |gauge| Gauge::from_arc(gauge.clone()))
     }
 
     fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
-        Histogram::from_arc(self.registry.histogram(key))
+        self.registry
+            .get_or_create_histogram(key, |histogram| Histogram::from_arc(histogram.clone()))
     }
 }
 
@@ -304,29 +231,29 @@ fn labels(key: &Key) -> HashMap<String, String> {
         .collect()
 }
 
-fn collect_points(registry: &LanceRegistry) -> Vec<MetricPoint> {
+fn collect_points(registry: &Registry<Key, LanceStorage>) -> Vec<MetricPoint> {
     let mut points = Vec::new();
-    for (key, handle) in registry.counters.lock().unwrap().iter() {
+    for (key, handle) in registry.get_counter_handles() {
         points.push(MetricPoint {
             name: key.name().to_string(),
             kind: "counter",
-            attributes: labels(key),
-            value: MetricValue::Scalar(handle.value.load(Ordering::Relaxed) as f64),
+            attributes: labels(&key),
+            value: MetricValue::Scalar(handle.load(Ordering::Relaxed) as f64),
         });
     }
-    for (key, handle) in registry.gauges.lock().unwrap().iter() {
+    for (key, handle) in registry.get_gauge_handles() {
         points.push(MetricPoint {
             name: key.name().to_string(),
             kind: "gauge",
-            attributes: labels(key),
-            value: MetricValue::Scalar(f64::from_bits(handle.value_bits.load(Ordering::Relaxed))),
+            attributes: labels(&key),
+            value: MetricValue::Scalar(f64::from_bits(handle.load(Ordering::Relaxed))),
         });
     }
-    for (key, handle) in registry.histograms.lock().unwrap().iter() {
+    for (key, handle) in registry.get_histogram_handles() {
         points.push(MetricPoint {
             name: key.name().to_string(),
             kind: "histogram",
-            attributes: labels(key),
+            attributes: labels(&key),
             value: handle.snapshot(),
         });
     }
@@ -337,7 +264,7 @@ fn register_lance_metrics_recorder() -> bool {
     if REGISTRY.get().is_some() {
         return true;
     }
-    let registry = Arc::new(LanceRegistry::default());
+    let registry = Arc::new(Registry::new(LanceStorage));
     let recorder = LanceRecorder {
         registry: registry.clone(),
     };
@@ -548,7 +475,7 @@ pub extern "system" fn Java_org_lance_otel_LanceMetrics_snapshotLanceMetricsNati
 #[cfg(test)]
 mod tests {
     use super::*;
-    use metrics::{GaugeFn, HistogramFn};
+    use metrics::HistogramFn;
 
     fn bucket_count(buckets: &[(String, u64)], le: &str) -> u64 {
         buckets
@@ -586,12 +513,29 @@ mod tests {
     }
 
     #[test]
-    fn test_atomic_gauge_adds_and_subtracts_values() {
-        let gauge = AtomicGauge::new();
+    fn test_registry_aggregates_counters_and_gauges() {
+        let registry = Arc::new(Registry::new(LanceStorage));
+        let recorder = LanceRecorder {
+            registry: registry.clone(),
+        };
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!("test_counter", "operation" => "get").increment(2);
+            metrics::counter!("test_counter", "operation" => "get").increment(3);
+            metrics::gauge!("test_gauge", "operation" => "get").increment(3.5);
+            metrics::gauge!("test_gauge", "operation" => "get").decrement(1.25);
+        });
 
-        gauge.increment(3.5);
-        gauge.decrement(1.25);
+        let points = collect_points(&registry);
+        let counter = points
+            .iter()
+            .find(|point| point.name == "test_counter")
+            .expect("counter recorded");
+        let gauge = points
+            .iter()
+            .find(|point| point.name == "test_gauge")
+            .expect("gauge recorded");
 
-        assert!((f64::from_bits(gauge.value_bits.load(Ordering::Relaxed)) - 2.25).abs() < 1e-9);
+        assert!(matches!(counter.value, MetricValue::Scalar(value) if value == 5.0));
+        assert!(matches!(gauge.value, MetricValue::Scalar(value) if (value - 2.25).abs() < 1e-9));
     }
 }

--- a/java/lance-jni/src/otel.rs
+++ b/java/lance-jni/src/otel.rs
@@ -508,8 +508,10 @@ fn lance_metrics_catalog_native<'local>(env: &mut JNIEnv<'local>) -> Result<JObj
     let catalog = CATALOG.lock().unwrap();
     let list = object_list(env)?;
     for (name, desc) in catalog.iter() {
-        let item = metric_description_to_java(env, name, desc)?;
-        add_to_list(env, &list, &item)?;
+        env.with_local_frame(16, |env| {
+            let item = metric_description_to_java(env, name, desc)?;
+            add_to_list(env, &list, &item)
+        })?;
     }
     Ok(list)
 }

--- a/java/lance-jni/src/otel.rs
+++ b/java/lance-jni/src/otel.rs
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Bridge from the [`metrics`] crate facade to Java OpenTelemetry.
+//!
+//! The Java layer owns the actual OpenTelemetry instruments. This module
+//! installs the process-global Rust [`metrics::Recorder`], keeps cumulative
+//! metric state, and exposes catalog/snapshot calls over JNI.
+
+use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock, RwLock};
+
+use jni::JNIEnv;
+use jni::objects::{JClass, JObject, JValue};
+use jni::sys::{jboolean, jobject};
+use metrics::atomics::AtomicU64;
+use metrics::{
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, Key, KeyName, Metadata, Recorder, SharedString,
+    Unit,
+};
+
+use crate::error::Result;
+
+const DEFAULT_BOUNDS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+
+#[derive(Clone, Copy)]
+enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+impl MetricKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Counter => "counter",
+            Self::Gauge => "gauge",
+            Self::Histogram => "histogram",
+        }
+    }
+}
+
+struct MetricDescription {
+    kind: MetricKind,
+    unit: Option<String>,
+    description: String,
+}
+
+static CATALOG: LazyLock<Mutex<HashMap<String, MetricDescription>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static HISTOGRAM_BOUNDS: LazyLock<RwLock<HashMap<String, Arc<[f64]>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+static REGISTRY: OnceLock<Arc<LanceRegistry>> = OnceLock::new();
+
+fn bounds_for(name: &str) -> Arc<[f64]> {
+    HISTOGRAM_BOUNDS
+        .read()
+        .unwrap()
+        .get(name)
+        .cloned()
+        .unwrap_or_else(|| Arc::from(DEFAULT_BOUNDS))
+}
+
+struct BucketedHistogram {
+    bounds: Arc<[f64]>,
+    counts: Box<[AtomicU64]>,
+    count: AtomicU64,
+    sum_bits: AtomicU64,
+}
+
+impl BucketedHistogram {
+    fn new(bounds: Arc<[f64]>) -> Self {
+        let counts = (0..bounds.len() + 1)
+            .map(|_| AtomicU64::new(0))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            bounds,
+            counts,
+            count: AtomicU64::new(0),
+            sum_bits: AtomicU64::new(0),
+        }
+    }
+
+    fn add_to_sum(&self, value: f64) {
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let updated = (f64::from_bits(current) + value).to_bits();
+            match self.sum_bits.compare_exchange_weak(
+                current,
+                updated,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    fn snapshot(&self) -> MetricValue {
+        let mut cumulative = 0u64;
+        let mut buckets = Vec::with_capacity(self.bounds.len() + 1);
+        for (i, bound) in self.bounds.iter().enumerate() {
+            cumulative += self.counts[i].load(Ordering::Relaxed);
+            buckets.push((format!("{}", bound), cumulative));
+        }
+        cumulative += self.counts[self.bounds.len()].load(Ordering::Relaxed);
+        buckets.push(("+Inf".to_string(), cumulative));
+        MetricValue::Histogram {
+            buckets,
+            count: self.count.load(Ordering::Relaxed),
+            sum: f64::from_bits(self.sum_bits.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl metrics::HistogramFn for BucketedHistogram {
+    fn record(&self, value: f64) {
+        let idx = self.bounds.partition_point(|&bound| bound < value);
+        self.counts[idx].fetch_add(1, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.add_to_sum(value);
+    }
+}
+
+struct AtomicCounter {
+    value: AtomicU64,
+}
+
+impl AtomicCounter {
+    fn new() -> Self {
+        Self {
+            value: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CounterFn for AtomicCounter {
+    fn increment(&self, value: u64) {
+        self.value.fetch_add(value, Ordering::Relaxed);
+    }
+
+    fn absolute(&self, value: u64) {
+        let mut current = self.value.load(Ordering::Relaxed);
+        while current < value {
+            match self.value.compare_exchange_weak(
+                current,
+                value,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+struct AtomicGauge {
+    value_bits: AtomicU64,
+}
+
+impl AtomicGauge {
+    fn new() -> Self {
+        Self {
+            value_bits: AtomicU64::new(0),
+        }
+    }
+
+    fn add(&self, value: f64) {
+        let mut current = self.value_bits.load(Ordering::Relaxed);
+        loop {
+            let updated = (f64::from_bits(current) + value).to_bits();
+            match self.value_bits.compare_exchange_weak(
+                current,
+                updated,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+impl GaugeFn for AtomicGauge {
+    fn increment(&self, value: f64) {
+        self.add(value);
+    }
+
+    fn decrement(&self, value: f64) {
+        self.add(-value);
+    }
+
+    fn set(&self, value: f64) {
+        self.value_bits.store(value.to_bits(), Ordering::Relaxed);
+    }
+}
+
+#[derive(Default)]
+struct LanceRegistry {
+    counters: Mutex<HashMap<Key, Arc<AtomicCounter>>>,
+    gauges: Mutex<HashMap<Key, Arc<AtomicGauge>>>,
+    histograms: Mutex<HashMap<Key, Arc<BucketedHistogram>>>,
+}
+
+impl LanceRegistry {
+    fn counter(&self, key: &Key) -> Arc<AtomicCounter> {
+        self.counters
+            .lock()
+            .unwrap()
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(AtomicCounter::new()))
+            .clone()
+    }
+
+    fn gauge(&self, key: &Key) -> Arc<AtomicGauge> {
+        self.gauges
+            .lock()
+            .unwrap()
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(AtomicGauge::new()))
+            .clone()
+    }
+
+    fn histogram(&self, key: &Key) -> Arc<BucketedHistogram> {
+        self.histograms
+            .lock()
+            .unwrap()
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(BucketedHistogram::new(bounds_for(key.name()))))
+            .clone()
+    }
+}
+
+struct LanceRecorder {
+    registry: Arc<LanceRegistry>,
+}
+
+impl LanceRecorder {
+    fn describe(
+        &self,
+        key: KeyName,
+        kind: MetricKind,
+        unit: Option<Unit>,
+        description: SharedString,
+    ) {
+        CATALOG.lock().unwrap().insert(
+            key.as_str().to_string(),
+            MetricDescription {
+                kind,
+                unit: unit.map(|u| u.as_canonical_label().to_string()),
+                description: description.into_owned(),
+            },
+        );
+    }
+}
+
+impl Recorder for LanceRecorder {
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.describe(key, MetricKind::Counter, unit, description);
+    }
+
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.describe(key, MetricKind::Gauge, unit, description);
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.describe(key, MetricKind::Histogram, unit, description);
+    }
+
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        Counter::from_arc(self.registry.counter(key))
+    }
+
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        Gauge::from_arc(self.registry.gauge(key))
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        Histogram::from_arc(self.registry.histogram(key))
+    }
+}
+
+fn register_bounds() {
+    let mut bounds = HISTOGRAM_BOUNDS.write().unwrap();
+    for (name, values) in lance_io::object_store::metrics::histogram_bounds() {
+        bounds.insert((*name).to_string(), Arc::from(*values));
+    }
+}
+
+fn describe_all() {
+    lance_io::object_store::metrics::describe_metrics();
+}
+
+enum MetricValue {
+    Scalar(f64),
+    Histogram {
+        buckets: Vec<(String, u64)>,
+        count: u64,
+        sum: f64,
+    },
+}
+
+struct MetricPoint {
+    name: String,
+    kind: &'static str,
+    attributes: HashMap<String, String>,
+    value: MetricValue,
+}
+
+fn labels(key: &Key) -> HashMap<String, String> {
+    key.labels()
+        .map(|label| (label.key().to_string(), label.value().to_string()))
+        .collect()
+}
+
+fn collect_points(registry: &LanceRegistry) -> Vec<MetricPoint> {
+    let mut points = Vec::new();
+    for (key, handle) in registry.counters.lock().unwrap().iter() {
+        points.push(MetricPoint {
+            name: key.name().to_string(),
+            kind: "counter",
+            attributes: labels(key),
+            value: MetricValue::Scalar(handle.value.load(Ordering::Relaxed) as f64),
+        });
+    }
+    for (key, handle) in registry.gauges.lock().unwrap().iter() {
+        points.push(MetricPoint {
+            name: key.name().to_string(),
+            kind: "gauge",
+            attributes: labels(key),
+            value: MetricValue::Scalar(f64::from_bits(handle.value_bits.load(Ordering::Relaxed))),
+        });
+    }
+    for (key, handle) in registry.histograms.lock().unwrap().iter() {
+        points.push(MetricPoint {
+            name: key.name().to_string(),
+            kind: "histogram",
+            attributes: labels(key),
+            value: handle.snapshot(),
+        });
+    }
+    points
+}
+
+fn register_lance_metrics_recorder() -> bool {
+    if REGISTRY.get().is_some() {
+        return true;
+    }
+    let registry = Arc::new(LanceRegistry::default());
+    let recorder = LanceRecorder {
+        registry: registry.clone(),
+    };
+    register_bounds();
+    match metrics::set_global_recorder(recorder) {
+        Ok(()) => {
+            let _ = REGISTRY.set(registry);
+            describe_all();
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+fn object_list<'local>(env: &mut JNIEnv<'local>) -> Result<JObject<'local>> {
+    Ok(env.new_object("java/util/ArrayList", "()V", &[])?)
+}
+
+fn add_to_list(env: &mut JNIEnv, list: &JObject, item: &JObject) -> Result<()> {
+    env.call_method(
+        list,
+        "add",
+        "(Ljava/lang/Object;)Z",
+        &[JValue::Object(item)],
+    )?;
+    Ok(())
+}
+
+fn string_object<'local>(env: &mut JNIEnv<'local>, value: Option<&str>) -> Result<JObject<'local>> {
+    match value {
+        Some(value) => Ok(env.new_string(value)?.into()),
+        None => Ok(JObject::null()),
+    }
+}
+
+fn attributes_to_java<'local>(
+    env: &mut JNIEnv<'local>,
+    attributes: &HashMap<String, String>,
+) -> Result<JObject<'local>> {
+    let java_map = env.new_object("java/util/HashMap", "()V", &[])?;
+    for (key, value) in attributes {
+        let java_key = env.new_string(key)?;
+        let java_value = env.new_string(value)?;
+        env.call_method(
+            &java_map,
+            "put",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            &[JValue::Object(&java_key), JValue::Object(&java_value)],
+        )?;
+    }
+    Ok(java_map)
+}
+
+fn buckets_to_java<'local>(
+    env: &mut JNIEnv<'local>,
+    buckets: Option<&[(String, u64)]>,
+) -> Result<JObject<'local>> {
+    let Some(buckets) = buckets else {
+        return Ok(JObject::null());
+    };
+    let list = object_list(env)?;
+    for (le, cumulative_count) in buckets {
+        let le = env.new_string(le)?;
+        let bucket = env.new_object(
+            "org/lance/otel/MetricBucket",
+            "(Ljava/lang/String;J)V",
+            &[JValue::Object(&le), JValue::Long(*cumulative_count as i64)],
+        )?;
+        add_to_list(env, &list, &bucket)?;
+    }
+    Ok(list)
+}
+
+fn boxed_double<'local>(env: &mut JNIEnv<'local>, value: Option<f64>) -> Result<JObject<'local>> {
+    match value {
+        Some(value) => Ok(env.new_object("java/lang/Double", "(D)V", &[JValue::Double(value)])?),
+        None => Ok(JObject::null()),
+    }
+}
+
+fn boxed_long<'local>(env: &mut JNIEnv<'local>, value: Option<u64>) -> Result<JObject<'local>> {
+    match value {
+        Some(value) => {
+            Ok(env.new_object("java/lang/Long", "(J)V", &[JValue::Long(value as i64)])?)
+        }
+        None => Ok(JObject::null()),
+    }
+}
+
+fn metric_description_to_java<'local>(
+    env: &mut JNIEnv<'local>,
+    name: &str,
+    desc: &MetricDescription,
+) -> Result<JObject<'local>> {
+    let name = env.new_string(name)?;
+    let kind = env.new_string(desc.kind.as_str())?;
+    let unit = string_object(env, desc.unit.as_deref())?;
+    let description = env.new_string(&desc.description)?;
+    Ok(env.new_object(
+        "org/lance/otel/MetricDescription",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+        &[
+            JValue::Object(&name),
+            JValue::Object(&kind),
+            JValue::Object(&unit),
+            JValue::Object(&description),
+        ],
+    )?)
+}
+
+fn metric_point_to_java<'local>(
+    env: &mut JNIEnv<'local>,
+    point: MetricPoint,
+) -> Result<JObject<'local>> {
+    let (value, buckets, count, sum) = match point.value {
+        MetricValue::Scalar(value) => (Some(value), None, None, None),
+        MetricValue::Histogram {
+            buckets,
+            count,
+            sum,
+        } => (None, Some(buckets), Some(count), Some(sum)),
+    };
+    let name = env.new_string(&point.name)?;
+    let kind = env.new_string(point.kind)?;
+    let attributes = attributes_to_java(env, &point.attributes)?;
+    let value = boxed_double(env, value)?;
+    let buckets = buckets_to_java(env, buckets.as_deref())?;
+    let count = boxed_long(env, count)?;
+    let sum = boxed_double(env, sum)?;
+    Ok(env.new_object(
+        "org/lance/otel/MetricPoint",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Double;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Double;)V",
+        &[
+            JValue::Object(&name),
+            JValue::Object(&kind),
+            JValue::Object(&attributes),
+            JValue::Object(&value),
+            JValue::Object(&buckets),
+            JValue::Object(&count),
+            JValue::Object(&sum),
+        ],
+    )?)
+}
+
+fn lance_metrics_catalog_native<'local>(env: &mut JNIEnv<'local>) -> Result<JObject<'local>> {
+    let catalog = CATALOG.lock().unwrap();
+    let list = object_list(env)?;
+    for (name, desc) in catalog.iter() {
+        let item = metric_description_to_java(env, name, desc)?;
+        add_to_list(env, &list, &item)?;
+    }
+    Ok(list)
+}
+
+fn snapshot_lance_metrics_native<'local>(env: &mut JNIEnv<'local>) -> Result<JObject<'local>> {
+    let list = object_list(env)?;
+    if let Some(registry) = REGISTRY.get() {
+        for point in collect_points(registry) {
+            let item = metric_point_to_java(env, point)?;
+            add_to_list(env, &list, &item)?;
+        }
+    }
+    Ok(list)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_otel_LanceMetrics_registerLanceMetricsRecorderNative(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jboolean {
+    register_lance_metrics_recorder() as jboolean
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_otel_LanceMetrics_lanceMetricsCatalogNative(
+    mut env: JNIEnv,
+    _class: JClass,
+) -> jobject {
+    ok_or_throw_with_return!(
+        env,
+        lance_metrics_catalog_native(&mut env),
+        std::ptr::null_mut()
+    )
+    .into_raw()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_otel_LanceMetrics_snapshotLanceMetricsNative(
+    mut env: JNIEnv,
+    _class: JClass,
+) -> jobject {
+    ok_or_throw_with_return!(
+        env,
+        snapshot_lance_metrics_native(&mut env),
+        std::ptr::null_mut()
+    )
+    .into_raw()
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>18.3.0</arrow.version>
-        <opentelemetry.version>1.30.0</opentelemetry.version>
+        <opentelemetry.version>1.64.0</opentelemetry.version>
         <substrait.version>0.28.1</substrait.version>
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.43.0</spotless.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>18.3.0</arrow.version>
+        <opentelemetry.version>1.30.0</opentelemetry.version>
         <substrait.version>0.28.1</substrait.version>
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.43.0</spotless.version>
@@ -122,6 +123,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.15.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
         <!-- AWS SDK for S3 integration testing -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -133,6 +139,18 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
             <version>2.20.26</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <version>${opentelemetry.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java/src/main/java/org/lance/otel/LanceMetrics.java
+++ b/java/src/main/java/org/lance/otel/LanceMetrics.java
@@ -87,7 +87,7 @@ public final class LanceMetrics {
     Map<String, RegisteredMetric> registeredMetrics = new HashMap<>();
     List<ObservableMeasurement> measurements = new ArrayList<>();
 
-    for (MetricDescription desc : catalog()) {
+    for (MetricDescription desc : supportedMetrics(catalog())) {
       String unit = desc.getUnit() == null ? "" : desc.getUnit();
       String description = desc.getDescription();
       switch (desc.getKind()) {
@@ -138,7 +138,9 @@ public final class LanceMetrics {
           measurements.add(sum);
           break;
         default:
-          throw new IllegalStateException("Unknown Lance metric kind: " + desc.getKind());
+          LOGGER.warning(
+              "Skipping Lance metric " + desc.getName() + " with unknown kind: " + desc.getKind());
+          continue;
       }
     }
 
@@ -171,6 +173,23 @@ public final class LanceMetrics {
   public static List<MetricPoint> snapshot() {
     JniLoader.ensureLoaded();
     return Collections.unmodifiableList(snapshotLanceMetricsNative());
+  }
+
+  static List<MetricDescription> supportedMetrics(List<MetricDescription> catalog) {
+    List<MetricDescription> supported = new ArrayList<>();
+    for (MetricDescription desc : catalog) {
+      switch (desc.getKind()) {
+        case "counter":
+        case "gauge":
+        case "histogram":
+          supported.add(desc);
+          break;
+        default:
+          LOGGER.warning(
+              "Skipping Lance metric " + desc.getName() + " with unknown kind: " + desc.getKind());
+      }
+    }
+    return supported;
   }
 
   private static void recordSnapshot(Map<String, RegisteredMetric> registeredMetrics) {

--- a/java/src/main/java/org/lance/otel/LanceMetrics.java
+++ b/java/src/main/java/org/lance/otel/LanceMetrics.java
@@ -18,12 +18,15 @@ import org.lance.JniLoader;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableMeasurement;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +38,7 @@ public final class LanceMetrics {
   private static final String METER_NAME = "lance";
   private static final List<AutoCloseable> INSTRUMENTS = new ArrayList<>();
   private static boolean instrumented;
+  private static MeterProvider instrumentedProvider;
 
   private LanceMetrics() {}
 
@@ -53,7 +57,9 @@ public final class LanceMetrics {
    *
    * <p>This installs a process-global Rust metrics recorder. If a different Rust metrics recorder
    * is already installed, this returns false and does not create instruments. Repeated successful
-   * calls are safe and return true without creating duplicate instruments.
+   * calls with the same provider are safe and return true without creating duplicate instruments.
+   * Calls with a different provider close the existing instruments and register new callbacks on
+   * the supplied provider.
    *
    * @param meterProvider the OpenTelemetry meter provider that owns the instruments
    * @return true if the recorder is installed and instruments are registered, false otherwise
@@ -71,61 +77,88 @@ public final class LanceMetrics {
     }
 
     if (instrumented) {
-      return true;
+      if (instrumentedProvider == meterProvider) {
+        return true;
+      }
+      closeInstruments();
     }
 
     Meter meter = meterProvider.meterBuilder(METER_NAME).build();
+    Map<String, RegisteredMetric> registeredMetrics = new HashMap<>();
+    List<ObservableMeasurement> measurements = new ArrayList<>();
+
     for (MetricDescription desc : catalog()) {
       String unit = desc.getUnit() == null ? "" : desc.getUnit();
       String description = desc.getDescription();
       switch (desc.getKind()) {
         case "counter":
-          INSTRUMENTS.add(
+          ObservableDoubleMeasurement counter =
               meter
                   .counterBuilder(desc.getName())
                   .ofDoubles()
                   .setUnit(unit)
                   .setDescription(description)
-                  .buildWithCallback(measurement -> recordScalar(desc.getName(), measurement)));
+                  .buildObserver();
+          registeredMetrics.put(desc.getName(), RegisteredMetric.scalar(counter));
+          measurements.add(counter);
           break;
         case "gauge":
-          INSTRUMENTS.add(
+          ObservableDoubleMeasurement gauge =
               meter
                   .gaugeBuilder(desc.getName())
                   .setUnit(unit)
                   .setDescription(description)
-                  .buildWithCallback(measurement -> recordScalar(desc.getName(), measurement)));
+                  .buildObserver();
+          registeredMetrics.put(desc.getName(), RegisteredMetric.scalar(gauge));
+          measurements.add(gauge);
           break;
         case "histogram":
-          INSTRUMENTS.add(
+          ObservableDoubleMeasurement buckets =
               meter
                   .counterBuilder(desc.getName() + "_bucket")
                   .ofDoubles()
                   .setDescription(description + " (cumulative buckets)")
-                  .buildWithCallback(measurement -> recordBuckets(desc.getName(), measurement)));
-          INSTRUMENTS.add(
+                  .buildObserver();
+          ObservableDoubleMeasurement count =
               meter
                   .counterBuilder(desc.getName() + "_count")
                   .ofDoubles()
                   .setDescription(description + " (count)")
-                  .buildWithCallback(
-                      measurement -> recordField(desc.getName(), "count", measurement)));
-          INSTRUMENTS.add(
+                  .buildObserver();
+          ObservableDoubleMeasurement sum =
               meter
                   .counterBuilder(desc.getName() + "_sum")
                   .ofDoubles()
                   .setUnit(unit)
                   .setDescription(description + " (sum)")
-                  .buildWithCallback(
-                      measurement -> recordField(desc.getName(), "sum", measurement)));
+                  .buildObserver();
+          registeredMetrics.put(desc.getName(), RegisteredMetric.histogram(buckets, count, sum));
+          measurements.add(buckets);
+          measurements.add(count);
+          measurements.add(sum);
           break;
         default:
           throw new IllegalStateException("Unknown Lance metric kind: " + desc.getKind());
       }
     }
 
+    if (!measurements.isEmpty()) {
+      ObservableMeasurement first = measurements.get(0);
+      ObservableMeasurement[] rest =
+          measurements.subList(1, measurements.size()).toArray(new ObservableMeasurement[0]);
+      BatchCallback callback =
+          meter.batchCallback(() -> recordSnapshot(registeredMetrics), first, rest);
+      INSTRUMENTS.add(callback);
+    }
+
     instrumented = true;
+    instrumentedProvider = meterProvider;
     return true;
+  }
+
+  /** Close registered OpenTelemetry callbacks. Rust metric state remains process-global. */
+  public static synchronized void close() {
+    closeInstruments();
   }
 
   /** Return the catalog of Lance metrics described by the native recorder. */
@@ -140,60 +173,87 @@ public final class LanceMetrics {
     return Collections.unmodifiableList(snapshotLanceMetricsNative());
   }
 
-  private static void recordScalar(String metricName, ObservableDoubleMeasurement measurement) {
+  private static void recordSnapshot(Map<String, RegisteredMetric> registeredMetrics) {
     for (MetricPoint point : snapshot()) {
-      if (metricName.equals(point.getName()) && point.getValue() != null) {
-        measurement.record(point.getValue(), attributes(point.getAttributes()));
-      }
-    }
-  }
-
-  private static void recordBuckets(String metricName, ObservableDoubleMeasurement measurement) {
-    for (MetricPoint point : snapshot()) {
-      if (!metricName.equals(point.getName()) || point.getBuckets() == null) {
+      RegisteredMetric metric = registeredMetrics.get(point.getName());
+      if (metric == null) {
         continue;
       }
-      for (MetricBucket bucket : point.getBuckets()) {
-        AttributesBuilder attributes = Attributes.builder();
-        for (Map.Entry<String, String> entry : point.getAttributes().entrySet()) {
-          attributes.put(entry.getKey(), entry.getValue());
-        }
-        attributes.put("le", bucket.getLe());
-        measurement.record(bucket.getCumulativeCount(), attributes.build());
-      }
+      metric.record(point);
     }
   }
 
-  private static void recordField(
-      String metricName, String fieldName, ObservableDoubleMeasurement measurement) {
-    for (MetricPoint point : snapshot()) {
-      if (!metricName.equals(point.getName())) {
-        continue;
-      }
-      Double value = fieldValue(point, fieldName);
-      if (value != null) {
-        measurement.record(value, attributes(point.getAttributes()));
+  private static void closeInstruments() {
+    for (AutoCloseable instrument : INSTRUMENTS) {
+      try {
+        instrument.close();
+      } catch (Exception e) {
+        LOGGER.warning("Failed to close Lance OpenTelemetry instrument: " + e.getMessage());
       }
     }
+    INSTRUMENTS.clear();
+    instrumented = false;
+    instrumentedProvider = null;
   }
 
-  private static Double fieldValue(MetricPoint point, String fieldName) {
-    switch (fieldName) {
-      case "count":
-        return point.getCount() == null ? null : point.getCount().doubleValue();
-      case "sum":
-        return point.getSum();
-      default:
-        throw new IllegalArgumentException("Unknown Lance metric field: " + fieldName);
-    }
-  }
-
-  private static Attributes attributes(Map<String, String> values) {
+  private static AttributesBuilder attributesBuilder(Map<String, String> values) {
     AttributesBuilder builder = Attributes.builder();
     for (Map.Entry<String, String> entry : values.entrySet()) {
       builder.put(entry.getKey(), entry.getValue());
     }
-    return builder.build();
+    return builder;
+  }
+
+  private static Attributes attributes(Map<String, String> values) {
+    return attributesBuilder(values).build();
+  }
+
+  private static final class RegisteredMetric {
+    private final ObservableDoubleMeasurement scalar;
+    private final ObservableDoubleMeasurement buckets;
+    private final ObservableDoubleMeasurement count;
+    private final ObservableDoubleMeasurement sum;
+
+    private RegisteredMetric(
+        ObservableDoubleMeasurement scalar,
+        ObservableDoubleMeasurement buckets,
+        ObservableDoubleMeasurement count,
+        ObservableDoubleMeasurement sum) {
+      this.scalar = scalar;
+      this.buckets = buckets;
+      this.count = count;
+      this.sum = sum;
+    }
+
+    private static RegisteredMetric scalar(ObservableDoubleMeasurement measurement) {
+      return new RegisteredMetric(measurement, null, null, null);
+    }
+
+    private static RegisteredMetric histogram(
+        ObservableDoubleMeasurement buckets,
+        ObservableDoubleMeasurement count,
+        ObservableDoubleMeasurement sum) {
+      return new RegisteredMetric(null, buckets, count, sum);
+    }
+
+    private void record(MetricPoint point) {
+      if (scalar != null && point.getValue() != null) {
+        scalar.record(point.getValue(), attributes(point.getAttributes()));
+      }
+      if (buckets != null && point.getBuckets() != null) {
+        for (MetricBucket bucket : point.getBuckets()) {
+          AttributesBuilder attributes = attributesBuilder(point.getAttributes());
+          attributes.put("le", bucket.getLe());
+          buckets.record(bucket.getCumulativeCount(), attributes.build());
+        }
+      }
+      if (count != null && point.getCount() != null) {
+        count.record(point.getCount().doubleValue(), attributes(point.getAttributes()));
+      }
+      if (sum != null && point.getSum() != null) {
+        sum.record(point.getSum(), attributes(point.getAttributes()));
+      }
+    }
   }
 
   private static native boolean registerLanceMetricsRecorderNative();

--- a/java/src/main/java/org/lance/otel/LanceMetrics.java
+++ b/java/src/main/java/org/lance/otel/LanceMetrics.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.otel;
+
+import org.lance.JniLoader;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/** Bridges Lance's internal Rust metrics into OpenTelemetry observable instruments. */
+public final class LanceMetrics {
+  private static final Logger LOGGER = Logger.getLogger(LanceMetrics.class.getName());
+  private static final String METER_NAME = "lance";
+  private static final List<AutoCloseable> INSTRUMENTS = new ArrayList<>();
+  private static boolean instrumented;
+
+  private LanceMetrics() {}
+
+  /**
+   * Register Lance metrics on the global OpenTelemetry {@link MeterProvider}.
+   *
+   * @return true if the recorder is installed and instruments are registered, false if a different
+   *     Rust metrics recorder is already installed in this process
+   */
+  public static synchronized boolean instrument() {
+    return instrument(GlobalOpenTelemetry.get().getMeterProvider());
+  }
+
+  /**
+   * Register Lance metrics as OpenTelemetry observable instruments.
+   *
+   * <p>This installs a process-global Rust metrics recorder. If a different Rust metrics recorder
+   * is already installed, this returns false and does not create instruments. Repeated successful
+   * calls are safe and return true without creating duplicate instruments.
+   *
+   * @param meterProvider the OpenTelemetry meter provider that owns the instruments
+   * @return true if the recorder is installed and instruments are registered, false otherwise
+   */
+  public static synchronized boolean instrument(MeterProvider meterProvider) {
+    Objects.requireNonNull(meterProvider, "meterProvider");
+    JniLoader.ensureLoaded();
+
+    if (!registerLanceMetricsRecorderNative()) {
+      LOGGER.warning(
+          "Could not install the Lance metrics recorder: another Rust metrics recorder is already"
+              + " installed in this process. Lance metrics will not be exported via"
+              + " OpenTelemetry.");
+      return false;
+    }
+
+    if (instrumented) {
+      return true;
+    }
+
+    Meter meter = meterProvider.meterBuilder(METER_NAME).build();
+    for (MetricDescription desc : catalog()) {
+      String unit = desc.getUnit() == null ? "" : desc.getUnit();
+      String description = desc.getDescription();
+      switch (desc.getKind()) {
+        case "counter":
+          INSTRUMENTS.add(
+              meter
+                  .counterBuilder(desc.getName())
+                  .ofDoubles()
+                  .setUnit(unit)
+                  .setDescription(description)
+                  .buildWithCallback(measurement -> recordScalar(desc.getName(), measurement)));
+          break;
+        case "gauge":
+          INSTRUMENTS.add(
+              meter
+                  .gaugeBuilder(desc.getName())
+                  .setUnit(unit)
+                  .setDescription(description)
+                  .buildWithCallback(measurement -> recordScalar(desc.getName(), measurement)));
+          break;
+        case "histogram":
+          INSTRUMENTS.add(
+              meter
+                  .counterBuilder(desc.getName() + "_bucket")
+                  .ofDoubles()
+                  .setDescription(description + " (cumulative buckets)")
+                  .buildWithCallback(measurement -> recordBuckets(desc.getName(), measurement)));
+          INSTRUMENTS.add(
+              meter
+                  .counterBuilder(desc.getName() + "_count")
+                  .ofDoubles()
+                  .setDescription(description + " (count)")
+                  .buildWithCallback(
+                      measurement -> recordField(desc.getName(), "count", measurement)));
+          INSTRUMENTS.add(
+              meter
+                  .counterBuilder(desc.getName() + "_sum")
+                  .ofDoubles()
+                  .setUnit(unit)
+                  .setDescription(description + " (sum)")
+                  .buildWithCallback(
+                      measurement -> recordField(desc.getName(), "sum", measurement)));
+          break;
+        default:
+          throw new IllegalStateException("Unknown Lance metric kind: " + desc.getKind());
+      }
+    }
+
+    instrumented = true;
+    return true;
+  }
+
+  /** Return the catalog of Lance metrics described by the native recorder. */
+  public static List<MetricDescription> catalog() {
+    JniLoader.ensureLoaded();
+    return Collections.unmodifiableList(lanceMetricsCatalogNative());
+  }
+
+  /** Return a point-in-time snapshot of all recorded Lance metric series. */
+  public static List<MetricPoint> snapshot() {
+    JniLoader.ensureLoaded();
+    return Collections.unmodifiableList(snapshotLanceMetricsNative());
+  }
+
+  private static void recordScalar(String metricName, ObservableDoubleMeasurement measurement) {
+    for (MetricPoint point : snapshot()) {
+      if (metricName.equals(point.getName()) && point.getValue() != null) {
+        measurement.record(point.getValue(), attributes(point.getAttributes()));
+      }
+    }
+  }
+
+  private static void recordBuckets(String metricName, ObservableDoubleMeasurement measurement) {
+    for (MetricPoint point : snapshot()) {
+      if (!metricName.equals(point.getName()) || point.getBuckets() == null) {
+        continue;
+      }
+      for (MetricBucket bucket : point.getBuckets()) {
+        AttributesBuilder attributes = Attributes.builder();
+        for (Map.Entry<String, String> entry : point.getAttributes().entrySet()) {
+          attributes.put(entry.getKey(), entry.getValue());
+        }
+        attributes.put("le", bucket.getLe());
+        measurement.record(bucket.getCumulativeCount(), attributes.build());
+      }
+    }
+  }
+
+  private static void recordField(
+      String metricName, String fieldName, ObservableDoubleMeasurement measurement) {
+    for (MetricPoint point : snapshot()) {
+      if (!metricName.equals(point.getName())) {
+        continue;
+      }
+      Double value = fieldValue(point, fieldName);
+      if (value != null) {
+        measurement.record(value, attributes(point.getAttributes()));
+      }
+    }
+  }
+
+  private static Double fieldValue(MetricPoint point, String fieldName) {
+    switch (fieldName) {
+      case "count":
+        return point.getCount() == null ? null : point.getCount().doubleValue();
+      case "sum":
+        return point.getSum();
+      default:
+        throw new IllegalArgumentException("Unknown Lance metric field: " + fieldName);
+    }
+  }
+
+  private static Attributes attributes(Map<String, String> values) {
+    AttributesBuilder builder = Attributes.builder();
+    for (Map.Entry<String, String> entry : values.entrySet()) {
+      builder.put(entry.getKey(), entry.getValue());
+    }
+    return builder.build();
+  }
+
+  private static native boolean registerLanceMetricsRecorderNative();
+
+  private static native List<MetricDescription> lanceMetricsCatalogNative();
+
+  private static native List<MetricPoint> snapshotLanceMetricsNative();
+}

--- a/java/src/main/java/org/lance/otel/MetricBucket.java
+++ b/java/src/main/java/org/lance/otel/MetricBucket.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.otel;
+
+/** A cumulative histogram bucket exported with Prometheus-style {@code le} semantics. */
+public final class MetricBucket {
+  private final String le;
+  private final long cumulativeCount;
+
+  public MetricBucket(String le, long cumulativeCount) {
+    this.le = le;
+    this.cumulativeCount = cumulativeCount;
+  }
+
+  public String getLe() {
+    return le;
+  }
+
+  public long getCumulativeCount() {
+    return cumulativeCount;
+  }
+}

--- a/java/src/main/java/org/lance/otel/MetricDescription.java
+++ b/java/src/main/java/org/lance/otel/MetricDescription.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.otel;
+
+/** Metadata for one Lance metric available through the OpenTelemetry bridge. */
+public final class MetricDescription {
+  private final String name;
+  private final String kind;
+  private final String unit;
+  private final String description;
+
+  public MetricDescription(String name, String kind, String unit, String description) {
+    this.name = name;
+    this.kind = kind;
+    this.unit = unit;
+    this.description = description;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public String getUnit() {
+    return unit;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/java/src/main/java/org/lance/otel/MetricPoint.java
+++ b/java/src/main/java/org/lance/otel/MetricPoint.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.otel;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** A cumulative Lance metric data point captured by the native metrics recorder. */
+public final class MetricPoint {
+  private final String name;
+  private final String kind;
+  private final Map<String, String> attributes;
+  private final Double value;
+  private final List<MetricBucket> buckets;
+  private final Long count;
+  private final Double sum;
+
+  public MetricPoint(
+      String name,
+      String kind,
+      Map<String, String> attributes,
+      Double value,
+      List<MetricBucket> buckets,
+      Long count,
+      Double sum) {
+    this.name = name;
+    this.kind = kind;
+    this.attributes =
+        attributes == null ? Collections.emptyMap() : Collections.unmodifiableMap(attributes);
+    this.value = value;
+    this.buckets = buckets == null ? null : Collections.unmodifiableList(buckets);
+    this.count = count;
+    this.sum = sum;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+  public List<MetricBucket> getBuckets() {
+    return buckets;
+  }
+
+  public Long getCount() {
+    return count;
+  }
+
+  public Double getSum() {
+    return sum;
+  }
+}

--- a/java/src/test/java/org/lance/otel/LanceMetricsTest.java
+++ b/java/src/test/java/org/lance/otel/LanceMetricsTest.java
@@ -16,7 +16,10 @@ package org.lance.otel;
 import org.lance.Dataset;
 import org.lance.TestUtils;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.apache.arrow.memory.RootAllocator;
@@ -25,13 +28,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -75,11 +82,39 @@ public class LanceMetricsTest {
       assertTrue(requests.getAttributes().containsKey("base"));
 
       Collection<MetricData> metrics = reader.collectAllMetrics();
-      Set<String> names = metrics.stream().map(MetricData::getName).collect(Collectors.toSet());
+      Map<String, MetricData> metricsByName =
+          metrics.stream().collect(Collectors.toMap(MetricData::getName, Function.identity()));
+      Set<String> names = metricsByName.keySet();
       assertTrue(names.contains(REQUESTS));
       assertTrue(names.contains(DURATION + "_bucket"));
       assertTrue(names.contains(DURATION + "_count"));
       assertTrue(names.contains(DURATION + "_sum"));
+
+      Collection<DoublePointData> bucketPoints =
+          metricsByName.get(DURATION + "_bucket").getDoubleSumData().getPoints();
+      Collection<DoublePointData> countPoints =
+          metricsByName.get(DURATION + "_count").getDoubleSumData().getPoints();
+      Collection<DoublePointData> sumPoints =
+          metricsByName.get(DURATION + "_sum").getDoubleSumData().getPoints();
+
+      assertFalse(bucketPoints.isEmpty());
+      assertTrue(
+          bucketPoints.stream()
+              .allMatch(point -> point.getAttributes().get(AttributeKey.stringKey("le")) != null));
+
+      Map<Attributes, Double> countsByAttributes =
+          countPoints.stream()
+              .collect(Collectors.toMap(DoublePointData::getAttributes, DoublePointData::getValue));
+      Map<Attributes, Double> infiniteBucketsByAttributes = new HashMap<>();
+      for (DoublePointData bucketPoint : bucketPoints) {
+        if ("+Inf".equals(bucketPoint.getAttributes().get(AttributeKey.stringKey("le")))) {
+          Attributes attributes =
+              bucketPoint.getAttributes().toBuilder().remove(AttributeKey.stringKey("le")).build();
+          infiniteBucketsByAttributes.put(attributes, bucketPoint.getValue());
+        }
+      }
+      assertEquals(countsByAttributes, infiniteBucketsByAttributes);
+      assertTrue(sumPoints.stream().anyMatch(point -> point.getValue() > 0));
     } finally {
       provider.close();
     }
@@ -101,10 +136,23 @@ public class LanceMetricsTest {
 
       assertTrue(LanceMetrics.instrument(secondProvider));
       assertTrue(metricNames(secondReader).contains(REQUESTS));
+      assertFalse(metricNames(firstReader).contains(REQUESTS));
     } finally {
       firstProvider.close();
       secondProvider.close();
     }
+  }
+
+  @Test
+  void testSupportedMetricsSkipsUnknownKinds() {
+    MetricDescription counter = new MetricDescription("counter", "counter", null, "counter");
+    MetricDescription unknown = new MetricDescription("unknown", "summary", null, "unknown");
+
+    List<MetricDescription> supported =
+        LanceMetrics.supportedMetrics(Arrays.asList(counter, unknown));
+
+    assertEquals(1, supported.size());
+    assertEquals("counter", supported.get(0).getName());
   }
 
   private static void generateObjectStoreMetrics(Path datasetPath) {

--- a/java/src/test/java/org/lance/otel/LanceMetricsTest.java
+++ b/java/src/test/java/org/lance/otel/LanceMetricsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.otel;
+
+import org.lance.Dataset;
+import org.lance.TestUtils;
+
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LanceMetricsTest {
+  private static final String REQUESTS = "lance_object_store_requests_total";
+  private static final String DURATION = "lance_object_store_request_duration_seconds";
+  private static final String RETRYABLE = "lance_object_store_retryable_responses_total";
+  private static final String IN_FLIGHT = "lance_object_store_in_flight_requests";
+
+  @Test
+  void testInstrumentLanceMetricsExportsObjectStoreMetrics(@TempDir Path tempDir) {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+
+    try {
+      assertTrue(LanceMetrics.instrument(provider));
+
+      Map<String, MetricDescription> catalog =
+          LanceMetrics.catalog().stream()
+              .collect(Collectors.toMap(MetricDescription::getName, Function.identity()));
+      assertTrue(catalog.containsKey(REQUESTS));
+      assertEquals("histogram", catalog.get(DURATION).getKind());
+      assertEquals("counter", catalog.get(RETRYABLE).getKind());
+      assertEquals("gauge", catalog.get(IN_FLIGHT).getKind());
+
+      try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+        String datasetPath = tempDir.resolve("otel_metrics.lance").toString();
+        TestUtils.SimpleTestDataset testDataset =
+            new TestUtils.SimpleTestDataset(allocator, datasetPath);
+        try (Dataset dataset = testDataset.createEmptyDataset()) {
+          assertEquals(0, dataset.countRows());
+        }
+      }
+
+      MetricPoint requests =
+          LanceMetrics.snapshot().stream()
+              .filter(point -> REQUESTS.equals(point.getName()))
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("expected object store request metric"));
+      assertNotNull(requests.getValue());
+      assertTrue(requests.getValue() > 0);
+      assertTrue(requests.getAttributes().containsKey("operation"));
+      assertTrue(requests.getAttributes().containsKey("base"));
+
+      Collection<MetricData> metrics = reader.collectAllMetrics();
+      Set<String> names = metrics.stream().map(MetricData::getName).collect(Collectors.toSet());
+      assertTrue(names.contains(REQUESTS));
+      assertTrue(names.contains(DURATION + "_bucket"));
+      assertTrue(names.contains(DURATION + "_count"));
+      assertTrue(names.contains(DURATION + "_sum"));
+    } finally {
+      provider.close();
+    }
+  }
+}

--- a/java/src/test/java/org/lance/otel/LanceMetricsTest.java
+++ b/java/src/test/java/org/lance/otel/LanceMetricsTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +41,11 @@ public class LanceMetricsTest {
   private static final String RETRYABLE = "lance_object_store_retryable_responses_total";
   private static final String IN_FLIGHT = "lance_object_store_in_flight_requests";
 
+  @AfterEach
+  void closeLanceMetrics() {
+    LanceMetrics.close();
+  }
+
   @Test
   void testInstrumentLanceMetricsExportsObjectStoreMetrics(@TempDir Path tempDir) {
     InMemoryMetricReader reader = InMemoryMetricReader.create();
@@ -56,14 +62,7 @@ public class LanceMetricsTest {
       assertEquals("counter", catalog.get(RETRYABLE).getKind());
       assertEquals("gauge", catalog.get(IN_FLIGHT).getKind());
 
-      try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
-        String datasetPath = tempDir.resolve("otel_metrics.lance").toString();
-        TestUtils.SimpleTestDataset testDataset =
-            new TestUtils.SimpleTestDataset(allocator, datasetPath);
-        try (Dataset dataset = testDataset.createEmptyDataset()) {
-          assertEquals(0, dataset.countRows());
-        }
-      }
+      generateObjectStoreMetrics(tempDir.resolve("otel_metrics.lance"));
 
       MetricPoint requests =
           LanceMetrics.snapshot().stream()
@@ -84,5 +83,42 @@ public class LanceMetricsTest {
     } finally {
       provider.close();
     }
+  }
+
+  @Test
+  void testInstrumentReRegistersWithNewProvider(@TempDir Path tempDir) {
+    InMemoryMetricReader firstReader = InMemoryMetricReader.create();
+    InMemoryMetricReader secondReader = InMemoryMetricReader.create();
+    SdkMeterProvider firstProvider =
+        SdkMeterProvider.builder().registerMetricReader(firstReader).build();
+    SdkMeterProvider secondProvider =
+        SdkMeterProvider.builder().registerMetricReader(secondReader).build();
+
+    try {
+      assertTrue(LanceMetrics.instrument(firstProvider));
+      generateObjectStoreMetrics(tempDir.resolve("first_provider.lance"));
+      assertTrue(metricNames(firstReader).contains(REQUESTS));
+
+      assertTrue(LanceMetrics.instrument(secondProvider));
+      assertTrue(metricNames(secondReader).contains(REQUESTS));
+    } finally {
+      firstProvider.close();
+      secondProvider.close();
+    }
+  }
+
+  private static void generateObjectStoreMetrics(Path datasetPath) {
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath.toString());
+      try (Dataset dataset = testDataset.createEmptyDataset()) {
+        assertEquals(0, dataset.countRows());
+      }
+    }
+  }
+
+  private static Set<String> metricNames(InMemoryMetricReader reader) {
+    Collection<MetricData> metrics = reader.collectAllMetrics();
+    return metrics.stream().map(MetricData::getName).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Summary

  - Add Java OpenTelemetry metrics support matching pylance’s metrics bridge.
  - Expose Lance Rust metrics through JNI with catalog and snapshot APIs.
  - Register Java observable instruments for counters, gauges, and histogram bucket/count/sum series.
  - Add focused coverage for object-store metrics export through OpenTelemetry.

  Tests

  - cargo fmt --check
  - cargo clippy --all-targets --locked -- -D warnings
  - cargo check --manifest-path ./lance-jni/Cargo.toml --locked
  - ./mvnw spotless:check
  - ./mvnw -Dskip.build.jni=true -DskipTests compile
  - ./mvnw -Dtest=org.lance.otel.LanceMetricsTest test