### PR TITLE
feat(fts): add composable scorer core for multimatch

### DIFF
--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -3,6 +3,7 @@
 
 pub mod builder;
 mod cache_codec;
+mod compound;
 mod documents;
 mod encoding;
 mod impact;
@@ -21,6 +22,7 @@ use std::sync::Arc;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
+pub use compound::compound_search;
 use datafusion::execution::SendableRecordBatchStream;
 pub use index::*;
 use lance_core::{Result, cache::LanceCache};

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -503,11 +503,12 @@ fn compare_scored_rows<K: Ord>(left: &ScoredRow<K>, right: &ScoredRow<K>) -> Ord
         .then_with(|| left.row_id.cmp(&right.row_id))
 }
 
-fn is_better<K: Ord>(candidate: ScoredRow<K>, current: ScoredRow<K>) -> bool {
-    compare_scored_rows(&candidate, &current) == Ordering::Less
-}
-
 /// The sole owner of top-k state for a compound scorer tree.
+///
+/// The heap retains every candidate tied at the kth score. Some document keys
+/// are only resolvable to row ids asynchronously, so equal-score candidates
+/// cannot be trimmed by their temporary keys without changing the final
+/// row-id tie-break.
 pub(super) struct TopKCollector<K = u64> {
     limit: usize,
     heap: BinaryHeap<HeapRow<K>>,
@@ -536,18 +537,47 @@ impl<K: Copy + Ord> TopKCollector<K> {
         }
         if self.heap.len() < self.limit {
             self.heap.push(HeapRow(row));
-        } else if self
-            .heap
-            .peek()
-            .is_some_and(|worst| is_better(row, worst.0))
-        {
-            self.heap.pop();
-            self.heap.push(HeapRow(row));
+        } else {
+            let floor = self
+                .heap
+                .peek()
+                .expect("a full top-k heap is non-empty")
+                .0
+                .score;
+            match row.score.total_cmp(&floor) {
+                Ordering::Less => {}
+                Ordering::Equal => self.heap.push(HeapRow(row)),
+                Ordering::Greater => {
+                    self.heap.push(HeapRow(row));
+                    self.prune_obsolete_score_floors();
+                }
+            }
         }
-        if self.heap.len() == self.limit
+        if self.heap.len() >= self.limit
             && let Some(worst) = self.heap.peek()
         {
             self.competitive_score.raise(worst.0.score);
+        }
+    }
+
+    fn prune_obsolete_score_floors(&mut self) {
+        while self.heap.len() > self.limit {
+            let floor = self
+                .heap
+                .peek()
+                .expect("a non-empty top-k heap has a score floor")
+                .0
+                .score;
+            let floor_count = self
+                .heap
+                .iter()
+                .filter(|row| row.0.score.total_cmp(&floor) == Ordering::Equal)
+                .count();
+            if self.heap.len() - floor_count < self.limit {
+                break;
+            }
+            self.heap
+                .retain(|row| row.0.score.total_cmp(&floor) != Ordering::Equal);
         }
     }
 
@@ -608,9 +638,17 @@ impl<K: Copy + Ord> TopKCollector<K> {
         Ok(())
     }
 
-    pub(super) fn into_rows(self) -> Vec<ScoredRow<K>> {
+    fn into_score_floor_rows(self) -> Vec<ScoredRow<K>> {
         let mut rows = self.heap.into_iter().map(|row| row.0).collect::<Vec<_>>();
         rows.sort_unstable_by(compare_scored_rows);
+        rows
+    }
+
+    #[cfg(test)]
+    fn into_rows(self) -> Vec<ScoredRow<K>> {
+        let limit = self.limit;
+        let mut rows = self.into_score_floor_rows();
+        rows.truncate(limit);
         rows
     }
 }
@@ -1259,6 +1297,7 @@ fn collect_loaded_partitions(
 async fn resolve_compound_rows(
     indices: &[Arc<InvertedIndex>],
     rows: Vec<ScoredRow<CompoundDocument>>,
+    limit: usize,
 ) -> Result<Vec<ScoredRow>> {
     let mut resolved = vec![None; rows.len()];
     let mut modern = BTreeMap::<(usize, usize), Vec<(usize, DocId)>>::new();
@@ -1308,6 +1347,7 @@ async fn resolve_compound_rows(
         })
         .collect::<Result<Vec<_>>>()?;
     rows.sort_unstable_by(compare_scored_rows);
+    rows.truncate(limit);
     Ok(rows)
 }
 
