### PR TITLE
fix(blob): preserve null and empty values across reads and compaction

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -239,14 +239,6 @@ def _is_null_blob_description(description: Any) -> bool:
         return False
     if description.keys() == {"position", "size"}:
         return description["position"] == 1 and description["size"] == 0
-    if description.keys() == {"kind", "position", "size", "blob_id", "blob_uri"}:
-        return (
-            description["kind"] == 0
-            and description["position"] == 0
-            and description["size"] == 0
-            and description["blob_id"] == 0
-            and description["blob_uri"] == ""
-        )
     return False
 
 

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -1946,6 +1946,80 @@ def dataset_for_pandas_no_blob_tests(tmp_path):
     return lance.write_dataset(table, tmp_path / "no_blob_pandas_ds")
 
 
+def _lazy_blob_values(dataset):
+    values = dataset.scanner(columns=["blob"]).to_pandas(blob_mode="lazy")["blob"]
+    return [None if value is None else value.readall() for value in values]
+
+
+@pytest.mark.parametrize(
+    "values, has_sidecar",
+    [
+        pytest.param([b"", b"payload", None], False, id="leading_empty"),
+        pytest.param([b"", b"", b""], False, id="all_empty"),
+        pytest.param(
+            [b"payload", b"", None, b"tail", b""],
+            False,
+            id="payload_empty_null",
+        ),
+        pytest.param(
+            [b"", b"p" * (64 * 1024 + 1024), None, b""],
+            True,
+            id="sidecar_backed",
+        ),
+    ],
+)
+def test_blob_v2_lazy_preserves_empty_and_null(tmp_path, values, has_sidecar):
+    dataset_path = tmp_path / "blob_v2_lazy_empty"
+    schema = pa.schema([lance.blob_field("blob")])
+    dataset = lance.write_dataset(
+        pa.Table.from_arrays([lance.blob_array(values)], schema=schema),
+        dataset_path,
+        data_storage_version="2.2",
+    )
+
+    descriptions = dataset.to_table(columns=["blob"]).column("blob").to_pylist()
+    assert [description is None for description in descriptions] == [
+        value is None for value in values
+    ]
+    if values[0] == b"":
+        assert descriptions[0]["position"] == 0
+        assert descriptions[0]["size"] == 0
+    if has_sidecar:
+        assert any(
+            description is not None and description["kind"] == 1
+            for description in descriptions
+        )
+        assert any(path.suffix == ".blob" for path in _dataset_file_set(dataset_path))
+
+    assert _lazy_blob_values(dataset) == values
+
+
+def test_blob_v1_lazy_preserves_empty_and_null_sentinels(tmp_path):
+    values = [b"", None, b"payload"]
+    schema = pa.schema(
+        [
+            pa.field(
+                "blob",
+                pa.large_binary(),
+                metadata={"lance-encoding:blob": "true"},
+            )
+        ]
+    )
+    dataset = lance.write_dataset(
+        pa.Table.from_arrays(
+            [pa.array(values, type=pa.large_binary())],
+            schema=schema,
+        ),
+        tmp_path / "blob_v1_lazy_empty",
+        data_storage_version="2.0",
+    )
+
+    descriptions = dataset.to_table(columns=["blob"]).column("blob").to_pylist()
+    assert descriptions[0] == {"position": 0, "size": 0}
+    assert descriptions[1] == {"position": 1, "size": 0}
+    assert _lazy_blob_values(dataset) == values
+
+
 @pytest.mark.parametrize("source", ["dataset", "scanner", "fragment"])
 def test_to_pandas_without_blobs_matches_arrow_with_kwargs(
     dataset_for_pandas_no_blob_tests,

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -69,6 +69,83 @@ def test_blob_compaction(tmp_path: Path):
     assert contents == blobs
 
 
+@pytest.mark.parametrize("storage_version", ["2.0", "2.1", "2.2"])
+def test_blob_compaction_preserves_null_empty_and_read_parity(
+    tmp_path: Path, storage_version: str
+):
+    base_dir = tmp_path / f"blob_dataset_{storage_version}"
+    if storage_version == "2.2":
+        blob_field = lance.blob_field("blob")
+    else:
+        blob_field = pa.field(
+            "blob",
+            pa.large_binary(),
+            metadata={"lance-encoding:blob": "true"},
+        )
+    schema = pa.schema([pa.field("id", pa.int64()), blob_field])
+
+    def make_blob_array(values):
+        if storage_version == "2.2":
+            return lance.blob_array(values)
+        return pa.array(values, type=pa.large_binary())
+
+    for index, (ids, values) in enumerate(
+        [
+            ([1, 2], [b"P1", None]),
+            ([3, 4, 5], [b"P3", None, b""]),
+        ]
+    ):
+        lance.write_dataset(
+            pa.Table.from_arrays(
+                [
+                    pa.array(ids, type=pa.int64()),
+                    make_blob_array(values),
+                ],
+                schema=schema,
+            ),
+            base_dir,
+            mode="create" if index == 0 else "append",
+            data_storage_version=storage_version,
+        )
+
+    dataset = lance.dataset(base_dir)
+    dataset.delete("id = 2")
+    dataset.optimize.compact_files(num_threads=1)
+
+    expected = {1: b"P1", 3: b"P3", 4: None, 5: b""}
+    binary_table = dataset.to_table(columns=["id", "blob"], blob_handling="all_binary")
+    scan_values = dict(
+        zip(
+            binary_table.column("id").to_pylist(),
+            binary_table.column("blob").to_pylist(),
+        )
+    )
+
+    ids = dataset.to_table(columns=["id"]).column("id").to_pylist()
+    blob_files = dataset.take_blobs("blob", indices=range(len(ids)))
+    take_values = {
+        row_id: None if blob_file is None else blob_file.readall()
+        for row_id, blob_file in zip(ids, blob_files)
+    }
+
+    assert take_values == expected
+    assert scan_values == take_values
+
+    descriptor_table = dataset.to_table(columns=["id", "blob"])
+    descriptions = dict(
+        zip(
+            descriptor_table.column("id").to_pylist(),
+            descriptor_table.column("blob").to_pylist(),
+        )
+    )
+    if storage_version == "2.0":
+        assert descriptions[4] == {"position": 1, "size": 0}
+    else:
+        assert descriptions[4] is None
+    assert descriptions[5] is not None
+    assert descriptions[5]["size"] == 0
+
+
 def test_optimize_max_bytes(tmp_path: Path):
     base_dir = tmp_path / "dataset"
     arr = pa.array(range(4 * 1024 * 1024))

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -137,14 +137,18 @@ impl FieldEncoder for BlobStructuralEncoder {
         let def = repdef.definition_levels.as_ref();
         let def_meaning: Arc<[DefinitionInterpretation]> = repdef.def_meaning.into();
 
-        match self.def_meaning.as_ref() {
-            None => {
-                self.def_meaning = Some(def_meaning.clone());
+        // A blob page stores one definition interpretation for all of its rows.
+        // The descriptor encoder can buffer multiple input arrays, so finish the
+        // pending page before a later array changes from all-valid to nullable (or
+        // vice versa).
+        let mut encode_tasks = match self.def_meaning.as_ref() {
+            Some(existing) if existing != &def_meaning => {
+                let existing = existing.clone();
+                Self::wrap_tasks(self.descriptor_encoder.flush(external_buffers)?, existing)
             }
-            Some(existing) => {
-                debug_assert_eq!(existing, &def_meaning);
-            }
-        }
+            _ => Vec::new(),
+        };
+        self.def_meaning = Some(def_meaning.clone());
 
         // Collect positions and sizes
         let mut positions = Vec::with_capacity(binary_array.len());
@@ -192,15 +196,16 @@ impl FieldEncoder for BlobStructuralEncoder {
         ));
 
         // Delegate to descriptor encoder
-        let encode_tasks = self.descriptor_encoder.maybe_encode(
+        let descriptor_tasks = self.descriptor_encoder.maybe_encode(
             descriptor_array,
             external_buffers,
             RepDefBuilder::default(),
             row_number,
             num_rows,
         )?;
+        encode_tasks.extend(Self::wrap_tasks(descriptor_tasks, def_meaning));
 
-        Ok(Self::wrap_tasks(encode_tasks, def_meaning))
+        Ok(encode_tasks)
     }
 
     fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
@@ -554,6 +559,28 @@ mod tests {
         ]));
 
         check_round_trip_encoding_of_data(vec![array], &TestCases::default(), blob_metadata).await;
