### PR TITLE
fix: validate primary key nullability on every path that can change it

### DIFF
--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -24,7 +24,7 @@ pub use manifest::{
     populate_manifest_schema_dictionaries,
 };
 pub use row_ids::{ExternalFile, InlineRowIds, RowIdMeta};
-pub use transaction::Transaction;
+pub use transaction::{Transaction, operation_may_change_schema};
 
 use lance_core::{Error, Result};
 

--- a/rust/lance-table/src/format/transaction.rs
+++ b/rust/lance-table/src/format/transaction.rs
@@ -61,6 +61,7 @@ pub fn operation_may_change_schema(transaction: &pb::Transaction) -> bool {
                 | Operation::UpdateConfig(_)
                 | Operation::UpdateMemWalState(_)
                 | Operation::UpdateBases(_)
+                | Operation::DataOverlay(_)
         )
     )
 }
@@ -102,6 +103,21 @@ mod tests {
         assert!(large.encoded_len() > small.encoded_len() * 100);
         assert!(!operation_may_change_schema(&small));
         assert!(!operation_may_change_schema(&large));
+    }
+
+    /// An overlay attaches files to existing fragments and supplies new cell
+    /// values; it carries no schema. Omitting it left a legacy nullable-key
+    /// dataset unable to commit one, which is the upgrade path this exemption
+    /// exists to keep open.
+    #[test]
+    fn a_data_overlay_is_exempt() {
+        let overlay = pb::Transaction {
+            operation: Some(pb::transaction::Operation::DataOverlay(
+                pb::transaction::DataOverlay::default(),
+            )),
+            ..Default::default()
+        };
+        assert!(!operation_may_change_schema(&overlay));
     }
 
     /// And the converse, so the exemption cannot silently widen to everything.

--- a/rust/lance-table/src/format/transaction.rs
+++ b/rust/lance-table/src/format/transaction.rs
@@ -35,10 +35,23 @@ impl Transaction {
     /// deletes needed to repair it. An unrecognized operation counts as
     /// schema-changing: an unknown write is not a safe one to exempt.
     pub fn may_change_schema(&self) -> bool {
-        use pb::transaction::Operation;
-        match self.inner.operation.as_ref() {
-            Some(
-                Operation::Append(_)
+        operation_may_change_schema(&self.inner)
+    }
+}
+
+/// The same classification for a protobuf that has not been wrapped yet.
+///
+/// The commit path has to classify the operation before it knows whether the
+/// encoded bytes are small enough to inline into the manifest. Reading the
+/// disposition off the inline copy instead would tie it to the payload size,
+/// so the identical operation would be classified one way under the inline
+/// limit and the other way above it.
+pub fn operation_may_change_schema(transaction: &pb::Transaction) -> bool {
+    use pb::transaction::Operation;
+    !matches!(
+        transaction.operation.as_ref(),
+        Some(
+            Operation::Append(_)
                 | Operation::Delete(_)
                 | Operation::CreateIndex(_)
                 | Operation::Rewrite(_)
@@ -47,11 +60,9 @@ impl Transaction {
                 | Operation::Update(_)
                 | Operation::UpdateConfig(_)
                 | Operation::UpdateMemWalState(_)
-                | Operation::UpdateBases(_),
-            ) => false,
-            _ => true,
-        }
-    }
+                | Operation::UpdateBases(_)
+        )
+    )
 }
 
 /// Write-boundary conversion: serialize using protobuf at the last step.
