### PR TITLE
fix(index): use zone map index for IS NOT NULL predicates

### DIFF
--- a/protos/index_old.proto
+++ b/protos/index_old.proto
@@ -39,6 +39,12 @@ message ZoneMapIndexDetails {
   // variable-length types (strings, binary) and fixed-width types wider than
   // 8 bytes, and to false for narrow fixed-width types (e.g. Int64, Float64).
   optional bool use_seeds = 2;
+  // Whether this index tracks exact null row addresses in a separate bitmap.
+  // Absent or false means legacy format: null positions are not tracked and
+  // IS NULL searches fall back to approximate zone-level statistics. Present
+  // true means IS NULL is exact and IS NOT NULL can be answered without a
+  // full scan.
+  optional bool has_null_bitmap = 3;
 }
 message InvertedIndexDetails {
   enum DocumentGranularity {

--- a/python/python/tests/compat/test_scalar_indices.py
+++ b/python/python/tests/compat/test_scalar_indices.py
@@ -194,12 +194,17 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
         self.path = path
 
     def create(self):
-        """Create dataset with ZONEMAP and BLOOMFILTER indices."""
+        """Create dataset with ZONEMAP and BLOOMFILTER indices.
+
+        The zonemap column contains nulls at rows 0 and 500 so that IS NULL
+        queries can be verified across version boundaries.
+        """
         shutil.rmtree(self.path, ignore_errors=True)
+        zonemap_values = [None if i in (0, 500) else i for i in range(1000)]
         data = pa.table(
             {
                 "idx": pa.array(range(1000)),
-                "zonemap": pa.array(range(1000)),
+                "zonemap": pa.array(zonemap_values, type=pa.int64()),
                 "bloomfilter": pa.array(range(1000)),
             }
         )
@@ -216,10 +221,16 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
         """Verify ZONEMAP and BLOOMFILTER indices can be queried."""
         ds = lance.dataset(self.path)
 
-        # Test ZONEMAP
+        # Test ZONEMAP equality
         table = ds.to_table(filter="zonemap == 7")
         assert table.num_rows == 1
         assert table.column("idx").to_pylist() == [7]
+
+        # Test ZONEMAP IS NULL — two nulls were inserted at rows 0 and 500.
+        # Older versions without a null bitmap fall back to a zone scan, which
+        # is still correct; newer versions may return an exact result.
+        table = ds.to_table(filter="zonemap IS NULL")
+        assert table.num_rows == 2
 
         # Test BLOOMFILTER
         table = ds.to_table(filter="bloomfilter == 7")
@@ -232,13 +243,19 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
         data = pa.table(
             {
                 "idx": pa.array([1000]),
-                "zonemap": pa.array([1000]),
+                "zonemap": pa.array([None], type=pa.int64()),
                 "bloomfilter": pa.array([1000]),
             }
         )
         ds.insert(data)
         ds.optimize.optimize_indices()
         ds.optimize.compact_files()
+
+        # IS NULL must still return results after the index is updated and
+        # files are compacted.  The newly inserted null must be found
+        # regardless of which version handles the seed-based index update.
+        table = ds.to_table(filter="zonemap IS NULL")
+        assert table.num_rows >= 1
 
 
 @compat_test(min_version="0.36.0")

--- a/python/python/tests/compat/test_scalar_indices.py
+++ b/python/python/tests/compat/test_scalar_indices.py
@@ -230,7 +230,12 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
         # Older versions without a null bitmap fall back to a zone scan, which
         # is still correct; newer versions may return an exact result.
         table = ds.to_table(filter="zonemap IS NULL")
-        assert table.num_rows == 2
+        if 1000 in table.column("idx").to_pylist():
+            # After write, there are 3 NULLs
+            assert table.num_rows == 3
+        else:
+            # Before write, there are 2 NULLs
+            assert table.num_rows == 2
 
         # Test BLOOMFILTER
         table = ds.to_table(filter="bloomfilter == 7")
@@ -256,6 +261,10 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
         # regardless of which version handles the seed-based index update.
         table = ds.to_table(filter="zonemap IS NULL")
         assert table.num_rows >= 1
+
+    def skip_downgrade(self, version: str) -> bool:
+        # In 0.X the zonemap index did not properly handle NULL in filters
+        return version.startswith("0.")
 
 
 @compat_test(min_version="0.36.0")

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -274,6 +274,10 @@ pub struct SargableQueryParser {
     index_name: String,
     index_type: String,
     needs_recheck: bool,
+    /// Whether IS NULL queries need post-filter rechecking. May be false even
+    /// when `needs_recheck` is true for indexes that track exact null positions
+    /// (e.g. zone maps with a null bitmap).
+    is_null_needs_recheck: bool,
     supports_like_prefix: bool,
 }
 
@@ -283,6 +287,7 @@ impl SargableQueryParser {
             index_name,
             index_type,
             needs_recheck,
+            is_null_needs_recheck: needs_recheck,
             supports_like_prefix: true,
         }
     }
@@ -292,6 +297,14 @@ impl SargableQueryParser {
     /// ordinary filtering instead of failing at search time.
     pub fn without_like_prefix(mut self) -> Self {
         self.supports_like_prefix = false;
+        self
+    }
+
+    /// Mark IS NULL as exact so that IS NOT NULL can be served by the index
+    /// without a post-filter. Use this when the index tracks null row addresses
+    /// precisely (e.g. a zone map with a null bitmap).
+    pub fn with_exact_null_tracking(mut self) -> Self {
+        self.is_null_needs_recheck = false;
         self
     }
 }
@@ -362,7 +375,7 @@ impl ScalarQueryParser for SargableQueryParser {
             self.index_name.clone(),
             self.index_type.clone(),
             Arc::new(SargableQuery::IsNull()),
-            self.needs_recheck,
+            self.is_null_needs_recheck,
         ))
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -742,10 +742,15 @@ impl ScalarIndex for ZoneMapIndex {
         builder.options.rows_per_zone = self.rows_per_zone;
         builder.maps = updated_zones;
         builder.null_rows = merged_null_rows;
+        let has_null_bitmap = builder.null_rows.is_some();
         let files = builder.write_index(dest_store).await?;
 
         Ok(CreatedIndex {
-            index_details: make_zone_map_index_details(self.rows_per_zone, self.use_seeds),
+            index_details: make_zone_map_index_details(
+                self.rows_per_zone,
+                self.use_seeds,
+                has_null_bitmap,
+            ),
             index_version: ZONEMAP_INDEX_VERSION,
             files,
         })
@@ -823,10 +828,15 @@ impl ZoneMapIndex {
         )?;
         builder.maps = new_zones;
         builder.null_rows = merged_null_rows;
+        let has_null_bitmap = builder.null_rows.is_some();
         let files = builder.write_index(dest_store).await?;
 
         Ok(Some(CreatedIndex {
-            index_details: make_zone_map_index_details(self.rows_per_zone, self.use_seeds),
+            index_details: make_zone_map_index_details(
+                self.rows_per_zone,
+                self.use_seeds,
+                has_null_bitmap,
+            ),
             index_version: ZONEMAP_INDEX_VERSION,
             files,
         }))
@@ -889,10 +899,11 @@ pub async fn merge_zonemap_indices(
     if !any_missing_bitmap {
         builder.null_rows = Some(merged_null_rows);
     }
+    let has_null_bitmap = builder.null_rows.is_some();
     let files = builder.write_index(dest_store).await?;
 
     Ok(CreatedIndex {
-        index_details: make_zone_map_index_details(rows_per_zone, use_seeds),
+        index_details: make_zone_map_index_details(rows_per_zone, use_seeds, has_null_bitmap),
         index_version: ZONEMAP_INDEX_VERSION,
         files,
     })
@@ -1172,11 +1183,15 @@ impl ZoneProcessor for ZoneMapProcessor {
     }
 }
 
-fn make_zone_map_index_details(rows_per_zone: u64, use_seeds: bool) -> prost_types::Any {
+fn make_zone_map_index_details(
+    rows_per_zone: u64,
+    use_seeds: bool,
+    has_null_bitmap: bool,
+) -> prost_types::Any {
     prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails {
         rows_per_zone: Some(rows_per_zone),
         use_seeds: Some(use_seeds),
-        has_null_bitmap: Some(true),
+        has_null_bitmap: Some(has_null_bitmap),
     })
     .unwrap()
 }
@@ -1282,8 +1297,10 @@ impl BasicTrainer for ZoneMapIndexPlugin {
         let rows_per_zone = request.params.rows_per_zone;
         let use_seeds = request.params.use_seeds.unwrap_or(false);
         let files = Self::train_zonemap_index(data, index_store, Some(request.params)).await?;
+        // Training a new index will always populate the null bitmap
+        let has_null_bitmap = true;
         Ok(CreatedIndex {
-            index_details: make_zone_map_index_details(rows_per_zone, use_seeds),
+            index_details: make_zone_map_index_details(rows_per_zone, use_seeds, has_null_bitmap),
             index_version: ZONEMAP_INDEX_VERSION,
             files,
         })
@@ -1514,12 +1531,16 @@ impl ZoneMapSeedWriter {
                     e
                 ))
             })?;
