### PR TITLE
fix(index): resolve nested vector index field paths

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2053,22 +2053,17 @@ def test_read_partition(indexed_dataset):
         VectorIndexReader(indexed_dataset, "id_idx")
 
 
-@pytest.mark.parametrize(
-    ("field_name", "column"),
-    [
-        ("embedding", "data.embedding"),
-        ("embedding.v1", "data.`embedding.v1`"),
-    ],
-)
-def test_read_partition_nested_vector(tmp_path, field_name, column):
+def test_read_partition_nested_vector_quoted_field(tmp_path):
     num_rows = 1024
     dimensions = 8
-    values = np.arange(num_rows * dimensions, dtype=np.uint8)
+    rng = np.random.default_rng(42)
+    values = rng.integers(0, 256, size=num_rows * dimensions, dtype=np.uint8)
     vectors = pa.FixedSizeListArray.from_arrays(pa.array(values), dimensions)
-    nested = pa.StructArray.from_arrays([vectors], names=[field_name])
+    nested = pa.StructArray.from_arrays([vectors], names=["embedding.v1"])
     dataset = lance.write_dataset(pa.table({"data": nested}), tmp_path)
+    # Match nested uint8 pHash indexes without introducing PQ training setup.
     dataset = dataset.create_index(
-        column,
+        "data.`embedding.v1`",
         index_type="IVF_FLAT",
         name="vector_idx",
         metric="hamming",
@@ -2076,13 +2071,14 @@ def test_read_partition_nested_vector(tmp_path, field_name, column):
     )
 
     reader = VectorIndexReader(dataset, "vector_idx")
-    partitions = [
-        reader.read_partition(partition_id)
-        for partition_id in range(reader.num_partitions())
-    ]
+    for with_vector in (False, True):
+        partitions = [
+            reader.read_partition(partition_id, with_vector=with_vector)
+            for partition_id in range(reader.num_partitions())
+        ]
 
-    assert all("_rowid" in partition.column_names for partition in partitions)
-    assert sum(partition.num_rows for partition in partitions) == num_rows
+        assert all("_rowid" in partition.column_names for partition in partitions)
+        assert sum(partition.num_rows for partition in partitions) == num_rows
 
 
 def test_vector_index_with_prefilter_and_scalar_index(indexed_dataset):
@@ -2303,6 +2299,14 @@ def test_nested_field_vector_index(tmp_path):
     indices = dataset.describe_indices()
     assert len(indices) == 1
     assert indices[0].field_names == ["data.embedding"]
+
+    reader = VectorIndexReader(dataset, indices[0].name)
+    for with_vector in (False, True):
+        partition_rows = sum(
+            reader.read_partition(partition_id, with_vector=with_vector).num_rows
+            for partition_id in range(reader.num_partitions())
+        )
+        assert partition_rows == num_rows
 
     # Test querying with the index
     query_vec = vectors[0]

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2053,6 +2053,38 @@ def test_read_partition(indexed_dataset):
         VectorIndexReader(indexed_dataset, "id_idx")
 
 
+@pytest.mark.parametrize(
+    ("field_name", "column"),
+    [
+        ("embedding", "data.embedding"),
+        ("embedding.v1", "data.`embedding.v1`"),
+    ],
+)
+def test_read_partition_nested_vector(tmp_path, field_name, column):
+    num_rows = 1024
+    dimensions = 8
+    values = np.arange(num_rows * dimensions, dtype=np.uint8)
+    vectors = pa.FixedSizeListArray.from_arrays(pa.array(values), dimensions)
+    nested = pa.StructArray.from_arrays([vectors], names=[field_name])
+    dataset = lance.write_dataset(pa.table({"data": nested}), tmp_path)
+    dataset = dataset.create_index(
+        column,
+        index_type="IVF_FLAT",
+        name="vector_idx",
+        metric="hamming",
+        num_partitions=4,
+    )
+
+    reader = VectorIndexReader(dataset, "vector_idx")
+    partitions = [
+        reader.read_partition(partition_id)
+        for partition_id in range(reader.num_partitions())
+    ]
+
+    assert all("_rowid" in partition.column_names for partition in partitions)
+    assert sum(partition.num_rows for partition in partitions) == num_rows
+
+
 def test_vector_index_with_prefilter_and_scalar_index(indexed_dataset):
     uri = indexed_dataset.uri
     new_table = create_table()

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1988,10 +1988,9 @@ impl DatasetIndexExt for Dataset {
         if indices.is_empty() {
             return Err(Error::index_not_found(format!("name={}", index_name)));
         }
-        let column = self.schema().field_by_id(indices[0].fields[0]).unwrap();
-        let logical_index = self
-            .open_logical_vector_index(&column.name, index_name)
-            .await?;
+        let field_id = indices[0].fields[0];
+        let column = self.schema().field_path(field_id)?;
+        let logical_index = self.open_logical_vector_index(&column, index_name).await?;
         logical_index
             .as_ivf()?
             .read_partition(partition_id, with_vector)

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1989,8 +1989,10 @@ impl DatasetIndexExt for Dataset {
             return Err(Error::index_not_found(format!("name={}", index_name)));
         }
         let field_id = indices[0].fields[0];
-        let column = self.schema().field_path(field_id)?;
-        let logical_index = self.open_logical_vector_index(&column, index_name).await?;
+        let field_path = self.schema().field_path(field_id)?;
+        let logical_index = self
+            .open_logical_vector_index(&field_path, index_name)
+            .await?;
         logical_index
             .as_ivf()?
             .read_partition(partition_id, with_vector)


### PR DESCRIPTION
## Summary

- resolve a vector index's column from its stored field ID using the canonical schema path
- cover partition reads for nested vector fields with both ordinary and quoted path segments
- exercise partition reads both with and without stored vector data

## Problem

`VectorIndexReader.read_partition` resolved the index metadata's field ID but passed only the leaf field name to the logical vector index opener. For a nested field such as `image_phash_v1.h1`, that changed the column path to `h1`, which cannot be resolved from the root schema.

This blocked direct IVF partition reads for otherwise healthy nested vector indexes, even though nearest-neighbor queries could still use those indexes.

## Fix

Use `Schema::field_path` to reconstruct the canonical path from the indexed field ID before opening the logical vector index. This also preserves the required quoting for field names containing dots or backticks.

## Testing

- `uv run pytest python/tests/test_vector_index.py::test_read_partition python/tests/test_vector_index.py::test_read_partition_nested_vector_quoted_field python/tests/test_vector_index.py::test_nested_field_vector_index`
- `uv run make lint`
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`

## Follow-up

- #8149 tracks the same leaf-name bug in `initialize_index`, which affects a separate index initialization workflow.