@@ -64,5 +75,49 @@ impl From<Transaction> for pb::Transaction {
 impl From<pb::Transaction> for Transaction {
     fn from(pb_tx: pb::Transaction) -> Self {
         Self { inner: pb_tx }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    /// The classification that must never depend on payload size. A MemWAL
+    /// table's transactions carry mem-table state and routinely outgrow the
+    /// inline limit, so an exempt operation has to stay exempt while large --
+    /// otherwise the deletes that repair an invalid key are blocked on exactly
+    /// the tables most likely to have one.
+    #[test]
+    fn an_exempt_operation_is_classified_the_same_at_any_size() {
+        let small = pb::Transaction {
+            operation: Some(pb::transaction::Operation::Delete(
+                pb::transaction::Delete::default(),
+            )),
+            ..Default::default()
+        };
+        let mut large = small.clone();
+        large.tag = "x".repeat(4 * 1024 * 1024);
+
+        assert!(large.encoded_len() > small.encoded_len() * 100);
+        assert!(!operation_may_change_schema(&small));
+        assert!(!operation_may_change_schema(&large));
+    }
+
+    /// And the converse, so the exemption cannot silently widen to everything.
+    #[test]
+    fn a_schema_carrying_operation_is_never_exempt() {
+        let overwrite = pb::Transaction {
+            operation: Some(pb::transaction::Operation::Overwrite(
+                pb::transaction::Overwrite::default(),
+            )),
+            ..Default::default()
+        };
+        assert!(operation_may_change_schema(&overwrite));
+
+        // An operation this build does not recognise must not be exempt
+        // either: an unknown write is not a safe one to skip.
+        let unknown = pb::Transaction::default();
+        assert!(operation_may_change_schema(&unknown));
     }
 }

--- a/rust/lance-table/src/format/transaction.rs
+++ b/rust/lance-table/src/format/transaction.rs
@@ -26,6 +26,32 @@ impl Transaction {
     pub fn as_pb(&self) -> &pb::Transaction {
         &self.inner
     }
+
+    /// Whether this transaction can change the schema, and so can introduce or
+    /// worsen an invalid primary key.
+    ///
+    /// The rest leave the key exactly as they found it, so a table that already
+    /// carries an invalid one stays writable through them -- including the
+    /// deletes needed to repair it. An unrecognized operation counts as
+    /// schema-changing: an unknown write is not a safe one to exempt.
+    pub fn may_change_schema(&self) -> bool {
+        use pb::transaction::Operation;
+        match self.inner.operation.as_ref() {
+            Some(
+                Operation::Append(_)
+                | Operation::Delete(_)
+                | Operation::CreateIndex(_)
+                | Operation::Rewrite(_)
+                | Operation::DataReplacement(_)
+                | Operation::ReserveFragments(_)
+                | Operation::Update(_)
+                | Operation::UpdateConfig(_)
+                | Operation::UpdateMemWalState(_)
+                | Operation::UpdateBases(_),
+            ) => false,
+            _ => true,
+        }
+    }
 }
 
 /// Write-boundary conversion: serialize using protobuf at the last step.

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -1446,6 +1446,11 @@ impl Transaction {
                         "the unenforced primary key is a reserved key and cannot be set to an invalid value",
                     ));
                 }