@@ -1315,8 +1355,9 @@ async fn resolve_compound_rows(
 ///
 /// The caller must provide all committed index segments for the column and a
 /// ready prefilter. One collector owns the global top-k heap and propagates its
-/// score floor through every partition-local scorer tree. Only its final
-/// bounded candidates are resolved to row addresses and returned.
+/// score floor through every partition-local scorer tree. Its score-bounded
+/// candidates, including every kth-score tie, are resolved to row addresses
+/// before the final row-id tie-break is applied.
 pub async fn compound_search(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
@@ -1372,7 +1413,7 @@ pub async fn compound_search(
         .await?;
     }
 
-    let rows = resolve_compound_rows(indices, collector.into_rows()).await?;
+    let rows = resolve_compound_rows(indices, collector.into_score_floor_rows(), limit).await?;
     Ok(rows.into_iter().map(|row| (row.row_id, row.score)).unzip())
 }
 

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -1,0 +1,1492 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BinaryHeap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+use futures::{StreamExt, TryStreamExt, stream};
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu};
+use lance_core::{Error, Result};
+use lance_select::RowAddrMask;
+use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
+
+use super::{
+    InvertedIndex, build_global_bm25_scorer,
+    document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer},
+    documents::{DocId, DocLengths, DocVisibility},
+    index::{DocSet, InvertedPartition},
+    query::{FtsQuery, FtsSearchParams, MatchQuery, Operator, Tokens, collect_query_tokens},
+    scorer::MemBM25Scorer,
+    tokenizer::document_tokenizer::TextTokenizer,
+    wand::{
+        FLAT_SEARCH_PERCENT_THRESHOLD, LegacyWandDocuments, ModernWandDocuments, PostingIterator,
+        WandCursor, WandDocuments,
+    },
+};
+use crate::{metrics::MetricsCollector, prefilter::PreFilter};
+
+const DEFAULT_BLOCK_SIZE: usize = 128;
+
+/// One exact FTS result in a compound collector's candidate domain.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ScoredRow<K = u64> {
+    pub row_id: K,
+    pub score: f32,
+}
+
+#[cfg(test)]
+impl ScoredRow<u64> {
+    pub(super) fn new(row_id: u64, score: f32) -> Result<Self> {
+        if !score.is_finite() {
+            return Err(Error::invalid_input(format!(
+                "FTS score for row_id={row_id} must be finite, got {score}"
+            )));
+        }
+        Ok(Self { row_id, score })
+    }
+}
+
+/// Conservative score bounds for a document range.
+///
+/// Arithmetic widens both sides by one representable `f32` so nested
+/// operations cannot round an upper bound below an exact score.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ScoreBounds {
+    lower: f32,
+    upper: f32,
+}
+
+impl ScoreBounds {
+    const ZERO: Self = Self {
+        lower: 0.0,
+        upper: 0.0,
+    };
+    const UNBOUNDED: Self = Self {
+        lower: f32::NEG_INFINITY,
+        upper: f32::INFINITY,
+    };
+
+    #[cfg(test)]
+    fn point(score: f32) -> Result<Self> {
+        if !score.is_finite() {
+            return Err(Error::invalid_input(format!(
+                "FTS score bounds require a finite score, got {score}"
+            )));
+        }
+        Ok(Self {
+            lower: score,
+            upper: score,
+        })
+    }
+
+    fn scale_non_negative(self, factor: f32) -> Self {
+        debug_assert!(factor.is_finite() && factor >= 0.0);
+        if factor == 0.0 {
+            return Self::ZERO;
+        }
+        if !self.lower.is_finite() || !self.upper.is_finite() {
+            return Self::UNBOUNDED;
+        }
+        Self {
+            lower: next_down(self.lower * factor),
+            upper: next_up(self.upper * factor),
+        }
+    }
+}
+
+fn next_up(value: f32) -> f32 {
+    if !value.is_finite() {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits(1);
+    }
+    let bits = value.to_bits();
+    if value > 0.0 {
+        f32::from_bits(bits + 1)
+    } else {
+        f32::from_bits(bits - 1)
+    }
+}
+
+fn next_down(value: f32) -> f32 {
+    if !value.is_finite() {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits((1_u32 << 31) | 1);
+    }
+    let bits = value.to_bits();
+    if value > 0.0 {
+        f32::from_bits(bits - 1)
+    } else {
+        f32::from_bits(bits + 1)
+    }
+}
+
+fn checked_score(score: f32, context: &str) -> Result<f32> {
+    if score.is_finite() {
+        Ok(score)
+    } else {
+        Err(Error::invalid_input(format!(
+            "{context} produced a non-finite FTS score: {score}"
+        )))
+    }
+}
+
+/// Internal document-at-a-time scorer protocol for compound FTS.
+///
+/// Implementations iterate matching partition-local document ids in ascending
+/// order and expose the corresponding candidate key separately. A collector
+/// may shallow-advance independently of the exact iterator, inspect a
+/// conservative range bound, and monotonically raise the competitive score.
+/// `matches` is the optional two-phase confirmation hook: cheap approximations
+/// return a candidate from `next` / `advance` and defer expensive checks such
+/// as phrase positions until confirmation.
+pub(super) trait ComposableScorer: Send {
+    fn doc(&self) -> Option<u64>;
+    fn document_key(&self) -> Option<u64> {
+        self.doc()
+    }
+    fn next(&mut self) -> Result<Option<u64>>;
+    fn advance(&mut self, target: u64) -> Result<Option<u64>>;
+    fn cost(&self) -> usize;
+    fn score(&mut self) -> Result<f32>;
+    fn advance_shallow(&mut self, target: u64) -> Result<u64>;
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds>;
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()>;
+
+    fn matches(&mut self) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        None
+    }
+}
+
+type BoxScorer<'a> = Box<dyn ComposableScorer + 'a>;
+
+#[derive(Debug, Clone)]
+enum CompoundScorerPlan {
+    Leaf { index: usize, boost: f32 },
+    MultiMatch(Vec<Self>),
+}
+
+impl CompoundScorerPlan {
+    fn from_query(query: &FtsQuery, num_leaves: &mut usize) -> Result<Self> {
+        match query {
+            FtsQuery::Match(query) => {
+                let index = *num_leaves;
+                *num_leaves += 1;
+                Ok(Self::Leaf {
+                    index,
+                    boost: query.boost,
+                })
+            }
+            FtsQuery::MultiMatch(query) => Ok(Self::MultiMatch(
+                query
+                    .match_queries
+                    .iter()
+                    .map(|query| Self::from_query(&FtsQuery::Match(query.clone()), num_leaves))
+                    .collect::<Result<Vec<_>>>()?,
+            )),
+            _ => Err(Error::not_supported(
+                "posting-backed compound FTS currently supports MultiMatch queries only",
+            )),
+        }
+    }
+
+    fn build<'a>(&self, leaves: &mut [Option<BoxScorer<'a>>]) -> Result<BoxScorer<'a>> {
+        match self {
+            Self::Leaf { index, boost } => {
+                let leaf = leaves
+                    .get_mut(*index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "compound FTS scorer references missing leaf index {index}"
+                        ))
+                    })?;
+                Ok(Box::new(ScaleScorer::try_new(leaf, *boost)?))
+            }
+            Self::MultiMatch(children) => Ok(Box::new(DisjunctionScorer::try_new(
+                children
+                    .iter()
+                    .map(|child| child.build(leaves))
+                    .collect::<Result<Vec<_>>>()?,
+            )?)),
+        }
+    }
+}
+
+impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
+    fn doc(&self) -> Option<u64> {
+        self.doc()
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.document_key()
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        self.next()
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        self.advance(target)
+    }
+
+    fn cost(&self) -> usize {
+        self.cost()
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        self.current_score()
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        self.advance_shallow(target)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        Ok(ScoreBounds {
+            lower: 0.0,
+            upper: self.score_upper_bound(up_to)?,
+        })
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        self.set_min_competitive_score(min_score)
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg(test)]
+struct ShallowRange {
+    target: u64,
+    up_to: u64,
+    start: usize,
+    end: usize,
+}
+
+/// Exact in-memory scorer used to unit-test compound nodes and the collector.
+#[cfg(test)]
+struct MaterializedScorer {
+    rows: Vec<ScoredRow>,
+    block_size: usize,
+    index: Option<usize>,
+    shallow: Option<ShallowRange>,
+    min_competitive_score: f32,
+}
+
+#[cfg(test)]
+impl MaterializedScorer {
+    fn try_new(mut rows: Vec<ScoredRow>) -> Result<Self> {
+        rows.sort_unstable_by_key(|row| row.row_id);
+        for pair in rows.windows(2) {
+            if pair[0].row_id == pair[1].row_id {
+                return Err(Error::internal(format!(
+                    "FTS leaf scorer produced duplicate row_id={}",
+                    pair[0].row_id
+                )));
+            }
+        }
+        Ok(Self {
+            rows,
+            block_size: DEFAULT_BLOCK_SIZE,
+            index: None,
+            shallow: None,
+            min_competitive_score: f32::NEG_INFINITY,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_block_size(mut self, block_size: usize) -> Self {
+        assert!(block_size > 0);
+        self.block_size = block_size;
+        self
+    }
+
+    fn block_bounds(&self, start: usize, end: usize) -> Result<ScoreBounds> {
+        let Some(first) = self.rows.get(start) else {
+            return Ok(ScoreBounds::ZERO);
+        };
+        let mut bounds = ScoreBounds::point(first.score)?;
+        for row in &self.rows[start + 1..end] {
+            bounds.lower = bounds.lower.min(row.score);
+            bounds.upper = bounds.upper.max(row.score);
+        }
+        Ok(bounds)
+    }
+
+    fn position_at(&mut self, mut index: usize) -> Result<Option<u64>> {
+        while index < self.rows.len() {
+            let block_start = (index / self.block_size) * self.block_size;
+            let block_end = (block_start + self.block_size).min(self.rows.len());
+            if self.block_bounds(block_start, block_end)?.upper < self.min_competitive_score {
+                index = block_end;
+                continue;
+            }
+            self.index = Some(index);
+            self.shallow = None;
+            return Ok(Some(self.rows[index].row_id));
+        }
+        self.index = None;
+        self.shallow = None;
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+impl ComposableScorer for MaterializedScorer {
+    fn doc(&self) -> Option<u64> {
+        self.index.map(|index| self.rows[index].row_id)
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        self.position_at(self.index.map_or(0, |index| index + 1))
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.doc().is_some_and(|doc| doc >= target) {
+            return Ok(self.doc());
+        }
+        let start = self.index.map_or(0, |index| index + 1);
+        let offset = self.rows[start..].partition_point(|row| row.row_id < target);
+        self.position_at(start + offset)
+    }
+
+    fn cost(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        self.index
+            .map(|index| self.rows[index].score)
+            .ok_or_else(|| Error::internal("FTS scorer is not positioned on a document"))
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let start = self.rows.partition_point(|row| row.row_id < target);
+        if start == self.rows.len() {
+            self.shallow = Some(ShallowRange {
+                target,
+                up_to: u64::MAX,
+                start,
+                end: start,
+            });
+            return Ok(u64::MAX);
+        }
+        let block_start = (start / self.block_size) * self.block_size;
+        let end = (block_start + self.block_size).min(self.rows.len());
+        let up_to = self
+            .rows
+            .get(end)
+            .map(|next| next.row_id.saturating_sub(1))
+            .unwrap_or(u64::MAX);
+        self.shallow = Some(ShallowRange {
+            target,
+            up_to,
+            start,
+            end,
+        });
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let shallow = self.shallow.ok_or_else(|| {
+            Error::internal("score_bounds requires advance_shallow on the FTS scorer")
+        })?;
+        if up_to < shallow.target || up_to > shallow.up_to {
+            return Err(Error::internal(format!(
+                "FTS score bound up_to={up_to} is outside shallow range [{}, {}]",
+                shallow.target, shallow.up_to
+            )));
+        }
+        let end = shallow.start
+            + self.rows[shallow.start..shallow.end].partition_point(|row| row.row_id <= up_to);
+        self.block_bounds(shallow.start, end)
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        if min_score > self.min_competitive_score {
+            self.min_competitive_score = min_score;
+        }
+        Ok(())
+    }
+}
+
+/// Monotonic score-only floor shared by partition-local top-k collectors.
+///
+/// Equal-score candidates are never pruned because final ordering also uses
+/// row id. The score-only floor is therefore a safe lower bound even when
+/// partitions encounter ties in different orders.
+#[derive(Debug)]
+pub(super) struct CompetitiveScore {
+    bits: AtomicU32,
+}
+
+impl Default for CompetitiveScore {
+    fn default() -> Self {
+        Self {
+            bits: AtomicU32::new(f32::NEG_INFINITY.to_bits()),
+        }
+    }
+}
+
+impl CompetitiveScore {
+    fn get(&self) -> f32 {
+        f32::from_bits(self.bits.load(AtomicOrdering::Relaxed))
+    }
+
+    fn raise(&self, score: f32) {
+        debug_assert!(!score.is_nan());
+        let mut current = self.bits.load(AtomicOrdering::Relaxed);
+        while score > f32::from_bits(current) {
+            match self.bits.compare_exchange_weak(
+                current,
+                score.to_bits(),
+                AtomicOrdering::Relaxed,
+                AtomicOrdering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HeapRow<K>(ScoredRow<K>);
+
+impl<K: PartialEq> PartialEq for HeapRow<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.row_id == other.0.row_id && self.0.score.to_bits() == other.0.score.to_bits()
+    }
+}
+
+impl<K: Eq> Eq for HeapRow<K> {}
+
+impl<K: Ord> PartialOrd for HeapRow<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: Ord> Ord for HeapRow<K> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // The worst result is the heap maximum: lower score, then higher row id.
+        other
+            .0
+            .score
+            .total_cmp(&self.0.score)
+            .then_with(|| self.0.row_id.cmp(&other.0.row_id))
+    }
+}
+
+fn compare_scored_rows<K: Ord>(left: &ScoredRow<K>, right: &ScoredRow<K>) -> Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.row_id.cmp(&right.row_id))
+}
+
+fn is_better<K: Ord>(candidate: ScoredRow<K>, current: ScoredRow<K>) -> bool {
+    compare_scored_rows(&candidate, &current) == Ordering::Less
+}
+
+/// The sole owner of top-k state for a compound scorer tree.
+pub(super) struct TopKCollector<K = u64> {
+    limit: usize,
+    heap: BinaryHeap<HeapRow<K>>,
+    competitive_score: Arc<CompetitiveScore>,
+}
+
+impl<K: Copy + Ord> TopKCollector<K> {
+    pub(super) fn new(limit: usize) -> Self {
+        Self::with_competitive_score(limit, Arc::new(CompetitiveScore::default()))
+    }
+
+    pub(super) fn with_competitive_score(
+        limit: usize,
+        competitive_score: Arc<CompetitiveScore>,
+    ) -> Self {
+        Self {
+            limit,
+            heap: BinaryHeap::with_capacity(limit.min(DEFAULT_BLOCK_SIZE)),
+            competitive_score,
+        }
+    }
+
+    fn insert(&mut self, row: ScoredRow<K>) {
+        if self.limit == 0 {
+            return;
+        }
+        if self.heap.len() < self.limit {
+            self.heap.push(HeapRow(row));
+        } else if self
+            .heap
+            .peek()
+            .is_some_and(|worst| is_better(row, worst.0))
+        {
+            self.heap.pop();
+            self.heap.push(HeapRow(row));
+        }
+        if self.heap.len() == self.limit
+            && let Some(worst) = self.heap.peek()
+        {
+            self.competitive_score.raise(worst.0.score);
+        }
+    }
+
+    pub(super) fn collect_mapped(
+        &mut self,
+        scorer: &mut dyn ComposableScorer,
+        mut map_document: impl FnMut(u64) -> Result<K>,
+    ) -> Result<()> {
+        if self.limit == 0 {
+            return Ok(());
+        }
+        let expected = scorer.cost().min(self.limit);
+        self.heap
+            .reserve(expected.saturating_sub(self.heap.capacity()));
+
+        scorer.set_min_competitive_score(self.competitive_score.get())?;
+        let mut doc = scorer.next()?;
+        while let Some(doc_id) = doc {
+            let min_score = self.competitive_score.get();
+            scorer.set_min_competitive_score(min_score)?;
+            let up_to = scorer.advance_shallow(doc_id)?;
+            let bounds = scorer.score_bounds(up_to)?;
+            if bounds.upper < min_score {
+                doc = if up_to == u64::MAX {
+                    None
+                } else {
+                    scorer.advance(up_to + 1)?
+                };
+                continue;
+            }
+
+            if let Some(match_cost) = scorer.match_cost()
+                && (!match_cost.is_finite() || match_cost < 0.0)
+            {
+                return Err(Error::internal(format!(
+                    "FTS scorer reported invalid two-phase match cost: {match_cost}"
+                )));
+            }
+            if scorer.matches()? {
+                let score = checked_score(scorer.score()?, "compound scorer")?;
+                // A shared partition floor is already known to be globally
+                // competitive. Scores strictly below it cannot enter final top-k.
+                if score >= self.competitive_score.get() {
+                    let document_key = scorer.document_key().ok_or_else(|| {
+                        Error::internal(
+                            "compound FTS scorer did not expose its current document key",
+                        )
+                    })?;
+                    self.insert(ScoredRow {
+                        row_id: map_document(document_key)?,
+                        score,
+                    });
+                }
+            }
+            doc = scorer.next()?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn into_rows(self) -> Vec<ScoredRow<K>> {
+        let mut rows = self.heap.into_iter().map(|row| row.0).collect::<Vec<_>>();
+        rows.sort_unstable_by(compare_scored_rows);
+        rows
+    }
+}
+
+impl TopKCollector<u64> {
+    #[cfg(test)]
+    fn collect(mut self, scorer: &mut dyn ComposableScorer) -> Result<Vec<ScoredRow>> {
+        self.collect_mapped(scorer, Ok)?;
+        Ok(self.into_rows())
+    }
+}
+
+struct EmptyScorer;
+
+impl ComposableScorer for EmptyScorer {
+    fn doc(&self) -> Option<u64> {
+        None
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn advance(&mut self, _target: u64) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn cost(&self) -> usize {
+        0
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        Err(Error::internal(
+            "score requested from an empty compound FTS scorer",
+        ))
+    }
+
+    fn advance_shallow(&mut self, _target: u64) -> Result<u64> {
+        Ok(u64::MAX)
+    }
+
+    fn score_bounds(&mut self, _up_to: u64) -> Result<ScoreBounds> {
+        Ok(ScoreBounds::ZERO)
+    }
+
+    fn set_min_competitive_score(&mut self, _min_score: f32) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct ScaleScorer<'a> {
+    child: BoxScorer<'a>,
+    factor: f32,
+}
+
+impl<'a> ScaleScorer<'a> {
+    fn try_new(child: BoxScorer<'a>, factor: f32) -> Result<Self> {
+        if !factor.is_finite() || factor < 0.0 {
+            return Err(Error::invalid_input(format!(
+                "MatchQuery boost must be finite and non-negative, got {factor}"
+            )));
+        }
+        Ok(Self { child, factor })
+    }
+}
+
+impl ComposableScorer for ScaleScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.child.doc()
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.child.document_key()
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        self.child.next()
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        self.child.advance(target)
+    }
+
+    fn cost(&self) -> usize {
+        self.child.cost()
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        checked_score(self.child.score()? * self.factor, "MatchQuery boost")
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        self.child.advance_shallow(target)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        Ok(self
+            .child
+            .score_bounds(up_to)?
+            .scale_non_negative(self.factor))
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if self.factor > 0.0 {
+            self.child
+                .set_min_competitive_score(next_down(min_score / self.factor))?;
+        }
+        Ok(())
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.child.matches()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.child.match_cost()
+    }
+}
+
+/// Union scorer used for MultiMatch DisMax.
+pub(super) struct DisjunctionScorer<'a> {
+    children: Vec<BoxScorer<'a>>,
+    current: Option<u64>,
+    confirmed_doc: Option<u64>,
+    confirmed: Vec<bool>,
+    min_competitive_score: f32,
+}
+
+impl<'a> DisjunctionScorer<'a> {
+    pub(super) fn try_new(children: Vec<BoxScorer<'a>>) -> Result<Self> {
+        if children.is_empty() {
+            return Err(Error::internal(
+                "FTS disjunction scorer requires at least one child",
+            ));
+        }
+        let confirmed = vec![false; children.len()];
+        Ok(Self {
+            children,
+            current: None,
+            confirmed_doc: None,
+            confirmed,
+            min_competitive_score: f32::NEG_INFINITY,
+        })
+    }
+
+    fn set_current_from_children(&mut self) -> Option<u64> {
+        self.current = self.children.iter().filter_map(|child| child.doc()).min();
+        self.confirmed_doc = None;
+        self.confirmed.fill(false);
+        self.current
+    }
+
+    fn ensure_confirmed(&mut self) -> Result<bool> {
+        let Some(current) = self.current else {
+            return Ok(false);
+        };
+        if self.confirmed_doc == Some(current) {
+            return Ok(self.confirmed.iter().any(|matched| *matched));
+        }
+        self.confirmed.fill(false);
+        for (matched, child) in self.confirmed.iter_mut().zip(&mut self.children) {
+            if child.doc() == Some(current) {
+                *matched = child.matches()?;
+            }
+        }
+        self.confirmed_doc = Some(current);
+        Ok(self.confirmed.iter().any(|matched| *matched))
+    }
+}
+
+impl ComposableScorer for DisjunctionScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        let current = self.current?;
+        self.children
+            .iter()
+            .find(|child| child.doc() == Some(current))
+            .and_then(|child| child.document_key())
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        match self.current {
+            None => {
+                for child in &mut self.children {
+                    child.next()?;
+                }
+            }
+            Some(current) => {
+                for child in &mut self.children {
+                    if child.doc() == Some(current) {
+                        child.next()?;
+                    }
+                }
+            }
+        }
+        Ok(self.set_current_from_children())
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.current.is_some_and(|current| current >= target) {
+            return Ok(self.current);
+        }
+        for child in &mut self.children {
+            if child.doc().is_none_or(|doc| doc < target) {
+                child.advance(target)?;
+            }
+        }
+        Ok(self.set_current_from_children())
+    }
+
+    fn cost(&self) -> usize {
+        self.children
+            .iter()
+            .map(|child| child.cost())
+            .fold(0, usize::saturating_add)
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        if !self.ensure_confirmed()? {
+            return Err(Error::internal(
+                "FTS disjunction score requested for an unconfirmed document",
+            ));
+        }
+        let mut score = f32::NEG_INFINITY;
+        for (matched, child) in self.confirmed.iter().zip(&mut self.children) {
+            if !matched {
+                continue;
+            }
+            let child_score = child.score()?;
+            score = score.max(child_score);
+        }
+        checked_score(score, "FTS disjunction")
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let mut up_to = u64::MAX;
+        for child in &mut self.children {
+            if let Some(doc) = child.doc() {
+                up_to = up_to.min(child.advance_shallow(target.max(doc))?);
+            }
+        }
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let mut bounds = ScoreBounds {
+            lower: f32::INFINITY,
+            upper: f32::NEG_INFINITY,
+        };
+        for child in &mut self.children {
+            let child_bounds = if child.doc().is_some_and(|doc| doc <= up_to) {
+                child.score_bounds(up_to)?
+            } else {
+                ScoreBounds::ZERO
+            };
+            bounds = ScoreBounds {
+                lower: bounds.lower.min(child_bounds.lower),
+                upper: bounds.upper.max(child_bounds.upper),
+            };
+        }
+        if bounds.lower == f32::INFINITY {
+            Ok(ScoreBounds::ZERO)
+        } else {
+            Ok(bounds)
+        }
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        if min_score <= self.min_competitive_score {
+            return Ok(());
+        }
+        self.min_competitive_score = min_score;
+        for child in &mut self.children {
+            child.set_min_competitive_score(min_score)?;
+        }
+        Ok(())
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.ensure_confirmed()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.children
+            .iter()
+            .filter_map(|child| child.match_cost())
+            .reduce(|left, right| left + right)
+    }
+}
+
+#[derive(Clone)]
+enum LeafQuery {
+    Match(MatchQuery),
+}
+
+impl LeafQuery {
+    fn terms(&self) -> &str {
+        match self {
+            Self::Match(query) => &query.terms,
+        }
+    }
+
+    fn operator(&self) -> Operator {
+        match self {
+            Self::Match(query) => query.operator,
+        }
+    }
+
+    fn effective_params(&self, params: &FtsSearchParams) -> FtsSearchParams {
+        match self {
+            Self::Match(query) => params
+                .clone()
+                .with_limit(None)
+                .with_phrase_slop(None)
+                .with_fuzziness(query.fuzziness)
+                .with_max_expansions(query.max_expansions)
+                .with_prefix_length(query.prefix_length),
+        }
+    }
+}
+
+fn collect_leaf_queries(query: &FtsQuery) -> Result<Vec<LeafQuery>> {
+    match query {
+        FtsQuery::MultiMatch(query) => Ok(query
+            .match_queries
+            .iter()
+            .cloned()
+            .map(LeafQuery::Match)
+            .collect()),
+        _ => Err(Error::not_supported(
+            "posting-backed compound FTS currently supports MultiMatch queries only",
+        )),
+    }
+}
+
+struct PreparedLeaf {
+    tokens_by_segment: Vec<Arc<Tokens>>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    scorer: Arc<MemBM25Scorer>,
+}
+
+fn tokenize_leaf(index: &InvertedIndex, leaf: &LeafQuery, params: &FtsSearchParams) -> Tokens {
+    let is_fuzzy_match = matches!(leaf, LeafQuery::Match(_))
+        && matches!(params.fuzziness, Some(distance) if distance != 0);
+    let mut tokenizer = if is_fuzzy_match {
+        let analyzer = TextAnalyzer::from(SimpleTokenizer::default());
+        match index.tokenizer().doc_type() {
+            DocType::Text => Box::new(TextTokenizer::new(analyzer)) as Box<dyn LanceTokenizer>,
+            DocType::Json => Box::new(JsonTokenizer::new(analyzer)) as Box<dyn LanceTokenizer>,
+        }
+    } else {
+        index.tokenizer()
+    };
+    collect_query_tokens(leaf.terms(), &mut tokenizer)
+}
+
+fn expanded_leaf_tokens(
+    index: &InvertedIndex,
+    tokens: &Tokens,
+    params: &FtsSearchParams,
+    operator: Operator,
+) -> Result<Tokens> {
+    if !matches!(params.fuzziness, Some(distance) if distance != 0) {
+        return Ok(tokens.clone());
+    }
+    let expanded = index.expand_fuzzy_tokens(tokens, params)?;
+    if operator == Operator::And || params.phrase_slop.is_some() {
+        let surviving = (0..expanded.len())
+            .map(|index| expanded.position(index))
+            .collect::<HashSet<_>>();
+        if (0..tokens.len()).any(|index| !surviving.contains(&tokens.position(index))) {
+            return Ok(Tokens::with_positions(
+                Vec::new(),
+                Vec::new(),
+                tokens.token_type().clone(),
+            ));
+        }
+    }
+    Ok(expanded)
+}
+
+async fn prepare_compound_query(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    metrics: &dyn MetricsCollector,
+) -> Result<(CompoundScorerPlan, Vec<PreparedLeaf>)> {
+    let first_index = indices
+        .first()
+        .ok_or_else(|| Error::invalid_input("compound FTS requires at least one index segment"))?;
+    let leaf_queries = collect_leaf_queries(query)?;
+    let mut num_plan_leaves = 0;
+    let plan = CompoundScorerPlan::from_query(query, &mut num_plan_leaves)?;
+    if num_plan_leaves != leaf_queries.len() {
+        return Err(Error::internal(format!(
+            "compound FTS planned {num_plan_leaves} leaves but prepared {}",
+            leaf_queries.len()
+        )));
+    }
+
+    let mut leaves = Vec::with_capacity(leaf_queries.len());
+    for leaf in leaf_queries {
+        let effective_params = leaf.effective_params(params);
+        let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
+        let scorer = Arc::new(
+            build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics)).await?,
+        );
+        let mut tokens_by_segment = Vec::with_capacity(indices.len());
+        for index in indices {
+            tokens_by_segment.push(Arc::new(expanded_leaf_tokens(
+                index,
+                &tokens,
+                &effective_params,
+                leaf.operator(),
+            )?));
+        }
+        leaves.push(PreparedLeaf {
+            tokens_by_segment,
+            params: Arc::new(effective_params),
+            operator: leaf.operator(),
+            scorer,
+        });
+    }
+    Ok((plan, leaves))
+}
+
+struct LoadedLeaf {
+    postings: Vec<PostingIterator>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    scorer: Arc<MemBM25Scorer>,
+}
+
+enum LoadedDocuments {
+    Legacy(Arc<DocSet>),
+    Modern {
+        lengths: Arc<DocLengths>,
+        visibility: DocVisibility,
+    },
+}
+
+struct LoadedPartition {
+    segment_ordinal: usize,
+    partition_ordinal: usize,
+    documents: LoadedDocuments,
+    leaves: Vec<LoadedLeaf>,
+}
+
+async fn load_compound_partition(
+    segment_ordinal: usize,
+    partition_ordinal: usize,
+    partition: Arc<InvertedPartition>,
+    leaves: &[PreparedLeaf],
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<LoadedPartition>> {
+    let leaf_loads = leaves.iter().map(|leaf| {
+        let partition = partition.clone();
+        let tokens = leaf.tokens_by_segment[segment_ordinal].clone();
+        let params = leaf.params.clone();
+        let scorer = leaf.scorer.clone();
+        let metrics = metrics.clone();
+        let operator = leaf.operator;
+        async move {
+            let postings = if tokens.is_empty() {
+                Vec::new()
+            } else {
+                partition
+                    .load_posting_lists(
+                        tokens.as_ref(),
+                        params.as_ref(),
+                        operator,
+                        scorer.as_ref(),
+                        metrics.as_ref(),
+                        true,
+                    )
+                    .await?
+                    .postings
+            };
+            Result::Ok(LoadedLeaf {
+                postings,
+                params,
+                operator,
+                scorer,
+            })
+        }
+    });
+    let leaves = futures::future::try_join_all(leaf_loads).await?;
+
+    let documents = if let Some(docs) = partition.docs.legacy() {
+        LoadedDocuments::Legacy(docs.clone())
+    } else {
+        let documents = partition.docs.modern().cloned().ok_or_else(|| {
+            Error::internal("FTS partition contains neither legacy nor modern documents")
+        })?;
+        let materialize_selected = mask.max_len().is_some_and(|selected| {
+            u128::from(selected).saturating_mul(100)
+                <= u128::from(*FLAT_SEARCH_PERCENT_THRESHOLD)
+                    .saturating_mul(documents.len() as u128)
+        });
+        let visibility = match documents.immediate_visibility(mask.clone(), materialize_selected) {
+            Some(visibility) => visibility,
+            None => {
+                documents
+                    .visibility(mask.clone(), materialize_selected)
+                    .await?
+            }
+        };
+        if visibility.is_empty() {
+            return Ok(None);
+        }
+        let lengths = match documents.cached_lengths() {
+            Some(lengths) => lengths,
+            None => documents.lengths().await?,
+        };
+        LoadedDocuments::Modern {
+            lengths,
+            visibility,
+        }
+    };
+
+    Ok(Some(LoadedPartition {
+        segment_ordinal,
+        partition_ordinal,
+        documents,
+        leaves,
+    }))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum CompoundDocument {
+    Legacy(u64),
+    Modern {
+        segment_ordinal: u32,
+        partition_ordinal: u32,
+        doc_id: u32,
+    },
+}
+
+fn collect_partition_with_documents<D: WandDocuments + Sync>(
+    documents: &D,
+    leaves: Vec<LoadedLeaf>,
+    plan: &CompoundScorerPlan,
+    metrics: &dyn MetricsCollector,
+    collector: &mut TopKCollector<CompoundDocument>,
+    mut map_document: impl FnMut(u64) -> Result<CompoundDocument>,
+) -> Result<()> {
+    let mut leaf_scorers = leaves
+        .into_iter()
+        .map(|leaf| {
+            let scorer: BoxScorer<'_> = if leaf.postings.is_empty() {
+                Box::new(EmptyScorer)
+            } else {
+                Box::new(WandCursor::new(
+                    leaf.operator,
+                    leaf.postings,
+                    documents,
+                    leaf.scorer,
+                    leaf.params.as_ref(),
+                    metrics,
+                ))
+            };
+            Some(scorer)
+        })
+        .collect::<Vec<_>>();
+    let mut scorer = plan.build(&mut leaf_scorers)?;
+    if leaf_scorers.iter().any(Option::is_some) {
+        return Err(Error::internal(
+            "compound FTS scorer did not consume every prepared leaf",
+        ));
+    }
+    collector.collect_mapped(scorer.as_mut(), &mut map_document)
+}
+
+fn collect_loaded_partitions(
+    partitions: Vec<LoadedPartition>,
+    plan: &CompoundScorerPlan,
+    mask: &RowAddrMask,
+    metrics: &dyn MetricsCollector,
+    mut collector: TopKCollector<CompoundDocument>,
+) -> Result<TopKCollector<CompoundDocument>> {
+    for partition in partitions {
+        match partition.documents {
+            LoadedDocuments::Legacy(docs) => {
+                let documents = LegacyWandDocuments::new(docs.as_ref(), mask);
+                collect_partition_with_documents(
+                    &documents,
+                    partition.leaves,
+                    plan,
+                    metrics,
+                    &mut collector,
+                    |row_id| Ok(CompoundDocument::Legacy(row_id)),
+                )?;
+            }
+            LoadedDocuments::Modern {
+                lengths,
+                visibility,
+            } => {
+                let segment_ordinal = u32::try_from(partition.segment_ordinal).map_err(|_| {
+                    Error::index(format!(
+                        "FTS segment ordinal {} exceeds u32::MAX",
+                        partition.segment_ordinal
+                    ))
+                })?;
+                let partition_ordinal =
+                    u32::try_from(partition.partition_ordinal).map_err(|_| {
+                        Error::index(format!(
+                            "FTS partition ordinal {} exceeds u32::MAX",
+                            partition.partition_ordinal
+                        ))
+                    })?;
+                let documents = ModernWandDocuments::filtered(lengths.as_ref(), &visibility);
+                collect_partition_with_documents(
+                    &documents,
+                    partition.leaves,
+                    plan,
+                    metrics,
+                    &mut collector,
+                    |doc_id| {
+                        Ok(CompoundDocument::Modern {
+                            segment_ordinal,
+                            partition_ordinal,
+                            doc_id: u32::try_from(doc_id).map_err(|_| {
+                                Error::index(format!(
+                                    "FTS DocId {doc_id} exceeds the modern u32 domain"
+                                ))
+                            })?,
+                        })
+                    },
+                )?;
+            }
+        }
+    }
+    Ok(collector)
+}
+
+async fn resolve_compound_rows(
+    indices: &[Arc<InvertedIndex>],
+    rows: Vec<ScoredRow<CompoundDocument>>,
+) -> Result<Vec<ScoredRow>> {
+    let mut resolved = vec![None; rows.len()];
+    let mut modern = BTreeMap::<(usize, usize), Vec<(usize, DocId)>>::new();
+    for (rank, row) in rows.iter().enumerate() {
+        match row.row_id {
+            CompoundDocument::Legacy(row_id) => resolved[rank] = Some(row_id),
+            CompoundDocument::Modern {
+                segment_ordinal,
+                partition_ordinal,
+                doc_id,
+            } => modern
+                .entry((segment_ordinal as usize, partition_ordinal as usize))
+                .or_default()
+                .push((rank, DocId::new(doc_id))),
+        }
+    }
+    for ((segment_ordinal, partition_ordinal), entries) in modern {
+        let documents = indices
+            .get(segment_ordinal)
+            .and_then(|index| index.partitions.get(partition_ordinal))
+            .and_then(|partition| partition.docs.modern())
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "missing modern FTS documents for segment {segment_ordinal}, partition {partition_ordinal}"
+                ))
+            })?;
+        let doc_ids = entries
+            .iter()
+            .map(|(_, doc_id)| *doc_id)
+            .collect::<Vec<_>>();
+        let addresses = documents.resolve_addresses(&doc_ids).await?;
+        for ((rank, _), address) in entries.into_iter().zip(addresses) {
+            resolved[rank] = Some(address);
+        }
+    }
+
+    let mut rows = rows
+        .into_iter()
+        .zip(resolved)
+        .map(|(row, row_id)| {
+            Ok(ScoredRow {
+                row_id: row_id.ok_or_else(|| {
+                    Error::internal("compound FTS candidate address was not resolved")
+                })?,
+                score: row.score,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    rows.sort_unstable_by(compare_scored_rows);
+    Ok(rows)
+}
+
+/// Search one-column compound FTS directly over posting-backed scorers.
+///
+/// The caller must provide all committed index segments for the column and a
+/// ready prefilter. One collector owns the global top-k heap and propagates its
+/// score floor through every partition-local scorer tree. Only its final
+/// bounded candidates are resolved to row addresses and returned.
+pub async fn compound_search(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    let limit = params.limit.unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let (plan, leaves) = prepare_compound_query(indices, query, params, metrics.as_ref()).await?;
+    prefilter.wait_for_ready().await?;
+    let mask = prefilter.mask();
+    let mut collector = TopKCollector::new(limit);
+
+    for (segment_ordinal, index) in indices.iter().enumerate() {
+        let loads =
+            index
+                .partitions
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(partition_ordinal, partition)| {
+                    load_compound_partition(
+                        segment_ordinal,
+                        partition_ordinal,
+                        partition,
+                        &leaves,
+                        mask.clone(),
+                        metrics.clone(),
+                    )
+                });
+        let partitions = stream::iter(loads)
+            .buffer_unordered(get_num_compute_intensive_cpus().clamp(1, 32))
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let plan = plan.clone();
+        let mask = mask.clone();
+        let metrics = metrics.clone();
+        collector = spawn_cpu(move || {
+            collect_loaded_partitions(
+                partitions,
+                &plan,
+                mask.as_ref(),
+                metrics.as_ref(),
+                collector,
+            )
+        })
+        .await?;
+    }
+
+    let rows = resolve_compound_rows(indices, collector.into_rows()).await?;
+    Ok(rows.into_iter().map(|row| (row.row_id, row.score)).unzip())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(values: &[(u64, f32)]) -> Vec<ScoredRow> {
+        values
+            .iter()
+            .map(|(row_id, score)| ScoredRow::new(*row_id, *score).unwrap())
+            .collect()
+    }
+
+    fn materialized(values: &[(u64, f32)]) -> Box<dyn ComposableScorer> {
+        Box::new(MaterializedScorer::try_new(rows(values)).unwrap())
+    }
+
+    #[test]
+    fn collector_propagates_threshold_across_partitions_and_keeps_ties() {
+        let mut collector = TopKCollector::new(2);
+        let mut first = MaterializedScorer::try_new(rows(&[(8, 9.0), (4, 10.0), (3, 9.0)]))
+            .unwrap()
+            .with_block_size(1);
+        collector.collect_mapped(&mut first, Ok).unwrap();
+        assert_eq!(collector.competitive_score.get(), 9.0);
+
+        let mut second = MaterializedScorer::try_new(rows(&[(1, 1.0), (2, 9.0)]))
+            .unwrap()
+            .with_block_size(1);
+        collector.collect_mapped(&mut second, Ok).unwrap();
+        assert_eq!(
+            collector.into_rows(),
+            vec![
+                ScoredRow {
+                    row_id: 4,
+                    score: 10.0
+                },
+                ScoredRow {
+                    row_id: 2,
+                    score: 9.0
+                }
+            ]
+        );
+    }
+
+    struct TwoPhaseScorer {
+        inner: MaterializedScorer,
+        accepted: Vec<u64>,
+        confirmations: usize,
+    }
+
+    impl ComposableScorer for TwoPhaseScorer {
+        fn doc(&self) -> Option<u64> {
+            self.inner.doc()
+        }
+
+        fn next(&mut self) -> Result<Option<u64>> {
+            self.inner.next()
+        }
+
+        fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+            self.inner.advance(target)
+        }
+
+        fn cost(&self) -> usize {
+            self.inner.cost()
+        }
+
+        fn score(&mut self) -> Result<f32> {
+            self.inner.score()
+        }
+
+        fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+            self.inner.advance_shallow(target)
+        }
+
+        fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+            self.inner.score_bounds(up_to)
+        }
+
+        fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+            self.inner.set_min_competitive_score(min_score)
+        }
+
+        fn matches(&mut self) -> Result<bool> {
+            self.confirmations += 1;
+            Ok(self
+                .doc()
+                .is_some_and(|doc| self.accepted.binary_search(&doc).is_ok()))
+        }
+    }
+
+    #[test]
+    fn collector_confirms_two_phase_matches_without_a_cost_hint() {
+        let mut scorer = TwoPhaseScorer {
+            inner: MaterializedScorer::try_new(rows(&[(1, 100.0), (2, 2.0), (3, 1.0)])).unwrap(),
+            accepted: vec![2, 3],
+            confirmations: 0,
+        };
+        let results = TopKCollector::new(2).collect(&mut scorer).unwrap();
+        assert_eq!(results, rows(&[(2, 2.0), (3, 1.0)]));
+        assert_eq!(scorer.confirmations, 3);
+        assert_eq!(scorer.match_cost(), None);
+    }
+
+    #[test]
+    fn dismax_preserves_exact_scores_and_order() {
+        let mut dismax = DisjunctionScorer::try_new(vec![
+            materialized(&[(1, 2.0), (3, 3.0)]),
+            materialized(&[(1, 4.0), (2, 4.0)]),
+        ])
+        .unwrap();
+        let results = TopKCollector::new(2).collect(&mut dismax).unwrap();
+        assert_eq!(results, rows(&[(1, 4.0), (2, 4.0)]));
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -471,8 +471,8 @@ fn rescore_partition_candidates<C>(
 }
 
 #[derive(Debug)]
-struct LoadedPostings {
-    postings: Vec<PostingIterator>,
+pub(super) struct LoadedPostings {
+    pub(super) postings: Vec<PostingIterator>,
     grouped_expansions: Vec<GroupedExpansionTerms>,
     impact_safe: bool,
     exact_scoring_required: bool,
@@ -1175,6 +1175,7 @@ impl InvertedIndex {
                                     operator,
                                     impact_scorer.as_ref(),
                                     metrics.as_ref(),
+                                    false,
                                 )
                                 .await?;
                             if postings.is_empty() {
@@ -1401,6 +1402,7 @@ impl InvertedIndex {
                                     operator,
                                     impact_scorer.as_ref(),
                                     metrics.as_ref(),
+                                    false,
                                 )
                                 .await?;
                             if postings.is_empty() {
@@ -2696,14 +2698,20 @@ impl InvertedPartition {
     // search the documents that contain the query
     // return the doc info and the doc length
     // ref: https://en.wikipedia.org/wiki/Okapi_BM25
+    //
+    // `force_global_scorer` is used by compound search, where leaf scores and
+    // bounds must share corpus-level statistics before the global collector
+    // can safely propagate its threshold. Old posting formats without impacts
+    // fall back to a scorer-derived global upper bound in that mode.
     #[instrument(level = "debug", skip_all)]
-    async fn load_posting_lists(
+    pub(super) async fn load_posting_lists(
         &self,
         tokens: &Tokens,
         params: &FtsSearchParams,
         operator: Operator,
         impact_scorer: &MemBM25Scorer,
         metrics: &dyn MetricsCollector,
+        force_global_scorer: bool,
     ) -> Result<LoadedPostings> {
         let is_phrase_query = params.phrase_slop.is_some();
         let is_and_query = operator == Operator::And;
@@ -2783,13 +2791,15 @@ impl InvertedPartition {
                 postings: loaded_postings
                     .into_iter()
                     .map(|(token_id, token, position, posting)| {
-                        let needs_scorer_upper_bound =
-                            exact_scoring_required && !posting.has_impacts();
-                        let query_weight = if impact_safe || exact_scoring_required {
-                            impact_scorer.query_weight(&token)
-                        } else {
-                            idf(posting.len(), num_docs)
-                        };
+                        let needs_scorer_upper_bound = (exact_scoring_required
+                            || force_global_scorer)
+                            && !posting.has_impacts();
+                        let query_weight =
+                            if impact_safe || exact_scoring_required || force_global_scorer {
+                                impact_scorer.query_weight(&token)
+                            } else {
+                                idf(posting.len(), num_docs)
+                            };
                         let posting = PostingIterator::with_query_weight(
                             token,
                             token_id,
@@ -11406,6 +11416,7 @@ mod tests {
                 Operator::Or,
                 scorer.as_ref(),
                 &NoOpMetricsCollector,
+                false,
             )
             .await
             .unwrap();

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -12,10 +12,11 @@ use std::collections::{HashMap, HashSet};
 pub struct FtsSearchParams {
     /// Controls result completeness for each recursively planned FTS node.
     ///
-    /// `Some(k)` permits bounded top-k execution, while `None` requires complete
-    /// results so an outer compound query can combine every candidate exactly.
-    /// Future competitive-score pruning must use a separate planning contract
-    /// instead of inferring a bound from the ambient scanner limit.
+    /// `Some(k)` permits bounded top-k execution. Posting-backed compound
+    /// queries apply it only at their root collector and propagate the
+    /// resulting competitive score through child scorers. The exact
+    /// DataFusion fallback passes `None` recursively so intermediate children
+    /// remain complete.
     pub limit: Option<usize>,
     pub wand_factor: f32,
     pub fuzziness: Option<u32>,
@@ -286,7 +287,9 @@ pub struct MatchQuery {
     pub column: Option<String>,
     pub terms: String,
 
-    // literal default is not supported so we set it by function
+    /// Finite, non-negative score multiplier. Validation occurs at the FTS
+    /// query boundary so direct struct deserialization follows the same
+    /// contract as builder-created queries.
     #[serde(default = "MatchQuery::default_boost")]
     pub boost: f32,
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -25,7 +25,7 @@ use super::{
     impact::{IMPACT_LEVEL1_BLOCKS, ImpactScoreCache, ImpactSkipData},
     index::{PositionStreamCodec, dequantize_doc_length},
     query::Operator,
-    scorer::{K1, bm25_doc_weight_with_norm, idf},
+    scorer::{K1, MemBM25Scorer, bm25_doc_weight_with_norm, idf},
 };
 use super::{
     CompressedPostingList, DocSet, PostingList, RawDocInfo,
@@ -4358,6 +4358,287 @@ impl<'a> PositionCursor<'a> {
 
     fn advance_next(&mut self) {
         self.index = self.index.saturating_add(1).min(self.len());
+    }
+}
+
+/// Incremental posting-backed scorer used by compound FTS.
+///
+/// Unlike [`Wand::search`], this cursor does not own a top-k heap. It exposes
+/// exact candidates and conservative block bounds to the compound collector,
+/// which owns the only competitive score for the whole scorer tree.
+pub(super) struct WandCursor<'a, D: WandDocuments> {
+    wand: Wand<'a, Arc<MemBM25Scorer>, D>,
+    wand_factor: f32,
+    cost: usize,
+    current_doc: Option<DocInfo>,
+    current_document_key: Option<u64>,
+    current_score: f32,
+    shallow: Option<(u64, u64, f32)>,
+    comparisons: usize,
+    metrics_recorded: bool,
+    metrics: &'a dyn MetricsCollector,
+}
+
+impl<'a, D: WandDocuments> WandCursor<'a, D> {
+    pub(super) fn new(
+        operator: Operator,
+        postings: Vec<PostingIterator>,
+        documents: &'a D,
+        scorer: Arc<MemBM25Scorer>,
+        params: &FtsSearchParams,
+        metrics: &'a dyn MetricsCollector,
+    ) -> Self {
+        let cost = match operator {
+            Operator::And => postings.iter().map(PostingIterator::cost).min(),
+            Operator::Or => Some(
+                postings
+                    .iter()
+                    .map(PostingIterator::cost)
+                    .fold(0, usize::saturating_add),
+            ),
+        }
+        .unwrap_or_default();
+        Self {
+            wand: Wand::new(operator, postings.into_iter(), documents, scorer),
+            wand_factor: params.wand_factor,
+            cost,
+            current_doc: None,
+            current_document_key: None,
+            current_score: 0.0,
+            shallow: None,
+            comparisons: 0,
+            metrics_recorded: false,
+            metrics,
+        }
+    }
+
+    pub(super) fn doc(&self) -> Option<u64> {
+        self.current_doc.map(|doc| doc.doc_id())
+    }
+
+    pub(super) fn document_key(&self) -> Option<u64> {
+        self.current_document_key
+    }
+
+    fn clear_current(&mut self) {
+        self.current_doc = None;
+        self.current_document_key = None;
+        self.current_score = 0.0;
+        self.shallow = None;
+    }
+
+    fn record_metrics(&mut self) {
+        if !self.metrics_recorded {
+            self.metrics.record_comparisons(self.comparisons);
+            self.metrics_recorded = true;
+        }
+    }
+
+    fn position_next(&mut self) -> Result<Option<u64>> {
+        loop {
+            let Some((doc, mut score)) = self.wand.next()? else {
+                self.clear_current();
+                self.record_metrics();
+                return Ok(None);
+            };
+            self.comparisons += 1;
+            let doc_id = doc.doc_id();
+            let Some(document_key) = self.wand.documents.document_key(&doc) else {
+                if self.wand.operator == Operator::Or {
+                    self.wand.push_back_leads(doc_id.saturating_add(1));
+                }
+                continue;
+            };
+            let doc_length = self.wand.documents.doc_length(&doc);
+            if self.wand.operator == Operator::Or {
+                self.wand
+                    .advance_all_tail(doc_id, Some(doc_length), Some(&mut score));
+            } else {
+                self.wand.advance_all_tail(doc_id, None, None);
+                score = self.wand.score(doc_length);
+            }
+            self.current_doc = Some(doc);
+            self.current_document_key = Some(document_key);
+            self.current_score = score;
+            self.shallow = None;
+            return Ok(Some(doc_id));
+        }
+    }
+
+    pub(super) fn next(&mut self) -> Result<Option<u64>> {
+        if let Some(doc) = self.current_doc
+            && self.wand.operator == Operator::Or
+        {
+            self.wand.push_back_leads(doc.doc_id().saturating_add(1));
+        }
+        self.clear_current();
+        self.position_next()
+    }
+
+    pub(super) fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.doc().is_some_and(|doc| doc >= target) {
+            return Ok(self.doc());
+        }
+        self.clear_current();
+        self.wand.seek(target);
+        self.position_next()
+    }
+
+    pub(super) fn cost(&self) -> usize {
+        self.cost
+    }
+
+    pub(super) fn current_score(&self) -> Result<f32> {
+        self.current_doc
+            .map(|_| self.current_score)
+            .ok_or_else(|| Error::internal("posting FTS scorer is not positioned on a document"))
+    }
+
+    pub(super) fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let (up_to, upper) = self.wand.compound_shallow_bound(target);
+        self.shallow = Some((target, up_to, upper));
+        Ok(up_to)
+    }
+
+    pub(super) fn score_upper_bound(&self, up_to: u64) -> Result<f32> {
+        let (target, shallow_up_to, upper) = self.shallow.ok_or_else(|| {
+            Error::internal("score bound requires advance_shallow on the posting FTS scorer")
+        })?;
+        if up_to < target || up_to > shallow_up_to {
+            return Err(Error::internal(format!(
+                "posting FTS score bound up_to={up_to} is outside shallow range [{target}, {shallow_up_to}]"
+            )));
+        }
+        Ok(upper)
+    }
+
+    pub(super) fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        let threshold = next_down_f32(min_score) * self.wand_factor;
+        if threshold > self.wand.threshold {
+            self.wand.threshold = threshold;
+        }
+        Ok(())
+    }
+}
+
+impl<D: WandDocuments> Drop for WandCursor<'_, D> {
+    fn drop(&mut self) {
+        self.record_metrics();
+    }
+}
+
+impl<S: Scorer, D: WandDocuments> Wand<'_, S, D> {
+    fn seek(&mut self, target: u64) {
+        self.up_to = None;
+        self.and_max_score = f32::INFINITY;
+        self.and_last_doc = None;
+        if self.operator == Operator::And {
+            for posting in &mut self.lead {
+                if posting.doc().is_some_and(|doc| doc.doc_id() < target) {
+                    posting.next(target);
+                }
+            }
+            return;
+        }
+
+        let mut postings = std::mem::take(&mut self.head)
+            .into_vec()
+            .into_iter()
+            .map(|posting| posting.posting)
+            .chain(self.lead.drain(..))
+            .chain(
+                std::mem::take(&mut self.tail)
+                    .into_vec()
+                    .into_iter()
+                    .map(|posting| posting.posting),
+            )
+            .collect::<Vec<_>>();
+        self.tail_max_score = 0.0;
+        for posting in &mut postings {
+            if posting.doc().is_some_and(|doc| doc.doc_id() < target) {
+                posting.next(target);
+            }
+        }
+        self.head = postings
+            .into_iter()
+            .filter(|posting| posting.doc().is_some())
+            .map(HeadPosting::new)
+            .collect();
+    }
+
+    fn compound_shallow_bound(&mut self, target: u64) -> (u64, f32) {
+        if self.operator == Operator::Or {
+            self.update_max_scores(target);
+            return (
+                self.up_to.unwrap_or(TERMINATED_DOC_ID),
+                conservative_score_sum(
+                    self.lead
+                        .iter()
+                        .map(|posting| posting.window_max_score(self.up_to, &self.scorer))
+                        .chain(self.head.iter().map(|posting| {
+                            posting.posting.window_max_score(self.up_to, &self.scorer)
+                        }))
+                        .chain(self.tail.iter().map(|posting| posting.upper_bound)),
+                ),
+            );
+        }
+
+        let mut up_to = TERMINATED_DOC_ID;
+        for posting in &mut self.lead {
+            posting.shallow_next(target);
+            up_to = up_to.min(Self::posting_block_up_to(posting, target));
+        }
+        let upper = conservative_score_sum(
+            self.lead
+                .iter()
+                .map(|posting| posting.block_max_score(&self.scorer)),
+        );
+        (up_to, upper)
+    }
+}
+
+fn conservative_score_sum(scores: impl Iterator<Item = f32>) -> f32 {
+    let exact = scores.map(f64::from).sum::<f64>();
+    let rounded = exact as f32;
+    if f64::from(rounded) < exact {
+        next_up_f32(rounded)
+    } else {
+        rounded
+    }
+}
+
+fn next_up_f32(value: f32) -> f32 {
+    if !value.is_finite() {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits(1);
+    }
+    let bits = value.to_bits();
+    if value > 0.0 {
+        f32::from_bits(bits + 1)
+    } else {
+        f32::from_bits(bits - 1)
+    }
+}
+
+fn next_down_f32(value: f32) -> f32 {
+    if !value.is_finite() {
+        return value;
+    }
+    if value == 0.0 {
+        return f32::from_bits((1_u32 << 31) | 1);
+    }
+    let bits = value.to_bits();
+    if value > 0.0 {
+        f32::from_bits(bits - 1)
+    } else {
+        f32::from_bits(bits + 1)
     }
 }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -99,7 +99,8 @@ use crate::io::exec::filtered_read::{
     FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
 };
 use crate::io::exec::fts::{
-    BoostQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
+    BoostQueryExec, CompoundQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
+    PhraseQueryExec,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -128,6 +129,89 @@ use lance_datafusion::substrait::parse_substrait;
 /// Rows per output batch when neither the scan options nor
 /// `LANCE_DEFAULT_BATCH_SIZE` specify one.
 pub const BATCH_SIZE_FALLBACK: usize = 8192;
+
+fn collect_all_fts_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
+    match query {
+        FtsQuery::Match(query) => {
+            if let Some(column) = &query.column {
+                columns.insert(column.clone());
+            }
+        }
+        FtsQuery::Phrase(query) => {
+            if let Some(column) = &query.column {
+                columns.insert(column.clone());
+            }
+        }
+        FtsQuery::Boost(query) => {
+            collect_all_fts_columns(&query.positive, columns);
+            collect_all_fts_columns(&query.negative, columns);
+        }
+        FtsQuery::MultiMatch(query) => {
+            for match_query in &query.match_queries {
+                if let Some(column) = &match_query.column {
+                    columns.insert(column.clone());
+                }
+            }
+        }
+        FtsQuery::Boolean(query) => {
+            for child in query
+                .should
+                .iter()
+                .chain(&query.must)
+                .chain(&query.must_not)
+            {
+                collect_all_fts_columns(child, columns);
+            }
+        }
+    }
+}
+
+fn supports_compound_scorer(query: &FtsQuery) -> bool {
+    if !matches!(query, FtsQuery::MultiMatch(_)) {
+        return false;
+    }
+    let mut columns = HashSet::new();
+    collect_all_fts_columns(query, &mut columns);
+    columns.len() == 1
+}
+
+fn validate_fts_match_boosts(query: &FtsQuery) -> Result<()> {
+    fn validate_multiplier(value: f32) -> Result<()> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(())
+        } else {
+            Err(Error::invalid_input(format!(
+                "MatchQuery boost must be finite and non-negative, got {value}"
+            )))
+        }
+    }
+
+    match query {
+        FtsQuery::Match(query) => validate_multiplier(query.boost),
+        FtsQuery::Phrase(_) => Ok(()),
+        FtsQuery::Boost(query) => {
+            validate_fts_match_boosts(&query.positive)?;
+            validate_fts_match_boosts(&query.negative)
+        }
+        FtsQuery::MultiMatch(query) => {
+            for match_query in &query.match_queries {
+                validate_multiplier(match_query.boost)?;
+            }
+            Ok(())
+        }
+        FtsQuery::Boolean(query) => {
+            for child in query
+                .should
+                .iter()
+                .chain(&query.must)
+                .chain(&query.must_not)
+            {
+                validate_fts_match_boosts(child)?;
+            }
+            Ok(())
+        }
+    }
+}
 
 /// Parse an environment variable as a specific type, logging a warning on parse failure.
 fn parse_env_var<T: std::str::FromStr>(env_var_name: &str, default_val: &str) -> Option<T>
@@ -3370,6 +3454,7 @@ impl Scanner {
         } else {
             query.query.clone()
         };
+        validate_fts_match_boosts(&query)?;
 
         // TODO: Could maybe walk the query here to find all the indices that will be
         // involved in the query to calculate a more accuarate required_fragments than
@@ -3390,6 +3475,62 @@ impl Scanner {
         Ok(fts_exec)
     }
 
+    async fn plan_compound_scorer(
+        &self,
+        query: &FtsQuery,
+        params: &FtsSearchParams,
+        prefilter_source: &PreFilterSource,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let mut columns = HashSet::new();
+        collect_all_fts_columns(query, &mut columns);
+        let Some(column) = columns.into_iter().next() else {
+            return Ok(None);
+        };
+
+        let index = self
+            .dataset
+            .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
+            .await?;
+        let Some(index) = index else {
+            return Ok(None);
+        };
+        let target_fragments = self
+            .fragments
+            .clone()
+            .unwrap_or_else(|| self.dataset.fragments().to_vec());
+        if !self
+            .retain_target_fragments(self.dataset.unindexed_fragments(&index.name).await?)
+            .is_empty()
+        {
+            // Flat and posting-backed leaves do not share a document domain.
+            // Preserve the exact DataFusion fallback until flat leaves expose
+            // the same candidate protocol.
+            return Ok(None);
+        }
+        let (stale_fragments, fresh_segments) = self
+            .fts_stale_frags_and_fresh_segments(&column, &target_fragments)
+            .await?;
+        if !stale_fragments.is_empty() {
+            return Ok(None);
+        }
+
+        let segments = match fresh_segments {
+            Some(segments) => segments,
+            None => load_segments(&self.dataset, &column)
+                .await?
+                .ok_or_else(|| {
+                    Error::invalid_input(format!("No Inverted index found for column {column}"))
+                })?,
+        };
+        Ok(Some(Arc::new(CompoundQueryExec::new_with_segments(
+            self.dataset.clone(),
+            query.clone(),
+            params.clone(),
+            prefilter_source.clone(),
+            segments,
+        ))))
+    }
+
     async fn plan_fts(
         &self,
         query: &FtsQuery,
@@ -3397,6 +3538,17 @@ impl Scanner {
         filter_plan: &ExprFilterPlan,
         prefilter_source: &PreFilterSource,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        if supports_compound_scorer(query)
+            && let Some(plan) = self
+                .plan_compound_scorer(query, params, prefilter_source)
+                .await?
+        {
+            return Ok(plan);
+        }
+
+        // Cross-column, flat, and overlay-backed compound queries retain the
+        // exact DataFusion fallback because their leaves do not share one
+        // posting document domain.
         let plan: Arc<dyn ExecutionPlan> = match query {
             FtsQuery::Match(query) => {
                 self.plan_match_query(query, params, filter_plan, prefilter_source)
@@ -5824,7 +5976,7 @@ mod test {
     };
     use lance_file::version::LanceFileVersion;
     use lance_index::optimize::OptimizeOptions;
-    use lance_index::scalar::inverted::query::{MatchQuery, PhraseQuery};
+    use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, PhraseQuery};
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::ivf::IvfBuildParams;
     use lance_index::vector::pq::PQBuildParams;
@@ -5847,6 +5999,14 @@ mod test {
     use crate::utils::test::{
         DatagenExt, FragmentCount, FragmentRowCount, ThrottledStoreWrapper, assert_plan_node_equals,
     };
+
+    #[test]
+    fn test_fts_match_boosts_reject_invalid_values() {
+        let negative_match = FtsQuery::Match(MatchQuery::new("hello".to_string()).with_boost(-1.0));
+        let error = validate_fts_match_boosts(&negative_match).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("finite and non-negative"));
+    }
 
     #[test]
     fn test_env_var_parsing() {

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1011,7 +1011,22 @@ async fn test_nested_multimatch_limit_propagation() {
         ),
     ])
     .into();
-    assert_compound_fts_top_k(&dataset, should_query, 2).await;
+    assert_compound_fts_top_k(&dataset, should_query.clone(), 2).await;
+    let mut fallback_scanner = dataset.scan();
+    fallback_scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(should_query))
+        .unwrap();
+    fallback_scanner.limit(Some(2), None).unwrap();
+    let fallback_plan = fallback_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        fallback_plan.contains("BooleanQuery"),
+        "cross-column compound FTS should retain its exact fallback:\n{fallback_plan}"
+    );
+    assert!(
+        !fallback_plan.contains("CompoundFtsScorer"),
+        "cross-column compound FTS is not yet supported by the scorer tree:\n{fallback_plan}"
+    );
 
     let boost_query: FtsQuery = BoostQuery::new(
         compound_multimatch_query(),
@@ -1022,6 +1037,56 @@ async fn test_nested_multimatch_limit_propagation() {
     assert_compound_fts_top_k(&dataset, boost_query, 2).await;
 
     assert_compound_fts_top_k(&dataset, compound_multimatch_query(), 1).await;
+}
+
+#[tokio::test]
+async fn test_same_column_multimatch_uses_compound_scorer() {
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        [
+            "common",
+            "common filler filler filler",
+            "irrelevant",
+            "common tie",
+            "common tie",
+            "common filler"
+        ]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "text").await;
+
+    let same_column_multimatch: FtsQuery = MultiMatchQuery::try_new(
+        "common".to_owned(),
+        vec!["text".to_owned(), "text".to_owned()],
+    )
+    .unwrap()
+    .try_with_boosts(vec![1.0, 0.5])
+    .unwrap()
+    .into();
+    assert_compound_fts_top_k(&dataset, same_column_multimatch.clone(), 2).await;
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(same_column_multimatch))
+        .unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("CompoundFtsScorer"),
+        "bounded same-column MultiMatch should use posting-backed scorers:\n{plan}"
+    );
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -864,6 +864,14 @@ async fn test_fts_on_multiple_columns() {
 }
 
 async fn create_fragmented_fts_index(dataset: &mut Dataset, column: &str) {
+    create_fragmented_fts_index_with_order(dataset, column, false).await;
+}
+
+async fn create_fragmented_fts_index_with_order(
+    dataset: &mut Dataset,
+    column: &str,
+    reverse_segments: bool,
+) {
     let index_name = format!("{column}_idx");
     let columns = [column];
     let params = InvertedIndexParams::default();
@@ -879,6 +887,9 @@ async fn create_fragmented_fts_index(dataset: &mut Dataset, column: &str) {
             .name(index_name.clone())
             .fragments(vec![*fragment_id]);
         segments.push(builder.execute_uncommitted().await.unwrap());
+    }
+    if reverse_segments {
+        segments.reverse();
     }
     dataset
         .commit_existing_index_segments(&index_name, column, segments)
@@ -1087,6 +1098,33 @@ async fn test_same_column_multimatch_uses_compound_scorer() {
         plan.contains("CompoundFtsScorer"),
         "bounded same-column MultiMatch should use posting-backed scorers:\n{plan}"
     );
+}
+
+#[tokio::test]
+async fn test_compound_tie_uses_resolved_row_id() {
+    let batch =
+        arrow_array::record_batch!(("text", Utf8, ["common", "common", "common", "common"]))
+            .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index_with_order(&mut dataset, "text", true).await;
+
+    let query: FtsQuery = MultiMatchQuery::try_new(
+        "common".to_owned(),
+        vec!["text".to_owned(), "text".to_owned()],
+    )
+    .unwrap()
+    .into();
+    assert_compound_fts_top_k(&dataset, query, 1).await;
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -46,12 +46,12 @@ use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
 use lance_index::scalar::inverted::document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer};
 use lance_index::scalar::inverted::query::{
-    BoostQuery, FtsSearchParams, MatchQuery, PhraseQuery, Tokens, collect_query_tokens,
-    has_query_token,
+    BoostQuery, FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, PhraseQuery, Tokens,
+    collect_query_tokens, has_query_token,
 };
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
-    FTS_SCHEMA, InvertedIndex, MemBM25Scorer, SCORE_COL, build_global_bm25_scorer,
+    FTS_SCHEMA, InvertedIndex, MemBM25Scorer, SCORE_COL, build_global_bm25_scorer, compound_search,
     flat_bm25_search_stream_with_metrics_and_operator,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
@@ -161,6 +161,220 @@ fn compare_scored_rows(
     right_score
         .total_cmp(left_score)
         .then_with(|| left_row_id.cmp(right_row_id))
+}
+
+fn count_fts_leaves(query: &FtsQuery) -> usize {
+    match query {
+        FtsQuery::Match(_) | FtsQuery::Phrase(_) => 1,
+        FtsQuery::Boost(query) => {
+            count_fts_leaves(&query.positive) + count_fts_leaves(&query.negative)
+        }
+        FtsQuery::MultiMatch(query) => query.match_queries.len(),
+        FtsQuery::Boolean(query) => query
+            .should
+            .iter()
+            .chain(&query.must)
+            .chain(&query.must_not)
+            .map(count_fts_leaves)
+            .sum(),
+    }
+}
+
+/// One DataFusion boundary around a posting-backed compound scorer tree.
+#[derive(Debug)]
+pub(crate) struct CompoundQueryExec {
+    dataset: Arc<Dataset>,
+    query: FtsQuery,
+    params: FtsSearchParams,
+    prefilter_source: PreFilterSource,
+    segment_selection: FtsSegmentSelection,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl CompoundQueryExec {
+    pub(crate) fn new_with_segments(
+        dataset: Arc<Dataset>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+        prefilter_source: PreFilterSource,
+        segments: Vec<IndexMetadata>,
+    ) -> Self {
+        Self {
+            dataset,
+            query,
+            params,
+            prefilter_source,
+            segment_selection: FtsSegmentSelection::ExactResolved(Arc::from(segments)),
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(FTS_SCHEMA.clone()),
+                Partitioning::RoundRobinBatch(1),
+                EmissionType::Final,
+                Boundedness::Bounded,
+            )),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl DisplayAs for CompoundQueryExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "CompoundFtsScorer: query={}", self.query)
+            }
+            DisplayFormatType::TreeRender => write!(f, "CompoundFtsScorer\nquery={}", self.query),
+        }
+    }
+}
+
+impl ExecutionPlan for CompoundQueryExec {
+    fn name(&self) -> &str {
+        "CompoundQueryExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        match &self.prefilter_source {
+            PreFilterSource::None => vec![],
+            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
+                vec![source]
+            }
+        }
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let prefilter_source = match children.len() {
+            0 if matches!(self.prefilter_source, PreFilterSource::None) => PreFilterSource::None,
+            1 => {
+                let Some(source) = children.pop() else {
+                    return Err(DataFusionError::Internal(
+                        "compound FTS lost its prefilter child".to_string(),
+                    ));
+                };
+                match &self.prefilter_source {
+                    PreFilterSource::FilteredRowIds(_) => PreFilterSource::FilteredRowIds(source),
+                    PreFilterSource::ScalarIndexQuery(_) => {
+                        PreFilterSource::ScalarIndexQuery(source)
+                    }
+                    PreFilterSource::None => {
+                        return Err(DataFusionError::Internal(
+                            "compound FTS received an unexpected prefilter child".to_string(),
+                        ));
+                    }
+                }
+            }
+            count => {
+                return Err(DataFusionError::Internal(format!(
+                    "compound FTS expected at most one prefilter child, got {count}"
+                )));
+            }
+        };
+        Ok(Arc::new(Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            params: self.params.clone(),
+            prefilter_source,
+            segment_selection: self.segment_selection.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }))
+    }
+
+    #[instrument(name = "compound_fts_scorer_exec", level = "debug", skip_all)]
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let dataset = self.dataset.clone();
+        let query = self.query.clone();
+        let params = self.params.clone();
+        let prefilter_source = self.prefilter_source.clone();
+        let segment_selection = self.segment_selection.clone();
+        let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
+
+        let stream = stream::once(async move {
+            let _timer = metrics.baseline_metrics.elapsed_compute().timer();
+            let columns = query.columns();
+            let column = columns.iter().next().ok_or_else(|| {
+                DataFusionError::Execution(
+                    "compound FTS query does not reference an indexed column".to_string(),
+                )
+            })?;
+            if columns.len() != 1 {
+                return Err(DataFusionError::Execution(
+                    "posting-backed compound FTS requires exactly one column".to_string(),
+                ));
+            }
+            let segments = segment_selection
+                .resolve(&dataset, column, &metrics.segment_bind_duration)
+                .await?;
+            let _details = load_segment_details(&dataset, column, &segments).await?;
+            let indices =
+                open_fts_segments(&dataset, column, &segments, &metrics.index_metrics).await?;
+            let mut prefilter =
+                build_prefilter(context, partition, &prefilter_source, dataset, &segments)?;
+            let deleted_fragments =
+                indices
+                    .iter()
+                    .fold(roaring::RoaringBitmap::new(), |mut deleted, index| {
+                        deleted |= index.deleted_fragments().clone();
+                        deleted
+                    });
+            if !deleted_fragments.is_empty() {
+                let prefilter = Arc::get_mut(&mut prefilter).ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "compound FTS prefilter was unexpectedly shared before initialization"
+                            .to_string(),
+                    )
+                })?;
+                prefilter.set_deleted_fragments(deleted_fragments);
+            }
+            metrics.record_parts_searched(
+                indices
+                    .iter()
+                    .map(|index| index.partition_count())
+                    .sum::<usize>()
+                    .saturating_mul(count_fts_leaves(&query)),
+            );
+            let (row_ids, scores) =
+                compound_search(&indices, &query, &params, prefilter, metrics.clone()).await?;
+            metrics.baseline_metrics.record_output(row_ids.len());
+            Ok::<_, DataFusionError>(RecordBatch::try_new(
+                FTS_SCHEMA.clone(),
+                vec![
+                    Arc::new(UInt64Array::from(row_ids)),
+                    Arc::new(Float32Array::from(scores)),
+                ],
+            )?)
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream.stream_in_current_span().boxed(),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
 }
 
 /// Fall back to the default simple tokenizer when no on-disk FTS segment exists.