-            let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes.as_slice()).map_err(|e| {
-                lance_core::Error::invalid_input(format!(
-                    "failed to deserialize seed null bitmap: {}",
-                    e
-                ))
-            })?;
+            let bitmap = if bitmap_bytes.is_empty() {
+                RoaringBitmap::default()
+            } else {
+                RoaringBitmap::deserialize_from(bitmap_bytes.as_slice()).map_err(|e| {
+                    lance_core::Error::invalid_input(format!(
+                        "failed to deserialize seed null bitmap: {}",
+                        e
+                    ))
+                })?
+            };
             Some(bitmap)
         } else {
             None
@@ -1656,8 +1677,8 @@ impl IndexSeedWriter for ZoneMapSeedWriter {
 
         // Embed null bitmap in schema metadata so deserialize_seed can reconstruct null_rows.
         let null_offsets = std::mem::take(&mut self.null_offsets);
-        let batch = if null_offsets.is_empty() {
-            batch
+        let bitmap_bytes = if null_offsets.is_empty() {
+            Vec::default()
         } else {
             let mut bitmap_bytes = Vec::with_capacity(null_offsets.serialized_size());
             null_offsets
@@ -1668,13 +1689,14 @@ impl IndexSeedWriter for ZoneMapSeedWriter {
                         e
                     ))
                 })?;
-            let mut schema = batch.schema().as_ref().clone();
-            schema.metadata.insert(
-                SEED_NULL_BITMAP_META_KEY.to_string(),
-                hex_encode(&bitmap_bytes),
-            );
-            RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec())?
+            bitmap_bytes
         };
