### PR TITLE
fix(index): keep address-domain indices off replaced fragments

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -3284,6 +3284,77 @@ mod tests {
         assert_eq!(before_scalar_result, after_scalar_result);
     }
 
+    /// Regression test for https://github.com/lance-format/lance/issues/8076
+    ///
+    /// A zone map or bloom filter index reports matches as physical row addresses, so
+    /// compaction invalidates it even under stable row ids. Reusing it for the rewritten
+    /// fragments made a filtered scan fail with an internal error (a fragment referenced
+    /// by the index no longer existed) or, once translation tolerated that, silently drop
+    /// every match.
+    #[rstest]
+    #[case::zone_map(BuiltinIndexType::ZoneMap, IndexType::ZoneMap)]
+    #[case::bloom_filter(BuiltinIndexType::BloomFilter, IndexType::BloomFilter)]
+    #[tokio::test]
+    async fn test_addr_domain_index_after_compaction_with_stable_row_ids(
+        #[case] builtin: BuiltinIndexType,
+        #[case] index_type: IndexType,
+    ) {
+        let mut data_gen =
+            BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("i".to_owned())));
+        let mut dataset = Dataset::write(
+            data_gen.batch(200),
+            "memory://test/table",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                max_rows_per_file: 100, // 2 fragments, so compaction has something to merge
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        dataset
+            .create_index(
+                &["i"],
+                index_type,
+                None,
+                &ScalarIndexParams::for_builtin(builtin),
+                false,
+            )
+            .await
+            .unwrap();
+
+        compact_files(&mut dataset, CompactionOptions::default(), None)
+            .await
+            .unwrap();
+
+        // The index only knows the pre-compaction fragments, so it must not claim to
+        // cover the fragment they were rewritten into.
+        let live_fragments: RoaringBitmap =
+            dataset.fragments().iter().map(|f| f.id as u32).collect();
+        let index = dataset
+            .load_indices()
+            .await
+            .unwrap()
+            .iter()
+            .find(|index| index.fields == vec![0])
+            .expect("index must survive compaction")
+            .clone();
+        assert!(
+            index
+                .effective_fragment_bitmap(&live_fragments)
+                .is_none_or(|covered| covered.is_empty()),
+            "compaction must not point an address-domain index at the fragments it wrote"
+        );
+
+        // Every fragment therefore falls back to a full scan, and the filter is answered
+        // in full.
+        let mut scanner = dataset.scan();
+        scanner.filter("i > 0").unwrap();
+        let matched = scanner.try_into_batch().await.unwrap();
+        assert_eq!(matched.num_rows(), 199);
+    }
+
     // Regression test for https://github.com/lancedb/lance/issues/6161
     // When FragReuseIndexDetails exceeds 204800 bytes it is written to an external
     // file. Previously the file was silently dropped (temp file deleted) because

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -94,20 +94,22 @@ pub async fn get_row_id_index(
 /// deletions are tracked by the deletion vector and do not compact the sequence,
 /// so a physical offset indexes the sequence directly (see [`RowIdIndex`], which
 /// maps ids to `start_address + position` and filters deletions separately).
-/// Addresses that point at deleted rows have no live counterpart and are dropped,
-/// which is correct: those rows are not part of the answer.
+/// Addresses that no longer have a live counterpart are dropped, which is correct:
+/// those rows are not part of the answer. That covers both a deleted row and a
+/// whole fragment that a maintenance operation replaced — an address-domain index
+/// is not remapped by compaction or `update` (neither the zone map nor the bloom
+/// filter index supports remap), so its results outlive the fragments they address.
+/// The replacement fragments are absent from the index's fragment bitmap, so the
+/// scanner routes them to a full scan and no match is lost.
 pub(crate) async fn translate_addr_treemap_to_row_ids(
     dataset: &Dataset,
     addrs: &RowAddrTreeMap,
 ) -> Result<RowAddrTreeMap> {
     let mut row_ids = RowAddrTreeMap::new();
     for (fragment_id, selection) in addrs.iter() {
-        let file_fragment = dataset.get_fragment(*fragment_id as usize).ok_or_else(|| {
-            Error::internal(format!(
-                "fragment {fragment_id} referenced by an address-domain index result \
-                 was not found in the dataset"
-            ))
-        })?;
+        let Some(file_fragment) = dataset.get_fragment(*fragment_id as usize) else {
+            continue;
+        };
         let sequence = load_row_id_sequence(dataset, file_fragment.metadata()).await?;
 
         match selection {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -16,6 +16,7 @@ use super::ManifestWriteConfig;
 use super::write::merge_insert::inserted_rows::KeyExistenceFilter;
 use crate::dataset::overlay::collect_overlay_stale_frags;
 use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
+use crate::index::index_results_are_row_addrs;
 use crate::index::mem_wal::update_mem_wal_index_compacted_sstables;
 use crate::utils::temporal::timestamp_to_nanos;
 use lance_core::datatypes::{
@@ -2122,9 +2123,21 @@ impl Transaction {
                     // We can re-use indices, but need to rewrite the fragment bitmaps
                     debug_assert!(rewritten_indices.is_empty());
                     for index in final_indices.iter_mut() {
+                        let results_are_row_addrs = index_results_are_row_addrs(index);
                         if let Some(fragment_bitmap) = &mut index.fragment_bitmap {
-                            *fragment_bitmap =
-                                Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?;
+                            *fragment_bitmap = if results_are_row_addrs {
+                                // Stable row ids survive a rewrite, so a row-id-domain index
+                                // can simply follow its data to the new fragments. An
+                                // address-domain index cannot: its stored addresses point into
+                                // the fragments the rewrite dropped. Claiming coverage of the
+                                // new fragments would make it answer queries with addresses
+                                // that no longer resolve, so drop the rewritten fragments from
+                                // its coverage instead and let the scanner fall back to a full
+                                // scan for them.
+                                Self::drop_rewritten_fragments(fragment_bitmap, groups)
+                            } else {
+                                Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?
+                            };
                         }
                     }
                 } else {
@@ -3021,6 +3034,18 @@ impl Transaction {
             }
         }
         Ok(new_bitmap)
+    }
+
+    /// Coverage of an index that a rewrite invalidates: the rewritten fragments are
+    /// removed and the fragments they became are *not* added.
+    fn drop_rewritten_fragments(old: &RoaringBitmap, groups: &[RewriteGroup]) -> RoaringBitmap {
+        let mut new_bitmap = old.clone();
+        for group in groups {
+            for old_fragment in &group.old_fragments {
+                new_bitmap.remove(old_fragment.id as u32);
+            }
+        }
+        new_bitmap
     }
 
     fn handle_rewrite_indices(

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -538,7 +538,7 @@ mod tests {
         array::AsArray,
         datatypes::{Int64Type, UInt32Type},
     };
-    use arrow_array::types::Float32Type;
+    use arrow_array::types::{Float32Type, Int32Type};
     use arrow_array::{Int64Array, RecordBatchIterator, StringArray, UInt32Array, UInt64Array};
     use arrow_schema::{Field, Schema as ArrowSchema};
     use arrow_select::concat::concat_batches;
@@ -550,7 +550,7 @@ mod tests {
     use lance_datagen::{Dimension, RowCount};
     use lance_file::version::LanceFileVersion;
     use lance_index::IndexType;
-    use lance_index::scalar::ScalarIndexParams;
+    use lance_index::scalar::{BuiltinIndexType, ScalarIndexParams};
     use lance_io::object_store::ObjectStoreParams;
     use lance_linalg::distance::MetricType;
     use object_store::throttle::ThrottleConfig;
@@ -1282,6 +1282,75 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    /// Regression test for https://github.com/lance-format/lance/issues/8076
+    ///
+    /// A bloom filter index reports matches as physical row addresses. An update that
+    /// replaces every row of a fragment removes that fragment, but the index keeps the
+    /// addresses it holds for it, so translating its results to row ids has to tolerate
+    /// a fragment that is gone rather than fail with an internal error.
+    #[tokio::test]
+    async fn test_addr_domain_index_after_update_drops_fragment() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset_with_params(
+                FragmentCount::from(2),
+                FragmentRowCount::from(3),
+                Some(WriteParams {
+                    max_rows_per_file: 3,
+                    enable_stable_row_ids: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::BloomFilter,
+                Some("i_idx".to_string()),
+                &ScalarIndexParams::for_builtin(BuiltinIndexType::BloomFilter),
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Rewrites all of fragment 1 (rows 3, 4, 5), which drops the fragment.
+        let dataset = UpdateBuilder::new(Arc::new(dataset))
+            .update_where("i >= 3")
+            .unwrap()
+            .set("i", "-1")
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap()
+            .new_dataset;
+        assert!(dataset.get_fragments().iter().all(|frag| frag.id() != 1));
+
+        // The index still holds a block for the dropped fragment, and a bloom filter
+        // cannot rule out a value it once held, so this query is the one that reaches
+        // the index with addresses in that fragment.
+        let matched = dataset
+            .scan()
+            .filter("i = 4")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(matched.num_rows(), 0);
+
+        let updated = dataset
+            .scan()
+            .filter("i = -1")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(updated.num_rows(), 3);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -633,6 +633,15 @@ fn segment_has_zonemap_details(segment: &IndexMetadata) -> bool {
         .is_some_and(|details| details.type_url.ends_with("ZoneMapIndexDetails"))
 }
 
+/// True when the index reports matches as physical row addresses rather than row ids
+/// (`ScalarIndex::results_are_row_addresses`).
+///
+/// Such an index cannot follow its data through a rewrite: the addresses it stores
+/// name fragments and offsets, and neither kind supports remap.
+pub(crate) fn index_results_are_row_addrs(index: &IndexMetadata) -> bool {
+    segment_has_zonemap_details(index) || segment_has_bloomfilter_details(index)
+}
+
 fn segment_has_fmindex_details(segment: &IndexMetadata) -> bool {
     segment
         .index_details


### PR DESCRIPTION
Zone map and bloom filter indices report their matches as physical row addresses (a fragment plus an offset) rather than as row ids, and neither can be remapped when a fragment is rewritten. Under stable row ids, compaction skipped index remapping altogether and just pointed each index's fragment coverage at the fragments it had written. An address-domain index would then be asked to answer queries about data whose addresses it never knew, and the addresses it did return named fragments that compaction had deleted. A filtered scan after compaction failed with `fragment 0 referenced by an address-domain index result was not found in the dataset`.

The same error site was reachable a second way: an update that replaces every row of a fragment removes that fragment, while the index keeps the addresses it held for it.

This PR makes compaction drop the rewritten fragments from an address-domain index's coverage instead of forwarding the coverage to the new fragments — the index keeps serving whatever the rewrite left alone, and the rewritten data falls back to a full scan. Address-to-row-id translation now also skips a reference to a fragment that is no longer in the dataset, the same way it already skips an address that points at a deleted row: in both cases the row has no live counterpart, so it is not part of any answer.

Both behaviors are specific to stable row ids. Without them an address *is* the row id, remapping runs (and drops these indices outright), and the sequences above already worked.

Fixes #8076
