### PR TITLE
fix(fts): propagate nested multimatch limits

### DIFF
--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -10,6 +10,12 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FtsSearchParams {
+    /// Controls result completeness for each recursively planned FTS node.
+    ///
+    /// `Some(k)` permits bounded top-k execution, while `None` requires complete
+    /// results so an outer compound query can combine every candidate exactly.
+    /// Future competitive-score pruning must use a separate planning contract
+    /// instead of inferring a bound from the ambient scanner limit.
     pub limit: Option<usize>,
     pub wand_factor: f32,
     pub fuzziness: Option<u32>,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3471,18 +3471,26 @@ impl Scanner {
                     fts_node,
                     schema,
                 )?);
-                let sort_expr = PhysicalSortExpr {
-                    expr: expressions::col(SCORE_COL, fts_node.schema().as_ref())?,
-                    options: SortOptions {
-                        descending: true,
-                        nulls_first: false,
+                let sort_exprs = [
+                    PhysicalSortExpr {
+                        expr: expressions::col(SCORE_COL, fts_node.schema().as_ref())?,
+                        options: SortOptions {
+                            descending: true,
+                            nulls_first: false,
+                        },
                     },
-                };
+                    PhysicalSortExpr {
+                        expr: expressions::col(ROW_ID, fts_node.schema().as_ref())?,
+                        options: SortOptions {
+                            descending: false,
+                            nulls_first: false,
+                        },
+                    },
+                ];
 
-                Arc::new(
-                    SortExec::new([sort_expr].into(), fts_node)
-                        .with_fetch(self.limit.map(|l| l as usize)),
-                )
+                // `params.limit` is the recursive planning contract. Compound
+                // parents pass `None` when they require every candidate.
+                Arc::new(SortExec::new(sort_exprs.into(), fts_node).with_fetch(params.limit))
             }
             FtsQuery::Boolean(query) => {
                 // TODO: rewrite the query for better performance

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -37,8 +37,8 @@ use lance_file::version::LanceFileVersion;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
-    InvertedListFormatVersion,
-    query::{BooleanQuery, MatchQuery, Occur, Operator, PhraseQuery},
+    InvertedListFormatVersion, SCORE_COL,
+    query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
 use lance_index::{FtsPrewarmOptions, PrewarmOptions};
@@ -861,6 +861,167 @@ async fn test_fts_on_multiple_columns() {
         .await
         .unwrap();
     assert_eq!(results.num_rows(), 1);
+}
+
+async fn create_fragmented_fts_index(dataset: &mut Dataset, column: &str) {
+    let index_name = format!("{column}_idx");
+    let columns = [column];
+    let params = InvertedIndexParams::default();
+    let fragment_ids = dataset
+        .get_fragments()
+        .iter()
+        .map(|fragment| fragment.id() as u32)
+        .collect::<Vec<_>>();
+    let mut segments = Vec::with_capacity(fragment_ids.len());
+    for fragment_id in &fragment_ids {
+        let mut builder = dataset
+            .create_index_builder(&columns, IndexType::Inverted, &params)
+            .name(index_name.clone())
+            .fragments(vec![*fragment_id]);
+        segments.push(builder.execute_uncommitted().await.unwrap());
+    }
+    dataset
+        .commit_existing_index_segments(&index_name, column, segments)
+        .await
+        .unwrap();
+
+    let segments = crate::index::scalar::inverted::load_segments(dataset, column)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(segments.len(), fragment_ids.len());
+}
+
+fn compound_multimatch_query() -> FtsQuery {
+    MultiMatchQuery::try_new(
+        "common".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .try_with_boosts(vec![10.0, 1.0])
+    .unwrap()
+    .into()
+}
+
+fn compound_match_query(term: &str, column: &str, boost: f32) -> FtsQuery {
+    MatchQuery::new(term.to_owned())
+        .with_column(Some(column.to_owned()))
+        .with_boost(boost)
+        .into()
+}
+
+async fn compound_fts_results(
+    dataset: &Dataset,
+    query: FtsQuery,
+    limit: Option<i64>,
+) -> Vec<(u64, f32)> {
+    let mut scan = dataset.scan();
+    scan.with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    row_ids
+        .iter()
+        .copied()
+        .zip(scores.iter().copied())
+        .collect()
+}
+
+async fn assert_compound_fts_top_k(dataset: &Dataset, query: FtsQuery, limit: usize) {
+    let exhaustive = compound_fts_results(dataset, query.clone(), None).await;
+    assert!(
+        exhaustive.len() > limit,
+        "the exhaustive result must contain candidates beyond k"
+    );
+    let limited = compound_fts_results(dataset, query, Some(limit as i64)).await;
+    assert_eq!(limited, exhaustive[..limit]);
+}
+
+#[tokio::test]
+async fn test_nested_multimatch_limit_propagation() {
+    let batch = arrow_array::record_batch!(
+        (
+            "title",
+            Utf8,
+            [
+                "common",
+                "common filler filler filler filler filler filler filler",
+                "irrelevant",
+                "common tie",
+                "common tie",
+                "irrelevant"
+            ]
+        ),
+        (
+            "body",
+            Utf8,
+            [
+                "penalty",
+                "special",
+                "common",
+                "neutral",
+                "neutral",
+                "common filler filler filler penalty"
+            ]
+        )
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 3);
+    create_fragmented_fts_index(&mut dataset, "title").await;
+    create_fragmented_fts_index(&mut dataset, "body").await;
+
+    let must_query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_multimatch_query()),
+        (
+            Occur::Should,
+            compound_match_query("special", "body", 100.0),
+        ),
+    ])
+    .into();
+    let must_results = compound_fts_results(&dataset, must_query.clone(), None).await;
+    assert!(
+        must_results
+            .windows(2)
+            .any(|rows| rows[0].1 == rows[1].1 && rows[0].0 < rows[1].0),
+        "the exhaustive result should include a deterministic score tie"
+    );
+    assert_compound_fts_top_k(&dataset, must_query, 2).await;
+
+    let should_query: FtsQuery = BooleanQuery::new([
+        (Occur::Should, compound_multimatch_query()),
+        (
+            Occur::Should,
+            compound_match_query("special", "body", 100.0),
+        ),
+    ])
+    .into();
+    assert_compound_fts_top_k(&dataset, should_query, 2).await;
+
+    let boost_query: FtsQuery = BoostQuery::new(
+        compound_multimatch_query(),
+        compound_match_query("penalty", "body", 100.0),
+        Some(1.0),
+    )
+    .into();
+    assert_compound_fts_top_k(&dataset, boost_query, 2).await;
+
+    assert_compound_fts_top_k(&dataset, compound_multimatch_query(), 1).await;
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -151,6 +152,15 @@ async fn search_segments(
         .into_iter()
         .map(|std::cmp::Reverse(doc)| (doc.row_id, doc.score.0))
         .unzip())
