### PR TITLE
fix(python): handle missing merge_insert_base tag in datagen

### DIFF
--- a/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
+++ b/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
@@ -95,12 +95,16 @@ class Target:
 def _open_target(name: str) -> Iterable[Target]:
     uri = get_dataset_uri(name)
     dataset = lance.dataset(uri)
-    base_version = dataset.tags.get_version(BASE_TAG)
-    if base_version is None:
+    # ``get_version`` is documented to return None for missing tags but in
+    # practice raises ``ValueError`` ("Ref not found").  Check the tag list
+    # first so a missing tag triggers a clean ``pytest.skip`` instead of a
+    # crash.
+    if BASE_TAG not in dataset.tags.list():
         pytest.skip(
             f"Dataset {name} has no {BASE_TAG} tag; "
             "run python/ci_benchmarks/datagen/gen_all.py"
         )
+    base_version = dataset.tags.get_version(BASE_TAG)
 
     yield Target(uri=uri, dataset=dataset, base_version=base_version)
 

--- a/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
+++ b/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
@@ -24,6 +24,7 @@ the ``merge_insert_base`` tag written by ``datagen/merge_insert.py``.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Sequence
@@ -50,6 +51,8 @@ from ci_benchmarks.datagen.merge_insert import (
 from ci_benchmarks.datasets import get_dataset_uri
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from lance.dataset import ExecuteResult
 
 PLANS = ["v1_indexed", "v2_hash"]
@@ -768,3 +771,71 @@ def test_io_mem_upsert_streaming_source(
         )
 
     io_mem_benchmark(job, narrow.dataset, warmup=False, setup=lambda: narrow.reset())
+
+
+# ---------------------------------------------------------------------------
+# F. Regression: missing `merge_insert_base` tag
+# ---------------------------------------------------------------------------
+#
+# `ds.tags.get_version()` is documented to return None for missing tags but
+# the underlying Rust binding raises ValueError ("Ref not found"). A crashed
+# benchmark run can leave a dataset on disk without the
+# ``merge_insert_base`` tag, which used to crash ``_already_generated`` and
+# ``_open_target`` mid-startup. These tests guard against a future change
+# restoring that crash by reproducing the post-crash state with a real
+# dataset written to a temp path.
+
+
+def test_already_generated_missing_tag_triggers_regen(tmp_path: Path) -> None:
+    """A dataset without ``merge_insert_base`` must report as not-generated.
+
+    Before the fix this raised ``ValueError: Ref not found: tag merge_insert_base
+    does not exist`` and aborted datagen. The fix must return ``False`` so the
+    caller regenerates the dataset.
+    """
+    from ci_benchmarks.datagen.merge_insert import _already_generated
+
+    uri = str(tmp_path / "merge_insert_narrow")
+    table = pa.table({"id_int": [1, 2, 3], "value": [10, 20, 30]})
+    lance.write_dataset(table, uri, mode="create")
+    # Deliberately do NOT create BASE_TAG -- the post-crash state.
+
+    assert _already_generated(uri, expected_rows=3) is False
+
+
+def test_already_generated_with_tag_and_matching_rows(tmp_path: Path) -> None:
+    """Sanity: when the tag exists and the row count matches, the dataset is
+    reported as generated. Guards against a fix that breaks the happy path.
+    """
+    from ci_benchmarks.datagen.merge_insert import _already_generated
+
+    uri = str(tmp_path / "merge_insert_narrow")
+    table = pa.table({"id_int": [1, 2, 3], "value": [10, 20, 30]})
+    ds = lance.write_dataset(table, uri, mode="create")
+    ds.tags.create(BASE_TAG, ds.version)
+
+    assert _already_generated(uri, expected_rows=3) is True
+
+
+def test_open_target_missing_tag_skips(tmp_path: Path) -> None:
+    """A dataset without ``merge_insert_base`` must ``pytest.skip`` cleanly.
+
+    Before the fix this raised ``ValueError`` and crashed the benchmark
+    fixture. The fix must call ``pytest.skip`` with a message pointing at the
+    datagen script, so a missing dataset fails informatively rather than
+    abruptly.
+    """
+    from unittest import mock
+
+    uri = str(tmp_path / "merge_insert_narrow")
+    table = pa.table({"id_int": [1, 2, 3], "value": [10, 20, 30]})
+    lance.write_dataset(table, uri, mode="create")
+    # Deliberately do NOT create BASE_TAG.
+
+    # ``_open_target`` looks up ``get_dataset_uri`` as a module-level name in
+    # this test module, so patch the attribute on this module rather than the
+    # source module -- the source binding is shadowed by the local import.
+    with mock.patch.object(sys.modules[__name__], "get_dataset_uri", return_value=uri):
+        gen = _open_target("merge_insert_narrow")
+        with pytest.raises(pytest.skip.Exception, match=BASE_TAG):
+            next(gen)

--- a/python/python/ci_benchmarks/datagen/merge_insert.py
+++ b/python/python/ci_benchmarks/datagen/merge_insert.py
@@ -257,14 +257,20 @@ def _already_generated(uri: str, expected_rows: int) -> bool:
 
     A previous benchmark run may have left extra versions behind, so the row
     count is checked at the tagged version rather than at the latest one.
+    A previous crashed run may also have left a dataset without the
+    ``merge_insert_base`` tag, in which case we treat it as not generated
+    and let the caller rebuild it.
     """
     try:
         ds = lance.dataset(uri)
     except ValueError:
         return False
-    base_version = ds.tags.get_version(BASE_TAG)
-    if base_version is None:
+    # ``get_version`` is documented to return None for missing tags but in
+    # practice raises ``ValueError`` ("Ref not found").  Check the tag list
+    # first, which is the same shape ``_tag_base`` uses for existence.
+    if BASE_TAG not in ds.tags.list():
         return False
+    base_version = ds.tags.get_version(BASE_TAG)
     return ds.checkout_version(base_version).count_rows() == expected_rows
 
 


### PR DESCRIPTION
`Tags.get_version` is documented to return None for missing tags but the underlying Rust binding (python/src/dataset.rs) raises ValueError ('Ref not found') instead. The previous `if base_version is None` checks in `_already_generated` and `_open_target` were therefore dead code.

When a crashed benchmark run leaves a stale dataset behind without the `merge_insert_base` tag, datagen aborts instead of regenerating.

Fix: check `BASE_TAG in ds.tags.list()` before calling `get_version`, matching the pattern already used in `_tag_base`. Both sites updated:
  * datagen/merge_insert.py: `_already_generated` returns False so the caller rebuilds the dataset.
  * benchmarks/test_merge_insert.py: `_open_target` triggers a clean `pytest.skip` instead of crashing.