### PR TITLE
feat(io)!: paginated directory listing on ObjectStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "axum",
  "byteorder",
  "bytes",
  "chrono",

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -53,7 +53,9 @@ test-log.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 mock_instant.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+# `net` for the in-process list emulator's listener.
+tokio = { workspace = true, features = ["test-util", "net"] }
+axum = { workspace = true }
 tracing-mock = { workspace = true }
 metrics-util = { workspace = true }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -161,7 +161,7 @@ pub struct ObjectStore {
     /// path uniquely identifies any object inside the store.
     pub store_prefix: String,
     /// The backend's paginated listing API, when it has one. `None` means
-    /// [`Self::read_dir_stream`] has to list a directory in full to page through it.
+    /// [`Self::read_dir_page`] has to list a directory in full to page through it.
     pub(crate) paginated_lister: Option<Arc<dyn PaginatedDirLister>>,
 }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -43,6 +43,7 @@ mod list_retry;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod providers;
+pub(crate) mod read_dir;
 pub mod storage_options;
 #[cfg(test)]
 pub(crate) mod test_utils;
@@ -85,6 +86,9 @@ pub static DEFAULT_MAX_IOP_SIZE: std::sync::LazyLock<u64> = std::sync::LazyLock:
 pub const DEFAULT_DOWNLOAD_RETRY_COUNT: usize = 3;
 
 pub use providers::{ObjectStoreProvider, ObjectStoreRegistry};
+pub use read_dir::{
+    DirCursor, DirEntry, DirEntryKind, DirListing, DirPage, PaginatedDirLister, ReadDirOptions,
+};
 pub use storage_options::{
     BASE_SCOPED_OPTION_PREFIX, BaseScopedStorageOptionsProvider, EXPIRES_AT_MILLIS_KEY,
     LanceNamespaceStorageOptionsProvider, REFRESH_OFFSET_MILLIS_KEY, StorageOptionsAccessor,
@@ -156,6 +160,9 @@ pub struct ObjectStore {
     /// which usually cannot be found in the URL such as Azure account name. The prefix plus the
     /// path uniquely identifies any object inside the store.
     pub store_prefix: String,
+    /// The backend's paginated listing API, when it has one. `None` means
+    /// [`Self::read_dir_stream`] has to list a directory in full to page through it.
+    pub(crate) paginated_lister: Option<Arc<dyn PaginatedDirLister>>,
 }
 
 impl DeepSizeOf for ObjectStore {
@@ -180,6 +187,28 @@ pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
     /// The store_prefix is a string which uniquely identifies the object
     /// store being wrapped.
     fn wrap(&self, store_prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
+
+    /// Wrap the paginated directory lister that goes with the store, if it has one.
+    ///
+    /// [`ObjectStore::read_dir_page`] pushes the resume position into the backend's own
+    /// listing API, which is reachable only through the lister and not through
+    /// [`OSObjectStore`]. So a listing that is pushed down does not pass through
+    /// [`Self::wrap`], and this is where a wrapper says what should happen instead:
+    ///
+    /// - `Some(lister)` keeps the pushdown, wrapping the lister or handing back the one
+    ///   given. Right for a wrapper that observes rather than intercepts — metering, caching,
+    ///   mirroring writes.
+    /// - `None` gives up the pushdown, so listings go through [`Self::wrap`] as a full
+    ///   directory read. Right for a wrapper that hides, rewrites or fails paths, which a
+    ///   pushed-down listing would otherwise walk straight past.
+    ///
+    /// There is deliberately no default: getting this wrong is either a silent loss of speed
+    /// or a silent loss of the wrapper, and neither announces itself.
+    fn wrap_paginated(
+        &self,
+        store_prefix: &str,
+        original: Arc<dyn PaginatedDirLister>,
+    ) -> Option<Arc<dyn PaginatedDirLister>>;
 }
 
 #[derive(Debug, Clone)]
@@ -202,6 +231,18 @@ impl WrappingObjectStore for ChainedWrappingObjectStore {
         self.wrappers
             .iter()
             .fold(original, |acc, wrapper| wrapper.wrap(store_prefix, acc))
+    }
+
+    // One wrapper giving up the pushdown gives it up for the chain: the listing has to go
+    // through `wrap`, which is every wrapper in the chain at once.
+    fn wrap_paginated(
+        &self,
+        store_prefix: &str,
+        original: Arc<dyn PaginatedDirLister>,
+    ) -> Option<Arc<dyn PaginatedDirLister>> {
+        self.wrappers.iter().try_fold(original, |acc, wrapper| {
+            wrapper.wrap_paginated(store_prefix, acc)
+        })
     }
 }
 
@@ -522,6 +563,8 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
                 store_prefix,
+                // Type-erased on the way in, so there is no telling if it can paginate.
+                paginated_lister: None,
             };
             let path = Path::parse(path.path())?;
             return Ok((Arc::new(store), path));
@@ -882,6 +925,9 @@ impl ObjectStore {
     }
 
     /// Read a directory (start from base directory) and returns all sub-paths in the directory.
+    ///
+    /// This enumerates the whole prefix before it returns, however many children it holds.
+    /// Use [`Self::read_dir_page`] to page through a directory instead.
     pub async fn read_dir(&self, dir_path: impl Into<Path>) -> Result<Vec<String>> {
         let path = dir_path.into();
         let path = Path::parse(&path)?;
@@ -1226,6 +1272,8 @@ impl ObjectStore {
             download_retry_count,
             io_tracker,
             store_prefix,
+            // Type-erased on the way in, so there is no telling if it can paginate.
+            paginated_lister: None,
         }
     }
 }
@@ -1626,12 +1674,114 @@ mod tests {
             // return a mocked value so we can check if the final store is the one we expect
             self.return_value.clone()
         }
+
+        // This one swaps the store out entirely, so a listing that went around it would be
+        // listing something else.
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn PaginatedDirLister>,
+        ) -> Option<Arc<dyn PaginatedDirLister>> {
+            None
+        }
     }
 
     impl TestWrapper {
         fn called(&self) -> bool {
             self.called.load(Ordering::Relaxed)
         }
+    }
+
+    /// A lister that exists only to be wrapped.
+    #[derive(Debug)]
+    struct StubLister;
+
+    #[async_trait]
+    impl PaginatedDirLister for StubLister {
+        async fn list_page(
+            &self,
+            _prefix: Option<&str>,
+            _resume: Option<&DirCursor>,
+            _limit: Option<usize>,
+        ) -> Result<DirPage> {
+            unimplemented!("this lister exists to be wrapped, not to list")
+        }
+    }
+
+    /// Records the listers it was handed, and leaves the store alone.
+    #[derive(Debug)]
+    struct PaginatedTestWrapper {
+        name: &'static str,
+        log: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl WrappingObjectStore for PaginatedTestWrapper {
+        fn wrap(
+            &self,
+            _store_prefix: &str,
+            original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            original
+        }
+
+        fn wrap_paginated(
+            &self,
+            store_prefix: &str,
+            original: Arc<dyn PaginatedDirLister>,
+        ) -> Option<Arc<dyn PaginatedDirLister>> {
+            self.log
+                .lock()
+                .unwrap()
+                .push(format!("{}@{store_prefix}", self.name));
+            Some(original)
+        }
+    }
+
+    #[test]
+    fn test_chained_wrappers_wrap_the_paginated_lister_in_order() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let chain = ChainedWrappingObjectStore::new(vec![
+            Arc::new(PaginatedTestWrapper {
+                name: "first",
+                log: log.clone(),
+            }),
+            Arc::new(PaginatedTestWrapper {
+                name: "second",
+                log: log.clone(),
+            }),
+        ]);
+
+        chain.wrap_paginated("memory", Arc::new(StubLister));
+
+        assert_eq!(*log.lock().unwrap(), vec!["first@memory", "second@memory"]);
+    }
+
+    /// One wrapper giving up the pushdown gives it up for the whole chain, and the wrappers
+    /// after it are never asked: the listing is going through `wrap` either way.
+    #[test]
+    fn test_a_chain_gives_up_the_pushdown_with_any_of_its_wrappers() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let chain = ChainedWrappingObjectStore::new(vec![
+            Arc::new(PaginatedTestWrapper {
+                name: "first",
+                log: log.clone(),
+            }),
+            Arc::new(TestWrapper {
+                called: AtomicBool::new(false),
+                return_value: Arc::new(InMemory::new()),
+            }),
+            Arc::new(PaginatedTestWrapper {
+                name: "last",
+                log: log.clone(),
+            }),
+        ]);
+
+        assert!(
+            chain
+                .wrap_paginated("memory", Arc::new(StubLister))
+                .is_none()
+        );
+        assert_eq!(*log.lock().unwrap(), vec!["first@memory"]);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -701,6 +701,19 @@ impl ObjectStore {
         self.io_tracker.incremental_stats()
     }
 
+    /// Apply a [`WrappingObjectStore`] to both `inner` and `paginated_lister` together.
+    ///
+    /// Keeps both halves in sync: a wrapper returning `None` from
+    /// [`WrappingObjectStore::wrap_paginated`] clears the lister so that
+    /// [`Self::read_dir_page`] falls back through the (already-wrapped) `inner`.
+    pub fn apply_wrapper(&mut self, wrapper: &dyn WrappingObjectStore) {
+        self.inner = wrapper.wrap(&self.store_prefix, self.inner.clone());
+        self.paginated_lister = self
+            .paginated_lister
+            .take()
+            .and_then(|lister| wrapper.wrap_paginated(&self.store_prefix, lister));
+    }
+
     /// Open a file for path.
     ///
     /// Parameters
@@ -1782,6 +1795,57 @@ mod tests {
                 .is_none()
         );
         assert_eq!(*log.lock().unwrap(), vec!["first@memory"]);
+    }
+
+    #[test]
+    fn test_apply_wrapper_replaces_inner_and_clears_lister() {
+        // Verify that apply_wrapper keeps inner and paginated_lister in sync: a wrapper
+        // that gives up the pushdown (returns None from wrap_paginated) must also clear
+        // the lister, so read_dir_page cannot reach the backend behind the wrapper's back.
+        let mut store = ObjectStore::memory();
+        store.paginated_lister = Some(Arc::new(StubLister) as Arc<dyn PaginatedDirLister>);
+
+        let replacement = Arc::new(InMemory::new());
+        let wrapper = TestWrapper {
+            called: AtomicBool::new(false),
+            return_value: replacement.clone(),
+        };
+
+        store.apply_wrapper(&wrapper);
+
+        assert!(wrapper.called(), "apply_wrapper must call wrap()");
+        assert!(
+            Arc::ptr_eq(&store.inner, &(replacement as Arc<dyn OSObjectStore>)),
+            "inner must be the replacement from wrap()"
+        );
+        assert!(
+            store.paginated_lister.is_none(),
+            "paginated_lister must be cleared when wrap_paginated returns None"
+        );
+    }
+
+    #[test]
+    fn test_apply_wrapper_keeps_lister_when_wrapper_passes_it_through() {
+        let mut store = ObjectStore::memory();
+        let original_lister: Arc<dyn PaginatedDirLister> = Arc::new(StubLister);
+        store.paginated_lister = Some(original_lister.clone());
+
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let wrapper = PaginatedTestWrapper {
+            name: "passthrough",
+            log: log.clone(),
+        };
+
+        store.apply_wrapper(&wrapper);
+
+        assert!(
+            store.paginated_lister.is_some(),
+            "paginated_lister must be kept when wrap_paginated returns Some"
+        );
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec![format!("passthrough@{}", store.store_prefix)]
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -270,12 +270,7 @@ impl ObjectStoreRegistry {
         crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, &cache_path);
 
         if let Some(wrapper) = &params.object_store_wrapper {
-            store.inner = wrapper.wrap(&cache_path, store.inner);
-            // A wrapper that gives up the pushdown leaves the store with no lister, so its
-            // listings go through the wrapped `inner` like every other request.
-            store.paginated_lister = store
-                .paginated_lister
-                .and_then(|lister| wrapper.wrap_paginated(&cache_path, lister));
+            store.apply_wrapper(wrapper.as_ref());
         }
 
         // Always wrap with IO tracking

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -271,6 +271,11 @@ impl ObjectStoreRegistry {
 
         if let Some(wrapper) = &params.object_store_wrapper {
             store.inner = wrapper.wrap(&cache_path, store.inner);
+            // A wrapper that gives up the pushdown leaves the store with no lister, so its
+            // listings go through the wrapped `inner` like every other request.
+            store.paginated_lister = store
+                .paginated_lister
+                .and_then(|lister| wrapper.wrap_paginated(&cache_path, lister));
         }
 
         // Always wrap with IO tracking
@@ -377,8 +382,14 @@ impl ObjectStoreRegistry {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
     use super::*;
+    use object_store::ObjectStore as OSObjectStore;
+
+    use crate::object_store::{
+        DirCursor, DirPage, PaginatedDirLister, providers::memory::MemoryStoreProvider,
+    };
 
     #[derive(Debug)]
     struct DummyProvider;
@@ -392,6 +403,165 @@ mod tests {
         ) -> Result<ObjectStore> {
             unreachable!("This test doesn't create stores")
         }
+    }
+
+    /// A lister that exists only to be handed to a wrapper.
+    #[derive(Debug)]
+    struct StubLister;
+
+    #[async_trait::async_trait]
+    impl PaginatedDirLister for StubLister {
+        async fn list_page(
+            &self,
+            _prefix: Option<&str>,
+            _resume: Option<&DirCursor>,
+            _limit: Option<usize>,
+        ) -> Result<DirPage> {
+            unimplemented!("this lister exists to be wrapped, not to list")
+        }
+    }
+
+    /// A provider whose stores come with a paginated lister, which the memory store does not.
+    #[derive(Debug)]
+    struct PaginatedProvider;
+
+    #[async_trait::async_trait]
+    impl ObjectStoreProvider for PaginatedProvider {
+        async fn new_store(
+            &self,
+            base_path: Url,
+            params: &ObjectStoreParams,
+        ) -> Result<ObjectStore> {
+            let mut store = MemoryStoreProvider.new_store(base_path, params).await?;
+            store.paginated_lister = Some(Arc::new(StubLister));
+            Ok(store)
+        }
+
+        fn calculate_object_store_prefix(
+            &self,
+            _url: &Url,
+            _storage_options: Option<&HashMap<String, String>>,
+        ) -> Result<String> {
+            Ok("memory".to_string())
+        }
+    }
+
+    /// Replaces the lister it is given and records the prefix each call was labelled with.
+    #[derive(Debug)]
+    struct ListerReplacingWrapper {
+        replacement: Arc<dyn PaginatedDirLister>,
+        prefixes: Mutex<Vec<String>>,
+    }
+
+    impl WrappingObjectStore for ListerReplacingWrapper {
+        fn wrap(
+            &self,
+            store_prefix: &str,
+            original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            self.prefixes
+                .lock()
+                .unwrap()
+                .push(format!("wrap@{store_prefix}"));
+            original
+        }
+
+        fn wrap_paginated(
+            &self,
+            store_prefix: &str,
+            _original: Arc<dyn PaginatedDirLister>,
+        ) -> Option<Arc<dyn PaginatedDirLister>> {
+            self.prefixes
+                .lock()
+                .unwrap()
+                .push(format!("wrap_paginated@{store_prefix}"));
+            Some(self.replacement.clone())
+        }
+    }
+
+    /// A decorator supplied through [`ObjectStoreParams`] has to reach the paginated lister
+    /// too, or `read_dir_page` would talk to the backend behind its back.
+    #[tokio::test]
+    async fn test_registry_hands_the_paginated_lister_to_the_wrapper() {
+        let replacement: Arc<dyn PaginatedDirLister> = Arc::new(StubLister);
+        let wrapper = Arc::new(ListerReplacingWrapper {
+            replacement: replacement.clone(),
+            prefixes: Mutex::new(Vec::new()),
+        });
+        let registry = ObjectStoreRegistry::default();
+        registry.insert("pagmem", Arc::new(PaginatedProvider));
+
+        let store = registry
+            .get_store(
+                Url::parse("pagmem:///").unwrap(),
+                &ObjectStoreParams {
+                    object_store_wrapper: Some(wrapper.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(
+            store.paginated_lister.as_ref().unwrap(),
+            &replacement
+        ));
+        // Both halves of the store are labelled with the same prefix.
+        assert_eq!(
+            *wrapper.prefixes.lock().unwrap(),
+            vec!["wrap@memory", "wrap_paginated@memory"]
+        );
+    }
+
+    /// Hides everything the store holds, the way a wrapper enforcing visibility would.
+    #[derive(Debug)]
+    struct HidingWrapper;
+
+    impl WrappingObjectStore for HidingWrapper {
+        fn wrap(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            Arc::new(object_store::memory::InMemory::new())
+        }
+
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn PaginatedDirLister>,
+        ) -> Option<Arc<dyn PaginatedDirLister>> {
+            None
+        }
+    }
+
+    /// A wrapper that gives up the pushdown gets a store with no lister, so its listings go
+    /// through the wrapped `inner` and see what the wrapper allows rather than what the
+    /// backend holds.
+    #[tokio::test]
+    async fn test_giving_up_the_pushdown_lists_through_the_wrapper() {
+        let registry = ObjectStoreRegistry::default();
+        registry.insert("pagmem", Arc::new(PaginatedProvider));
+
+        let store = registry
+            .get_store(
+                Url::parse("pagmem:///").unwrap(),
+                &ObjectStoreParams {
+                    object_store_wrapper: Some(Arc::new(HidingWrapper)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(store.paginated_lister.is_none());
+        // `StubLister` panics if it is ever asked to list, so reaching a page at all is the
+        // other half of the assertion.
+        let page = store
+            .read_dir_page(Path::from(""), Default::default())
+            .await
+            .unwrap();
+        assert!(page.values.is_empty());
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -23,7 +23,7 @@ use object_store::{
     ClientOptions, CredentialProvider, Result as ObjectStoreResult, RetryConfig,
     StaticCredentialProvider,
     aws::{
-        AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
+        AmazonS3, AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
         AwsCredentialProvider,
     },
 };
@@ -34,7 +34,8 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::{NamespaceCredentialsProvider, build_dynamic_credential_provider},
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    read_dir::native::NativeDirLister,
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -49,7 +50,9 @@ impl AwsStoreProvider {
         storage_options: &StorageOptions,
         is_s3_express: bool,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<AmazonS3>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -104,14 +107,14 @@ impl AwsStoreProvider {
 
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 
-    async fn build_opendal_s3_store(
+    fn build_opendal_s3_operator(
         &self,
         base_path: &Url,
         storage_options: &StorageOptions,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+    ) -> Result<Operator> {
         let bucket = base_path
             .host_str()
             .ok_or_else(|| Error::invalid_input("S3 URL must contain bucket name"))?
@@ -140,7 +143,7 @@ impl AwsStoreProvider {
         let operator = Operator::from_iter::<S3>(config_map)
             .map_err(|e| Error::invalid_input(format!("Failed to create S3 operator: {:?}", e)))?;
 
-        Ok(Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>)
+        Ok(operator)
     }
 }
 
@@ -179,30 +182,32 @@ impl ObjectStoreProvider for AwsStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // Use OpenDAL implementation
-            self.build_opendal_s3_store(&base_path, &storage_options)
-                .await?
+            let operator = self.build_opendal_s3_operator(&base_path, &storage_options)?;
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>,
+                None,
+            )
         } else {
             // Use default Amazon S3 implementation
-            self.build_amazon_s3_store(
-                &mut base_path,
-                params,
-                &storage_options,
-                is_s3_express,
-                throttle_state.as_ref(),
+            let store = self
+                .build_amazon_s3_store(
+                    &mut base_path,
+                    params,
+                    &storage_options,
+                    is_s3_express,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(NativeDirLister::for_store(store)),
             )
-            .await?
         };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
-        } else {
-            inner
-        };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -216,6 +221,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 }
@@ -736,6 +742,36 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.scheme, "s3");
+    }
+
+    /// S3 Express ignores `start-after` and does not list in key order, but it does hand back
+    /// continuation tokens, which is all the native store resumes from — so an Express bucket
+    /// pages like any other. The OpenDAL arm has no lister to page with at all.
+    #[rstest::rstest]
+    #[case::native("false", true)]
+    #[case::opendal("true", false)]
+    #[tokio::test]
+    async fn test_s3_express_is_paged_by_continuation_token(
+        #[case] use_opendal: &str,
+        #[case] paginated: bool,
+    ) {
+        let provider = AwsStoreProvider;
+        // Express bucket names carry their availability zone, which the S3 client validates.
+        let url = Url::parse("s3://test-bucket--use1-az4--x-s3/path").unwrap();
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([
+                    ("use_opendal".to_string(), use_opendal.to_string()),
+                    ("region".to_string(), "us-west-2".to_string()),
+                ]),
+            ))),
+            ..Default::default()
+        };
+
+        let store = provider.new_store(url, &params).await.unwrap();
+
+        assert!(!store.list_is_lexically_ordered);
+        assert_eq!(store.paginated_lister.is_some(), paginated);
     }
 
     #[derive(Debug)]

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -14,7 +14,7 @@ use opendal::{Operator, services::Azblob, services::Azdls};
 
 use object_store::{
     RetryConfig,
-    azure::{AzureConfigKey, AzureCredential, MicrosoftAzureBuilder},
+    azure::{AzureConfigKey, AzureCredential, MicrosoftAzure, MicrosoftAzureBuilder},
 };
 use url::Url;
 
@@ -22,7 +22,8 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::build_dynamic_credential_provider,
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    read_dir::native::NativeDirLister,
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -148,22 +149,15 @@ impl AzureBlobStoreProvider {
         }
     }
 
