### PR TITLE
fix(blob): compact struct-nested blob v2 columns

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1848,11 +1848,7 @@ impl Dataset {
     pub fn read_blobs(self: &Arc<Self>, column: impl AsRef<str>) -> Result<ReadBlobsBuilder> {
         let column = column.as_ref();
         let blob_field_id = blob::validate_blob_column(self, column)?;
-        Ok(ReadBlobsBuilder::new(
-            self.clone(),
-            column.to_string(),
-            blob_field_id,
-        ))
+        Ok(ReadBlobsBuilder::new(self.clone(), blob_field_id))
     }
 
     /// Create a planned reader for row-specific blob-local byte ranges.

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -39,7 +39,9 @@ use crate::blob::{
     is_logical_blob_v2_field, is_prepared_blob_v2_field, validate_prepared_blob_array,
 };
 use arrow_array::StructArray;
-use lance_core::datatypes::{BlobKind, BlobVersion, Field as LanceField, Schema, parse_field_path};
+use lance_core::datatypes::{
+    BlobKind, BlobVersion, Field as LanceField, Schema, format_field_path_minimal,
+};
 use lance_core::utils::blob::blob_path;
 use lance_core::{Error, ROW_ADDR, Result, utils::address::RowAddress};
 use lance_io::traits::Reader;
@@ -1720,17 +1722,15 @@ impl Default for ReadBlobsOptions {
 #[derive(Debug, Clone)]
 pub struct ReadBlobsBuilder {
     dataset: Arc<Dataset>,
-    column: String,
     blob_field_id: u32,
     selection: ReadBlobsSelection,
     options: ReadBlobsOptions,
 }
 
 impl ReadBlobsBuilder {
-    pub(crate) fn new(dataset: Arc<Dataset>, column: String, blob_field_id: u32) -> Self {
+    pub(crate) fn new(dataset: Arc<Dataset>, blob_field_id: u32) -> Self {
         Self {
             dataset,
-            column,
             blob_field_id,
             selection: ReadBlobsSelection::None,
             options: ReadBlobsOptions::default(),
@@ -1776,7 +1776,6 @@ impl ReadBlobsBuilder {
         let collected = collect_blob_selection_for_selection(
             &self.dataset,
             self.blob_field_id,
-            &self.column,
             &self.selection,
         )
         .await?;
@@ -1907,7 +1906,6 @@ impl ReadBlobRangesBuilder {
         let mut selections = collect_blob_selection_for_selection(
             &self.inner.dataset,
             self.inner.blob_field_id,
-            &self.inner.column,
             &row_selection,
         )
         .await?;
@@ -2690,7 +2688,6 @@ pub(super) async fn take_blobs(
     let collected = collect_blob_selection_for_selection(
         dataset,
         blob_field_id,
-        column,
         &ReadBlobsSelection::RowIds(row_ids.to_vec()),
     )
     .await?;
@@ -2713,10 +2710,21 @@ pub async fn take_blobs_by_addresses(
     column: &str,
 ) -> Result<Vec<Option<BlobFile>>> {
     let blob_field_id = validate_blob_column(dataset, column)?;
+    take_blobs_by_field_id(dataset, row_addrs, blob_field_id).await
+}
+
+/// Take [BlobFile] by row addresses, for a blob column identified by its field id.
+///
+/// Callers that already hold the field id should use this rather than a column
+/// name: the id is stable across renames and needs no field-path escaping.
+pub(super) async fn take_blobs_by_field_id(
+    dataset: &Arc<Dataset>,
+    row_addrs: &[u64],
+    blob_field_id: u32,
+) -> Result<Vec<Option<BlobFile>>> {
     let collected = collect_blob_selection_for_selection(
         dataset,
         blob_field_id,
-        column,
         &ReadBlobsSelection::RowAddresses(row_addrs.to_vec()),
     )
     .await?;
@@ -2740,13 +2748,43 @@ pub(super) fn validate_blob_column(dataset: &Arc<Dataset>, column: &str) -> Resu
     Ok(blob_field.id as u32)
 }
 
+/// The names from the schema root down to the blob column, unescaped.
+///
+/// Blob columns are addressed by field id, but reading a descriptor batch still
+/// means walking into it by name, and errors are clearer with the whole path.
+fn blob_column_path(dataset: &Arc<Dataset>, blob_field_id: u32) -> Result<Vec<String>> {
+    let schema = dataset.schema();
+    schema
+        .field_ancestry_by_id(blob_field_id as i32)
+        .map(|ancestry| ancestry.iter().map(|field| field.name.clone()).collect())
+        .ok_or_else(|| {
+            Error::internal(format!(
+                "Blob field id {} is not present in the dataset schema",
+                blob_field_id
+            ))
+        })
+}
+
+/// Render a [`blob_column_path`] for display, quoting segments where needed.
+fn display_blob_column_path(column_path: &[String]) -> String {
+    let segments = column_path.iter().map(String::as_str).collect::<Vec<_>>();
+    format_field_path_minimal(&segments)
+}
+
+/// Project just the blob column, keeping its descriptor children.
+fn blob_column_projection(dataset: &Arc<Dataset>, blob_field_id: u32) -> Schema {
+    dataset
+        .schema()
+        .project_by_ids(&[blob_field_id as i32], true)
+}
+
 /// Load blob descriptor rows for a stable-row-id selection.
 async fn take_blob_descriptions_by_row_ids(
     dataset: &Arc<Dataset>,
     row_ids: &[u64],
-    column: &str,
+    blob_field_id: u32,
 ) -> Result<RecordBatch> {
-    let projection = dataset.schema().project(&[column])?;
+    let projection = blob_column_projection(dataset, blob_field_id);
     dataset
         .take_builder(row_ids, projection)?
         .with_missing_row_policy(MissingRowPolicy::Error)
@@ -2759,9 +2797,9 @@ async fn take_blob_descriptions_by_row_ids(
 async fn take_blob_descriptions_by_row_addresses(
     dataset: &Arc<Dataset>,
     row_addrs: &[u64],
-    column: &str,
+    blob_field_id: u32,
 ) -> Result<RecordBatch> {
-    let projection = dataset.schema().project(&[column])?;
+    let projection = blob_column_projection(dataset, blob_field_id);
     let projection_request = ProjectionRequest::from(projection);
     let projection_plan = Arc::new(projection_request.into_projection_plan(dataset.clone())?);
     TakeBuilder::try_new_from_addresses(dataset.clone(), row_addrs.to_vec(), projection_plan)?
@@ -2774,9 +2812,9 @@ async fn take_blob_descriptions_by_row_addresses(
 async fn collect_blob_selection_for_selection(
     dataset: &Arc<Dataset>,
     blob_field_id: u32,
-    column: &str,
     selection: &ReadBlobsSelection,
 ) -> Result<Vec<ResolvedBlobSelection>> {
+    let column_path = blob_column_path(dataset, blob_field_id)?;
     let description_and_addr = match selection {
         ReadBlobsSelection::None => {
             return Err(Error::invalid_input(
@@ -2784,16 +2822,16 @@ async fn collect_blob_selection_for_selection(
             ));
         }
         ReadBlobsSelection::RowIds(row_ids) => {
-            take_blob_descriptions_by_row_ids(dataset, row_ids, column).await?
+            take_blob_descriptions_by_row_ids(dataset, row_ids, blob_field_id).await?
         }
         ReadBlobsSelection::RowIndices(row_indices) => {
             let row_addrs =
                 super::take::row_offsets_to_row_addresses(&dataset.get_fragments(), row_indices)
                     .await?;
-            take_blob_descriptions_by_row_addresses(dataset, &row_addrs, column).await?
+            take_blob_descriptions_by_row_addresses(dataset, &row_addrs, blob_field_id).await?
         }
         ReadBlobsSelection::RowAddresses(row_addrs) => {
-            take_blob_descriptions_by_row_addresses(dataset, row_addrs, column).await?
+            take_blob_descriptions_by_row_addresses(dataset, row_addrs, blob_field_id).await?
         }
     };
 
@@ -2801,7 +2839,7 @@ async fn collect_blob_selection_for_selection(
         return Ok(Vec::new());
     }
 
-    let descriptions = leaf_descriptor_struct(&description_and_addr, column)?;
+    let descriptions = leaf_descriptor_struct(&description_and_addr, &column_path)?;
     let row_addrs = description_and_addr.column(1).as_primitive::<UInt64Type>();
 
     let files = match blob_version_from_descriptions(descriptions)? {
@@ -2830,11 +2868,13 @@ async fn collect_blob_selection_for_selection(
         .collect())
 }
 
-/// Walk into the descriptor `RecordBatch` at `column` and return the leaf
-/// descriptor `StructArray`, descending through nested struct children for
-/// dotted paths.
-fn leaf_descriptor_struct<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a StructArray> {
-    let current = leaf_descriptor_array(batch, column)?;
+/// Walk into the descriptor `RecordBatch` at `column_path` and return the leaf
+/// descriptor `StructArray`, descending through nested struct children.
+fn leaf_descriptor_struct<'a>(
+    batch: &'a RecordBatch,
+    column_path: &[String],
+) -> Result<&'a StructArray> {
+    let current = leaf_descriptor_array(batch, column_path)?;
     current
         .as_any()
         .downcast_ref::<StructArray>()
@@ -2842,7 +2882,7 @@ fn leaf_descriptor_struct<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'
             Error::invalid_input_source(
                 format!(
                     "Blob column '{}' expected descriptor struct but got {}",
-                    column,
+                    display_blob_column_path(column_path),
                     current.data_type()
                 )
                 .into(),
@@ -2850,18 +2890,25 @@ fn leaf_descriptor_struct<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'
         })
 }
 
-fn leaf_descriptor_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a dyn Array> {
-    let path = parse_field_path(column)?;
+fn leaf_descriptor_array<'a>(
+    batch: &'a RecordBatch,
+    column_path: &[String],
+) -> Result<&'a dyn Array> {
+    let Some((root, rest)) = column_path.split_first() else {
+        return Err(Error::internal(
+            "Blob column path was empty in descriptor batch".to_string(),
+        ));
+    };
     let mut current: &dyn Array = batch
-        .column_by_name(&path[0])
+        .column_by_name(root)
         .ok_or_else(|| {
             Error::invalid_input(format!(
                 "Blob column '{}' was not found in descriptor batch",
-                column
+                display_blob_column_path(column_path)
             ))
         })?
         .as_ref();
-    for segment in &path[1..] {
+    for segment in rest {
         let struct_array = current
             .as_any()
             .downcast_ref::<StructArray>()
@@ -2869,7 +2916,7 @@ fn leaf_descriptor_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a
                 Error::invalid_input_source(
                     format!(
                         "Blob column path '{}' expected struct before segment '{}' but got {}",
-                        column,
+                        display_blob_column_path(column_path),
                         segment,
                         current.data_type()
                     )
@@ -2881,7 +2928,8 @@ fn leaf_descriptor_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a
             .ok_or_else(|| {
                 Error::invalid_input(format!(
                     "Blob column path '{}' missing segment '{}'",
-                    column, segment
+                    display_blob_column_path(column_path),
+                    segment
                 ))
             })?
             .as_ref();

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -103,13 +103,15 @@ use crate::io::commit::{commit_transaction, migrate_fragments};
 use arrow::array::AsArray;
 use arrow::datatypes::{UInt8Type, UInt32Type, UInt64Type};
 use arrow_array::Array;
+use arrow_array::ArrayRef;
 use arrow_array::RecordBatch;
 use arrow_array::StructArray;
 use arrow_array::builder::{LargeBinaryBuilder, PrimitiveBuilder, StringBuilder};
 use arrow_buffer::NullBuffer;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use futures::{StreamExt, TryStreamExt};
+use futures::future::BoxFuture;
+use futures::{FutureExt, StreamExt, TryStreamExt};
 use lance_core::Error;
 use lance_core::datatypes::{BlobHandling, BlobKind};
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
@@ -1176,6 +1178,167 @@ async fn build_user_view_struct(
     )?)
 }
 
+/// Returns true when `field` itself or any of its descendants is a blob v2 field.
+fn contains_blob_v2(field: &lance_core::datatypes::Field) -> bool {
+    field.is_blob_v2() || field.children.iter().any(contains_blob_v2)
+}
+
+/// The Arrow field that [`transform_blob_v2_column`] produces for `arrow_field`.
+///
+/// Blob v2 descriptor structs become the writer's user view; enclosing structs are
+/// rebuilt around their transformed children.
+fn transformed_blob_v2_field(
+    lance_field: &lance_core::datatypes::Field,
+    arrow_field: &Arc<arrow_schema::Field>,
+) -> Arc<arrow_schema::Field> {
+    if lance_field.is_blob_v2() {
+        let logical_field = arrow_schema::Field::from(lance_field);
+        return Arc::new(
+            arrow_schema::Field::new(
+                arrow_field.name(),
+                lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
+                arrow_field.is_nullable(),
+            )
+            .with_metadata(logical_field.metadata().clone()),
+        );
+    }
+
+    let arrow_schema::DataType::Struct(children) = arrow_field.data_type() else {
+        return arrow_field.clone();
+    };
+
+    let new_children = children
+        .iter()
+        .map(|child| match lance_field.child(child.name()) {
+            Some(child_lance_field) if contains_blob_v2(child_lance_field) => {
+                transformed_blob_v2_field(child_lance_field, child)
+            }
+            _ => child.clone(),
+        })
+        .collect::<Vec<_>>();
+    Arc::new(
+        arrow_schema::Field::new(
+            arrow_field.name(),
+            arrow_schema::DataType::Struct(new_children.into()),
+            arrow_field.is_nullable(),
+        )
+        .with_metadata(arrow_field.metadata().clone()),
+    )
+}
+
+/// Rewrite a blob v2 descriptor column, or a struct containing one, into the
+/// writer's user view. `column_path` is the dotted path to `array` in the dataset
+/// schema, which is how blob payloads are addressed when they are read back.
+fn transform_blob_v2_column<'a>(
+    dataset: &'a Arc<Dataset>,
+    lance_field: &'a lance_core::datatypes::Field,
+    arrow_field: &'a Arc<arrow_schema::Field>,
+    array: ArrayRef,
+    row_addrs: &'a arrow::array::UInt64Array,
+    column_path: String,
+) -> BoxFuture<'a, Result<(ArrayRef, Arc<arrow_schema::Field>)>> {
+    async move {
+        // Blob payloads are addressed by row address, so a blob v2 leaf can only be
+        // reached through struct children, where there is still one value per row.
+        let Some(struct_arr) = array.as_any().downcast_ref::<StructArray>() else {
+            return Err(Error::not_supported(format!(
+                "Compacting a blob v2 column nested under '{}' of type {}; \
+                 only struct nesting is supported",
+                column_path,
+                array.data_type()
+            )));
+        };
+
+        if !lance_field.is_blob_v2() {
+            let mut new_children = Vec::with_capacity(struct_arr.num_columns());
+            let mut new_child_fields = Vec::with_capacity(struct_arr.num_columns());
+            for (child_idx, child_field) in struct_arr.fields().iter().enumerate() {
+                let child_array = struct_arr.column(child_idx).clone();
+                match lance_field.child(child_field.name()) {
+                    Some(child_lance_field) if contains_blob_v2(child_lance_field) => {
+                        let (new_child, new_child_field) = transform_blob_v2_column(
+                            dataset,
+                            child_lance_field,
+                            child_field,
+                            child_array,
+                            row_addrs,
+                            format!("{column_path}.{}", child_field.name()),
+                        )
+                        .await?;
+                        new_children.push(new_child);
+                        new_child_fields.push(new_child_field);
+                    }
+                    _ => {
+                        new_children.push(child_array);
+                        new_child_fields.push(child_field.clone());
+                    }
+                }
+            }
+            let new_struct = StructArray::try_new(
+                new_child_fields.clone().into(),
+                new_children,
+                struct_arr.nulls().cloned(),
+            )?;
+            let new_field = Arc::new(
+                arrow_schema::Field::new(
+                    arrow_field.name(),
+                    arrow_schema::DataType::Struct(new_child_fields.into()),
+                    arrow_field.is_nullable(),
+                )
+                .with_metadata(arrow_field.metadata().clone()),
+            );
+            return Ok((Arc::new(new_struct) as ArrayRef, new_field));
+        }
+
+        // Merge-insert may supply a blob v2 value directly from the source.
+        // Those values are already in the writer's user view and do not refer
+        // to a row in the target dataset, unlike descriptor values from scans.
+        if struct_arr.column_by_name("kind").is_none() {
+            return Ok((array.clone(), arrow_field.clone()));
+        }
+
+        let descriptor = BlobV2Descriptor::try_from_struct(struct_arr, &column_path)?;
+        let classification = classify_rows(struct_arr, &descriptor, row_addrs, &column_path)?;
+        let new_struct = build_user_view_struct(
+            dataset,
+            &descriptor,
+            &classification,
+            &column_path,
+            struct_arr.len(),
+            struct_arr.nulls().cloned(),
+        )
+        .await?;
+
+        Ok((
+            Arc::new(new_struct) as ArrayRef,
+            transformed_blob_v2_field(lance_field, arrow_field),
+        ))
+    }
+    .boxed()
+}
+
+/// The Arrow schema that [`transform_blob_v2_batch`] produces for `read_schema`.
+pub(crate) fn transformed_blob_v2_schema(
+    read_schema: &arrow_schema::Schema,
+    dataset_schema: &lance_core::datatypes::Schema,
+) -> Arc<arrow_schema::Schema> {
+    let fields = read_schema
+        .fields()
+        .iter()
+        .filter(|field| field.name() != lance_core::ROW_ADDR)
+        .map(|field| match dataset_schema.field(field.name()) {
+            Some(lance_field) if contains_blob_v2(lance_field) => {
+                transformed_blob_v2_field(lance_field, field)
+            }
+            _ => field.clone(),
+        })
+        .collect::<Vec<_>>();
+    Arc::new(arrow_schema::Schema::new_with_metadata(
+        fields,
+        read_schema.metadata().clone(),
+    ))
+}
+
 pub(crate) async fn transform_blob_v2_batch(
     dataset: &Arc<Dataset>,
     schema: &lance_core::datatypes::Schema,
@@ -1208,73 +1371,30 @@ pub(crate) async fn transform_blob_v2_batch(
             continue;
         }
 
-        let lance_field = schema.field(field.name());
-        let is_blob_v2 = lance_field.is_some_and(|f| f.is_blob_v2());
-
-        if !is_blob_v2 {
-            new_columns.push(batch.column(col_idx).clone());
-            new_fields.push(field.clone());
-            continue;
+        let column = batch.column(col_idx).clone();
+        match schema.field(field.name()) {
+            Some(lance_field) if contains_blob_v2(lance_field) => {
+                let (new_column, new_field) = transform_blob_v2_column(
+                    dataset,
+                    lance_field,
+                    field,
+                    column,
+                    row_addrs,
+                    field.name().clone(),
+                )
+                .await?;
+                new_columns.push(new_column);
+                new_fields.push(new_field);
+            }
+            _ => {
+                new_columns.push(column);
+                new_fields.push(field.clone());
+            }
         }
-
-        let struct_arr = batch
-            .column(col_idx)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .ok_or_else(|| {
-                Error::internal(format!(
-                    "Blob v2 column '{}' expected StructArray, got {:?}",
-                    field.name(),
-                    batch.column(col_idx).data_type()
-                ))
-            })?;
-
-        // Merge-insert may supply a blob v2 value directly from the source.
-        // Those values are already in the writer's user view and do not refer
-        // to a row in the target dataset, unlike descriptor values from scans.
-        if struct_arr.column_by_name("kind").is_none() {
-            new_columns.push(batch.column(col_idx).clone());
-            new_fields.push(field.clone());
-            continue;
-        }
-
-        let column_name = field.name();
-        let descriptor = BlobV2Descriptor::try_from_struct(struct_arr, column_name)?;
-        let classification = classify_rows(struct_arr, &descriptor, row_addrs, column_name)?;
-        let num_rows = struct_arr.len();
-
-        let new_struct = build_user_view_struct(
-            dataset,
-            &descriptor,
-            &classification,
-            column_name,
-            num_rows,
-            struct_arr.nulls().cloned(),
-        )
-        .await?;
-
-        new_columns.push(Arc::new(new_struct));
-        let logical_field = arrow_schema::Field::from(lance_field.ok_or_else(|| {
-            Error::internal(format!(
-                "Blob v2 column '{}' missing from dataset schema during compaction",
-                field.name()
-            ))
-        })?);
-        new_fields.push(Arc::new(
-            arrow_schema::Field::new(
-                field.name(),
-                lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
-                field.is_nullable(),
-            )
-            .with_metadata(logical_field.metadata().clone()),
-        ));
     }
 
     let new_schema = Arc::new(arrow_schema::Schema::new_with_metadata(
-        new_fields
-            .iter()
-            .map(|f| f.as_ref().clone())
-            .collect::<Vec<_>>(),
+        new_fields,
         batch_schema.metadata().clone(),
     ));
 
@@ -1684,35 +1804,7 @@ async fn rewrite_files(
                         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))
                 }
             });
-            let transformed_schema = {
-                let mut fields: Vec<Arc<arrow_schema::Field>> = Vec::new();
-                for field in schema.fields().iter() {
-                    if field.name() == lance_core::ROW_ADDR {
-                        continue;
-                    }
-                    let lance_field = dataset.schema().field(field.name());
-                    if let Some(lance_field) = lance_field.filter(|f| f.is_blob_v2()) {
-                        let logical_field = arrow_schema::Field::from(lance_field);
-                        fields.push(Arc::new(
-                            arrow_schema::Field::new(
-                                field.name(),
-                                lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
-                                field.is_nullable(),
-                            )
-                            .with_metadata(logical_field.metadata().clone()),
-                        ));
-                    } else {
-                        fields.push(field.clone());
-                    }
-                }
-                Arc::new(arrow_schema::Schema::new_with_metadata(
-                    fields
-                        .iter()
-                        .map(|f| f.as_ref().clone())
-                        .collect::<Vec<_>>(),
-                    schema.metadata().clone(),
-                ))
-            };
+            let transformed_schema = transformed_blob_v2_schema(&schema, dataset.schema());
             reader = Some(Box::pin(RecordBatchStreamAdapter::new(
                 transformed_schema,
                 transformed,
@@ -7935,6 +8027,184 @@ mod tests {
                 (1, None),
                 (2, Some(b"thumb-2".to_vec()))
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compact_blob_v2_struct_nested_column() {
+        use crate::BlobArrayBuilder;
+        use arrow_array::StringArray;
+        use lance_core::utils::tempfile::TempDir;
+
+        let test_dir = TempDir::default();
+
+        let expected: Vec<(i32, Option<Vec<u8>>)> = vec![
+            (0, Some(b"payload-0".to_vec())),
+            (1, Some(Vec::new())),
+            (2, None),
+            (3, Some(b"payload-3".to_vec())),
+        ];
+
+        let mut blob_builder = BlobArrayBuilder::new(expected.len());
+        for (_, value) in &expected {
+            match value {
+                Some(value) => blob_builder.push_bytes(value).unwrap(),
+                None => blob_builder.push_null().unwrap(),
+            }
+        }
+
+        let payload_field = crate::blob_field("payload", true);
+        let asset_fields = vec![Field::new("mime", DataType::Utf8, true), payload_field];
+        let asset_array: ArrayRef = Arc::new(
+            StructArray::try_new(
+                asset_fields.clone().into(),
+                vec![
+                    Arc::new(StringArray::from(vec!["image/png"; expected.len()])) as ArrayRef,
+                    blob_builder.finish().unwrap(),
+                ],
+                None,
+            )
+            .unwrap(),
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("asset", DataType::Struct(asset_fields.into()), true),
+        ]));
+        let id_array: ArrayRef = Arc::new(Int32Array::from_iter_values(0..expected.len() as i32));
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, asset_array]).unwrap();
+        let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+
+        let mut dataset = Dataset::write(
+            reader,
+            &test_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                max_rows_per_file: 2,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 2);
+
+        dataset.delete("id = 1").await.unwrap();
+
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 1024 * 1024,
+                materialize_deletions_threshold: 0.0,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 1);
+
+        let dataset = Arc::new(dataset);
+        let batch = dataset
+            .scan()
+            .project(&["id", "asset"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>();
+        assert_eq!(ids.values(), &[0, 2, 3]);
+
+        let mime = batch
+            .column_by_name("asset")
+            .unwrap()
+            .as_struct()
+            .column_by_name("mime")
+            .unwrap()
+            .as_string::<i32>();
+        assert!((0..mime.len()).all(|i| mime.value(i) == "image/png"));
+
+        let blobs = dataset
+            .take_blobs_by_indices(&[0, 1, 2], "asset.payload")
+            .await
+            .unwrap();
+        let mut actual = Vec::with_capacity(blobs.len());
+        for blob in blobs {
+            match blob {
+                Some(blob) => actual.push(Some(blob.read().await.unwrap().to_vec())),
+                None => actual.push(None),
+            }
+        }
+        assert_eq!(
+            actual,
+            vec![
+                Some(b"payload-0".to_vec()),
+                None,
+                Some(b"payload-3".to_vec())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compact_blob_v2_list_nested_column_is_not_supported() {
+        use crate::BlobArrayBuilder;
+        use lance_core::utils::tempfile::TempDir;
+
+        let test_dir = TempDir::default();
+
+        let mut blob_builder = BlobArrayBuilder::new(2);
+        blob_builder.push_bytes(b"payload-0").unwrap();
+        blob_builder.push_bytes(b"payload-1").unwrap();
+        let item_field = Arc::new(crate::blob_field("item", true));
+        let blobs_array: ArrayRef = Arc::new(
+            arrow_array::ListArray::try_new(
+                item_field.clone(),
+                arrow_buffer::OffsetBuffer::new(arrow_buffer::ScalarBuffer::from(vec![0i32, 1, 2])),
+                blob_builder.finish().unwrap(),
+                None,
+            )
+            .unwrap(),
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("blobs", DataType::List(item_field), true),
+        ]));
+        let id_array: ArrayRef = Arc::new(Int32Array::from(vec![0, 1]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![id_array, blobs_array]).unwrap();
+        let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+
+        let mut dataset = Dataset::write(
+            reader,
+            &test_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                max_rows_per_file: 1,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let err = compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 1024 * 1024,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::NotSupported { .. }),
+            "expected NotSupported, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("only struct nesting is supported"),
+            "unexpected error message: {err}"
         );
     }
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1120,6 +1120,7 @@ async fn build_user_view_struct(
     dataset: &Arc<Dataset>,
     descriptor: &BlobV2Descriptor<'_>,
     classification: &RowClassification,
+    blob_field_id: u32,
     column_name: &str,
     num_rows: usize,
     null_buffer: Option<NullBuffer>,
@@ -1127,7 +1128,7 @@ async fn build_user_view_struct(
     let blob_files = if classification.blob_read_addrs.is_empty() {
         Vec::new()
     } else {
-        super::blob::take_blobs_by_addresses(dataset, &classification.blob_read_addrs, column_name)
+        super::blob::take_blobs_by_field_id(dataset, &classification.blob_read_addrs, blob_field_id)
             .await?
     };
 
@@ -1251,15 +1252,13 @@ fn transformed_blob_v2_field(
 }
 
 /// Rewrite a blob v2 descriptor column, or a struct containing one, into the
-/// writer's user view. `column_path` is the dotted path to `array` in the dataset
-/// schema, which is how blob payloads are addressed when they are read back.
+/// writer's user view.
 fn transform_blob_v2_column<'a>(
     dataset: &'a Arc<Dataset>,
     lance_field: &'a lance_core::datatypes::Field,
     arrow_field: &'a Arc<arrow_schema::Field>,
     array: ArrayRef,
     row_addrs: &'a arrow::array::UInt64Array,
-    column_path: String,
 ) -> BoxFuture<'a, Result<(ArrayRef, Arc<arrow_schema::Field>)>> {
     async move {
         // Blob payloads are addressed by row address, so a blob v2 leaf can only be
@@ -1268,7 +1267,7 @@ fn transform_blob_v2_column<'a>(
             return Err(Error::not_supported(format!(
                 "Compacting a blob v2 column nested under '{}' of type {}; \
                  only struct nesting is supported",
-                column_path,
+                dataset.schema().field_path_minimal(lance_field.id)?,
                 array.data_type()
             )));
         };
@@ -1286,7 +1285,6 @@ fn transform_blob_v2_column<'a>(
                             child_field,
                             child_array,
                             row_addrs,
-                            format!("{column_path}.{}", child_field.name()),
                         )
                         .await?;
                         new_children.push(new_child);
@@ -1321,12 +1319,15 @@ fn transform_blob_v2_column<'a>(
             return Ok((array.clone(), arrow_field.clone()));
         }
 
+        // Only for error context; the payload read below addresses the column by id.
+        let column_path = dataset.schema().field_path_minimal(lance_field.id)?;
         let descriptor = BlobV2Descriptor::try_from_struct(struct_arr, &column_path)?;
         let classification = classify_rows(struct_arr, &descriptor, row_addrs, &column_path)?;
         let new_struct = build_user_view_struct(
             dataset,
             &descriptor,
             &classification,
+            lance_field.id as u32,
             &column_path,
             struct_arr.len(),
             struct_arr.nulls().cloned(),
@@ -1403,15 +1404,9 @@ pub(crate) async fn transform_blob_v2_batch(
         let column = batch.column(col_idx).clone();
         match schema.field(field.name()) {
             Some(lance_field) if contains_blob_v2(lance_field) => {
-                let (new_column, new_field) = transform_blob_v2_column(
-                    dataset,
-                    lance_field,
-                    field,
-                    column,
-                    row_addrs,
-                    field.name().clone(),
-                )
-                .await?;
+                let (new_column, new_field) =
+                    transform_blob_v2_column(dataset, lance_field, field, column, row_addrs)
+                        .await?;
                 new_columns.push(new_column);
                 new_fields.push(new_field);
             }
@@ -8059,8 +8054,15 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::plain("payload", "asset.payload")]
+    #[case::dotted("payload.with.dot", "asset.`payload.with.dot`")]
+    #[case::backticked("payload`quote", "asset.`payload``quote`")]
     #[tokio::test]
-    async fn test_compact_blob_v2_struct_nested_column() {
+    async fn test_compact_blob_v2_struct_nested_column(
+        #[case] leaf_name: &str,
+        #[case] leaf_path: &str,
+    ) {
         use crate::BlobArrayBuilder;
         use arrow_array::StringArray;
         use lance_core::utils::tempfile::TempDir;
@@ -8082,7 +8084,7 @@ mod tests {
             }
         }
 
-        let payload_field = crate::blob_field("payload", true);
+        let payload_field = crate::blob_field(leaf_name, true);
         let asset_fields = vec![Field::new("mime", DataType::Utf8, true), payload_field];
         let asset_array: ArrayRef = Arc::new(
             StructArray::try_new(
@@ -8156,7 +8158,7 @@ mod tests {
         assert!((0..mime.len()).all(|i| mime.value(i) == "image/png"));
 
         let blobs = dataset
-            .take_blobs_by_indices(&[0, 1, 2], "asset.payload")
+            .take_blobs_by_indices(&[0, 1, 2], leaf_path)
             .await
             .unwrap();
         let mut actual = Vec::with_capacity(blobs.len());

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -968,6 +968,25 @@ impl CompactionPlan {
     }
 }
 
+// Blob v2 columns take two different struct shapes on the compaction path, and
+// neither is a named Rust type — each is identified by the child fields present:
+//
+//   descriptor view  struct<kind, position, size, blob_id, blob_uri>
+//                    `BLOB_V2_DESC_FIELDS`. What a scan of a written dataset
+//                    returns: where the payload lives, not the payload itself.
+//                    `position`/`size` are relative to a Lance data or pack file,
+//                    except when `kind == External`, where they are an offset and
+//                    length within the external object. See [`BlobKind`].
+//
+//   user view        struct<data, uri, position, size>
+//                    `BLOB_V2_USER_FIELDS`. What the writer accepts, carrying the
+//                    payload bytes inline. Also what a merge-insert source
+//                    supplies directly.
+//
+// Compaction reads the descriptor view and must hand the writer the user view, so
+// every blob v2 leaf in the batch has to be converted. `kind` is the field that
+// tells the two apart.
+
 /// Classification for one blob v2 row during compaction.
 ///
 /// - `Null`: NULL row.
@@ -979,7 +998,12 @@ enum RowClass {
     DataBlob,
 }
 
-/// Column views for the 5 fields in a blob v2 descriptor struct.
+/// Returns true when `struct_arr` is the descriptor view rather than the user view.
+fn is_descriptor_view(struct_arr: &StructArray) -> bool {
+    struct_arr.column_by_name("kind").is_some()
+}
+
+/// Column views for the 5 fields of the descriptor view (`BLOB_V2_DESC_FIELDS`).
 struct BlobV2Descriptor<'a> {
     kind_col: &'a arrow::array::UInt8Array,
     position_col: &'a arrow::array::UInt64Array,
@@ -1088,7 +1112,7 @@ fn classify_rows(
     })
 }
 
-/// Build a blob v2 user-view struct array from classification and descriptor.
+/// Convert the descriptor view into the user view, reading each payload back in.
 ///
 /// Reads blob data lazily using row addresses to avoid materializing all blob
 /// payloads in memory at once.
@@ -1185,8 +1209,8 @@ fn contains_blob_v2(field: &lance_core::datatypes::Field) -> bool {
 
 /// The Arrow field that [`transform_blob_v2_column`] produces for `arrow_field`.
 ///
-/// Blob v2 descriptor structs become the writer's user view; enclosing structs are
-/// rebuilt around their transformed children.
+/// Blob v2 leaves take the user-view type; enclosing structs are rebuilt around
+/// their transformed children.
 fn transformed_blob_v2_field(
     lance_field: &lance_core::datatypes::Field,
     arrow_field: &Arc<arrow_schema::Field>,
@@ -1290,10 +1314,10 @@ fn transform_blob_v2_column<'a>(
             return Ok((Arc::new(new_struct) as ArrayRef, new_field));
         }
 
-        // Merge-insert may supply a blob v2 value directly from the source.
-        // Those values are already in the writer's user view and do not refer
-        // to a row in the target dataset, unlike descriptor values from scans.
-        if struct_arr.column_by_name("kind").is_none() {
+        // Merge-insert may supply a blob v2 value directly from the source. Those
+        // values are already in the user view and, unlike descriptors read from a
+        // scan, do not refer to a row in the target dataset.
+        if !is_descriptor_view(struct_arr) {
             return Ok((array.clone(), arrow_field.clone()));
         }
 
@@ -1339,6 +1363,11 @@ pub(crate) fn transformed_blob_v2_schema(
     ))
 }
 
+/// Convert every blob v2 leaf in `batch` from the descriptor view to the user
+/// view, so the batch can be handed to the writer.
+///
+/// Requires a `_rowaddr` column, which is how each descriptor's payload is
+/// located; `keep_row_addr` controls whether it survives into the output.
 pub(crate) async fn transform_blob_v2_batch(
     dataset: &Arc<Dataset>,
     schema: &lance_core::datatypes::Schema,


### PR DESCRIPTION
Compaction rewrites blob v2 columns from their stored descriptor form back into the writer's user view, but it only did so for columns at the top level of the schema. A blob v2 field nested inside a struct — e.g. `struct<mime: string, payload: blob>` — was passed through untouched, so the writer received a descriptor struct where it expected a payload and every fragment rewrite failed with "Blob struct missing `data` field". The dataset was still readable, but permanently un-compactable: it could never reclaim space from deleted rows or merge small fragments.

This PR walks struct children when rewriting a batch, and when building the transformed stream schema, addressing each blob leaf by its schema field id so its payloads are read back correctly.

Fixes #8082

## Addressing blobs by field id

The first cut built a dotted path by concatenating raw field names, which does not round-trip for a name containing `.` or a backtick — the payload read then failed with `FieldNotFound`. Names are the wrong key here anyway, so the read now takes the field id instead, down through `collect_blob_selection_for_selection` and the descriptor take. Every caller already held the id; the redundant column-name parameter is gone, along with `ReadBlobsBuilder`'s unused `column` field.

Names remain only in error messages and in the walk into a descriptor batch, both derived from the id via schema ancestry and rendered with `format_field_path_minimal`. The regression test is parameterized over a plain, a dotted, and a backticked leaf name.

## Readability

A blob v2 column takes two different struct shapes on this path — the stored descriptor (`kind, position, size, blob_id, blob_uri`) and the writer's user view (`data, uri, position, size`) — and neither is a named type; they were told apart by an inline `column_by_name("kind").is_none()`. The second commit names both shapes where the conversion happens and gives that probe a name. It is comments and one predicate, no behavior change.

That is a local fix to the file this PR already touches. There are five such shapes across the blob code and four different styles of probing for them, which is the underlying reason this bug was invisible until it reached the writer. Filed as #8201 rather than expanded here.

## Not included

Blob v2 nested under a list is still not supported by compaction: payloads are addressed one per row, and a list holds many values per row. That case previously hit the same misleading "missing `data` field" error and now reports `NotSupported` with an explanation instead.

A **top-level** blob column whose name contains a backtick still cannot be compacted, and the cause is outside this path: the take's projection drops the column before any blob code runs (`create_physical_expr` on `Column::from_name("my`blob")` against a schema that no longer has it). Top-level names containing `.` are already rejected by `Schema::validate`, so escaping is not the issue there. Left alone here.
