### PR TITLE
docs(index): fix stale default values in HnswBuildParams doc comments

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -61,7 +61,7 @@ pub(crate) const HNSW_LEVEL_RNG_SEED: u64 = 42;
 /// Parameters of building HNSW index
 #[derive(Debug, Clone, Serialize, Deserialize, DeepSizeOf)]
 pub struct HnswBuildParams {
-    /// max level ofm
+    /// max level of the graph
     pub max_level: u16,
 
     /// number of connections to establish while inserting new element
@@ -97,14 +97,14 @@ impl Default for HnswBuildParams {
 
 impl HnswBuildParams {
     /// The maximum level of the graph.
-    /// The default value is `8`.
+    /// The default value is `7`.
     pub fn max_level(mut self, max_level: u16) -> Self {
         self.max_level = max_level;
         self
     }
 
     /// The number of connections to establish while inserting new element
-    /// The default value is `30`.
+    /// The default value is `20`.
     pub fn num_edges(mut self, m: usize) -> Self {
         self.m = m;
         self
@@ -113,7 +113,7 @@ impl HnswBuildParams {
     /// Number of candidates to be considered when searching for the nearest neighbors
     /// during the construction of the graph.
     ///
-    /// The default value is `100`.
+    /// The default value is `150`.
     pub fn ef_construction(mut self, ef_construction: usize) -> Self {
         self.ef_construction = ef_construction;
         self


### PR DESCRIPTION
The three builder methods on `HnswBuildParams` document default values that no longer match `impl Default`.

| Method | Doc said | `Default` gives |
| --- | --- | --- |
| `max_level` | `8` | `7` |
| `num_edges` | `30` | `20` |
| `ef_construction` | `100` | `150` |

The format spec table in `docs/src/format/index/vector/index.md` already lists the correct values, so these builder doc comments are the only place left stating the old ones.

Also fixes the `max_level` field doc, which currently reads "max level ofm".

Docs only, no behavior change.

One question while I am here: `lance.util.HNSW.build` in the Python bindings still defaults `ef_construction` to 100, the value the Rust default carried before it moved to 150. That is a real default rather than a doc, so I left it untouched. Should it be lined up with 150? I can fold that into this PR or send it as a separate follow-up, whichever you prefer.
