### PR TITLE
feat(sql): add blob handling to query builder

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5511,6 +5511,23 @@ class SqlQueryBuilder:
         self._builder = self._builder.with_row_addr(with_row_addr)
         return self
 
+    def blob_handling(
+        self,
+        blob_handling: Literal[
+            "all_binary", "blobs_descriptions", "all_descriptions"
+        ],
+    ) -> "SqlQueryBuilder":
+        """
+        Control how blob columns are returned by this SQL query.
+
+        - ``"all_binary"`` materializes blob columns as binary values.
+        - ``"blobs_descriptions"`` returns blob descriptors (the default).
+        - ``"all_descriptions"`` returns descriptions for all binary-like
+          columns.
+        """
+        self._builder = self._builder.blob_handling(blob_handling)
+        return self
+
     def build(self) -> SqlQuery:
         """
         Build the query.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5513,9 +5513,7 @@ class SqlQueryBuilder:
 
     def blob_handling(
         self,
-        blob_handling: Literal[
-            "all_binary", "blobs_descriptions", "all_descriptions"
-        ],
+        blob_handling: Literal["all_binary", "blobs_descriptions", "all_descriptions"],
     ) -> "SqlQueryBuilder":
         """
         Control how blob columns are returned by this SQL query.

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -182,6 +182,29 @@ def test_scan_blob_as_binary(tmp_path):
     assert tbl.column("blobs").to_pylist() == values
 
 
+def test_sql_blob_as_binary(tmp_path):
+    values = [b"foo", b"bar", b"baz"]
+    table = pa.table(
+        [pa.array(values, pa.large_binary())],
+        schema=pa.schema(
+            [
+                pa.field(
+                    "blobs", pa.large_binary(), metadata={"lance-encoding:blob": "true"}
+                )
+            ]
+        ),
+    )
+    ds = lance.write_dataset(table, tmp_path / "test_ds")
+
+    batches = (
+        ds.sql("SELECT blobs FROM dataset")
+        .blob_handling("all_binary")
+        .build()
+        .to_batch_records()
+    )
+    assert pa.Table.from_batches(batches).column("blobs").to_pylist() == values
+
+
 def test_v2_0_blob_descriptor_projection_and_reads(tmp_path):
     values = [b"abc", b"defgh", b"ijklmnop"]
     blob_field = pa.field(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4163,6 +4163,23 @@ impl SqlQueryBuilder {
         }
     }
 
