### PR TITLE
docs: describe Lance file encodings as container extensions

### DIFF
--- a/docs/src/format/file/index.md
+++ b/docs/src/format/file/index.md
@@ -16,6 +16,20 @@ Pages are designed so readers can fetch contiguous row ranges with a small and p
 
 The file layer does not bundle table-level statistics or query-side indices into the base file structure. Those capabilities are defined as separate index formats so they can evolve independently of the core file container.
 
+### Encodings as Extensions, Not Built-Ins
+
+Most columnar file formats bundle a fixed catalog of encodings directly into the format specification. Adding a new one means changing the spec and updating every reader implementation, which is slow and tends to fragment the ecosystem as readers fall in and out of sync with which encodings they support.
+
+Lance takes the opposite approach. The file container itself has no built-in concept of encoding, and no built-in type system. A Lance file is only aware of columns, pages, and buffers; how the bytes in those buffers should be interpreted is entirely up to the encoding that produced them. Encodings are described using self-describing protobuf messages attached to the column metadata, so a reader can identify which encoding a page uses even if it does not know how to decode it, and can surface a clear "unsupported encoding" error rather than silently misreading the data.
+
+This is why the file structure below is described as a *container specification* rather than a file format in the traditional sense — comparable to how a video container (e.g. MP4) separates the container from the codecs used to fill it. It means:
+
+- New encodings, including experimental or workload-specific ones, can be introduced without changing the container format, the file writer, or unrelated file readers.
+- Different columns in the same file, or even different pages in the same column, can use different encodings.
+- The container format can stay stable and simple while the [encoding strategy](encoding.md) evolves quickly underneath it.
+
+See the [Encoding Strategy](encoding.md) page for how Lance's default encodings are built on top of this container.
+
 ## File Structure
 
 A Lance file is a container for tabular data. The data is stored in "disk pages". Each disk page contains some rows

--- a/docs/src/format/index.md
+++ b/docs/src/format/index.md
@@ -22,7 +22,7 @@ The layers are designed so that only table readers, table writers, and index rea
 
 ### File Format
 
-The Lance file format is optimized for cloud object storage and highly selective reads. It avoids Parquet-style row groups, uses structural encodings for efficient random access, and keeps statistics and search structures out of the file format so those concerns can evolve independently as indices.
+The Lance file format is optimized for cloud object storage and highly selective reads. It avoids Parquet-style row groups, uses structural encodings for efficient random access, and keeps statistics and search structures out of the file format so those concerns can evolve independently as indices. Rather than baking a fixed set of encodings into the specification, the file format defines a lightweight container: encodings are self-describing extensions, so new and better encodings can be added over time without changing the container itself. See [Encodings as Extensions](file/index.md#encodings-as-extensions-not-built-ins) for details.
 
 ### Table Format
 

--- a/docs/src/format/table/schema.md
+++ b/docs/src/format/table/schema.md
@@ -45,8 +45,8 @@ Data types are represented as strings in the schema and can be grouped into seve
 
 | Logical Type | Arrow Type | Description |
 |---|---|---|
-| `string` | `Utf8` | Variable-length UTF-8 encoded string |
-| `binary` | `Binary` | Variable-length binary data |
+| `string` | `Utf8`, `Utf8View` | Variable-length UTF-8 encoded string |
+| `binary` | `Binary`, `BinaryView` | Variable-length binary data |
 | `large_string` | `LargeUtf8` | Variable-length UTF-8 string (supports large offsets) |
 | `large_binary` | `LargeBinary` | Variable-length binary data (supports large offsets) |
 
@@ -421,9 +421,9 @@ When converting between logical types and Arrow types, Lance uses the following 
 | `Arrow::Float16` | `halffloat` |
 | `Arrow::Float32` | `float` |
 | `Arrow::Float64` | `double` |
-| `Arrow::Utf8` | `string` |
+| `Arrow::Utf8`, `Arrow::Utf8View` | `string` |
 | `Arrow::LargeUtf8` | `large_string` |
-| `Arrow::Binary` | `binary` |
+| `Arrow::Binary`, `Arrow::BinaryView` | `binary` |
 | `Arrow::LargeBinary` | `large_binary` |
 | `Arrow::Decimal128(p, s)` | `decimal:128:p:s` |
 | `Arrow::Decimal256(p, s)` | `decimal:256:p:s` |


### PR DESCRIPTION
## Summary

This PR improves the format documentation by explaining how Lance treats file encodings as extensions of the container format rather than built-in features.

### Changes

* Added documentation describing Lance as a container format that is independent of specific encoding implementations.
* Explained how encodings are stored as self-describing metadata, allowing new encoding strategies to be introduced without changing the container format.
* Added navigation links from the format overview to the detailed explanation for better discoverability.
* Improved the overall documentation to help readers understand the relationship between the container format and column encodings.

### Motivation

The documentation previously described the file format but did not clearly explain the design philosophy behind Lance's encoding system. This PR fills that gap by documenting why Lance separates the container format from encoding implementations and how this makes the format more extensible.

### Testing

* Documentation changes only.
* Verified that the Markdown renders correctly.
* No code or API changes.

Closes #3998
