### PR TITLE
fix(core): key row id sequence cache on fragment contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5088,6 +5088,7 @@ dependencies = [
  "async-trait",
  "aws-credential-types",
  "aws-sdk-dynamodb",
+ "blake3",
  "byteorder",
  "bytes",
  "chrono",

--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -141,7 +141,7 @@ Keys are often a composite of multiple fields and all keys are scoped to the dat
 | Deletion Files    | Dataset URI, fragment_id, version, id, file_type | The deletion vector for a frag      |
 | Row Id Mask       | Dataset URI, version                             | The row id sequence for the dataset |
 | Row Id Index      | Dataset URI, version                             | The row id index for the dataset    |
-| Row Id Sequence   | Dataset URI, fragment_id                         | The row id sequence for a fragment  |
+| Row Id Sequence   | Dataset URI, fragment_id, row_id_meta            | The row id sequence for a fragment  |
 | Index Metadata    | Dataset URI, version                             | The index metadata for the dataset  |
 | Index Details¹    | Dataset URI, index uuid                          | The index details for an index      |
 | File Global Meta  | Dataset URI, file path                           | The global metadata for a file      |

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4250,6 +4250,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "async-trait",
+ "blake3",
  "byteorder",
  "bytes",
  "chrono",

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -568,7 +568,7 @@ fn inner_encode_row_ids(env: &mut JNIEnv, row_ids: &JLongArray) -> Result<String
     env.get_long_array_region(row_ids, 0, buf.as_mut_slice())?;
     let ids: Vec<u64> = buf.into_iter().map(|x| x as u64).collect();
     let seq = RowIdSequence::from(ids.as_slice());
-    let meta = RowIdMeta::Inline(write_row_ids(&seq));
+    let meta = RowIdMeta::Inline(write_row_ids(&seq).into());
     let json = serde_json::to_string(&meta)?;
     Ok(json)
 }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4542,6 +4542,7 @@ dependencies = [
  "async-trait",
  "aws-credential-types",
  "aws-sdk-dynamodb",
+ "blake3",
  "byteorder",
  "bytes",
  "chrono",

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -24,6 +24,7 @@ arrow-ipc.workspace = true
 arrow-schema.workspace = true
 async-trait.workspace = true
 aws-credential-types = { workspace = true, optional = true }
+blake3.workspace = true
 aws-sdk-dynamodb = { workspace = true, optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
 byteorder.workspace = true
 bytes.workspace = true

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -3,10 +3,11 @@
 
 use std::collections::HashMap;
 use std::num::NonZero;
-use std::sync::Arc;
+use std::ops::Deref;
+use std::sync::{Arc, OnceLock};
 
 use lance_core::Error;
-use lance_core::deepsize::DeepSizeOf;
+use lance_core::deepsize::{Context, DeepSizeOf};
 use lance_file::version::ConcreteFileVersion;
 use lance_io::utils::CachedFileSize;
 use object_store::path::Path;
@@ -453,10 +454,111 @@ pub struct ExternalFile {
     pub size: u64,
 }
 
+/// A fragment's row id sequence, encoded inline in the manifest.
+///
+/// Carries a memoized [`digest`](Self::digest) of the encoded bytes. The digest
+/// identifies *which* sequence these bytes are, which is what the row id
+/// sequence cache keys on: a fragment id alone does not identify a sequence,
+/// because fragment ids are reused across dataset generations.
+///
+/// The digest is memoized because computing it is proportional to the encoded
+/// size. A run-encoded sequence is a handful of bytes per run, but a heavily
+/// fragmented one is array-encoded at 8 bytes per row, and the cache is
+/// consulted on every scan, count, prefilter and index load.
+///
+/// Bytes and memo share one immutable allocation, so cloning shares both. That
+/// is what makes the memo worth having: callers clone `Fragment` before loading
+/// its sequence (see `count_from_mask`), and a memo held per clone would be
+/// filled and dropped by each scan, rehashing the whole sequence every time.
+/// Sharing also keeps a cloned fragment from duplicating the encoded bytes.
+///
+/// The digest lives *with* the bytes rather than beside them so the two cannot
+/// drift: several write paths replace a fragment's `row_id_meta` after the
+/// fragment is built, and a digest that outlived its bytes would silently
+/// resolve to another generation's sequence.
+#[derive(Clone)]
+pub struct InlineRowIds {
+    inner: Arc<InlineRowIdsInner>,
+}
+
+struct InlineRowIdsInner {
+    data: Vec<u8>,
+    digest: OnceLock<[u8; 32]>,
+}
+
+impl InlineRowIds {
+    /// Digest of the encoded bytes, computed on first use and shared by clones.
+    pub fn digest(&self) -> &[u8; 32] {
+        self.inner
+            .digest
+            .get_or_init(|| blake3::hash(&self.inner.data).into())
+    }
+}
+
+impl From<Vec<u8>> for InlineRowIds {
+    fn from(data: Vec<u8>) -> Self {
+        Self {
+            inner: Arc::new(InlineRowIdsInner {
+                data,
+                digest: OnceLock::new(),
+            }),
+        }
+    }
+}
+
+impl Deref for InlineRowIds {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.data
+    }
+}
+
+// Debug, equality and serialization all present the bytes alone: the memo is a
+// derived value and must not show up in output, comparisons or the manifest.
+impl std::fmt::Debug for InlineRowIds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.data.fmt(f)
+    }
+}
+
+impl PartialEq for InlineRowIds {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner) || self.inner.data == other.inner.data
+    }
+}
+
+impl Eq for InlineRowIds {}
+
+impl Serialize for InlineRowIds {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        self.inner.data.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for InlineRowIds {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        Vec::<u8>::deserialize(deserializer).map(Self::from)
+    }
+}
+
+impl DeepSizeOf for InlineRowIds {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        // Delegate to the `Arc` so clones sharing one allocation are counted once.
+        self.inner.deep_size_of_children(context)
+    }
+}
+
+impl DeepSizeOf for InlineRowIdsInner {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.data.deep_size_of_children(context)
+    }
+}
+
 /// Metadata about location of the row id sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
 pub enum RowIdMeta {
-    Inline(Vec<u8>),
+    Inline(InlineRowIds),
     External(ExternalFile),
 }
 