+                if writes_primary_key {
+                    // Installing by field metadata skips the Arrow-schema
+                    // conversion that would otherwise validate the key.
+                    manifest.schema.verify_primary_key()?;
+                }
                 let clustering_key_after: Vec<i32> = manifest
                     .schema
                     .unenforced_clustering_key()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4080,6 +4080,7 @@ pub(crate) async fn write_manifest_file(
     config: &ManifestWriteConfig,
     naming_scheme: ManifestNamingScheme,
     transaction: Option<lance_table::format::Transaction>,
+    may_change_schema: bool,
 ) -> std::result::Result<ManifestLocation, CommitError> {
     validate_paired_feature_flags(manifest)?;
     // Every manifest write funnels through here, including restore and clone,
@@ -4093,7 +4094,14 @@ pub(crate) async fn write_manifest_file(
     // including through the delete that removes the offending rows, which is
     // the first step of repairing it. A repair still has to pass: it changes
     // the schema, and the schema it produces is valid.
-    if transaction.as_ref().is_none_or(|t| t.may_change_schema()) {
+    //
+    // The caller classifies the operation, rather than this reading it off
+    // `transaction`, which is None whenever the encoded bytes were too large
+    // to inline. Deriving it here would make the verdict depend on payload
+    // size, so the same operation would be exempt while small and validated
+    // once it spilled -- and a MemWAL table spills routinely, since its
+    // transactions carry mem-table state.
+    if may_change_schema {
         manifest
             .schema
             .verify_primary_key()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4082,6 +4082,15 @@ pub(crate) async fn write_manifest_file(
     transaction: Option<lance_table::format::Transaction>,
 ) -> std::result::Result<ManifestLocation, CommitError> {
     validate_paired_feature_flags(manifest)?;
+    // Every manifest write funnels through here, including restore and clone,
+    // which rebuild a manifest from a stored one rather than from an Arrow
+    // schema. Checking here is what makes the invariant hold for a schema that
+    // never passed through that conversion.
+    manifest
+        .schema
+        .verify_primary_key()
+        .map_err(CommitError::OtherError)?;
+
     if config.auto_set_feature_flags {
         // build_manifest may have already set FLAG_STABLE_ROW_IDS on the manifest.
         // Preserve it here so this second apply_feature_flags call does not clear it

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4084,12 +4084,21 @@ pub(crate) async fn write_manifest_file(
     validate_paired_feature_flags(manifest)?;
     // Every manifest write funnels through here, including restore and clone,
     // which rebuild a manifest from a stored one rather than from an Arrow
-    // schema. Checking here is what makes the invariant hold for a schema that
-    // never passed through that conversion.
-    manifest
-        .schema
-        .verify_primary_key()
-        .map_err(CommitError::OtherError)?;
+    // schema, so this is where the invariant holds for a schema that never
+    // passed through that conversion.
+    //
+    // Only for transactions that can change the schema. Released versions could
+    // install a key on a nullable column through the metadata path, and
+    // validating every write would make such a table read-only on upgrade --
+    // including through the delete that removes the offending rows, which is
+    // the first step of repairing it. A repair still has to pass: it changes
+    // the schema, and the schema it produces is valid.
+    if transaction.as_ref().is_none_or(|t| t.may_change_schema()) {
+        manifest
+            .schema
+            .verify_primary_key()
+            .map_err(CommitError::OtherError)?;
+    }
 
     if config.auto_set_feature_flags {
         // build_manifest may have already set FLAG_STABLE_ROW_IDS on the manifest.

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -215,6 +215,8 @@ impl<'a> InitializeMemWalBuilder<'a> {
         // Resolve (and validate) the sharding choice before any I/O.
         let (sharding_specs, num_shards) = resolve_sharding(dataset, sharding)?;
 
+        dataset.schema().verify_primary_key()?;
+
         let indices = dataset.load_indices().await?;
         if indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME) {
             return Err(Error::invalid_input(

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -10789,4 +10789,42 @@ mod shard_writer_tests {
 
         writer.close().await.unwrap();
     }
+
+    /// The other paths now prevent a nullable key, so this forges one to stand
+    /// in for a table written before they were closed.
+    #[tokio::test]
+    async fn test_initialize_mem_wal_rejects_a_nullable_primary_key() {
+        let vector_dim = 128;
+        let schema = create_append_only_schema(vector_dim);
+        let uri = format!("memory://test_mem_wal_nullable_pk_{}", Uuid::new_v4());
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        {
+            let manifest = Arc::make_mut(&mut dataset.manifest);
+            let id_field = manifest
+                .schema
+                .fields
+                .iter_mut()
+                .find(|field| field.name == "id")
+                .expect("schema has an id column");
+            id_field.unenforced_primary_key_position = Some(1);
+            id_field.nullable = true;
+        }
+
+        let err = dataset
+            .initialize_mem_wal()
+            .unsharded()
+            .execute()
+            .await
+            .expect_err("MemWAL must not enable on a nullable primary key");
+        assert!(
+            err.to_string().contains("must not be nullable"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/rust/lance/src/dataset/metadata.rs
+++ b/rust/lance/src/dataset/metadata.rs
@@ -189,6 +189,25 @@ mod tests {
     };
     use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
 
+    /// A dataset whose columns are all **non-nullable**, so a primary key can be
+    /// installed on one. `gen_batch` produces nullable columns, and a primary
+    /// key column must not be nullable.
+    async fn dataset_with_non_nullable_columns(uri: &str, names: &[&str]) -> Dataset {
+        let schema = Arc::new(ArrowSchema::new(
+            names
+                .iter()
+                .map(|name| ArrowField::new(*name, DataType::Int32, false))
+                .collect::<Vec<_>>(),
+        ));
+        let columns: Vec<ArrayRef> = names
+            .iter()
+            .map(|_| Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>())) as ArrayRef)
+            .collect();
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        Dataset::write(reader, uri, None).await.unwrap()
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_update_config() {
@@ -548,10 +567,7 @@ mod tests {
 
         let tmp_dir = lance_core::utils::tempfile::TempStrDir::default();
         let uri = tmp_dir.as_str();
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, uri, None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns(uri, &["a"]).await;
         assert!(dataset.schema().unenforced_primary_key().is_empty());
 
         dataset
@@ -578,10 +594,7 @@ mod tests {
         use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY;
 
         for truthy in ["true", "1", "yes", "TRUE", "Yes"] {
-            let data = gen_batch()
-                .col("a", array::step::<Int32Type>())
-                .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-            let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+            let mut dataset = dataset_with_non_nullable_columns("memory://", &["a"]).await;
             dataset
                 .update_field_metadata()
                 .replace("a", [(LANCE_UNENFORCED_PRIMARY_KEY, truthy)])
@@ -606,10 +619,7 @@ mod tests {
             LANCE_UNENFORCED_PRIMARY_KEY, LANCE_UNENFORCED_PRIMARY_KEY_POSITION,
         };
 
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns("memory://", &["a"]).await;
         dataset
             .update_field_metadata()
             .replace(
@@ -633,11 +643,7 @@ mod tests {
         // alters the set of primary key columns, is rejected.
         use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY_POSITION;
 
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .col("b", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns("memory://", &["a", "b"]).await;
 
         // The first install of the primary key is allowed.
         dataset
@@ -682,6 +688,31 @@ mod tests {
         assert_eq!(pk[0].name, "a");
     }
 
+    /// Installing the key by field metadata skips the Arrow-schema conversion
+    /// that validates one, so a nullable target must be rejected here.
+    #[tokio::test]
+    async fn test_unenforced_primary_key_rejects_a_nullable_column() {
+        use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY_POSITION;
+
+        // `gen_batch` columns are nullable.
+        let data = gen_batch()
+            .col("a", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+        let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+
+        let err = dataset
+            .update_field_metadata()
+            .update("a", [(LANCE_UNENFORCED_PRIMARY_KEY_POSITION, "1")])
+            .unwrap()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("must not be nullable"),
+            "got {err:?}"
+        );
+        assert!(dataset.schema().unenforced_primary_key().is_empty());
+    }
+
     #[tokio::test]
     async fn test_unenforced_primary_key_rejects_invalid_marker() {
         // Writing a reserved primary key metadata key with a value that is not
@@ -689,10 +720,7 @@ mod tests {
         // silently ignored.
         use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY;
 
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns("memory://", &["a"]).await;
 
         for invalid in ["no", "false", "0", "anything-else"] {
             let err = dataset
@@ -741,10 +769,7 @@ mod tests {
 
         let tmp_dir = lance_core::utils::tempfile::TempStrDir::default();
         let uri = tmp_dir.as_str();
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, uri, None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns(uri, &["a"]).await;
         assert!(dataset.schema().unenforced_clustering_key().is_empty());
 
         dataset
@@ -856,10 +881,7 @@ mod tests {
         // not a valid position is rejected rather than silently ignored.
         use lance_core::datatypes::LANCE_UNENFORCED_CLUSTERING_KEY_POSITION;
 
-        let data = gen_batch()
-            .col("a", array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
-        let mut dataset = Dataset::write(data, "memory://", None).await.unwrap();
+        let mut dataset = dataset_with_non_nullable_columns("memory://", &["a"]).await;
 
         for invalid in ["not-a-number", "", "1.5"] {
             let err = dataset

--- a/rust/lance/src/dataset/metadata.rs
+++ b/rust/lance/src/dataset/metadata.rs
@@ -899,4 +899,58 @@ mod tests {
             assert!(dataset.schema().unenforced_clustering_key().is_empty());
         }
     }
+
+    /// A table that already carries a nullable primary key must stay writable,
+    /// including through the delete that repairs it.
+    ///
+    /// Released versions could install a key on a nullable column through this
+    /// metadata path, so such tables exist. Validating every manifest write
+    /// would make them read-only on upgrade and leave a full overwrite as the
+    /// only repair.
+    #[tokio::test]
+    async fn nullable_primary_key_stays_repairable() {
+        let test_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let uri: &str = &test_dir;
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(RecordBatchIterator::new([Ok(batch)], schema), uri, None)
+            .await
+            .unwrap();
+
+        // Forge the state a released version could persist: a key on a
+        // nullable column, without passing the checks that now prevent it.
+        {
+            let manifest = Arc::make_mut(&mut dataset.manifest);
+            let field = manifest
+                .schema
+                .fields
+                .iter_mut()
+                .find(|f| f.name == "id")
+                .unwrap();
+            field.unenforced_primary_key_position = Some(1);
+        }
+
+        // Unrelated writes must still go through.
+        dataset
+            .update_config([("unrelated".to_string(), "value".to_string())])
+            .await
+            .expect("an unrelated write must not be blocked by a pre-existing bad key");
+
+        // And so must the delete that removes the offending rows -- without it
+        // there is no way to tighten the column afterwards.
+        dataset
+            .delete("id IS NULL")
+            .await
+            .expect("the repairing delete must not be blocked");
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 1);
+    }
 }

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -790,6 +790,7 @@ pub(super) async fn alter_columns(
     }
 
     new_schema.validate()?;
+    new_schema.verify_primary_key()?;
 
     // If any column being cast has an attached index, fail fast. Cast operations
     // rewrite the underlying column data and silently invalidate any index on the
@@ -4100,5 +4101,53 @@ mod test {
         .with_metadata(packed_meta);
         let field4 = ArrowField::new("test", DataType::Struct(vec![conflict_field].into()), false);
         assert!(check_field_conflict(&field1, &field4, &ConcreteFileVersion::V2_2).is_err());
+    }
+
+    /// Table creation rejects a nullable primary key; altering one afterwards
+    /// reached the same state without passing that check.
+    #[tokio::test]
+    async fn test_alter_columns_cannot_make_a_primary_key_nullable() -> Result<()> {
+        let pk = ArrowField::new("id", DataType::Int32, false).with_metadata(
+            [(
+                "lance-schema:unenforced-primary-key:position".to_string(),
+                "1".to_string(),
+            )]
+            .into(),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![
+            pk,
+            ArrowField::new("value", DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![10, 20])),
+            ],
+        )?;
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &test_dir,
+            None,
+        )
+        .await?;
+
+        let err = dataset
+            .alter_columns(&[ColumnAlteration::new("id".into()).set_nullable(true)])
+            .await
+            .expect_err("making a primary key nullable must be rejected");
+        assert!(
+            err.to_string().contains("must not be nullable"),
+            "unexpected error: {err}"
+        );
+
+        // Specific to the key: other columns may still be altered.
+        dataset
+            .alter_columns(&[ColumnAlteration::new("value".into()).rename("val".into())])
+            .await?;
+        assert!(!dataset.schema().unenforced_primary_key()[0].nullable);
+
+        Ok(())
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -3602,6 +3602,36 @@ async fn a_legacy_nullable_primary_key_can_be_repaired_in_place() {
 
 /// The MemWAL variant of the repair path. This is the state the original report
 /// was about, and the one a size-coupled gate blocks: its transactions carry
+/// An overlay attaches files to existing fragments; it carries no schema, so a
+/// dataset that already holds a nullable primary key must still be able to
+/// commit one. `DataOverlay` was missing from the exempt classifier, which
+/// closed that path for exactly the legacy datasets this validation is meant to
+/// leave repairable.
+#[tokio::test]
+async fn an_overlay_commits_on_a_legacy_nullable_primary_key() {
+    use lance_core::utils::tempfile::TempStrDir;
+    use lance_table::transaction::Operation;
+
+    let test_dir = TempStrDir::default();
+    let dataset = write_dataset_with_a_legacy_nullable_primary_key(&test_dir).await;
+    let read_version = dataset.manifest.version;
+
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::DataOverlay { groups: vec![] },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .expect("an overlay leaves the schema alone, so the legacy key must not block it");
+
+    assert_eq!(dataset.manifest.version, read_version + 1);
+    assert_eq!(dataset.count_rows(None).await.unwrap(), 2);
+}
+
 /// mem-table state, so they stop inlining long before a config update does.
 #[tokio::test]
 async fn a_legacy_nullable_primary_key_can_be_repaired_under_mem_wal() {

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -3378,3 +3378,65 @@ async fn test_validate_dataset_root_for_drop_allows_missing_path() {
         .await
         .unwrap();
 }
+
+/// Restore and clone rebuild a manifest from a stored one, never passing
+/// through the Arrow-schema conversion that validates a primary key. Both write
+/// through `write_manifest_file`, so the invariant is enforced there — a schema
+/// that reached a manifest before the write paths were validated cannot be
+/// carried forward into a new version.
+#[tokio::test]
+async fn write_manifest_file_rejects_a_nullable_primary_key() {
+    use lance_core::utils::tempfile::TempStrDir;
+
+    let test_dir = TempStrDir::default();
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]));
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))]).unwrap();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        &test_dir,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Stand in for a manifest stored before the write paths were validated.
+    let mut manifest = dataset.manifest.as_ref().clone();
+    let id_field = manifest
+        .schema
+        .fields
+        .iter_mut()
+        .find(|field| field.name == "id")
+        .expect("schema has an id column");
+    id_field.unenforced_primary_key_position = Some(1);
+    id_field.nullable = true;
+    manifest.version += 1;
+
+    let err = write_manifest_file(
+        dataset.object_store.as_ref(),
+        dataset.commit_handler.as_ref(),
+        &dataset.base,
+        &mut manifest,
+        None,
+        &ManifestWriteConfig {
+            auto_set_feature_flags: false,
+            timestamp: None,
+            use_stable_row_ids: false,
+            use_legacy_format: None,
+            storage_format: None,
+            disable_transaction_file: false,
+        },
+        dataset.manifest_location.naming_scheme,
+        None,
+    )
+    .await
+    .expect_err("a nullable primary key must not reach a manifest");
+    assert!(
+        format!("{err:?}").contains("must not be nullable"),
+        "unexpected error: {err:?}"
+    );
+}

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1389,6 +1389,8 @@ async fn test_restore_rejects_unknown_target_flags() {
         &write_config,
         dataset.manifest_location.naming_scheme,
         None,
+        // No inline transaction to classify from, so validate.
+        true,
     )
     .await
     .unwrap();
@@ -1404,6 +1406,8 @@ async fn test_restore_rejects_unknown_target_flags() {
         &write_config,
         dataset.manifest_location.naming_scheme,
         None,
+        // No inline transaction to classify from, so validate.
+        true,
     )
     .await
     .unwrap();
@@ -1448,6 +1452,8 @@ async fn test_checkout_latest_rejects_unsupported_reader_before_caching() {
         },
         dataset.manifest_location.naming_scheme,
         None,
+        // No inline transaction to classify from, so validate.
+        true,
     )
     .await
     .unwrap();
@@ -1900,6 +1906,8 @@ async fn test_deep_clone_rejects_unsupported_writer_before_copying() {
         },
         source.manifest_location.naming_scheme,
         None,
+        // No inline transaction to classify from, so validate.
+        true,
     )
     .await
     .unwrap();
@@ -1946,6 +1954,8 @@ async fn test_shallow_clone_rejects_unsupported_writer_before_writing_target() {
         },
         source.manifest_location.naming_scheme,
         None,
+        // No inline transaction to classify from, so validate.
+        true,
     )
     .await
     .unwrap();

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -13,6 +13,8 @@ use super::dataset_common::{create_file, require_send};
 use crate::dataset::WriteDestination;
 use crate::dataset::WriteMode::Overwrite;
 use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::mem_wal::DatasetMemWalExt;
+use crate::dataset::schema_evolution::ColumnAlteration;
 use crate::dataset::transaction::Operation;
 use crate::dataset::{ManifestWriteConfig, validate_dataset_root_for_drop, write_manifest_file};
 use crate::session::Session;
@@ -1333,6 +1335,8 @@ async fn test_write_manifest(
         },
         dataset.manifest_location.naming_scheme,
         None,
+        // Previously classified from a None inline copy, which validated.
+        true,
     )
     .await
     .unwrap();
@@ -3439,9 +3443,12 @@ async fn write_manifest_file_rejects_a_nullable_primary_key() {
             use_legacy_format: None,
             storage_format: None,
             disable_transaction_file: false,
+            migration_next_row_id: None,
         },
         dataset.manifest_location.naming_scheme,
         None,
+        // Previously classified from a None inline copy, which validated.
+        true,
     )
     .await
     .expect_err("a nullable primary key must not reach a manifest");
@@ -3449,4 +3456,177 @@ async fn write_manifest_file_rejects_a_nullable_primary_key() {
         format!("{err:?}").contains("must not be nullable"),
         "unexpected error: {err:?}"
     );
+}
+
+/// Stand in for a table written by a released version, where the metadata path
+/// could install a primary key on a column that permits nulls. The forging goes
+/// through `write_manifest_file` classified as schema-preserving, which is
+/// precisely the hole those versions had, so the resulting manifest is the one
+/// an upgrade actually finds on disk.
+///
+/// The two rows are `[1, NULL]`, so the null the key must not hold is really
+/// present and the repairing delete has something to remove.
+async fn write_dataset_with_a_legacy_nullable_primary_key(uri: &str) -> Dataset {
+    forge_legacy_nullable_primary_key(uri, false).await
+}
+
+/// The originally reported sequence initialised MemWAL *before* the key was
+/// installed, so `initialize_mem_wal`'s own check never saw it. That ordering
+/// matters: a MemWAL transaction carries mem-table state, so it is far more
+/// likely to outgrow the inline limit than a bare config update.
+async fn forge_legacy_nullable_primary_key(uri: &str, with_mem_wal: bool) -> Dataset {
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        true,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![Some(1), None]))],
+    )
+    .unwrap();
+    let mut dataset = Dataset::write(RecordBatchIterator::new(vec![Ok(batch)], schema), uri, None)
+        .await
+        .unwrap();
+
+    if with_mem_wal {
+        dataset
+            .initialize_mem_wal()
+            .unsharded()
+            .execute()
+            .await
+            .expect("MemWAL initialises while the key is still valid");
+    }
+
+    // Carried forward explicitly: passing None here would drop the MemWAL index
+    // the fixture just installed.
+    let indices = dataset.load_indices().await.unwrap().as_ref().clone();
+
+    let mut manifest = dataset.manifest.as_ref().clone();
+    let id_field = manifest
+        .schema
+        .fields
+        .iter_mut()
+        .find(|field| field.name == "id")
+        .expect("schema has an id column");
+    id_field.unenforced_primary_key_position = Some(1);
+    manifest.version += 1;
+
+    // Committed below `write_manifest_file` on purpose. Going through it would
+    // make building the fixture depend on the very validation these tests
+    // exercise, so a regression would show up as a fixture that cannot be
+    // built rather than as the behaviour under test changing.
+    manifest.set_timestamp(crate::dataset::timestamp_to_nanos(None));
+    manifest.update_max_fragment_id();
+    dataset
+        .commit_handler
+        .commit(
+            &mut manifest,
+            (!indices.is_empty()).then_some(indices),
+            &dataset.base,
+            dataset.object_store.as_ref(),
+            lance_table::io::commit::write_manifest_file_to_path,
+            dataset.manifest_location.naming_scheme,
+            None,
+        )
+        .await
+        .expect("forging a legacy manifest must not itself be blocked");
+
+    Dataset::open(uri).await.unwrap()
+}
+
+/// An unrelated config update leaves the key exactly as it found it, so it is
+/// exempt -- and must stay exempt no matter how large its payload is. The
+/// disposition comes from the operation; only the inline copy depends on size.
+#[tokio::test]
+async fn an_exempt_operation_stays_exempt_when_its_transaction_spills() {
+    use crate::io::commit::MAX_INLINE_TRANSACTION_BYTES;
+    use lance_core::utils::tempfile::TempStrDir;
+
+    let test_dir = TempStrDir::default();
+    let mut dataset = write_dataset_with_a_legacy_nullable_primary_key(&test_dir).await;
+
+    dataset
+        .update_config([("unrelated".to_string(), "small".to_string())])
+        .await
+        .expect("a small unrelated config update must be exempt");
+    let after_small = dataset.version().version;
+
+    dataset
+        .update_config([(
+            "large-unrelated".to_string(),
+            "x".repeat(2 * MAX_INLINE_TRANSACTION_BYTES),
+        )])
+        .await
+        .expect("the same update must stay exempt once its bytes stop inlining");
+
+    assert!(
+        dataset.version().version > after_small,
+        "the spilling update must have committed a new version"
+    );
+}
+
+/// The repair path: drop the offending rows, then tighten the column. Both have
+/// to be reachable on a table that already carries the bad key, or the only
+/// remaining fix is a full overwrite.
+#[tokio::test]
+async fn a_legacy_nullable_primary_key_can_be_repaired_in_place() {
+    use lance_core::utils::tempfile::TempStrDir;
+
+    let test_dir = TempStrDir::default();
+    let mut dataset = write_dataset_with_a_legacy_nullable_primary_key(&test_dir).await;
+    assert_eq!(dataset.count_rows(None).await.unwrap(), 2);
+
+    dataset
+        .delete("id IS NULL")
+        .await
+        .expect("removing the offending rows must not be blocked");
+    assert_eq!(dataset.count_rows(None).await.unwrap(), 1);
+
+    dataset
+        .alter_columns(&[ColumnAlteration::new("id".into()).set_nullable(false)])
+        .await
+        .expect("tightening the column completes the repair");
+
+    let id_field = dataset
+        .schema()
+        .fields
+        .iter()
+        .find(|field| field.name == "id")
+        .expect("schema has an id column");
+    assert!(
+        !id_field.nullable,
+        "the key column must end up non-nullable"
+    );
+}
+
+/// The MemWAL variant of the repair path. This is the state the original report
+/// was about, and the one a size-coupled gate blocks: its transactions carry
+/// mem-table state, so they stop inlining long before a config update does.
+#[tokio::test]
+async fn a_legacy_nullable_primary_key_can_be_repaired_under_mem_wal() {
+    use lance_core::utils::tempfile::TempStrDir;
+
+    let test_dir = TempStrDir::default();
+    let mut dataset = forge_legacy_nullable_primary_key(&test_dir, true).await;
+    assert!(
+        dataset
+            .load_indices()
+            .await
+            .unwrap()
+            .iter()
+            .any(|index| index.name == lance_index::mem_wal::MEM_WAL_INDEX_NAME),
+        "the fixture must really have MemWAL initialised"
+    );
+
+    dataset
+        .update_config([("unrelated".to_string(), "small".to_string())])
+        .await
+        .expect("an unrelated config update must be exempt");
+
+    dataset
+        .delete("id IS NULL")
+        .await
+        .expect("removing the offending rows must not be blocked under MemWAL");
+    assert_eq!(dataset.count_rows(None).await.unwrap(), 1);
 }

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -427,6 +427,8 @@ async fn test_inline_transaction() {
         &ManifestWriteConfig::default(),
         ds.manifest_location.naming_scheme,
         None,
+        // Previously classified from a None inline copy, which validated.
+        true,
     )
     .await
     .unwrap();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -37,7 +37,7 @@ use lance_select::RowAddrTreeMap;
 use lance_table::feature_flags::ensure_can_write_manifest;
 use lance_table::format::{
     DETACHED_VERSION_MASK, DeletionFile, Fragment, IndexMetadata, Manifest, WriterVersion,
-    is_detached_version, list_index_files_with_sizes, pb,
+    is_detached_version, list_index_files_with_sizes, operation_may_change_schema, pb,
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme,
@@ -358,6 +358,9 @@ async fn do_commit_new_dataset(
 ) -> Result<(Manifest, ManifestLocation)> {
     let pb_transaction = pb::Transaction::from(transaction);
     let inline_transaction = pb_transaction.encoded_len() <= MAX_INLINE_TRANSACTION_BYTES;
+    // Classified from the operation itself. Reading it back off the inline
+    // copy would tie the verdict to the payload size instead.
+    let may_change_schema = operation_may_change_schema(&pb_transaction);
 
     let clone_source = if let Operation::Clone {
         ref_version,
@@ -497,6 +500,7 @@ async fn do_commit_new_dataset(
         write_config,
         manifest_naming_scheme,
         inline_transaction.then(|| pb_transaction.into()),
+        may_change_schema,
     )
     .await;
 
@@ -1058,6 +1062,9 @@ pub(crate) async fn do_commit_detached_transaction(
     ensure_can_write_manifest(&dataset.manifest)?;
     let pb_transaction = pb::Transaction::from(transaction);
     let inline_transaction = pb_transaction.encoded_len() <= MAX_INLINE_TRANSACTION_BYTES;
+    // Classified from the operation itself. Reading it back off the inline
+    // copy would tie the verdict to the payload size instead.
+    let may_change_schema = operation_may_change_schema(&pb_transaction);
 
     // We don't strictly need a transaction file but we go ahead and create one for
     // record-keeping if nothing else.
@@ -1133,6 +1140,7 @@ pub(crate) async fn do_commit_detached_transaction(
             write_config,
             ManifestNamingScheme::V2,
             inline_tx.take(),
+            may_change_schema,
         )
         .await;
 
@@ -1411,6 +1419,9 @@ pub(crate) async fn commit_transaction(
         // transaction.
         let pb_transaction = pb::Transaction::from(&transaction);
         let inline_transaction = pb_transaction.encoded_len() <= MAX_INLINE_TRANSACTION_BYTES;
+        // Classified from the operation itself. Reading it back off the inline
+        // copy would tie the verdict to the payload size instead.
+        let may_change_schema = operation_may_change_schema(&pb_transaction);
 
         current_transaction_file = if !write_config.disable_transaction_file() {
             write_transaction_file(object_store, &dataset.base, &pb_transaction).await?
@@ -1488,6 +1499,7 @@ pub(crate) async fn commit_transaction(
             write_config,
             manifest_naming_scheme,
             inline_transaction.then(|| pb_transaction.into()),
+            may_change_schema,
         )
         .await;
 


### PR DESCRIPTION
`Schema::verify_primary_key` rejects a primary key column that permits nulls, but its only caller is `TryFrom<&ArrowSchema> for Schema` — table creation and nothing else.

It matters because a multi-column key match treats a null as unequal to everything, including another null. A row holding a null in its key never matches its own earlier copy, so `merge_insert` inserts a second row rather than overwriting, and every repeat write adds another. MemWAL compaction folds flushed data in by matching on the key, so such a table duplicates rows silently.

## Enforced where a schema becomes durable

The check goes in `write_manifest_file`, which every manifest write funnels through. Four kinds of path reach a manifest without the Arrow-schema conversion:

| Path | Why it escapes |
|---|---|
| `UpdateConfig` field metadata | installs the key by writing metadata onto a field |
| `ColumnAlteration::set_nullable(true)` | changes an existing key column's nullability |
| Restore and clone | rebuild a manifest from a stored one; `Operation::Clone` carries no schema at all |
| `Operation::Project` / `Merge` / `Overwrite` | public, and `validate_operation` checks the schema only against fragments |

Enumerating them per operation would leave the next schema-carrying operation uncovered. One check at the manifest boundary does not.

## Early errors

Three API-level checks report the same violation before work is done — installing the key through field metadata, altering nullability, and initializing MemWAL on a table already carrying a bad key. `InitializeMemWalBuilder::execute` is also the gate for callers outside this crate, which is why it is checked there rather than by each caller.

## Tests

Four, each verified to fail with its own check removed:

- `write_manifest_file_rejects_a_nullable_primary_key` — forges a manifest, since a stored one can no longer be produced. Restore and clone are covered by routing through this call.
- `test_unenforced_primary_key_rejects_a_nullable_column`
- `test_alter_columns_cannot_make_a_primary_key_nullable` — also alters a non-key column, so the rejection is specific to the key
- `test_initialize_mem_wal_rejects_a_nullable_primary_key`

Plus four covering the exemption, added after review found the gate could be
driven by payload size:

- `an_exempt_operation_stays_exempt_when_its_transaction_spills` — the same
  unrelated config update, once small and once past the inline limit
- `a_legacy_nullable_primary_key_can_be_repaired_in_place` — delete the
  offending rows, then tighten the column
- `a_legacy_nullable_primary_key_can_be_repaired_under_mem_wal` — the same, on
  the state the report was actually about
- two on the classifier itself, at 4MiB and at nothing, in both directions

The last three build their fixture below `write_manifest_file` rather than
through it, so a regression shows up as the behaviour under test changing
rather than as a fixture that can no longer be built.

Four tests in `dataset/metadata.rs` installed a key on a `gen_batch` column, which is nullable. Their subject is metadata translation and key immutability, so they now build from an explicit non-nullable schema. Clustering-key tests are untouched — `verify_primary_key` does not govern them.

Full `lance --lib` suite: 2927 pass.

## Classification, not a blanket check

An earlier revision validated every manifest write, which made a table that
already carries an invalid key read-only on upgrade — including through the
delete that removes the offending rows, which is the first step of repairing
it. Operations that cannot touch the schema are therefore exempt.

That disposition is computed from the operation and passed in. It deliberately
does not read the inline transaction copy, which is absent whenever the encoded
protobuf exceeds `MAX_INLINE_TRANSACTION_BYTES`: deriving it there made the
verdict depend on payload size, so the same operation was exempt while small
and validated once it spilled. MemWAL made that worse rather than rarer, since
its transactions carry mem-table state and stop inlining early.

## Not addressed here

**Tables that already carry an invalid key are not protected against key-matched
writes.** `Operation::Update` cannot change the schema, so it is exempt, and a
`merge_insert` on such a table still matches on the invalid key and still
duplicates rows. What this PR establishes is narrower: a new invalid key can no
longer be installed, and an existing one can be repaired in place. Guarding the
sites that consume the key is a behaviour change against tables that work today
— it can start rejecting a live workload — so it belongs in its own change with
its own release note rather than here.

Casting a primary key column rebuilds the field from a freshly constructed Arrow field carrying no metadata, which drops the key marker. Unchanged by this; `verify_primary_key` then passes because the schema has no key.

## Related

#6324 — a sibling symptom of the same gap, about protobuf population on the metadata path rather than validation.