+        let mut schema = batch.schema().as_ref().clone();
+        schema.metadata.insert(
+            SEED_NULL_BITMAP_META_KEY.to_string(),
+            hex_encode(&bitmap_bytes),
+        );
+        let batch = RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec())?;
 
         // Serialize to Arrow IPC
         let mut buf = Cursor::new(Vec::new());
@@ -1716,6 +1738,9 @@ fn hex_encode(data: &[u8]) -> String {
 }
 
 fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
+    if s.is_empty() {
+        return Ok(Vec::default());
+    }
     if !s.len().is_multiple_of(2) {
         return Err(format!("odd hex length: {}", s.len()));
     }
@@ -3686,8 +3711,8 @@ mod tests {
             ZoneMapSeedWriter::deserialize_seed(42, &bytes, rows_per_zone).unwrap();
         assert_eq!(zones.len(), 3, "expected 3 zones");
 
-        // No nulls in the input, so no null bitmap
-        assert!(null_bitmap.is_none(), "no nulls → no null bitmap");
+        // No nulls in the input, so null bitmap is empty
+        assert_eq!(null_bitmap, Some(RoaringBitmap::default()));
 
         // Zone 0: values 0..4 -> min=0, max=3
         assert_eq!(zones[0].bound.fragment_id, 42);

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -53,6 +53,7 @@ const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 const ZONEMAP_FILENAME: &str = "zonemap.lance";
 const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
 const NULL_BITMAP_META_KEY: &str = "null_bitmap";
+const SEED_NULL_BITMAP_META_KEY: &str = "seed_null_bitmap";
 const ZONEMAP_INDEX_VERSION: u32 = 0;
 
 /// Basic stats about zonemap index
@@ -782,13 +783,37 @@ impl ZoneMapIndex {
         dest_store: &dyn IndexStore,
     ) -> Result<Option<CreatedIndex>> {
         let mut new_zones = self.zones.clone();
+        let mut merged_null_rows = self.null_rows.clone();
+        let mut any_missing_bitmap = self.null_rows.is_none();
+
         for seed in seeds {
-            let mut zones = ZoneMapSeedWriter::deserialize_seed(
+            let (mut zones, seed_null_bitmap) = ZoneMapSeedWriter::deserialize_seed(
                 seed.fragment_id,
                 &seed.bytes,
                 self.rows_per_zone,
             )?;
             new_zones.append(&mut zones);
+
+            if !any_missing_bitmap {
+                match seed_null_bitmap {
+                    Some(bitmap) => {
+                        let frag_id = u32::try_from(seed.fragment_id).map_err(|_| {
+                            Error::invalid_input(format!(
+                                "fragment_id {} exceeds u32::MAX",
+                                seed.fragment_id
+                            ))
+                        })?;
+                        merged_null_rows
+                            .as_mut()
+                            .unwrap()
+                            .insert_bitmap(frag_id, bitmap);
+                    }
+                    None => {
+                        any_missing_bitmap = true;
+                        merged_null_rows = None;
+                    }
+                }
+            }
         }
         new_zones.sort_by_key(|z| (z.bound.fragment_id, z.bound.start));
 
@@ -797,6 +822,7 @@ impl ZoneMapIndex {
             self.data_type.clone(),
         )?;
         builder.maps = new_zones;
+        builder.null_rows = merged_null_rows;
         let files = builder.write_index(dest_store).await?;
 
         Ok(Some(CreatedIndex {
@@ -1394,6 +1420,8 @@ pub struct ZoneMapSeedWriter {
     processor: ZoneMapProcessor,
     rows_in_current_zone: u64,
     next_zone_start: u64,
+    /// Null row offsets within this fragment (sequential, 0-indexed).
+    null_offsets: RoaringBitmap,
 }
 
 impl ZoneMapSeedWriter {
@@ -1417,6 +1445,7 @@ impl ZoneMapSeedWriter {
             processor,
             rows_in_current_zone: 0,
             next_zone_start: 0,
+            null_offsets: RoaringBitmap::new(),
         })
     }
 
@@ -1459,15 +1488,16 @@ impl ZoneMapSeedWriter {
         Ok(arrow_array::RecordBatch::try_new(schema, columns)?)
     }
 
-    /// Deserialize zone map seed bytes (Arrow IPC) into zone statistics.
+    /// Deserialize zone map seed bytes (Arrow IPC) into zone statistics and a null bitmap.
     ///
-    /// Returns a list of `ZoneMapStatistics` with bounds reconstructed from
-    /// the sequential layout (zone `i` starts at `i * rows_per_zone`).
+    /// Returns zone statistics (bounds reconstructed from sequential fragment layout) and an
+    /// optional `RoaringBitmap` of null row offsets within the fragment. The bitmap is absent
+    /// for seeds written by older code that did not track null positions.
     pub(crate) fn deserialize_seed(
         fragment_id: u64,
         bytes: &bytes::Bytes,
         rows_per_zone: u64,
-    ) -> Result<Vec<ZoneMapStatistics>> {
+    ) -> Result<(Vec<ZoneMapStatistics>, Option<RoaringBitmap>)> {
         use arrow_ipc::reader::FileReader;
         use std::io::Cursor;
 
@@ -1475,6 +1505,25 @@ impl ZoneMapSeedWriter {
         let mut reader = FileReader::try_new(cursor, None).map_err(|e| {
             lance_core::Error::invalid_input(format!("failed to read zone map seed IPC: {}", e))
         })?;
+
+        let null_bitmap = if let Some(hex) = reader.schema().metadata.get(SEED_NULL_BITMAP_META_KEY)
+        {
+            let bitmap_bytes = hex_decode(hex).map_err(|e| {
+                lance_core::Error::invalid_input(format!(
+                    "failed to decode seed null bitmap hex: {}",
+                    e
+                ))
+            })?;
+            let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes.as_slice()).map_err(|e| {
+                lance_core::Error::invalid_input(format!(
+                    "failed to deserialize seed null bitmap: {}",
+                    e
+                ))
+            })?;
+            Some(bitmap)
+        } else {
+            None
+        };
 
         let batch = match reader.next() {
             Some(Ok(batch)) => batch,
@@ -1484,7 +1533,7 @@ impl ZoneMapSeedWriter {
                     e
                 )));
             }
-            None => return Ok(Vec::new()),
+            None => return Ok((Vec::new(), null_bitmap)),
         };
 
         let min_col = batch
@@ -1535,7 +1584,7 @@ impl ZoneMapSeedWriter {
                 },
             });
         }
