### PR TITLE
perf(fts): bound compound score-floor tie buffering

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -7,6 +7,12 @@ pub const AND_CANDIDATES_SEEN_METRIC: &str = "and_candidates_seen";
 pub const AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC: &str = "and_candidates_pruned_before_return";
 pub const AND_FULL_SCORES_METRIC: &str = "and_full_scores";
 pub const FREQS_COLLECTED_METRIC: &str = "freqs_collected";
+pub const COMPOUND_ADDRESSES_RESOLVED_METRIC: &str = "compound_addresses_resolved";
+pub const COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC: &str = "compound_address_resolution_batches";
+pub const COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC: &str =
+    "compound_peak_address_resolution_batch_size";
+pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_overflows";
+pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
 
 /// A trait used by the index to report metrics
 ///
@@ -84,6 +90,21 @@ pub trait MetricsCollector: Send + Sync {
     fn record_and_full_scores(&self, _num_scores: usize) {}
 
     fn record_freqs_collected(&self, _num_collections: usize) {}
+
+    /// Record compound FTS document addresses resolved for final row-ID ties.
+    fn record_compound_addresses_resolved(&self, _num_addresses: usize) {}
+
+    /// Record bounded compound FTS address-resolution batches.
+    fn record_compound_address_resolution_batches(&self, _num_batches: usize) {}
+
+    /// Record the largest compound FTS address-resolution batch.
+    fn record_compound_peak_address_resolution_batch_size(&self, _num_addresses: usize) {}
+
+    /// Record unresolved score floors that required a resolved-key retry.
+    fn record_compound_score_floor_overflows(&self, _num_overflows: usize) {}
+
+    /// Record a candidate-buffer high-water mark for compound FTS.
+    fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BinaryHeap, HashSet};
+use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -15,7 +15,7 @@ use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
 use super::{
     InvertedIndex, build_global_bm25_scorer,
     document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer},
