### PR TITLE
feat(fts): compose boolean and phrase scorers

### DIFF
--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -17,7 +17,9 @@ use super::{
     document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer},
     documents::{DocId, DocLengths, DocVisibility},
     index::{DocSet, InvertedPartition},
-    query::{FtsQuery, FtsSearchParams, MatchQuery, Operator, Tokens, collect_query_tokens},
+    query::{
+        FtsQuery, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens, collect_query_tokens,
+    },
     scorer::MemBM25Scorer,
     tokenizer::document_tokenizer::TextTokenizer,
     wand::{
@@ -92,6 +94,27 @@ impl ScoreBounds {
         Self {
             lower: next_down(self.lower * factor),
             upper: next_up(self.upper * factor),
+        }
+    }
+
+    fn include_zero(self) -> Self {
+        Self {
+            lower: self.lower.min(0.0),
+            upper: self.upper.max(0.0),
+        }
+    }
+
+    fn add(self, other: Self) -> Self {
+        if !self.lower.is_finite()
+            || !self.upper.is_finite()
+            || !other.lower.is_finite()
+            || !other.upper.is_finite()
+        {
+            return Self::UNBOUNDED;
+        }
+        Self {
+            lower: next_down(self.lower + other.lower),
+            upper: next_up(self.upper + other.upper),
         }
     }
 }
@@ -171,8 +194,16 @@ type BoxScorer<'a> = Box<dyn ComposableScorer + 'a>;
 
 #[derive(Debug, Clone)]
 enum CompoundScorerPlan {
-    Leaf { index: usize, boost: f32 },
+    Leaf {
+        index: usize,
+        boost: f32,
+    },
     MultiMatch(Vec<Self>),
+    Boolean {
+        should: Vec<Self>,
+        must: Vec<Self>,
+        must_not: Vec<Self>,
+    },
 }
 
 impl CompoundScorerPlan {
@@ -186,6 +217,11 @@ impl CompoundScorerPlan {
                     boost: query.boost,
                 })
             }
