### PR TITLE
fix(core): key row id sequence cache on fragment contents

### DIFF
--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -446,7 +446,7 @@ impl TryFrom<pb::DeletionFile> for DeletionFile {
 }
 
 /// A reference to a part of a file.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, DeepSizeOf)]
 pub struct ExternalFile {
     pub path: String,
     pub offset: u64,
@@ -454,7 +454,7 @@ pub struct ExternalFile {
 }
 
 /// Metadata about location of the row id sequence.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, DeepSizeOf)]
 pub enum RowIdMeta {
     Inline(Vec<u8>),
     External(ExternalFile),

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -18,25 +18,24 @@ pub async fn load_row_id_sequence(
     dataset: &Dataset,
     fragment: &Fragment,
 ) -> Result<Arc<RowIdSequence>> {
-    // Virtual path to prevent collisions in the cache.
-    match &fragment.row_id_meta {
-        None => Err(Error::internal("Missing row id meta")),
-        Some(RowIdMeta::Inline(data)) => {
+    let Some(row_id_meta) = &fragment.row_id_meta else {
+        return Err(Error::internal("Missing row id meta"));
+    };
+    let key = RowIdSequenceKey {
+        fragment_id: fragment.id,
+        row_id_meta,
+    };
+    match row_id_meta {
+        RowIdMeta::Inline(data) => {
             let data = data.clone();
-            let key = RowIdSequenceKey {
-                fragment_id: fragment.id,
-            };
             dataset
                 .metadata_cache
                 .get_or_insert_with_key(key, || async move { read_row_ids(&data) })
                 .await
         }
-        Some(RowIdMeta::External(file_slice)) => {
+        RowIdMeta::External(file_slice) => {
             let file_slice = file_slice.clone();
             let dataset_clone = dataset.clone();
-            let key = RowIdSequenceKey {
-                fragment_id: fragment.id,
-            };
             dataset
                 .metadata_cache
                 .get_or_insert_with_key(key, || async move {
@@ -424,6 +423,69 @@ mod test {
         let index = get_row_id_index(&dataset).await.unwrap().unwrap();
         assert!(index.get(0).is_none());
         assert!(index.get(num_rows).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_row_ids_overwrite_with_shared_session() {
+        // Regression test for https://github.com/lance-format/lance/issues/8075:
+        // overwrite restarts fragment ids at 0, so a cache entry keyed only on the
+        // fragment id serves the previous generation's sequence to every reader.
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        // The shared session is what carries the cache entry across the overwrite.
+        let write_params = WriteParams {
+            enable_stable_row_ids: true,
+            session: Some(Arc::new(crate::session::Session::default())),
+            ..Default::default()
+        };
+
+        let write = |values: Range<i32>, mode: WriteMode| {
+            let batch = sequence_batch(values);
+            let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+            let params = WriteParams {
+                mode,
+                ..write_params.clone()
+            };
+            async move {
+                Dataset::write(reader, tmp_path, Some(params))
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Generation 1: fragment 0 holds ids 0..100. `count_rows` with a filter goes
+        // through the per-fragment sequences, warming `row_id_sequence/0`.
+        let dataset = write(0..100, WriteMode::Create).await;
+        assert_eq!(
+            dataset.count_rows(Some("id >= 0".into())).await.unwrap(),
+            100
+        );
+
+        // Generation 2: a brand new fragment 0 holding 60 rows with ids 100..160.
+        let dataset = write(0..60, WriteMode::Overwrite).await;
+        let sequence = load_row_id_sequence(&dataset, &dataset.manifest.fragments[0])
+            .await
+            .unwrap();
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            (100..160).collect::<Vec<u64>>()
+        );
+
+        // Compaction rechunks the sequences of the fragments it merges, so a stale
+        // sequence there corrupts the ids of every surviving row.
+        let mut dataset = write(0..100, WriteMode::Append).await;
+        compact(&mut dataset, 1024).await;
+
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 160);
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        let result = scan.try_into_batch().await.unwrap();
+        let mut ids = result[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .to_vec();
+        ids.sort_unstable();
+        assert_eq!(ids, (100..260).collect::<Vec<u64>>());
     }
 
     #[tokio::test]

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -10,6 +10,8 @@
 //!     │    │
 //!     └────┴──► FileMetadataCache (prefixed by file path)
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::{borrow::Cow, ops::Deref};
 
 use lance_core::deepsize::{Context, DeepSizeOf};
@@ -19,7 +21,7 @@ use lance_core::{
 };
 use lance_select::RowAddrMask;
 use lance_table::{
-    format::{DeletionFile, DeletionFileType, Manifest},
+    format::{DeletionFile, DeletionFileType, Manifest, RowIdMeta},
     rowids::{RowIdIndex, RowIdSequence},
 };
 use object_store::path::Path;
@@ -221,25 +223,48 @@ impl CacheKey for RowIdIndexKey {
 }
 
 #[derive(Debug)]
-pub struct RowIdSequenceKey {
+pub struct RowIdSequenceKey<'a> {
     pub fragment_id: u64,
+    /// Identifies which generation of the fragment the sequence belongs to.
+    /// `WriteMode::Overwrite` restarts fragment ids at 0, so a key carrying only
+    /// the fragment id would serve a previous generation's sequence for a reused
+    /// id.
+    pub row_id_meta: &'a RowIdMeta,
 }
 
-impl CacheKey for RowIdSequenceKey {
+impl CacheKey for RowIdSequenceKey<'_> {
     type ValueType = RowIdSequence;
     fn key(&self) -> Cow<'_, str> {
-        Cow::Owned(format!("row_id_sequence/{}", self.fragment_id))
+        let mut hasher = DefaultHasher::new();
+        self.row_id_meta.hash(&mut hasher);
+        Cow::Owned(format!(
+            "row_id_sequence/{}/{:x}",
+            self.fragment_id,
+            hasher.finish()
+        ))
     }
     fn type_name() -> &'static str {
         "RowIdSequence"
     }
 
     fn schema() -> CacheKeySchema {
-        CacheKeySchema::new("lance.dataset.row-id-sequence-key", 1)
+        CacheKeySchema::new("lance.dataset.row-id-sequence-key", 2)
     }
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_u64(self.fragment_id);
+        match self.row_id_meta {
+            RowIdMeta::Inline(data) => {
+                builder.write_variant(0);
+                builder.write_bytes(data);
+            }
+            RowIdMeta::External(file) => {
+                builder.write_variant(1);
+                builder.write_str(&file.path);
+                builder.write_u64(file.offset);
+                builder.write_u64(file.size);
+            }
+        }
     }
 }
 
@@ -254,6 +279,8 @@ impl DSMetadataCache {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
+    use lance_table::rowids::write_row_ids;
 
     use super::*;
 
@@ -289,6 +316,43 @@ mod tests {
                 })
                 .await
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn row_id_sequence_key_separates_fragment_generations() {
+        // Overwrite restarts fragment ids at 0, so the same id must not resolve
+        // to a previous generation's sequence.
+        let cache = LanceCache::with_capacity(4096);
+        let first_generation = RowIdMeta::Inline(write_row_ids(&(0..100).into()));
+        cache
+            .insert_with_key(
+                &RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &first_generation,
+                },
+                Arc::new(RowIdSequence::from(0..100)),
+            )
+            .await;
+
+        let second_generation = RowIdMeta::Inline(write_row_ids(&(100..160).into()));
+        assert!(
+            cache
+                .get_with_key(&RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &second_generation,
+                })
+                .await
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_with_key(&RowIdSequenceKey {
+                    fragment_id: 0,
+                    row_id_meta: &first_generation,
+                })
+                .await
+                .is_some()
         );
     }
 }


### PR DESCRIPTION
Each fragment's stable row id sequence is cached in the `Session` metadata cache. That cache entry was keyed only on the fragment id, and nothing else in the key distinguished one generation of a fragment from another. `WriteMode::Overwrite` restarts fragment ids at 0, so after an overwrite every reader that loaded a row id sequence for the reused fragment id was handed the *previous* generation's sequence.

The result was silent stable-row-id corruption — row ids belonging to rows that no longer exist, row counts that disagree with the manifest, and row ids that look live in two fragments at once. It surfaced in several unrelated-looking ways depending on which reader hit the stale entry first: a `debug_assert` mismatch during compaction, `row id index corrupt: stable row id N is live in multiple fragments`, `all columns in a record batch must have the same length`, and `count_rows(filter)` disagreeing with an equivalent scan.

This PR adds the fragment's row id metadata (the inline sequence bytes, or the external file path/offset/size) to the cache key, so a new generation of a reused fragment id is a cache miss rather than a stale hit. Keying on the manifest version would also fix it, but would discard the cache on every commit.

Only datasets using stable row ids and a shared `Session` were affected; with no session, the cache never carried an entry across the overwrite.

Fixes #8075