+    #[pyo3(signature = (blob_handling))]
+    fn blob_handling(&self, blob_handling: &str) -> PyResult<Self> {
+        let blob_handling = match blob_handling {
+            "all_binary" => BlobHandling::AllBinary,
+            "blobs_descriptions" => BlobHandling::BlobsDescriptions,
+            "all_descriptions" => BlobHandling::AllDescriptions,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid blob_handling: {other}. Expected one of: all_binary, blobs_descriptions, all_descriptions"
+                )));
+            }
+        };
+        Ok(Self {
+            builder: self.builder.clone().blob_handling(blob_handling),
+        })
+    }
+
     /// Build the SQL query.
     fn build(&self) -> PyResult<SqlQuery> {
         Ok(SqlQuery {

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -75,10 +75,22 @@ impl LanceTableProvider {
     }
 
     /// Overrides how blob columns are read during [`TableProvider::scan`].
-    ///
     /// When unset, the underlying dataset scan uses its default
     /// [`BlobHandling`](lance_core::datatypes::BlobHandling) policy.
     pub fn with_blob_handling(mut self, handling: lance_core::datatypes::BlobHandling) -> Self {
+        let converted = self
+            .dataset
+            .full_projection()
+            .with_blob_handling(handling.clone())
+            .to_bare_schema();
+        let mut full_schema = Schema::from(&converted);
+        if self.row_id_idx.is_some() {
+            full_schema = full_schema.try_with_column(ROW_ID_FIELD.clone()).unwrap();
+        }
+        if self.row_addr_idx.is_some() {
+            full_schema = full_schema.try_with_column(ROW_ADDR_FIELD.clone()).unwrap();
+        }
+        self.full_schema = Arc::new(full_schema);
         self.blob_handling = Some(handling);
         self
     }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -246,6 +246,28 @@ mod tests {
         let is_foo = batches[0].column(0).as_boolean();
         assert!(is_foo.value(0));
         assert!(!is_foo.value(1));
+
+        let batches = dataset
+            .sql("SELECT blob, _rowid, _rowaddr FROM dataset")
+            .with_row_id(true)
+            .with_row_addr(true)
+            .blob_handling(BlobHandling::AllBinary)
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        let batch = &batches[0];
+        let blobs = batch.column(0).as_binary::<i64>();
+        assert_eq!(blobs.value(0), b"foo");
+        assert_eq!(blobs.value(1), b"bar");
+        let row_ids = batch.column(1).as_primitive::<UInt64Type>();
+        assert_eq!(row_ids.value(0), 0);
+        assert_eq!(row_ids.value(1), 1);
+        let row_addrs = batch.column(2).as_primitive::<UInt64Type>();
+        assert_eq!(row_addrs.value(0), 0);
+        assert_eq!(row_addrs.value(1), 1);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -231,6 +231,21 @@ mod tests {
         let blobs = batches[0].column(0).as_binary::<i64>();
         assert_eq!(blobs.value(0), b"foo");
         assert_eq!(blobs.value(1), b"bar");
+
+        // Expressions over the blob column require the planner to see the
+        // materialized LargeBinary type instead of the blob descriptor struct.
+        let batches = dataset
+            .sql("SELECT blob = X'666f6f' FROM dataset")
+            .blob_handling(BlobHandling::AllBinary)
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        let is_foo = batches[0].column(0).as_boolean();
+        assert!(is_foo.value(0));
+        assert!(!is_foo.value(1));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -9,6 +9,7 @@ use datafusion::dataframe::DataFrame;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
 use futures::TryStreamExt;
+use lance_core::datatypes::BlobHandling;
 use lance_datafusion::udf::register_functions;
 use std::sync::Arc;
 
@@ -29,6 +30,9 @@ pub struct SqlQueryBuilder {
 
     /// If true, the query result will include the internal row address
     pub(crate) with_row_addr: bool,
+
+    /// Override how blob columns are materialized for this query.
+    pub(crate) blob_handling: Option<BlobHandling>,
 }
 
 impl SqlQueryBuilder {
@@ -39,6 +43,7 @@ impl SqlQueryBuilder {
             table_name: "dataset".to_string(),
             with_row_id: false,
             with_row_addr: false,
+            blob_handling: None,
         }
     }
 
@@ -65,18 +70,24 @@ impl SqlQueryBuilder {
         self
     }
 
+    /// Override how blob columns are materialized for this query.
+    ///
+    /// When unset, the underlying dataset scan uses its default
+    /// [`BlobHandling::BlobsDescriptions`] policy.
+    pub fn blob_handling(mut self, blob_handling: BlobHandling) -> Self {
+        self.blob_handling = Some(blob_handling);
+        self
+    }
+
     pub async fn build(self) -> lance_core::Result<SqlQuery> {
         let ctx = SessionContext::new();
         let row_id = self.with_row_id;
         let row_addr = self.with_row_addr;
-        ctx.register_table(
-            self.table_name,
-            Arc::new(LanceTableProvider::new(
-                self.dataset.clone(),
-                row_id,
-                row_addr,
-            )),
-        )?;
+        let mut provider = LanceTableProvider::new(self.dataset.clone(), row_id, row_addr);
+        if let Some(blob_handling) = self.blob_handling {
+            provider = provider.with_blob_handling(blob_handling);
+        }
+        ctx.register_table(self.table_name, Arc::new(provider))?;
         register_functions(&ctx);
         let df = ctx.sql(&self.sql).await?;
         Ok(SqlQuery::new(df))
@@ -123,10 +134,12 @@ impl SqlQuery {
 #[cfg(test)]
 mod tests {
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount, assert_string_matches};
+    use crate::{BlobArrayBuilder, blob_field};
     use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::Dataset;
+    use crate::dataset::write::WriteParams;
     use all_asserts::assert_true;
     use arrow_array::cast::AsArray;
     use arrow_array::types::{Int32Type, Int64Type, UInt64Type};
@@ -135,7 +148,9 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use lance_arrow::ARROW_EXT_NAME_KEY;
     use lance_arrow::json::ARROW_JSON_EXT_NAME;
+    use lance_core::datatypes::BlobHandling;
     use lance_datagen::{array, gen_batch};
+    use lance_file::version::LanceFileVersion;
 
     #[tokio::test]
     async fn test_sql_execute() {
@@ -184,6 +199,38 @@ mod tests {
         pretty_assertions::assert_eq!(results.num_columns(), 4);
         assert_true!(results.column(2).as_primitive::<UInt64Type>().value(0) > 100);
         assert_true!(results.column(3).as_primitive::<UInt64Type>().value(0) > 100);
+    }
+
+    #[tokio::test]
+    async fn test_sql_blob_all_binary() {
+        let schema = Arc::new(ArrowSchema::new(vec![blob_field("blob", true)]));
+        let mut blobs = BlobArrayBuilder::new(2);
+        blobs.push_bytes(b"foo").unwrap();
+        blobs.push_bytes(b"bar").unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![blobs.finish().unwrap()]).unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            "memory://test_sql_blob_all_binary",
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_3),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let batches = dataset
+            .sql("SELECT blob FROM dataset")
+            .blob_handling(BlobHandling::AllBinary)
+            .build()
+            .await
+            .unwrap()
+            .into_batch_records()
+            .await
+            .unwrap();
+        let blobs = batches[0].column(0).as_binary::<i64>();
+        assert_eq!(blobs.value(0), b"foo");
+        assert_eq!(blobs.value(1), b"bar");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes https://github.com/lance-format/lance/issues/8086

This PR exposes `blob_handling` option to SQL builder interface.

AI assistent usage disclaimer: GPT-5.5 helped me make the code change.