-        Ok(zones)
+        Ok((zones, null_bitmap))
     }
 }
 
@@ -1552,6 +1601,16 @@ impl IndexSeedWriter for ZoneMapSeedWriter {
             let chunk_len = ((values.len() as u64 - offset as u64).min(remaining_in_zone)) as usize;
             let chunk = values.slice(offset, chunk_len);
             self.processor.process_chunk(&chunk)?;
+
+            if chunk.null_count() > 0 {
+                let base_offset = (self.next_zone_start + self.rows_in_current_zone) as u32;
+                for i in 0..chunk_len {
+                    if chunk.is_null(i) {
+                        self.null_offsets.insert(base_offset + i as u32);
+                    }
+                }
+            }
+
             self.rows_in_current_zone += chunk_len as u64;
             offset += chunk_len;
 
@@ -1595,6 +1654,28 @@ impl IndexSeedWriter for ZoneMapSeedWriter {
 
         let batch = Self::seed_batch_from_zones(&self.completed_zones, &self.data_type)?;
 
+        // Embed null bitmap in schema metadata so deserialize_seed can reconstruct null_rows.
+        let null_offsets = std::mem::take(&mut self.null_offsets);
+        let batch = if null_offsets.is_empty() {
+            batch
+        } else {
+            let mut bitmap_bytes = Vec::with_capacity(null_offsets.serialized_size());
+            null_offsets
+                .serialize_into(&mut bitmap_bytes)
+                .map_err(|e| {
+                    lance_core::Error::invalid_input(format!(
+                        "failed to serialize seed null bitmap: {}",
+                        e
+                    ))
+                })?;
+            let mut schema = batch.schema().as_ref().clone();
+            schema.metadata.insert(
+                SEED_NULL_BITMAP_META_KEY.to_string(),
+                hex_encode(&bitmap_bytes),
+            );
+            RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec())?
+        };
+
         // Serialize to Arrow IPC
         let mut buf = Cursor::new(Vec::new());
         {
@@ -1628,6 +1709,22 @@ impl IndexSeedWriter for ZoneMapSeedWriter {
     fn schema_metadata_value(&self, buf_index: u32) -> String {
         format!("{}:{}", buf_index, self.rows_per_zone)
     }
+}
+
+fn hex_encode(data: &[u8]) -> String {
+    data.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
+    if !s.len().is_multiple_of(2) {
+        return Err(format!("odd hex length: {}", s.len()));
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| format!("invalid hex at {}: {}", i, e))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -3585,8 +3682,12 @@ mod tests {
         assert_eq!(meta_val, "3:4");
 
         // Deserialize and verify
-        let zones = ZoneMapSeedWriter::deserialize_seed(42, &bytes, rows_per_zone).unwrap();
+        let (zones, null_bitmap) =
+            ZoneMapSeedWriter::deserialize_seed(42, &bytes, rows_per_zone).unwrap();
         assert_eq!(zones.len(), 3, "expected 3 zones");
+
+        // No nulls in the input, so no null bitmap
+        assert!(null_bitmap.is_none(), "no nulls → no null bitmap");
 
         // Zone 0: values 0..4 -> min=0, max=3
         assert_eq!(zones[0].bound.fragment_id, 42);
@@ -3630,7 +3731,8 @@ mod tests {
         writer.observe_batch(&batch).unwrap();
 
         let bytes = writer.finish().unwrap().expect("should produce bytes");
-        let zones = ZoneMapSeedWriter::deserialize_seed(1, &bytes, rows_per_zone).unwrap();
+        let (zones, _null_bitmap) =
+            ZoneMapSeedWriter::deserialize_seed(1, &bytes, rows_per_zone).unwrap();
         assert_eq!(
             zones.len(),
             3,
@@ -3659,6 +3761,401 @@ mod tests {
         let mut writer = ZoneMapSeedWriter::new("col", 8, DataType::Int32).unwrap();
         let result = writer.finish().unwrap();
         assert!(result.is_none(), "empty fragment should return None");
+    }
+
+    /// Seeds produced for fragments that contain null values must carry a null
+    /// bitmap so that `try_update_with_seeds` can reconstruct `null_rows` without
+    /// rescanning data.
+    #[tokio::test]
+    async fn test_seed_null_bitmap_round_trip() {
+        use crate::scalar::seed::IndexSeedWriter;
+        use crate::scalar::zonemap::ZoneMapSeedWriter;
+        use arrow_array::Int32Array;
+        use lance_select::RowSetOps;
+
+        // rows_per_zone = 4, 10 rows: nulls at positions 1, 3, 5, 9
+        //   zone 0: rows 0-3 → nulls at 1, 3
+        //   zone 1: rows 4-7 → null at 5
+        //   zone 2: rows 8-9 → null at 9
+        let rows_per_zone = 4u64;
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(0),
+            None, // offset 1
+            Some(2),
+            None, // offset 3
+            Some(4),
+            None, // offset 5
+            Some(6),
+            Some(7),
+            Some(8),
+            None, // offset 9
+        ]));
+
+        let mut writer = ZoneMapSeedWriter::new("col", rows_per_zone, DataType::Int32).unwrap();
+        writer.observe_batch(&values).unwrap();
+        let bytes = writer.finish().unwrap().expect("should produce bytes");
+
+        let (zones, null_bitmap) =
+            ZoneMapSeedWriter::deserialize_seed(7, &bytes, rows_per_zone).unwrap();
+        assert_eq!(zones.len(), 3);
+        assert_eq!(zones[0].null_count, 2);
+        assert_eq!(zones[1].null_count, 1);
+        assert_eq!(zones[2].null_count, 1);
+
+        let bitmap = null_bitmap.expect("null bitmap must be present");
+        assert!(bitmap.contains(1), "offset 1 must be in bitmap");
+        assert!(bitmap.contains(3), "offset 3 must be in bitmap");
+        assert!(bitmap.contains(5), "offset 5 must be in bitmap");
+        assert!(bitmap.contains(9), "offset 9 must be in bitmap");
+        assert_eq!(bitmap.len(), 4, "exactly 4 null positions");
+
+        // Reconstruct a RowAddrTreeMap as try_update_with_seeds would do.
+        let mut null_rows = RowAddrTreeMap::new();
+        null_rows.insert_bitmap(7, bitmap);
+        // Verify the row addresses are (fragment 7 << 32 | offset).
+        let frag7 = 7u64 << 32;
+        assert!(null_rows.contains(frag7 | 1));
+        assert!(null_rows.contains(frag7 | 3));
+        assert!(null_rows.contains(frag7 | 5));
+        assert!(null_rows.contains(frag7 | 9));
+        assert!(!null_rows.contains(frag7));
+    }
+
+    /// After updating a zone map index via seeds from a fragment that contains
+    /// nulls, IS NULL must return an exact result (not a zone-scan approximation).
+    #[tokio::test]
+    async fn test_update_with_seeds_propagates_null_bitmap() {
+        use crate::scalar::seed::{FragmentSeed, IndexSeedWriter};
+        use crate::scalar::zonemap::{ZoneMapIndexBuilder, ZoneMapSeedWriter};
+        use arrow_array::Int32Array;
+        use lance_select::RowSetOps;
+
+        // Build an initial zone map index with one fragment that has nulls at rows 0 and 2.
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Initial training: fragment 0, rows 0-3, nulls at 0 and 2.
+        let rows_per_zone = 4u64;
+        let initial_values: ArrayRef = Arc::new(Int32Array::from(vec![
+            None, // frag 0, row 0
+            Some(1),
+            None, // frag 0, row 2
+            Some(3),
+        ]));
+        let mut builder = ZoneMapIndexBuilder::try_new(
+            ZoneMapIndexBuilderParams::new(rows_per_zone),
+            DataType::Int32,
+        )
+        .unwrap();
+        let row_addrs: ArrayRef = Arc::new(UInt64Array::from(vec![0u64, 1, 2, 3]));
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            Field::new("value", DataType::Int32, true),
+            Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![initial_values, row_addrs]).unwrap();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            futures::stream::once(async { Ok(batch) }),
+        ));
+        builder.train(stream).await.unwrap();
+        builder.write_index(store.as_ref()).await.unwrap();
+
+        // Load the trained index.
+        let index = ZoneMapIndex::load(store.clone(), None, &LanceCache::no_cache(), true)
+            .await
+            .unwrap();
+        assert!(
+            index.null_rows.is_some(),
+            "initial index must have null bitmap"
+        );
+
+        // Build a seed for fragment 1: rows 0-3, null at row 1.
+        let seed_values: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(10),
+            None, // frag 1, row 1
+            Some(12),
+            Some(13),
+        ]));
+        let mut seed_writer =
+            ZoneMapSeedWriter::new("value", rows_per_zone, DataType::Int32).unwrap();
+        seed_writer.observe_batch(&seed_values).unwrap();
+        let seed_bytes = seed_writer
+            .finish()
+            .unwrap()
+            .expect("seed must produce bytes");
+
+        let seed = FragmentSeed {
+            fragment_id: 1,
+            bytes: seed_bytes,
+            metadata_value: format!("0:{}", rows_per_zone),
+        };
+
+        // Update the index with the seed.
+        let dest_tmpdir = TempObjDir::default();
+        let dest_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            dest_tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        index
+            .try_update_with_seeds(&[seed], dest_store.as_ref())
+            .await
+            .unwrap()
+            .expect("update must produce a result");
+
+        let updated_index = ZoneMapIndex::load(dest_store, None, &LanceCache::no_cache(), true)
+            .await
+            .unwrap();
+
+        // The updated index must have a null bitmap covering both fragments.
+        let null_rows = updated_index
+            .null_rows
+            .as_ref()
+            .expect("updated index must have null bitmap");
+
+        // Fragment 0: nulls at offsets 0 and 2
+        assert!(null_rows.contains(0u64), "frag 0 row 0 must be null");
+        assert!(null_rows.contains(2u64), "frag 0 row 2 must be null");
+        assert!(!null_rows.contains(1u64), "frag 0 row 1 must not be null");
+
+        // Fragment 1: null at offset 1
+        let frag1 = 1u64 << 32;
+        assert!(null_rows.contains(frag1 | 1), "frag 1 row 1 must be null");
+        assert!(!null_rows.contains(frag1), "frag 1 row 0 must not be null");
+
+        // IS NULL must return exact results (not a zone-scan approximation).
+        let result = updated_index
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(result.is_exact(), "IS NULL after seed update must be exact");
+    }
+
+    /// A legacy index (null_rows = None) updated with a seed must still have
+    /// null_rows = None in the result.  The seed cannot retroactively supply null
+    /// positions for the rows already in the old index, so the updated index must
+    /// stay conservative and fall back to zone-scan for IS NULL.
+    #[tokio::test]
+    async fn test_update_with_seeds_legacy_index_keeps_null_rows_none() {
+        use crate::scalar::seed::{FragmentSeed, IndexSeedWriter};
+        use crate::scalar::zonemap::{ZoneMapIndex, ZoneMapSeedWriter};
+        use arrow_array::{Int32Array, UInt32Array};
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Build a legacy index (fragment 0, null_rows = None).
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(0i32)])) as _,
+                Arc::new(Int32Array::from(vec![Some(9i32)])) as _,
+                Arc::new(UInt32Array::from(vec![2u32])) as _, // 2 nulls, positions unknown
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![10u64])) as _,
+            ],
+        )
+        .unwrap();
+        let cache = LanceCache::no_cache();
+        let legacy_index = Arc::new(
+            ZoneMapIndex::try_from_serialized(
+                batch,
+                store.clone(),
+                None,
+                &cache,
+                10,
+                None, // legacy: null positions unknown
+                true,
+            )
+            .unwrap(),
+        );
+        assert!(legacy_index.null_rows.is_none());
+
+        // Build a seed for fragment 1 with known null positions.
+        let rows_per_zone = 10u64;
+        let seed_values: ArrayRef = Arc::new(Int32Array::from(vec![
+            None, // frag 1, row 0
+            Some(1),
+        ]));
+        let mut seed_writer =
+            ZoneMapSeedWriter::new("value", rows_per_zone, DataType::Int32).unwrap();
+        seed_writer.observe_batch(&seed_values).unwrap();
+        let seed_bytes = seed_writer
+            .finish()
+            .unwrap()
+            .expect("seed must produce bytes");
+
+        let dest_tmpdir = TempObjDir::default();
+        let dest_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            dest_tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        legacy_index
+            .try_update_with_seeds(
+                &[FragmentSeed {
+                    fragment_id: 1,
+                    bytes: seed_bytes,
+                    metadata_value: format!("0:{}", rows_per_zone),
+                }],
+                dest_store.as_ref(),
+            )
+            .await
+            .unwrap()
+            .expect("update must produce a result");
+
+        let updated = ZoneMapIndex::load(dest_store, None, &LanceCache::no_cache(), true)
+            .await
+            .unwrap();
+
+        assert!(
+            updated.null_rows.is_none(),
+            "updating a legacy index must not fabricate a null bitmap: \
+             the old fragment's null positions were never tracked"
+        );
+
+        let result = updated
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_exact(),
+            "IS NULL on an index derived from a legacy source must use zone scan, not exact lookup"
+        );
+    }
+
+    /// Merging a modern index (null_rows = Some) with a legacy index (null_rows = None)
+    /// must produce a merged index with null_rows = None.  Returning the modern
+    /// fragment's bitmap as-is would be a false negative for the legacy fragment.
+    #[tokio::test]
+    async fn test_merge_modern_and_legacy_index_drops_null_bitmap() {
+        use arrow_array::{Int32Array, UInt32Array};
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let cache = LanceCache::no_cache();
+
+        // Modern index: fragment 0, null_rows = Some(bitmap with 1 known null).
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+        ]));
+        let modern_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1i32)])) as _,
+                Arc::new(Int32Array::from(vec![Some(5i32)])) as _,
+                Arc::new(UInt32Array::from(vec![1u32])) as _,
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![10u64])) as _,
+            ],
+        )
+        .unwrap();
+        let mut modern_null_rows = RowAddrTreeMap::new();
+        modern_null_rows.insert(2u64); // frag 0, row 2
+        let modern_index = Arc::new(
+            ZoneMapIndex::try_from_serialized(
+                modern_batch,
+                store.clone(),
+                None,
+                &cache,
+                10,
+                Some(modern_null_rows),
+                false,
+            )
+            .unwrap(),
+        );
+
+        // Legacy index: fragment 1, null_rows = None.
+        let legacy_batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(10i32)])) as _,
+                Arc::new(Int32Array::from(vec![Some(20i32)])) as _,
+                Arc::new(UInt32Array::from(vec![3u32])) as _, // 3 nulls, positions unknown
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![1u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![10u64])) as _,
+            ],
+        )
+        .unwrap();
+        let legacy_index = Arc::new(
+            ZoneMapIndex::try_from_serialized(
+                legacy_batch,
+                store.clone(),
+                None,
+                &cache,
+                10,
+                None, // legacy: null positions unknown
+                false,
+            )
+            .unwrap(),
+        );
+
+        let dest_tmpdir = TempObjDir::default();
+        let dest_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            dest_tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let all_frags = RoaringBitmap::from_iter([0u32, 1]);
+        merge_zonemap_indices(
+            &[modern_index.as_ref(), legacy_index.as_ref()],
+            dest_store.as_ref(),
+            &all_frags,
+        )
+        .await
+        .unwrap();
+
+        let merged = ZoneMapIndex::load(dest_store, None, &LanceCache::no_cache(), false)
+            .await
+            .unwrap();
+
+        assert!(
+            merged.null_rows.is_none(),
+            "merging a modern index with a legacy index must drop the null bitmap: \
+             the legacy fragment's null positions are unknown"
+        );
+
+        let result = merged
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_exact(),
+            "IS NULL on a merged index with a legacy source must use zone scan, not exact lookup"
+        );
     }
 
     // ───────────────────────────── Nested type zone map tests ─────────────────────────────

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -1150,6 +1150,7 @@ fn make_zone_map_index_details(rows_per_zone: u64, use_seeds: bool) -> prost_typ
     prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails {
         rows_per_zone: Some(rows_per_zone),
         use_seeds: Some(use_seeds),
+        has_null_bitmap: Some(true),
     })
     .unwrap()
 }