+}
+
+fn compare_scored_rows(
+    (left_row_id, left_score): &(u64, f32),
+    (right_row_id, right_score): &(u64, f32),
+) -> Ordering {
+    right_score
+        .total_cmp(left_score)
+        .then_with(|| left_row_id.cmp(right_row_id))
 }
 
 /// Fall back to the default simple tokenizer when no on-disk FTS segment exists.
@@ -1790,7 +1800,7 @@ impl ExecutionPlan for BoostQueryExec {
 
             let (doc_ids, scores): (Vec<_>, Vec<_>) = res
                 .into_iter()
-                .sorted_unstable_by(|(_, a), (_, b)| b.total_cmp(a))
+                .sorted_unstable_by(compare_scored_rows)
                 .take(params.limit.unwrap_or(usize::MAX))
                 .unzip();
             metrics.baseline_metrics.record_output(doc_ids.len());
@@ -2126,7 +2136,7 @@ impl ExecutionPlan for BooleanQueryExec {
             let _timer = elapsed_time.timer();
             let (row_ids, scores): (Vec<_>, Vec<_>) = res
                 .into_iter()
-                .sorted_unstable_by(|(_, a), (_, b)| b.total_cmp(a))
+                .sorted_unstable_by(compare_scored_rows)
                 .take(params.limit.unwrap_or(usize::MAX))
                 .unzip();
             metrics.baseline_metrics.record_output(row_ids.len());


### PR DESCRIPTION
## What is the bug?

`BooleanQuery` and `BoostQuery` recursively plan their children without a limit so outer score composition remains exact. Nested `MultiMatchQuery`, however, applied its final fetch from the ambient scanner limit instead of the recursively supplied FTS search parameters.

Linear: [OSS-1599](https://linear.app/lancedb/issue/OSS-1599/fix-nested-multimatch-limit-propagation-in-compound-fts-queries)

## What issues or incorrect behavior does the bug cause?

A nested MultiMatch could discard candidates before an outer MUST clause, SHOULD score accumulation, or BoostQuery demotion finished combining scores. This could omit the true top-k or return incomplete scores. Equal-score rows could also appear in a different order between bounded and exhaustive execution.

## How does this PR fix the problem?

- Use `FtsSearchParams::limit` as the recursive planning contract for MultiMatch fetches.
- Treat `None` as complete execution for compound parents and document that future competitive-score pruning needs a separate contract.
- Order compound FTS ties by `_score DESC, _rowid ASC`.
- Add a regression test covering MUST, SHOULD, BoostQuery, standalone MultiMatch, no limit, small k, multiple fields, three fragments/segments, and score ties.

This is a correctness and planning-semantics fix. It does not replace the current MultiMatch Union/Aggregate/Sort execution.

## Validation

- `cargo test -p lance --lib test_nested_multimatch_limit_propagation -- --nocapture`
- `cargo test -p lance --lib io::exec::fts::tests -- --nocapture` (15 passed)
- `cargo test -p lance --lib dataset::tests::dataset_index::test_fts_ -- --nocapture` (22 passed)
- `cargo clippy -p lance -p lance-index --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`