### PR TITLE
perf: avoid cloning every fragment descriptor in take and FTS planning

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3591,12 +3591,12 @@ impl Scanner {
         // phrase queries already do not search — overlaid fragments are simply dropped from the
         // phrase result; new phrase matches there surface once compaction folds the overlay into
         // the base. This removes stale hits without introducing wrong ones.
-        let target_fragments = self
+        let target_fragments: &[Fragment] = self
             .fragments
-            .clone()
-            .unwrap_or_else(|| self.dataset.fragments().to_vec());
+            .as_deref()
+            .unwrap_or_else(|| self.dataset.fragments());
         let (_flat_frag_ids, fresh_segments) = self
-            .fts_stale_frags_and_fresh_segments(&column, &target_fragments)
+            .fts_stale_frags_and_fresh_segments(&column, target_fragments)
             .await?;
 
         let exec: Arc<dyn ExecutionPlan> = match fresh_segments {
@@ -3641,10 +3641,10 @@ impl Scanner {
             .await?;
 
         // Get target fragments
-        let target_fragments = self
+        let target_fragments: &[Fragment] = self
             .fragments
-            .clone()
-            .unwrap_or_else(|| self.dataset.fragments().to_vec());
+            .as_deref()
+            .unwrap_or_else(|| self.dataset.fragments());
 
         let (match_plan, flat_match_plan) = match &index {
             Some(index) => {
@@ -3655,7 +3655,7 @@ impl Scanner {
                 // Fragments whose FTS index entries may be stale due to a newer data overlay.
                 // These are excluded from the indexed path and re-evaluated on the flat path.
                 let (stale_flat_frag_ids, fresh_segments) = self
-                    .fts_stale_frags_and_fresh_segments(&column, &target_fragments)
+                    .fts_stale_frags_and_fresh_segments(&column, target_fragments)
                     .await?;
 
                 // Fragments that need flat evaluation: unindexed + stale (deduplicated).
@@ -3718,7 +3718,7 @@ impl Scanner {
                 }
                 // No index: flat search all target fragments
                 let flat_match_plan = self
-                    .plan_flat_match_query(target_fragments.clone(), query, params, filter_plan)
+                    .plan_flat_match_query(target_fragments.to_vec(), query, params, filter_plan)
                     .await?;
                 (None, Some(flat_match_plan))
             }

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -299,10 +299,6 @@ async fn do_take_rows(
                 .or_insert_with(|| vec![offset]);
         });
 
-        // Only construct FileFragment handles for the fragments actually addressed
-        // by this take: get_fragments() clones every fragment descriptor, which is
-        // O(dataset fragments) per call and dominates take cost on datasets with
-        // many fragments.
         let addressed_ids: Vec<u32> = row_addrs_per_fragment.keys().copied().collect();
         let fragments = builder
             .dataset

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -299,7 +299,14 @@ async fn do_take_rows(
                 .or_insert_with(|| vec![offset]);
         });
 
-        let fragments = builder.dataset.get_fragments();
+        // Only construct FileFragment handles for the fragments actually addressed
+        // by this take: get_fragments() clones every fragment descriptor, which is
+        // O(dataset fragments) per call and dominates take cost on datasets with
+        // many fragments.
+        let addressed_ids: Vec<u32> = row_addrs_per_fragment.keys().copied().collect();
+        let fragments = builder
+            .dataset
+            .get_existing_fragments_from_ids(&addressed_ids);
         let fragment_and_indices = fragments.into_iter().filter_map(|f| {
             let row_offset = row_addrs_per_fragment.remove(&(f.id() as u32))?;
             Some((f, row_offset))


### PR DESCRIPTION
## Problem

Two hot paths deep-copy the entire fragment descriptor list on every call, costing O(dataset fragments) regardless of how many fragments are actually touched:

- `do_take_rows` called `dataset.get_fragments()` — cloning every `Fragment` descriptor (including `DataFile` path strings) — and then kept only the fragments addressed by the take.
- `plan_match_query` / `plan_phrase_query` materialized `self.dataset.fragments().to_vec()` per query, even though the list is only read.

On a 126M-row dataset with 3,150 fragments this costs ~1 ms per call (~300 ns per descriptor clone+drop). Under a take-heavy workload both FTS plan build and the take pay it on every request, which showed up as a hard ~1,000 qps per-process ceiling with the machine >95% idle: thread dumps showed active threads dominated by `Fragment::clone` / `drop_in_place<DataFile>` under `Scanner::plan_fts` and `do_take_rows`.

## Fix

- `do_take_rows`: construct `FileFragment` handles only for the addressed fragment ids via `get_existing_fragments_from_ids` (same skip-missing semantics as the previous `filter_map`).
- `plan_match_query` / `plan_phrase_query`: borrow the fragment slice (`&[Fragment]`); materialize only in the no-index flat fallback.