@@ -1284,13 +1285,20 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
     fn new_query_parser(
         &self,
         index_name: String,
-        _index_details: &prost_types::Any,
+        index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(
-            index_name,
-            self.name().to_string(),
-            true,
-        )))
+        let has_null_bitmap = index_details
+            .to_msg::<pbold::ZoneMapIndexDetails>()
+            .ok()
+            .and_then(|d| d.has_null_bitmap)
+            .unwrap_or(false);
+        let parser = SargableQueryParser::new(index_name, self.name().to_string(), true);
+        let parser = if has_null_bitmap {
+            parser.with_exact_null_tracking()
+        } else {
+            parser
+        };
+        Some(Box::new(parser))
     }
 
     async fn load_index(

--- a/rust/lance/tests/query/primitives.rs
+++ b/rust/lance/tests/query/primitives.rs
@@ -10,7 +10,7 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use lance::Dataset;
-use lance::dataset::WriteParams;
+use lance::dataset::{InsertBuilder, WriteParams};
 use lance::dataset::optimize::{CompactionOptions, compact_files};
 
 use lance::index::DatasetIndexExt;
@@ -516,4 +516,89 @@ async fn test_filtered_scan_after_compact_with_srid() {
         "Expected 90 rows (100 written - 10 deleted) but got {}",
         results.num_rows()
     );
+}
+
+/// Verifies that a zone map index on a string column is used (ScalarIndexQuery
+/// in the plan) for both IS NULL and IS NOT NULL predicate filters.
+///
+/// IS NOT NULL must not silently fall back to a full scan when a zone map
+/// index exists — both predicates should leverage the index.
+#[tokio::test]
+async fn test_zone_map_null_index_used() {
+    // 6 non-null strings and 4 null values across 10 rows.
+    let string_values = vec![
+        Some("alpha"),
+        None,
+        Some("beta"),
+        Some("gamma"),
+        None,
+        Some("delta"),
+        None,
+        Some("epsilon"),
+        Some("zeta"),
+        None,
+    ];
+    let value_array = Arc::new(StringArray::from(string_values)) as ArrayRef;
+    let id_array = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>())) as ArrayRef;
+    let batch =
+        RecordBatch::try_from_iter(vec![("id", id_array), ("value", value_array)]).unwrap();
+
+    let mut ds = InsertBuilder::new("memory://")
+        .execute(vec![batch])
+        .await
+        .unwrap();
+
+    ds.create_index(
+        &["value"],
+        IndexType::ZoneMap,
+        None,
+        &lance_index::scalar::ScalarIndexParams::default(),
+        true,
+    )
+    .await
+    .unwrap();
+
+    // IS NULL: the zone map index must appear in the plan.
+    let plan = ds
+        .scan()
+        .filter("value IS NULL")
+        .unwrap()
+        .explain_plan(false)
+        .await
+        .unwrap();
+    assert!(
+        plan.contains("ScalarIndexQuery"),
+        "IS NULL should use zone map index, got plan:\n{}",
+        plan
+    );
+    let null_batch = ds
+        .scan()
+        .filter("value IS NULL")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(null_batch.num_rows(), 4);
+
+    // IS NOT NULL: the zone map index must also appear in the plan.
+    let plan = ds
+        .scan()
+        .filter("value IS NOT NULL")
+        .unwrap()
+        .explain_plan(false)
+        .await
+        .unwrap();
+    assert!(
+        plan.contains("ScalarIndexQuery"),
+        "IS NOT NULL should use zone map index, got plan:\n{}",
+        plan
+    );
+    let non_null_batch = ds
+        .scan()
+        .filter("value IS NOT NULL")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(non_null_batch.num_rows(), 6);
 }

