### PR TITLE
fix(index): report distance comparisons from HNSW search

### DIFF
--- a/rust/examples/src/hnsw.rs
+++ b/rust/examples/src/hnsw.rs
@@ -134,6 +134,7 @@ async fn main() {
         let results: HashSet<u32> = hnsw
             .search_basic(q.clone(), k, &params, None, vector_store.as_ref())
             .unwrap()
+            .0
             .iter()
             .map(|node| node.id)
             .collect();

--- a/rust/lance-index/benches/hnsw.rs
+++ b/rust/lance-index/benches/hnsw.rs
@@ -59,6 +59,7 @@ fn bench_hnsw(c: &mut Criterion) {
                     vectors.as_ref(),
                 )
                 .unwrap()
+                .0
                 .iter()
                 .map(|node| node.id)
                 .collect();
@@ -88,6 +89,7 @@ fn bench_hnsw(c: &mut Criterion) {
                     vectors.as_ref(),
                 )
                 .unwrap()
+                .0
                 .iter()
                 .map(|node| node.id)
                 .collect();
@@ -149,6 +151,7 @@ fn bench_hnsw_load(c: &mut Criterion) {
                         vectors.as_ref(),
                     )
                     .unwrap()
+                    .0
                     .iter()
                     .map(|node| node.id)
                     .collect();
@@ -215,6 +218,7 @@ fn bench_hnsw_sq(c: &mut Criterion) {
                         vectors.as_ref(),
                     )
                     .unwrap()
+                    .0
                     .iter()
                     .map(|node| node.id)
                     .collect();
@@ -245,6 +249,7 @@ fn bench_hnsw_sq(c: &mut Criterion) {
                     vectors.as_ref(),
                 )
                 .unwrap()
+                .0
                 .iter()
                 .map(|node| node.id)
                 .collect();
@@ -313,6 +318,7 @@ fn bench_hnsw_pq(c: &mut Criterion) {
                         vectors.as_ref(),
                     )
                     .unwrap()
+                    .0
                     .iter()
                     .map(|node| node.id)
                     .collect();
@@ -343,6 +349,7 @@ fn bench_hnsw_pq(c: &mut Criterion) {
                     vectors.as_ref(),
                 )
                 .unwrap()
+                .0
                 .iter()
                 .map(|node| node.id)
                 .collect();

--- a/rust/lance-index/examples/acorn_bench.rs
+++ b/rust/lance-index/examples/acorn_bench.rs
@@ -111,7 +111,7 @@ fn main() {
             let query = fsl.value(query_id as usize);
             let truth = ground_truth(&storage, query.clone(), &all_mask);
             let t = Instant::now();
-            let nodes = hnsw
+            let (nodes, _) = hnsw
                 .search_basic(query.clone(), K, &params, None, storage.as_ref())
                 .unwrap();
             control.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -187,7 +187,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_basic(query.clone(), K, &params, Some(bitset), storage.as_ref())
                         .unwrap();
                     basic.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -202,7 +202,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_basic(query.clone(), K, &params_hi, Some(bitset), storage.as_ref())
                         .unwrap();
                     basic_hi.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -217,7 +217,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_acorn(query.clone(), K, &params, &bitset, storage.as_ref())
                         .unwrap();
                     acorn.latency_us.push(t.elapsed().as_secs_f64() * 1e6);

--- a/rust/lance-index/examples/acorn_bench_sift.rs
+++ b/rust/lance-index/examples/acorn_bench_sift.rs
@@ -160,7 +160,7 @@ fn main() {
             let query = query_vec(query_id);
             let truth: Vec<u32> = official_gt[query_id][..K].to_vec();
             let t = Instant::now();
-            let nodes = hnsw
+            let (nodes, _) = hnsw
                 .search_basic(query, K, &params, None, storage.as_ref())
                 .unwrap();
             control.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -240,7 +240,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_basic(query.clone(), K, &params, Some(bitset), storage.as_ref())
                         .unwrap();
                     basic.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -255,7 +255,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_basic(query.clone(), K, &params_hi, Some(bitset), storage.as_ref())
                         .unwrap();
                     basic_hi.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -270,7 +270,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_acorn(query.clone(), K, &params, &bitset, storage.as_ref())
                         .unwrap();
                     acorn.latency_us.push(t.elapsed().as_secs_f64() * 1e6);
@@ -285,7 +285,7 @@ fn main() {
                         bitset.insert(id);
                     }
                     let t = Instant::now();
-                    let nodes = hnsw
+                    let (nodes, _) = hnsw
                         .search_acorn(query.clone(), K, &params_hi, &bitset, storage.as_ref())
                         .unwrap();
                     acorn_hi.latency_us.push(t.elapsed().as_secs_f64() * 1e6);

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -304,6 +304,7 @@ macro_rules! beam_search_loop {
         $k:expr,
         $dist_calc:expr,
         $accepts_result:expr,
+        $comparisons:ident,
         |$current:ident, $process_neighbor:ident| $visit_neighbors:block
     ) => {{
         while !$candidates.is_empty() {
@@ -320,6 +321,7 @@ macro_rules! beam_search_loop {
                 }
                 $visited.insert(neighbor);
                 let dist: OrderedFloat = $dist_calc.distance(neighbor).into();
+                $comparisons += 1;
                 // Algorithm 2 refreshes the furthest result after every
                 // update to W, including updates made by an earlier neighbor
                 // of this same expanded node.
@@ -341,12 +343,14 @@ macro_rules! greedy_search_loop {
         $current:ident,
         $closest_dist:ident,
         $dist_calc:expr,
+        $comparisons:ident,
         |$process_neighbor:ident| $visit_neighbors:block
     ) => {{
         loop {
             let mut next = None;
             let $process_neighbor = |neighbor: u32| {
                 let dist = $dist_calc.distance(neighbor);
+                $comparisons += 1;
                 if dist < $closest_dist {
                     $closest_dist = dist;
                     next = Some(neighbor);
@@ -382,7 +386,8 @@ macro_rules! greedy_search_loop {
 ///
 /// Returns
 /// -------
-/// A descending sorted list of ``(dist, node_id)`` pairs.
+/// A descending sorted list of ``(dist, node_id)`` pairs, and the number of
+/// distances computed while producing it.
 ///
 /// WARNING: Internal API,  API stability is not guaranteed
 ///
@@ -395,13 +400,14 @@ pub fn beam_search(
     bitset: Option<&Visited>,
     prefetch_distance: Option<usize>,
     visited: &mut Visited,
-) -> Vec<OrderedNode> {
+) -> (Vec<OrderedNode>, usize) {
     let k = params.ef;
     let mut candidates = BinaryHeap::with_capacity(k);
     visited.insert(ep.id);
     candidates.push(Reverse(ep.clone()));
 
     let mut results = BinaryHeap::with_capacity(k);
+    let mut comparisons = 0;
     let no_filter =
         bitset.is_none() && params.lower_bound.is_none() && params.upper_bound.is_none();
 
@@ -415,6 +421,7 @@ pub fn beam_search(
             k,
             dist_calc,
             accepts_result,
+            comparisons,
             |current, process_neighbor| {
                 let neighbors = graph.neighbors(current.id);
                 process_neighbors_with_look_ahead(
@@ -425,7 +432,7 @@ pub fn beam_search(
                 );
             }
         );
-        return results.into_sorted_vec();
+        return (results.into_sorted_vec(), comparisons);
     }
 
     // add range search support
@@ -453,6 +460,7 @@ pub fn beam_search(
         k,
         dist_calc,
         accepts_result,
+        comparisons,
         |current, process_neighbor| {
             let neighbors = graph.neighbors(current.id);
             process_neighbors_with_look_ahead(
@@ -463,9 +471,11 @@ pub fn beam_search(
             );
         }
     );
-    results.into_sorted_vec()
+    (results.into_sorted_vec(), comparisons)
 }
 
+/// Like [beam_search] but over a [BorrowingGraph]. Also returns the number of
+/// distances computed.
 pub fn beam_search_borrowed(
     graph: &impl BorrowingGraph,
     ep: &OrderedNode,
@@ -474,13 +484,14 @@ pub fn beam_search_borrowed(
     bitset: Option<&Visited>,
     prefetch_distance: Option<usize>,
     visited: &mut Visited,
-) -> Vec<OrderedNode> {
+) -> (Vec<OrderedNode>, usize) {
     let k = params.ef;
     let mut candidates = BinaryHeap::with_capacity(k);
     visited.insert(ep.id);
     candidates.push(Reverse(ep.clone()));
 
     let mut results = BinaryHeap::with_capacity(k);
+    let mut comparisons = 0;
     let no_filter =
         bitset.is_none() && params.lower_bound.is_none() && params.upper_bound.is_none();
 
@@ -494,6 +505,7 @@ pub fn beam_search_borrowed(
             k,
             dist_calc,
             accepts_result,
+            comparisons,
             |current, process_neighbor| {
                 let neighbors = graph.neighbors(current.id);
                 process_neighbors_with_look_ahead(
@@ -504,7 +516,7 @@ pub fn beam_search_borrowed(
                 );
             }
         );
-        return results.into_sorted_vec();
+        return (results.into_sorted_vec(), comparisons);
     }
 
     let lower_bound: OrderedFloat = params.lower_bound.unwrap_or(f32::MIN).into();
@@ -531,6 +543,7 @@ pub fn beam_search_borrowed(
         k,
         dist_calc,
         accepts_result,
+        comparisons,
         |current, process_neighbor| {
             let neighbors = graph.neighbors(current.id);
             process_neighbors_with_look_ahead(
@@ -541,7 +554,7 @@ pub fn beam_search_borrowed(
             );
         }
     );
-    results.into_sorted_vec()
+    (results.into_sorted_vec(), comparisons)
 }
 
 /// Number of mask-passing nodes used to seed [beam_search_acorn]'s frontier.
@@ -559,6 +572,8 @@ const ACORN_BRIDGE_BUDGET_FACTOR: usize = 4;
 /// starts from the entry point plus mask-sampled seeds. May return fewer than
 /// `min(ef, passing)` results if the budget runs out, so callers needing a
 /// guarantee must check the count.
+///
+/// Also returns the number of distances computed.
 #[allow(clippy::too_many_arguments)]
 pub fn beam_search_acorn(
     graph: &impl BorrowingGraph,
@@ -569,7 +584,7 @@ pub fn beam_search_acorn(
     prefetch_distance: Option<usize>,
     visited: &mut Visited,
     expanded: &mut Visited,
-) -> Vec<OrderedNode> {
+) -> (Vec<OrderedNode>, usize) {
     let ef = params.ef;
     let lower_bound: OrderedFloat = params.lower_bound.unwrap_or(f32::MIN).into();
     let upper_bound: OrderedFloat = params.upper_bound.unwrap_or(f32::MAX).into();
@@ -583,6 +598,7 @@ pub fn beam_search_acorn(
     // deduped against `expanded` at pop rather than at push
     let mut waypoints: VecDeque<u32> = VecDeque::new();
     let mut bridge_budget = ACORN_BRIDGE_BUDGET_FACTOR * ef;
+    let mut comparisons = 0;
 
     // the entry point seeds the traversal even if it fails the mask
     visited.insert(ep.id);
@@ -599,6 +615,7 @@ pub fn beam_search_acorn(
         }
         visited.insert(seed);
         let dist: OrderedFloat = dist_calc.distance(seed).into();
+        comparisons += 1;
         if dist >= lower_bound && dist < upper_bound {
             push_result(&mut results, (dist, seed).into(), ef);
         }
@@ -627,6 +644,7 @@ pub fn beam_search_acorn(
                         if !visited.contains(neighbor) {
                             visited.insert(neighbor);
                             let dist: OrderedFloat = dist_calc.distance(neighbor).into();
+                            comparisons += 1;
                             if dist >= lower_bound && dist < upper_bound {
                                 push_result(&mut results, (dist, neighbor).into(), ef);
                             }
@@ -676,6 +694,7 @@ pub fn beam_search_acorn(
             &passing,
             |node| {
                 let dist: OrderedFloat = dist_calc.distance(node).into();
+                comparisons += 1;
                 if dist <= furthest_distance(&results) || results.len() < ef {
                     if dist >= lower_bound && dist < upper_bound {
                         push_result(&mut results, (dist, node).into(), ef);
@@ -687,7 +706,7 @@ pub fn beam_search_acorn(
             dist_calc,
         );
     }
-    results.into_sorted_vec()
+    (results.into_sorted_vec(), comparisons)
 }
 
 /// Greedy search over a graph
@@ -705,7 +724,7 @@ pub fn beam_search_acorn(
 ///
 /// Returns
 /// -------
-/// A ``(dist, node_id)`` pair.
+/// A ``(dist, node_id)`` pair, and the number of distances computed.
 ///
 /// WARNING: Internal API,  API stability is not guaranteed
 pub fn greedy_search(
@@ -713,39 +732,55 @@ pub fn greedy_search(
     start: OrderedNode,
     dist_calc: &impl DistCalculator,
     prefetch_distance: Option<usize>,
-) -> OrderedNode {
+) -> (OrderedNode, usize) {
     let mut current = start.id;
     let mut closest_dist = start.dist.0;
-    greedy_search_loop!(current, closest_dist, dist_calc, |process_neighbor| {
-        let neighbors = graph.neighbors(current);
-        process_neighbors_with_look_ahead(
-            &neighbors,
-            process_neighbor,
-            prefetch_distance,
-            dist_calc,
-        );
-    });
-    OrderedNode::new(current, closest_dist.into())
+    let mut comparisons = 0;
+    greedy_search_loop!(
+        current,
+        closest_dist,
+        dist_calc,
+        comparisons,
+        |process_neighbor| {
+            let neighbors = graph.neighbors(current);
+            process_neighbors_with_look_ahead(
+                &neighbors,
+                process_neighbor,
+                prefetch_distance,
+                dist_calc,
+            );
+        }
+    );
+    (OrderedNode::new(current, closest_dist.into()), comparisons)
 }
 
+/// Like [greedy_search] but over a [BorrowingGraph]. Also returns the number
+/// of distances computed.
 pub fn greedy_search_borrowed(
     graph: &impl BorrowingGraph,
     start: OrderedNode,
     dist_calc: &impl DistCalculator,
     prefetch_distance: Option<usize>,
-) -> OrderedNode {
+) -> (OrderedNode, usize) {
     let mut current = start.id;
     let mut closest_dist = start.dist.0;
-    greedy_search_loop!(current, closest_dist, dist_calc, |process_neighbor| {
-        let neighbors = graph.neighbors(current);
-        process_neighbors_with_look_ahead(
-            neighbors,
-            process_neighbor,
-            prefetch_distance,
-            dist_calc,
-        );
-    });
-    OrderedNode::new(current, closest_dist.into())
+    let mut comparisons = 0;
+    greedy_search_loop!(
+        current,
+        closest_dist,
+        dist_calc,
+        comparisons,
+        |process_neighbor| {
+            let neighbors = graph.neighbors(current);
+            process_neighbors_with_look_ahead(
+                neighbors,
+                process_neighbor,
+                prefetch_distance,
+                dist_calc,
+            );
+        }
+    );
+    (OrderedNode::new(current, closest_dist.into()), comparisons)
 }
 
 #[cfg(test)]
@@ -820,7 +855,7 @@ mod tests {
         let entry = OrderedNode::new(0, distances[0].into());
         let mut visited_generator = VisitedGenerator::new(graph.len());
 
-        let results = beam_search_borrowed(
+        let (results, _) = beam_search_borrowed(
             &graph,
             &entry,
             &params,
@@ -874,7 +909,7 @@ mod tests {
 
         let mut acorn_visited_generator = VisitedGenerator::new(graph.len());
         let mut acorn_expanded_generator = VisitedGenerator::new(graph.len());
-        let acorn_results = beam_search_acorn(
+        let (acorn_results, _) = beam_search_acorn(
             &graph,
             &entry,
             &params,
@@ -886,7 +921,7 @@ mod tests {
         );
 
         let mut basic_visited_generator = VisitedGenerator::new(graph.len());
-        let basic_results = beam_search_borrowed(
+        let (basic_results, _) = beam_search_borrowed(
             &graph,
             &entry,
             &params,

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -2684,26 +2684,6 @@ mod tests {
         }
     }
 
-    struct MaskPreFilter {
-        mask: Arc<lance_select::RowAddrMask>,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::prefilter::PreFilter for MaskPreFilter {
-        async fn wait_for_ready(&self) -> lance_core::Result<()> {
-            Ok(())
-        }
-        fn is_empty(&self) -> bool {
-            false
-        }
-        fn mask(&self) -> Arc<lance_select::RowAddrMask> {
-            self.mask.clone()
-        }
-        fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64> {
-            self.mask.selected_indices(row_ids)
-        }
-    }
-
     fn masked_prefilter(allowed: Vec<u64>) -> Arc<dyn PreFilter> {
         Arc::new(MaskPreFilter {
             mask: Arc::new(lance_select::RowAddrMask::from_allowed(
@@ -3370,7 +3350,7 @@ mod tests {
         // The safe direction, and the matching one, both still search.
         let over = build_store(NODES * 2);
         for storage in [full.as_ref(), over.as_ref()] {
-            let results = hnsw
+            let (results, _) = hnsw
                 .search_basic(query.clone(), 10, &params, None, storage)
                 .expect("storage that covers the graph must search");
             assert!(!results.is_empty());
@@ -3485,7 +3465,7 @@ mod tests {
             dist_q_c: 0.0,
             use_acorn: false,
         };
-        let results = loaded
+        let (results, _) = loaded
             .search_basic(query, 10, &params, None, store.as_ref())
             .expect("search must survive a dropped edge");
         assert!(!results.is_empty(), "the query still returns neighbors");

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -1905,10 +1905,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use arrow_array::cast::AsArray;
+    use arrow_array::types::Float32Type;
     use arrow_array::{
         ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, UInt8Array, UInt32Array,
     };
-    use arrow_schema::Schema;
+    use arrow_schema::{Schema, SchemaRef};
     use async_trait::async_trait;
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::{Error, Result, deepsize::DeepSizeOf};
@@ -1921,7 +1922,7 @@ mod tests {
     use lance_select::{RowAddrMask, RowAddrTreeMap};
     use lance_table::format::SelfDescribingFileReader;
     use lance_table::io::manifest::ManifestDescribing;
-    use lance_testing::datagen::generate_random_array;
+    use lance_testing::datagen::{generate_random_array, generate_random_array_with_seed};
     use object_store::path::Path;
     use rand::{Rng, SeedableRng, rngs::SmallRng};
     use rstest::rstest;
@@ -1930,13 +1931,13 @@ mod tests {
         HNSW_LEVEL_RNG_SEED, HNSW_METADATA_KEY, HnswBuilder, HnswGraph, ImmutableHnswBottomView,
         ImmutableHnswLevelView, MIN_HNSW_M, random_level_with,
     };
-    use crate::metrics::NoOpMetricsCollector;
-    use crate::prefilter::PreFilter;
+    use crate::metrics::{LocalMetricsCollector, NoOpMetricsCollector};
+    use crate::prefilter::{NoFilter, PreFilter};
     use crate::vector::graph::builder::GraphBuilderNode;
     use crate::vector::storage::{DistCalculator, VectorStore};
     use crate::vector::v3::subindex::IvfSubIndex;
     use crate::vector::{
-        flat::storage::{FlatBinStorage, FlatFloatStorage},
+        flat::storage::{FlatBinStorage, FlatFloatDistanceCalc, FlatFloatStorage},
         graph::{DISTS_FIELD, NEIGHBORS_FIELD, OrderedNode, VisitedGenerator},
         hnsw::{
             HNSW, HnswMetadata, VECTOR_ID_FIELD,
@@ -2765,6 +2766,117 @@ mod tests {
         }
     }
 
+    fn masked_prefilter(allowed: Vec<u64>) -> Arc<dyn PreFilter> {
+        Arc::new(MaskPreFilter {
+            mask: Arc::new(lance_select::RowAddrMask::from_allowed(
+                lance_select::RowAddrTreeMap::from_iter(allowed),
+            )),
+        })
+    }
+
+    /// Counts the distances a search actually computes, so a reported metric
+    /// can be checked against an independent oracle instead of a bound.
+    /// Prefetches are forwarded uncounted: they compute no distance, and the
+    /// default `prefetch_distance` keeps that path live.
+    #[derive(Clone)]
+    struct CountingStorage {
+        inner: FlatFloatStorage,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl CountingStorage {
+        fn new(inner: FlatFloatStorage) -> Self {
+            Self {
+                inner,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        /// Distances computed since the previous call.
+        fn take(&self) -> usize {
+            self.calls.swap(0, Ordering::Relaxed)
+        }
+    }
+
+    struct CountingDistCalc<'a> {
+        inner: FlatFloatDistanceCalc<'a>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl DistCalculator for CountingDistCalc<'_> {
+        fn distance(&self, id: u32) -> f32 {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.distance(id)
+        }
+
+        fn distance_all(&self, k_hint: usize) -> Vec<f32> {
+            let dists = self.inner.distance_all(k_hint);
+            self.calls.fetch_add(dists.len(), Ordering::Relaxed);
+            dists
+        }
+
+        fn prefetch(&self, id: u32) {
+            self.inner.prefetch(id);
+        }
+    }
+
+    impl VectorStore for CountingStorage {
+        type DistanceCalculator<'a> = CountingDistCalc<'a>;
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn schema(&self) -> &SchemaRef {
+            self.inner.schema()
+        }
+
+        fn to_batches(&self) -> lance_core::Result<impl Iterator<Item = RecordBatch> + Send> {
+            self.inner.to_batches()
+        }
+
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+
+        fn distance_type(&self) -> DistanceType {
+            self.inner.distance_type()
+        }
+
+        fn row_id(&self, id: u32) -> u64 {
+            self.inner.row_id(id)
+        }
+
+        fn row_ids(&self) -> impl Iterator<Item = &u64> {
+            self.inner.row_ids()
+        }
+
+        fn append_batch(
+            &self,
+            batch: RecordBatch,
+            vector_column: &str,
+        ) -> lance_core::Result<Self> {
+            Ok(Self {
+                inner: self.inner.append_batch(batch, vector_column)?,
+                calls: self.calls.clone(),
+            })
+        }
+
+        fn dist_calculator(&self, query: ArrayRef, dist_q_c: f32) -> Self::DistanceCalculator<'_> {
+            CountingDistCalc {
+                inner: self.inner.dist_calculator(query, dist_q_c),
+                calls: self.calls.clone(),
+            }
+        }
+
+        fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
+            CountingDistCalc {
+                inner: self.inner.dist_calculator_from_id(id),
+                calls: self.calls.clone(),
+            }
+        }
+    }
+
     /// Dispatch: dense prefilters take the graph traversal, sparse ones the
     /// exact flat scan, and both return only mask-passing row ids.
     #[tokio::test]
@@ -2792,18 +2904,13 @@ mod tests {
                 dist_q_c: 0.0,
                 use_acorn,
             };
-            let filter = Arc::new(MaskPreFilter {
-                mask: Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
-                    allowed,
-                ))),
-            });
             let batch = hnsw
                 .search(
                     query_key.clone(),
                     k,
                     params,
                     store.as_ref(),
-                    filter,
+                    masked_prefilter(allowed),
                     &NoOpMetricsCollector,
                 )
                 .unwrap();
@@ -2916,28 +3023,33 @@ mod tests {
         assert_eq!(search_row_ids((0..60).collect()), vec![0]);
     }
 
-    /// Every dispatch path reports the distances it computed, so an HNSW query
-    /// no longer shows up as zero comparisons in per-query metrics.
+    /// Every dispatch path reports exactly the distances it computed: the
+    /// metric is compared against a [CountingStorage] oracle, so a dropped or
+    /// double-counted call fails even though the reported number itself is
+    /// graph-dependent.
     #[tokio::test]
     async fn test_search_reports_distance_comparisons() {
-        use crate::metrics::LocalMetricsCollector;
-        use crate::prefilter::NoFilter;
-
         const DIM: usize = 32;
         const TOTAL: usize = 2048;
-        let fsl =
-            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
-                .unwrap();
-        let store = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+        let fsl = FixedSizeListArray::try_new_from_values(
+            generate_random_array_with_seed::<Float32Type>(TOTAL * DIM, [42; 32]),
+            DIM as i32,
+        )
+        .unwrap();
+        let store = FlatFloatStorage::new(fsl.clone(), DistanceType::L2);
         let hnsw = HNSW::index_vectors(
-            store.as_ref(),
+            &store,
             HnswBuildParams::default().num_edges(20).ef_construction(50),
         )
         .unwrap();
+        // build through the plain storage, search through the counting one, so
+        // only query-time distances reach the oracle
+        let counting = CountingStorage::new(store);
 
         let k = 10;
         let query_key = fsl.value(0);
-        let comparisons = |prefilter: Arc<dyn PreFilter>, use_acorn: bool| {
+        let reported = |prefilter: Arc<dyn PreFilter>, use_acorn: bool| {
+            counting.take();
             let metrics = LocalMetricsCollector::default();
             hnsw.search(
                 query_key.clone(),
@@ -2949,43 +3061,138 @@ mod tests {
                     dist_q_c: 0.0,
                     use_acorn,
                 },
-                store.as_ref(),
+                &counting,
                 prefilter,
                 &metrics,
             )
             .unwrap();
-            metrics.comparisons.load(Ordering::Relaxed)
-        };
-        let masked = |allowed: Vec<u64>| -> Arc<dyn PreFilter> {
-            Arc::new(MaskPreFilter {
-                mask: Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
-                    allowed,
-                ))),
-            })
+            let reported = metrics.comparisons.load(Ordering::Relaxed);
+            let computed = counting.take();
+            assert_eq!(
+                reported, computed,
+                "reported {reported} distances, computed {computed} (use_acorn={use_acorn})"
+            );
+            reported
         };
 
-        // Graph traversal, unfiltered: returning k results takes at least k
-        // distances, and the point of the graph is to stay well under a scan.
-        let unfiltered = comparisons(Arc::new(NoFilter), false);
+        // Unfiltered graph traversal: exact against the oracle, and the point
+        // of the graph is to stay under a full scan.
+        let unfiltered = reported(Arc::new(NoFilter), false);
         assert!(
             (k..TOTAL).contains(&unfiltered),
             "unfiltered comparisons {unfiltered} outside [{k}, {TOTAL})"
         );
 
-        // Sparse mask takes the exact flat scan, which scores every passing
-        // row exactly once, so the count is known rather than merely non-zero.
-        let sparse: Vec<u64> = (0..TOTAL as u64).step_by(25).collect();
-        assert_eq!(comparisons(masked(sparse.clone()), false), sparse.len());
+        // A mask that passes every row is dispatched as unfiltered, so it must
+        // cost exactly the same.
+        let all: Vec<u64> = (0..TOTAL as u64).collect();
+        assert_eq!(reported(masked_prefilter(all), false), unfiltered);
 
-        // Dense mask, both traversals.
+        // Sparse mask takes the exact flat scan, which scores every passing row
+        // once, so the count is also known up front.
+        let sparse: Vec<u64> = (0..TOTAL as u64).step_by(25).collect();
+        assert_eq!(
+            reported(masked_prefilter(sparse.clone()), false),
+            sparse.len()
+        );
+
+        // Dense mask, both graph traversals.
         let dense: Vec<u64> = (0..TOTAL as u64).step_by(2).collect();
         for use_acorn in [false, true] {
-            let dense_comparisons = comparisons(masked(dense.clone()), use_acorn);
-            assert!(
-                dense_comparisons >= k,
-                "dense comparisons {dense_comparisons} below k={k} (use_acorn={use_acorn})"
-            );
+            reported(masked_prefilter(dense.clone()), use_acorn);
         }
+    }
+
+    /// When ACORN under-delivers, the query re-runs the basic traversal and the
+    /// reported count is the sum of both: the abandoned work was still paid for.
+    #[tokio::test]
+    async fn test_acorn_fallback_reports_both_traversals() {
+        const DIM: usize = 32;
+        const TOTAL: usize = 2048;
+        const STEP: usize = 5;
+        let fsl = FixedSizeListArray::try_new_from_values(
+            generate_random_array_with_seed::<Float32Type>(TOTAL * DIM, [42; 32]),
+            DIM as i32,
+        )
+        .unwrap();
+        let store = FlatFloatStorage::new(fsl.clone(), DistanceType::L2);
+        // A low degree fragments the mask-passing subgraph, which is what
+        // starves the ACORN frontier in the first place; `MIN_HNSW_M` is as low
+        // as the builder allows. How many passing nodes end up unreachable is a
+        // property of the graph, and insertion runs in parallel, so build on a
+        // single-threaded pool: with the level RNG already seeded that makes the
+        // graph reproducible and keeps the fallback from being a coin flip.
+        let hnsw = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| {
+                HNSW::index_vectors(
+                    &store,
+                    HnswBuildParams::default()
+                        .num_edges(MIN_HNSW_M)
+                        .ef_construction(MIN_HNSW_M),
+                )
+            })
+            .unwrap();
+        let counting = CountingStorage::new(store);
+
+        let passing: Vec<u64> = (0..TOTAL as u64).step_by(STEP).collect();
+        let remained = passing.len();
+        // above the flat-scan threshold, so the query is dispatched to ACORN
+        assert!((TOTAL * 10 / 100..TOTAL).contains(&remained));
+        // `k.min(remained) == remained` demands every passing node, which the
+        // fragmented traversal cannot reach in full, so the fallback fires
+        let k = remained;
+        let params = HnswQueryParams {
+            ef: k,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+            use_acorn: true,
+        };
+        let query_key = fsl.value(0);
+
+        let mut generator = VisitedGenerator::new(TOTAL);
+        let mut bitset = generator.generate(TOTAL);
+        for id in &passing {
+            bitset.insert(*id as u32);
+        }
+        counting.take();
+        let (acorn_results, acorn_reported) = hnsw
+            .search_acorn_counted(query_key.clone(), k, &params, &bitset, &counting)
+            .unwrap();
+        assert_eq!(acorn_reported, counting.take());
+        assert!(
+            acorn_results.len() < k.min(remained),
+            "ACORN delivered {} of {} demanded, so the fallback is no longer forced",
+            acorn_results.len(),
+            k.min(remained)
+        );
+        drop(bitset);
+
+        let mut bitset = generator.generate(TOTAL);
+        for id in &passing {
+            bitset.insert(*id as u32);
+        }
+        let (_, basic_reported) = hnsw
+            .search_basic_counted(query_key.clone(), k, &params, Some(bitset), &counting)
+            .unwrap();
+        assert_eq!(basic_reported, counting.take());
+
+        let metrics = LocalMetricsCollector::default();
+        hnsw.search(
+            query_key,
+            k,
+            params,
+            &counting,
+            masked_prefilter(passing),
+            &metrics,
+        )
+        .unwrap();
+        let reported = metrics.comparisons.load(Ordering::Relaxed);
+        assert_eq!(reported, counting.take());
+        assert_eq!(reported, acorn_reported + basic_reported);
     }
 
     /// Every fresh `level_offsets` range must exactly delimit the rows emitted

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -3026,20 +3026,21 @@ mod tests {
     #[tokio::test]
     async fn test_acorn_fallback_reports_both_traversals() {
         const DIM: usize = 32;
-        const TOTAL: usize = 2048;
-        const STEP: usize = 5;
+        const TOTAL: usize = 4096;
+        const STEP: usize = 9;
         let fsl = FixedSizeListArray::try_new_from_values(
             generate_random_array_with_seed::<Float32Type>(TOTAL * DIM, [42; 32]),
             DIM as i32,
         )
         .unwrap();
         let store = FlatFloatStorage::new(fsl.clone(), DistanceType::L2);
-        // A low degree fragments the mask-passing subgraph, which is what
-        // starves the ACORN frontier in the first place; `MIN_HNSW_M` is as low
-        // as the builder allows. How many passing nodes end up unreachable is a
-        // property of the graph, and insertion runs in parallel, so build on a
-        // single-threaded pool: with the level RNG already seeded that makes the
-        // graph reproducible and keeps the fallback from being a coin flip.
+        // ACORN scores only mask-passing nodes and bridges through masked ones
+        // on a budget of `ACORN_BRIDGE_BUDGET_FACTOR * ef`, so a thin mask
+        // starves it: at one row in `STEP` the budget runs out with a handful
+        // of passing nodes still unreached, and `MIN_HNSW_M` keeps the degree
+        // low enough for that to bite. Insertion runs in parallel, so build on
+        // a single-threaded pool: with the level RNG already seeded that makes
+        // the graph reproducible and keeps the fallback from being a coin flip.
         let hnsw = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
             .build()
@@ -3060,7 +3061,7 @@ mod tests {
         // above the flat-scan threshold, so the query is dispatched to ACORN
         assert!((TOTAL * 10 / 100..TOTAL).contains(&remained));
         // `k.min(remained) == remained` demands every passing node, which the
-        // fragmented traversal cannot reach in full, so the fallback fires
+        // starved frontier cannot deliver in full, so the fallback fires
         let k = remained;
         let params = HnswQueryParams {
             ef: k,

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -347,6 +347,32 @@ impl HNSW {
         storage: &impl VectorStore,
         prefetch_distance: Option<usize>,
     ) -> Result<Vec<OrderedNode>> {
+        Ok(self
+            .search_inner_counted(
+                query,
+                k,
+                params,
+                bitset,
+                visited_generator,
+                storage,
+                prefetch_distance,
+            )?
+            .0)
+    }
+
+    /// [Self::search_inner], additionally reporting how many distances the
+    /// traversal computed.
+    #[allow(clippy::too_many_arguments)]
+    fn search_inner_counted(
+        &self,
+        query: ArrayRef,
+        k: usize,
+        params: &HnswQueryParams,
+        bitset: Option<Visited>,
+        visited_generator: &mut VisitedGenerator,
+        storage: &impl VectorStore,
+        prefetch_distance: Option<usize>,
+    ) -> Result<(Vec<OrderedNode>, usize)> {
         self.ensure_storage_covers_graph(storage)?;
         let dist_calc = storage.dist_calculator(query, params.dist_q_c);
         let entry = self.inner.entry_point;
@@ -357,7 +383,7 @@ impl HNSW {
         // generic over those view types so the loop is single-sourced:
         // each backend supplies a per-level view closure and a
         // bottom-level view.
-        let result = match &self.inner.graph {
+        let (result, comparisons) = match &self.inner.graph {
             HnswGraph::Built(nodes) => {
                 let nodes = nodes.as_slice();
                 self.run_search(
@@ -389,7 +415,8 @@ impl HNSW {
                 )
             }
         };
-        Ok(result)
+        // the entry point distance is computed above, outside the traversal
+        Ok((result, comparisons + 1))
     }
 
     /// Drives the shared HNSW query path over backend-specific graph
@@ -412,7 +439,7 @@ impl HNSW {
         dist_calc: &impl DistCalculator,
         make_level: impl Fn(u16) -> L,
         bottom: B,
-    ) -> Vec<OrderedNode>
+    ) -> (Vec<OrderedNode>, usize)
     where
         L: BorrowingGraph,
         B: BorrowingGraph,
@@ -423,17 +450,20 @@ impl HNSW {
         // minimum, which costs extra distance computations and measurably
         // hurts recall at low ef (https://github.com/lance-format/lance/issues/5208).
         let mut ep = ep;
+        let mut comparisons = 0;
         for level in (1..self.max_level()).rev() {
             let cur_level = make_level(level);
-            ep = greedy_search_borrowed(
+            let (next, level_comparisons) = greedy_search_borrowed(
                 &cur_level,
                 ep,
                 dist_calc,
                 self.inner.params.prefetch_distance,
             );
+            ep = next;
+            comparisons += level_comparisons;
         }
         let mut visited = visited_generator.generate(storage_len);
-        beam_search_borrowed(
+        let (results, beam_comparisons) = beam_search_borrowed(
             &bottom,
             &ep,
             params,
@@ -441,10 +471,12 @@ impl HNSW {
             bitset,
             prefetch_distance,
             &mut visited,
+        );
+        comparisons += beam_comparisons;
+        (
+            results.into_iter().take(k).collect::<Vec<OrderedNode>>(),
+            comparisons,
         )
-        .into_iter()
-        .take(k)
-        .collect::<Vec<OrderedNode>>()
     }
 
     #[instrument(level = "debug", skip(self, query, bitset, storage))]
@@ -456,12 +488,27 @@ impl HNSW {
         bitset: Option<Visited>,
         storage: &impl VectorStore,
     ) -> Result<Vec<OrderedNode>> {
+        Ok(self
+            .search_basic_counted(query, k, params, bitset, storage)?
+            .0)
+    }
+
+    /// [Self::search_basic], additionally reporting how many distances the
+    /// traversal computed.
+    fn search_basic_counted(
+        &self,
+        query: ArrayRef,
+        k: usize,
+        params: &HnswQueryParams,
+        bitset: Option<Visited>,
+        storage: &impl VectorStore,
+    ) -> Result<(Vec<OrderedNode>, usize)> {
         let mut visited_generator = self
             .inner
             .visited_generator_queue
             .pop()
             .unwrap_or_else(|| VisitedGenerator::new(storage.len()));
-        let result = self.search_inner(
+        let result = self.search_inner_counted(
             query,
             k,
             params,
@@ -491,6 +538,21 @@ impl HNSW {
         bitset: &Visited,
         storage: &impl VectorStore,
     ) -> Result<Vec<OrderedNode>> {
+        Ok(self
+            .search_acorn_counted(query, k, params, bitset, storage)?
+            .0)
+    }
+
+    /// [Self::search_acorn], additionally reporting how many distances the
+    /// traversal computed.
+    fn search_acorn_counted(
+        &self,
+        query: ArrayRef,
+        k: usize,
+        params: &HnswQueryParams,
+        bitset: &Visited,
+        storage: &impl VectorStore,
+    ) -> Result<(Vec<OrderedNode>, usize)> {
         let mut visited_generator = self
             .inner
             .visited_generator_queue
@@ -530,13 +592,13 @@ impl HNSW {
         expanded_generator: &mut VisitedGenerator,
         storage: &impl VectorStore,
         prefetch_distance: Option<usize>,
-    ) -> Result<Vec<OrderedNode>> {
+    ) -> Result<(Vec<OrderedNode>, usize)> {
         self.ensure_storage_covers_graph(storage)?;
         let dist_calc = storage.dist_calculator(query, params.dist_q_c);
         let entry = self.inner.entry_point;
         let ep = OrderedNode::new(entry, dist_calc.distance(entry).into());
 
-        let result = match &self.inner.graph {
+        let (result, comparisons) = match &self.inner.graph {
             HnswGraph::Built(nodes) => {
                 let nodes = nodes.as_slice();
                 self.run_search_acorn(
@@ -568,7 +630,8 @@ impl HNSW {
                 )
             }
         };
-        Ok(result.into_iter().take(k).collect())
+        // the entry point distance is computed above, outside the traversal
+        Ok((result.into_iter().take(k).collect(), comparisons + 1))
     }
 
     /// [Self::run_search] for the ACORN traversal: same level descent, but
@@ -586,7 +649,7 @@ impl HNSW {
         dist_calc: &impl DistCalculator,
         make_level: impl Fn(u16) -> L,
         bottom: B,
-    ) -> Vec<OrderedNode>
+    ) -> (Vec<OrderedNode>, usize)
     where
         L: BorrowingGraph,
         B: BorrowingGraph,
@@ -594,18 +657,21 @@ impl HNSW {
         // Same level descent as [Self::run_search]: greedy stops at level 1
         // (see the comment there); level 0 is left to the beam below.
         let mut ep = ep;
+        let mut comparisons = 0;
         for level in (1..self.max_level()).rev() {
             let cur_level = make_level(level);
-            ep = greedy_search_borrowed(
+            let (next, level_comparisons) = greedy_search_borrowed(
                 &cur_level,
                 ep,
                 dist_calc,
                 self.inner.params.prefetch_distance,
             );
+            ep = next;
+            comparisons += level_comparisons;
         }
         let mut visited = visited_generator.generate(storage_len);
         let mut expanded = expanded_generator.generate(storage_len);
-        beam_search_acorn(
+        let (results, beam_comparisons) = beam_search_acorn(
             &bottom,
             &ep,
             params,
@@ -614,7 +680,8 @@ impl HNSW {
             prefetch_distance,
             &mut visited,
             &mut expanded,
-        )
+        );
+        (results, comparisons + beam_comparisons)
     }
 
     #[instrument(level = "debug", skip(self, storage, query, prefilter_bitset))]
@@ -625,9 +692,11 @@ impl HNSW {
         k: usize,
         prefilter_bitset: Visited,
         params: &HnswQueryParams,
-    ) -> Vec<OrderedNode> {
+    ) -> (Vec<OrderedNode>, usize) {
         let lower_bound: OrderedFloat = params.lower_bound.unwrap_or(f32::MIN).into();
         let upper_bound: OrderedFloat = params.upper_bound.unwrap_or(f32::MAX).into();
+        // every set bit gets exactly one distance on both branches below
+        let comparisons = prefilter_bitset.count_ones();
 
         let dist_calc = storage.dist_calculator(query, params.dist_q_c);
         let mut heap = BinaryHeap::<OrderedNode>::with_capacity(k);
@@ -679,7 +748,7 @@ impl HNSW {
                 }
             }
         };
-        heap.into_sorted_vec()
+        (heap.into_sorted_vec(), comparisons)
     }
 
     /// Returns the metadata of this [`HNSW`].
@@ -837,7 +906,7 @@ impl HnswBuilder {
         // ```
         for level in (target_level + 1..=entry_level).rev() {
             let cur_level = HnswLevelView::new(level, nodes);
-            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance);
+            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance).0;
         }
 
         let mut pruned_neighbors_per_level: Vec<Vec<_>> =
@@ -903,6 +972,7 @@ impl HnswBuilder {
             self.params.prefetch_distance,
             &mut visited,
         )
+        .0
     }
 
     /// Give every node an inbound path from the entry point on level 0.
@@ -1608,7 +1678,7 @@ impl IvfSubIndex for HNSW {
         Some(&[VECTOR_ID_COL, NEIGHBORS_COL])
     }
 
-    #[instrument(level = "debug", skip(self, query, storage, prefilter, _metrics))]
+    #[instrument(level = "debug", skip(self, query, storage, prefilter, metrics))]
     fn search(
         &self,
         query: ArrayRef,
@@ -1616,7 +1686,7 @@ impl IvfSubIndex for HNSW {
         params: Self::QueryParams,
         storage: &impl VectorStore,
         prefilter: Arc<dyn PreFilter>,
-        _metrics: &dyn MetricsCollector,
+        metrics: &dyn MetricsCollector,
     ) -> Result<RecordBatch> {
         if params.ef < k {
             return Err(Error::index(
@@ -1634,8 +1704,8 @@ impl IvfSubIndex for HNSW {
             .visited_generator_queue
             .pop()
             .unwrap_or_else(|| VisitedGenerator::new(storage.len()));
-        let results = if prefilter.is_empty() {
-            self.search_basic(query, k, &params, None, storage)?
+        let (results, comparisons) = if prefilter.is_empty() {
+            self.search_basic_counted(query, k, &params, None, storage)?
         } else {
             // the bitset must be moved into a callee on every path so its
             // borrow of `prefilter_generator` ends before the push below
@@ -1648,27 +1718,41 @@ impl IvfSubIndex for HNSW {
             if remained == storage.len() {
                 // mask passes every row: same as unfiltered
                 drop(prefilter_bitset);
-                self.search_basic(query, k, &params, None, storage)?
+                self.search_basic_counted(query, k, &params, None, storage)?
             } else if remained < self.len() * 10 / 100 {
                 // few matching rows: brute force is cheaper and exact
                 self.flat_search(storage, query, k, prefilter_bitset, &params)
             } else if params.use_acorn {
-                let acorn_results =
-                    self.search_acorn(query.clone(), k, &params, &prefilter_bitset, storage)?;
+                let (acorn_results, acorn_comparisons) = self.search_acorn_counted(
+                    query.clone(),
+                    k,
+                    &params,
+                    &prefilter_bitset,
+                    storage,
+                )?;
                 // under-delivery means the budget ran out on a fragmented
                 // mask, except range-bounded queries which return short
                 // legitimately
                 let bounded = params.lower_bound.is_some() || params.upper_bound.is_some();
                 if !bounded && acorn_results.len() < k.min(remained) {
-                    self.search_basic(query, k, &params, Some(prefilter_bitset), storage)?
+                    // the abandoned ACORN traversal still cost its distances
+                    let (results, basic_comparisons) = self.search_basic_counted(
+                        query,
+                        k,
+                        &params,
+                        Some(prefilter_bitset),
+                        storage,
+                    )?;
+                    (results, acorn_comparisons + basic_comparisons)
                 } else {
                     drop(prefilter_bitset);
-                    acorn_results
+                    (acorn_results, acorn_comparisons)
                 }
             } else {
-                self.search_basic(query, k, &params, Some(prefilter_bitset), storage)?
+                self.search_basic_counted(query, k, &params, Some(prefilter_bitset), storage)?
             }
         };
+        metrics.record_comparisons(comparisons);
         // if the queue is full, we just don't push it back, so ignore the error here
         let _ = self.inner.visited_generator_queue.push(prefilter_generator);
 
@@ -2505,7 +2589,7 @@ mod tests {
         let ep = OrderedNode::new(0, dist_calc.distance(0).into());
         let mut visited_generator = VisitedGenerator::new(N);
 
-        let results = hnsw.run_search(
+        let (results, _) = hnsw.run_search(
             ep.clone(),
             3,
             &query_params,
@@ -2535,7 +2619,7 @@ mod tests {
         }
         let mut expanded_generator = VisitedGenerator::new(N);
         calls.store(0, Ordering::Relaxed);
-        let results = hnsw.run_search_acorn(
+        let (results, _) = hnsw.run_search_acorn(
             ep,
             &query_params,
             &mask,
@@ -2658,6 +2742,26 @@ mod tests {
             let hits = results.iter().filter(|n| truth.contains(&n.id)).count();
             let recall = hits as f32 / k as f32;
             assert!(recall >= 0.5, "recall {recall} below 0.5 (k={k})");
+        }
+    }
+
+    struct MaskPreFilter {
+        mask: Arc<lance_select::RowAddrMask>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::prefilter::PreFilter for MaskPreFilter {
+        async fn wait_for_ready(&self) -> lance_core::Result<()> {
+            Ok(())
+        }
+        fn is_empty(&self) -> bool {
+            false
+        }
+        fn mask(&self) -> Arc<lance_select::RowAddrMask> {
+            self.mask.clone()
+        }
+        fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64> {
+            self.mask.selected_indices(row_ids)
         }
     }
 
@@ -2810,6 +2914,78 @@ mod tests {
         // the graph. Both must include the lower bound and exclude the upper.
         assert_eq!(search_row_ids(vec![0, 1, 2]), vec![0]);
         assert_eq!(search_row_ids((0..60).collect()), vec![0]);
+    }
+
+    /// Every dispatch path reports the distances it computed, so an HNSW query
+    /// no longer shows up as zero comparisons in per-query metrics.
+    #[tokio::test]
+    async fn test_search_reports_distance_comparisons() {
+        use crate::metrics::LocalMetricsCollector;
+        use crate::prefilter::NoFilter;
+
+        const DIM: usize = 32;
+        const TOTAL: usize = 2048;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+        let hnsw = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+
+        let k = 10;
+        let query_key = fsl.value(0);
+        let comparisons = |prefilter: Arc<dyn PreFilter>, use_acorn: bool| {
+            let metrics = LocalMetricsCollector::default();
+            hnsw.search(
+                query_key.clone(),
+                k,
+                HnswQueryParams {
+                    ef: 50,
+                    lower_bound: None,
+                    upper_bound: None,
+                    dist_q_c: 0.0,
+                    use_acorn,
+                },
+                store.as_ref(),
+                prefilter,
+                &metrics,
+            )
+            .unwrap();
+            metrics.comparisons.load(Ordering::Relaxed)
+        };
+        let masked = |allowed: Vec<u64>| -> Arc<dyn PreFilter> {
+            Arc::new(MaskPreFilter {
+                mask: Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
+                    allowed,
+                ))),
+            })
+        };
+
+        // Graph traversal, unfiltered: returning k results takes at least k
+        // distances, and the point of the graph is to stay well under a scan.
+        let unfiltered = comparisons(Arc::new(NoFilter), false);
+        assert!(
+            (k..TOTAL).contains(&unfiltered),
+            "unfiltered comparisons {unfiltered} outside [{k}, {TOTAL})"
+        );
+
+        // Sparse mask takes the exact flat scan, which scores every passing
+        // row exactly once, so the count is known rather than merely non-zero.
+        let sparse: Vec<u64> = (0..TOTAL as u64).step_by(25).collect();
+        assert_eq!(comparisons(masked(sparse.clone()), false), sparse.len());
+
+        // Dense mask, both traversals.
+        let dense: Vec<u64> = (0..TOTAL as u64).step_by(2).collect();
+        for use_acorn in [false, true] {
+            let dense_comparisons = comparisons(masked(dense.clone()), use_acorn);
+            assert!(
+                dense_comparisons >= k,
+                "dense comparisons {dense_comparisons} below k={k} (use_acorn={use_acorn})"
+            );
+        }
     }
 
     /// Every fresh `level_offsets` range must exactly delimit the rows emitted

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -336,34 +336,9 @@ impl HNSW {
         Ok(())
     }
 
+    /// Returns the top-`k` results and the number of distances computed.
     #[allow(clippy::too_many_arguments)]
     pub fn search_inner(
-        &self,
-        query: ArrayRef,
-        k: usize,
-        params: &HnswQueryParams,
-        bitset: Option<Visited>,
-        visited_generator: &mut VisitedGenerator,
-        storage: &impl VectorStore,
-        prefetch_distance: Option<usize>,
-    ) -> Result<Vec<OrderedNode>> {
-        Ok(self
-            .search_inner_counted(
-                query,
-                k,
-                params,
-                bitset,
-                visited_generator,
-                storage,
-                prefetch_distance,
-            )?
-            .0)
-    }
-
-    /// [Self::search_inner], additionally reporting how many distances the
-    /// traversal computed.
-    #[allow(clippy::too_many_arguments)]
-    fn search_inner_counted(
         &self,
         query: ArrayRef,
         k: usize,
@@ -479,23 +454,9 @@ impl HNSW {
         )
     }
 
+    /// Returns the top-`k` results and the number of distances computed.
     #[instrument(level = "debug", skip(self, query, bitset, storage))]
     pub fn search_basic(
-        &self,
-        query: ArrayRef,
-        k: usize,
-        params: &HnswQueryParams,
-        bitset: Option<Visited>,
-        storage: &impl VectorStore,
-    ) -> Result<Vec<OrderedNode>> {
-        Ok(self
-            .search_basic_counted(query, k, params, bitset, storage)?
-            .0)
-    }
-
-    /// [Self::search_basic], additionally reporting how many distances the
-    /// traversal computed.
-    fn search_basic_counted(
         &self,
         query: ArrayRef,
         k: usize,
@@ -508,7 +469,7 @@ impl HNSW {
             .visited_generator_queue
             .pop()
             .unwrap_or_else(|| VisitedGenerator::new(storage.len()));
-        let result = self.search_inner_counted(
+        let result = self.search_inner(
             query,
             k,
             params,
@@ -530,22 +491,9 @@ impl HNSW {
 
     /// Like [Self::search_basic] but the bottom level runs
     /// [beam_search_acorn], which only scores mask-passing nodes.
+    ///
+    /// Also returns the number of distances computed.
     pub fn search_acorn(
-        &self,
-        query: ArrayRef,
-        k: usize,
-        params: &HnswQueryParams,
-        bitset: &Visited,
-        storage: &impl VectorStore,
-    ) -> Result<Vec<OrderedNode>> {
-        Ok(self
-            .search_acorn_counted(query, k, params, bitset, storage)?
-            .0)
-    }
-
-    /// [Self::search_acorn], additionally reporting how many distances the
-    /// traversal computed.
-    fn search_acorn_counted(
         &self,
         query: ArrayRef,
         k: usize,
@@ -1705,7 +1653,7 @@ impl IvfSubIndex for HNSW {
             .pop()
             .unwrap_or_else(|| VisitedGenerator::new(storage.len()));
         let (results, comparisons) = if prefilter.is_empty() {
-            self.search_basic_counted(query, k, &params, None, storage)?
+            self.search_basic(query, k, &params, None, storage)?
         } else {
             // the bitset must be moved into a callee on every path so its
             // borrow of `prefilter_generator` ends before the push below
@@ -1718,38 +1666,28 @@ impl IvfSubIndex for HNSW {
             if remained == storage.len() {
                 // mask passes every row: same as unfiltered
                 drop(prefilter_bitset);
-                self.search_basic_counted(query, k, &params, None, storage)?
+                self.search_basic(query, k, &params, None, storage)?
             } else if remained < self.len() * 10 / 100 {
                 // few matching rows: brute force is cheaper and exact
                 self.flat_search(storage, query, k, prefilter_bitset, &params)
             } else if params.use_acorn {
-                let (acorn_results, acorn_comparisons) = self.search_acorn_counted(
-                    query.clone(),
-                    k,
-                    &params,
-                    &prefilter_bitset,
-                    storage,
-                )?;
+                let (acorn_results, acorn_comparisons) =
+                    self.search_acorn(query.clone(), k, &params, &prefilter_bitset, storage)?;
                 // under-delivery means the budget ran out on a fragmented
                 // mask, except range-bounded queries which return short
                 // legitimately
                 let bounded = params.lower_bound.is_some() || params.upper_bound.is_some();
                 if !bounded && acorn_results.len() < k.min(remained) {
                     // the abandoned ACORN traversal still cost its distances
-                    let (results, basic_comparisons) = self.search_basic_counted(
-                        query,
-                        k,
-                        &params,
-                        Some(prefilter_bitset),
-                        storage,
-                    )?;
+                    let (results, basic_comparisons) =
+                        self.search_basic(query, k, &params, Some(prefilter_bitset), storage)?;
                     (results, acorn_comparisons + basic_comparisons)
                 } else {
                     drop(prefilter_bitset);
                     (acorn_results, acorn_comparisons)
                 }
             } else {
-                self.search_basic_counted(query, k, &params, Some(prefilter_bitset), storage)?
+                self.search_basic(query, k, &params, Some(prefilter_bitset), storage)?
             }
         };
         metrics.record_comparisons(comparisons);
@@ -2032,10 +1970,10 @@ mod tests {
             dist_q_c: 0.0,
             use_acorn: false,
         };
-        let builder_results = builder
+        let (builder_results, _) = builder
             .search_basic(query.clone(), k, &params, None, store.as_ref())
             .unwrap();
-        let loaded_results = loaded_hnsw
+        let (loaded_results, _) = loaded_hnsw
             .search_basic(query, k, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(builder_results, loaded_results);
@@ -2094,10 +2032,10 @@ mod tests {
             dist_q_c: 0.0,
             use_acorn: false,
         };
-        let builder_results = builder
+        let (builder_results, _) = builder
             .search_basic(query.clone(), k, &params, None, store.as_ref())
             .unwrap();
-        let loaded_results = loaded_hnsw
+        let (loaded_results, _) = loaded_hnsw
             .search_basic(query, k, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(builder_results, loaded_results);
@@ -2356,7 +2294,7 @@ mod tests {
         )
         .unwrap();
         assert_all_reachable_on_level0(&hnsw);
-        let results = hnsw
+        let (results, _) = hnsw
             .search_basic(
                 vectors.value(0),
                 TOTAL,
@@ -2490,10 +2428,10 @@ mod tests {
         };
         let query = fsl.value(0);
 
-        let builder_results = builder
+        let (builder_results, _) = builder
             .search_basic(query.clone(), k, &params, None, store.as_ref())
             .unwrap();
-        let loaded_results = loaded
+        let (loaded_results, _) = loaded
             .search_basic(query.clone(), k, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(builder_results, loaded_results);
@@ -2701,7 +2639,7 @@ mod tests {
             for id in (0..TOTAL as u32).step_by(2) {
                 bitset.insert(id);
             }
-            let results = hnsw
+            let (results, _) = hnsw
                 .search_acorn(query.clone(), k, &params, &bitset, store.as_ref())
                 .unwrap();
             assert_eq!(results.len(), k);
@@ -2729,7 +2667,7 @@ mod tests {
                 brute_force_topk_masked(store.as_ref(), query.clone(), k, passes)
                     .into_iter()
                     .collect();
-            let results = builder
+            let (results, _) = builder
                 .search_acorn(
                     query.clone(),
                     k,
@@ -2930,7 +2868,7 @@ mod tests {
 
         // All-pass mask: shortcuts to the unfiltered path.
         let all: Vec<u64> = (0..TOTAL as u64).collect();
-        let unfiltered = hnsw
+        let (unfiltered, _) = hnsw
             .search_basic(
                 query_key.clone(),
                 k,
@@ -3160,7 +3098,7 @@ mod tests {
         }
         counting.take();
         let (acorn_results, acorn_reported) = hnsw
-            .search_acorn_counted(query_key.clone(), k, &params, &bitset, &counting)
+            .search_acorn(query_key.clone(), k, &params, &bitset, &counting)
             .unwrap();
         assert_eq!(acorn_reported, counting.take());
         assert!(
@@ -3176,7 +3114,7 @@ mod tests {
             bitset.insert(*id as u32);
         }
         let (_, basic_reported) = hnsw
-            .search_basic_counted(query_key.clone(), k, &params, Some(bitset), &counting)
+            .search_basic(query_key.clone(), k, &params, Some(bitset), &counting)
             .unwrap();
         assert_eq!(basic_reported, counting.take());
 
@@ -3330,10 +3268,10 @@ mod tests {
         assert_eq!(query_indices.len(), 3);
         for query_index in query_indices {
             let query = fsl.value(query_index);
-            let builder_results = builder
+            let (builder_results, _) = builder
                 .search_basic(query.clone(), 10, &params, None, store.as_ref())
                 .unwrap();
-            let loaded_results = loaded
+            let (loaded_results, _) = loaded
                 .search_basic(query, 10, &params, None, store.as_ref())
                 .unwrap();
             assert_eq!(builder_results, loaded_results);
@@ -3645,10 +3583,10 @@ mod tests {
             use_acorn: false,
         };
         let query = fsl.value(7);
-        let a = builder
+        let (a, _) = builder
             .search_basic(query.clone(), 10, &params, None, store.as_ref())
             .unwrap();
-        let b = reloaded
+        let (b, _) = reloaded
             .search_basic(query, 10, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(a, b);

--- a/rust/lance-index/src/vector/hnsw/online.rs
+++ b/rust/lance-index/src/vector/hnsw/online.rs
@@ -262,7 +262,7 @@ impl OnlineHnswBuilder {
         // Walk down upper levels with greedy_search to refine the entry point.
         for level in (target_level + 1..=entry_target_level).rev() {
             let cur_level = OnlineHnswLevelView::new(level, nodes);
-            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance);
+            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance).0;
         }
 
         // Insert at each level from target_level down to 0.
@@ -364,6 +364,7 @@ impl OnlineHnswBuilder {
             self.params.prefetch_distance,
             &mut visited,
         )
+        .0
     }
 
     fn prune(
@@ -420,7 +421,7 @@ impl OnlineHnswBuilder {
         let nodes = self.nodes.as_slice();
         for level in (1..=nodes[entry as usize].target_level()).rev() {
             let cur_level = OnlineHnswLevelView::new(level, nodes);
-            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance);
+            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance).0;
         }
 
         let bottom = OnlineHnswBottomView::new(nodes);
@@ -432,7 +433,7 @@ impl OnlineHnswBuilder {
             dist_q_c: 0.0,
             use_acorn: false,
         };
-        let result = beam_search(
+        let (result, _) = beam_search(
             &bottom,
             &ep,
             &params,

--- a/rust/lance-index/src/vector/hnsw/online.rs
+++ b/rust/lance-index/src/vector/hnsw/online.rs
@@ -743,7 +743,7 @@ mod tests {
 
         let hnsw = builder.finalize();
         let mut visited = VisitedGenerator::new(N);
-        let bottom_results = hnsw
+        let (bottom_results, _) = hnsw
             .search_inner(
                 fsl.value(0),
                 10,

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -167,7 +167,7 @@ impl SimpleIndex {
             dist_q_c: 0.0,
             use_acorn: false,
         };
-        let res = match &self.store {
+        let (res, _) = match &self.store {
             SimpleStore::Float(store) => self.index.search_basic(query, 1, &params, None, store)?,
             SimpleStore::Binary(store) => {
                 let query = if query.data_type() == &DataType::UInt8 {


### PR DESCRIPTION
`HNSW::search` takes `_metrics: &dyn MetricsCollector` and never touches it, so every HNSW query reports zero distance comparisons in per-query metrics while `FlatIndex` reports real numbers for the same workload. That makes the comparison count useless for exactly the case it is most interesting in: judging whether a graph traversal is doing more work than a scan would.

## Change

The traversal primitives in `graph.rs` now return how many distances they computed alongside their results, and `HNSW::search` sums the paths it actually took and reports the total in a single `record_comparisons` call.

Counting happens where the distance is computed, so all four dispatch paths are covered: the unfiltered graph traversal, the filtered one, the ACORN traversal, and the exact flat scan. Two details worth calling out:

- The flat scan needs no loop instrumentation, since it scores every set bit in the mask exactly once, so its count is `count_ones()`.
- When ACORN under-delivers and falls back to the basic traversal, both traversals' distances are summed. The abandoned work was still paid for.

The entry point distance is computed outside the traversal, so it is added explicitly rather than being silently dropped.

## Cost

The hot loops gain one `usize` increment per distance computation, which is the accumulate-locally-report-once shape the other index types already use (`wand.rs` does the same with its `comparisons` field). Index construction is unaffected: the build path goes through `beam_search` and `greedy_search`, the query path through the `_borrowed` variants and `beam_search_acorn`, and the two sets are disjoint.

`search_basic`, `search_acorn`, and `search_inner` keep their existing signatures, since they are public and have callers in the benches and examples. The counted variants sit underneath them.

## Tests

`test_search_reports_distance_comparisons` covers all four dispatch paths. The sparse-mask case asserts an exact count rather than merely a non-zero one, since the flat scan's work is known up front. The test fails on `main` (every path reports 0) and passes here.

`MaskPreFilter` moved from inside `test_subindex_prefilter_dispatch` to the enclosing test module so both tests can use it.