### PR DESCRIPTION
## Feature

### What is the new feature?

Introduce the posting-backed compound FTS scoring core and use it for bounded same-column `MultiMatchQuery` execution. The change adds the internal `ComposableScorer` protocol, a cross-partition `TopKCollector`, incremental `WandCursor` support, and `CompoundQueryExec` integration.

### Why do we need this feature?

Compound FTS currently falls back to DataFusion plans that remove the query limit and materialize intermediate results. Leaf FTS already has WAND/MAXSCORE bounds; this PR establishes the composable scorer and collector layer needed to preserve exact top-k semantics while applying the limit inside posting-backed execution.

### How does it work?

- Scorers expose ordered document iteration, exact scores, shallow score bounds, competitive-score feedback, and two-phase confirmation.
- One collector owns the competitive threshold across all index partitions and applies deterministic score/row-id tie ordering.
- Same-column, fully indexed, fresh `MultiMatchQuery` shapes use DisMax over posting-backed leaves.
- Cross-column, incomplete-index, stale-overlay, and unsupported query shapes retain the existing exact fallback.

## Stack

1. This PR: scorer core + same-column MultiMatch
2. #8093: Boolean + Phrase
3. #8094: Boost + nested composition

Related: https://linear.app/lancedb/issue/OSS-1598/introduce-a-composable-scorer-interface-for-compound-fts

## Validation

- `cargo check -p lance-index -p lance --lib`
- `cargo test -p lance-index scalar::inverted::compound::tests --lib`
- `cargo test -p lance dataset::tests::dataset_index::test_same_column_multimatch_uses_compound_scorer --lib`
- `cargo test -p lance dataset::tests::dataset_index::test_nested_multimatch_limit_propagation --lib`
- `cargo clippy -p lance-index -p lance --lib --tests -- -D warnings`
- `cargo fmt --all`