### PR TITLE
ci: shard Rust coverage tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,7 +102,7 @@ jobs:
           log-level: warn
           command: check
 
-  linux-build:
+  linux-coverage-build:
     runs-on: "ubuntu-24.04-8x"
     timeout-minutes: 75
     env:
@@ -116,22 +116,197 @@ jobs:
       - name: Setup rust toolchain
         run: |
           # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
-          rustup toolchain install nightly-2026-07-13
+          rustup toolchain install nightly-2026-07-13 --component llvm-tools-preview
           rustup default nightly-2026-07-13
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          key: llvm-cov-ci
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler libssl-dev
-      - name: Start DynamodDB and S3
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # nextest
+        with:
+          tool: nextest
+      - name: Build coverage tests
+        run: |
+          ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
+          cargo +nightly-2026-07-13 llvm-cov nextest-archive \
+            --cargo-profile ci \
+            --locked \
+            --workspace \
+            --features ${ALL_FEATURES} \
+            --archive-file rust-coverage-tests.tar.zst
+      - name: Upload coverage tests
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-coverage-tests
+          path: rust-coverage-tests.tar.zst
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+  # Temporary same-SHA control for measuring the sharded coverage workflow.
+  # Remove after the cold and warm A/B runs complete.
+  linux-coverage-baseline:
+    runs-on: "ubuntu-24.04-8x"
+    timeout-minutes: 75
+    env:
+      RUSTFLAGS: "-C target-cpu=native -C debuginfo=1"
+      RUST_BACKTRACE: "1"
+      RUST_MIN_STACK: "16777216"
+      CARGO_BUILD_JOBS: "8"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup rust toolchain
+        run: |
+          # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
+          rustup toolchain install nightly-2026-07-13
+          rustup default nightly-2026-07-13
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          key: llvm-cov-ci
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler libssl-dev
+      - name: Start DynamoDB and S3
         run: docker compose -f docker-compose.yml up -d --wait
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
           cargo +nightly-2026-07-13 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-coverage-baseline-codecov