+            FtsQuery::Phrase(_) => {
+                let index = *num_leaves;
+                *num_leaves += 1;
+                Ok(Self::Leaf { index, boost: 1.0 })
+            }
             FtsQuery::MultiMatch(query) => Ok(Self::MultiMatch(
                 query
                     .match_queries
@@ -193,8 +229,25 @@ impl CompoundScorerPlan {
                     .map(|query| Self::from_query(&FtsQuery::Match(query.clone()), num_leaves))
                     .collect::<Result<Vec<_>>>()?,
             )),
-            _ => Err(Error::not_supported(
-                "posting-backed compound FTS currently supports MultiMatch queries only",
+            FtsQuery::Boolean(query) => Ok(Self::Boolean {
+                should: query
+                    .should
+                    .iter()
+                    .map(|query| Self::from_query(query, num_leaves))
+                    .collect::<Result<Vec<_>>>()?,
+                must: query
+                    .must
+                    .iter()
+                    .map(|query| Self::from_query(query, num_leaves))
+                    .collect::<Result<Vec<_>>>()?,
+                must_not: query
+                    .must_not
+                    .iter()
+                    .map(|query| Self::from_query(query, num_leaves))
+                    .collect::<Result<Vec<_>>>()?,
+            }),
+            FtsQuery::Boost(_) => Err(Error::not_supported(
+                "posting-backed compound FTS does not support BoostQuery yet",
             )),
         }
     }
@@ -214,6 +267,24 @@ impl CompoundScorerPlan {
             }
             Self::MultiMatch(children) => Ok(Box::new(DisjunctionScorer::try_new(
                 children
+                    .iter()
+                    .map(|child| child.build(leaves))
+                    .collect::<Result<Vec<_>>>()?,
+                DisjunctionScore::Max,
+            )?)),
+            Self::Boolean {
+                should,
+                must,
+                must_not,
+            } => Ok(Box::new(BooleanScorer::try_new(
+                should
+                    .iter()
+                    .map(|child| child.build(leaves))
+                    .collect::<Result<Vec<_>>>()?,
+                must.iter()
+                    .map(|child| child.build(leaves))
+                    .collect::<Result<Vec<_>>>()?,
+                must_not
                     .iter()
                     .map(|child| child.build(leaves))
                     .collect::<Result<Vec<_>>>()?,
@@ -263,7 +334,11 @@ impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
     }
 
     fn matches(&mut self) -> Result<bool> {
-        Ok(true)
+        self.matches()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.match_cost()
     }
 }
 
@@ -661,6 +736,12 @@ impl TopKCollector<u64> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum DisjunctionScore {
+    Sum,
+    Max,
+}
+
 struct EmptyScorer;
 
 impl ComposableScorer for EmptyScorer {
@@ -768,9 +849,10 @@ impl ComposableScorer for ScaleScorer<'_> {
     }
 }
 
-/// Union scorer used for MultiMatch DisMax.
+/// Union scorer used for Boolean SHOULD sums and MultiMatch DisMax.
 pub(super) struct DisjunctionScorer<'a> {
     children: Vec<BoxScorer<'a>>,
+    mode: DisjunctionScore,
     current: Option<u64>,
     confirmed_doc: Option<u64>,
     confirmed: Vec<bool>,
@@ -778,7 +860,7 @@ pub(super) struct DisjunctionScorer<'a> {
 }
 
 impl<'a> DisjunctionScorer<'a> {
-    pub(super) fn try_new(children: Vec<BoxScorer<'a>>) -> Result<Self> {
+    pub(super) fn try_new(children: Vec<BoxScorer<'a>>, mode: DisjunctionScore) -> Result<Self> {
         if children.is_empty() {
             return Err(Error::internal(
                 "FTS disjunction scorer requires at least one child",
@@ -787,6 +869,7 @@ impl<'a> DisjunctionScorer<'a> {
         let confirmed = vec![false; children.len()];
         Ok(Self {
             children,
+            mode,
             current: None,
             confirmed_doc: None,
             confirmed,
@@ -875,13 +958,19 @@ impl ComposableScorer for DisjunctionScorer<'_> {
                 "FTS disjunction score requested for an unconfirmed document",
             ));
         }
-        let mut score = f32::NEG_INFINITY;
+        let mut score = match self.mode {
+            DisjunctionScore::Sum => 0.0_f32,
+            DisjunctionScore::Max => f32::NEG_INFINITY,
+        };
         for (matched, child) in self.confirmed.iter().zip(&mut self.children) {
             if !matched {
                 continue;
             }
             let child_score = child.score()?;
-            score = score.max(child_score);
+            score = match self.mode {
+                DisjunctionScore::Sum => score + child_score,
+                DisjunctionScore::Max => score.max(child_score),
+            };
         }
         checked_score(score, "FTS disjunction")
     }
@@ -897,9 +986,12 @@ impl ComposableScorer for DisjunctionScorer<'_> {
     }
 
     fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
-        let mut bounds = ScoreBounds {
-            lower: f32::INFINITY,
-            upper: f32::NEG_INFINITY,
+        let mut bounds = match self.mode {
+            DisjunctionScore::Sum => ScoreBounds::ZERO,
+            DisjunctionScore::Max => ScoreBounds {
+                lower: f32::INFINITY,
+                upper: f32::NEG_INFINITY,
+            },
         };
         for child in &mut self.children {
             let child_bounds = if child.doc().is_some_and(|doc| doc <= up_to) {
@@ -907,9 +999,12 @@ impl ComposableScorer for DisjunctionScorer<'_> {
             } else {
                 ScoreBounds::ZERO
             };
-            bounds = ScoreBounds {
-                lower: bounds.lower.min(child_bounds.lower),
-                upper: bounds.upper.max(child_bounds.upper),
+            bounds = match self.mode {
+                DisjunctionScore::Sum => bounds.add(child_bounds.include_zero()),
+                DisjunctionScore::Max => ScoreBounds {
+                    lower: bounds.lower.min(child_bounds.lower),
+                    upper: bounds.upper.max(child_bounds.upper),
+                },
             };
         }
         if bounds.lower == f32::INFINITY {
@@ -929,8 +1024,13 @@ impl ComposableScorer for DisjunctionScorer<'_> {
             return Ok(());
         }
         self.min_competitive_score = min_score;
-        for child in &mut self.children {
-            child.set_min_competitive_score(min_score)?;
+        // A child below a DisMax threshold cannot affect a competitive max.
+        // Sum scorers need sibling-global bounds before translating the floor,
+        // so they keep it at this node and prune from their combined block bound.
+        if matches!(self.mode, DisjunctionScore::Max) {
+            for child in &mut self.children {
+                child.set_min_competitive_score(min_score)?;
+            }
         }
         Ok(())
     }
@@ -947,21 +1047,325 @@ impl ComposableScorer for DisjunctionScorer<'_> {
     }
 }
 
+/// Intersection scorer preserving the existing Boolean MUST score contract:
+/// all children filter membership, while the first MUST child supplies score.
+pub(super) struct RequiredConjunctionScorer<'a> {
+    children: Vec<BoxScorer<'a>>,
+    current: Option<u64>,
+    confirmed_doc: Option<u64>,
+    confirmed: bool,
+}
+
+impl<'a> RequiredConjunctionScorer<'a> {
+    pub(super) fn try_new(children: Vec<BoxScorer<'a>>) -> Result<Self> {
+        if children.is_empty() {
+            return Err(Error::internal(
+                "FTS conjunction scorer requires at least one child",
+            ));
+        }
+        Ok(Self {
+            children,
+            current: None,
+            confirmed_doc: None,
+            confirmed: false,
+        })
+    }
+
+    fn align(&mut self, target: u64) -> Result<Option<u64>> {
+        let mut target = target;
+        loop {
+            for child in &mut self.children {
+                if child.doc().is_none_or(|doc| doc < target) {
+                    let Some(doc) = child.advance(target)? else {
+                        self.current = None;
+                        return Ok(None);
+                    };
+                    target = target.max(doc);
+                }
+            }
+            let min_doc = self.children.iter().filter_map(|child| child.doc()).min();
+            let max_doc = self.children.iter().filter_map(|child| child.doc()).max();
+            if min_doc == max_doc {
+                self.current = min_doc;
+                self.confirmed_doc = None;
+                self.confirmed = false;
+                return Ok(self.current);
+            }
+            target = max_doc.ok_or_else(|| {
+                Error::internal("FTS conjunction lost a child while aligning scorers")
+            })?;
+        }
+    }
+
+    fn ensure_confirmed(&mut self) -> Result<bool> {
+        let Some(current) = self.current else {
+            return Ok(false);
+        };
+        if self.confirmed_doc == Some(current) {
+            return Ok(self.confirmed);
+        }
+        self.confirmed = true;
+        for child in &mut self.children {
+            if !child.matches()? {
+                self.confirmed = false;
+            }
+        }
+        self.confirmed_doc = Some(current);
+        Ok(self.confirmed)
+    }
+}
+
+impl ComposableScorer for RequiredConjunctionScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.children.first().and_then(|child| child.document_key())
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        let target = match self.current {
+            None => 0,
+            Some(u64::MAX) => return Ok(None),
+            Some(current) => current + 1,
+        };
+        self.align(target)
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.current.is_some_and(|current| current >= target) {
+            return Ok(self.current);
+        }
+        self.align(target)
+    }
+
+    fn cost(&self) -> usize {
+        self.children
+            .iter()
+            .map(|child| child.cost())
+            .min()
+            .unwrap_or(0)
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        if !self.ensure_confirmed()? {
+            return Err(Error::internal(
+                "FTS conjunction score requested for an unconfirmed document",
+            ));
+        }
+        self.children[0].score()
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let mut up_to = u64::MAX;
+        for child in &mut self.children {
+            let child_target = child.doc().map_or(target, |doc| target.max(doc));
+            up_to = up_to.min(child.advance_shallow(child_target)?);
+        }
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        self.children[0].score_bounds(up_to)
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        // Only the first MUST child contributes score. The remaining children
+        // are exact membership filters and must never be score-pruned.
+        self.children[0].set_min_competitive_score(min_score)
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.ensure_confirmed()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.children
+            .iter()
+            .filter_map(|child| child.match_cost())
+            .reduce(|left, right| left + right)
+    }
+}
+
+/// Boolean scorer preserving the current membership and score semantics.
+pub(super) struct BooleanScorer<'a> {
+    driver: BoxScorer<'a>,
+    optional: Option<BoxScorer<'a>>,
+    prohibited: Option<BoxScorer<'a>>,
+    current: Option<u64>,
+    optional_matches: bool,
+}
+
+impl<'a> BooleanScorer<'a> {
+    pub(super) fn try_new(
+        should: Vec<BoxScorer<'a>>,
+        must: Vec<BoxScorer<'a>>,
+        must_not: Vec<BoxScorer<'a>>,
+    ) -> Result<Self> {
+        let mut optional = if should.is_empty() {
+            None
+        } else {
+            Some(
+                Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
+                    as BoxScorer<'a>,
+            )
+        };
+        let driver = if must.is_empty() {
+            optional.take().ok_or_else(|| {
+                Error::invalid_input("boolean query must have at least one should/must query")
+            })?
+        } else {
+            Box::new(RequiredConjunctionScorer::try_new(must)?) as BoxScorer<'a>
+        };
+        let prohibited = if must_not.is_empty() {
+            None
+        } else {
+            Some(
+                Box::new(DisjunctionScorer::try_new(must_not, DisjunctionScore::Max)?)
+                    as BoxScorer<'a>,
+            )
+        };
+        Ok(Self {
+            driver,
+            optional,
+            prohibited,
+            current: None,
+            optional_matches: false,
+        })
+    }
+
+    fn accept_driver_doc(&mut self) -> Result<bool> {
+        let Some(current) = self.driver.doc() else {
+            return Ok(false);
+        };
+        if !self.driver.matches()? {
+            return Ok(false);
+        }
+        if let Some(prohibited) = &mut self.prohibited
+            && prohibited.advance(current)? == Some(current)
+            && prohibited.matches()?
+        {
+            return Ok(false);
+        }
+        self.optional_matches = if let Some(optional) = &mut self.optional {
+            optional.advance(current)? == Some(current) && optional.matches()?
+        } else {
+            false
+        };
+        self.current = Some(current);
+        Ok(true)
+    }
+
+    fn next_accepted(&mut self, target: Option<u64>) -> Result<Option<u64>> {
+        let mut doc = match target {
+            Some(target) => self.driver.advance(target)?,
+            None => self.driver.next()?,
+        };
+        while doc.is_some() {
+            if self.accept_driver_doc()? {
+                return Ok(self.current);
+            }
+            doc = self.driver.next()?;
+        }
+        self.current = None;
+        self.optional_matches = false;
+        Ok(None)
+    }
+}
+
+impl ComposableScorer for BooleanScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.driver.document_key()
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        self.next_accepted(None)
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.current.is_some_and(|current| current >= target) {
+            return Ok(self.current);
+        }
+        self.next_accepted(Some(target))
+    }
+
+    fn cost(&self) -> usize {
+        self.driver.cost()
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        if self.current.is_none() {
+            return Err(Error::internal(
+                "Boolean FTS scorer is not positioned on a document",
+            ));
+        }
+        let mut score = self.driver.score()?;
+        if self.optional_matches
+            && let Some(optional) = &mut self.optional
+        {
+            score += optional.score()?;
+        }
+        checked_score(score, "BooleanQuery scorer")
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let mut up_to = self.driver.advance_shallow(target)?;
+        if let Some(optional) = &mut self.optional
+            && let Some(doc) = optional.doc()
+        {
+            up_to = up_to.min(optional.advance_shallow(target.max(doc))?);
+        }
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let mut bounds = self.driver.score_bounds(up_to)?;
+        if let Some(optional) = &mut self.optional
+            && optional.doc().is_some_and(|doc| doc <= up_to)
+        {
+            bounds = bounds.add(optional.score_bounds(up_to)?.include_zero());
+        }
+        Ok(bounds)
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        // When SHOULD is also present, a global sibling bound is required to
+        // translate the parent threshold safely. The combined block bound still
+        // prunes at this node. Without SHOULD, driver score is the full score.
+        if self.optional.is_none() {
+            self.driver.set_min_competitive_score(min_score)?;
+        }
+        Ok(())
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        Ok(self.current.is_some())
+    }
+}
+
 #[derive(Clone)]
 enum LeafQuery {
     Match(MatchQuery),
+    Phrase(PhraseQuery),
 }
 
 impl LeafQuery {
     fn terms(&self) -> &str {
         match self {
             Self::Match(query) => &query.terms,
+            Self::Phrase(query) => &query.terms,
         }
     }
 
     fn operator(&self) -> Operator {
         match self {
             Self::Match(query) => query.operator,
+            Self::Phrase(_) => Operator::And,
         }
     }
 
@@ -974,22 +1378,38 @@ impl LeafQuery {
                 .with_fuzziness(query.fuzziness)
                 .with_max_expansions(query.max_expansions)
                 .with_prefix_length(query.prefix_length),
+            Self::Phrase(query) => params
+                .clone()
+                .with_limit(None)
+                .with_phrase_slop(Some(query.slop)),
         }
     }
 }
 