-    async fn build_opendal_azure_store(
-        &self,
-        base_path: &Url,
-        storage_options: &StorageOptions,
-    ) -> Result<Arc<dyn OSObjectStore>> {
-        let operator = Self::build_opendal_operator(base_path, storage_options)?;
-        Ok(Arc::new(OpendalStore::new(operator)))
-    }
-
     async fn build_microsoft_azure_store(
         &self,
         base_path: &Url,
         storage_options: &StorageOptions,
         accessor: Option<Arc<StorageOptionsAccessor>>,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<MicrosoftAzure>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -190,7 +184,7 @@ impl AzureBlobStoreProvider {
             self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?;
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 
     fn calculate_object_store_prefix_with_env(
@@ -262,29 +256,31 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner: Arc<dyn OSObjectStore> = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // OpenDAL Azure intentionally uses static/environment-backed configuration only.
             // Namespace-vended dynamic credentials are supported on the native object_store path.
-            self.build_opendal_azure_store(&base_path, &storage_options)
-                .await?
-        } else {
-            self.build_microsoft_azure_store(
-                &base_path,
-                &storage_options,
-                accessor,
-                throttle_state.as_ref(),
+            let operator = Self::build_opendal_operator(&base_path, &storage_options)?;
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>,
+                None,
             )
-            .await?
-        };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
         } else {
-            inner
+            let store = self
+                .build_microsoft_azure_store(
+                    &base_path,
+                    &storage_options,
+                    accessor,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(NativeDirLister::for_store(store)),
+            )
         };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -298,6 +294,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 
@@ -578,6 +575,29 @@ mod tests {
             "abfss:// without use_opendal should use MicrosoftAzureBuilder, got: {}",
             inner_desc
         );
+        assert!(
+            store.paginated_lister.is_some(),
+            "the native store pages an ADLS Gen2 account by continuation token"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_blob_container_is_paged() {
+        use crate::object_store::StorageOptionsAccessor;
+        let provider = AzureBlobStoreProvider;
+        let url = Url::parse("az://container@testaccount.blob.core.windows.net/data").unwrap();
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([
+                    ("account_name".to_string(), "testaccount".to_string()),
+                    ("account_key".to_string(), "dGVzdA==".to_string()),
+                ]),
+            ))),
+            ..Default::default()
+        };
+
+        let store = provider.new_store(url, &params).await.unwrap();
+        assert!(store.paginated_lister.is_some());
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -9,7 +9,7 @@ use opendal::{Operator, services::Gcs};
 
 use object_store::{
     RetryConfig, StaticCredentialProvider,
-    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
+    gcp::{GcpCredential, GoogleCloudStorage, GoogleCloudStorageBuilder, GoogleConfigKey},
 };
 use url::Url;
 
