### PR TITLE
perf: skip index metadata deep clone and compare when no vector inference is needed

### DIFF
--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -64,7 +64,8 @@ use serde_json::json;
 use tracing::{info, instrument, warn};
 use uuid::Uuid;
 use vector::details::{
-    derive_vector_index_type, infer_missing_vector_details, vector_details_as_json,
+    derive_vector_index_type, infer_missing_vector_details, needs_vector_details_inference,
+    vector_details_as_json,
 };
 pub(crate) use vector::details::{vector_index_details, vector_index_details_default};
 use vector::ivf::v2::{IVFIndex, IvfStateEntryBox};
@@ -1505,14 +1506,24 @@ impl DatasetIndexExt for Dataset {
         // Infer details for legacy vector indices (once per index name, concurrently).
         // This may run on indices that were opportunistically cached during Dataset::open
         // before the full Dataset was available for inference.
+        // Only legacy vector indices missing details need inference; checking the
+        // predicate first avoids deep-cloning and deep-comparing the whole index
+        // metadata list (including per-index fragment bitmaps) on every call —
+        // this path runs per segment per query on the FTS read path.
         {
-            let mut updated = indices.as_ref().clone();
-            infer_missing_vector_details(self, &mut updated).await;
-            if updated != *indices {
-                indices = Arc::new(updated);
-                self.index_cache
-                    .insert_with_key(&metadata_key, indices.clone())
-                    .await;
+            let schema = self.schema();
+            if indices
+                .iter()
+                .any(|idx| needs_vector_details_inference(idx, schema))
+            {
+                let mut updated = indices.as_ref().clone();
+                infer_missing_vector_details(self, &mut updated).await;
+                if updated != *indices {
+                    indices = Arc::new(updated);
+                    self.index_cache
+                        .insert_with_key(&metadata_key, indices.clone())
+                        .await;
+                }
             }
         }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1506,10 +1506,6 @@ impl DatasetIndexExt for Dataset {
         // Infer details for legacy vector indices (once per index name, concurrently).
         // This may run on indices that were opportunistically cached during Dataset::open
         // before the full Dataset was available for inference.
-        // Only legacy vector indices missing details need inference; checking the
-        // predicate first avoids deep-cloning and deep-comparing the whole index
-        // metadata list (including per-index fragment bitmaps) on every call —
-        // this path runs per segment per query on the FTS read path.
         {
             let schema = self.schema();
             if indices

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -982,6 +982,88 @@ mod tests {
         assert_eq!(metric, None);
     }
 
+    // Schema with a vector column ("vec", FixedSizeList) and a scalar column
+    // ("tag", Utf8). Field ids are assigned by `set_field_id` during conversion,
+    // so look them up by name rather than hardcoding.
+    fn schema_with_vector_and_scalar() -> lance_core::datatypes::Schema {
+        use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    8,
+                ),
+                true,
+            ),
+            ArrowField::new("tag", DataType::Utf8, true),
+        ]);
+        lance_core::datatypes::Schema::try_from(&arrow).unwrap()
+    }
+
+    fn index_over_field(field_id: i32, index_details: Option<prost_types::Any>) -> IndexMetadata {
+        IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fields: vec![field_id],
+            name: "idx".to_string(),
+            dataset_version: 1,
+            fragment_bitmap: None,
+            index_details: index_details.map(Arc::new),
+            index_version: 1,
+            created_at: None,
+            base_id: None,
+            files: None,
+        }
+    }
+
+    #[test]
+    fn test_needs_inference_missing_details_on_vector_field() {
+        // Oldest legacy case (<=0.19.2): no details, but the indexed field is a
+        // vector type => must infer.
+        let schema = schema_with_vector_and_scalar();
+        let vec_id = schema.field("vec").unwrap().id;
+        let index = index_over_field(vec_id, None);
+        assert!(needs_vector_details_inference(&index, &schema));
+    }
+
+    #[test]
+    fn test_needs_inference_missing_details_on_scalar_field() {
+        // No details and the indexed field is not a vector type (e.g. an FTS or
+        // scalar index) => nothing to infer, so the load_indices fast path may
+        // skip the clone/infer/compare.
+        let schema = schema_with_vector_and_scalar();
+        let tag_id = schema.field("tag").unwrap().id;
+        let index = index_over_field(tag_id, None);
+        assert!(!needs_vector_details_inference(&index, &schema));
+    }
+
+    #[test]
+    fn test_needs_inference_empty_vector_details() {
+        // Newer pre-details case: a VectorIndexDetails type_url with empty value
+        // bytes => must infer.
+        let schema = schema_with_vector_and_scalar();
+        let vec_id = schema.field("vec").unwrap().id;
+        let index = index_over_field(vec_id, Some(vector_index_details_default()));
+        assert!(needs_vector_details_inference(&index, &schema));
+    }
+
+    #[test]
+    fn test_needs_inference_populated_vector_details() {
+        // Modern vector index with populated details => no inference needed.
+        let schema = schema_with_vector_and_scalar();
+        let vec_id = schema.field("vec").unwrap().id;
+        let details = make_details(
+            VectorMetricType::L2,
+            None,
+            Some(Compression::Pq(ProductQuantization {
+                num_bits: 8,
+                num_sub_vectors: 16,
+            })),
+        );
+        let index = index_over_field(vec_id, Some(details));
+        assert!(!needs_vector_details_inference(&index, &schema));
+    }
+
     #[test]
     fn test_metric_type_from_index_metadata_all_metrics() {
         // Test all supported metric types.


### PR DESCRIPTION
## Problem

`DatasetIndexExt::load_indices` unconditionally deep-clones the cached `IndexMetadata` list — including every index's roaring fragment bitmap — runs legacy vector-detail inference over the copy, and then deep-compares the whole list against the original to detect changes. This happens on **every call, even on cache hits, and even when the dataset has no legacy vector index** (inference is then a guaranteed no-op).

On the FTS read path, `open_fts_segments` calls `open_scalar_index` → `load_indices` once **per segment per query**. On a 126M-row table with a 28-segment inverted index over 3,150 fragments, that is ~784 bitmap clones + ~784 bitmap deep-compares per query. Under a concurrency-256 FTS benchmark, thread dumps showed the async workers dominated by `IndexMetadata::eq` → `roaring::bitmap::Store::eq` while **291 of 319 dedicated search-pool threads sat idle** — query dispatch was serialized behind metadata busywork.

## Fix

Hoist the existing `needs_vector_details_inference` predicate above the clone: if no index needs inference (all FTS/scalar/modern-vector indices), skip the clone + infer + compare entirely. Behavior for legacy vector indices is unchanged.

## Benchmark

Real FTS (`match_any`, mid-frequency words across 42 languages, k=100, rowid+score only), 126M rows / 3,150 fragments, 28-segment v3 inverted index (286 GB) fully resident in the in memory index cache on a 320-core node:

| cell | before → after |
|---|---|
| 3-term, c=16 (peak) | 2268 → **2429 qps (+7%)** |
| 3-term, c=64 | 1756 → **1828 (+4%)** |
| 3-term, c=256 | 1703 → **1789 (+5%)**, p99 181 → 175 ms |
| 1-term, c=256 | 1744 → **1893 (+9%)**, p99 156 → 145 ms |

Executor CPU utilization under c=256 rose from ~35 to ~54 cores and active search-pool threads from ~27 to ~39 (dispatch is no longer the sole bottleneck).

`cargo test -p lance --lib index::` (659 passed), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)