--- a/rust/lance/tests/query/primitives.rs
+++ b/rust/lance/tests/query/primitives.rs
@@ -10,8 +10,8 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use lance::Dataset;
-use lance::dataset::{InsertBuilder, WriteParams};
 use lance::dataset::optimize::{CompactionOptions, compact_files};
+use lance::dataset::{InsertBuilder, WriteParams};
 
 use lance::index::DatasetIndexExt;
 use lance_datagen::{ArrayGeneratorExt, RowCount, array, gen_batch};
@@ -540,8 +540,7 @@ async fn test_zone_map_null_index_used() {
     ];
     let value_array = Arc::new(StringArray::from(string_values)) as ArrayRef;
     let id_array = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>())) as ArrayRef;
-    let batch =
-        RecordBatch::try_from_iter(vec![("id", id_array), ("value", value_array)]).unwrap();
+    let batch = RecordBatch::try_from_iter(vec![("id", id_array), ("value", value_array)]).unwrap();
 
     let mut ds = InsertBuilder::new("memory://")
         .execute(vec![batch])


### PR DESCRIPTION
We recently started tracking null bitmaps in the zone map index so we can give an exact answer to IS NULL queries.

We have a failsafe in query planning that disables `NOT <index-search>` for an inexact index since the result will most likely be a small AtLeast result which will not meaningfully speed up the query and may slow it down slightly by wasting time on an index search.

Unfortunately, we have to make this failsafe at planning time, so we haven't loaded the index yet, and so we don't know if a zonemap is new enough to handle exact nulls.

This PR adds a flag to the zone map details recording whether or not we have a null bitmap.  We then use that at planning time to determine if we need to recheck on is null queries or not.