### PR TITLE
perf(encoding): preallocate fixed-width decode buffers exactly

### DIFF
--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -885,6 +885,16 @@ pub fn try_raw_block(data: &DataBlock) -> Option<(Box<dyn BlockCompressor>, Comp
 
 pub trait MiniBlockDecompressor: std::fmt::Debug + Send + Sync {
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock>;
+
+    /// Returns the exact aggregate decoded size when it is determined solely by the value count.
+    ///
+    /// Implementations should only return `Some` when this aggregate estimate can be used by
+    /// [`DataBlockBuilder`](crate::data::DataBlockBuilder) to preallocate the decoded output
+    /// exactly. Outputs with multiple buffers or whose layout-dependent allocation cannot be
+    /// represented by one aggregate estimate should return `None`.
+    fn decoded_size_bytes(&self, _num_values: u64) -> Option<u64> {
+        None
+    }
 }
 
 pub trait FixedPerValueDecompressor: std::fmt::Debug + Send + Sync {
@@ -894,6 +904,16 @@ pub trait FixedPerValueDecompressor: std::fmt::Debug + Send + Sync {
     ///
     /// Currently (and probably long term) this must be a multiple of 8
     fn bits_per_value(&self) -> u64;
+
+    /// Returns the exact aggregate decoded size when it is determined solely by the value count.
+    ///
+    /// Implementations should only return `Some` when this aggregate estimate can be used by
+    /// [`DataBlockBuilder`](crate::data::DataBlockBuilder) to preallocate the decoded output
+    /// exactly. Outputs with multiple buffers or whose layout-dependent allocation cannot be
+    /// represented by one aggregate estimate should return `None`.
+    fn decoded_size_bytes(&self, _num_values: u64) -> Option<u64> {
+        None
+    }
 }
 
 pub trait VariablePerValueDecompressor: std::fmt::Debug + Send + Sync {

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -174,6 +174,19 @@ struct DecodeMiniBlockTask {
 }
 
 impl DecodeMiniBlockTask {
+    fn decoded_size_bytes(&self) -> Option<u64> {
+        if self.rep_decompressor.is_some() || self.def_decompressor.is_some() {
+            return None;
+        }
+        let num_values = self
+            .instructions
+            .iter()
+            .try_fold(0_u64, |total, (instruction, _)| {
+                total.checked_add(instruction.rows_to_take)
+            })?;
+        self.value_decompressor.decoded_size_bytes(num_values)
+    }
+
     fn decode_levels(
         rep_decompressor: &dyn BlockDecompressor,
         levels: LanceBuffer,
@@ -556,15 +569,15 @@ impl DecodePageTask for DecodeMiniBlockTask {
 
         let max_rep = self.def_meaning.iter().filter(|l| l.is_list()).count() as u16;
 
-        // This is probably an over-estimate but it's quick and easy to calculate
-        let estimated_size_bytes = self
-            .instructions
-            .iter()
-            .map(|(_, chunk)| chunk.data.len())
-            .sum::<usize>()
-            * 2;
-        let mut data_builder =
-            DataBlockBuilder::with_capacity_estimate(estimated_size_bytes as u64);
+        let estimated_size_bytes = self.decoded_size_bytes().unwrap_or_else(|| {
+            // Variable-width and rep/def encoded output sizes are not known before decoding.
+            self.instructions
+                .iter()
+                .map(|(_, chunk)| chunk.data.len() as u64)
+                .sum::<u64>()
+                * 2
+        });
+        let mut data_builder = DataBlockBuilder::with_capacity_estimate(estimated_size_bytes);
 
         // We need to keep track of the offset into repbuf/defbuf that we are building up
         let mut level_offset = 0;
@@ -3759,15 +3772,31 @@ struct FixedFullZipDecodeTask {
 
 impl DecodePageTask for FixedFullZipDecodeTask {
     fn decode(self: Box<Self>) -> Result<DecodedPage> {
-        // Multiply by 2 to make a stab at the size of the output buffer (which will be decompressed and thus bigger)
-        let estimated_size_bytes = self
-            .data
-            .iter()
-            .map(|task_item| task_item.data.data_size() as usize)
-            .sum::<usize>()
-            * 2;
-        let mut data_builder =
-            DataBlockBuilder::with_capacity_estimate(estimated_size_bytes as u64);
+        let estimated_size_bytes = if self.details.ctrl_word_parser.bytes_per_word() == 0 {
+            let PerValueDecompressor::Fixed(decompressor) = &self.details.value_decompressor else {
+                return Err(Error::internal(
+                    "FixedFullZipDecodeTask requires a fixed-width decompressor",
+                ));
+            };
+            decompressor
+                .decoded_size_bytes(self.num_rows as u64)
+                .unwrap_or_else(|| {
+                    self.data
+                        .iter()
+                        .map(|task_item| task_item.data.data_size())
+                        .sum::<u64>()
+                        * 2
+                })
+        } else {
+            // Rep/def levels can suppress values, so the exact output size is not known
+            // until they are decoded. Keep the existing conservative estimate.
+            self.data
+                .iter()
+                .map(|task_item| task_item.data.data_size())
+                .sum::<u64>()
+                * 2
+        };
+        let mut data_builder = DataBlockBuilder::with_capacity_estimate(estimated_size_bytes);
 
         if self.details.ctrl_word_parser.bytes_per_word() == 0 {
             // Fast path, no need to unzip because there is no rep/def
@@ -6968,16 +6997,19 @@ impl FieldEncoder for PrimitiveStructuralEncoder {
 #[allow(clippy::single_range_in_vec_init)]
 mod tests {
     use super::{
-        ChunkInstructions, DataBlock, DecodeMiniBlockTask, FixedPerValueDecompressor,
-        FixedWidthDataBlock, FixedWidthDictionaryEncoding, FullZipCacheableState,
-        FullZipDecodeDetails, FullZipReadSource, FullZipRepIndexDetails, FullZipScheduler,
-        LazyLevels, LevelCodec, LevelCursor, LevelPlan, MiniBlockChunk, MiniBlockChunkIndex,
-        MiniBlockCompressed, MiniblockChunkSize, PerValueDecompressor, PreambleAction,
-        RunEndsBuilder, RunPosition, RunStorage, StructuralPageScheduler, VariableFullZipDecoder,
-        dense_levels_from_block, validate_complex_all_null_levels,
+        ChunkInstructions, DataBlock, DecodeMiniBlockTask, DecodePageTask, FixedFullZipDecodeTask,
+        FixedPerValueDecompressor, FixedWidthDataBlock, FixedWidthDictionaryEncoding,
+        FullZipCacheableState, FullZipDecodeDetails, FullZipDecodeTaskItem, FullZipReadSource,
+        FullZipRepIndexDetails, FullZipScheduler, LazyLevels, LevelCodec, LevelCursor, LevelPlan,
+        MiniBlockChunk, MiniBlockChunkIndex, MiniBlockCompressed, MiniblockChunkSize,
+        PerValueDataBlock, PerValueDecompressor, PreambleAction, RunEndsBuilder, RunPosition,
+        RunStorage, StructuralPageScheduler, VariableFullZipDecoder, dense_levels_from_block,
+        validate_complex_all_null_levels,
     };
     use crate::buffer::LanceBuffer;
-    use crate::compression::{BlockCompressor, DefaultDecompressionStrategy};
+    use crate::compression::{
+        BlockCompressor, DefaultDecompressionStrategy, MiniBlockDecompressor,
+    };
     use crate::constants::{
         COMPRESSION_LEVEL_META_KEY, COMPRESSION_META_KEY, DICT_VALUES_COMPRESSION_LEVEL_META_KEY,
         DICT_VALUES_COMPRESSION_META_KEY, STRUCTURAL_ENCODING_META_KEY,
@@ -6985,17 +7017,23 @@ mod tests {
     };
     use crate::data::BlockInfo;
     use crate::decoder::{PageEncoding, StructuralFieldDecoder};
+    use crate::encodings::logical::primitive::fullzip::PerValueCompressor;
     use crate::encodings::logical::primitive::{
-        ChunkDrainInstructions, PrimitiveStructuralEncoder, StructuralPrimitiveFieldDecoder,
+        ChunkDrainInstructions, LoadedChunk, PrimitiveStructuralEncoder,
+        StructuralPrimitiveFieldDecoder,
     };
     use crate::encodings::physical::rle::{RleDecompressor, RleEncoder, RleRuns, RunLengthWidth};
+    use crate::encodings::physical::value::{ValueDecompressor, ValueEncoder};
     use crate::format::ProtobufUtils21;
     use crate::format::pb21;
     use crate::format::pb21::compressive_encoding::Compression;
     use crate::repdef::build_control_word_iterator;
     use crate::testing::TestEncoding;
     use crate::testing::{TestCases, check_round_trip_encoding_of_data};
-    use arrow_array::{ArrayRef, Int8Array, StringArray};
+    use arrow_array::{
+        Array, ArrayRef, FixedSizeListArray, Float32Array, Int8Array, StringArray, UInt8Array,
+        make_array,
+    };
     use arrow_buffer::ScalarBuffer;
     use arrow_schema::{DataType, Field as ArrowField};
     use std::collections::HashMap;
@@ -7065,6 +7103,312 @@ mod tests {
         assert!(
             err.to_string().contains("byte aligned"),
             "unexpected error: {err}"
+        );
+    }
+
+    fn decode_fixed_fullzip_no_levels(
+        decompressor: Arc<dyn FixedPerValueDecompressor>,
+        data: Vec<FullZipDecodeTaskItem>,
+        num_rows: usize,
+        bytes_per_value: usize,
+    ) -> DataBlock {
+        Box::new(FixedFullZipDecodeTask {
+            details: Arc::new(FullZipDecodeDetails {
+                value_decompressor: PerValueDecompressor::Fixed(decompressor),
+                def_meaning: Arc::from([]),
+                ctrl_word_parser: crate::repdef::ControlWordParser::new(0, 0),
+                max_rep: 0,
+                max_visible_def: u16::MAX,
+            }),
+            data,
+            num_rows,
+            bytes_per_value,
+        })
+        .decode()
+        .unwrap()
+        .data
+    }
+
+    #[test]
+    fn test_fixed_fullzip_decode_preallocates_exact_output_size() {
+        #[derive(Debug)]
+        struct IdentityFixedDecompressor;
+
+        impl FixedPerValueDecompressor for IdentityFixedDecompressor {
+            fn decompress(
+                &self,
+                data: FixedWidthDataBlock,
+                num_rows: u64,
+            ) -> crate::Result<DataBlock> {
+                assert_eq!(data.num_values, num_rows);
+                Ok(DataBlock::FixedWidth(data))
+            }
+
+            fn bits_per_value(&self) -> u64 {
+                32
+            }
+
+            fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+                num_values.checked_mul(4)
+            }
+        }
+
+        let make_item = |num_rows: u64| FullZipDecodeTaskItem {
+            data: PerValueDataBlock::Fixed(FixedWidthDataBlock {
+                data: LanceBuffer::from(vec![7_u8; num_rows as usize * 4]),
+                bits_per_value: 32,
+                num_values: num_rows,
+                block_info: BlockInfo::new(),
+            }),
+            rows_in_buf: num_rows,
+        };
+
+        let num_rows = 512;
+        let decoded = decode_fixed_fullzip_no_levels(
+            Arc::new(IdentityFixedDecompressor),
+            vec![make_item(128), make_item(384)],
+            num_rows,
+            4,
+        );
+        let values = decoded.as_fixed_width_ref().unwrap();
+        let expected_size = num_rows * 4;
+        assert_eq!(values.data.len(), expected_size);
+        assert_eq!(values.data.clone().into_buffer().capacity(), expected_size);
+    }
+
+    #[test]
+    fn test_fixed_fullzip_decode_falls_back_when_output_size_is_not_exact() {
+        #[derive(Debug)]
+        struct FallbackFixedDecompressor;
+
+        impl FixedPerValueDecompressor for FallbackFixedDecompressor {
+            fn decompress(
+                &self,
+                data: FixedWidthDataBlock,
+                num_rows: u64,
+            ) -> crate::Result<DataBlock> {
+                assert_eq!(data.num_values, num_rows);
+                Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+                    data: LanceBuffer::from(vec![7_u8; num_rows as usize * 4]),
+                    bits_per_value: 32,
+                    num_values: num_rows,
+                    block_info: BlockInfo::new(),
+                }))
+            }
+
+            fn bits_per_value(&self) -> u64 {
+                // This deliberately cannot be multiplied by num_rows. If FullZip treats
+                // bits_per_value as an exact decoded-size estimate, decoding will fail.
+                u64::MAX - 7
+            }
+        }
+
+        let num_rows = 2;
+        let decoded = decode_fixed_fullzip_no_levels(
+            Arc::new(FallbackFixedDecompressor),
+            vec![FullZipDecodeTaskItem {
+                data: PerValueDataBlock::Fixed(FixedWidthDataBlock {
+                    data: LanceBuffer::from(vec![0_u8; num_rows * 4]),
+                    bits_per_value: 32,
+                    num_values: num_rows as u64,
+                    block_info: BlockInfo::new(),
+                }),
+                rows_in_buf: num_rows as u64,
+            }],
+            num_rows,
+            4,
+        );
+        let values = decoded.as_fixed_width_ref().unwrap();
+        assert_eq!(values.num_values, num_rows as u64);
+        assert_eq!(values.data.len(), num_rows * 4);
+    }
+
+    #[test]
+    fn test_fixed_fullzip_real_fsl_preallocates_exact_output_size() {
+        let num_rows = 64;
+        let dimension = 32;
+        let items = Arc::new(Float32Array::from_iter_values(
+            (0..num_rows * dimension).map(|value| value as f32),
+        ));
+        let item_field = Arc::new(ArrowField::new("item", DataType::Float32, false));
+        let sample = FixedSizeListArray::new(item_field, dimension as i32, items, None);
+
+        let (data, compression) = PerValueCompressor::compress(
+            &ValueEncoder::default(),
+            DataBlock::from_array(sample.clone()),
+        )
+        .unwrap();
+        let Compression::FixedSizeList(fsl) = compression.compression.unwrap() else {
+            panic!("expected fixed-size-list compression");
+        };
+        let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
+        let expected_size = num_rows * dimension * size_of::<f32>();
+        assert_eq!(
+            FixedPerValueDecompressor::decoded_size_bytes(&decompressor, num_rows as u64),
+            Some(expected_size as u64)
+        );
+
+        let decoded = decode_fixed_fullzip_no_levels(
+            Arc::new(decompressor),
+            vec![FullZipDecodeTaskItem {
+                data,
+                rows_in_buf: num_rows as u64,
+            }],
+            num_rows,
+            dimension * size_of::<f32>(),
+        );
+        let fsl = decoded.as_fixed_size_list_ref().unwrap();
+        let values = fsl.child.as_fixed_width_ref().unwrap();
+        assert_eq!(values.data.len(), expected_size);
+        assert_eq!(values.data.clone().into_buffer().capacity(), expected_size);
+
+        let decoded_array = make_array(
+            decoded
+                .into_arrow(sample.data_type().clone(), true)
+                .unwrap(),
+        );
+        assert_eq!(decoded_array.as_ref(), &sample);
+    }
+
+    #[test]
+    fn test_fixed_fullzip_nullable_fsl_uses_fallback_end_to_end() {
+        #[derive(Debug)]
+        struct NullableFslDecompressor {
+            inner: ValueDecompressor,
+        }
+
+        impl FixedPerValueDecompressor for NullableFslDecompressor {
+            fn decompress(
+                &self,
+                data: FixedWidthDataBlock,
+                num_rows: u64,
+            ) -> crate::Result<DataBlock> {
+                FixedPerValueDecompressor::decompress(&self.inner, data, num_rows)
+            }
+
+            fn bits_per_value(&self) -> u64 {
+                // FullZip must not use this physical row width as an exact decoded-size
+                // estimate for the nullable, multi-buffer Arrow output.
+                u64::MAX - 7
+            }
+
+            fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+                FixedPerValueDecompressor::decoded_size_bytes(&self.inner, num_values)
+            }
+        }
+
+        let num_rows = 64;
+        let items = Arc::new(UInt8Array::from_iter(
+            (0..num_rows).map(|value| (value % 3 != 0).then_some(value as u8)),
+        ));
+        let item_field = Arc::new(ArrowField::new("item", DataType::UInt8, true));
+        let sample = FixedSizeListArray::new(item_field, 1, items, None);
+
+        let (data, compression) = PerValueCompressor::compress(
+            &ValueEncoder::default(),
+            DataBlock::from_array(sample.clone()),
+        )
+        .unwrap();
+        let Compression::FixedSizeList(fsl) = compression.compression.unwrap() else {
+            panic!("expected fixed-size-list compression");
+        };
+        let decompressor = NullableFslDecompressor {
+            inner: ValueDecompressor::from_fsl(fsl.as_ref()),
+        };
+        assert_eq!(
+            FixedPerValueDecompressor::decoded_size_bytes(&decompressor, num_rows as u64),
+            None
+        );
+
+        let decoded = decode_fixed_fullzip_no_levels(
+            Arc::new(decompressor),
+            vec![FullZipDecodeTaskItem {
+                data,
+                rows_in_buf: num_rows as u64,
+            }],
+            num_rows,
+            2,
+        );
+        let decoded_array = make_array(
+            decoded
+                .into_arrow(sample.data_type().clone(), true)
+                .unwrap(),
+        );
+        assert_eq!(decoded_array.as_ref(), &sample);
+    }
+
+    #[test]
+    fn test_miniblock_decode_uses_exact_fixed_width_output_size() {
+        #[derive(Debug)]
+        struct FixedWidthMiniBlockDecompressor;
+
+        impl MiniBlockDecompressor for FixedWidthMiniBlockDecompressor {
+            fn decompress(
+                &self,
+                data: Vec<LanceBuffer>,
+                num_values: u64,
+            ) -> crate::Result<DataBlock> {
+                assert_eq!(data.len(), 1);
+                Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+                    data: data.into_iter().next().unwrap(),
+                    bits_per_value: 32,
+                    num_values,
+                    block_info: BlockInfo::new(),
+                }))
+            }
+
+            fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+                num_values.checked_mul(4)
+            }
+        }
+
+        let num_rows = 512;
+        let expected_size = num_rows * 4;
+        let mut chunk_data = Vec::new();
+        chunk_data.extend_from_slice(&0_u16.to_le_bytes());
+        chunk_data.extend_from_slice(&(expected_size as u16).to_le_bytes());
+        let header_padding =
+            lance_core::utils::bit::pad_bytes::<{ super::MINIBLOCK_ALIGNMENT }>(chunk_data.len());
+        chunk_data.resize(chunk_data.len() + header_padding, 0);
+        chunk_data.resize(chunk_data.len() + expected_size as usize, 7);
+
+        let task = DecodeMiniBlockTask {
+            rep_decompressor: None,
+            def_decompressor: None,
+            value_decompressor: Arc::new(FixedWidthMiniBlockDecompressor),
+            dictionary_data: None,
+            def_meaning: Arc::from([]),
+            num_buffers: 1,
+            max_visible_level: 0,
+            instructions: vec![(
+                ChunkDrainInstructions {
+                    chunk_instructions: ChunkInstructions {
+                        chunk_idx: 0,
+                        preamble: PreambleAction::Absent,
+                        rows_to_skip: 0,
+                        rows_to_take: num_rows,
+                        take_trailer: false,
+                    },
+                    rows_to_skip: 0,
+                    rows_to_take: num_rows,
+                    preamble_action: PreambleAction::Absent,
+                },
+                LoadedChunk {
+                    byte_range: 0..chunk_data.len() as u64,
+                    data: LanceBuffer::from(chunk_data),
+                    items_in_chunk: num_rows,
+                    chunk_idx: 0,
+                },
+            )],
+            has_large_chunk: false,
+        };
+
+        let decoded = Box::new(task).decode().unwrap();
+        let values = decoded.data.as_fixed_width_ref().unwrap();
+        assert_eq!(values.data.len(), expected_size as usize);
+        assert_eq!(
+            values.data.clone().into_buffer().capacity(),
+            expected_size as usize
         );
     }
 

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -326,6 +326,12 @@ impl MiniBlockDecompressor for InlineBitpacking {
             _ => unimplemented!("Bitpacking word size must be 8, 16, 32, or 64"),
         }
     }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        num_values
+            .checked_mul(self.uncompressed_bit_width)
+            .map(|bits| bits.div_ceil(8))
+    }
 }
 
 impl BlockDecompressor for InlineBitpacking {

--- a/rust/lance-encoding/src/encodings/physical/byte_stream_split.rs
+++ b/rust/lance-encoding/src/encodings/physical/byte_stream_split.rs
@@ -267,6 +267,10 @@ impl MiniBlockDecompressor for ByteStreamSplitDecompressor {
             block_info: BlockInfo::new(),
         }))
     }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        num_values.checked_mul(self.bytes_per_value() as u64)