@@ -465,7 +567,7 @@ impl TryFrom<pb::data_fragment::RowIdSequence> for RowIdMeta {
 
     fn try_from(value: pb::data_fragment::RowIdSequence) -> Result<Self> {
         match value {
-            pb::data_fragment::RowIdSequence::InlineRowIds(data) => Ok(Self::Inline(data)),
+            pb::data_fragment::RowIdSequence::InlineRowIds(data) => Ok(Self::Inline(data.into())),
             pb::data_fragment::RowIdSequence::ExternalRowIds(file) => {
                 Ok(Self::External(ExternalFile {
                     path: file.path.clone(),
@@ -714,7 +816,9 @@ impl From<&Fragment> for pb::DataFragment {
         });
 
         let row_id_sequence = f.row_id_meta.as_ref().map(|m| match m {
-            RowIdMeta::Inline(data) => pb::data_fragment::RowIdSequence::InlineRowIds(data.clone()),
+            RowIdMeta::Inline(data) => {
+                pb::data_fragment::RowIdSequence::InlineRowIds(data.to_vec())
+            }
             RowIdMeta::External(file) => {
                 pb::data_fragment::RowIdSequence::ExternalRowIds(pb::ExternalFile {
                     path: file.path.clone(),
@@ -998,5 +1102,65 @@ mod tests {
         data_file
             .validate(&base_path)
             .expect("validation should allow extra columns without field ids");
+    }
+
+    #[test]
+    fn inline_row_ids_digest_identifies_contents() {
+        let first = InlineRowIds::from(vec![1, 2, 3]);
+        let same = InlineRowIds::from(vec![1, 2, 3]);
+        let other = InlineRowIds::from(vec![1, 2, 4]);
+
+        // The digest is what the row id sequence cache keys on, so it must
+        // follow the bytes exactly: same bytes, same key; any change, new key.
+        assert_eq!(first.digest(), same.digest());
+        assert_ne!(first.digest(), other.digest());
+        assert_eq!(first, same);
+        assert_ne!(first, other);
+
+        // Memoized on first use, so repeat use must return the same digest.
+        let memoized = *first.digest();
+        assert_eq!(first.digest(), &memoized);
+    }
+
+    #[test]
+    fn inline_row_ids_clones_share_bytes_and_memo() {
+        let first = InlineRowIds::from(vec![1, 2, 3]);
+        let cloned = first.clone();
+
+        // Callers clone `Fragment` before loading its row id sequence, so a memo
+        // held per clone would be filled and dropped by each scan and rehash the
+        // whole sequence every time. Sharing one allocation is what makes the
+        // memo pay off, and it keeps clones from duplicating the bytes.
+        assert!(std::ptr::eq(first.as_ptr(), cloned.as_ptr()));
+        assert!(std::ptr::eq(first.digest(), cloned.digest()));
+
+        // Guard against the assertions above passing vacuously: only clones
+        // share storage, equal bytes built separately do not.
+        let separate = InlineRowIds::from(vec![1, 2, 3]);
+        assert_eq!(first, separate);
+        assert!(!std::ptr::eq(first.as_ptr(), separate.as_ptr()));
+
+        // Computing through one clone must be visible from the other.
+        let fresh = InlineRowIds::from(vec![4, 5, 6]);
+        let fresh_clone = fresh.clone();
+        let via_clone = *fresh_clone.digest();
+        assert_eq!(fresh.digest(), &via_clone);
+    }
+
+    #[test]
+    fn inline_row_ids_serializes_as_bare_bytes() {
+        // The manifest is a stable format: the memo must not reach the wire.
+        let meta = RowIdMeta::Inline(InlineRowIds::from(vec![7, 8, 9]));
+        let json = serde_json::to_string(&meta).unwrap();
+        assert_eq!(json, r#"{"Inline":[7,8,9]}"#);
+        assert_eq!(serde_json::from_str::<RowIdMeta>(&json).unwrap(), meta);
+
+        // ...and round-trips through protobuf unchanged.
+        let fragment = Fragment {
+            row_id_meta: Some(meta.clone()),
+            ..Fragment::new(0)
+        };
+        let restored = Fragment::try_from(pb::DataFragment::from(&fragment)).unwrap();
+        assert_eq!(restored.row_id_meta, Some(meta));
     }
 }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1934,7 +1934,7 @@ async fn rechunk_stable_row_ids(
     for (fragment, sequence) in new_fragments.iter_mut().zip(new_sequences) {
         // TODO: if large enough, serialize to separate file
         let serialized = lance_table::rowids::write_row_ids(&sequence);
-        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
     }
 
     Ok(())

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -497,13 +497,9 @@ mod test {
         let num_rows = 10u64;
         let batch = sequence_batch(0..num_rows as i32);
 
-        // The session is shared across both writes so the metadata cache stays
-        // warm across the overwrite.
-        let session = Arc::new(Session::default());
         let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
         let write_params = WriteParams {
             enable_stable_row_ids: true,
-            session: Some(session.clone()),
             ..Default::default()
         };
         let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
@@ -514,26 +510,9 @@ mod test {
 
         assert_eq!(dataset.manifest().next_row_id, num_rows);
 
-        let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
-            .await
-            .unwrap();
-        assert_eq!(
-            sequence.iter().collect::<Vec<_>>(),
-            (0..num_rows).collect::<Vec<_>>()
-        );
-
-        // Loading the same fragment again must be served from the cache: the key
-        // discriminates on the row id metadata, which has not changed.
-        let hits_before = session.metadata_cache_stats().await.hits;
-        load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
-            .await
-            .unwrap();
-        assert_eq!(session.metadata_cache_stats().await.hits, hits_before + 1);
-
         let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
         let write_params = WriteParams {
             mode: WriteMode::Overwrite,
-            session: Some(session.clone()),
             ..Default::default()
         };
         let dataset = Dataset::write(reader, tmp_path, Some(write_params))
@@ -549,34 +528,70 @@ mod test {
         let index = get_row_id_index(&dataset).await.unwrap().unwrap();
         assert!(index.get(0).is_none());
         assert!(index.get(num_rows).is_some());
+    }
 
-        // The new fragment holds the row ids the overwrite wrote, not the ones
-        // cached for the generation it replaced.
+    /// Fragment ids are a high water mark within one dataset, but a dataset
+    /// dropped and recreated at the same URI restarts them at 0 while sharing the
+    /// cache namespace of its predecessor (see #7645). The two generations must
+    /// still be told apart.
+    #[tokio::test]
+    async fn test_row_ids_recreate_at_same_uri() {
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        // Shared so the cache stays warm across the drop, as it would for a host
+        // that keeps one session open for the lifetime of the process.
+        let session = Arc::new(Session::default());
+        let write = |rows: Range<i32>| {
+            let batch = sequence_batch(rows);
+            let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+            let params = WriteParams {
+                enable_stable_row_ids: true,
+                session: Some(session.clone()),
+                ..Default::default()
+            };
+            async move {
+                Dataset::write(reader, tmp_path, Some(params))
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let dataset = write(0..100).await;
+        let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(sequence.len(), 100);
+
+        // Reloading the unchanged fragment must still hit: keying on contents has
+        // to leave the sequence cacheable, not just make it distinguishable.
+        let hits_before = session.metadata_cache_stats().await.hits;
+        load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(session.metadata_cache_stats().await.hits, hits_before + 1);
+
+        drop(dataset);
+        std::fs::remove_dir_all(tmp_path.as_str()).unwrap();
+
+        // Shorter than the dataset it replaces, so a stale hit is observable: an
+        // equal-length sequence would be byte-identical and harmless.
+        let dataset = write(0..60).await;
+        assert_eq!(dataset.manifest.fragments[0].id, 0);
+
         let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
             .await
             .unwrap();
         assert_eq!(
             sequence.iter().collect::<Vec<_>>(),
-            (num_rows..(2 * num_rows)).collect::<Vec<_>>()
-        );
-
-        // Neither generation displaces the other: the version written before the
-        // overwrite still reads its own sequence out of the same cache.
-        let previous = dataset.checkout_version(1).await.unwrap();
-        let sequence = load_row_id_sequence(&previous, &previous.manifest.fragments[0])
-            .await
-            .unwrap();
-        assert_eq!(
-            sequence.iter().collect::<Vec<_>>(),
-            (0..num_rows).collect::<Vec<_>>()
+            (0..60).collect::<Vec<_>>()
         );
     }
 
     #[tokio::test]
-    async fn test_compaction_after_overwrite() {
-        // Compaction rechunks the row id sequences of the fragments it merges.
-        // If a sequence cached before the overwrite were served for one of them,
-        // the rechunk would hand out ids the fragments do not hold.
+    async fn test_compaction_after_recreate() {
+        // Compaction rechunks the row id sequences of the fragments it merges, so
+        // a sequence cached for a dropped dataset does not just misreport ids, it
+        // writes ids the fragments do not hold back into the manifest.
         let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
         let tmp_path = &temp_dir;
         let session = Arc::new(Session::default());
@@ -605,9 +620,12 @@ mod test {
             .await
             .unwrap();
 
-        // The overwrite replaces those 100 rows with 60 holding row ids 100..160.
-        write(0..60, WriteMode::Overwrite).await;
-        // A second fragment, so compaction has something to merge.
+        drop(dataset);
+        std::fs::remove_dir_all(tmp_path.as_str()).unwrap();
+
+        // The recreated dataset holds 60 rows in fragment 0, not the 100 cached
+        // above, and a second fragment so compaction has something to merge.
+        write(0..60, WriteMode::Create).await;
         let mut dataset = write(0..100, WriteMode::Append).await;
 
         compact(&mut dataset, 1024).await;
@@ -622,9 +640,9 @@ mod test {
             .iter()
             .copied()
             .collect::<HashSet<_>>();
-        // 100..160 from the overwrite, 160..260 from the append. A stale
-        // sequence would put 0..100 back into circulation.
-        assert_eq!(row_ids, (100..260).collect::<HashSet<_>>());
+        // A stale 100-long sequence would rechunk 0..100 onto the 60 rows of
+        // fragment 0 and shift everything after it.
+        assert_eq!(row_ids, (0..160).collect::<HashSet<_>>());
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -18,24 +18,25 @@ pub async fn load_row_id_sequence(
     dataset: &Dataset,
     fragment: &Fragment,
 ) -> Result<Arc<RowIdSequence>> {
-    // Virtual path to prevent collisions in the cache.
     match &fragment.row_id_meta {
         None => Err(Error::internal("Missing row id meta")),
-        Some(RowIdMeta::Inline(data)) => {
+        Some(row_id_meta @ RowIdMeta::Inline(data)) => {
             let data = data.clone();
             let key = RowIdSequenceKey {
                 fragment_id: fragment.id,
+                row_id_meta,
             };
             dataset
                 .metadata_cache
                 .get_or_insert_with_key(key, || async move { read_row_ids(&data) })
                 .await
         }
-        Some(RowIdMeta::External(file_slice)) => {
+        Some(row_id_meta @ RowIdMeta::External(file_slice)) => {
             let file_slice = file_slice.clone();
             let dataset_clone = dataset.clone();
             let key = RowIdSequenceKey {
                 fragment_id: fragment.id,
+                row_id_meta,
             };
             dataset
                 .metadata_cache
@@ -286,6 +287,7 @@ mod test {
 
     use crate::dataset::optimize::{CompactionOptions, compact_files};
     use crate::index::DatasetIndexExt;
+    use crate::session::Session;
     use crate::utils::test::{DatagenExt, FailingProxyStore, FragmentCount, FragmentRowCount};
     use arrow_array::cast::AsArray;
     use arrow_array::types::{Float32Type, Int32Type, UInt64Type};
@@ -495,9 +497,13 @@ mod test {
         let num_rows = 10u64;
         let batch = sequence_batch(0..num_rows as i32);
 
+        // The session is shared across both writes so the metadata cache stays
+        // warm across the overwrite.
+        let session = Arc::new(Session::default());
         let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
         let write_params = WriteParams {
             enable_stable_row_ids: true,
+            session: Some(session.clone()),
             ..Default::default()
         };
         let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
@@ -508,9 +514,26 @@ mod test {
 
         assert_eq!(dataset.manifest().next_row_id, num_rows);
 
+        let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            (0..num_rows).collect::<Vec<_>>()
+        );
+
+        // Loading the same fragment again must be served from the cache: the key
+        // discriminates on the row id metadata, which has not changed.
+        let hits_before = session.metadata_cache_stats().await.hits;
+        load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(session.metadata_cache_stats().await.hits, hits_before + 1);
+
         let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
         let write_params = WriteParams {
             mode: WriteMode::Overwrite,
+            session: Some(session.clone()),
             ..Default::default()
         };
         let dataset = Dataset::write(reader, tmp_path, Some(write_params))
@@ -526,6 +549,82 @@ mod test {
         let index = get_row_id_index(&dataset).await.unwrap().unwrap();
         assert!(index.get(0).is_none());
         assert!(index.get(num_rows).is_some());
+
+        // The new fragment holds the row ids the overwrite wrote, not the ones
+        // cached for the generation it replaced.
+        let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            (num_rows..(2 * num_rows)).collect::<Vec<_>>()
+        );
+
+        // Neither generation displaces the other: the version written before the
+        // overwrite still reads its own sequence out of the same cache.
+        let previous = dataset.checkout_version(1).await.unwrap();
+        let sequence = load_row_id_sequence(&previous, &previous.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            (0..num_rows).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compaction_after_overwrite() {
+        // Compaction rechunks the row id sequences of the fragments it merges.
+        // If a sequence cached before the overwrite were served for one of them,
+        // the rechunk would hand out ids the fragments do not hold.
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        let session = Arc::new(Session::default());
+        let params = WriteParams {
+            enable_stable_row_ids: true,
+            session: Some(session.clone()),
+            ..Default::default()
+        };
+
+        let write = |rows: Range<i32>, mode: WriteMode| {
+            let batch = sequence_batch(rows);
+            let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+            let params = WriteParams {
+                mode,
+                ..params.clone()
+            };
+            async move {
+                Dataset::write(reader, tmp_path, Some(params))
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let dataset = write(0..100, WriteMode::Create).await;
+        load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+
+        // The overwrite replaces those 100 rows with 60 holding row ids 100..160.
+        write(0..60, WriteMode::Overwrite).await;
+        // A second fragment, so compaction has something to merge.
+        let mut dataset = write(0..100, WriteMode::Append).await;
+
+        compact(&mut dataset, 1024).await;
+
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 160);
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        let batch = scan.try_into_batch().await.unwrap();
+        let row_ids = batch[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        // 100..160 from the overwrite, 160..260 from the append. A stale
+        // sequence would put 0..100 back into circulation.
+        assert_eq!(row_ids, (100..260).collect::<HashSet<_>>());
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3254,7 +3254,7 @@ impl Transaction {
                         let combined_sequence = RowIdSequence::from(row_ids.as_slice());
 
                         let serialized = write_row_ids(&combined_sequence);
-                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
                         *next_row_id += remaining_rows;
                     }
                     Ordering::Greater => {
@@ -3270,7 +3270,7 @@ impl Transaction {
                 let sequence = RowIdSequence::from(row_ids);
                 // TODO: write to a separate file if large. Possibly share a file with other fragments.
                 let serialized = write_row_ids(&sequence);
-                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
                 *next_row_id += physical_rows;
             }
         }
@@ -4626,7 +4626,7 @@ mod tests {
         let mut fragments = vec![Fragment {
             id: 1,
             physical_rows: Some(50),
-            row_id_meta: Some(RowIdMeta::Inline(serialized)),
+            row_id_meta: Some(RowIdMeta::Inline(serialized.into())),
             files: vec![],
             overlays: vec![],
             deletion_file: None,
@@ -4659,7 +4659,7 @@ mod tests {
         let mut fragments = vec![Fragment {
             id: 1,
             physical_rows: Some(50), // More physical rows than existing row IDs
-            row_id_meta: Some(RowIdMeta::Inline(serialized)),
+            row_id_meta: Some(RowIdMeta::Inline(serialized.into())),
             files: vec![],
             overlays: vec![],
             deletion_file: None,
@@ -4695,7 +4695,7 @@ mod tests {
         let mut fragments = vec![Fragment {
             id: 1,
             physical_rows: Some(50), // Less physical rows than existing row IDs
-            row_id_meta: Some(RowIdMeta::Inline(serialized)),
+            row_id_meta: Some(RowIdMeta::Inline(serialized.into())),
             files: vec![],
             overlays: vec![],
             deletion_file: None,
@@ -4734,7 +4734,7 @@ mod tests {
             Fragment {
                 id: 2,
                 physical_rows: Some(25), // Partial existing row IDs
-                row_id_meta: Some(RowIdMeta::Inline(serialized)),
+                row_id_meta: Some(RowIdMeta::Inline(serialized.into())),
                 files: vec![],
                 overlays: vec![],
                 deletion_file: None,
@@ -5292,7 +5292,7 @@ mod tests {
     #[test]
     fn test_partial_rewrite_skips_fragment_with_no_version_meta() {
         let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
-        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids)));
+        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids).into()));
 
         let data_file = DataFile::new(
             "data.lance",
@@ -5670,7 +5670,7 @@ mod tests {
         let lance_schema = LanceSchema::try_from(&arrow_schema).unwrap();
 
         let row_ids = RowIdSequence::from([100u64, 101, 102, 103, 104].as_slice());
-        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids)));
+        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids).into()));
 
         let prev_fragment = Fragment {
             id: 0,
@@ -5746,7 +5746,7 @@ mod tests {
         let lance_schema = LanceSchema::try_from(&arrow_schema).unwrap();
 
         let row_ids = RowIdSequence::from([200u64, 201, 202, 203, 204].as_slice());
-        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids)));
+        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids).into()));
 
         let uniform_v1 = RowDatasetVersionSequence::from_uniform_row_count(5, 1);
         let meta_v1 = RowDatasetVersionMeta::from_sequence(&uniform_v1).unwrap();
@@ -5907,7 +5907,7 @@ mod tests {
             files: vec![mk_file("existing.lance")],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids_0))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids_0).into())),
             physical_rows: Some(3),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
@@ -5930,7 +5930,7 @@ mod tests {
             files: vec![mk_file("new.lance")],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids_1))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids_1).into())),
             physical_rows: Some(4),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
@@ -5993,7 +5993,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(3),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&created_at_seq).unwrap(),
@@ -6007,7 +6007,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6050,7 +6050,7 @@ mod tests {
                 files: vec![],
                 overlays: vec![],
                 deletion_file: None,
-                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&frag_a_seq))),
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&frag_a_seq).into())),
                 physical_rows: Some(2),
                 created_at_version_meta: Some(
                     RowDatasetVersionMeta::from_sequence(&frag_a_created).unwrap(),
@@ -6062,7 +6062,7 @@ mod tests {
                 files: vec![],
                 overlays: vec![],
                 deletion_file: None,
-                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&frag_b_seq))),
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&frag_b_seq).into())),
                 physical_rows: Some(3),
                 created_at_version_meta: Some(
                     RowDatasetVersionMeta::from_sequence(&frag_b_created).unwrap(),
@@ -6078,7 +6078,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6120,7 +6120,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&existing_created).unwrap(),
@@ -6135,7 +6135,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6180,7 +6180,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&existing_created).unwrap(),
@@ -6194,7 +6194,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(4),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6228,7 +6228,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6240,7 +6240,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(1),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6269,7 +6269,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6311,7 +6311,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: Some(RowDatasetVersionMeta::Inline(Arc::from(
                 vec![0xFFu8; 8].as_slice(),
@@ -6325,7 +6325,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(1),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6367,7 +6367,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&in_range_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&in_range_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&in_range_created).unwrap(),
@@ -6388,7 +6388,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&out_of_range_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&out_of_range_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&out_of_range_created).unwrap(),
@@ -6403,7 +6403,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6442,7 +6442,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq).into())),
             physical_rows: Some(3),
             created_at_version_meta: Some(RowDatasetVersionMeta::from_sequence(&created).unwrap()),
             last_updated_at_version_meta: None,
@@ -6455,7 +6455,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6504,7 +6504,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&src_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&src_seq).into())),
             physical_rows: Some(100),
             created_at_version_meta: Some(
                 RowDatasetVersionMeta::from_sequence(&src_created).unwrap(),
@@ -6519,7 +6519,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(100),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,
@@ -6567,7 +6567,7 @@ mod tests {
                 files: vec![],
                 overlays: vec![],
                 deletion_file: None,
-                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq_a))),
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq_a).into())),
                 physical_rows: Some(3),
                 created_at_version_meta: Some(
                     RowDatasetVersionMeta::from_sequence(&created_a).unwrap(),
@@ -6579,7 +6579,7 @@ mod tests {
                 files: vec![],
                 overlays: vec![],
                 deletion_file: None,
-                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq_b))),
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq_b).into())),
                 physical_rows: Some(3),
                 created_at_version_meta: Some(
                     RowDatasetVersionMeta::from_sequence(&created_b).unwrap(),
@@ -6595,7 +6595,7 @@ mod tests {
             files: vec![],
             overlays: vec![],
             deletion_file: None,
-            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq).into())),
             physical_rows: Some(2),
             created_at_version_meta: None,
             last_updated_at_version_meta: None,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2354,7 +2354,7 @@ impl MergeInsertJob {
 
                     for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {
                         let serialized = lance_table::rowids::write_row_ids(&sequence);
-                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
                     }
                 }
 

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -1023,7 +1023,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
 
                     for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {
                         let serialized = lance_table::rowids::write_row_ids(&sequence);
-                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+                        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
                     }
                 }
                 Ok(())

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -356,7 +356,7 @@ impl UpdateJob {
             })?;
             for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {
                 let serialized = lance_table::rowids::write_row_ids(&sequence);
-                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized));
+                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
             }
         }
 

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -223,18 +223,24 @@ impl CacheKey for RowIdIndexKey {
 #[derive(Debug)]
 pub struct RowIdSequenceKey<'a> {
     pub fragment_id: u64,
-    /// Where the sequence is stored, which identifies which generation of the
-    /// fragment it belongs to. A fragment id alone is not enough: this cache is
-    /// namespaced by dataset URI only (see [`GlobalMetadataCache::for_dataset`])
-    /// and fragment ids restart at 0 both for an overwrite and for a dataset
-    /// dropped and recreated at the same URI, so a reused id would otherwise be
-    /// served the earlier generation's sequence. Rewriting a fragment always
-    /// rewrites its `row_id_meta`, while operations that leave row ids alone
-    /// (deletes, added columns) keep hitting the cache.
+    /// Where the sequence is stored. A fragment id alone is not enough: this
+    /// cache is namespaced by dataset URI only (see
+    /// [`GlobalMetadataCache::for_dataset`]) and fragment ids restart at 0 both
+    /// for an overwrite and for a dataset dropped and recreated at the same URI,
+    /// so a reused id would otherwise be served the earlier generation's
+    /// sequence. The `row_id_meta` is used to differentiate generations of
+    /// dataset fragments.
     ///
-    /// Inline metadata is the fragment's run-encoded sequence, so for those the
-    /// key hashes the value's own bytes. That is the point — identity *is* the
-    /// content — and the encoded form is a handful of bytes per run.
+    /// Any operation that changes which row ids a fragment holds also writes it
+    /// new `row_id_meta`, so generations stay distinct; operations that leave
+    /// row ids alone (deletes, added columns) leave it untouched and keep
+    /// hitting the cache.
+    ///
+    /// For inline metadata the identity of the sequence *is* its encoded bytes,
+    /// so the key uses
+    /// [`InlineRowIds::digest`](lance_table::format::InlineRowIds::digest),
+    /// which those bytes memoize on first use — an array-encoded sequence is
+    /// 8 bytes per row, too much to rehash on every lookup.
     pub row_id_meta: &'a RowIdMeta,
 }
 