+    }
+
+    #[tokio::test]
+    async fn test_blob_round_trip_varying_chunk_nullability() {
+        let blob_metadata =
+            HashMap::from([(lance_arrow::BLOB_META_KEY.to_string(), "true".to_string())]);
+        let all_valid = Arc::new(LargeBinaryArray::from(vec![Some(b"first".as_ref())]));
+        let with_null = Arc::new(LargeBinaryArray::from(vec![
+            Some(b"second".as_ref()),
+            None,
+            Some(b"".as_ref()),
+        ]));
+        let all_valid_again = Arc::new(LargeBinaryArray::from(vec![Some(b"last".as_ref())]));
+
+        check_round_trip_encoding_of_data(
+            vec![all_valid, with_null, all_valid_again],
+            &TestCases::default()
+                .with_min_file_version(LanceFileVersion::V2_1)
+                .with_max_file_version(LanceFileVersion::V2_1),
+            blob_metadata,
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #8067.
Fixes #8069.

Blob v2 empty descriptors at position zero are valid values, but Python lazy conversion treated their descriptor contents as a null sentinel even though Blob v2 nullness is already carried by Arrow validity.

Storage 2.1 compaction can also change a blob encoder's input from an all-valid batch to a nullable batch after deletion filtering. The descriptor encoder buffered both batches while retaining the first batch's definition interpretation, so a surviving null's packed definition level (`1 << 16`) could be exposed as a valid zero-length descriptor.

This keeps the Python and storage fixes at their separate semantic boundaries: lazy conversion relies on Arrow validity while the storage 2.1 writer closes a pending descriptor page before its repetition/definition interpretation changes. Blob v1 sentinel behavior and storage 2.0/2.2 semantics remain unchanged.