-    documents::{DocId, DocLengths, DocVisibility},
+    documents::{DocId, DocLengths, DocVisibility, PartitionDocuments, ResidentAddressProjection},
     index::{DocSet, InvertedPartition},
     query::{
         FtsQuery, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens, collect_query_tokens,
@@ -30,6 +30,7 @@ use super::{
 use crate::{metrics::MetricsCollector, prefilter::PreFilter};
 
 const DEFAULT_BLOCK_SIZE: usize = 128;
+const SCORE_FLOOR_RESOLUTION_BATCH_SIZE: usize = DEFAULT_BLOCK_SIZE;
 
 /// One exact FTS result in a compound collector's candidate domain.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -625,16 +626,29 @@ fn compare_scored_rows<K: Ord>(left: &ScoredRow<K>, right: &ScoredRow<K>) -> Ord
         .then_with(|| left.row_id.cmp(&right.row_id))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CollectionStatus {
+    Complete,
+    ScoreFloorOverflow,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TieHandling {
+    ResolveByKey,
+    RetainScoreFloor { max_buffered: usize },
+}
+
 /// The sole owner of top-k state for a compound scorer tree.
 ///
-/// The heap retains every candidate tied at the kth score. Some document keys
-/// are only resolvable to row ids asynchronously, so equal-score candidates
-/// cannot be trimmed by their temporary keys without changing the final
-/// row-id tie-break.
+/// Resolved document keys use the normal `(score DESC, row_id ASC)` ordering
+/// and keep exactly `limit` rows. An unresolved partition temporarily retains
+/// its kth-score floor, but stops once the bounded resolution buffer fills.
 pub(super) struct TopKCollector<K = u64> {
     limit: usize,
     heap: BinaryHeap<HeapRow<K>>,
     competitive_score: Arc<CompetitiveScore>,
+    tie_handling: TieHandling,
+    peak_buffered: usize,
 }
 
 impl<K: Copy + Ord> TopKCollector<K> {
@@ -646,35 +660,89 @@ impl<K: Copy + Ord> TopKCollector<K> {
         limit: usize,
         competitive_score: Arc<CompetitiveScore>,
     ) -> Self {
+        Self::with_tie_handling(limit, competitive_score, TieHandling::ResolveByKey)
+    }
+
+    fn retaining_score_floor(
+        limit: usize,
+        competitive_score: Arc<CompetitiveScore>,
+        max_buffered: usize,
+    ) -> Self {
+        debug_assert!(max_buffered >= limit);
+        Self::with_tie_handling(
+            limit,
+            competitive_score,
+            TieHandling::RetainScoreFloor { max_buffered },
+        )
+    }
+
+    fn with_tie_handling(
+        limit: usize,
+        competitive_score: Arc<CompetitiveScore>,
+        tie_handling: TieHandling,
+    ) -> Self {
         Self {
             limit,
             heap: BinaryHeap::with_capacity(limit.min(DEFAULT_BLOCK_SIZE)),
             competitive_score,
+            tie_handling,
+            peak_buffered: 0,
         }
     }
 
-    fn insert(&mut self, row: ScoredRow<K>) {
+    fn insert(&mut self, row: ScoredRow<K>) -> CollectionStatus {
         if self.limit == 0 {
-            return;
+            return CollectionStatus::Complete;
         }
         if self.heap.len() < self.limit {
             self.heap.push(HeapRow(row));
         } else {
-            let floor = self
-                .heap
-                .peek()
-                .expect("a full top-k heap is non-empty")
-                .0
-                .score;
-            match row.score.total_cmp(&floor) {
+            let worst = self.heap.peek().expect("a full top-k heap is non-empty").0;
+            match row.score.total_cmp(&worst.score) {
                 Ordering::Less => {}
-                Ordering::Equal => self.heap.push(HeapRow(row)),
+                Ordering::Equal => match self.tie_handling {
+                    TieHandling::ResolveByKey => {
+                        if row.row_id < worst.row_id {
+                            self.heap.pop();
+                            self.heap.push(HeapRow(row));
+                        }
+                    }
+                    TieHandling::RetainScoreFloor { max_buffered } => {
+                        if self.heap.len() >= max_buffered {
+                            self.raise_competitive_score();
+                            return CollectionStatus::ScoreFloorOverflow;
+                        }
+                        self.heap.push(HeapRow(row));
+                    }
+                },
                 Ordering::Greater => {
-                    self.heap.push(HeapRow(row));
-                    self.prune_obsolete_score_floors();
+                    match self.tie_handling {
+                        TieHandling::ResolveByKey => {
+                            self.heap.pop();
+                            self.heap.push(HeapRow(row));
+                        }
+                        TieHandling::RetainScoreFloor { max_buffered } => {
+                            self.heap.push(HeapRow(row));
+                            self.prune_obsolete_score_floors();
+                            if self.heap.len() > max_buffered {
+                                // This collector is discarded and the partition is
+                                // retried with resolved keys. Keep its observable
+                                // working set within the advertised bound meanwhile.
+                                self.heap.pop();
+                                self.raise_competitive_score();
+                                return CollectionStatus::ScoreFloorOverflow;
+                            }
+                        }
+                    }
                 }
             }
         }
+        self.peak_buffered = self.peak_buffered.max(self.heap.len());
+        self.raise_competitive_score();
+        CollectionStatus::Complete
+    }
+
+    fn raise_competitive_score(&self) {
         if self.heap.len() >= self.limit
             && let Some(worst) = self.heap.peek()
         {
@@ -707,11 +775,15 @@ impl<K: Copy + Ord> TopKCollector<K> {
         &mut self,
         scorer: &mut dyn ComposableScorer,
         mut map_document: impl FnMut(u64) -> Result<K>,
-    ) -> Result<()> {
+    ) -> Result<CollectionStatus> {
         if self.limit == 0 {
-            return Ok(());
+            return Ok(CollectionStatus::Complete);
         }
-        let expected = scorer.cost().min(self.limit);
+        let capacity_limit = match self.tie_handling {
+            TieHandling::ResolveByKey => self.limit,
+            TieHandling::RetainScoreFloor { max_buffered } => max_buffered,
+        };
+        let expected = scorer.cost().min(capacity_limit);
         self.heap
             .reserve(expected.saturating_sub(self.heap.capacity()));
 
@@ -748,28 +820,30 @@ impl<K: Copy + Ord> TopKCollector<K> {
                             "compound FTS scorer did not expose its current document key",
                         )
                     })?;
-                    self.insert(ScoredRow {
+                    let status = self.insert(ScoredRow {
                         row_id: map_document(document_key)?,
                         score,
                     });
+                    if status == CollectionStatus::ScoreFloorOverflow {
+                        return Ok(status);
+                    }
                 }
             }
             doc = scorer.next()?;
         }
 
-        Ok(())
+        Ok(CollectionStatus::Complete)
     }
 
-    fn into_score_floor_rows(self) -> Vec<ScoredRow<K>> {
+    fn into_candidates(self) -> Vec<ScoredRow<K>> {
         let mut rows = self.heap.into_iter().map(|row| row.0).collect::<Vec<_>>();
         rows.sort_unstable_by(compare_scored_rows);
         rows
     }
 
-    #[cfg(test)]
     fn into_rows(self) -> Vec<ScoredRow<K>> {
         let limit = self.limit;
-        let mut rows = self.into_score_floor_rows();
+        let mut rows = self.into_candidates();
         rows.truncate(limit);
         rows
     }
@@ -1723,14 +1797,17 @@ struct LoadedLeaf {
 enum LoadedDocuments {
     Legacy(Arc<DocSet>),
     Modern {
+        documents: Arc<PartitionDocuments>,
         lengths: Arc<DocLengths>,
         visibility: DocVisibility,
+        projection: Option<ResidentAddressProjection>,
     },
 }
 
 struct LoadedPartition {
     segment_ordinal: usize,
     partition_ordinal: usize,
+    partition: Arc<InvertedPartition>,
     documents: LoadedDocuments,
     leaves: Vec<LoadedLeaf>,
 }
@@ -1802,38 +1879,59 @@ async fn load_compound_partition(
             Some(lengths) => lengths,
             None => documents.lengths().await?,
         };
+        let projection = documents.resident_address_projection();
         LoadedDocuments::Modern {
+            documents,
             lengths,
             visibility,
+            projection,
         }
     };
 
     Ok(Some(LoadedPartition {
         segment_ordinal,
         partition_ordinal,
+        partition,
         documents,
         leaves,
     }))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum CompoundDocument {
-    Legacy(u64),
-    Modern {
-        segment_ordinal: u32,
-        partition_ordinal: u32,
-        doc_id: u32,
-    },
+struct DeferredCompoundRows {
+    documents: Arc<PartitionDocuments>,
+    rows: Vec<ScoredRow<DocId>>,
 }
 
-fn collect_partition_with_documents<D: WandDocuments + Sync>(
+struct OverflowedCompoundPartition {
+    segment_ordinal: usize,
+    partition_ordinal: usize,
+    partition: Arc<InvertedPartition>,
+    documents: Arc<PartitionDocuments>,
+}
+
+enum PartitionCollectionBoundary {
+    Deferred(DeferredCompoundRows),
+    Overflow(OverflowedCompoundPartition),
+}
+
+struct CollectedPartitions {
+    collector: TopKCollector<u64>,
+    remaining: Vec<LoadedPartition>,
+    boundary: Option<PartitionCollectionBoundary>,
+}
+
+fn collect_partition_with_documents<D, K>(
     documents: &D,
     leaves: Vec<LoadedLeaf>,
     plan: &CompoundScorerPlan,
     metrics: &dyn MetricsCollector,
-    collector: &mut TopKCollector<CompoundDocument>,
-    mut map_document: impl FnMut(u64) -> Result<CompoundDocument>,
-) -> Result<()> {
+    collector: &mut TopKCollector<K>,
+    mut map_document: impl FnMut(u64) -> Result<K>,
+) -> Result<CollectionStatus>
+where
+    D: WandDocuments + Sync,
+    K: Copy + Ord,
+{
     let mut leaf_scorers = leaves
         .into_iter()
         .map(|leaf| {
@@ -1866,127 +1964,196 @@ fn collect_loaded_partitions(
     plan: &CompoundScorerPlan,
     mask: &RowAddrMask,
     metrics: &dyn MetricsCollector,
-    mut collector: TopKCollector<CompoundDocument>,
-) -> Result<TopKCollector<CompoundDocument>> {
-    for partition in partitions {
-        match partition.documents {
+    mut collector: TopKCollector<u64>,
+) -> Result<CollectedPartitions> {
+    let mut partitions = partitions.into_iter();
+    while let Some(partition) = partitions.next() {
+        let LoadedPartition {
+            segment_ordinal,
+            partition_ordinal,
+            partition: source,
+            documents,
+            leaves,
+        } = partition;
+        match documents {
             LoadedDocuments::Legacy(docs) => {
                 let documents = LegacyWandDocuments::new(docs.as_ref(), mask);
-                collect_partition_with_documents(
+                let status = collect_partition_with_documents(
                     &documents,
-                    partition.leaves,
+                    leaves,
                     plan,
                     metrics,
                     &mut collector,
-                    |row_id| Ok(CompoundDocument::Legacy(row_id)),
+                    Ok,
                 )?;
+                debug_assert_eq!(status, CollectionStatus::Complete);
             }
             LoadedDocuments::Modern {
+                documents: partition_documents,
                 lengths,
                 visibility,
+                projection,
             } => {
-                let segment_ordinal = u32::try_from(partition.segment_ordinal).map_err(|_| {
-                    Error::index(format!(
-                        "FTS segment ordinal {} exceeds u32::MAX",
-                        partition.segment_ordinal
-                    ))
-                })?;
-                let partition_ordinal =
-                    u32::try_from(partition.partition_ordinal).map_err(|_| {
-                        Error::index(format!(
-                            "FTS partition ordinal {} exceeds u32::MAX",
-                            partition.partition_ordinal
-                        ))
-                    })?;
                 let documents = ModernWandDocuments::filtered(lengths.as_ref(), &visibility);
-                collect_partition_with_documents(
-                    &documents,
-                    partition.leaves,
-                    plan,
-                    metrics,
-                    &mut collector,
-                    |doc_id| {
-                        Ok(CompoundDocument::Modern {
-                            segment_ordinal,
-                            partition_ordinal,
-                            doc_id: u32::try_from(doc_id).map_err(|_| {
+                if let Some(projection) = projection {
+                    let mut addresses_resolved = 0;
+                    let status = collect_partition_with_documents(
+                        &documents,
+                        leaves,
+                        plan,
+                        metrics,
+                        &mut collector,
+                        |doc_id| {
+                            let doc_id = DocId::new(u32::try_from(doc_id).map_err(|_| {
                                 Error::index(format!(
                                     "FTS DocId {doc_id} exceeds the modern u32 domain"
                                 ))
-                            })?,
-                        })
-                    },
-                )?;
+                            })?);
+                            let row_id = projection.address(doc_id).ok_or_else(|| {
+                                Error::internal(format!(
+                                    "compound FTS scorer returned non-visible DocId {} in segment {segment_ordinal}, partition {partition_ordinal}",
+                                    doc_id.get()
+                                ))
+                            })?;
+                            addresses_resolved += 1;
+                            Ok(row_id)
+                        },
+                    )?;
+                    debug_assert_eq!(status, CollectionStatus::Complete);
+                    metrics.record_compound_addresses_resolved(addresses_resolved);
+                } else {
+                    let max_buffered = collector
+                        .limit
+                        .saturating_add(SCORE_FLOOR_RESOLUTION_BATCH_SIZE);
+                    let mut local_collector = TopKCollector::retaining_score_floor(
+                        collector.limit,
+                        collector.competitive_score.clone(),
+                        max_buffered,
+                    );
+                    let status = collect_partition_with_documents(
+                        &documents,
+                        leaves,
+                        plan,
+                        metrics,
+                        &mut local_collector,
+                        |doc_id| {
+                            Ok(DocId::new(u32::try_from(doc_id).map_err(|_| {
+                                Error::index(format!(
+                                    "FTS DocId {doc_id} exceeds the modern u32 domain"
+                                ))
+                            })?))
+                        },
+                    )?;
+                    metrics.record_compound_peak_buffered_candidates(local_collector.peak_buffered);
+                    let boundary = match status {
+                        CollectionStatus::Complete => {
+                            PartitionCollectionBoundary::Deferred(DeferredCompoundRows {
+                                documents: partition_documents,
+                                rows: local_collector.into_candidates(),
+                            })
+                        }
+                        CollectionStatus::ScoreFloorOverflow => {
+                            metrics.record_compound_score_floor_overflows(1);
+                            PartitionCollectionBoundary::Overflow(OverflowedCompoundPartition {
+                                segment_ordinal,
+                                partition_ordinal,
+                                partition: source,
+                                documents: partition_documents,
+                            })
+                        }
+                    };
+                    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
+                    return Ok(CollectedPartitions {
+                        collector,
+                        remaining: partitions.collect(),
+                        boundary: Some(boundary),
+                    });
+                }
             }
         }
     }
-    Ok(collector)
+    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
+    Ok(CollectedPartitions {
+        collector,
+        remaining: Vec::new(),
+        boundary: None,
+    })
 }
 
-async fn resolve_compound_rows(
-    indices: &[Arc<InvertedIndex>],
-    rows: Vec<ScoredRow<CompoundDocument>>,
-    limit: usize,
-) -> Result<Vec<ScoredRow>> {
-    let mut resolved = vec![None; rows.len()];
-    let mut modern = BTreeMap::<(usize, usize), Vec<(usize, DocId)>>::new();
-    for (rank, row) in rows.iter().enumerate() {
-        match row.row_id {
-            CompoundDocument::Legacy(row_id) => resolved[rank] = Some(row_id),
-            CompoundDocument::Modern {
-                segment_ordinal,
-                partition_ordinal,
-                doc_id,
-            } => modern
-                .entry((segment_ordinal as usize, partition_ordinal as usize))
-                .or_default()
-                .push((rank, DocId::new(doc_id))),
+async fn merge_resolved_compound_rows(
+    collector: &mut TopKCollector<u64>,
+    deferred: DeferredCompoundRows,
+    metrics: &dyn MetricsCollector,
+) -> Result<()> {
+    for rows in deferred.rows.chunks(SCORE_FLOOR_RESOLUTION_BATCH_SIZE) {
+        let doc_ids = rows.iter().map(|row| row.row_id).collect::<Vec<_>>();
+        let addresses = deferred.documents.resolve_addresses(&doc_ids).await?;
+        if addresses.len() != rows.len() {
+            return Err(Error::internal(format!(
+                "compound FTS resolved {} addresses for {} DocIds",
+                addresses.len(),
+                rows.len()
+            )));
         }
-    }
-    for ((segment_ordinal, partition_ordinal), entries) in modern {
-        let documents = indices
-            .get(segment_ordinal)
-            .and_then(|index| index.partitions.get(partition_ordinal))
-            .and_then(|partition| partition.docs.modern())
-            .ok_or_else(|| {
-                Error::internal(format!(
-                    "missing modern FTS documents for segment {segment_ordinal}, partition {partition_ordinal}"
-                ))
-            })?;
-        let doc_ids = entries
-            .iter()
-            .map(|(_, doc_id)| *doc_id)
-            .collect::<Vec<_>>();
-        let addresses = documents.resolve_addresses(&doc_ids).await?;
-        for ((rank, _), address) in entries.into_iter().zip(addresses) {
-            resolved[rank] = Some(address);
-        }
-    }
-
-    let mut rows = rows
-        .into_iter()
-        .zip(resolved)
-        .map(|(row, row_id)| {
-            Ok(ScoredRow {
-                row_id: row_id.ok_or_else(|| {
-                    Error::internal("compound FTS candidate address was not resolved")
-                })?,
+        metrics.record_compound_address_resolution_batches(1);
+        metrics.record_compound_peak_address_resolution_batch_size(rows.len());
+        metrics.record_compound_addresses_resolved(addresses.len());
+        for (row, row_id) in rows.iter().zip(addresses) {
+            let status = collector.insert(ScoredRow {
+                row_id,
                 score: row.score,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    rows.sort_unstable_by(compare_scored_rows);
-    rows.truncate(limit);
-    Ok(rows)
+            });
+            debug_assert_eq!(status, CollectionStatus::Complete);
+        }
+    }
+    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
+    Ok(())
+}
+
+async fn reload_compound_partition_with_projection(
+    overflow: OverflowedCompoundPartition,
+    leaves: &[PreparedLeaf],
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<LoadedPartition> {
+    let projection = overflow.documents.address_projection().await?;
+    let mut loaded = load_compound_partition(
+        overflow.segment_ordinal,
+        overflow.partition_ordinal,
+        overflow.partition,
+        leaves,
+        mask,
+        metrics,
+    )
+    .await?
+    .ok_or_else(|| {
+        Error::internal(format!(
+            "compound FTS retry lost visible documents in segment {}, partition {}",
+            overflow.segment_ordinal, overflow.partition_ordinal
+        ))
+    })?;
+    match &mut loaded.documents {
+        LoadedDocuments::Modern {
+            projection: loaded_projection,
+            ..
+        } => *loaded_projection = Some(projection),
+        LoadedDocuments::Legacy(_) => {
+            return Err(Error::internal(format!(
+                "compound FTS retry changed segment {}, partition {} from modern to legacy documents",
+                overflow.segment_ordinal, overflow.partition_ordinal
+            )));
+        }
+    }
+    Ok(loaded)
 }
 
 /// Search one-column compound FTS directly over posting-backed scorers.
 ///
 /// The caller must provide all committed index segments for the column and a
 /// ready prefilter. One collector owns the global top-k heap and propagates its
-/// score floor through every partition-local scorer tree. Its score-bounded
-/// candidates, including every kth-score tie, are resolved to row addresses
-/// before the final row-id tie-break is applied.
+/// score floor through every partition-local scorer tree. Modern partitions
+/// resolve candidates in bounded batches; an oversized kth-score tie is retried
+/// against a resident row-address projection so final row-id ordering stays exact.
 pub async fn compound_search(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
@@ -2056,29 +2223,50 @@ async fn compound_search_impl(
                         metrics.clone(),
                     )
                 });
-        let partitions = stream::iter(loads)
+        let mut partitions = stream::iter(loads)
             .buffer_unordered(get_num_compute_intensive_cpus().clamp(1, 32))
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        let plan = plan.clone();
-        let mask = mask.clone();
-        let metrics = metrics.clone();
-        collector = spawn_cpu(move || {
-            collect_loaded_partitions(
-                partitions,
-                &plan,
-                mask.as_ref(),
-                metrics.as_ref(),
-                collector,
-            )
-        })
-        .await?;
+        while !partitions.is_empty() {
+            let cpu_plan = plan.clone();
+            let cpu_mask = mask.clone();
+            let cpu_metrics = metrics.clone();
+            let collected = spawn_cpu(move || {
+                collect_loaded_partitions(
+                    partitions,
+                    &cpu_plan,
+                    cpu_mask.as_ref(),
+                    cpu_metrics.as_ref(),
+                    collector,
+                )
+            })
+            .await?;
+            collector = collected.collector;
+            partitions = collected.remaining;
+            match collected.boundary {
+                Some(PartitionCollectionBoundary::Deferred(deferred)) => {
+                    merge_resolved_compound_rows(&mut collector, deferred, metrics.as_ref())
+                        .await?;
+                }
+                Some(PartitionCollectionBoundary::Overflow(overflow)) => {
+                    let retry = reload_compound_partition_with_projection(
+                        overflow,
+                        &leaves,
+                        mask.clone(),
+                        metrics.clone(),
+                    )
+                    .await?;
+                    partitions.insert(0, retry);
+                }
+                None => debug_assert!(partitions.is_empty()),
+            }
+        }
     }
 
-    let rows = resolve_compound_rows(indices, collector.into_score_floor_rows(), limit).await?;
+    let rows = collector.into_rows();
     Ok(rows.into_iter().map(|row| (row.row_id, row.score)).unzip())
 }
 
@@ -2152,6 +2340,54 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn collector_bounds_equal_score_candidates() {
+        let limit = 1;
+        let num_candidates = DEFAULT_BLOCK_SIZE * 4;
+        let values = (0..num_candidates)
+            .map(|row_id| (row_id as u64, 1.0))
+            .collect::<Vec<_>>();
+        let mut scorer = MaterializedScorer::try_new(rows(&values)).unwrap();
+        let max_buffered = limit + SCORE_FLOOR_RESOLUTION_BATCH_SIZE;
+        let mut collector = TopKCollector::retaining_score_floor(
+            limit,
+            Arc::new(CompetitiveScore::default()),
+            max_buffered,
+        );
+
+        let status = collector.collect_mapped(&mut scorer, Ok).unwrap();
+
+        assert_eq!(status, CollectionStatus::ScoreFloorOverflow);
+        assert_eq!(collector.heap.len(), max_buffered);
+    }
+
+    #[test]
+    fn collector_reclaims_obsolete_score_floor_before_overflowing() {
+        let limit = 2;
+        let max_buffered = 4;
+        let values = [
+            (0, 1.0),
+            (1, 1.0),
+            (2, 1.0),
+            (3, 2.0),
+            (4, 2.0),
+            (5, 2.0),
+            (6, 2.0),
+            (7, 2.0),
+        ];
+        let mut scorer = MaterializedScorer::try_new(rows(&values)).unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        let mut collector =
+            TopKCollector::retaining_score_floor(limit, competitive_score.clone(), max_buffered);
+
+        let status = collector.collect_mapped(&mut scorer, Ok).unwrap();
+
+        assert_eq!(status, CollectionStatus::ScoreFloorOverflow);
+        assert_eq!(collector.heap.len(), max_buffered);
+        assert!(collector.heap.iter().all(|row| row.0.score == 2.0));
+        assert_eq!(competitive_score.get(), 2.0);
     }
 
     struct TwoPhaseScorer {

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -473,7 +473,7 @@ impl ResidentAddressProjection {
         }
     }
 
-    fn address(&self, doc_id: DocId) -> Option<u64> {
+    pub(super) fn address(&self, doc_id: DocId) -> Option<u64> {
         if self
             .projection
             .live_docs
@@ -866,7 +866,7 @@ impl PartitionDocuments {
         self.lengths.get().cloned()
     }
 
-    fn resident_address_projection(&self) -> Option<ResidentAddressProjection> {
+    pub(super) fn resident_address_projection(&self) -> Option<ResidentAddressProjection> {
         let projection = self.projection.get()?.clone();
         let shared_addresses = match &projection.addresses {
             AddressValues::Shared { .. } => self.shared_addresses.load().upgrade(),

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::vec;
 
 use crate::dataset::ROW_ID;
@@ -31,9 +31,15 @@ use arrow_schema::{
 use lance_arrow::ARROW_EXT_NAME_KEY;
 use lance_core::cache::LanceCache;
 use lance_core::utils::tempfile::TempStrDir;
+use lance_datafusion::exec::ExecutionSummaryCounts;
 use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::LanceFileVersion;
+use lance_index::metrics::{
+    COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
+    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
+};
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
@@ -1142,15 +1148,13 @@ async fn test_same_column_compound_scorer_is_exact_and_bounded() {
 
 #[tokio::test]
 async fn test_compound_tie_uses_resolved_row_id() {
-    let batch =
-        arrow_array::record_batch!(("text", Utf8, ["common", "common", "common", "common"]))
-            .unwrap();
+    let batch = arrow_array::record_batch!(("text", Utf8, vec!["common"; 384])).unwrap();
     let schema = batch.schema();
     let mut dataset = Dataset::write(
         RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
         "memory://",
         Some(WriteParams {
-            max_rows_per_file: 1,
+            max_rows_per_file: 256,
             ..Default::default()
         }),
     )
@@ -1164,7 +1168,61 @@ async fn test_compound_tie_uses_resolved_row_id() {
     )
     .unwrap()
     .into();
-    assert_compound_fts_top_k(&dataset, query, 1).await;
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    scanner.limit(Some(1), None).unwrap();
+    let limited = scanner.try_into_batch().await.unwrap();
+    let limited_row_id = limited[ROW_ID].as_primitive::<UInt64Type>().value(0);
+
+    let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(limited_row_id, exhaustive[0].0);
+    assert_eq!(exhaustive.len(), 384);
+
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
+        Some(&384)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC),
+        Some(&1)
+    );
+
+    let mut analyze_scanner = dataset.scan();
+    analyze_scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    analyze_scanner.limit(Some(1), None).unwrap();
+    let analysis = analyze_scanner.analyze_plan().await.unwrap();
+    let compound_line = analysis
+        .lines()
+        .find(|line| line.contains("CompoundFtsScorer"))
+        .unwrap();
+    assert!(
+        compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
+        "compound FTS metrics missing the bounded candidate peak: {compound_line}"
+    );
+    assert!(
+        compound_line.contains(&format!(
+            "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
+        )),
+        "compound FTS metrics missing the bounded resolution batch: {compound_line}"
+    );
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -40,7 +40,9 @@ use crate::index::scalar::inverted::{load_segment_details, load_segments};
 use crate::{Dataset, index::DatasetIndexInternalExt};
 use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
-    FREQS_COLLECTED_METRIC, MetricsCollector,
+    COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
+    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -576,6 +578,11 @@ pub struct FtsIndexMetrics {
     and_candidates_pruned_before_return: Count,
     and_full_scores: Count,
     freqs_collected: Count,
+    compound_addresses_resolved: Count,
+    compound_address_resolution_batches: Count,
+    compound_peak_address_resolution_batch_size: Gauge,
+    compound_score_floor_overflows: Count,
+    compound_peak_buffered_candidates: Gauge,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -593,6 +600,18 @@ impl FtsIndexMetrics {
                 .new_count(AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, partition),
             and_full_scores: metrics.new_count(AND_FULL_SCORES_METRIC, partition),
             freqs_collected: metrics.new_count(FREQS_COLLECTED_METRIC, partition),
+            compound_addresses_resolved: metrics
+                .new_count(COMPOUND_ADDRESSES_RESOLVED_METRIC, partition),
+            compound_address_resolution_batches: metrics
+                .new_count(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, partition),
+            compound_peak_address_resolution_batch_size: metrics.new_gauge(
+                COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
+                partition,
+            ),
+            compound_score_floor_overflows: metrics
+                .new_count(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
+            compound_peak_buffered_candidates: metrics
+                .new_gauge(COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -643,6 +662,28 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_freqs_collected(&self, num_collections: usize) {
         self.freqs_collected.add(num_collections);
+    }
+
+    fn record_compound_addresses_resolved(&self, num_addresses: usize) {
+        self.compound_addresses_resolved.add(num_addresses);
+    }
+
+    fn record_compound_address_resolution_batches(&self, num_batches: usize) {
+        self.compound_address_resolution_batches.add(num_batches);
+    }
+
+    fn record_compound_peak_address_resolution_batch_size(&self, num_addresses: usize) {
+        self.compound_peak_address_resolution_batch_size
+            .set_max(num_addresses);
+    }
+
+    fn record_compound_score_floor_overflows(&self, num_overflows: usize) {
+        self.compound_score_floor_overflows.add(num_overflows);
+    }
+
+    fn record_compound_peak_buffered_candidates(&self, num_candidates: usize) {
+        self.compound_peak_buffered_candidates
+            .set_max(num_candidates);
     }
 }
 


### PR DESCRIPTION
## What is the performance issue?

Compound FTS preserves exact `(score DESC, row_id ASC)` ordering by retaining every candidate tied at the kth score until modern document IDs are resolved to row addresses. Large BM25 tie groups therefore make the candidate heap, address-resolution input, and final sort proportional to the full tie population, even when `limit=1`.

## How does this PR improve performance?

- Keep the final global top-k heap keyed by resolved row ID.
- Bound unresolved score-floor candidates at `limit + 128`.
- Resolve modern addresses in batches of at most 128 candidates.
- If a partition exceeds the unresolved bound, load its resident address projection and retry only that partition with exact row-ID keys.
- Preserve the legacy document path and the shared score-only competitive threshold.
- Expose addresses resolved, batch count, peak batch size, score-floor overflow count, and peak buffered candidates as execution metrics.

## Measurement

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `limit=1`, 512 equal-score candidates; peak unresolved candidates (lower is better) | 512 candidates | 129 candidates | 3.97x smaller peak |

Measured deterministically with the in-memory compound collector regression in the local macOS debug test profile. This table measures candidate working-set size, not wall-clock latency. Comparable MMLB latency and memory benchmarks have not yet been run, so this PR does not claim a latency or throughput improvement.

## Correctness

A 384-row equal-score regression spans reversed committed segments and multiple modern partitions. It compares limited output with the exhaustive oracle, exercises both bounded batch resolution and overflow retry, and verifies the emitted resolution metrics.

Linear: [OSS-1618](https://linear.app/lancedb/issue/OSS-1618/bound-compound-fts-score-floor-tie-handling-by-resolved-row-id)

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-index scalar::inverted::compound::tests --lib` (6 passed)
- `cargo test -p lance compound --lib` (5 passed)
- `git diff --check`