-fn collect_leaf_queries(query: &FtsQuery) -> Result<Vec<LeafQuery>> {
+fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>) -> Result<()> {
     match query {
-        FtsQuery::MultiMatch(query) => Ok(query
-            .match_queries
-            .iter()
-            .cloned()
-            .map(LeafQuery::Match)
-            .collect()),
-        _ => Err(Error::not_supported(
-            "posting-backed compound FTS currently supports MultiMatch queries only",
-        )),
+        FtsQuery::Match(query) => leaves.push(LeafQuery::Match(query.clone())),
+        FtsQuery::Phrase(query) => leaves.push(LeafQuery::Phrase(query.clone())),
+        FtsQuery::MultiMatch(query) => {
+            leaves.extend(query.match_queries.iter().cloned().map(LeafQuery::Match));
+        }
+        FtsQuery::Boolean(query) => {
+            for child in query
+                .should
+                .iter()
+                .chain(&query.must)
+                .chain(&query.must_not)
+            {
+                collect_leaf_queries(child, leaves)?;
+            }
+        }
+        FtsQuery::Boost(_) => {
+            return Err(Error::not_supported(
+                "posting-backed compound FTS does not support BoostQuery yet",
+            ));
+        }
     }
+    Ok(())
 }
 
 struct PreparedLeaf {
@@ -1048,7 +1468,8 @@ async fn prepare_compound_query(
     let first_index = indices
         .first()
         .ok_or_else(|| Error::invalid_input("compound FTS requires at least one index segment"))?;
-    let leaf_queries = collect_leaf_queries(query)?;
+    let mut leaf_queries = Vec::new();
+    collect_leaf_queries(query, &mut leaf_queries)?;
     let mut num_plan_leaves = 0;
     let plan = CompoundScorerPlan::from_query(query, &mut num_plan_leaves)?;
     if num_plan_leaves != leaf_queries.len() {
@@ -1521,11 +1942,33 @@ mod tests {
     }
 
     #[test]
-    fn dismax_preserves_exact_scores_and_order() {
-        let mut dismax = DisjunctionScorer::try_new(vec![
-            materialized(&[(1, 2.0), (3, 3.0)]),
-            materialized(&[(1, 4.0), (2, 4.0)]),
-        ])
+    fn boolean_and_dismax_preserve_exact_scores_and_order() {
+        let must = vec![
+            materialized(&[(1, 3.0), (2, 2.0), (3, 1.0)]),
+            materialized(&[(1, 30.0), (3, 10.0)]),
+        ];
+        let should = vec![
+            materialized(&[(1, 0.5), (3, 4.0)]),
+            materialized(&[(3, 2.0)]),
+        ];
+        let must_not = vec![materialized(&[(1, 9.0)])];
+        let mut boolean = BooleanScorer::try_new(should, must, must_not).unwrap();
+        let results = TopKCollector::new(10).collect(&mut boolean).unwrap();
+        assert_eq!(
+            results,
+            vec![ScoredRow {
+                row_id: 3,
+                score: 7.0
+            }]
+        );
+
+        let mut dismax = DisjunctionScorer::try_new(
+            vec![
+                materialized(&[(1, 2.0), (3, 3.0)]),
+                materialized(&[(1, 4.0), (2, 4.0)]),
+            ],
+            DisjunctionScore::Max,
+        )
         .unwrap();
         let results = TopKCollector::new(2).collect(&mut dismax).unwrap();
         assert_eq!(results, rows(&[(1, 4.0), (2, 4.0)]));

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -4368,11 +4368,13 @@ impl<'a> PositionCursor<'a> {
 /// which owns the only competitive score for the whole scorer tree.
 pub(super) struct WandCursor<'a, D: WandDocuments> {
     wand: Wand<'a, Arc<MemBM25Scorer>, D>,
+    phrase_slop: Option<u32>,
     wand_factor: f32,
     cost: usize,
     current_doc: Option<DocInfo>,
     current_document_key: Option<u64>,
     current_score: f32,
+    confirmation: Option<bool>,
     shallow: Option<(u64, u64, f32)>,
     comparisons: usize,
     metrics_recorded: bool,
@@ -4400,11 +4402,13 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         .unwrap_or_default();
         Self {
             wand: Wand::new(operator, postings.into_iter(), documents, scorer),
+            phrase_slop: params.phrase_slop,
             wand_factor: params.wand_factor,
             cost,
             current_doc: None,
             current_document_key: None,
             current_score: 0.0,
+            confirmation: None,
             shallow: None,
             comparisons: 0,
             metrics_recorded: false,
@@ -4424,6 +4428,7 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         self.current_doc = None;
         self.current_document_key = None;
         self.current_score = 0.0;
+        self.confirmation = None;
         self.shallow = None;
     }
 
@@ -4460,6 +4465,7 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             self.current_doc = Some(doc);
             self.current_document_key = Some(document_key);
             self.current_score = score;
+            self.confirmation = self.phrase_slop.is_none().then_some(true);
             self.shallow = None;
             return Ok(Some(doc_id));
         }
@@ -4492,6 +4498,25 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         self.current_doc
             .map(|_| self.current_score)
             .ok_or_else(|| Error::internal("posting FTS scorer is not positioned on a document"))
+    }
+
+    pub(super) fn matches(&mut self) -> Result<bool> {
+        let Some(_) = self.current_doc else {
+            return Ok(false);
+        };
+        if let Some(confirmed) = self.confirmation {
+            return Ok(confirmed);
+        }
+        let phrase_slop = self.phrase_slop.ok_or_else(|| {
+            Error::internal("posting FTS scorer requires phrase slop for position confirmation")
+        })?;
+        let confirmed = self.wand.check_positions(phrase_slop as i32)?;
+        self.confirmation = Some(confirmed);
+        Ok(confirmed)
+    }
+
+    pub(super) fn match_cost(&self) -> Option<f32> {
+        self.phrase_slop.map(|_| self.wand.num_terms.max(1) as f32)
     }
 
     pub(super) fn advance_shallow(&mut self, target: u64) -> Result<u64> {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -167,7 +167,23 @@ fn collect_all_fts_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
 }
 
 fn supports_compound_scorer(query: &FtsQuery) -> bool {
-    if !matches!(query, FtsQuery::MultiMatch(_)) {
+    fn supports_shape(query: &FtsQuery) -> bool {
+        match query {
+            FtsQuery::Match(_) | FtsQuery::Phrase(_) | FtsQuery::MultiMatch(_) => true,
+            FtsQuery::Boolean(query) => {
+                (!query.should.is_empty() || !query.must.is_empty())
+                    && query
+                        .should
+                        .iter()
+                        .chain(&query.must)
+                        .chain(&query.must_not)
+                        .all(supports_shape)
+            }
+            FtsQuery::Boost(_) => false,
+        }
+    }
+
+    if matches!(query, FtsQuery::Match(_) | FtsQuery::Phrase(_)) || !supports_shape(query) {
         return false;
     }
     let mut columns = HashSet::new();
@@ -175,7 +191,23 @@ fn supports_compound_scorer(query: &FtsQuery) -> bool {
     columns.len() == 1
 }
 
-fn validate_fts_match_boosts(query: &FtsQuery) -> Result<()> {
+fn contains_phrase_query(query: &FtsQuery) -> bool {
+    match query {
+        FtsQuery::Phrase(_) => true,
+        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) => false,
+        FtsQuery::Boost(query) => {
+            contains_phrase_query(&query.positive) || contains_phrase_query(&query.negative)
+        }
+        FtsQuery::Boolean(query) => query
+            .should
+            .iter()
+            .chain(&query.must)
+            .chain(&query.must_not)
+            .any(contains_phrase_query),
+    }
+}
+
+fn validate_fts_query_contract(query: &FtsQuery) -> Result<()> {
     fn validate_multiplier(value: f32) -> Result<()> {
         if value.is_finite() && value >= 0.0 {
             Ok(())
@@ -190,8 +222,8 @@ fn validate_fts_match_boosts(query: &FtsQuery) -> Result<()> {
         FtsQuery::Match(query) => validate_multiplier(query.boost),
         FtsQuery::Phrase(_) => Ok(()),
         FtsQuery::Boost(query) => {
-            validate_fts_match_boosts(&query.positive)?;
-            validate_fts_match_boosts(&query.negative)
+            validate_fts_query_contract(&query.positive)?;
+            validate_fts_query_contract(&query.negative)
         }
         FtsQuery::MultiMatch(query) => {
             for match_query in &query.match_queries {
@@ -200,13 +232,18 @@ fn validate_fts_match_boosts(query: &FtsQuery) -> Result<()> {
             Ok(())
         }
         FtsQuery::Boolean(query) => {
+            if query.should.is_empty() && query.must.is_empty() {
+                return Err(Error::invalid_input(
+                    "boolean query must have at least one should/must query",
+                ));
+            }
             for child in query
                 .should
                 .iter()
                 .chain(&query.must)
                 .chain(&query.must_not)
             {
-                validate_fts_match_boosts(child)?;
+                validate_fts_query_contract(child)?;
             }
             Ok(())
         }
@@ -3454,7 +3491,7 @@ impl Scanner {
         } else {
             query.query.clone()
         };
-        validate_fts_match_boosts(&query)?;
+        validate_fts_query_contract(&query)?;
 
         // TODO: Could maybe walk the query here to find all the indices that will be
         // involved in the query to calculate a more accuarate required_fragments than
@@ -3522,6 +3559,15 @@ impl Scanner {
                     Error::invalid_input(format!("No Inverted index found for column {column}"))
                 })?,
         };
+        if contains_phrase_query(query) {
+            let details = load_segment_details(&self.dataset, &column, &segments).await?;
+            if !details.with_position {
+                return Err(Error::invalid_input(
+                    "position is not found but required for phrase queries, try recreating the index with position"
+                        .to_string(),
+                ));
+            }
+        }
         Ok(Some(Arc::new(CompoundQueryExec::new_with_segments(
             self.dataset.clone(),
             query.clone(),
@@ -5976,7 +6022,9 @@ mod test {
     };
     use lance_file::version::LanceFileVersion;
     use lance_index::optimize::OptimizeOptions;
-    use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, PhraseQuery};
+    use lance_index::scalar::inverted::query::{
+        BooleanQuery, FtsQuery, MatchQuery, Occur, PhraseQuery,
+    };
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::ivf::IvfBuildParams;
     use lance_index::vector::pq::PQBuildParams;
@@ -6001,11 +6049,16 @@ mod test {
     };
 
     #[test]
-    fn test_fts_match_boosts_reject_invalid_values() {
+    fn test_fts_query_contract_rejects_invalid_values() {
         let negative_match = FtsQuery::Match(MatchQuery::new("hello".to_string()).with_boost(-1.0));
-        let error = validate_fts_match_boosts(&negative_match).unwrap_err();
+        let error = validate_fts_query_contract(&negative_match).unwrap_err();
         assert!(matches!(error, Error::InvalidInput { .. }));
         assert!(error.to_string().contains("finite and non-negative"));
+
+        let empty_boolean = FtsQuery::Boolean(BooleanQuery::new(Vec::<(Occur, FtsQuery)>::new()));
+        let error = validate_fts_query_contract(&empty_boolean).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("at least one should/must query"));
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -863,18 +863,19 @@ async fn test_fts_on_multiple_columns() {
     assert_eq!(results.num_rows(), 1);
 }
 
-async fn create_fragmented_fts_index(dataset: &mut Dataset, column: &str) {
-    create_fragmented_fts_index_with_order(dataset, column, false).await;
+async fn create_fragmented_fts_index(dataset: &mut Dataset, column: &str, with_position: bool) {
+    create_fragmented_fts_index_with_order(dataset, column, with_position, false).await;
 }
 
 async fn create_fragmented_fts_index_with_order(
     dataset: &mut Dataset,
     column: &str,
+    with_position: bool,
     reverse_segments: bool,
 ) {
     let index_name = format!("{column}_idx");
     let columns = [column];
-    let params = InvertedIndexParams::default();
+    let params = InvertedIndexParams::default().with_position(with_position);
     let fragment_ids = dataset
         .get_fragments()
         .iter()
@@ -994,8 +995,8 @@ async fn test_nested_multimatch_limit_propagation() {
     .await
     .unwrap();
     assert_eq!(dataset.get_fragments().len(), 3);
-    create_fragmented_fts_index(&mut dataset, "title").await;
-    create_fragmented_fts_index(&mut dataset, "body").await;
+    create_fragmented_fts_index(&mut dataset, "title", false).await;
+    create_fragmented_fts_index(&mut dataset, "body", false).await;
 
     let must_query: FtsQuery = BooleanQuery::new([
         (Occur::Must, compound_multimatch_query()),
@@ -1051,7 +1052,7 @@ async fn test_nested_multimatch_limit_propagation() {
 }
 
 #[tokio::test]
-async fn test_same_column_multimatch_uses_compound_scorer() {
+async fn test_same_column_compound_scorer_is_exact_and_bounded() {
     let batch = arrow_array::record_batch!((
         "text",
         Utf8,
@@ -1076,7 +1077,43 @@ async fn test_same_column_multimatch_uses_compound_scorer() {
     )
     .await
     .unwrap();
-    create_fragmented_fts_index(&mut dataset, "text").await;
+    create_fragmented_fts_index(&mut dataset, "text", true).await;
+
+    let match_query = |term: &str| {
+        MatchQuery::new(term.to_owned())
+            .with_column(Some("text".to_owned()))
+            .into()
+    };
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("common")),
+        (Occur::Should, match_query("tie")),
+        (
+            Occur::Should,
+            PhraseQuery::new("common tie".to_owned())
+                .with_column(Some("text".to_owned()))
+                .into(),
+        ),
+        (Occur::MustNot, match_query("irrelevant")),
+    ])
+    .into();
+
+    assert_compound_fts_top_k(&dataset, query.clone(), 2).await;
+
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("CompoundFtsScorer"),
+        "same-column compound FTS should use the scorer tree:\n{plan}"
+    );
+    assert!(
+        !plan.contains("HashJoinExec"),
+        "same-column compound FTS should not materialize intermediate joins:\n{plan}"
+    );
 
     let same_column_multimatch: FtsQuery = MultiMatchQuery::try_new(
         "common".to_owned(),
@@ -1116,7 +1153,7 @@ async fn test_compound_tie_uses_resolved_row_id() {
     )
     .await
     .unwrap();
-    create_fragmented_fts_index_with_order(&mut dataset, "text", true).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "text", false, true).await;
 
     let query: FtsQuery = MultiMatchQuery::try_new(
         "common".to_owned(),

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -2855,13 +2855,13 @@ mod tests {
             .full_text_search(FullTextSearchQuery::new_query(query.into()))
             .unwrap();
         let analysis = scanner.analyze_plan().await.unwrap();
-        let boolean_line = analysis
+        let compound_line = analysis
             .lines()
-            .find(|line| line.contains("BooleanQuery"))
+            .find(|line| line.contains("CompoundFtsScorer"))
             .unwrap();
         assert!(
-            boolean_line.contains(&format!("{PARTITIONS_SEARCHED_METRIC}={expected_total}")),
-            "BooleanQuery metrics missing partitions_searched: {boolean_line}"
+            compound_line.contains(&format!("{PARTITIONS_SEARCHED_METRIC}={expected_total}")),
+            "compound FTS scorer metrics missing partitions_searched: {compound_line}"
         );
     }
 


### PR DESCRIPTION
## Feature

Review this PR as the Boolean/Phrase increment only.

### What is the new feature?

Extend the composable FTS scorer tree with same-column `BooleanQuery` and `PhraseQuery` execution.

### Why do we need this feature?

Boolean clauses need exact composition of required, optional, and prohibited matches without materializing join intermediates. Phrase clauses additionally require an approximation/confirmation split so posting iteration remains cheap while positional checks stay exact.

### How does it work?

- Boolean SHOULD clauses use score sums; MUST clauses intersect membership while preserving the existing first-MUST scoring contract; MUST NOT clauses filter confirmed matches.
- Phrase leaves use the scorer's two-phase `matches()` hook for positional confirmation.
- Sum and Boolean score bounds remain conservative before propagating competitive thresholds.
- Phrase-containing compound queries require an index with positions.
- Cross-column, incomplete-index, stale-overlay, and Boost-containing shapes continue to use the exact fallback in this layer.

## Stack

1. #8092: scorer core + same-column MultiMatch
2. This PR: Boolean + Phrase
3. #8094: Boost + nested composition

Related: https://linear.app/lancedb/issue/OSS-1598/introduce-a-composable-scorer-interface-for-compound-fts

## Validation

- `cargo check -p lance-index -p lance --lib`
- `cargo test -p lance-index scalar::inverted::compound::tests --lib`
- `cargo test -p lance dataset::tests::dataset_index::test_same_column_compound_scorer_is_exact_and_bounded --lib`
- `cargo test -p lance dataset::tests::dataset_index::test_nested_multimatch_limit_propagation --lib`
- `cargo test -p lance io::exec::fts::tests::test_boolean_query_parts_searched_metrics --lib`
- `cargo test -p lance dataset::scanner::test::test_fts_query_contract_rejects_invalid_values --lib`
- `cargo clippy -p lance-index -p lance --lib --tests -- -D warnings`
- `cargo fmt --all`