### PR TITLE
feat(fts): export CompoundQueryExec and support an injected base scorer

### DIFF
--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
-pub use compound::compound_search;
+pub use compound::{compound_search, compound_search_with_base_scorer};
 use datafusion::execution::SendableRecordBatchStream;
 pub use index::*;
 use lance_core::{Result, cache::LanceCache};

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -1464,6 +1464,7 @@ async fn prepare_compound_query(
     query: &FtsQuery,
     params: &FtsSearchParams,
     metrics: &dyn MetricsCollector,
+    base_scorer: Option<Arc<MemBM25Scorer>>,
 ) -> Result<(CompoundScorerPlan, Vec<PreparedLeaf>)> {
     let first_index = indices
         .first()
@@ -1483,9 +1484,15 @@ async fn prepare_compound_query(
     for leaf in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
-        let scorer = Arc::new(
-            build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics)).await?,
-        );
+        // A preset scorer carries corpus-wide stats keyed by the full
+        // query token set, which covers every leaf's tokens.
+        let scorer = match &base_scorer {
+            Some(scorer) => scorer.clone(),
+            None => Arc::new(
+                build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics))
+                    .await?,
+            ),
+        };
         let mut tokens_by_segment = Vec::with_capacity(indices.len());
         for index in indices {
             tokens_by_segment.push(Arc::new(expanded_leaf_tokens(
@@ -1785,12 +1792,14 @@ pub async fn compound_search(
     params: &FtsSearchParams,
     prefilter: Arc<dyn PreFilter>,
     metrics: Arc<dyn MetricsCollector>,
+    base_scorer: Option<Arc<MemBM25Scorer>>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
     let limit = params.limit.unwrap_or(usize::MAX);
     if limit == 0 {
         return Ok((Vec::new(), Vec::new()));
     }
-    let (plan, leaves) = prepare_compound_query(indices, query, params, metrics.as_ref()).await?;
+    let (plan, leaves) =
+        prepare_compound_query(indices, query, params, metrics.as_ref(), base_scorer).await?;
     prefilter.wait_for_ready().await?;
     let mask = prefilter.mask();
     let mut collector = TopKCollector::new(limit);

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -1459,6 +1459,17 @@ fn expanded_leaf_tokens(
     Ok(expanded)
 }
 
+fn validate_injected_scorer_tokens(scorer: &MemBM25Scorer, tokens: &Tokens) -> Result<()> {
+    for token in tokens {
+        if !scorer.token_docs.contains_key(token) {
+            return Err(Error::invalid_input(format!(
+                "injected BM25 scorer is missing compound FTS token '{token}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 async fn prepare_compound_query(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
@@ -1484,8 +1495,6 @@ async fn prepare_compound_query(
     for leaf in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
-        // A preset scorer carries corpus-wide stats keyed by the full
-        // query token set, which covers every leaf's tokens.
         let scorer = match &base_scorer {
             Some(scorer) => scorer.clone(),
             None => Arc::new(
@@ -1495,12 +1504,12 @@ async fn prepare_compound_query(
         };
         let mut tokens_by_segment = Vec::with_capacity(indices.len());
         for index in indices {
-            tokens_by_segment.push(Arc::new(expanded_leaf_tokens(
-                index,
-                &tokens,
-                &effective_params,
-                leaf.operator(),
-            )?));
+            let expanded_tokens =
+                expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())?;
+            if base_scorer.is_some() {
+                validate_injected_scorer_tokens(&scorer, &expanded_tokens)?;
+            }
+            tokens_by_segment.push(Arc::new(expanded_tokens));
         }
         leaves.push(PreparedLeaf {
             tokens_by_segment,
@@ -1787,6 +1796,40 @@ async fn resolve_compound_rows(
 /// candidates, including every kth-score tie, are resolved to row addresses
 /// before the final row-id tie-break is applied.
 pub async fn compound_search(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    compound_search_impl(indices, query, params, prefilter, metrics, None).await
+}
+
+/// Search one-column compound FTS with caller-supplied corpus-wide BM25 statistics.
+///
+/// The scorer must contain an entry for every token used by every query leaf,
+/// including terms produced by fuzzy expansion. An incomplete scorer is rejected
+/// instead of treating missing token statistics as zero.
+pub async fn compound_search_with_base_scorer(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+    base_scorer: Arc<MemBM25Scorer>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    compound_search_impl(
+        indices,
+        query,
+        params,
+        prefilter,
+        metrics,
+        Some(base_scorer),
+    )
+    .await
+}
+
+async fn compound_search_impl(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
     params: &FtsSearchParams,

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -182,30 +182,66 @@ fn count_fts_leaves(query: &FtsQuery) -> usize {
 
 /// One DataFusion boundary around a posting-backed compound scorer tree.
 #[derive(Debug)]
-pub(crate) struct CompoundQueryExec {
+pub struct CompoundQueryExec {
     dataset: Arc<Dataset>,
     query: FtsQuery,
     params: FtsSearchParams,
     prefilter_source: PreFilterSource,
+    /// When set, leaf scorers use this instead of building one from the
+    /// searched segments — see [`MatchQueryExec::with_base_scorer`].
+    base_scorer: Option<Arc<MemBM25Scorer>>,
     segment_selection: FtsSegmentSelection,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
 impl CompoundQueryExec {
-    pub(crate) fn new_with_segments(
+    pub fn new_with_segments(
         dataset: Arc<Dataset>,
         query: FtsQuery,
         params: FtsSearchParams,
         prefilter_source: PreFilterSource,
         segments: Vec<IndexMetadata>,
     ) -> Self {
+        Self::new_inner(
+            dataset,
+            query,
+            params,
+            prefilter_source,
+            FtsSegmentSelection::ExactResolved(Arc::from(segments)),
+        )
+    }
+
+    pub fn new_with_segment_uuids(
+        dataset: Arc<Dataset>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+        prefilter_source: PreFilterSource,
+        segment_uuids: Vec<Uuid>,
+    ) -> Self {
+        Self::new_inner(
+            dataset,
+            query,
+            params,
+            prefilter_source,
+            FtsSegmentSelection::exact_uuids(segment_uuids),
+        )
+    }
+
+    fn new_inner(
+        dataset: Arc<Dataset>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+        prefilter_source: PreFilterSource,
+        segment_selection: FtsSegmentSelection,
+    ) -> Self {
         Self {
             dataset,
             query,
             params,
             prefilter_source,
-            segment_selection: FtsSegmentSelection::ExactResolved(Arc::from(segments)),
+            base_scorer: None,
+            segment_selection,
             properties: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(FTS_SCHEMA.clone()),
                 Partitioning::RoundRobinBatch(1),
@@ -214,6 +250,36 @@ impl CompoundQueryExec {
             )),
             metrics: ExecutionPlanMetricsSet::new(),
         }
+    }
+
+    pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
+        self.base_scorer = Some(scorer);
+        self
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    pub fn query(&self) -> &FtsQuery {
+        &self.query
+    }
+
+    pub fn params(&self) -> &FtsSearchParams {
+        &self.params
+    }
+
+    pub fn prefilter_source(&self) -> &PreFilterSource {
+        &self.prefilter_source
+    }
+
+    pub fn base_scorer(&self) -> Option<&Arc<MemBM25Scorer>> {
+        self.base_scorer.as_ref()
+    }
+
+    /// See [`MatchQueryExec::explicit_segment_uuids`].
+    pub fn explicit_segment_uuids(&self) -> Option<Vec<Uuid>> {
+        self.segment_selection.explicit_segment_uuids()
     }
 }
 
@@ -284,6 +350,7 @@ impl ExecutionPlan for CompoundQueryExec {
             query: self.query.clone(),
             params: self.params.clone(),
             prefilter_source,
+            base_scorer: self.base_scorer.clone(),
             segment_selection: self.segment_selection.clone(),
             properties: self.properties.clone(),
             metrics: ExecutionPlanMetricsSet::new(),
@@ -300,6 +367,7 @@ impl ExecutionPlan for CompoundQueryExec {
         let query = self.query.clone();
         let params = self.params.clone();
         let prefilter_source = self.prefilter_source.clone();
+        let base_scorer = self.base_scorer.clone();
         let segment_selection = self.segment_selection.clone();
         let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
 
@@ -347,8 +415,15 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
-            let (row_ids, scores) =
-                compound_search(&indices, &query, &params, prefilter, metrics.clone()).await?;
+            let (row_ids, scores) = compound_search(
+                &indices,
+                &query,
+                &params,
+                prefilter,
+                metrics.clone(),
+                base_scorer,
+            )
+            .await?;
             metrics.baseline_metrics.record_output(row_ids.len());
             Ok::<_, DataFusionError>(RecordBatch::try_new(
                 FTS_SCHEMA.clone(),

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -52,7 +52,7 @@ use lance_index::scalar::inverted::query::{
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
     FTS_SCHEMA, InvertedIndex, MemBM25Scorer, SCORE_COL, build_global_bm25_scorer, compound_search,
-    flat_bm25_search_stream_with_metrics_and_operator,
+    compound_search_with_base_scorer, flat_bm25_search_stream_with_metrics_and_operator,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
@@ -252,6 +252,10 @@ impl CompoundQueryExec {
         }
     }
 
+    /// Override locally computed BM25 statistics with a corpus-wide scorer.
+    ///
+    /// The scorer must cover every token in every query leaf, including fuzzy
+    /// expansions. Execution returns an error when any required token is absent.
     pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
         self.base_scorer = Some(scorer);
         self
@@ -415,15 +419,22 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
-            let (row_ids, scores) = compound_search(
-                &indices,
-                &query,
-                &params,
-                prefilter,
-                metrics.clone(),
-                base_scorer,
-            )
-            .await?;
+            let (row_ids, scores) = match base_scorer {
+                Some(base_scorer) => {
+                    compound_search_with_base_scorer(
+                        &indices,
+                        &query,
+                        &params,
+                        prefilter,
+                        metrics.clone(),
+                        base_scorer,
+                    )
+                    .await?
+                }
+                None => {
+                    compound_search(&indices, &query, &params, prefilter, metrics.clone()).await?
+                }
+            };
             metrics.baseline_metrics.record_output(row_ids.len());
             Ok::<_, DataFusionError>(RecordBatch::try_new(
                 FTS_SCHEMA.clone(),
@@ -2495,9 +2506,9 @@ mod tests {
     };
 
     use super::{
-        BoolSlot, BoostQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec,
-        FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec, build_boolean_query_children,
-        open_fts_segments,
+        BoolSlot, BoostQueryExec, CompoundQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC,
+        FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
+        build_boolean_query_children, open_fts_segments,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -3477,6 +3488,124 @@ mod tests {
             out.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             out
         }
+    }
+
+    #[tokio::test]
+    async fn test_compound_query_exec_validates_base_scorer() {
+        let (dataset, segments, _) = create_segment_selection_fixture().await;
+        let search_params = FtsSearchParams::default().with_limit(Some(10));
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = IndexMetrics::new(&metrics_set, 0);
+        let indices = open_fts_segments(&dataset, "text", &segments, &metrics)
+            .await
+            .unwrap();
+
+        let query: FtsQuery = BooleanQuery::new([
+            (
+                Occur::Should,
+                MatchQuery::new("quick".to_string())
+                    .with_column(Some("text".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::Should,
+                MatchQuery::new("brown".to_string())
+                    .with_column(Some("text".to_string()))
+                    .into(),
+            ),
+        ])
+        .into();
+
+        let baseline = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            segments.clone(),
+        );
+        let baseline_results = execute_results(&baseline).await.unwrap();
+
+        let mut tokenizer = indices[0].tokenizer();
+        let complete_tokens = collect_query_tokens("quick brown", &mut tokenizer);
+        let complete_scorer = Arc::new(
+            build_global_bm25_scorer(&indices, &complete_tokens, &search_params, None)
+                .await
+                .unwrap(),
+        );
+        let complete_override = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            segments.clone(),
+        )
+        .with_base_scorer(complete_scorer);
+        assert_eq!(
+            execute_results(&complete_override).await.unwrap(),
+            baseline_results
+        );
+
+        let mut tokenizer = indices[0].tokenizer();
+        let incomplete_tokens = collect_query_tokens("quick", &mut tokenizer);
+        let incomplete_scorer = Arc::new(
+            build_global_bm25_scorer(&indices, &incomplete_tokens, &search_params, None)
+                .await
+                .unwrap(),
+        );
+        let incomplete_override = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            query,
+            search_params.clone(),
+            PreFilterSource::None,
+            segments.clone(),
+        )
+        .with_base_scorer(incomplete_scorer);
+
+        let error = execute_results(&incomplete_override).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected BM25 scorer is missing compound FTS token 'brown'"),
+            "unexpected incomplete-scorer error: {error}"
+        );
+
+        let mut tokenizer = indices[0].tokenizer();
+        let brown_tokens = collect_query_tokens("brown", &mut tokenizer);
+        let scorer_without_fuzzy_expansion = Arc::new(
+            build_global_bm25_scorer(&indices, &brown_tokens, &search_params, None)
+                .await
+                .unwrap(),
+        );
+        let fuzzy_query = BooleanQuery::new([
+            (
+                Occur::Should,
+                MatchQuery::new("quik".to_string())
+                    .with_column(Some("text".to_string()))
+                    .with_fuzziness(Some(1))
+                    .into(),
+            ),
+            (
+                Occur::Should,
+                MatchQuery::new("brown".to_string())
+                    .with_column(Some("text".to_string()))
+                    .into(),
+            ),
+        ]);
+        let fuzzy_override = CompoundQueryExec::new_with_segments(
+            dataset,
+            fuzzy_query.into(),
+            search_params,
+            PreFilterSource::None,
+            segments,
+        )
+        .with_base_scorer(scorer_without_fuzzy_expansion);
+        let error = execute_results(&fuzzy_override).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected BM25 scorer is missing compound FTS token 'quick'"),
+            "unexpected fuzzy-scorer error: {error}"
+        );
     }
 
     fn empty_fts_child() -> Arc<dyn ExecutionPlan> {


### PR DESCRIPTION
## Summary

`CompoundQueryExec` (the single-column compound FTS boundary introduced with the posting-backed compound scorer) is `pub(crate)`, so engines that rewrite physical plans cannot rebuild it against a subset of segments the way they already do with `MatchQueryExec`/`PhraseQueryExec`. This PR gives it the same surface:

- `pub struct CompoundQueryExec` with `query()` / `params()` / `prefilter_source()` / `dataset()` / `base_scorer()` / `explicit_segment_uuids()` accessors, a `pub new_with_segments`, and a `new_with_segment_uuids` constructor (mirroring `MatchQueryExec`)
- `with_base_scorer(Arc<MemBM25Scorer>)`: `compound_search` / `prepare_compound_query` take an optional preset scorer; when present every leaf uses it instead of building segment-local stats. A preset scorer carries stats keyed by the full query token set, which covers every leaf's tokens — the same contract `MatchQueryExec::with_base_scorer` documents for cross-segment BM25 consistency.

No behavior change when no scorer is injected (the default and the only in-crate path).

Note: rebased onto current main. A `v10.1.0-beta.1`-based twin of the same change lives on branch `lu/v10.1-compound-pin` for downstream pinning until the next release.

## Test plan

- `cargo check` clean; exercised end-to-end by a downstream distributed engine: compound boundaries rebuilt per worker with injected corpus-wide scorers return results identical to single-node execution across an e2e suite (44 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
