### PR TITLE
fix: allow CreateIndex to retry against a concurrent Overwrite

### DIFF
--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1137,6 +1137,51 @@ mod tests {
         assert_ne!(latest_indices[0].uuid, original.uuid);
     }
 
+    #[tokio::test]
+    async fn test_concurrent_create_index_vs_overwrite_returns_retryable_conflict() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let reader = gen_batch()
+            .col("a", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(
+                lance_datagen::RowCount::from(100),
+                lance_datagen::BatchCount::from(1),
+            );
+        let dataset = Dataset::write(reader, &dataset_uri, None).await.unwrap();
+
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::BTree);
+        let read_version = dataset.manifest.version;
+        let mut index_reader = dataset.checkout_version(read_version).await.unwrap();
+
+        // A concurrent overwrite commits before the CreateIndex started below,
+        // replacing every fragment the in-flight index was built against.
+        let overwrite_data = gen_batch()
+            .col("a", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(
+                lance_datagen::RowCount::from(50),
+                lance_datagen::BatchCount::from(1),
+            );
+        Dataset::write(
+            overwrite_data,
+            &dataset_uri,
+            Some(WriteParams {
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let result = CreateIndexBuilder::new(&mut index_reader, &["a"], IndexType::BTree, &params)
+            .name("a_idx".to_string())
+            .execute()
+            .await;
+        assert!(
+            matches!(result, Err(Error::RetryableCommitConflict { .. })),
+            "create_index racing a concurrent overwrite should be retryable, got {result:?}"
+        );
+    }
+
     // Helper function to create test data with text field suitable for inverted index
     fn create_text_batch(start: i32, end: i32) -> RecordBatch {
         let schema = Arc::new(ArrowSchema::new(vec![

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -750,7 +750,14 @@ impl<'a> TransactionRebase<'a> {
                         Err(self.incompatible_conflict_err(other_transaction, other_version))
                     }
                 }
-                Operation::Overwrite { .. } | Operation::Restore { .. } => {
+                // An overwrite replaces every fragment, so none of this
+                // index's fragment coverage still exists. Retry lets the
+                // caller decide to rebuild against the new data, mirroring
+                // how concurrent overwrites are handled against each other.
+                Operation::Overwrite { .. } => {
+                    Err(self.retryable_conflict_err(other_transaction, other_version))
+                }
+                Operation::Restore { .. } => {
                     Err(self.incompatible_conflict_err(other_transaction, other_version))
                 }
             }
@@ -2812,16 +2819,19 @@ mod tests {
                     removed_indices: vec![index0],
                 },
                 // Conflicts with row-id-changing operations and same-name CreateIndex.
+                // A concurrent overwrite is retryable, not incompatible: it
+                // replaces every fragment, so retry lets the caller rebuild
+                // the index against the new data instead of failing outright.
                 [
-                    Compatible,    // append
-                    Retryable,     // create index
-                    Compatible,    // delete
-                    Compatible,    // merge
-                    NotCompatible, // overwrite
-                    Retryable,     // rewrite
-                    Compatible,    // reserve
-                    Compatible,    // update
-                    Compatible,    // update config
+                    Compatible, // append
+                    Retryable,  // create index
+                    Compatible, // delete
+                    Compatible, // merge
+                    Retryable,  // overwrite
+                    Retryable,  // rewrite
+                    Compatible, // reserve
+                    Compatible, // update
+                    Compatible, // update config
                 ],
             ),
             (


### PR DESCRIPTION
## Problem

`TransactionRebase::check_create_index_txn` treats a concurrent `Overwrite` as unconditionally incompatible (`conflict_resolver.rs`, the `Operation::Overwrite { .. } | Operation::Restore { .. }` arm), so a `CreateIndex` that races an `Overwrite` fails outright instead of giving the caller a chance to rebuild the index against the new data.

This is inconsistent with two things already in the codebase:

- The `Rewrite` branch just above it in the same function *is* retryable when the rewrite touches fragments the index covers.
- Concurrent `Overwrite`s are already retryable against each other (#6014): "Concurrent overwrites are retryable so user can decide if their overwrite should still proceed."

## Fix

An `Overwrite` replaces every fragment in the dataset, so there's no partial-overlap case to check the way there is for `Rewrite` — any concurrent `Overwrite` invalidates 100% of a new index's fragment coverage. So unlike the `Rewrite` branch's fragment-bitmap intersection check, this can just be unconditionally retryable, the same reasoning `f9ff67287` already applied to Overwrite-vs-Overwrite.

Split the combined `Operation::Overwrite { .. } | Operation::Restore { .. }` arm so only `Overwrite` becomes retryable. `Restore` keeps its existing incompatible handling — it can revert to a version that still shares fragments with the index, which needs separate analysis and wasn't part of the reported failure.