### PR TITLE
chore(index): remove unused GraphBuilderStats

### DIFF
--- a/rust/lance-index/src/vector/graph/builder.rs
+++ b/rust/lance-index/src/vector/graph/builder.rs
@@ -70,15 +70,3 @@ impl GraphBuilderNode {
         }
     }
 }
-
-#[derive(Debug)]
-pub struct GraphBuilderStats {
-    #[allow(dead_code)]
-    pub num_nodes: usize,
-    #[allow(dead_code)]
-    pub max_edges: usize,
-    #[allow(dead_code)]
-    pub mean_edges: f32,
-    #[allow(dead_code)]
-    pub mean_distance: f32,
-}


### PR DESCRIPTION
`GraphBuilderStats` has had no producer since #2193 removed the `stats()` method that returned it, and each of its four fields carries `#[allow(dead_code)]` to keep the compiler quiet. `rust/CLAUDE.md` asks for the opposite: "Remove dead code instead of adding `#[allow(dead_code)]`."

A grep over the tree finds exactly one occurrence of the name, its own definition.

One thing worth flagging: the struct is nominally reachable as `lance_index::vector::graph::builder::GraphBuilderStats`. Nothing in the crate constructs or returns it and it carries no behavior, and its neighbour `GraphBuilderNode` in the same module is marked "WARNING: Internal API, API stability is not guaranteed", so I treated it as internal. Happy to put it through a `#[deprecated]` cycle instead if you would rather treat it as public surface.