@@ -257,7 +263,7 @@ impl CacheKey for RowIdSequenceKey<'_> {
         match self.row_id_meta {
             RowIdMeta::Inline(data) => {
                 builder.write_variant(0);
-                builder.write_bytes(data);
+                builder.write_fixed_bytes(data.digest());
             }
             RowIdMeta::External(file) => {
                 builder.write_variant(1);
@@ -327,7 +333,7 @@ mod tests {
         // restarts fragment ids, so the same id must not resolve to the earlier
         // generation's sequence.
         let cache = LanceCache::with_capacity(4096);
-        let first_generation = RowIdMeta::Inline(write_row_ids(&(0..100).into()));
+        let first_generation = RowIdMeta::Inline(write_row_ids(&(0..100).into()).into());
         let key = RowIdSequenceKey {
             fragment_id: 0,
             row_id_meta: &first_generation,
@@ -337,7 +343,7 @@ mod tests {
             .await;
         assert!(cache.get_with_key(&key).await.is_some());
 
-        let second_generation = RowIdMeta::Inline(write_row_ids(&(100..160).into()));
+        let second_generation = RowIdMeta::Inline(write_row_ids(&(100..160).into()).into());
         assert!(
             cache
                 .get_with_key(&RowIdSequenceKey {
@@ -383,7 +389,7 @@ mod tests {
                 .is_none()
         );
         // An inline sequence never aliases an external one.
-        let inline = RowIdMeta::Inline(write_row_ids(&(0..100).into()));
+        let inline = RowIdMeta::Inline(write_row_ids(&(0..100).into()).into());
         assert!(
             cache
                 .get_with_key(&RowIdSequenceKey {

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -225,11 +225,10 @@ pub struct RowIdSequenceKey<'a> {
     pub fragment_id: u64,
     /// Where the sequence is stored. A fragment id alone is not enough: this
     /// cache is namespaced by dataset URI only (see
-    /// [`GlobalMetadataCache::for_dataset`]) and fragment ids restart at 0 both
-    /// for an overwrite and for a dataset dropped and recreated at the same URI,
-    /// so a reused id would otherwise be served the earlier generation's
-    /// sequence. The `row_id_meta` is used to differentiate generations of
-    /// dataset fragments.
+    /// [`GlobalMetadataCache::for_dataset`]), and a dataset dropped and
+    /// recreated at the same URI restarts fragment ids at 0, so a reused id
+    /// would otherwise be served the earlier generation's sequence (#7645).
+    /// The `row_id_meta` differentiates generations of dataset fragments.
     ///
     /// Any operation that changes which row ids a fragment holds also writes it
     /// new `row_id_meta`, so generations stay distinct; operations that leave
@@ -329,9 +328,8 @@ mod tests {
 
     #[tokio::test]
     async fn row_id_sequence_key_separates_fragment_generations() {
-        // An overwrite, or a dataset dropped and recreated at the same URI,
-        // restarts fragment ids, so the same id must not resolve to the earlier
-        // generation's sequence.
+        // A dataset dropped and recreated at the same URI restarts fragment ids,
+        // so the same id must not resolve to the earlier generation's sequence.
         let cache = LanceCache::with_capacity(4096);
         let first_generation = RowIdMeta::Inline(write_row_ids(&(0..100).into()).into());
         let key = RowIdSequenceKey {

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -19,7 +19,7 @@ use lance_core::{
 };
 use lance_select::RowAddrMask;
 use lance_table::{
-    format::{DeletionFile, DeletionFileType, Manifest},
+    format::{DeletionFile, DeletionFileType, Manifest, RowIdMeta},
     rowids::{RowIdIndex, RowIdSequence},
 };
 use object_store::path::Path;
@@ -221,12 +221,26 @@ impl CacheKey for RowIdIndexKey {
 }
 
 #[derive(Debug)]
-pub struct RowIdSequenceKey {
+pub struct RowIdSequenceKey<'a> {
     pub fragment_id: u64,
+    /// Where the sequence is stored, which identifies which generation of the
+    /// fragment it belongs to. A fragment id alone is not enough: this cache is
+    /// namespaced by dataset URI only (see [`GlobalMetadataCache::for_dataset`])
+    /// and fragment ids restart at 0 both for an overwrite and for a dataset
+    /// dropped and recreated at the same URI, so a reused id would otherwise be
+    /// served the earlier generation's sequence. Rewriting a fragment always
+    /// rewrites its `row_id_meta`, while operations that leave row ids alone
+    /// (deletes, added columns) keep hitting the cache.
+    ///
+    /// Inline metadata is the fragment's run-encoded sequence, so for those the
+    /// key hashes the value's own bytes. That is the point — identity *is* the
+    /// content — and the encoded form is a handful of bytes per run.
+    pub row_id_meta: &'a RowIdMeta,
 }
 
-impl CacheKey for RowIdSequenceKey {
+impl CacheKey for RowIdSequenceKey<'_> {
     type ValueType = RowIdSequence;
+    // Only the legacy display form. Identity comes from `write_key` below.
     fn key(&self) -> Cow<'_, str> {
         Cow::Owned(format!("row_id_sequence/{}", self.fragment_id))
     }
@@ -235,11 +249,23 @@ impl CacheKey for RowIdSequenceKey {
     }
 
     fn schema() -> CacheKeySchema {
-        CacheKeySchema::new("lance.dataset.row-id-sequence-key", 1)
+        CacheKeySchema::new("lance.dataset.row-id-sequence-key", 2)
     }
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_u64(self.fragment_id);
+        match self.row_id_meta {
+            RowIdMeta::Inline(data) => {
+                builder.write_variant(0);
+                builder.write_bytes(data);
+            }
+            RowIdMeta::External(file) => {
+                builder.write_variant(1);
+                builder.write_str(&file.path);
+                builder.write_u64(file.offset);
+                builder.write_u64(file.size);
+            }
+        }
     }
 }
 
@@ -254,6 +280,9 @@ impl DSMetadataCache {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
+    use lance_table::format::ExternalFile;
+    use lance_table::rowids::write_row_ids;
 
     use super::*;
 
@@ -286,6 +315,80 @@ mod tests {
                 .get_with_key(&DeletionFileKey {
                     fragment_id: 2,
                     deletion_file: &deletion_file_on_other_base,
+                })
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn row_id_sequence_key_separates_fragment_generations() {
+        // An overwrite, or a dataset dropped and recreated at the same URI,
+        // restarts fragment ids, so the same id must not resolve to the earlier
+        // generation's sequence.
+        let cache = LanceCache::with_capacity(4096);
+        let first_generation = RowIdMeta::Inline(write_row_ids(&(0..100).into()));
+        let key = RowIdSequenceKey {
+            fragment_id: 0,
+            row_id_meta: &first_generation,
+        };
+        cache
+            .insert_with_key(&key, Arc::new(RowIdSequence::from(0..100)))
+            .await;
+        assert!(cache.get_with_key(&key).await.is_some());
+
+        let second_generation = RowIdMeta::Inline(write_row_ids(&(100..160).into()));
+        assert!(
+            cache
+                .get_with_key(&RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &second_generation,
+                })
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn row_id_sequence_key_separates_external_slices() {
+        // External metadata is a read-only legacy shape, but the same slice of
+        // the same file is the only thing that may share a cache entry.
+        let cache = LanceCache::with_capacity(4096);
+        let external = |offset| {
+            RowIdMeta::External(ExternalFile {
+                path: "_row_ids/1.rowids".into(),
+                offset,
+                size: 16,
+            })
+        };
+        let first_slice = external(0);
+        cache
+            .insert_with_key(
+                &RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &first_slice,
+                },
+                Arc::new(RowIdSequence::from(0..100)),
+            )
+            .await;
+
+        let second_slice = external(16);
+        assert!(
+            cache
+                .get_with_key(&RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &second_slice,
+                })
+                .await
+                .is_none()
+        );
+        // An inline sequence never aliases an external one.
+        let inline = RowIdMeta::Inline(write_row_ids(&(0..100).into()));
+        assert!(
+            cache
+                .get_with_key(&RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &inline,
                 })
                 .await
                 .is_none()


### PR DESCRIPTION
`RowIdSequenceKey` was keyed on `fragment_id` alone, while the metadata cache is namespaced by dataset URI only. Fragment ids restart at 0 after `WriteMode::Overwrite`, so with a `Session` shared between the writer and the reader, every read after an overwrite was served the previous generation's `RowIdSequence` for the reused id.

That silently corrupts stable row ids: row ids are reported for rows that no longer exist, row counts disagree with the manifest, compaction rechunks more ids than the fragments physically hold, and the same id can look live in two fragments at once.

The key now also carries the fragment's `row_id_meta`, which identifies where the sequence bytes live. Identical metadata implies identical sequence bytes, so a hit is always a valid hit, while a rewritten fragment misses. Operations that leave row ids alone (deletes, added columns) keep hitting the cache. This matches the sibling `DeletionFileKey`, which already keys on the deletion file's identity rather than the fragment id alone.

## Why not make fragment ids unique instead

Discussion #5540 asks for `fragment_id` and `row_id` to be globally unique across a table's history, and #5508 was closed in favour of that over a version-scoped cache key. Seeding the id counter from `max_fragment_id` on overwrite (the restore half shipped as #5554) is *not* a drop-in: `Fragment::id == 0` doubles as the "unassigned" sentinel in `Transaction::fragments_with_ids`, and today's overwrite masks that by starting the counter at 0, so a real fragment 0 is "reassigned" 0. With a high-water-mark counter, a pre-existing fragment passed through `Operation::Overwrite` — a supported public pattern, e.g. `LanceOperation.Overwrite(schema, fragments)` with fragments from `get_fragments()` — is renumbered, orphaning its deletion vector at `_deletions/{old_id}-…`. `test_append_new_columns` catches exactly this.

So #5540 needs the sentinel made explicit first, and is left to a follow-up. Content-keying is correct independently of it, and also covers ids reused by paths that never consult a previous manifest: drop a dataset and create a new one at the same URI (#7645), or datasets written before any id-allocation change that already hold duplicate ids in their history.

This does not fully close #7645. A dataset recreated at the same URI restarts at version 1, and the version-scoped keys that do not carry the manifest e-tag — `TransactionKey`, `RowIdIndexKey`, `RowAddrMaskKey`, and `IndexMetadataKey` in the index cache — still collide with the previous generation. `ManifestKey` already carries the e-tag; extending that to the rest is a follow-up.

Fixes #8075