@@ -17,7 +17,8 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::build_dynamic_credential_provider,
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    read_dir::native::NativeDirLister,
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -25,11 +26,11 @@ use lance_core::error::{Error, Result};
 pub struct GcsStoreProvider;
 
 impl GcsStoreProvider {
-    async fn build_opendal_gcs_store(
+    fn build_opendal_gcs_operator(
         &self,
         base_path: &Url,
         storage_options: &StorageOptions,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+    ) -> Result<Operator> {
         let bucket = base_path
             .host_str()
             .ok_or_else(|| Error::invalid_input("GCS URL must contain bucket name"))?
@@ -51,7 +52,7 @@ impl GcsStoreProvider {
         let operator = Operator::from_iter::<Gcs>(config_map)
             .map_err(|e| Error::invalid_input(format!("Failed to create GCS operator: {:?}", e)))?;
 
-        Ok(Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>)
+        Ok(operator)
     }
 
     async fn build_google_cloud_store(
@@ -60,7 +61,9 @@ impl GcsStoreProvider {
         storage_options: &StorageOptions,
         accessor: Option<Arc<StorageOptionsAccessor>>,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<GoogleCloudStorage>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -93,7 +96,7 @@ impl GcsStoreProvider {
             self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?;
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 }
 
@@ -121,29 +124,31 @@ impl ObjectStoreProvider for GcsStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // OpenDAL GCS intentionally uses static/environment-backed configuration only.
             // Namespace-vended dynamic credentials are supported on the native object_store path.
-            self.build_opendal_gcs_store(&base_path, &storage_options)
-                .await?
-        } else {
-            self.build_google_cloud_store(
-                &base_path,
-                &storage_options,
-                accessor,
-                throttle_state.as_ref(),
+            let operator = self.build_opendal_gcs_operator(&base_path, &storage_options)?;
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>,
+                None,
             )
-            .await?
-        };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
         } else {
-            inner
+            let store = self
+                .build_google_cloud_store(
+                    &base_path,
+                    &storage_options,
+                    accessor,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(NativeDirLister::for_store(store)),
+            )
         };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -157,6 +162,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -190,6 +190,8 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -216,6 +216,8 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -33,6 +33,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -33,6 +33,8 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: reading a directory is one local walk whatever the page size,
+            // so there is no request for a page to be pushed into.
             paginated_lister: None,
         })
     }

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -33,6 +33,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -33,6 +33,8 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: the store is already in memory, so a page costs no less than
+            // the directory does.
             paginated_lister: None,
         })
     }

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -144,6 +144,8 @@ impl ObjectStoreProvider for OssStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -100,6 +100,8 @@ impl ObjectStoreProvider for TencentStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -150,6 +150,8 @@ impl ObjectStoreProvider for TosStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -192,13 +192,19 @@ pub struct DirPage {
 /// Kept separate from [`ObjectStore::inner`] because paginated listing is not part of the
 /// `ObjectStore` trait and so cannot be reached through a `dyn ObjectStore`.
 ///
-/// This is where a backend joins the fast path: implement it, hand one to
-/// [`ObjectStore::paginated_lister`], and pages are pushed down instead of listed in full.
+/// This is where a backend joins the fast path: implement it, hand one to the store's
+/// `paginated_lister`, and pages are pushed down instead of listed in full.
 ///
-/// A backend mints [`DirCursor::backend`] and resumes from its own token, which is exact and
+/// Backends live in this crate for now: minting a cursor and installing a lister are both
+/// crate private, and they would have to open together, against a real second backend. What
+/// an outside crate implements is a decorator — metering, caching, throttling — which wraps
+/// the lister [`super::WrappingObjectStore::wrap_paginated`] handed it and passes that
+/// lister's cursors straight back, so it never needs to mint one.
+///
+/// A backend mints a cursor of its own and resumes from its own token, which is exact and
 /// needs no key order to be correct. A cursor minted by the full-listing fallback is not one
-/// of its own: a walk cannot start on one path and finish on the other, and
-/// [`DirCursor::expect_backend`] says so rather than guessing at a position.
+/// of its own: a walk cannot start on one path and finish on the other, and the listing fails
+/// rather than guessing at a position.
 #[async_trait::async_trait]
 pub trait PaginatedDirLister: std::fmt::Debug + Send + Sync + 'static {
     /// One page of the immediate children of `prefix`, resuming after `resume`.

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -505,13 +505,11 @@ mod tests {
         /// A paginated API over a store that lists in key order, like S3, GCS, or Azure over a
         /// flat namespace.
         KeyOrdered,
-        /// A paginated API over a store that orders each directory level by child name rather
-        /// than by whole key, which Azure documents for accounts with a hierarchical namespace.
-        NameOrdered,
-        /// A paginated API over a store that lists in no particular order, like S3 Express.
+        /// A paginated API over a store that lists in no particular order, like S3 Express or
+        /// an Azure account with a hierarchical namespace.
         Unordered,
     }
-    use Backend::{FullListing, KeyOrdered, NameOrdered, Unordered};
+    use Backend::{FullListing, KeyOrdered, Unordered};
 
     /// One list request, as the backend saw it.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -655,7 +653,6 @@ mod tests {
         let requests = Arc::new(Mutex::new(Vec::new()));
         if backend != FullListing {
             let order = match backend {
-                NameOrdered => KeyOrder::DelimiterLowest,
                 Unordered => KeyOrder::Reversed,
                 _ => KeyOrder::ByKey,
             };
@@ -679,7 +676,8 @@ mod tests {
     ];
 
     /// Walking a directory hands back every child exactly once, however the store resolves the
-    /// listing, whatever order it lists in, and however small the pages are.
+    /// listing and however small the pages are. That it holds whatever order the store lists
+    /// in is [`test_an_unordered_store_is_still_paged`].
     #[rstest]
     #[case::whole_directory(TABLES, "db", vec!["a.lance", "b.lance", "c.lance", "loose.txt"])]
     #[case::empty_directory(TABLES, "nonexistent", vec![])]
@@ -687,19 +685,19 @@ mod tests {
     // A directory and the sibling that follows it: `foo/` and `foo0` are adjacent in key order
     // with nothing between them, so resuming past `foo`'s contents must not swallow `foo0`.
     #[case::the_sibling_after_a_directory(&["db/foo/inside", "db/foo0"], "db", vec!["foo", "foo0"])]
-    // The two orders a store can list a level in disagree over siblings where one name is a
-    // prefix of another: `foo/` and `foo-bar/` differ at `/` against `-`.
+    // Siblings where one name is a prefix of another, which is where a page boundary is easiest
+    // to get wrong: `foo/` and `foo-bar/` differ at `/` against `-`.
     #[case::a_prefix_shaped_sibling(&["db/foo/inside", "db/foo-bar/inside", "db/zzz.txt"], "db", vec!["foo", "foo-bar", "zzz.txt"])]
     // A store that keeps a marker object for a directory reports the directory itself when
     // that directory is listed. Dropping the marker must not also drop the progress the page
     // made, or a page holding nothing but the marker reads as the end of the listing.
     #[case::a_directory_marker(&["db/marked/", "db/marked/a.txt", "db/marked/b.txt"], "db/marked", vec!["a.txt", "b.txt"])]
-    // A name holding a character `Path::from` would percent-encode still pages in the
-    // backend's own order.
+    // A name holding a character `Path::from` would percent-encode is still reported, and
+    // sorted, under the name it was stored with.
     #[case::an_encodable_name(&["db/az", "db/a~"], "db", vec!["az", "a~"])]
     #[tokio::test]
     async fn test_walking_a_directory_is_complete(
-        #[values(FullListing, KeyOrdered, NameOrdered, Unordered)] backend: Backend,
+        #[values(FullListing, KeyOrdered)] backend: Backend,
         #[values(None, Some(1), Some(2), Some(3))] limit: Option<usize>,
         #[case] keys: &[&str],
         #[case] dir: &str,
@@ -734,12 +732,9 @@ mod tests {
 
     /// The point of the pushdown: a caller that wants one child of a directory holding more
     /// makes one request, for one child.
-    #[rstest]
     #[tokio::test]
-    async fn test_a_bounded_page_makes_one_request(
-        #[values(KeyOrdered, NameOrdered, Unordered)] backend: Backend,
-    ) {
-        let store = test_store(backend, TABLES).await;
+    async fn test_a_bounded_page_makes_one_request() {
+        let store = test_store(KeyOrdered, TABLES).await;
 
         let page = store.first_page("db", Some(1)).await;
 
@@ -793,12 +788,9 @@ mod tests {
     /// A page whose whole budget went on things that are not children still has to move. The
     /// directory marker is the cheap way to arrange that: on a store that lists in key order it
     /// sorts first, so with a page of one it arrives on its own, leaving nothing to hand back.
-    #[rstest]
     #[tokio::test]
-    async fn test_a_page_of_no_entries_keeps_going(
-        #[values(KeyOrdered, NameOrdered)] backend: Backend,
-    ) {
-        let store = test_store(backend, &["db/marked/", "db/marked/a.txt"]).await;
+    async fn test_a_page_of_no_entries_keeps_going() {
+        let store = test_store(KeyOrdered, &["db/marked/", "db/marked/a.txt"]).await;
 
         let page = store.first_page("db/marked", Some(1)).await;
 

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -1,0 +1,1075 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Paginated listing of a single directory level.
+//!
+//! [`ObjectStore::read_dir_page`] returns one page of the immediate children of a prefix, plus
+//! a token that resumes after it. Where the backend has a paginated list API the page size and
+//! the resume position are pushed into the list request, so a caller that wants the first few
+//! children pays for the first few children rather than for the whole prefix.
+//!
+//! The token is opaque. It carries whatever resumes the store it came from — a continuation
+//! token where the store has one, a key where it does not — and a caller only ever hands it
+//! back. That is what lets a store without key-ordered listings, such as S3 Express, be paged
+//! at all: nothing outside this module compares one token to another.
+//!
+//! This module holds the listing itself: the cursor, the paging loop, and the
+//! [`PaginatedDirLister`] contract a backend implements. The backends live beside it, one per
+//! way of asking. There is one so far — [`native`], over `object_store`'s own paginated API,
+//! which covers S3, GCS and Azure. Everything else lists in full and pages locally, which is
+//! correct but costs what the whole directory costs.
+
+use std::sync::Arc;
+
+use object_store::{ListResult, ObjectMeta, ObjectStore as OSObjectStore, path::Path};
+use tracing::instrument;
+
+use lance_core::{Error, Result};
+
+use super::ObjectStore;
+use crate::utils::tracking_store::IOTracker;
+
+#[cfg(all(test, feature = "aws", feature = "gcp", feature = "azure"))]
+mod conformance;
+#[cfg(all(test, feature = "aws", feature = "gcp", feature = "azure"))]
+mod emulator;
+// The paginated list API is only reached through the native cloud stores, and through the
+// recording store the tests below stand in their place.
+#[cfg(any(test, feature = "aws", feature = "azure", feature = "gcp"))]
+pub mod native;
+#[cfg(test)]
+mod store_model;
+
+#[cfg(feature = "metrics")]
+use crate::object_store::metrics::{InFlightGuard, record_outcome};
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+/// The path delimiter that separates directory levels.
+const DELIMITER: &str = "/";
+
+/// Operation label for the metrics and IO statistics a paginated listing records.
+const LIST_OP: &str = "list_paginated";
+
+/// Marks the encoding a page token was written with, so that a token from another build is
+/// rejected rather than read as something it is not.
+const TOKEN_VERSION: char = '1';
+
+/// Where a listing resumes.
+///
+/// Opaque to callers: [`ObjectStore::read_dir_page`] mints one, hands it over as the string in
+/// [`DirListing::next_token`], and takes it back in [`ReadDirOptions::page_token`]. What it
+/// holds depends on the store that minted it, so a token means nothing anywhere else.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirCursor(Resume);
+
+/// The two things a store can give a listing to resume from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resume {
+    /// The store's own continuation token, which resumes exactly where the page stopped.
+    ///
+    /// Nothing is compared against it, so a store whose listings are not in key order — S3
+    /// Express, or an Azure account with a hierarchical namespace — pages correctly on one.
+    Backend(String),
+    /// A key within the directory, which the next page resumes strictly after: the last key
+    /// the page reported. For stores with no continuation token of their own, which can only
+    /// be paged when they list in key order.
+    Key(String),
+}
+
+impl DirCursor {
+    pub(crate) fn backend(token: impl Into<String>) -> Self {
+        Self(Resume::Backend(token.into()))
+    }
+
+    pub(crate) fn key(key: impl Into<String>) -> Self {
+        Self(Resume::Key(key.into()))
+    }
+
+    /// Only the native lister takes both kinds; everything else goes through
+    /// [`Self::expect_key`].
+    #[cfg(any(test, feature = "aws", feature = "azure", feature = "gcp"))]
+    pub(crate) fn resume(&self) -> &Resume {
+        &self.0
+    }
+
+    /// The key to resume after, for a backend that can only resume from one.
+    pub(crate) fn expect_key(&self) -> Result<&str> {
+        match &self.0 {
+            Resume::Key(key) => Ok(key),
+            Resume::Backend(_) => Err(Error::invalid_input(
+                "this page token came from a store that resumes by continuation token, \
+                 which this one cannot use",
+            )),
+        }
+    }
+
+    fn encode(&self) -> String {
+        let (tag, value) = match &self.0 {
+            Resume::Backend(token) => ('b', token),
+            Resume::Key(key) => ('k', key),
+        };
+        format!("{TOKEN_VERSION}{tag}{value}")
+    }
+
+    fn decode(token: &str) -> Result<Self> {
+        let invalid = || Error::invalid_input(format!("not a directory page token: '{token}'"));
+        let rest = token.strip_prefix(TOKEN_VERSION).ok_or_else(invalid)?;
+        let (tag, value) = rest.split_at_checked(1).ok_or_else(invalid)?;
+        match tag {
+            "b" => Ok(Self::backend(value)),
+            "k" => Ok(Self::key(value)),
+            _ => Err(invalid()),
+        }
+    }
+}
+
+/// What kind of child a [`DirEntry`] is.
+#[derive(Debug, Clone)]
+pub enum DirEntryKind {
+    /// A child directory: a common prefix, which has no metadata of its own.
+    Directory,
+    /// A child object, with the metadata the listing reported for it.
+    File(ObjectMeta),
+}
+
+/// An immediate child of a directory.
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    /// The child's name relative to the directory that was listed, with no trailing delimiter.
+    pub name: String,
+    /// Whether the child is a directory or a file, and the file's metadata if it is one.
+    pub kind: DirEntryKind,
+}
+
+impl DirEntry {
+    /// Whether this child is a directory rather than an object.
+    pub fn is_dir(&self) -> bool {
+        matches!(self.kind, DirEntryKind::Directory)
+    }
+}
+
+/// Options for [`ObjectStore::read_dir_page`].
+#[derive(Debug, Clone, Default)]
+pub struct ReadDirOptions {
+    /// Resume after the page a previous call returned, using the token it handed back.
+    pub page_token: Option<String>,
+    /// The most children to return. Must be at least one. `None` reads the whole directory.
+    pub limit: Option<usize>,
+}
+
+/// One page of a directory listing.
+#[derive(Debug)]
+pub struct DirListing {
+    /// The children found, at most [`ReadDirOptions::limit`] of them.
+    pub values: Vec<DirEntry>,
+    /// The token that resumes after this page, or `None` when the directory is exhausted.
+    ///
+    /// A page can hold fewer children than the limit asked for and still be followed by more,
+    /// so this is the only thing that ends a walk.
+    pub next_token: Option<String>,
+}
+
+/// One page as a backend reports it.
+#[derive(Debug)]
+pub struct DirPage {
+    /// The children found, in the order the backend listed them.
+    pub entries: Vec<DirEntry>,
+    /// Where the next page resumes, or `None` when there is nothing after this one.
+    pub next: Option<DirCursor>,
+}
+
+/// A backend that can list one directory level a page at a time.
+///
+/// Kept separate from [`ObjectStore::inner`] because paginated listing is not part of the
+/// `ObjectStore` trait and so cannot be reached through a `dyn ObjectStore`.
+///
+/// This is where a backend joins the fast path: implement it, hand one to
+/// [`ObjectStore::paginated_lister`], and pages are pushed down instead of listed in full. A
+/// backend that resumes from its own continuation token mints [`DirCursor::backend`] and needs
+/// no ordering at all; one that can only resume from a key mints [`DirCursor::key`], which is
+/// sound only where the backend lists in key order and reports its pages in that same order.
+#[async_trait::async_trait]
+pub trait PaginatedDirLister: std::fmt::Debug + Send + Sync + 'static {
+    /// One page of the immediate children of `prefix`, resuming after `resume`.
+    ///
+    /// `prefix` carries a trailing delimiter, and is `None` at the root of the store. `limit`
+    /// is the most entries the page may hold; a backend may return fewer and still have more
+    /// to give, which is what [`DirPage::next`] reports.
+    ///
+    /// Two things the caller relies on. Every entry in the page is strictly after `resume`,
+    /// so nothing is handed over twice. And a page with a `next` has moved: the caller asks
+    /// again from it, so a cursor that stood still would never finish — a page holding no
+    /// entries, which is what a directory marker or a run of collapsed keys can cost, still
+    /// has to leave the listing somewhere new to resume from.
+    async fn list_page(
+        &self,
+        prefix: Option<&str>,
+        resume: Option<&DirCursor>,
+        limit: Option<usize>,
+    ) -> Result<DirPage>;
+}
+
+impl ObjectStore {
+    /// One page of the immediate children of `dir`, one directory level deep.
+    ///
+    /// On backends with a paginated list API — S3, GCS and Azure — the resume position and the
+    /// page size are pushed into the list request, so the page costs what the page holds.
+    /// Elsewhere the directory is listed in full and paged locally, which is correct but no
+    /// cheaper than [`Self::read_dir`].
+    ///
+    /// A page can hold fewer children than `limit` asked for and still be followed by more:
+    /// with a delimiter a backend spends its page budget on keys it collapses away. Walk until
+    /// [`DirListing::next_token`] is `None` rather than until a page comes back short.
+    ///
+    /// ```
+    /// # use lance_io::object_store::{ObjectStore, ReadDirOptions};
+    /// # async fn example(store: &ObjectStore) -> lance_core::Result<Vec<String>> {
+    /// let mut tables = Vec::new();
+    /// let mut page_token = None;
+    /// loop {
+    ///     let page = store
+    ///         .read_dir_page("my_db", ReadDirOptions { page_token, limit: Some(10) })
+    ///         .await?;
+    ///     tables.extend(
+    ///         page.values
+    ///             .iter()
+    ///             .filter_map(|entry| entry.name.strip_suffix(".lance"))
+    ///             .map(String::from),
+    ///     );
+    ///     page_token = page.next_token;
+    ///     if page_token.is_none() || tables.len() >= 10 {
+    ///         break;
+    ///     }
+    /// }
+    /// # Ok(tables)
+    /// # }
+    /// ```
+    pub async fn read_dir_page(
+        &self,
+        dir: impl Into<Path>,
+        options: ReadDirOptions,
+    ) -> Result<DirListing> {
+        let dir = dir.into();
+        // A page of nothing cannot advance a listing, and the two paths below would disagree
+        // about what it means: the pushdown path would report an empty directory while the
+        // full listing ignored the limit and returned everything.
+        if options.limit == Some(0) {
+            return Err(Error::invalid_input(
+                "read_dir_page limit must be at least 1, got 0",
+            ));
+        }
+        let resume = options
+            .page_token
+            .as_deref()
+            .map(DirCursor::decode)
+            .transpose()?;
+
+        match &self.paginated_lister {
+            Some(lister) => {
+                let lister = InstrumentedDirLister {
+                    inner: lister.clone(),
+                    io_tracker: self.io_tracker.clone(),
+                    dir: dir.clone(),
+                    #[cfg(feature = "metrics")]
+                    store_prefix: self.store_prefix.clone(),
+                };
+                fill_page(&lister, &dir, resume, options.limit).await
+            }
+            // Goes through `inner`, so the wrappers around it instrument the request. The
+            // pushdown path talks to the backend directly and instruments itself.
+            None => full_listing_page(self.inner.as_ref(), &dir, resume, options.limit).await,
+        }
+    }
+}
+
+/// The prefix to list under, carrying the trailing delimiter that the paginated API expects.
+/// `None` for the root of the store, which has no prefix at all.
+fn list_prefix(dir: &Path) -> Option<String> {
+    let dir = dir.as_ref();
+    (!dir.is_empty()).then(|| format!("{dir}{DELIMITER}"))
+}
+
+/// Ask the backend for pages until the limit is met or the directory runs out.
+///
+/// More than one request only where a page came back holding less than it could: a backend
+/// spends its page budget on keys, and a directory marker or a common prefix collapsing many
+/// keys can leave a page short of entries — or empty — while the listing is far from over.
+async fn fill_page(
+    lister: &dyn PaginatedDirLister,
+    dir: &Path,
+    mut resume: Option<DirCursor>,
+    limit: Option<usize>,
+) -> Result<DirListing> {
+    let prefix = list_prefix(dir);
+    let mut values: Vec<DirEntry> = Vec::new();
+    loop {
+        // `None` once the page is full, which also covers a backend that overshot the limit.
+        let remaining = match limit {
+            Some(limit) => limit.checked_sub(values.len()).filter(|left| *left > 0),
+            None => Some(usize::MAX),
+        };
+        let Some(remaining) = remaining else {
+            break;
+        };
+        let page = lister
+            .list_page(prefix.as_deref(), resume.as_ref(), limit.map(|_| remaining))
+            .await?;
+        values.extend(page.entries);
+        match page.next {
+            // A page that hands back the position it was given has not moved, and asking
+            // again from it would repeat forever. The contract forbids it; a backend that
+            // does it anyway fails the listing rather than hanging the caller.
+            Some(next) if resume.as_ref() == Some(&next) => {
+                return Err(Error::io(format!(
+                    "listing '{dir}' did not advance past the position it resumed from"
+                )));
+            }
+            Some(next) => resume = Some(next),
+            // The backend says there is nothing more, so there is nothing more, however short
+            // the page came back.
+            None => {
+                return Ok(DirListing {
+                    values,
+                    next_token: None,
+                });
+            }
+        }
+    }
+    Ok(DirListing {
+        values,
+        next_token: resume.as_ref().map(DirCursor::encode),
+    })
+}
+
+/// One page of a directory on a store with no paginated list API: list the level in full and
+/// page it locally.
+///
+/// The page has to be the smallest `limit` children past the cursor rather than any `limit` of
+/// them, since the next call lists the same directory again and keeps only what sorts after
+/// the key this page hands back. That means putting the listing in key order, which
+/// `list_with_delimiter` does not promise — a sort over children already in memory, costing no
+/// extra request.
+async fn full_listing_page(
+    store: &dyn OSObjectStore,
+    dir: &Path,
+    resume: Option<DirCursor>,
+    limit: Option<usize>,
+) -> Result<DirListing> {
+    let listed = store.list_with_delimiter(Some(dir)).await?;
+    let mut children = keyed_entries(&listed, list_prefix(dir).as_deref());
+    if let Some(resume) = &resume {
+        let key = resume.expect_key()?;
+        children.retain(|child| child.key.as_str() > key);
+    }
+    let taken = limit.unwrap_or(children.len()).min(children.len());
+    let next_token =
+        (taken < children.len()).then(|| DirCursor::key(children[taken - 1].key.clone()).encode());
+    children.truncate(taken);
+    Ok(DirListing {
+        values: children.into_iter().map(|child| child.entry).collect(),
+        next_token,
+    })
+}
+
+/// A child of the directory being listed, with the key the backend listed it under.
+pub struct KeyedEntry {
+    /// The key relative to the directory, which is what a [`Resume::Key`] cursor names. A
+    /// child directory keeps its trailing delimiter, since that is the prefix its keys share
+    /// and so where it sits in the listing; a child file is its name.
+    pub key: String,
+    pub entry: DirEntry,
+}
+
+/// The children in `listed`, in key order, each with the key it was listed under relative to
+/// `prefix`.
+///
+/// Stores report common prefixes and objects as two separate lists, so the two are put back
+/// into one order here. Anything that is not a child of this level is dropped, which covers
+/// the marker object some stores keep for a directory: it lists as an object whose key is the
+/// directory's own prefix.
+pub fn keyed_entries(listed: &ListResult, prefix: Option<&str>) -> Vec<KeyedEntry> {
+    let listed = listed
+        .common_prefixes
+        .iter()
+        .map(|location| (location, None))
+        .chain(
+            listed
+                .objects
+                .iter()
+                .map(|object| (&object.location, Some(object))),
+        );
+    let mut children: Vec<KeyedEntry> = listed
+        .filter_map(|(location, meta)| {
+            let key = listed_key(prefix, location, meta.is_none())?;
+            let entry = DirEntry {
+                name: location.filename()?.to_string(),
+                kind: match meta {
+                    Some(meta) => DirEntryKind::File(meta.clone()),
+                    None => DirEntryKind::Directory,
+                },
+            };
+            Some(KeyedEntry { key, entry })
+        })
+        .collect();
+    children.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+    children
+}
+
+/// Where a listed location sits in the directory being listed, which is the space cursors live
+/// in, or `None` if it is not a child of that directory at all.
+fn listed_key(prefix: Option<&str>, location: &Path, is_dir: bool) -> Option<String> {
+    let location = location.as_ref();
+    let relative = match prefix {
+        // Both halves of the prefix, so a location that merely starts with the directory's
+        // name — `dbx/y` against `db/` — is reported as not being under it, and so is the
+        // directory's own marker, whose location is `db`.
+        Some(prefix) => location.strip_prefix(prefix)?,
+        None => location,
+    };
+    (!relative.is_empty()).then(|| match is_dir {
+        true => format!("{relative}{DELIMITER}"),
+        false => relative.to_string(),
+    })
+}
+
+/// Records what a pushed-down listing costs.
+///
+/// The pushdown path holds the backend directly, so its requests never pass through the
+/// wrappers around [`ObjectStore::inner`] that would otherwise record them. The full-listing
+/// fallback does go through those wrappers and is not wrapped in this.
+#[derive(Debug)]
+struct InstrumentedDirLister {
+    inner: Arc<dyn PaginatedDirLister>,
+    io_tracker: IOTracker,
+    dir: Path,
+    #[cfg(feature = "metrics")]
+    store_prefix: String,
+}
+
+#[async_trait::async_trait]
+impl PaginatedDirLister for InstrumentedDirLister {
+    #[instrument(level = "debug", skip_all, fields(prefix = prefix))]
+    async fn list_page(
+        &self,
+        prefix: Option<&str>,
+        resume: Option<&DirCursor>,
+        limit: Option<usize>,
+    ) -> Result<DirPage> {
+        self.io_tracker
+            .record_read(LIST_OP, self.dir.clone(), 0, None);
+        #[cfg(feature = "metrics")]
+        let _in_flight = InFlightGuard::new(&self.store_prefix, LIST_OP);
+        #[cfg(feature = "metrics")]
+        let start = Instant::now();
+
+        let page = self.inner.list_page(prefix, resume, limit).await;
+
+        #[cfg(feature = "metrics")]
+        record_outcome(&self.store_prefix, LIST_OP, start, 0, page.is_err());
+        page
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::native::NativeDirLister;
+    use super::store_model::{BudgetMode, KeyOrder, OffsetMode, Resume as ModelResume, StoreModel};
+    use super::*;
+    use crate::object_store::throttle::{AimdThrottleConfig, AimdThrottledStore};
+    use crate::object_store::{ObjectStoreParams, ObjectStoreRegistry};
+    use chrono::Utc;
+    use object_store::list::{PaginatedListOptions, PaginatedListStore};
+    use object_store::memory::InMemory;
+    use object_store::{ListResult, ObjectStoreExt, PutPayload};
+    use rstest::rstest;
+
+    /// How the store under test resolves a listing.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Backend {
+        /// No paginated API: list the whole directory and page it locally.
+        FullListing,
+        /// A paginated API whose offset is exclusive: `start-after`, which S3 takes and which
+        /// GCS takes too, since `object_store` lists it over the S3-compatible XML API.
+        ExclusiveOffset,
+        /// A paginated API whose offset is inclusive, like Azure's `startFrom`.
+        InclusiveOffset,
+        /// A paginated API over a store that orders each directory level by child name rather
+        /// than by whole key, which Azure documents for accounts with a hierarchical namespace.
+        NameOrdered,
+        /// A paginated API over a store that lists in no particular order, like S3 Express.
+        Unordered,
+    }
+    use Backend::{ExclusiveOffset, FullListing, InclusiveOffset, NameOrdered, Unordered};
+
+    /// One list request, as the backend saw it.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ListRequest {
+        resume: Option<DirCursor>,
+        limit: Option<usize>,
+    }
+
+    /// A stand-in for a backend with a paginated list API.
+    ///
+    /// The store's behaviour comes from [`StoreModel`], which the wire-level emulator in
+    /// [`conformance`](super::conformance) shares, so the two cannot drift. `limit` is spent on
+    /// the keys the backend scans rather than on the entries it returns, which is the harsher
+    /// of the two things a real store does with a delimiter: a common prefix collapses many
+    /// keys into one entry but still costs what it collapsed. A page can therefore come back
+    /// short and still be truncated, so [`DirPage::next`] is the only way to know whether a
+    /// listing is finished.
+    #[derive(Debug)]
+    struct FakeDirLister {
+        model: StoreModel,
+        requests: Arc<Mutex<Vec<ListRequest>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PaginatedDirLister for FakeDirLister {
+        async fn list_page(
+            &self,
+            prefix: Option<&str>,
+            resume: Option<&DirCursor>,
+            limit: Option<usize>,
+        ) -> Result<DirPage> {
+            self.requests.lock().unwrap().push(ListRequest {
+                resume: resume.cloned(),
+                limit,
+            });
+            let prefix = prefix.unwrap_or("");
+            // The cursor is relative to the prefix, and the backend joins the two.
+            let offset = match resume.map(DirCursor::resume) {
+                Some(super::Resume::Key(key)) => Some(format!("{prefix}{key}")),
+                _ => None,
+            };
+            let resume = match (resume.map(DirCursor::resume), &offset) {
+                (Some(super::Resume::Backend(token)), _) => ModelResume::Token(token),
+                (_, Some(offset)) => ModelResume::Offset(offset),
+                _ => ModelResume::Start,
+            };
+            let page = self.model.list_level(prefix, resume, limit);
+
+            // Keys are reported as `Path::parse`, which is how `object_store`'s own S3, GCS
+            // and Azure clients report them: verbatim, so that the entries a caller sees
+            // sort the way the backend sorted them.
+            let listed = ListResult {
+                common_prefixes: page
+                    .prefixes
+                    .iter()
+                    .map(|prefix| Path::parse(prefix).unwrap())
+                    .collect(),
+                objects: page
+                    .objects
+                    .iter()
+                    .map(|key| ObjectMeta {
+                        location: Path::parse(key).unwrap(),
+                        last_modified: Utc::now(),
+                        size: 1,
+                        e_tag: None,
+                        version: None,
+                    })
+                    .collect(),
+            };
+            let entries = keyed_entries(&listed, Some(prefix).filter(|p| !p.is_empty()));
+            let entries = match &offset {
+                // The offset is a key, so anything at or before it has already been handed
+                // over: a resumed directory comes back as its own prefix again.
+                Some(offset) => entries
+                    .into_iter()
+                    .filter(|child| format!("{prefix}{}", child.key).as_str() > offset.as_str())
+                    .collect(),
+                None => entries,
+            };
+            Ok(DirPage {
+                entries: entries.into_iter().map(|child| child.entry).collect(),
+                next: page.next_token.map(DirCursor::backend),
+            })
+        }
+    }
+
+    struct TestStore {
+        store: ObjectStore,
+        requests: Arc<Mutex<Vec<ListRequest>>>,
+    }
+
+    impl TestStore {
+        /// Every child of `dir`, taken a page at a time, which is how a caller walks a
+        /// directory: the token ends the walk, never a short page.
+        async fn walk(&self, dir: &str, limit: Option<usize>) -> Result<Vec<String>> {
+            let mut names = Vec::new();
+            let mut page_token = None;
+            loop {
+                let page = self
+                    .store
+                    .read_dir_page(Path::from(dir), ReadDirOptions { page_token, limit })
+                    .await?;
+                names.extend(page.values.into_iter().map(|entry| entry.name));
+                page_token = page.next_token;
+                if page_token.is_none() {
+                    return Ok(names);
+                }
+            }
+        }
+
+        async fn names(&self, dir: &str, limit: Option<usize>) -> Vec<String> {
+            self.walk(dir, limit).await.unwrap()
+        }
+
+        /// The first page only, as a caller wanting a bounded number of children would take it.
+        async fn first_page(&self, dir: &str, limit: Option<usize>) -> DirListing {
+            self.store
+                .read_dir_page(
+                    Path::from(dir),
+                    ReadDirOptions {
+                        page_token: None,
+                        limit,
+                    },
+                )
+                .await
+                .unwrap()
+        }
+    }
+
+    async fn test_store(backend: Backend, keys: &[&str]) -> TestStore {
+        let inner = Arc::new(InMemory::new());
+        for key in keys {
+            // `Path::parse`, so that a key holding a character `Path::from` would encode is
+            // stored under the name it was given.
+            inner
+                .put(&Path::parse(key).unwrap(), PutPayload::from_static(b"x"))
+                .await
+                .unwrap();
+        }
+        #[allow(deprecated)]
+        let params = ObjectStoreParams {
+            object_store: Some((inner, url::Url::parse("memory:///").unwrap())),
+            // The deprecated hand-built path assumes nothing about the store it was given.
+            list_is_lexically_ordered: Some(backend != Unordered),
+            ..Default::default()
+        };
+        let (store, _) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            "memory:///",
+            &params,
+        )
+        .await
+        .unwrap();
+        let mut store = Arc::try_unwrap(store).unwrap();
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        if backend != FullListing {
+            let offset = match backend {
+                InclusiveOffset => OffsetMode::Inclusive,
+                _ => OffsetMode::Exclusive,
+            };
+            let order = match backend {
+                NameOrdered => KeyOrder::DelimiterLowest,
+                Unordered => KeyOrder::Reversed,
+                _ => KeyOrder::ByKey,
+            };
+            store.paginated_lister = Some(Arc::new(FakeDirLister {
+                model: StoreModel::new(keys.to_vec())
+                    .with_offset(offset)
+                    .with_order(order)
+                    .with_budget(BudgetMode::PerScannedKey),
+                requests: requests.clone(),
+            }));
+        }
+        TestStore { store, requests }
+    }
+
+    const TABLES: &[&str] = &[
+        "db/a.lance/_versions/1.manifest",
+        "db/a.lance/data/1.lance",
+        "db/b.lance/data/1.lance",
+        "db/c.lance/data/1.lance",
+        "db/loose.txt",
+        "other/d.lance/data/1.lance",
+    ];
+
+    /// Walking a directory hands back every child exactly once, whatever the store does with a
+    /// resume position, whatever order it lists in, and however small the pages are.
+    #[rstest]
+    #[case::whole_directory(TABLES, "db", vec!["a.lance", "b.lance", "c.lance", "loose.txt"])]
+    #[case::empty_directory(TABLES, "nonexistent", vec![])]
+    #[case::only_files(&["db/a.txt", "db/b.txt", "db/c.txt"], "db", vec!["a.txt", "b.txt", "c.txt"])]
+    // A directory and the sibling that follows it: `foo/` and `foo0` are adjacent in key order
+    // with nothing between them, so resuming past `foo`'s contents must not swallow `foo0`.
+    #[case::the_sibling_after_a_directory(&["db/foo/inside", "db/foo0"], "db", vec!["foo", "foo0"])]
+    // The two orders a store can list a level in disagree over siblings where one name is a
+    // prefix of another: `foo/` and `foo-bar/` differ at `/` against `-`.
+    #[case::a_prefix_shaped_sibling(&["db/foo/inside", "db/foo-bar/inside", "db/zzz.txt"], "db", vec!["foo", "foo-bar", "zzz.txt"])]
+    // A store that keeps a marker object for a directory reports the directory itself when
+    // that directory is listed. Dropping the marker must not also drop the progress the page
+    // made, or a page holding nothing but the marker reads as the end of the listing.
+    #[case::a_directory_marker(&["db/marked/", "db/marked/a.txt", "db/marked/b.txt"], "db/marked", vec!["a.txt", "b.txt"])]
+    // A name holding a character `Path::from` would percent-encode still pages in the
+    // backend's own order.
+    #[case::an_encodable_name(&["db/az", "db/a~"], "db", vec!["az", "a~"])]
+    #[tokio::test]
+    async fn test_walking_a_directory_is_complete(
+        #[values(FullListing, ExclusiveOffset, InclusiveOffset, NameOrdered, Unordered)]
+        backend: Backend,
+        #[values(None, Some(1), Some(2), Some(3))] limit: Option<usize>,
+        #[case] keys: &[&str],
+        #[case] dir: &str,
+        #[case] expected: Vec<&str>,
+    ) {
+        let store = test_store(backend, keys).await;
+
+        // The order children come back in is the store's, so the walk is checked for holding
+        // every child once rather than for holding them in one particular order.
+        let mut listed = store.names(dir, limit).await;
+        let seen = listed.clone();
+        listed.sort();
+        assert_eq!(listed, expected, "from {seen:?}");
+    }
+
+    /// A store that lists in no particular order — S3 Express — is still paged, because a
+    /// continuation token is never compared to anything. This is the case a cursor spelled as
+    /// a key could not serve.
+    #[tokio::test]
+    async fn test_an_unordered_store_is_still_paged() {
+        let store = test_store(Unordered, TABLES).await;
+
+        let mut names = store.names("db", Some(1)).await;
+        names.sort();
+
+        assert_eq!(names, vec!["a.lance", "b.lance", "c.lance", "loose.txt"]);
+        assert!(
+            !store.requests.lock().unwrap().is_empty(),
+            "the paginated lister should have been used"
+        );
+    }
+
+    /// The point of the pushdown: a caller that wants one child of a directory holding more
+    /// makes one request, for one child.
+    #[rstest]
+    #[tokio::test]
+    async fn test_a_bounded_page_makes_one_request(
+        #[values(ExclusiveOffset, InclusiveOffset, NameOrdered, Unordered)] backend: Backend,
+    ) {
+        let store = test_store(backend, TABLES).await;
+
+        let page = store.first_page("db", Some(1)).await;
+
+        assert_eq!(page.values.len(), 1);
+        assert!(page.next_token.is_some());
+        assert_eq!(
+            *store.requests.lock().unwrap(),
+            vec![ListRequest {
+                resume: None,
+                limit: Some(1)
+            }]
+        );
+    }
+
+    /// A backend page that comes back short is asked again rather than handed on. With a
+    /// delimiter the backend spends its limit on keys it collapses away, so a page can hold one
+    /// entry, be nowhere near the limit, and still be followed by more; a caller that stopped
+    /// there would see a page far smaller than the one it asked for.
+    #[rstest]
+    #[tokio::test]
+    async fn test_a_short_backend_page_is_filled_from_the_next(
+        #[values(ExclusiveOffset, InclusiveOffset)] backend: Backend,
+    ) {
+        // `big.lance` holds more keys than a page is allowed to scan, so the page that reports
+        // it comes back with a single entry and more to come.
+        let store = test_store(
+            backend,
+            &[
+                "db/big.lance/data/1.lance",
+                "db/big.lance/data/2.lance",
+                "db/big.lance/data/3.lance",
+                "db/big.lance/data/4.lance",
+                "db/zzz.txt",
+            ],
+        )
+        .await;
+
+        let page = store.first_page("db", Some(3)).await;
+
+        assert_eq!(
+            page.values
+                .iter()
+                .map(|entry| &entry.name)
+                .collect::<Vec<_>>(),
+            vec!["big.lance", "zzz.txt"]
+        );
+        assert_eq!(
+            store.requests.lock().unwrap().len(),
+            2,
+            "the short first page should have been followed up"
+        );
+    }
+
+    /// A page whose whole budget went on things that are not children still has to move. The
+    /// directory marker is the cheap way to arrange that: on a store that lists in key order it
+    /// sorts first, so with a page of one it arrives on its own, leaving nothing to hand back.
+    #[rstest]
+    #[tokio::test]
+    async fn test_a_page_of_no_entries_keeps_going(
+        #[values(ExclusiveOffset, InclusiveOffset, NameOrdered)] backend: Backend,
+    ) {
+        let store = test_store(backend, &["db/marked/", "db/marked/a.txt"]).await;
+
+        let page = store.first_page("db/marked", Some(1)).await;
+
+        assert_eq!(
+            page.values.iter().map(|e| &e.name).collect::<Vec<_>>(),
+            vec!["a.txt"]
+        );
+        assert!(
+            store.requests.lock().unwrap().len() > 1,
+            "the marker page should have been followed by another"
+        );
+    }
+
+    /// A page of nothing is rejected rather than left to mean whatever the backend makes of it:
+    /// pushing it down reports an empty directory, and a full listing ignores it. The rejection
+    /// comes before the store is consulted, so one backend covers it.
+    #[tokio::test]
+    async fn test_zero_limit_is_rejected() {
+        let store = test_store(ExclusiveOffset, TABLES).await;
+
+        let err = store.walk("db", Some(0)).await.unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err:?}");
+        assert!(err.to_string().contains("limit must be at least 1"));
+        assert!(store.requests.lock().unwrap().is_empty());
+    }
+
+    /// A token is opaque, so a string that did not come from a listing is rejected rather than
+    /// read as a key and silently skipping part of the directory.
+    #[rstest]
+    #[case::not_a_token("a.lance")]
+    #[case::wrong_version("9ka.lance")]
+    #[case::unknown_kind("1za.lance")]
+    #[case::empty("")]
+    #[tokio::test]
+    async fn test_a_token_from_nowhere_is_rejected(#[case] page_token: &str) {
+        let store = test_store(ExclusiveOffset, TABLES).await;
+
+        let err = store
+            .store
+            .read_dir_page(
+                Path::from("db"),
+                ReadDirOptions {
+                    page_token: Some(page_token.to_string()),
+                    limit: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err:?}");
+    }
+
+    /// A token round-trips through its string form unchanged, including one holding the
+    /// characters the encoding itself uses.
+    #[rstest]
+    #[case(DirCursor::backend("1kabc"))]
+    #[case(DirCursor::key("a.lance/"))]
+    #[case(DirCursor::key(""))]
+    fn test_a_token_round_trips(#[case] cursor: DirCursor) {
+        assert_eq!(DirCursor::decode(&cursor.encode()).unwrap(), cursor);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_entry_kinds(#[values(FullListing, ExclusiveOffset)] backend: Backend) {
+        let store = test_store(backend, TABLES).await;
+
+        let page = store.first_page("db", None).await;
+        let directory = page.values.iter().find(|e| e.name == "a.lance").unwrap();
+        let file = page.values.iter().find(|e| e.name == "loose.txt").unwrap();
+
+        assert!(directory.is_dir());
+        assert!(!file.is_dir());
+        let DirEntryKind::File(meta) = &file.kind else {
+            panic!("expected a file entry, got {:?}", file.kind);
+        };
+        assert_eq!(meta.size, 1);
+    }
+
+    /// The pushdown path holds the backend directly, so it has to record its own IO. A listing
+    /// invisible to `io_tracker` would also be invisible to the metrics and tracing layers that
+    /// sit in the same chain. Every request a page cost is recorded, not just its first.
+    #[rstest]
+    #[tokio::test]
+    async fn test_listing_is_recorded_in_io_stats(
+        #[values(FullListing, ExclusiveOffset)] backend: Backend,
+    ) {
+        let store = test_store(backend, TABLES).await;
+        assert_eq!(store.store.io_tracker().stats().read_iops, 0);
+
+        let _ = store.first_page("db", Some(2)).await;
+
+        // The full listing reaches the store through its wrappers, which record it there.
+        let requests = store.requests.lock().unwrap().len().max(1) as u64;
+        assert_eq!(store.store.io_tracker().stats().read_iops, requests);
+    }
+
+    /// A backend stuck on one page: it reports the same children every time and always claims
+    /// there are more. The contract says a page with a `next` has moved, so a backend that
+    /// breaks it must not be able to spin the caller forever.
+    #[derive(Debug)]
+    struct StuckLister {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl PaginatedDirLister for StuckLister {
+        async fn list_page(
+            &self,
+            _prefix: Option<&str>,
+            _resume: Option<&DirCursor>,
+            _limit: Option<usize>,
+        ) -> Result<DirPage> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(DirPage {
+                entries: Vec::new(),
+                next: Some(DirCursor::backend("stuck")),
+            })
+        }
+    }
+
+    /// Such a backend fails the listing instead of spinning on it. A page that hands back the
+    /// position it was given is asking to be requested forever, and a repeat of ready futures
+    /// never yields to the runtime, so it would hang rather than time out.
+    #[tokio::test]
+    async fn test_a_backend_that_never_moves_fails_the_listing() {
+        let lister = Arc::new(StuckLister {
+            calls: AtomicUsize::new(0),
+        });
+        let mut store = test_store(ExclusiveOffset, TABLES).await;
+        store.store.paginated_lister = Some(lister.clone());
+
+        let err = store.walk("db", Some(1)).await.unwrap_err();
+
+        assert!(err.to_string().contains("did not advance"), "{err:?}");
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// A recording [`PaginatedListStore`], so the translation `NativeDirLister` performs can be
+    /// checked without a cloud backend. This is the adapter the native S3, GCS and Azure stores
+    /// actually use.
+    #[derive(Debug, Default)]
+    struct RecordingListStore {
+        calls: Mutex<Vec<(Option<String>, PaginatedListOptions)>>,
+        next_page_token: Option<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl PaginatedListStore for RecordingListStore {
+        async fn list_paginated(
+            &self,
+            prefix: Option<&str>,
+            opts: PaginatedListOptions,
+        ) -> object_store::Result<object_store::list::PaginatedListResult> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((prefix.map(String::from), opts));
+            Ok(object_store::list::PaginatedListResult {
+                result: ListResult {
+                    common_prefixes: vec![Path::from("db/a.lance")],
+                    objects: Vec::new(),
+                },
+                page_token: self.next_page_token.clone(),
+            })
+        }
+    }
+
+    fn recording_store(next_page_token: Option<&str>) -> Arc<RecordingListStore> {
+        Arc::new(RecordingListStore {
+            calls: Mutex::new(Vec::new()),
+            next_page_token: next_page_token.map(String::from),
+        })
+    }
+
+    /// The native lister resumes from the store's own continuation token, and reads truncation
+    /// from the token it gets back rather than from how full the page is.
+    #[rstest]
+    #[case::truncated(Some("token"), true)]
+    #[case::last_page(None, false)]
+    #[tokio::test]
+    async fn test_native_lister_pushes_the_token_and_limit_down(
+        #[case] next_page_token: Option<&str>,
+        #[case] has_more: bool,
+    ) {
+        let store = recording_store(next_page_token);
+        let lister = NativeDirLister::for_store(store.clone());
+
+        let page = lister
+            .list_page(Some("db/"), Some(&DirCursor::backend("prev")), Some(7))
+            .await
+            .unwrap();
+
+        let calls = store.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (prefix, opts) = &calls[0];
+        assert_eq!(prefix.as_deref(), Some("db/"));
+        assert_eq!(opts.page_token.as_deref(), Some("prev"));
+        // A continuation token is a position of its own, so no offset goes with it.
+        assert_eq!(opts.offset, None);
+        // Without a delimiter the listing would be recursive rather than one level deep.
+        assert_eq!(opts.delimiter.as_deref(), Some("/"));
+        assert_eq!(opts.max_keys, Some(7));
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.next.is_some(), has_more);
+    }
+
+    /// A key cursor is what a listing resumed from a store with no continuation token brings,
+    /// and the native API takes it as an offset. The entry it names comes back again on a
+    /// store whose offset is inclusive, and always for a directory, so it is dropped here.
+    #[tokio::test]
+    async fn test_native_lister_takes_a_key_cursor_as_an_offset() {
+        let store = recording_store(None);
+        let lister = NativeDirLister::for_store(store.clone());
+
+        let page = lister
+            .list_page(Some("db/"), Some(&DirCursor::key("a.lance/")), Some(7))
+            .await
+            .unwrap();
+
+        let calls = store.calls.lock().unwrap();
+        // The cursor arrives relative to the prefix and is resolved against it here.
+        assert_eq!(calls[0].1.offset.as_deref(), Some("db/a.lance/"));
+        assert_eq!(calls[0].1.page_token, None);
+        assert!(
+            page.entries.is_empty(),
+            "the resumed directory is not handed over twice"
+        );
+    }
+
+    /// Throttling only adds waiting, so a throttled store — S3, GCS and Azure all reach their
+    /// lister through [`with_throttling`](crate::object_store::throttle::with_throttling) —
+    /// must page exactly as an unthrottled one does.
+    #[rstest]
+    #[tokio::test]
+    async fn test_throttling_does_not_change_the_listing(#[values(false, true)] throttled: bool) {
+        let mut store = test_store(ExclusiveOffset, TABLES).await;
+        let lister = Arc::new(FakeDirLister {
+            model: StoreModel::new(TABLES.to_vec()).with_budget(BudgetMode::PerScannedKey),
+            requests: store.requests.clone(),
+        }) as Arc<dyn PaginatedDirLister>;
+        store.store.paginated_lister = Some(match throttled {
+            true => AimdThrottledStore::new(
+                Arc::new(InMemory::new()) as Arc<dyn OSObjectStore>,
+                AimdThrottleConfig::default(),
+            )
+            .unwrap()
+            .wrap_paginated(lister),
+            false => lister,
+        });
+
+        assert_eq!(
+            store.names("db", Some(1)).await,
+            vec!["a.lance", "b.lance", "c.lance", "loose.txt"]
+        );
+    }
+}

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -500,7 +500,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::native::NativeDirLister;
-    use super::store_model::{BudgetMode, KeyOrder, Resume as ModelResume, StoreModel};
+    use super::store_model::{BudgetMode, KeyOrder, Resume, StoreModel};
     use super::*;
     use crate::object_store::throttle::{AimdThrottleConfig, AimdThrottledStore};
     use crate::object_store::{ObjectStoreParams, ObjectStoreRegistry};
@@ -560,8 +560,8 @@ mod tests {
             });
             let prefix = prefix.unwrap_or("");
             let resume = match resume {
-                Some(cursor) => ModelResume::Token(cursor.expect_backend()?),
-                None => ModelResume::Start,
+                Some(cursor) => Resume::Token(cursor.expect_backend()?),
+                None => Resume::Start,
             };
             let page = self.model.list_level(prefix, resume, limit);
 
@@ -650,8 +650,10 @@ mod tests {
         #[allow(deprecated)]
         let params = ObjectStoreParams {
             object_store: Some((inner, url::Url::parse("memory:///").unwrap())),
-            // The deprecated hand-built path assumes nothing about the store it was given.
-            list_is_lexically_ordered: Some(backend != Unordered),
+            // Set because the deprecated hand-built path assumes nothing about the store it
+            // was given, and set conservatively: nothing on the `read_dir_page` path reads it,
+            // since the fallback sorts what it listed and the pushdown never compares keys.
+            list_is_lexically_ordered: Some(false),
             ..Default::default()
         };
         let (store, _) = ObjectStore::from_uri_and_params(
@@ -837,6 +839,7 @@ mod tests {
     #[case::not_a_token("a.lance")]
     #[case::wrong_version("9ka.lance")]
     #[case::unknown_kind("1za.lance")]
+    #[case::no_kind("1")]
     #[case::empty("")]
     #[tokio::test]
     async fn test_a_token_from_nowhere_is_rejected(#[case] page_token: &str) {
@@ -855,6 +858,31 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, Error::InvalidInput { .. }), "{err:?}");
+    }
+
+    /// The other half of keeping the two kinds apart: a continuation token handed to a store
+    /// that lists in full. Read as a key it would compare as one, drop whatever sorted before
+    /// it, and report a short directory as a complete one.
+    #[tokio::test]
+    async fn test_a_backend_token_is_rejected_by_a_full_listing() {
+        let store = test_store(FullListing, TABLES).await;
+
+        let err = store
+            .store
+            .read_dir_page(
+                Path::from("db"),
+                ReadDirOptions {
+                    page_token: Some(DirCursor::backend("opaque").encode()),
+                    limit: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("resumes by continuation token"),
+            "unexpected error: {err}"
+        );
     }
 
     /// A token round-trips through its string form unchanged, including one holding the

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -55,77 +55,78 @@ const LIST_OP: &str = "list_paginated";
 /// rejected rather than read as something it is not.
 const TOKEN_VERSION: char = '1';
 
+/// Marks a cursor a backend minted, holding its own continuation token.
+const BACKEND_TAG: char = 'b';
+/// Marks a cursor the full-listing fallback minted, holding a key within the directory.
+const KEY_TAG: char = 'k';
+
 /// Where a listing resumes.
 ///
 /// Opaque to callers: [`ObjectStore::read_dir_page`] mints one, hands it over as the string in
 /// [`DirListing::next_token`], and takes it back in [`ReadDirOptions::page_token`]. What it
-/// holds depends on the store that minted it, so a token means nothing anywhere else.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirCursor(Resume);
-
-/// The two things a listing can resume from, one for each path that serves a page.
+/// holds depends on the path that minted it, so a token means nothing anywhere else.
 ///
-/// A cursor is only ever handed back to the path that minted it. The tag is what makes the
-/// other path reject it rather than read it as something it is not.
+/// The string is the token exactly as a caller sees it: the version, then a tag naming the
+/// path that minted it, then that path's own position. A cursor is only ever handed back to
+/// the path that minted it, and the tag is what makes the other path reject it rather than
+/// read it as something it is not.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Resume {
-    /// The backend's own continuation token, which resumes exactly where the page stopped.
+pub struct DirCursor(String);
+
+impl DirCursor {
+    /// A backend's own continuation token, which resumes exactly where the page stopped.
     ///
     /// Nothing is compared against it, so a store whose listings are not in key order — S3
     /// Express, or an Azure account with a hierarchical namespace — pages correctly on one.
-    Backend(String),
-    /// A key within the directory, which the next page resumes strictly after: the last key
-    /// the page reported. What the full-listing fallback mints, having no token of its own.
-    Key(String),
-}
-
-impl DirCursor {
-    pub(crate) fn backend(token: impl Into<String>) -> Self {
-        Self(Resume::Backend(token.into()))
+    pub(crate) fn backend(token: impl AsRef<str>) -> Self {
+        Self::tagged(BACKEND_TAG, token.as_ref())
     }
 
-    pub(crate) fn key(key: impl Into<String>) -> Self {
-        Self(Resume::Key(key.into()))
+    /// A key within the directory, which the next page resumes strictly after: the last key
+    /// the page reported. What the full-listing fallback mints, having no token of its own.
+    pub(crate) fn key(key: impl AsRef<str>) -> Self {
+        Self::tagged(KEY_TAG, key.as_ref())
+    }
+
+    fn tagged(tag: char, value: &str) -> Self {
+        Self(format!("{TOKEN_VERSION}{tag}{value}"))
     }
 
     /// The continuation token to resume from, for a backend that pages by its own token.
     #[cfg(any(test, feature = "aws", feature = "azure", feature = "gcp"))]
     pub(crate) fn expect_backend(&self) -> Result<&str> {
-        match &self.0 {
-            Resume::Backend(token) => Ok(token),
-            Resume::Key(_) => Err(Error::invalid_input(
+        self.untag(BACKEND_TAG).ok_or_else(|| {
+            Error::invalid_input(
                 "this page token came from a store that lists a directory in full, \
                  which this one cannot resume from",
-            )),
-        }
+            )
+        })
     }
 
     /// The key to resume after, for a store that lists a directory in full.
     pub(crate) fn expect_key(&self) -> Result<&str> {
-        match &self.0 {
-            Resume::Key(key) => Ok(key),
-            Resume::Backend(_) => Err(Error::invalid_input(
+        self.untag(KEY_TAG).ok_or_else(|| {
+            Error::invalid_input(
                 "this page token came from a store that resumes by continuation token, \
                  which this one cannot use",
-            )),
-        }
+            )
+        })
     }
 
-    fn encode(&self) -> String {
-        let (tag, value) = match &self.0 {
-            Resume::Backend(token) => ('b', token),
-            Resume::Key(key) => ('k', key),
-        };
-        format!("{TOKEN_VERSION}{tag}{value}")
+    /// The position this cursor holds, if `tag` is the path that minted it.
+    fn untag(&self, tag: char) -> Option<&str> {
+        self.0.strip_prefix(TOKEN_VERSION)?.strip_prefix(tag)
+    }
+
+    fn encode(self) -> String {
+        self.0
     }
 
     fn decode(token: &str) -> Result<Self> {
         let invalid = || Error::invalid_input(format!("not a directory page token: '{token}'"));
         let rest = token.strip_prefix(TOKEN_VERSION).ok_or_else(invalid)?;
-        let (tag, value) = rest.split_at_checked(1).ok_or_else(invalid)?;
-        match tag {
-            "b" => Ok(Self::backend(value)),
-            "k" => Ok(Self::key(value)),
+        match rest.chars().next() {
+            Some(BACKEND_TAG | KEY_TAG) => Ok(Self(token.to_string())),
             _ => Err(invalid()),
         }
     }
@@ -347,7 +348,7 @@ async fn fill_page(
     }
     Ok(DirListing {
         values,
-        next_token: resume.as_ref().map(DirCursor::encode),
+        next_token: resume.map(DirCursor::encode),
     })
 }
 
@@ -373,7 +374,7 @@ async fn full_listing_page(
     }
     let taken = limit.unwrap_or(children.len()).min(children.len());
     let next_token =
-        (taken < children.len()).then(|| DirCursor::key(children[taken - 1].key.clone()).encode());
+        (taken < children.len()).then(|| DirCursor::key(&children[taken - 1].key).encode());
     children.truncate(taken);
     Ok(DirListing {
         values: children.into_iter().map(|child| child.entry).collect(),
@@ -383,7 +384,7 @@ async fn full_listing_page(
 
 /// A child of the directory being listed, with the key the backend listed it under.
 pub struct KeyedEntry {
-    /// The key relative to the directory, which is what a [`Resume::Key`] cursor names. A
+    /// The key relative to the directory, which is what a [`DirCursor::key`] cursor names. A
     /// child directory keeps its trailing delimiter, since that is the prefix its keys share
     /// and so where it sits in the listing; a child file is its name.
     pub key: String,
@@ -858,7 +859,8 @@ mod tests {
     #[case(DirCursor::key("a.lance/"))]
     #[case(DirCursor::key(""))]
     fn test_a_token_round_trips(#[case] cursor: DirCursor) {
-        assert_eq!(DirCursor::decode(&cursor.encode()).unwrap(), cursor);
+        let token = cursor.clone().encode();
+        assert_eq!(DirCursor::decode(&token).unwrap(), cursor);
     }
 
     #[rstest]

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -63,17 +63,19 @@ const TOKEN_VERSION: char = '1';
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirCursor(Resume);
 
-/// The two things a store can give a listing to resume from.
+/// The two things a listing can resume from, one for each path that serves a page.
+///
+/// A cursor is only ever handed back to the path that minted it. The tag is what makes the
+/// other path reject it rather than read it as something it is not.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Resume {
-    /// The store's own continuation token, which resumes exactly where the page stopped.
+    /// The backend's own continuation token, which resumes exactly where the page stopped.
     ///
     /// Nothing is compared against it, so a store whose listings are not in key order — S3
     /// Express, or an Azure account with a hierarchical namespace — pages correctly on one.
     Backend(String),
     /// A key within the directory, which the next page resumes strictly after: the last key
-    /// the page reported. For stores with no continuation token of their own, which can only
-    /// be paged when they list in key order.
+    /// the page reported. What the full-listing fallback mints, having no token of its own.
     Key(String),
 }
 
@@ -86,14 +88,19 @@ impl DirCursor {
         Self(Resume::Key(key.into()))
     }
 
-    /// Only the native lister takes both kinds; everything else goes through
-    /// [`Self::expect_key`].
+    /// The continuation token to resume from, for a backend that pages by its own token.
     #[cfg(any(test, feature = "aws", feature = "azure", feature = "gcp"))]
-    pub(crate) fn resume(&self) -> &Resume {
-        &self.0
+    pub(crate) fn expect_backend(&self) -> Result<&str> {
+        match &self.0 {
+            Resume::Backend(token) => Ok(token),
+            Resume::Key(_) => Err(Error::invalid_input(
+                "this page token came from a store that lists a directory in full, \
+                 which this one cannot resume from",
+            )),
+        }
     }
 
-    /// The key to resume after, for a backend that can only resume from one.
+    /// The key to resume after, for a store that lists a directory in full.
     pub(crate) fn expect_key(&self) -> Result<&str> {
         match &self.0 {
             Resume::Key(key) => Ok(key),
@@ -185,10 +192,12 @@ pub struct DirPage {
 /// `ObjectStore` trait and so cannot be reached through a `dyn ObjectStore`.
 ///
 /// This is where a backend joins the fast path: implement it, hand one to
-/// [`ObjectStore::paginated_lister`], and pages are pushed down instead of listed in full. A
-/// backend that resumes from its own continuation token mints [`DirCursor::backend`] and needs
-/// no ordering at all; one that can only resume from a key mints [`DirCursor::key`], which is
-/// sound only where the backend lists in key order and reports its pages in that same order.
+/// [`ObjectStore::paginated_lister`], and pages are pushed down instead of listed in full.
+///
+/// A backend mints [`DirCursor::backend`] and resumes from its own token, which is exact and
+/// needs no key order to be correct. A cursor minted by the full-listing fallback is not one
+/// of its own: a walk cannot start on one path and finish on the other, and
+/// [`DirCursor::expect_backend`] says so rather than guessing at a position.
 #[async_trait::async_trait]
 pub trait PaginatedDirLister: std::fmt::Debug + Send + Sync + 'static {
     /// One page of the immediate children of `prefix`, resuming after `resume`.
@@ -477,7 +486,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::native::NativeDirLister;
-    use super::store_model::{BudgetMode, KeyOrder, OffsetMode, Resume as ModelResume, StoreModel};
+    use super::store_model::{BudgetMode, KeyOrder, Resume as ModelResume, StoreModel};
     use super::*;
     use crate::object_store::throttle::{AimdThrottleConfig, AimdThrottledStore};
     use crate::object_store::{ObjectStoreParams, ObjectStoreRegistry};
@@ -492,18 +501,16 @@ mod tests {
     enum Backend {
         /// No paginated API: list the whole directory and page it locally.
         FullListing,
-        /// A paginated API whose offset is exclusive: `start-after`, which S3 takes and which
-        /// GCS takes too, since `object_store` lists it over the S3-compatible XML API.
-        ExclusiveOffset,
-        /// A paginated API whose offset is inclusive, like Azure's `startFrom`.
-        InclusiveOffset,
+        /// A paginated API over a store that lists in key order, like S3, GCS, or Azure over a
+        /// flat namespace.
+        KeyOrdered,
         /// A paginated API over a store that orders each directory level by child name rather
         /// than by whole key, which Azure documents for accounts with a hierarchical namespace.
         NameOrdered,
         /// A paginated API over a store that lists in no particular order, like S3 Express.
         Unordered,
     }
-    use Backend::{ExclusiveOffset, FullListing, InclusiveOffset, NameOrdered, Unordered};
+    use Backend::{FullListing, KeyOrdered, NameOrdered, Unordered};
 
     /// One list request, as the backend saw it.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -540,15 +547,9 @@ mod tests {
                 limit,
             });
             let prefix = prefix.unwrap_or("");
-            // The cursor is relative to the prefix, and the backend joins the two.
-            let offset = match resume.map(DirCursor::resume) {
-                Some(super::Resume::Key(key)) => Some(format!("{prefix}{key}")),
-                _ => None,
-            };
-            let resume = match (resume.map(DirCursor::resume), &offset) {
-                (Some(super::Resume::Backend(token)), _) => ModelResume::Token(token),
-                (_, Some(offset)) => ModelResume::Offset(offset),
-                _ => ModelResume::Start,
+            let resume = match resume {
+                Some(cursor) => ModelResume::Token(cursor.expect_backend()?),
+                None => ModelResume::Start,
             };
             let page = self.model.list_level(prefix, resume, limit);
 
@@ -574,15 +575,6 @@ mod tests {
                     .collect(),
             };
             let entries = keyed_entries(&listed, Some(prefix).filter(|p| !p.is_empty()));
-            let entries = match &offset {
-                // The offset is a key, so anything at or before it has already been handed
-                // over: a resumed directory comes back as its own prefix again.
-                Some(offset) => entries
-                    .into_iter()
-                    .filter(|child| format!("{prefix}{}", child.key).as_str() > offset.as_str())
-                    .collect(),
-                None => entries,
-            };
             Ok(DirPage {
                 entries: entries.into_iter().map(|child| child.entry).collect(),
                 next: page.next_token.map(DirCursor::backend),
@@ -661,10 +653,6 @@ mod tests {
 
         let requests = Arc::new(Mutex::new(Vec::new()));
         if backend != FullListing {
-            let offset = match backend {
-                InclusiveOffset => OffsetMode::Inclusive,
-                _ => OffsetMode::Exclusive,
-            };
             let order = match backend {
                 NameOrdered => KeyOrder::DelimiterLowest,
                 Unordered => KeyOrder::Reversed,
@@ -672,7 +660,6 @@ mod tests {
             };
             store.paginated_lister = Some(Arc::new(FakeDirLister {
                 model: StoreModel::new(keys.to_vec())
-                    .with_offset(offset)
                     .with_order(order)
                     .with_budget(BudgetMode::PerScannedKey),
                 requests: requests.clone(),
@@ -690,8 +677,8 @@ mod tests {
         "other/d.lance/data/1.lance",
     ];
 
-    /// Walking a directory hands back every child exactly once, whatever the store does with a
-    /// resume position, whatever order it lists in, and however small the pages are.
+    /// Walking a directory hands back every child exactly once, however the store resolves the
+    /// listing, whatever order it lists in, and however small the pages are.
     #[rstest]
     #[case::whole_directory(TABLES, "db", vec!["a.lance", "b.lance", "c.lance", "loose.txt"])]
     #[case::empty_directory(TABLES, "nonexistent", vec![])]
@@ -711,8 +698,7 @@ mod tests {
     #[case::an_encodable_name(&["db/az", "db/a~"], "db", vec!["az", "a~"])]
     #[tokio::test]
     async fn test_walking_a_directory_is_complete(
-        #[values(FullListing, ExclusiveOffset, InclusiveOffset, NameOrdered, Unordered)]
-        backend: Backend,
+        #[values(FullListing, KeyOrdered, NameOrdered, Unordered)] backend: Backend,
         #[values(None, Some(1), Some(2), Some(3))] limit: Option<usize>,
         #[case] keys: &[&str],
         #[case] dir: &str,
@@ -750,7 +736,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_a_bounded_page_makes_one_request(
-        #[values(ExclusiveOffset, InclusiveOffset, NameOrdered, Unordered)] backend: Backend,
+        #[values(KeyOrdered, NameOrdered, Unordered)] backend: Backend,
     ) {
         let store = test_store(backend, TABLES).await;
 
@@ -771,15 +757,12 @@ mod tests {
     /// delimiter the backend spends its limit on keys it collapses away, so a page can hold one
     /// entry, be nowhere near the limit, and still be followed by more; a caller that stopped
     /// there would see a page far smaller than the one it asked for.
-    #[rstest]
     #[tokio::test]
-    async fn test_a_short_backend_page_is_filled_from_the_next(
-        #[values(ExclusiveOffset, InclusiveOffset)] backend: Backend,
-    ) {
+    async fn test_a_short_backend_page_is_filled_from_the_next() {
         // `big.lance` holds more keys than a page is allowed to scan, so the page that reports
         // it comes back with a single entry and more to come.
         let store = test_store(
-            backend,
+            KeyOrdered,
             &[
                 "db/big.lance/data/1.lance",
                 "db/big.lance/data/2.lance",
@@ -812,7 +795,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_a_page_of_no_entries_keeps_going(
-        #[values(ExclusiveOffset, InclusiveOffset, NameOrdered)] backend: Backend,
+        #[values(KeyOrdered, NameOrdered)] backend: Backend,
     ) {
         let store = test_store(backend, &["db/marked/", "db/marked/a.txt"]).await;
 
@@ -833,7 +816,7 @@ mod tests {
     /// comes before the store is consulted, so one backend covers it.
     #[tokio::test]
     async fn test_zero_limit_is_rejected() {
-        let store = test_store(ExclusiveOffset, TABLES).await;
+        let store = test_store(KeyOrdered, TABLES).await;
 
         let err = store.walk("db", Some(0)).await.unwrap_err();
 
@@ -851,7 +834,7 @@ mod tests {
     #[case::empty("")]
     #[tokio::test]
     async fn test_a_token_from_nowhere_is_rejected(#[case] page_token: &str) {
-        let store = test_store(ExclusiveOffset, TABLES).await;
+        let store = test_store(KeyOrdered, TABLES).await;
 
         let err = store
             .store
@@ -880,7 +863,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_entry_kinds(#[values(FullListing, ExclusiveOffset)] backend: Backend) {
+    async fn test_entry_kinds(#[values(FullListing, KeyOrdered)] backend: Backend) {
         let store = test_store(backend, TABLES).await;
 
         let page = store.first_page("db", None).await;
@@ -901,7 +884,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_listing_is_recorded_in_io_stats(
-        #[values(FullListing, ExclusiveOffset)] backend: Backend,
+        #[values(FullListing, KeyOrdered)] backend: Backend,
     ) {
         let store = test_store(backend, TABLES).await;
         assert_eq!(store.store.io_tracker().stats().read_iops, 0);
@@ -945,7 +928,7 @@ mod tests {
         let lister = Arc::new(StuckLister {
             calls: AtomicUsize::new(0),
         });
-        let mut store = test_store(ExclusiveOffset, TABLES).await;
+        let mut store = test_store(KeyOrdered, TABLES).await;
         store.store.paginated_lister = Some(lister.clone());
 
         let err = store.walk("db", Some(1)).await.unwrap_err();
@@ -1023,26 +1006,26 @@ mod tests {
         assert_eq!(page.next.is_some(), has_more);
     }
 
-    /// A key cursor is what a listing resumed from a store with no continuation token brings,
-    /// and the native API takes it as an offset. The entry it names comes back again on a
-    /// store whose offset is inclusive, and always for a directory, so it is dropped here.
+    /// A key cursor is what the full-listing fallback mints, and a walk cannot cross from one
+    /// path to the other. Resuming from it would mean sending the store an offset, which every
+    /// store interprets its own way, so the listing fails instead of guessing at a position.
     #[tokio::test]
-    async fn test_native_lister_takes_a_key_cursor_as_an_offset() {
+    async fn test_native_lister_rejects_a_key_cursor() {
         let store = recording_store(None);
         let lister = NativeDirLister::for_store(store.clone());
 
-        let page = lister
+        let err = lister
             .list_page(Some("db/"), Some(&DirCursor::key("a.lance/")), Some(7))
             .await
-            .unwrap();
+            .expect_err("a key cursor is not this lister's to resume from");
 
-        let calls = store.calls.lock().unwrap();
-        // The cursor arrives relative to the prefix and is resolved against it here.
-        assert_eq!(calls[0].1.offset.as_deref(), Some("db/a.lance/"));
-        assert_eq!(calls[0].1.page_token, None);
         assert!(
-            page.entries.is_empty(),
-            "the resumed directory is not handed over twice"
+            err.to_string().contains("lists a directory in full"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            store.calls.lock().unwrap().is_empty(),
+            "the listing has to fail before it reaches the store"
         );
     }
 
@@ -1052,7 +1035,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_throttling_does_not_change_the_listing(#[values(false, true)] throttled: bool) {
-        let mut store = test_store(ExclusiveOffset, TABLES).await;
+        let mut store = test_store(KeyOrdered, TABLES).await;
         let lister = Arc::new(FakeDirLister {
             model: StoreModel::new(TABLES.to_vec()).with_budget(BudgetMode::PerScannedKey),
             requests: store.requests.clone(),

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -329,12 +329,21 @@ async fn fill_page(
         let page = lister
             .list_page(prefix.as_deref(), resume.as_ref(), remaining)
             .await?;
-        // The limit is the caller's, not the backend's: a page that came back holding more
-        // than it was asked for is held to what was asked for.
-        match remaining {
-            Some(remaining) => values.extend(page.entries.into_iter().take(remaining)),
-            None => values.extend(page.entries),
+        // A backend that returns more entries than asked for has already advanced its opaque
+        // cursor past the entire page. Truncating would silently discard the surplus entries,
+        // and there is no cursor this layer can synthesize for the retained prefix — the
+        // backend's cursor points past entries we would be dropping.
+        if let Some(remaining) = remaining {
+            if page.entries.len() > remaining {
+                return Err(Error::io(format!(
+                    "listing '{dir}': backend returned {} entries when at most {} were requested; \
+                     no cursor can represent the retained subset",
+                    page.entries.len(),
+                    remaining
+                )));
+            }
         }
+        values.extend(page.entries);
         match page.next {
             // A page that hands back the position it was given has not moved, and asking
             // again from it would repeat forever. The contract forbids it; a backend that
@@ -997,17 +1006,29 @@ mod tests {
         }
     }
 
-    /// The limit is what the caller asked for, not a hint the backend may round up. Holding a
-    /// page to it here is what makes the count [`DirListing::values`] documents true whatever
-    /// the backend does.
+    /// An overeager backend cannot be corrected locally: its cursor already points past
+    /// all the entries it returned, so truncating would silently drop the surplus.
     #[tokio::test]
-    async fn test_a_page_is_held_to_the_limit_asked_for() {
+    async fn test_a_page_exceeding_the_limit_is_rejected() {
         let mut store = test_store(KeyOrdered, TABLES).await;
         store.store.paginated_lister = Some(Arc::new(OvereagerLister));
 
-        let page = store.first_page("db", Some(2)).await;
+        let err = store
+            .store
+            .read_dir_page(
+                Path::from("db"),
+                ReadDirOptions {
+                    limit: Some(2),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
 
-        assert_eq!(page.values.len(), 2);
+        assert!(
+            err.to_string().contains("no cursor can represent"),
+            "{err:?}"
+        );
     }
 
     /// A recording [`PaginatedListStore`], so the translation `NativeDirLister` performs can be

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -320,18 +320,21 @@ async fn fill_page(
     let prefix = list_prefix(dir);
     let mut values: Vec<DirEntry> = Vec::new();
     loop {
-        // `None` once the page is full, which also covers a backend that overshot the limit.
         let remaining = match limit {
-            Some(limit) => limit.checked_sub(values.len()).filter(|left| *left > 0),
-            None => Some(usize::MAX),
-        };
-        let Some(remaining) = remaining else {
-            break;
+            Some(limit) if values.len() >= limit => break,
+            Some(limit) => Some(limit - values.len()),
+            // A listing with no limit spends nothing, so there is nothing left to ask for.
+            None => None,
         };
         let page = lister
-            .list_page(prefix.as_deref(), resume.as_ref(), limit.map(|_| remaining))
+            .list_page(prefix.as_deref(), resume.as_ref(), remaining)
             .await?;
-        values.extend(page.entries);
+        // The limit is the caller's, not the backend's: a page that came back holding more
+        // than it was asked for is held to what was asked for.
+        match remaining {
+            Some(remaining) => values.extend(page.entries.into_iter().take(remaining)),
+            None => values.extend(page.entries),
+        }
         match page.next {
             // A page that hands back the position it was given has not moved, and asking
             // again from it would repeat forever. The contract forbids it; a backend that
@@ -378,10 +381,14 @@ async fn full_listing_page(
         let key = resume.expect_key()?;
         children.retain(|child| child.key.as_str() > key);
     }
-    let taken = limit.unwrap_or(children.len()).min(children.len());
-    let next_token =
-        (taken < children.len()).then(|| DirCursor::key(&children[taken - 1].key).encode());
-    children.truncate(taken);
+    let total = children.len();
+    children.truncate(limit.unwrap_or(total).min(total));
+    // The last key this page took, so a page that took nothing ends the listing rather than
+    // resuming from a position no page ever reached.
+    let next_token = match children.last() {
+        Some(last) if children.len() < total => Some(DirCursor::key(&last.key).encode()),
+        _ => None,
+    };
     Ok(DirListing {
         values: children.into_iter().map(|child| child.entry).collect(),
         next_token,
@@ -935,6 +942,44 @@ mod tests {
 
         assert!(err.to_string().contains("did not advance"), "{err:?}");
         assert_eq!(lister.calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// A backend that hands back more than the page it was asked for.
+    #[derive(Debug)]
+    struct OvereagerLister;
+
+    #[async_trait::async_trait]
+    impl PaginatedDirLister for OvereagerLister {
+        async fn list_page(
+            &self,
+            _prefix: Option<&str>,
+            _resume: Option<&DirCursor>,
+            limit: Option<usize>,
+        ) -> Result<DirPage> {
+            let entries = (0..limit.unwrap_or(1) + 3)
+                .map(|index| DirEntry {
+                    name: format!("child{index}"),
+                    kind: DirEntryKind::Directory,
+                })
+                .collect();
+            Ok(DirPage {
+                entries,
+                next: None,
+            })
+        }
+    }
+
+    /// The limit is what the caller asked for, not a hint the backend may round up. Holding a
+    /// page to it here is what makes the count [`DirListing::values`] documents true whatever
+    /// the backend does.
+    #[tokio::test]
+    async fn test_a_page_is_held_to_the_limit_asked_for() {
+        let mut store = test_store(KeyOrdered, TABLES).await;
+        store.store.paginated_lister = Some(Arc::new(OvereagerLister));
+
+        let page = store.first_page("db", Some(2)).await;
+
+        assert_eq!(page.values.len(), 2);
     }
 
     /// A recording [`PaginatedListStore`], so the translation `NativeDirLister` performs can be

--- a/rust/lance-io/src/object_store/read_dir/conformance.rs
+++ b/rust/lance-io/src/object_store/read_dir/conformance.rs
@@ -29,7 +29,7 @@ use rstest::rstest;
 use super::super::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use super::emulator::{ListEmulator, Wire};
 use super::native::NativeDirLister;
-use super::store_model::{BudgetMode, OffsetMode, StoreModel};
+use super::store_model::{BudgetMode, StoreModel};
 use super::{DirEntry, PaginatedDirLister, ReadDirOptions};
 
 /// The directory under test. Kept free of characters that need encoding: it is the caller's
@@ -267,19 +267,16 @@ async fn emulated(client: Client, model: StoreModel) -> (Conformance, ListEmulat
     (stores, emulator)
 }
 
-/// Every client, against every way a store is allowed to treat a resume position and a page
-/// limit. A listing that only works when the store is generous is not a working listing.
+/// Every client, against every way a store is allowed to spend a page limit. A listing that
+/// only works when the store is generous is not a working listing.
 #[rstest]
 #[tokio::test]
 async fn test_paging_is_invisible_over_the_wire(
     #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
-    #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)] offset: OffsetMode,
     #[values(BudgetMode::PerEntry, BudgetMode::PerScannedKey)] budget: BudgetMode,
 ) {
     let keys: Vec<&str> = SHAPES.iter().chain(MARKED_CHILDREN).copied().collect();
-    let model = StoreModel::new(keys)
-        .with_offset(offset)
-        .with_budget(budget);
+    let model = StoreModel::new(keys).with_budget(budget);
     let (stores, emulator) = emulated(client, model).await;
 
     // A listing that cannot make progress would spin rather than fail, so bound the wait
@@ -333,17 +330,14 @@ async fn test_a_page_of_one_asks_the_backend_for_one(
 /// A caller that asks for no page size at all, over a directory larger than the store will
 /// return in one request.
 ///
-/// Nothing then bounds a page but the store's own limit, so the resume position is the only
-/// thing carrying the listing forward and there is no page size to widen when it does not
-/// work. The listing still has to be complete, whatever the store does with that position.
+/// Nothing then bounds a page but the store's own limit, so the continuation token is the only
+/// thing carrying the listing forward. The listing still has to be complete.
 #[rstest]
 #[tokio::test]
 async fn test_a_listing_without_a_page_size_is_complete(
     #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
-    #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)] offset: OffsetMode,
 ) {
     let model = StoreModel::new(SHAPES.to_vec())
-        .with_offset(offset)
         // Small enough that the fixture takes several pages, so the listing has to resume.
         .with_page_bound(4);
     let (stores, _emulator) = emulated(client, model).await;

--- a/rust/lance-io/src/object_store/read_dir/conformance.rs
+++ b/rust/lance-io/src/object_store/read_dir/conformance.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! What a paginated directory listing has to get right, over the wire.
+//!
+//! The tests in [`read_dir`](super) drive the paging logic through a fake lister. These drive
+//! the whole path instead — a real `object_store` client, real query parameters, real XML —
+//! against the [`emulator`](super::emulator), which can be told to behave the ways a store is
+//! allowed to behave. The same fixtures and the same invariant then run against a real bucket
+//! in the `#[ignore]`d tests at the bottom.
+//!
+//! The invariant is a differential one: for every page size, paging has to produce exactly
+//! what one unpaginated listing of the same directory produces. Anything else — a child
+//! dropped at a page boundary, a child served twice, an order that disagrees — fails, and
+//! nothing has to be restated per backend as an expected list of names.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{StreamExt, TryStreamExt};
+use object_store::aws::AmazonS3Builder;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::list::PaginatedListStore;
+use object_store::{ClientOptions, ObjectStore as OSObjectStore, path::Path};
+use rstest::rstest;
+
+use super::super::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
+use super::emulator::{ListEmulator, Wire};
+use super::native::NativeDirLister;
+use super::store_model::{BudgetMode, OffsetMode, StoreModel};
+use super::{DirEntry, PaginatedDirLister, ReadDirOptions};
+
+/// The directory under test. Kept free of characters that need encoding: it is the caller's
+/// own path, and the interesting cases are the children.
+const DIR: &str = "db";
+
+/// The children a listing has to get right. Not an exhaustive character set — the point is
+/// the shapes: names adjacent in key order, names that are prefixes of one another, and
+/// names carrying characters that have to survive an XML document and a query string.
+const SHAPES: &[&str] = &[
+    "db/a.lance/_versions/1.manifest",
+    "db/a.lance/data/1.lance",
+    // A directory and a file that sit next to each other in key order with nothing that can
+    // sort between them: `foo/` and `foo0`.
+    "db/foo/inside",
+    "db/foo0",
+    // A file and a directory of the same name. The file's key sorts first.
+    "db/twin",
+    "db/twin/inside",
+    // Names that order differently by key than by name: `-` sorts before `/`, `2` after.
+    "db/foo-bar/inside",
+    "db/foo2/inside",
+    // Depth below the level being listed, which the delimiter collapses.
+    "db/deep/a/b/c/d",
+    // Characters `Path::from` percent-encodes, so a listing that re-encoded its keys would
+    // reorder them.
+    "db/tilde~/inside",
+    "db/bracket[1]",
+    "db/star*",
+    // Characters that have to be escaped in the response XML.
+    "db/amp&ersand",
+    "db/less<than",
+    // Characters whose treatment in a query string is the risk: a literal `+` and a space
+    // both become `+` under form encoding, so a store that decodes the resume position as a
+    // form value and one that decodes it as a URI path disagree about which key was meant.
+    "db/plus+one",
+    "db/with space",
+    // Characters that are legal in a key but reserved in a URL.
+    "db/per%cent",
+    "db/equals=sign",
+    "db/quote'single",
+    "db/paren(s)",
+    // Non-ASCII, one inside the basic multilingual plane and one outside it.
+    "db/héllo/inside",
+    "db/emoji😀",
+    "db/zzz.txt",
+];
+
+/// A key ending in the delimiter: the directory marker consoles and older SDKs leave behind.
+/// `Path` normalises the trailing delimiter away, so this cannot be created through
+/// `object_store` and only the emulator can serve it.
+const DIRECTORY_MARKER: &str = "db/marked/";
+
+const MARKED_CHILDREN: &[&str] = &[DIRECTORY_MARKER, "db/marked/inside"];
+
+/// Page sizes to hold the listing to. One is the interesting case — every entry is a page
+/// boundary — and the rest move the boundary onto different entries.
+const PAGE_SIZES: &[usize] = &[1, 2, 3, 4, 10];
+
+/// The client under test. All three speak to the emulator without credentials; S3 and GCS
+/// share a wire format, and Azure has its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Client {
+    S3,
+    Gcs,
+    Azure,
+}
+
+impl Client {
+    fn wire(&self) -> Wire {
+        match self {
+            Self::S3 | Self::Gcs => Wire::S3,
+            Self::Azure => Wire::Azure,
+        }
+    }
+
+    /// A client pointed at `endpoint`, as both an [`OSObjectStore`] and the paginated trait
+    /// the pushdown path needs. Both handles are the same store, so the paginated and the
+    /// full listing see the same keys.
+    fn build(&self, endpoint: &str) -> (Arc<dyn OSObjectStore>, Arc<dyn PaginatedListStore>) {
+        let allow_http = ClientOptions::new().with_allow_http(true);
+        match self {
+            Self::S3 => {
+                let store = Arc::new(
+                    AmazonS3Builder::new()
+                        .with_bucket_name("bucket")
+                        .with_region("us-east-1")
+                        .with_endpoint(endpoint)
+                        .with_allow_http(true)
+                        .with_skip_signature(true)
+                        .build()
+                        .unwrap(),
+                );
+                (store.clone(), store)
+            }
+            Self::Gcs => {
+                let store = Arc::new(
+                    GoogleCloudStorageBuilder::new()
+                        .with_bucket_name("bucket")
+                        .with_base_url(endpoint)
+                        .with_client_options(allow_http)
+                        .with_skip_signature(true)
+                        .build()
+                        .unwrap(),
+                );
+                (store.clone(), store)
+            }
+            Self::Azure => {
+                let store = Arc::new(
+                    MicrosoftAzureBuilder::new()
+                        .with_account("account")
+                        .with_container_name("bucket")
+                        .with_endpoint(endpoint.to_string())
+                        .with_allow_http(true)
+                        .with_skip_signature(true)
+                        .build()
+                        .unwrap(),
+                );
+                (store.clone(), store)
+            }
+        }
+    }
+}
+
+/// How an entry is spelled when listings are compared: its name, plus a delimiter if it is a
+/// directory. A file and a directory can share a name — the fixture holds both a `twin` file
+/// and a `twin/` directory — so a name on its own cannot tell an entry served twice from two
+/// entries that happen to be called the same thing.
+fn label(entry: &DirEntry) -> String {
+    match entry.is_dir() {
+        true => format!("{}/", entry.name),
+        false => entry.name.clone(),
+    }
+}
+
+/// A pair of stores over the same backend: one that pushes paging down, and one that lists
+/// the directory in full and is the reference the paginated one is held to.
+struct Conformance {
+    paginated: ObjectStore,
+    reference: ObjectStore,
+}
+
+impl Conformance {
+    /// Wraps `inner` in a lance store twice, once with the paginated lister installed.
+    ///
+    /// The lister is installed here rather than by a provider so the test needs no
+    /// credentials and no provider-specific configuration; that the providers install it is
+    /// covered in [`providers`](super::super::providers).
+    async fn new(
+        inner: Arc<dyn OSObjectStore>,
+        lister: Arc<dyn PaginatedDirLister>,
+        uri: &str,
+    ) -> Self {
+        let build = || async {
+            #[allow(deprecated)]
+            let params = ObjectStoreParams {
+                object_store: Some((inner.clone(), url::Url::parse(uri).unwrap())),
+                // What every store served here does, and what paging by cursor requires.
+                list_is_lexically_ordered: Some(true),
+                ..Default::default()
+            };
+            let (store, _) = ObjectStore::from_uri_and_params(
+                Arc::new(ObjectStoreRegistry::default()),
+                uri,
+                &params,
+            )
+            .await
+            .unwrap();
+            Arc::try_unwrap(store).unwrap()
+        };
+        let mut paginated = build().await;
+        paginated.paginated_lister = Some(lister);
+        Self {
+            paginated,
+            reference: build().await,
+        }
+    }
+
+    /// Every child of `dir`, taken `limit` at a time, which is how a caller walks a directory:
+    /// the token ends the walk, never a short page.
+    async fn names(store: &ObjectStore, dir: &str, limit: Option<usize>) -> Vec<String> {
+        let mut names = Vec::new();
+        let mut page_token = None;
+        loop {
+            let page = store
+                .read_dir_page(Path::from(dir), ReadDirOptions { page_token, limit })
+                .await
+                .unwrap();
+            names.extend(page.values.iter().map(label));
+            page_token = page.next_token;
+            if page_token.is_none() {
+                return names;
+            }
+            assert!(
+                names.len() <= SHAPES.len() + MARKED_CHILDREN.len(),
+                "the walk is serving entries more than once: {names:?}"
+            );
+        }
+    }
+
+    /// The listing a caller gets with no paging at all, which is what paging has to match.
+    async fn reference_names(&self, dir: &str) -> Vec<String> {
+        let names = Self::names(&self.reference, dir, None).await;
+        let unique: HashSet<&String> = names.iter().collect();
+        assert_eq!(
+            unique.len(),
+            names.len(),
+            "fixture has duplicates: {names:?}"
+        );
+        names
+    }
+
+    /// Paging must be invisible: whatever the page size, walking the directory a page at a
+    /// time produces exactly the reference listing.
+    async fn assert_paging_is_invisible(&self, dir: &str) {
+        let reference = self.reference_names(dir).await;
+        assert!(!reference.is_empty(), "fixture listed nothing under {dir}");
+
+        for &page_size in PAGE_SIZES {
+            assert_eq!(
+                Self::names(&self.paginated, dir, Some(page_size)).await,
+                reference,
+                "a page size of {page_size} changed the listing"
+            );
+        }
+    }
+}
+
+/// A conformance pair over an emulator behaving as `model` says.
+async fn emulated(client: Client, model: StoreModel) -> (Conformance, ListEmulator) {
+    let emulator = ListEmulator::start(model, client.wire()).await;
+    let (inner, paginated) = client.build(emulator.url());
+    let stores =
+        Conformance::new(inner, NativeDirLister::for_store(paginated), "s3://bucket/").await;
+    (stores, emulator)
+}
+
+/// Every client, against every way a store is allowed to treat a resume position and a page
+/// limit. A listing that only works when the store is generous is not a working listing.
+#[rstest]
+#[tokio::test]
+async fn test_paging_is_invisible_over_the_wire(
+    #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
+    #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)] offset: OffsetMode,
+    #[values(BudgetMode::PerEntry, BudgetMode::PerScannedKey)] budget: BudgetMode,
+) {
+    let keys: Vec<&str> = SHAPES.iter().chain(MARKED_CHILDREN).copied().collect();
+    let model = StoreModel::new(keys)
+        .with_offset(offset)
+        .with_budget(budget);
+    let (stores, emulator) = emulated(client, model).await;
+
+    // A listing that cannot make progress would spin rather than fail, so bound the wait
+    // instead of hanging a CI run. Each page is a real request, so the timeout can fire.
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        stores.assert_paging_is_invisible(DIR),
+    )
+    .await
+    .expect("paging did not finish");
+
+    // Loose, but it catches a listing that only terminates by exhausting the directory over
+    // and over. The tightest case is page_size 1 over ~25 children, twice per page size.
+    assert!(
+        emulator.requests() < 1000,
+        "paging took {} requests",
+        emulator.requests()
+    );
+}
+
+/// The page size has to reach the backend. A listing that quietly fell back to listing the
+/// whole directory would satisfy every invariant above, since it answers the same thing, so
+/// what tells the two apart is the request: one entry at page size one asks for one key.
+#[rstest]
+#[tokio::test]
+async fn test_a_page_of_one_asks_the_backend_for_one(
+    #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
+) {
+    let (stores, emulator) = emulated(client, StoreModel::new(SHAPES.to_vec())).await;
+
+    let page = stores
+        .paginated
+        .read_dir_page(
+            Path::from(DIR),
+            ReadDirOptions {
+                page_token: None,
+                limit: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(page.values.len(), 1);
+    assert_eq!(
+        emulator.limits(),
+        vec![Some(1)],
+        "the page size was not pushed down to the backend"
+    );
+}
+
+/// A caller that asks for no page size at all, over a directory larger than the store will
+/// return in one request.
+///
+/// Nothing then bounds a page but the store's own limit, so the resume position is the only
+/// thing carrying the listing forward and there is no page size to widen when it does not
+/// work. The listing still has to be complete, whatever the store does with that position.
+#[rstest]
+#[tokio::test]
+async fn test_a_listing_without_a_page_size_is_complete(
+    #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
+    #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)] offset: OffsetMode,
+) {
+    let model = StoreModel::new(SHAPES.to_vec())
+        .with_offset(offset)
+        // Small enough that the fixture takes several pages, so the listing has to resume.
+        .with_page_bound(4);
+    let (stores, _emulator) = emulated(client, model).await;
+
+    let reference = stores.reference_names(DIR).await;
+    let listed = Conformance::names(&stores.paginated, DIR, None).await;
+
+    assert_eq!(listed, reference);
+}
+
+/// A store that reports a directory marker — a key that is just the directory itself — must
+/// not have it served as a child of itself.
+#[rstest]
+#[tokio::test]
+async fn test_a_directory_marker_is_not_its_own_child(
+    #[values(Client::S3, Client::Gcs, Client::Azure)] client: Client,
+) {
+    let (stores, _emulator) = emulated(client, StoreModel::new(MARKED_CHILDREN.to_vec())).await;
+
+    let listed = Conformance::names(&stores.paginated, "db/marked", Some(1)).await;
+    assert_eq!(listed, vec!["inside"]);
+}
+
+/// A page boundary landing on a directory costs nothing extra. The continuation token names a
+/// position past everything the directory collapsed, so resuming from it does not re-scan the
+/// keys behind that prefix however the store spends its page limit.
+#[rstest]
+#[tokio::test]
+async fn test_resuming_at_a_directory_costs_one_page_per_child(
+    #[values(BudgetMode::PerEntry, BudgetMode::PerScannedKey)] budget: BudgetMode,
+) {
+    // Three tables, each holding more files than a page is allowed to return, so every page
+    // boundary lands on a directory whose contents the next request has to get past.
+    let keys: Vec<String> = ["a", "b", "c"]
+        .iter()
+        .flat_map(|table| (0..20).map(move |file| format!("db/{table}.lance/data/{file}.lance")))
+        .collect();
+    let keys: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let model = StoreModel::new(keys).with_budget(budget);
+    let (stores, emulator) = emulated(Client::S3, model).await;
+
+    let names = Conformance::names(&stores.paginated, DIR, Some(1)).await;
+
+    assert_eq!(names, vec!["a.lance/", "b.lance/", "c.lance/"]);
+    assert_eq!(
+        emulator.requests(),
+        3,
+        "expected one request per child however the store spends its page limit"
+    );
+}
+
+/// Same fixtures against a real bucket. Not run in CI: it needs credentials, and it exists
+/// to answer the questions an emulator cannot — whether each store's resume position works
+/// at all, and what a page limit is really spent on.
+///
+/// ```ignore
+/// LANCE_READ_DIR_TEST_URI=s3://my-bucket/read-dir-conformance RUST_LOG=info \
+///   cargo test -p lance-io --lib read_dir::conformance::cloud -- --ignored --nocapture
+/// ```
+mod cloud {
+    use super::*;
+
+    /// The bucket and prefix to run against, e.g. `s3://bucket/prefix`, `gs://…`, `az://…`.
+    const URI_VAR: &str = "LANCE_READ_DIR_TEST_URI";
+    /// How many objects the cost fixture puts in one directory.
+    const OBJECTS_VAR: &str = "LANCE_READ_DIR_BUDGET_OBJECTS";
+
+    fn base_uri() -> String {
+        std::env::var(URI_VAR)
+            .unwrap_or_else(|_| panic!("set {URI_VAR} to a bucket and prefix to run this test"))
+            .trim_end_matches('/')
+            .to_string()
+    }
+
+    /// Create `keys` under `root`, relative to the store's own prefix.
+    async fn create(store: &ObjectStore, root: &Path, keys: &[String]) {
+        futures::stream::iter(keys.iter().map(|key| {
+            // `Path::parse`, not `Path::from`: a key holding a character `Path::from` would
+            // encode has to reach the store as it was written, or the fixture is not the
+            // fixture any more.
+            let path = Path::parse(format!("{root}/{key}")).unwrap();
+            async move { store.put(&path, b"x").await.unwrap() }
+        }))
+        .buffer_unordered(32)
+        .collect::<Vec<_>>()
+        .await;
+    }
+
+    async fn remove(store: &ObjectStore, root: &Path) {
+        let paths: Vec<Path> = store
+            .list(Some(root.clone()))
+            .map_ok(|meta| meta.location)
+            .try_collect()
+            .await
+            .unwrap();
+        futures::stream::iter(paths.iter().map(|path| store.delete(path)))
+            .buffer_unordered(32)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+    }
+
+    /// The shapes fixture, minus the directory marker, which cannot be created through a
+    /// `Path`. Names are created with `Path::parse` so the store holds them as written
+    /// rather than percent-encoded.
+    #[tokio::test]
+    #[ignore = "needs cloud credentials; run by hand"]
+    async fn test_shapes_against_a_real_store() {
+        let uri = format!("{}/shapes", base_uri());
+        // The store as a caller would get it, provider wiring and all.
+        let (store, root) = ObjectStore::from_uri(&uri).await.unwrap();
+        let keys: Vec<String> = SHAPES.iter().map(|key| key.to_string()).collect();
+
+        remove(&store, &root).await;
+        create(&store, &root, &keys).await;
+
+        let stores = Conformance {
+            reference: reference_of(&store),
+            paginated: store.as_ref().clone(),
+        };
+        stores
+            .assert_paging_is_invisible(&format!("{root}/{DIR}"))
+            .await;
+
+        remove(&store, &root).await;
+    }
+
+    /// What a page boundary on a large directory costs. Prints the request count per page
+    /// size: that number is the reason this test exists.
+    #[test_log::test(tokio::test)]
+    #[ignore = "needs cloud credentials and creates thousands of objects; run by hand"]
+    async fn test_page_cost_against_a_real_store() {
+        let objects: usize = std::env::var(OBJECTS_VAR)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(10_000);
+        let uri = format!("{}/cost", base_uri());
+        // The store as a caller would get it, provider wiring and all.
+        let (store, root) = ObjectStore::from_uri(&uri).await.unwrap();
+
+        // One big table whose keys a resumed page has to get past, and two siblings after it
+        // so a page boundary lands on the big one.
+        let mut keys: Vec<String> = (0..objects)
+            .map(|file| format!("{DIR}/big.lance/data/{file:07}.lance"))
+            .collect();
+        keys.push(format!("{DIR}/next.lance/data/1.lance"));
+        keys.push(format!("{DIR}/zzz.txt"));
+
+        remove(&store, &root).await;
+        create(&store, &root, &keys).await;
+
+        let dir = format!("{root}/{DIR}");
+        for page_size in [1usize, 2, 10] {
+            let before = store.io_tracker().stats().read_iops;
+            let names = Conformance::names(&store, &dir, Some(page_size)).await;
+            let requests = store.io_tracker().stats().read_iops - before;
+            assert_eq!(names, vec!["big.lance/", "next.lance/", "zzz.txt"]);
+            // The measurement this test exists for. `test-log` prints it under `--nocapture`.
+            tracing::info!(page_size, requests, objects, "list requests for 3 children");
+            // One request per child is the floor, and the continuation token should hold the
+            // listing to it: resuming after `big.lance/` must not re-scan what that prefix
+            // collapsed.
+            assert!(
+                requests <= 32,
+                "page_size {page_size} took {requests} requests"
+            );
+        }
+
+        remove(&store, &root).await;
+    }
+
+    /// The same store with the pushdown removed, so it lists directories in full.
+    fn reference_of(store: &Arc<ObjectStore>) -> ObjectStore {
+        let mut reference = store.as_ref().clone();
+        reference.paginated_lister = None;
+        reference
+    }
+}

--- a/rust/lance-io/src/object_store/read_dir/conformance.rs
+++ b/rust/lance-io/src/object_store/read_dir/conformance.rs
@@ -62,9 +62,9 @@ const SHAPES: &[&str] = &[
     // Characters that have to be escaped in the response XML.
     "db/amp&ersand",
     "db/less<than",
-    // Characters whose treatment in a query string is the risk: a literal `+` and a space
-    // both become `+` under form encoding, so a store that decodes the resume position as a
-    // form value and one that decodes it as a URI path disagree about which key was meant.
+    // A literal `+` and a space, which collapse together under form encoding. Nothing in a
+    // request carries a key any more, so what these hold to account is the response: two names
+    // that a client decoding the XML too eagerly would report as the same child.
     "db/plus+one",
     "db/with space",
     // Characters that are legal in a key but reserved in a URL.

--- a/rust/lance-io/src/object_store/read_dir/emulator.rs
+++ b/rust/lance-io/src/object_store/read_dir/emulator.rs
@@ -103,10 +103,16 @@ async fn list(
         Wire::Azure => ("startFrom", "maxresults", "marker"),
     };
     let prefix = params.get("prefix").map(String::as_str).unwrap_or_default();
-    let resume = match (params.get(token_param), params.get(offset_param)) {
-        (Some(token), _) => Resume::Token(token),
-        (None, Some(offset)) => Resume::Offset(offset),
-        (None, None) => Resume::Start,
+    // A listing resumes from the store's own token and nothing else. What an offset excludes
+    // is the store's choice — S3 excludes the position, Azure includes it, Azurite drops it —
+    // so sending one would make the listing depend on which store answered.
+    assert!(
+        !params.contains_key(offset_param),
+        "a listing must not resume by offset, but sent {offset_param}"
+    );
+    let resume = match params.get(token_param) {
+        Some(token) => Resume::Token(token),
+        None => Resume::Start,
     };
     let max_keys = params.get(limit_param).and_then(|keys| keys.parse().ok());
     state.limits.lock().unwrap().push(max_keys);

--- a/rust/lance-io/src/object_store/read_dir/emulator.rs
+++ b/rust/lance-io/src/object_store/read_dir/emulator.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! An in-process stand-in for the list API of a cloud object store.
+//!
+//! The unit tests in [`read_dir`](super) drive a fake that implements
+//! [`PaginatedDirLister`](super::PaginatedDirLister) directly, which leaves everything between
+//! this crate and the network untested: the query parameters `object_store` builds, the XML it
+//! parses, and whether a key survives a round trip through a URL. This serves the wire protocol
+//! instead, so the real S3, GCS and Azure clients can be pointed at it without credentials,
+//! behaving however [`StoreModel`] is told to behave.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::header;
+use axum::response::IntoResponse;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use super::store_model::{LevelPage, Resume, StoreModel};
+
+/// Every entry the emulator reports carries this timestamp, in each wire format's spelling.
+const LAST_MODIFIED_ISO: &str = "2025-01-01T00:00:00.000Z";
+const LAST_MODIFIED_RFC1123: &str = "Wed, 01 Jan 2025 00:00:00 GMT";
+
+/// Which wire format the emulator speaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Wire {
+    /// The S3 XML API, which the S3 and GCS clients both use.
+    S3,
+    /// Azure's list-blobs XML, whose parameters and element names are its own.
+    Azure,
+}
+
+struct EmulatorState {
+    model: StoreModel,
+    wire: Wire,
+    requests: AtomicUsize,
+    /// The page limit each request asked for, in order, so a test can tell a listing that
+    /// pushed its page size down from one that asked for the whole directory.
+    limits: Mutex<Vec<Option<usize>>>,
+}
+
+/// A running emulator. Listening stops when this is dropped.
+pub struct ListEmulator {
+    url: String,
+    state: Arc<EmulatorState>,
+    server: JoinHandle<()>,
+}
+
+impl Drop for ListEmulator {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl ListEmulator {
+    pub async fn start(model: StoreModel, wire: Wire) -> Self {
+        let state = Arc::new(EmulatorState {
+            model,
+            wire,
+            requests: AtomicUsize::new(0),
+            limits: Mutex::new(Vec::new()),
+        });
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new().fallback(list).with_state(state.clone());
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self { url, state, server }
+    }
+
+    /// The endpoint to point a client at. The bucket or container is the first path segment
+    /// and is ignored: the emulator holds one flat key space.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// How many list requests the emulator has answered.
+    pub fn requests(&self) -> usize {
+        self.state.requests.load(Ordering::SeqCst)
+    }
+
+    /// The page limit each request asked for, in the order the requests arrived.
+    pub fn limits(&self) -> Vec<Option<usize>> {
+        self.state.limits.lock().unwrap().clone()
+    }
+}
+
+async fn list(
+    State(state): State<Arc<EmulatorState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+
+    let (offset_param, limit_param, token_param) = match state.wire {
+        Wire::S3 => ("start-after", "max-keys", "continuation-token"),
+        Wire::Azure => ("startFrom", "maxresults", "marker"),
+    };
+    let prefix = params.get("prefix").map(String::as_str).unwrap_or_default();
+    let resume = match (params.get(token_param), params.get(offset_param)) {
+        (Some(token), _) => Resume::Token(token),
+        (None, Some(offset)) => Resume::Offset(offset),
+        (None, None) => Resume::Start,
+    };
+    let max_keys = params.get(limit_param).and_then(|keys| keys.parse().ok());
+    state.limits.lock().unwrap().push(max_keys);
+
+    let page = state.model.list_level(prefix, resume, max_keys);
+    let body = match state.wire {
+        Wire::S3 => s3_xml(&page),
+        Wire::Azure => azure_xml(&page),
+    };
+    ([(header::CONTENT_TYPE, "application/xml")], body)
+}
+
+fn s3_xml(page: &LevelPage) -> String {
+    let mut body = String::from(r#"<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>"#);
+    for prefix in &page.prefixes {
+        let prefix = escape(prefix);
+        body.push_str(&format!(
+            "<CommonPrefixes><Prefix>{prefix}</Prefix></CommonPrefixes>"
+        ));
+    }
+    for key in &page.objects {
+        let key = escape(key);
+        body.push_str(&format!(
+            "<Contents><Key>{key}</Key><Size>1</Size>\
+             <LastModified>{LAST_MODIFIED_ISO}</LastModified><ETag>\"1\"</ETag></Contents>"
+        ));
+    }
+    body.push_str(&format!("<IsTruncated>{}</IsTruncated>", page.truncated));
+    if let Some(token) = &page.next_token {
+        let token = escape(token);
+        body.push_str(&format!(
+            "<NextContinuationToken>{token}</NextContinuationToken>"
+        ));
+    }
+    body.push_str("</ListBucketResult>");
+    body
+}
+
+fn azure_xml(page: &LevelPage) -> String {
+    let mut body =
+        String::from(r#"<?xml version="1.0" encoding="utf-8"?><EnumerationResults><Blobs>"#);
+    for prefix in &page.prefixes {
+        let prefix = escape(prefix);
+        body.push_str(&format!("<BlobPrefix><Name>{prefix}</Name></BlobPrefix>"));
+    }
+    for key in &page.objects {
+        let key = escape(key);
+        body.push_str(&format!(
+            "<Blob><Name>{key}</Name><Properties>\
+             <Last-Modified>{LAST_MODIFIED_RFC1123}</Last-Modified>\
+             <Content-Length>1</Content-Length>\
+             <Content-Type>application/octet-stream</Content-Type>\
+             <Etag>1</Etag></Properties></Blob>"
+        ));
+    }
+    body.push_str("</Blobs>");
+    if let Some(token) = &page.next_token {
+        let token = escape(token);
+        body.push_str(&format!("<NextMarker>{token}</NextMarker>"));
+    }
+    body.push_str("</EnumerationResults>");
+    body
+}
+
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/rust/lance-io/src/object_store/read_dir/native.rs
+++ b/rust/lance-io/src/object_store/read_dir/native.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! One directory level at a time over `object_store`'s own paginated list API.
+
+use std::sync::Arc;
+
+use object_store::list::{PaginatedListOptions, PaginatedListStore};
+
+use lance_core::Result;
+
+use super::{DELIMITER, DirCursor, DirPage, PaginatedDirLister, Resume, keyed_entries};
+
+/// [`PaginatedDirLister`] over `object_store`'s paginated listing API, used by the native S3,
+/// GCS and Azure stores.
+///
+/// Resumes from the store's own continuation token, which is exact and needs no key order to
+/// be correct. That is what lets S3 Express and an Azure account with a hierarchical namespace
+/// be paged: neither lists in key order, and neither has to.
+pub struct NativeDirLister(Arc<dyn PaginatedListStore>);
+
+impl NativeDirLister {
+    pub(crate) fn for_store(store: Arc<dyn PaginatedListStore>) -> Arc<dyn PaginatedDirLister> {
+        Arc::new(Self(store))
+    }
+}
+
+impl std::fmt::Debug for NativeDirLister {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NativeDirLister")
+    }
+}
+
+#[async_trait::async_trait]
+impl PaginatedDirLister for NativeDirLister {
+    async fn list_page(
+        &self,
+        prefix: Option<&str>,
+        resume: Option<&DirCursor>,
+        limit: Option<usize>,
+    ) -> Result<DirPage> {
+        // A key cursor only ever starts a listing: it comes from a caller resuming a walk that
+        // began on a store with no continuation token of its own. Every page after the first
+        // resumes from the token this one hands back. `object_store` addresses keys by their
+        // `Path` spelling, which is also how it reported the key, so the two join as they are.
+        let (page_token, offset) = match resume.map(DirCursor::resume) {
+            Some(Resume::Backend(token)) => (Some(token.to_string()), None),
+            Some(Resume::Key(key)) => (None, Some(format!("{}{key}", prefix.unwrap_or_default()))),
+            None => (None, None),
+        };
+        let page = self
+            .0
+            .list_paginated(
+                prefix,
+                PaginatedListOptions {
+                    offset,
+                    delimiter: Some(DELIMITER.into()),
+                    max_keys: limit,
+                    page_token,
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        let mut entries = keyed_entries(&page.result, prefix);
+        // An offset is a key, and the entry it names can come back anyway: Azure's `startFrom`
+        // is inclusive, and a directory is a prefix whose keys all sort after it, so it
+        // collapses back into the same entry even under an exclusive `start-after`.
+        if let Some(Resume::Key(key)) = resume.map(DirCursor::resume) {
+            entries.retain(|child| child.key.as_str() > key.as_str());
+        }
+        Ok(DirPage {
+            entries: entries.into_iter().map(|child| child.entry).collect(),
+            next: page.page_token.map(DirCursor::backend),
+        })
+    }
+}

--- a/rust/lance-io/src/object_store/read_dir/native.rs
+++ b/rust/lance-io/src/object_store/read_dir/native.rs
@@ -9,7 +9,7 @@ use object_store::list::{PaginatedListOptions, PaginatedListStore};
 
 use lance_core::Result;
 
-use super::{DELIMITER, DirCursor, DirPage, PaginatedDirLister, Resume, keyed_entries};
+use super::{DELIMITER, DirCursor, DirPage, PaginatedDirLister, keyed_entries};
 
 /// [`PaginatedDirLister`] over `object_store`'s paginated listing API, used by the native S3,
 /// GCS and Azure stores.
@@ -39,21 +39,18 @@ impl PaginatedDirLister for NativeDirLister {
         resume: Option<&DirCursor>,
         limit: Option<usize>,
     ) -> Result<DirPage> {
-        // A key cursor only ever starts a listing: it comes from a caller resuming a walk that
-        // began on a store with no continuation token of its own. Every page after the first
-        // resumes from the token this one hands back. `object_store` addresses keys by their
-        // `Path` spelling, which is also how it reported the key, so the two join as they are.
-        let (page_token, offset) = match resume.map(DirCursor::resume) {
-            Some(Resume::Backend(token)) => (Some(token.to_string()), None),
-            Some(Resume::Key(key)) => (None, Some(format!("{}{key}", prefix.unwrap_or_default()))),
-            None => (None, None),
+        // Only this lister's own token. `offset` is left unset: a caller-supplied key means
+        // something different on every store — S3 excludes it, Azure includes it, Azurite
+        // drops it — and a continuation token needs none of that.
+        let page_token = match resume {
+            Some(cursor) => Some(cursor.expect_backend()?.to_string()),
+            None => None,
         };
         let page = self
             .0
             .list_paginated(
                 prefix,
                 PaginatedListOptions {
-                    offset,
                     delimiter: Some(DELIMITER.into()),
                     max_keys: limit,
                     page_token,
@@ -62,13 +59,7 @@ impl PaginatedDirLister for NativeDirLister {
             )
             .await?;
 
-        let mut entries = keyed_entries(&page.result, prefix);
-        // An offset is a key, and the entry it names can come back anyway: Azure's `startFrom`
-        // is inclusive, and a directory is a prefix whose keys all sort after it, so it
-        // collapses back into the same entry even under an exclusive `start-after`.
-        if let Some(Resume::Key(key)) = resume.map(DirCursor::resume) {
-            entries.retain(|child| child.key.as_str() > key.as_str());
-        }
+        let entries = keyed_entries(&page.result, prefix);
         Ok(DirPage {
             entries: entries.into_iter().map(|child| child.entry).collect(),
             next: page.page_token.map(DirCursor::backend),

--- a/rust/lance-io/src/object_store/read_dir/store_model.rs
+++ b/rust/lance-io/src/object_store/read_dir/store_model.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! How an object store answers a list request, as a model the tests can vary.
+//!
+//! Two things a paginated listing rests on are not pinned down by any API: what a resume
+//! position means, and what a page limit is spent on. Both are choices a store makes, and a
+//! listing that only works for one of the choices is not a working listing. Holding them here
+//! lets the fake lister in [`read_dir`](super) and the wire-level [`emulator`](super::emulator)
+//! put the same store behaviours under test.
+
+/// The largest page a store will return, whatever a request asks for. Real stores have one —
+/// S3 caps `max-keys` at a thousand — and it is the reason a listing cannot page by asking for
+/// ever more at once.
+const DEFAULT_PAGE_BOUND: usize = 1000;
+
+/// What a store's resume position means, which is not the same everywhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OffsetMode {
+    /// Keys strictly after the position, as S3's `start-after` does, and GCS's too since
+    /// `object_store` lists it over the S3-compatible XML API.
+    Exclusive,
+    /// Keys at or after the position, as Azure's `startFrom` does.
+    Inclusive,
+    /// The position is dropped and the listing starts from the top, as Azurite does with
+    /// `startFrom`. A listing has to stay correct and still finish, which is the point of
+    /// having this here.
+    Ignored,
+}
+
+/// The order a store lists its keys in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyOrder {
+    /// Byte order over whole keys, which is what a flat namespace gives: a key is a name and
+    /// names sort against each other whole.
+    ByKey,
+    /// Byte order with the delimiter below every other character. A store that holds a real
+    /// directory tree orders each level by child name, so a directory comes before a sibling
+    /// whose name extends it — `foo/` before `foo-bar/`, where byte order has them the other
+    /// way round. Azure documents this for accounts with a hierarchical namespace.
+    DelimiterLowest,
+    /// No order a caller could predict, which is what S3 Express gives. Spelled as byte order
+    /// backwards so that a test is repeatable, but nothing may rely on the shape of it.
+    Reversed,
+}
+
+impl KeyOrder {
+    fn cmp(&self, left: &str, right: &str) -> std::cmp::Ordering {
+        match self {
+            Self::ByKey => left.cmp(right),
+            Self::DelimiterLowest => left
+                .bytes()
+                .map(Self::rank)
+                .cmp(right.bytes().map(Self::rank)),
+            Self::Reversed => right.cmp(left),
+        }
+    }
+
+    /// The delimiter moved below every byte that sorts under it, and nothing else disturbed.
+    fn rank(byte: u8) -> u8 {
+        match byte {
+            b'/' => 0,
+            byte if byte < b'/' => byte + 1,
+            byte => byte,
+        }
+    }
+}
+
+/// What a page limit is spent on, which the S3 API does not pin down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetMode {
+    /// The limit counts the entries in the page, so a collapsed prefix costs one.
+    PerEntry,
+    /// The limit counts the keys the store scans, so a collapsed prefix costs every key it
+    /// collapsed. A page can then come back holding one entry and still be truncated.
+    PerScannedKey,
+}
+
+/// The keys a store holds, and how it behaves when listing them.
+#[derive(Debug, Clone)]
+pub struct StoreModel {
+    /// Every key in the store, in the order the store would return them.
+    keys: Vec<String>,
+    offset: OffsetMode,
+    budget: BudgetMode,
+    order: KeyOrder,
+    page_bound: usize,
+}
+
+impl StoreModel {
+    pub fn new<K: Into<String>>(keys: impl IntoIterator<Item = K>) -> Self {
+        let keys: Vec<String> = keys.into_iter().map(Into::into).collect();
+        Self {
+            keys,
+            offset: OffsetMode::Exclusive,
+            budget: BudgetMode::PerEntry,
+            order: KeyOrder::ByKey,
+            page_bound: DEFAULT_PAGE_BOUND,
+        }
+        .sorted()
+    }
+
+    fn sorted(mut self) -> Self {
+        let order = self.order;
+        self.keys.sort_by(|left, right| order.cmp(left, right));
+        self
+    }
+
+    pub fn with_offset(mut self, offset: OffsetMode) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn with_order(mut self, order: KeyOrder) -> Self {
+        self.order = order;
+        self.sorted()
+    }
+
+    pub fn with_budget(mut self, budget: BudgetMode) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Cap pages at `page_bound` entries, so that a directory holding more than that cannot be
+    /// listed in one request however large a page the caller asks for.
+    pub fn with_page_bound(mut self, page_bound: usize) -> Self {
+        self.page_bound = page_bound;
+        self
+    }
+
+    /// One page of the immediate children of `prefix`.
+    ///
+    /// `resume` is a position within the listing: a continuation token if the request
+    /// carried one, which is exact and always exclusive, otherwise the caller's offset,
+    /// which [`OffsetMode`] interprets.
+    ///
+    /// The delimiter is always applied. Every request this crate makes sets one, and a
+    /// recursive listing would not exercise anything a paginated directory listing does.
+    pub fn list_level(
+        &self,
+        prefix: &str,
+        resume: Resume<'_>,
+        max_keys: Option<usize>,
+    ) -> LevelPage {
+        let mut page = LevelPage::default();
+        let mut budget = max_keys.unwrap_or(self.page_bound).min(self.page_bound);
+        let mut idx = 0;
+
+        while idx < self.keys.len() {
+            let key = &self.keys[idx];
+            let Some(rest) = key.strip_prefix(prefix) else {
+                idx += 1;
+                continue;
+            };
+            if resume.consumes(key, self.offset, self.order) {
+                idx += 1;
+                continue;
+            }
+            if budget == 0 {
+                page.truncated = true;
+                // A real token is opaque and resumes exactly where the page stopped. The
+                // last key this page consumed says the same thing.
+                page.next_token = Some(self.keys[idx - 1].clone());
+                break;
+            }
+            match rest.find('/') {
+                Some(end) => {
+                    let child = format!("{prefix}{}/", &rest[..end]);
+                    page.prefixes.push(child.clone());
+                    while idx < self.keys.len() && self.keys[idx].starts_with(&child) {
+                        idx += 1;
+                        if self.budget == BudgetMode::PerScannedKey {
+                            budget = budget.saturating_sub(1);
+                        }
+                    }
+                    if self.budget == BudgetMode::PerEntry {
+                        budget -= 1;
+                    }
+                }
+                None => {
+                    page.objects.push(key.clone());
+                    idx += 1;
+                    budget -= 1;
+                }
+            }
+        }
+
+        page
+    }
+}
+
+/// Where a list request asks the store to pick up from.
+#[derive(Debug, Clone, Copy)]
+pub enum Resume<'a> {
+    Start,
+    /// The caller's offset, whose meaning is the store's to decide.
+    Offset(&'a str),
+    /// The store's own continuation token, which it always honours exactly.
+    Token(&'a str),
+}
+
+impl Resume<'_> {
+    fn consumes(&self, key: &str, offset: OffsetMode, order: KeyOrder) -> bool {
+        use std::cmp::Ordering::{Equal, Less};
+        match self {
+            Self::Start => false,
+            Self::Token(token) => order.cmp(key, token) != std::cmp::Ordering::Greater,
+            Self::Offset(offset_key) => match offset {
+                OffsetMode::Exclusive => matches!(order.cmp(key, offset_key), Less | Equal),
+                OffsetMode::Inclusive => order.cmp(key, offset_key) == Less,
+                OffsetMode::Ignored => false,
+            },
+        }
+    }
+}
+
+/// One page of a directory level, as the store would report it.
+#[derive(Debug, Default)]
+pub struct LevelPage {
+    /// Child directories, as keys ending in the delimiter.
+    pub prefixes: Vec<String>,
+    /// Child objects, as whole keys.
+    pub objects: Vec<String>,
+    pub truncated: bool,
+    pub next_token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Two tables and a loose file, so a page can hold a collapsed prefix and an object.
+    const KEYS: &[&str] = &[
+        "db/a.lance/data/1.lance",
+        "db/a.lance/data/2.lance",
+        "db/b.lance/data/1.lance",
+        "db/loose.txt",
+    ];
+
+    fn model(offset: OffsetMode, budget: BudgetMode) -> StoreModel {
+        StoreModel::new(KEYS.to_vec())
+            .with_offset(offset)
+            .with_budget(budget)
+    }
+
+    /// What an offset excludes is the store's choice, and all three choices are real: S3 and
+    /// GCS exclude the position itself, Azure includes it, and Azurite ignores it. A file key
+    /// shows the difference; a directory's prefix cannot, since the keys inside it sort after
+    /// it and come back under every mode.
+    #[rstest]
+    #[case::exclusive(OffsetMode::Exclusive, vec![], vec![])]
+    #[case::inclusive(OffsetMode::Inclusive, vec![], vec!["db/loose.txt"])]
+    #[case::ignored(
+        OffsetMode::Ignored,
+        vec!["db/a.lance/", "db/b.lance/"],
+        vec!["db/loose.txt"]
+    )]
+    fn test_offset_modes_differ_at_the_position_itself(
+        #[case] offset: OffsetMode,
+        #[case] prefixes: Vec<&str>,
+        #[case] objects: Vec<&str>,
+    ) {
+        let page = model(offset, BudgetMode::PerEntry).list_level(
+            "db/",
+            Resume::Offset("db/loose.txt"),
+            Some(4),
+        );
+        assert_eq!(page.prefixes, prefixes);
+        assert_eq!(page.objects, objects);
+    }
+
+    /// A collapsed prefix costs one entry on a store that counts entries and everything it
+    /// collapsed on a store that counts scanned keys. The second kind returns a page that is
+    /// short and truncated at once, which is why a short page cannot end a listing.
+    #[rstest]
+    #[case::per_entry(BudgetMode::PerEntry, vec!["db/a.lance/", "db/b.lance/"])]
+    #[case::per_scanned_key(BudgetMode::PerScannedKey, vec!["db/a.lance/"])]
+    fn test_budget_modes_differ_over_a_collapsed_prefix(
+        #[case] budget: BudgetMode,
+        #[case] expected: Vec<&str>,
+    ) {
+        let page = model(OffsetMode::Exclusive, budget).list_level("db/", Resume::Start, Some(2));
+        assert_eq!(page.prefixes, expected);
+        assert!(page.truncated, "loose.txt is still to come");
+    }
+
+    /// A continuation token is the store's own position and is exact, so it resumes the same
+    /// way whatever the store does with a caller-supplied offset.
+    #[rstest]
+    fn test_a_token_resumes_exactly(
+        #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)]
+        offset: OffsetMode,
+    ) {
+        let model = model(offset, BudgetMode::PerScannedKey);
+        let first = model.list_level("db/", Resume::Start, Some(1));
+        assert_eq!(first.prefixes, vec!["db/a.lance/"]);
+        assert!(first.truncated);
+
+        let token = first
+            .next_token
+            .expect("a truncated page hands back a token");
+        let second = model.list_level("db/", Resume::Token(&token), Some(2));
+        assert_eq!(second.prefixes, vec!["db/b.lance/"]);
+        assert_eq!(second.objects, vec!["db/loose.txt"]);
+        assert!(!second.truncated);
+    }
+}

--- a/rust/lance-io/src/object_store/read_dir/store_model.rs
+++ b/rust/lance-io/src/object_store/read_dir/store_model.rs
@@ -3,8 +3,8 @@
 
 //! How an object store answers a list request, as a model the tests can vary.
 //!
-//! Two things a paginated listing rests on are not pinned down by any API: what a resume
-//! position means, and what a page limit is spent on. Both are choices a store makes, and a
+//! Two things a paginated listing rests on are not pinned down by any API: the order a store
+//! lists its keys in, and what a page limit is spent on. Both are choices a store makes, and a
 //! listing that only works for one of the choices is not a working listing. Holding them here
 //! lets the fake lister in [`read_dir`](super) and the wire-level [`emulator`](super::emulator)
 //! put the same store behaviours under test.
@@ -13,20 +13,6 @@
 /// S3 caps `max-keys` at a thousand — and it is the reason a listing cannot page by asking for
 /// ever more at once.
 const DEFAULT_PAGE_BOUND: usize = 1000;
-
-/// What a store's resume position means, which is not the same everywhere.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OffsetMode {
-    /// Keys strictly after the position, as S3's `start-after` does, and GCS's too since
-    /// `object_store` lists it over the S3-compatible XML API.
-    Exclusive,
-    /// Keys at or after the position, as Azure's `startFrom` does.
-    Inclusive,
-    /// The position is dropped and the listing starts from the top, as Azurite does with
-    /// `startFrom`. A listing has to stay correct and still finish, which is the point of
-    /// having this here.
-    Ignored,
-}
 
 /// The order a store lists its keys in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,7 +67,6 @@ pub enum BudgetMode {
 pub struct StoreModel {
     /// Every key in the store, in the order the store would return them.
     keys: Vec<String>,
-    offset: OffsetMode,
     budget: BudgetMode,
     order: KeyOrder,
     page_bound: usize,
@@ -92,7 +77,6 @@ impl StoreModel {
         let keys: Vec<String> = keys.into_iter().map(Into::into).collect();
         Self {
             keys,
-            offset: OffsetMode::Exclusive,
             budget: BudgetMode::PerEntry,
             order: KeyOrder::ByKey,
             page_bound: DEFAULT_PAGE_BOUND,
@@ -103,11 +87,6 @@ impl StoreModel {
     fn sorted(mut self) -> Self {
         let order = self.order;
         self.keys.sort_by(|left, right| order.cmp(left, right));
-        self
-    }
-
-    pub fn with_offset(mut self, offset: OffsetMode) -> Self {
-        self.offset = offset;
         self
     }
 
@@ -130,9 +109,9 @@ impl StoreModel {
 
     /// One page of the immediate children of `prefix`.
     ///
-    /// `resume` is a position within the listing: a continuation token if the request
-    /// carried one, which is exact and always exclusive, otherwise the caller's offset,
-    /// which [`OffsetMode`] interprets.
+    /// `resume` is a position within the listing: the store's own continuation token, which is
+    /// exact and always exclusive, or the start of the directory. Nothing else — a caller
+    /// never supplies a position of its own.
     ///
     /// The delimiter is always applied. Every request this crate makes sets one, and a
     /// recursive listing would not exercise anything a paginated directory listing does.
@@ -152,7 +131,7 @@ impl StoreModel {
                 idx += 1;
                 continue;
             };
-            if resume.consumes(key, self.offset, self.order) {
+            if resume.consumes(key, self.order) {
                 idx += 1;
                 continue;
             }
@@ -193,23 +172,15 @@ impl StoreModel {
 #[derive(Debug, Clone, Copy)]
 pub enum Resume<'a> {
     Start,
-    /// The caller's offset, whose meaning is the store's to decide.
-    Offset(&'a str),
     /// The store's own continuation token, which it always honours exactly.
     Token(&'a str),
 }
 
 impl Resume<'_> {
-    fn consumes(&self, key: &str, offset: OffsetMode, order: KeyOrder) -> bool {
-        use std::cmp::Ordering::{Equal, Less};
+    fn consumes(&self, key: &str, order: KeyOrder) -> bool {
         match self {
             Self::Start => false,
             Self::Token(token) => order.cmp(key, token) != std::cmp::Ordering::Greater,
-            Self::Offset(offset_key) => match offset {
-                OffsetMode::Exclusive => matches!(order.cmp(key, offset_key), Less | Equal),
-                OffsetMode::Inclusive => order.cmp(key, offset_key) == Less,
-                OffsetMode::Ignored => false,
-            },
         }
     }
 }
@@ -238,36 +209,8 @@ mod tests {
         "db/loose.txt",
     ];
 
-    fn model(offset: OffsetMode, budget: BudgetMode) -> StoreModel {
-        StoreModel::new(KEYS.to_vec())
-            .with_offset(offset)
-            .with_budget(budget)
-    }
-
-    /// What an offset excludes is the store's choice, and all three choices are real: S3 and
-    /// GCS exclude the position itself, Azure includes it, and Azurite ignores it. A file key
-    /// shows the difference; a directory's prefix cannot, since the keys inside it sort after
-    /// it and come back under every mode.
-    #[rstest]
-    #[case::exclusive(OffsetMode::Exclusive, vec![], vec![])]
-    #[case::inclusive(OffsetMode::Inclusive, vec![], vec!["db/loose.txt"])]
-    #[case::ignored(
-        OffsetMode::Ignored,
-        vec!["db/a.lance/", "db/b.lance/"],
-        vec!["db/loose.txt"]
-    )]
-    fn test_offset_modes_differ_at_the_position_itself(
-        #[case] offset: OffsetMode,
-        #[case] prefixes: Vec<&str>,
-        #[case] objects: Vec<&str>,
-    ) {
-        let page = model(offset, BudgetMode::PerEntry).list_level(
-            "db/",
-            Resume::Offset("db/loose.txt"),
-            Some(4),
-        );
-        assert_eq!(page.prefixes, prefixes);
-        assert_eq!(page.objects, objects);
+    fn model(budget: BudgetMode) -> StoreModel {
+        StoreModel::new(KEYS.to_vec()).with_budget(budget)
     }
 
     /// A collapsed prefix costs one entry on a store that counts entries and everything it
@@ -280,19 +223,16 @@ mod tests {
         #[case] budget: BudgetMode,
         #[case] expected: Vec<&str>,
     ) {
-        let page = model(OffsetMode::Exclusive, budget).list_level("db/", Resume::Start, Some(2));
+        let page = model(budget).list_level("db/", Resume::Start, Some(2));
         assert_eq!(page.prefixes, expected);
         assert!(page.truncated, "loose.txt is still to come");
     }
 
-    /// A continuation token is the store's own position and is exact, so it resumes the same
-    /// way whatever the store does with a caller-supplied offset.
-    #[rstest]
-    fn test_a_token_resumes_exactly(
-        #[values(OffsetMode::Exclusive, OffsetMode::Inclusive, OffsetMode::Ignored)]
-        offset: OffsetMode,
-    ) {
-        let model = model(offset, BudgetMode::PerScannedKey);
+    /// A continuation token is the store's own position and is exact: it resumes strictly after
+    /// the key the page stopped on, whatever the store collapsed to get there.
+    #[test]
+    fn test_a_token_resumes_exactly() {
+        let model = model(BudgetMode::PerScannedKey);
         let first = model.list_level("db/", Resume::Start, Some(1));
         assert_eq!(first.prefixes, vec!["db/a.lance/"]);
         assert!(first.truncated);

--- a/rust/lance-io/src/object_store/read_dir/store_model.rs
+++ b/rust/lance-io/src/object_store/read_dir/store_model.rs
@@ -20,13 +20,10 @@ pub enum KeyOrder {
     /// Byte order over whole keys, which is what a flat namespace gives: a key is a name and
     /// names sort against each other whole.
     ByKey,
-    /// Byte order with the delimiter below every other character. A store that holds a real
-    /// directory tree orders each level by child name, so a directory comes before a sibling
-    /// whose name extends it — `foo/` before `foo-bar/`, where byte order has them the other
-    /// way round. Azure documents this for accounts with a hierarchical namespace.
-    DelimiterLowest,
-    /// No order a caller could predict, which is what S3 Express gives. Spelled as byte order
-    /// backwards so that a test is repeatable, but nothing may rely on the shape of it.
+    /// No order a caller could predict, which is what S3 Express gives, and which an Azure
+    /// account with a hierarchical namespace gives too by ordering each level by child name.
+    /// Spelled as byte order backwards so that a test is repeatable, but nothing may rely on
+    /// the shape of it: a listing that survives this survives any order a store might use.
     Reversed,
 }
 
@@ -34,20 +31,7 @@ impl KeyOrder {
     fn cmp(&self, left: &str, right: &str) -> std::cmp::Ordering {
         match self {
             Self::ByKey => left.cmp(right),
-            Self::DelimiterLowest => left
-                .bytes()
-                .map(Self::rank)
-                .cmp(right.bytes().map(Self::rank)),
             Self::Reversed => right.cmp(left),
-        }
-    }
-
-    /// The delimiter moved below every byte that sorts under it, and nothing else disturbed.
-    fn rank(byte: u8) -> u8 {
-        match byte {
-            b'/' => 0,
-            byte if byte < b'/' => byte + 1,
-            byte => byte,
         }
     }
 }

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -97,8 +97,6 @@ fn message_is_throttle(message: &str) -> bool {
         || lowercase.contains("slowdown")
         || lowercase.contains("please reduce your request rate")
         || lowercase.contains("rate limit")
-        // OpenDAL renders `ErrorKind::RateLimited` without a separator.
-        || lowercase.contains("ratelimited")
         || lowercase.contains("throttling")
         || lowercase.contains("throttled")
 }
@@ -1158,10 +1156,6 @@ mod tests {
         assert!(is_throttle_error_lance(&wrapped));
         assert!(!is_throttle_error_lance(&lance_core::Error::from(
             make_generic_error("Access denied")
-        )));
-        // OpenDAL errors arrive as text rather than as an `object_store::Error`.
-        assert!(is_throttle_error_lance(&lance_core::Error::io(
-            "failed to list 'db/': RateLimited (temporary) at list"
         )));
     }
 

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -48,6 +48,8 @@ use rand::Rng;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+use super::read_dir::{DirCursor, DirPage, PaginatedDirLister};
+
 /// Check whether an `object_store::Error` represents a throttle response
 /// (HTTP 429 / 503) from a cloud object store.
 ///
@@ -68,24 +70,37 @@ use tracing::{debug, warn};
 pub fn is_throttle_error(err: &object_store::Error) -> bool {
     // Only Generic errors can carry throttle responses
     if let object_store::Error::Generic { source, .. } = err {
-        let message = source.to_string();
-        let lowercase = message.to_ascii_lowercase();
-        lowercase.contains("retries, max_retries")
-            || lowercase.contains("serverbusy")
-            || lowercase.contains("server busy")
-            || lowercase.contains("egress is over the account limit")
-            || lowercase.contains("http 429")
-            || lowercase.contains("status code: 429")
-            || lowercase.contains("429 too many requests")
-            || lowercase.contains("too many requests")
-            || lowercase.contains("slowdown")
-            || lowercase.contains("please reduce your request rate")
-            || lowercase.contains("rate limit")
-            || lowercase.contains("throttling")
-            || lowercase.contains("throttled")
+        message_is_throttle(&source.to_string())
     } else {
         false
     }
+}
+
+/// Whether a Lance error came back from a throttled request.
+///
+/// Lance renders the error it wrapped, so the same heuristic applies whether the request
+/// went through `object_store` or through OpenDAL.
+fn is_throttle_error_lance(err: &lance_core::Error) -> bool {
+    message_is_throttle(&err.to_string())
+}
+
+fn message_is_throttle(message: &str) -> bool {
+    let lowercase = message.to_ascii_lowercase();
+    lowercase.contains("retries, max_retries")
+        || lowercase.contains("serverbusy")
+        || lowercase.contains("server busy")
+        || lowercase.contains("egress is over the account limit")
+        || lowercase.contains("http 429")
+        || lowercase.contains("status code: 429")
+        || lowercase.contains("429 too many requests")
+        || lowercase.contains("too many requests")
+        || lowercase.contains("slowdown")
+        || lowercase.contains("please reduce your request rate")
+        || lowercase.contains("rate limit")
+        // OpenDAL renders `ErrorKind::RateLimited` without a separator.
+        || lowercase.contains("ratelimited")
+        || lowercase.contains("throttling")
+        || lowercase.contains("throttled")
 }
 
 /// Configuration for the AIMD-throttled ObjectStore wrapper.
@@ -458,12 +473,27 @@ impl OperationThrottle {
         F: Fn() -> Fut,
         Fut: std::future::Future<Output = OSResult<T>>,
     {
+        self.throttled_with(is_throttle_error, f).await
+    }
+
+    /// [`Self::throttled`] for operations that report a different error type, such as the
+    /// paginated listing API.
+    async fn throttled_with<T, E, F, Fut>(
+        &self,
+        is_throttled: fn(&E) -> bool,
+        f: F,
+    ) -> std::result::Result<T, E>
+    where
+        E: Display,
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = std::result::Result<T, E>>,
+    {
         for attempt in 0..=self.max_retries {
             self.acquire_token().await;
             let result = f().await;
             let outcome = match &result {
                 Ok(_) => RequestOutcome::Success,
-                Err(err) if is_throttle_error(err) => {
+                Err(err) if is_throttled(err) => {
                     debug!(
                         target: TRACE_OBJECT_STORE_THROTTLE,
                         error = %err,
@@ -481,7 +511,7 @@ impl OperationThrottle {
             self.update_bucket_rate(new_rate).await;
 
             match &result {
-                Err(err) if is_throttle_error(err) && attempt < self.max_retries => {
+                Err(err) if is_throttled(err) && attempt < self.max_retries => {
                     let backoff_ms =
                         rand::rng().random_range(self.min_backoff_ms..=self.max_backoff_ms);
                     debug!(
@@ -873,6 +903,72 @@ impl AimdThrottledStore {
             multipart_parts_throttled_at_http,
         }
     }
+
+    /// Put a paginated lister on the same list budget as this store.
+    pub fn wrap_paginated(
+        &self,
+        inner: Arc<dyn PaginatedDirLister>,
+    ) -> Arc<dyn PaginatedDirLister> {
+        Arc::new(ThrottledDirLister {
+            inner,
+            throttle: self.list.clone(),
+        })
+    }
+}
+
+/// A store paired with the paginated lister that shares its rate limits.
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+type StoreWithLister = (Arc<dyn ObjectStore>, Option<Arc<dyn PaginatedDirLister>>);
+
+/// Apply AIMD throttling to a store and to the lister that shares its list budget.
+///
+/// [`crate::object_store::ObjectStore::read_dir_page`] goes to the lister rather than
+/// through the store, so both have to be wrapped for list requests to be counted once
+/// against one rate.
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+pub(crate) fn with_throttling(
+    state: Option<AimdThrottleState>,
+    multipart_parts_throttled_at_http: bool,
+    store: Arc<dyn ObjectStore>,
+    lister: Option<Arc<dyn PaginatedDirLister>>,
+) -> StoreWithLister {
+    let Some(state) = state else {
+        return (store, lister);
+    };
+    let store = Arc::new(AimdThrottledStore::new_with_state(
+        store,
+        state,
+        multipart_parts_throttled_at_http,
+    ));
+    let lister = lister.map(|lister| store.wrap_paginated(lister));
+    (store, lister)
+}
+
+/// A [`PaginatedDirLister`] whose requests draw on a store's list token bucket.
+#[derive(Debug)]
+struct ThrottledDirLister {
+    inner: Arc<dyn PaginatedDirLister>,
+    throttle: Arc<OperationThrottle>,
+}
+
+// Throttling only adds waiting, so every semantic of the lister it wraps has to reach the
+// listing unchanged; the lint keeps a method added to the trait from silently falling back to
+// its default here.
+#[async_trait]
+#[deny(clippy::missing_trait_methods)]
+impl PaginatedDirLister for ThrottledDirLister {
+    async fn list_page(
+        &self,
+        prefix: Option<&str>,
+        resume: Option<&DirCursor>,
+        limit: Option<usize>,
+    ) -> lance_core::Result<DirPage> {
+        self.throttle
+            .throttled_with(is_throttle_error_lance, || {
+                self.inner.list_page(prefix, resume, limit)
+            })
+            .await
+    }
 }
 
 #[async_trait]
@@ -1052,6 +1148,112 @@ mod tests {
             .body(object_store::client::HttpRequestBody::empty())
             .unwrap();
         assert_eq!(is_multipart_part_request(&request), expected);
+    }
+
+    /// A listing error reaches the throttle as a Lance error that has rendered whatever it
+    /// wrapped, so the classification has to survive the conversion.
+    #[test]
+    fn test_wrapped_throttle_errors_are_recognized() {
+        let wrapped = lance_core::Error::from(make_generic_error(THROTTLE_ERROR_RESPONSE));
+        assert!(is_throttle_error_lance(&wrapped));
+        assert!(!is_throttle_error_lance(&lance_core::Error::from(
+            make_generic_error("Access denied")
+        )));
+        // OpenDAL errors arrive as text rather than as an `object_store::Error`.
+        assert!(is_throttle_error_lance(&lance_core::Error::io(
+            "failed to list 'db/': RateLimited (temporary) at list"
+        )));
+    }
+
+    use super::super::read_dir::{DirEntry, DirEntryKind};
+
+    /// One page of a fixed directory, counting the requests that reached it.
+    #[derive(Debug, Default)]
+    struct CountingDirLister {
+        calls: AtomicUsize,
+        fail_with: Option<String>,
+    }
+
+    #[async_trait]
+    impl PaginatedDirLister for CountingDirLister {
+        async fn list_page(
+            &self,
+            _prefix: Option<&str>,
+            _resume: Option<&DirCursor>,
+            _limit: Option<usize>,
+        ) -> lance_core::Result<DirPage> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match &self.fail_with {
+                Some(message) => Err(lance_core::Error::io(message.clone())),
+                None => Ok(DirPage {
+                    entries: vec![DirEntry {
+                        name: "child".to_string(),
+                        kind: DirEntryKind::Directory,
+                    }],
+                    next: None,
+                }),
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_paginated_lister_acquires_a_token_before_listing() {
+        let lister = Arc::new(CountingDirLister::default());
+        let throttled = AimdThrottledStore::new(
+            Arc::new(InMemory::new()) as Arc<dyn ObjectStore>,
+            list_start_throttle_config(),
+        )
+        .unwrap();
+        let throttled_lister = throttled.wrap_paginated(lister.clone());
+
+        let mut page = Box::pin(throttled_lister.list_page(Some("prefix/"), None, Some(10)));
+        // With rate=10 tokens/s and burst_capacity=0, the token acquisition sleeps for
+        // 100 ms. A 50 ms timeout must expire before that.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut page)
+                .await
+                .is_err()
+        );
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 0);
+
+        let page = tokio::time::timeout(std::time::Duration::from_millis(300), page)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_lister_throttle_errors_decrease_rate() {
+        let lister = Arc::new(CountingDirLister {
+            calls: AtomicUsize::new(0),
+            fail_with: Some(THROTTLE_ERROR_RESPONSE.to_string()),
+        });
+        let mut config = AimdThrottleConfig::default().with_list_aimd(
+            AimdConfig::default()
+                .with_initial_rate(100.0)
+                .with_decrease_factor(0.5)
+                .with_window_duration(std::time::Duration::from_millis(1)),
+        );
+        config.max_retries = 1;
+        config.min_backoff_ms = 0;
+        config.max_backoff_ms = 0;
+        let throttled =
+            AimdThrottledStore::new(Arc::new(InMemory::new()) as Arc<dyn ObjectStore>, config)
+                .unwrap();
+        let throttled_lister = throttled.wrap_paginated(lister.clone());
+
+        assert!(
+            throttled_lister
+                .list_page(Some("prefix/"), None, None)
+                .await
+                .is_err()
+        );
+
+        // The request was retried once, and the throttle response pushed the rate down.
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 2);
+        assert!(throttled.list.controller.current_rate() < 100.0);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -27,9 +27,9 @@ use object_store::{
     Result as OSResult, UploadPart,
 };
 
-use crate::object_store::WrappingObjectStore;
 #[cfg(feature = "metrics")]
 use crate::object_store::metrics::{InFlightGuard, record_outcome};
+use crate::object_store::{PaginatedDirLister, WrappingObjectStore};
 
 #[derive(Debug, Default, Clone)]
 pub struct IOTracker {
@@ -182,6 +182,16 @@ impl IoMetricsGuard {
 impl WrappingObjectStore for IOTracker {
     fn wrap(&self, _store_prefix: &str, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
         Arc::new(IoTrackingStore::new(target, self.stats.clone()))
+    }
+
+    // A pushed-down listing records itself against the store's tracker, so it is already
+    // counted without passing through here.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn PaginatedDirLister>,
+    ) -> Option<Arc<dyn PaginatedDirLister>> {
+        Some(original)
     }
 }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2041,8 +2041,7 @@ impl Dataset {
         let mut cloned = self.clone();
         let mut object_store = self.object_store.as_ref().clone();
         for wrapper in &wrappers {
-            object_store.inner =
-                wrapper.wrap(&object_store.store_prefix, object_store.inner.clone());
+            object_store.apply_wrapper(wrapper.as_ref());
         }
         cloned.object_store = Arc::new(object_store);
         cloned.refs = Refs::new(

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1640,6 +1640,15 @@ mod tests {
         ) -> Arc<dyn object_store::ObjectStore> {
             Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
         }
+
+        // Injects behaviour into every request, so a listing must not go around it.
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn lance_io::object_store::PaginatedDirLister>,
+        ) -> Option<Arc<dyn lance_io::object_store::PaginatedDirLister>> {
+            None
+        }
     }
 
     impl MockObjectStore {

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -89,6 +89,15 @@ impl WrappingObjectStore for FailingWrapper {
             controls: self.controls.clone(),
         })
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn lance_io::object_store::PaginatedDirLister>,
+    ) -> Option<Arc<dyn lance_io::object_store::PaginatedDirLister>> {
+        None
+    }
 }
 
 /// Delegates everything to `inner`, failing WAL-entry PUTs per [`FailControls`].

--- a/rust/lance/src/utils/test/failing_store.rs
+++ b/rust/lance/src/utils/test/failing_store.rs
@@ -105,4 +105,13 @@ impl WrappingObjectStore for FailingProxyStore {
     ) -> Arc<dyn object_store::ObjectStore> {
         Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn lance_io::object_store::PaginatedDirLister>,
+    ) -> Option<Arc<dyn lance_io::object_store::PaginatedDirLister>> {
+        None
+    }
 }

--- a/rust/lance/src/utils/test/throttle_store.rs
+++ b/rust/lance/src/utils/test/throttle_store.rs
@@ -19,4 +19,13 @@ impl WrappingObjectStore for ThrottledStoreWrapper {
         let throttle_store = ThrottledStore::new(original, self.config);
         Arc::new(throttle_store)
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn lance_io::object_store::PaginatedDirLister>,
+    ) -> Option<Arc<dyn lance_io::object_store::PaginatedDirLister>> {
+        None
+    }
 }


### PR DESCRIPTION
`ObjectStore::read_dir` lists an entire directory before it returns anything, because `object_store`'s `list_with_delimiter` loops over every page internally. A caller that only wants the first few children — listing the tables in a database, say — pays for the whole directory, and once a directory holds enough children that takes longer than a client is willing to wait.

This adds `ObjectStore::read_dir_page`, which returns one page of the immediate children of a prefix along with a token that resumes after it, and pushes the resume position and the page size into the list request on backends that support it. Asking for ten children out of a hundred thousand is one request instead of a hundred.

One backend does that pushdown today: the **native `object_store` clients** for S3, GCS and Azure, which resume from the store's own continuation token. Paginated listing lives on `PaginatedListStore`, a separate trait from `ObjectStore`, so it cannot be reached through a `dyn ObjectStore`; those providers keep the concrete store alongside `inner` and hand it to the new API.

Every other store — OpenDAL-backed ones, local files, memory — falls back to a full `list_with_delimiter` with the resume position applied locally, which is exactly what callers get today. The fallback sorts what it listed before paging it, so it is correct on a store that lists in any order.

## Example

```rust
let mut options = ReadDirOptions { limit: Some(10), ..Default::default() };
loop {
    let listing = store.read_dir_page("my_db", options.clone()).await?;
    for entry in &listing.values {
        println!("{}", entry.name);
    }
    // A page can come back short and still be followed by more, so the token is what
    // ends the walk.
    let Some(token) = listing.next_token else { break };
    options.page_token = Some(token);
}
```

The token is opaque and round-trips as a string. Callers hand it back and never construct or interpret one, which is what lets a store resume however it likes: a continuation token where the backend has one, a key where it does not.

## Why a continuation token rather than a key

A directory is a common prefix rather than a key, so there is no key that means "after everything under `foo/`" — a position past it would have to sort after every key inside and before a sibling file named `foo0`, and nothing sorts between those two.

A continuation token has no such trouble: it already names a position past everything the prefix collapsed, so nothing has to be compared against it. That is what makes the pushdown path work on a store that does not list in key order at all, which is why **S3 Express and Azure hierarchical namespaces are paged too** rather than being excluded.

Key cursors still exist, because the fallback has nothing else to hand back. A walk that starts on the fallback and later reaches a store with a lister therefore arrives with a key, and the native lister takes one as an offset. The directory it names then comes back again — every key inside `foo/` sorts after `foo/`, so they collapse into the same entry, and Azure's `startFrom` is inclusive besides — so those repeats are dropped against the position being resumed from. That can leave a page short of what was asked for, so the listing asks again from the position the page reported until the page is full or the directory runs out. A page that got nowhere costs one more request rather than any special handling, and a backend that hands back the position it was given errors instead of spinning.

## Observability

Pushing down bypasses the wrappers around `inner`, so the paginated path records what it would otherwise have lost: IO stats, the `metrics` counters/histogram/in-flight gauge, and a tracing span per list call. `MeteringHttpConnector` sits inside the concrete store and was never bypassed.

List requests also take tokens from the AIMD throttle, so a paginated listing and `ObjectStore::list` draw on one rate rather than two. Recognising a throttle response is shared with the `object_store` path, and `ratelimited` joins the patterns it matches, which widens that path too: an error whose message contains `ratelimited` — how OpenDAL renders `ErrorKind::RateLimited`, with no separator — now counts as a throttle response where before it did not.

## Wrappers

A pushed-down listing does not pass through the decorators `ObjectStoreParams` installs around `inner`, so `WrappingObjectStore` gains a `wrap_paginated` that says what should happen instead: `Some(lister)` keeps the pushdown, `None` gives it up so listings go through `wrap` as a full directory read. A wrapper that observes — metering, caching, mirroring writes — returns the lister; one that hides, rewrites or fails paths returns `None`, because a pushed-down listing would walk straight past it.

It has no default, which makes this a **breaking change for implementors of `WrappingObjectStore`**: each one now has to say which it is. That is deliberate. Either default is wrong somewhere, and both fail silently — one loses the wrapper, the other loses the speed, and neither announces itself.

## Testing

Unit tests drive the paging logic through a fake lister. On top of that, a small in-process emulator serves the S3 and Azure list APIs over HTTP, so the real `object_store` S3, GCS and Azure clients are pointed at it without credentials and the whole path is under test: the query parameters each client builds, the XML it parses, and whether a key survives a round trip through a URL. It runs in CI.

The emulator also behaves in ways a real store is allowed to behave but cannot be asked to on demand — a resume position that is exclusive, inclusive or ignored outright, a page limit spent either on the entries returned or on the keys scanned, and a listing that reports keys in reverse order. The store model behind those knobs is shared with the unit-test fake, so the two cannot drift.

Two of the tests need a real bucket and are `#[ignore]`d, for the questions an emulator cannot answer: whether a store's resume position works at all, and what a page limit is really spent on. Run against S3, both pass, and the second reports what a page boundary costs on a directory holding three children, one of which is a prefix collapsing 10,000 keys:

| page size | list requests for 3 children |
|---|---|
| 1 | 3 |
| 2 | 2 |
| 10 | 1 |

One request per page, with the 10,000 collapsed keys never re-scanned — which is the thing the continuation token is there to guarantee.

Measured end to end through LanceDB and Sophon against databases on S3, timing the REST list-tables call:

| | 10k tables | | 100k tables | |
|---|---|---|---|---|
| | before | after | before | after |
| first page of 1 | 1.164s | 0.089s | 12.232s | 0.086s |
| first page of 1000 | 1.083s | 0.125s | 11.327s | 0.114s |
| full walk in pages of 1000 | 14.7s | 1.7s | 1236.9s | 18.2s |

The cost of a first page before tracks the size of the directory — ten times the children, ten times the wait. After, it is flat: the same 0.086s against 100k as against 10k, because the page is one list request either way.

## Not included

**Pushdown for OpenDAL-backed stores**, which an earlier revision of this PR had. OpenDAL's `Lister` keeps its continuation state to itself, so the only thing it can resume from is a key — and its S3 adapter yields every common prefix of a response before every object in it, so the keys do not arrive in the order a key cursor needs. Making that safe is its own change, and those stores lose nothing here: they keep the full listing they have today. `PaginatedDirLister` is the seam it plugs into when it comes, and the fallback already mints the key cursors such a backend would resume from, so nothing about the token format has to change.

**Pushdown for local files**, for the same reason: it is a separate backend behind the same trait, and reading a directory off a local disk was never the latency this PR is about.

`read_dir` itself is untouched. It returns every child name at once, which no token can express, and its callers are not paging.