+    }
 }
 
 /// Determine if BSS should be used based on mode and data characteristics

--- a/rust/lance-encoding/src/encodings/physical/general.rs
+++ b/rust/lance-encoding/src/encodings/physical/general.rs
@@ -138,6 +138,10 @@ impl MiniBlockDecompressor for GeneralMiniBlockDecompressor {
 
         self.inner.decompress(data, num_values)
     }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        self.inner.decoded_size_bytes(num_values)
+    }
 }
 
 #[cfg(test)]

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -1556,6 +1556,12 @@ impl MiniBlockDecompressor for RleDecompressor {
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         self.decode_data(data, num_values, true)
     }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        num_values
+            .checked_mul(self.bits_per_value)
+            .map(|bits| bits.div_ceil(8))
+    }
 }
 
 impl BlockDecompressor for RleDecompressor {

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -610,6 +610,15 @@ impl MiniBlockDecompressor for ValueDecompressor {
         assert_eq!(lists.num_values(), num_values);
         Ok(lists)
     }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        if self.has_validity() {
+            return None;
+        }
+        num_values
+            .checked_mul(self.bits_per_value)
+            .map(|bits| bits.div_ceil(8))
+    }
 }
 
 struct FslDecompressorValidityBuilder {
@@ -737,6 +746,15 @@ impl FixedPerValueDecompressor for ValueDecompressor {
 
     fn bits_per_value(&self) -> u64 {
         self.bits_per_value
+    }
+
+    fn decoded_size_bytes(&self, num_values: u64) -> Option<u64> {
+        if self.has_validity() {
+            return None;
+        }
+        num_values
+            .checked_mul(self.bits_per_value)
+            .map(|bits| bits.div_ceil(8))
     }
 }
 
@@ -1080,6 +1098,11 @@ mod tests {
         let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
 
         let num_values = data.num_values;
+        assert_eq!(
+            FixedPerValueDecompressor::decoded_size_bytes(&decompressor, num_values),
+            None,
+            "nullable FSL output uses multiple buffers and requires the fallback estimate"
+        );
         let decompressed =
             FixedPerValueDecompressor::decompress(&decompressor, data, num_values).unwrap();
 


### PR DESCRIPTION
## Summary

- add optional exact decoded-size contracts to `MiniBlockDecompressor` and `FixedPerValueDecompressor`
- derive exact decoded sizes for fixed-width value, bitpacking, RLE, byte-stream-split, and wrapped MiniBlock decompressors
- preallocate MiniBlock and fixed FullZip output buffers exactly when one aggregate estimate represents the actual decoded Arrow layout
- keep the existing conservative allocation fallback for variable-width, rep/def, nullable fixed-size-list, and other multi-buffer or layout-dependent outputs

## Motivation

Fixed-width decoding currently estimates output capacity as roughly `compressed_bytes * 2`. This is intentionally conservative, but the resulting spare capacity is retained by Arrow buffers. For vector indexes this inflates the index-cache weight and can cause users to provision substantially more cache memory than the decoded index data requires.

The decoded size is deterministic for fixed-width data when the selected value count and output layout are known. Allocating that size up front avoids both retained spare capacity and the copy / temporary peak memory that a post-decode `shrink_to_fit` would introduce.

## Index-cache results

These measurements report the byte weight retained and accounted for by Lance's index-cache entries. They are not process RSS measurements.

The baseline binary was built from this PR's parent commit, and the patched binary was built from the PR head. Each pair loaded the same prebuilt on-disk index through the same recording cache backend, so the decode-buffer allocation behavior was the only code difference.

| Rows / dimension / IVF partitions | Index | Baseline cache weight | This change | Reduction |
| --- | --- | ---: | ---: | ---: |
| 4,096 / 32 / 4 | IVF_FLAT | 1,116,368 B | 560,928 B | 49.75% |
| 4,096 / 32 / 4 | IVF_PQ | 270,060 B | 217,268 B | 19.55% |
| 4,096 / 32 / 4 | IVF_SQ | 334,788 B | 167,412 B | 50.00% |
| 16,384 / 64 / 8 | IVF_FLAT | 8,562,082 B | 4,332,514 B | 49.40% |
| 16,384 / 64 / 8 | IVF_PQ | 1,084,070 B | 859,766 B | 20.69% |
| 16,384 / 64 / 8 | IVF_SQ | 2,331,558 B | 1,186,166 B | 49.13% |
| 4,096 / 64 / 64 | IVF_FLAT | 2,350,786 B | 1,127,010 B | 52.06% |
| 4,096 / 64 / 64 | IVF_PQ | 5,100,486 B | 4,375,286 B | 14.22% |
| 4,096 / 64 / 64 | IVF_SQ | 1,290,950 B | 335,478 B | 74.01% |
| 32,768 / 128 / 32 | IVF_FLAT | 33,957,990 B | 17,071,206 B | 49.73% |
| 32,768 / 128 / 32 | IVF_PQ | 6,086,538 B | 5,145,850 B | 15.45% |
| 32,768 / 128 / 32 | IVF_SQ | 9,082,762 B | 4,485,754 B | 50.61% |

No `shrink_to_fit` or second buffer copy is used.

## Decode performance

The existing 128 MiB fixed-size-list decode benchmark (`decode_fsl/float32_32_v2.1_nullfalse`) produced the following result:

| Version | Decode time |
| --- | ---: |
| Parent commit | 96.68 ms |
| This change | 95.33 ms |

In this benchmark run, Criterion detected no statistically significant difference between the parent commit and this change (`p = 0.15`).

## Compatibility

This does not change the on-disk format. Both new trait methods have default implementations, so existing decompressor implementations do not require changes. Decompressors return `None` when one aggregate byte count cannot exactly represent the decoded Arrow buffer layout; decoding then retains the previous conservative allocation behavior. Paths with rep/def levels also continue to use the existing fallback.

Exact-size calculations use checked arithmetic. Unsupported layouts or arithmetic overflow return `None` and retain the existing conservative allocation path.

The tests include a real non-null fixed-size-list FullZip path that verifies `capacity == len`, plus a real nullable fixed-size-list FullZip round trip that verifies the multi-buffer output takes the conservative fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lance-encoding --all-targets -- -D warnings`
- `cargo test -p lance-encoding --lib -- --skip test_sparse_large_string_list`: 526 passed, 5 ignored, 2 filtered
- `cargo test -p lance-encoding test_sparse_large_string_list -- --nocapture`: 2 passed
- focused exact/fallback/real FSL tests: 4 passed
- vector index-cache A/B measurements: 12 IVF_FLAT / IVF_PQ / IVF_SQ scenarios completed