+          path: coverage.codecov
+          retention-days: 1
+          if-no-files-found: error
+
+  linux-coverage-test:
+    needs: linux-coverage-build
+    runs-on: "ubuntu-24.04-8x"
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup rust toolchain
+        run: |
+          # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
+          rustup toolchain install nightly-2026-07-13 --component llvm-tools-preview
+          rustup default nightly-2026-07-13
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libssl-dev
+      - name: Start DynamoDB and S3
+        run: docker compose -f docker-compose.yml up -d --wait
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # nextest
+        with:
+          tool: nextest
+      - name: Download coverage tests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rust-coverage-tests
+          path: coverage-artifacts
+      - name: Run coverage tests
+        run: |
+          cargo +nightly-2026-07-13 llvm-cov nextest \
+            --no-report \
+            --archive-file coverage-artifacts/rust-coverage-tests.tar.zst \
+            --partition slice:${{ matrix.shard }}/3
+      - name: Merge shard coverage
+        run: |
+          TOOLCHAIN_ROOT=`rustc +nightly-2026-07-13 --print sysroot`
+          HOST_TRIPLE=`rustc +nightly-2026-07-13 -vV | awk '/^host:/ {print $2}'`
+          LLVM_PROFDATA="${TOOLCHAIN_ROOT}/lib/rustlib/${HOST_TRIPLE}/bin/llvm-profdata"
+          find target/llvm-cov-target -maxdepth 1 -name '*.profraw' -print > coverage-artifacts/profraw-files
+          "${LLVM_PROFDATA}" merge \
+            -sparse \
+            -f coverage-artifacts/profraw-files \
+            -o coverage-artifacts/coverage-shard-${{ matrix.shard }}.profdata
+      - name: Upload shard coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-coverage-profile-${{ matrix.shard }}
+          path: coverage-artifacts/coverage-shard-${{ matrix.shard }}.profdata
+          retention-days: 1
+          if-no-files-found: error
+
+  linux-build:
+    needs: [linux-coverage-build, linux-coverage-test]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup rust toolchain
+        run: |
+          # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
+          rustup toolchain install nightly-2026-07-13 --component llvm-tools-preview
+          rustup default nightly-2026-07-13
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # nextest
+        with:
+          tool: nextest
+      - name: Download coverage tests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rust-coverage-tests
+          path: coverage-artifacts
+      - name: Download shard coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: rust-coverage-profile-*
+          path: coverage-artifacts/profiles
+          merge-multiple: true
+      - name: Merge coverage
+        run: |
+          mkdir -p target/llvm-cov-target
+          cargo +nightly-2026-07-13 nextest list \
+            --archive-file coverage-artifacts/rust-coverage-tests.tar.zst \
+            --extract-to target/llvm-cov-target > /dev/null
+          TOOLCHAIN_ROOT=`rustc +nightly-2026-07-13 --print sysroot`
+          HOST_TRIPLE=`rustc +nightly-2026-07-13 -vV | awk '/^host:/ {print $2}'`
+          LLVM_PROFDATA="${TOOLCHAIN_ROOT}/lib/rustlib/${HOST_TRIPLE}/bin/llvm-profdata"
+          "${LLVM_PROFDATA}" merge \
+            -sparse \
+            coverage-artifacts/profiles/*.profdata \
+            -o target/llvm-cov-target/lance.profdata
+          cargo +nightly-2026-07-13 llvm-cov report \
+            --nextest-archive-file coverage-artifacts/rust-coverage-tests.tar.zst \
+            --codecov \
+            --output-path coverage.codecov
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-coverage-codecov
+          path: coverage.codecov
+          retention-days: 1
+          if-no-files-found: error
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
@@ -140,6 +315,7 @@ jobs:
           files: coverage.codecov
           flags: unittests
           fail_ci_if_error: false
+
   linux-arm:
     runs-on: ubuntu-24.04-arm64-8x
     timeout-minutes: 75

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,57 +152,6 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Temporary same-archive control for verifying that profile sharding preserves
-  # the Codecov report. Remove after the coverage artifacts are compared.
-  linux-coverage-unsharded:
-    needs: linux-coverage-build
-    runs-on: "ubuntu-24.04-8x"
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup rust toolchain
-        run: |
-          # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
-          rustup toolchain install nightly-2026-07-13 --component llvm-tools-preview
-          rustup default nightly-2026-07-13
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y libssl-dev
-      - name: Start DynamoDB and S3
-        run: docker compose -f docker-compose.yml up -d --wait
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
-        with:
-          tool: cargo-llvm-cov
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # nextest
-        with:
-          tool: nextest
-      - name: Download coverage tests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: rust-coverage-tests
-          path: coverage-artifacts
-      - name: Run coverage tests
-        run: |
-          cargo +nightly-2026-07-13 llvm-cov nextest \
-            --no-report \
-            --archive-file coverage-artifacts/rust-coverage-tests.tar.zst
-      - name: Generate coverage report
-        run: |
-          cargo +nightly-2026-07-13 llvm-cov report \
-            --nextest-archive-file coverage-artifacts/rust-coverage-tests.tar.zst \
-            --codecov \
-            --output-path coverage.codecov
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: rust-coverage-unsharded-codecov
-          path: coverage.codecov
-          retention-days: 1
-          if-no-files-found: error
-
   linux-coverage-test:
     needs: linux-coverage-build
     runs-on: "ubuntu-24.04-8x"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,45 +152,53 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Temporary same-SHA control for measuring the sharded coverage workflow.
-  # Remove after the cold and warm A/B runs complete.
-  linux-coverage-baseline:
+  # Temporary same-archive control for verifying that profile sharding preserves
+  # the Codecov report. Remove after the coverage artifacts are compared.
+  linux-coverage-unsharded:
+    needs: linux-coverage-build
     runs-on: "ubuntu-24.04-8x"
-    timeout-minutes: 75
-    env:
-      RUSTFLAGS: "-C target-cpu=native -C debuginfo=1"
-      RUST_BACKTRACE: "1"
-      RUST_MIN_STACK: "16777216"
-      CARGO_BUILD_JOBS: "8"
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup rust toolchain
         run: |
           # Temporary mitigation for https://github.com/rust-lang/rust/issues/159261.
-          rustup toolchain install nightly-2026-07-13
+          rustup toolchain install nightly-2026-07-13 --component llvm-tools-preview
           rustup default nightly-2026-07-13
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-        with:
-          key: llvm-cov-ci
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y protobuf-compiler libssl-dev
+          sudo apt install -y libssl-dev
       - name: Start DynamoDB and S3
         run: docker compose -f docker-compose.yml up -d --wait
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # cargo-llvm-cov
         with:
           tool: cargo-llvm-cov
-      - name: Run tests
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # nextest
+        with:
+          tool: nextest
+      - name: Download coverage tests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rust-coverage-tests
+          path: coverage-artifacts
+      - name: Run coverage tests
         run: |
-          ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
-          cargo +nightly-2026-07-13 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo +nightly-2026-07-13 llvm-cov nextest \
+            --no-report \
+            --archive-file coverage-artifacts/rust-coverage-tests.tar.zst
+      - name: Generate coverage report
+        run: |
+          cargo +nightly-2026-07-13 llvm-cov report \
+            --nextest-archive-file coverage-artifacts/rust-coverage-tests.tar.zst \
+            --codecov \
+            --output-path coverage.codecov
       - name: Upload coverage artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: rust-coverage-baseline-codecov
+          name: rust-coverage-unsharded-codecov
           path: coverage.codecov
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
Rust PR CI's warm-cache Linux coverage job has a 34:04 critical path. In the reference run, the `Run tests` step took 32:42: compilation accounted for about 3:51, while serial test-binary execution consumed roughly 29 minutes, led by `lance` at about 18 minutes and `lance-encoding` at about 7 minutes.

This change builds the canonical `ci`-profile coverage binaries once, fans the archived tests out across three Linux runners, merges each shard's coverage profile before transfer, and produces the existing single Codecov report in the final `linux-build` check. It preserves the coverage optimization level and required check name while moving serial test execution off the critical path.

## Benchmark

- Successful warm reference: 34:04.
- Sharded cold run: 24:46, at least 31.6% faster than the same-SHA control's 36:14 lower bound.
- Final-head warm run: 20:49, 38.9% faster than the successful warm reference. The stages were 5:02 to build and upload once, 13:10 for the slowest shard, and 2:27 to merge, report, and upload.
- Three warm sharded runs completed in 20:49, 22:03, and 22:39. The median is 22:03, a 35.3% reduction.

The same-SHA serial controls reached the final `lance-linalg` test binary at 36:14 and 37:31, then hit the same two existing randomized f16 property-test failures. The successful historical warm run is therefore the primary speed baseline; the same-SHA controls provide conservative lower bounds rather than successful end-to-end samples.

Coverage was compared from the same instrumented archive with three shards versus one unsharded nextest job. Both reports contain exactly 531 files, 334,985 line mappings, and 655,891 segment denominators, with zero missing or changed denominators. The sharded report covered 11 more segments (89.2064% versus 89.2048%, +0.0017 percentage points), smaller than the observed 44-segment variation between two sharded runs.

Aggregate final-head work was 30:54 on 8x runners plus 2:27 on a standard runner, versus 34:04 on one 8x runner for the reference. The speedup comes from parallelism without increasing aggregate large-runner time. The main tradeoff is a 1.49 GB test archive and roughly 1–2 minutes of artifact transfer per stage; artifacts are retained for one day.

Evidence: [successful warm reference](https://github.com/lance-format/lance/actions/runs/30464415673/attempts/2), [cold and warm sharded runs](https://github.com/lance-format/lance/actions/runs/30475524847), [same-archive coverage validation](https://github.com/lance-format/lance/actions/runs/30481552021), and [successful final-head workflow](https://github.com/lance-format/lance/actions/runs/30483893465).
