### PR TITLE
fix(fts): align list post-filter with indexed semantics

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5665,8 +5665,8 @@ impl Scanner {
         )?))
     }
 
-    /// Here we use a full text search as a post-filter.  Any rows that
-    /// do not contain at least one query token are removed.
+    /// Here we use a full text search as a post-filter. Rows are retained
+    /// according to the match query's token operator.
     ///
     /// Only valid (currently) for match queries.
     async fn flat_fts_filter(

--- a/rust/lance/src/dataset/tests/dataset_scanner.rs
+++ b/rust/lance/src/dataset/tests/dataset_scanner.rs
@@ -12,7 +12,7 @@ use lance_arrow::{ARROW_EXT_NAME_KEY, FixedSizeListArrayExt};
 use crate::index::DatasetIndexExt;
 use arrow::compute::concat_batches;
 use arrow_array::cast::AsArray;
-use arrow_array::{Array, FixedSizeListArray, ListArray, StructArray};
+use arrow_array::{Array, ArrayRef, FixedSizeListArray, LargeListArray, ListArray, StructArray};
 use arrow_array::{Float32Array, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_array::{Int64Array, UInt64Array};
 use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
@@ -25,7 +25,9 @@ use lance_file::reader::{FileReader, FileReaderOptions, describe_encoding};
 use lance_file::version::LanceFileVersion;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
-    SCORE_FIELD, query::PhraseQuery, tokenizer::InvertedIndexParams,
+    SCORE_FIELD,
+    query::{FtsQuery, MatchQuery, Operator, PhraseQuery},
+    tokenizer::InvertedIndexParams,
 };
 use lance_index::{IndexType, vector::DIST_COL};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
@@ -33,15 +35,15 @@ use lance_io::utils::CachedFileSize;
 use lance_linalg::distance::MetricType;
 use uuid::Uuid;
 
-use crate::Dataset;
 use crate::dataset::NewColumnTransform;
 use crate::dataset::scanner::{DatasetRecordBatchStream, QueryFilter};
 use crate::dataset::write::WriteParams;
-use lance_index::scalar::inverted::query::FtsQuery;
+use crate::{Dataset, Error};
 use lance_index::vector::ivf::IvfBuildParams;
 use lance_index::vector::pq::PQBuildParams;
 use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
 use pretty_assertions::assert_eq;
+use rstest::rstest;
 
 /// A null struct must not read back as a valid struct with null children.
 ///
@@ -540,6 +542,212 @@ async fn test_fts_filter_vector_search() {
         .try_into_stream()
         .await;
     assert!(stream.is_err());
+}
+
+#[rstest]
+#[case::list(false)]
+#[case::large_list(true)]
+#[tokio::test]
+async fn test_fts_list_postfilter_vector_search(#[case] is_large_list: bool) {
+    async fn indexed_ids(dataset: &Dataset, query: FullTextSearchQuery) -> Vec<i32> {
+        let result = dataset
+            .scan()
+            .project(&["id"])
+            .unwrap()
+            .full_text_search(query)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let mut ids = result["id"]
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        ids.sort_unstable();
+        ids
+    }
+
+    async fn postfilter_ids(dataset: &Dataset, query: FullTextSearchQuery) -> Vec<i32> {
+        let query_vector = Float32Array::from(vec![0.0, 0.0]);
+        let mut scanner = dataset.scan();
+        scanner
+            .nearest("vector", &query_vector, 5)
+            .unwrap()
+            .prefilter(false)
+            .filter_query(QueryFilter::Fts(query))
+            .unwrap();
+        let plan = scanner.explain_plan(false).await.unwrap();
+        let post_filter_position = plan
+            .find("FlatMatchFilter: column=docs")
+            .expect("expected FTS to run as a flat match filter");
+        let vector_search_position = plan
+            .find("ANNSubIndex")
+            .expect("expected the query to use the vector index");
+        assert!(
+            post_filter_position < vector_search_position,
+            "expected FTS to wrap the vector search as a post-filter, got:\n{plan}"
+        );
+        let result = scanner.try_into_batch().await.unwrap();
+        let mut ids = result["id"]
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn match_query(terms: &str, operator: Operator) -> FullTextSearchQuery {
+        FullTextSearchQuery::new_query(FtsQuery::Match(
+            MatchQuery::new(terms.to_owned())
+                .with_column(Some("docs".to_owned()))
+                .with_operator(operator),
+        ))
+    }
+
+    let item_field = Arc::new(ArrowField::new("item", DataType::Utf8, true));
+    let values = Arc::new(StringArray::from(vec![
+        Some("target"),
+        Some("alpha"),
+        Some("beta"),
+        Some(""),
+        None,
+        Some("target"),
+    ])) as ArrayRef;
+    let validity = Some(NullBuffer::from(vec![true, true, true, true, false]));
+    let docs: ArrayRef = if is_large_list {
+        Arc::new(LargeListArray::new(
+            item_field.clone(),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0_i64, 2, 3, 3, 6, 6])),
+            values,
+            validity,
+        ))
+    } else {
+        Arc::new(ListArray::new(
+            item_field,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3, 3, 6, 6])),
+            values,
+            validity,
+        ))
+    };
+    let vectors = FixedSizeListArray::try_new_from_values(
+        Float32Array::from(vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0]),
+        2,
+    )
+    .unwrap();
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("vector", vectors.data_type().clone(), false),
+        ArrowField::new("docs", docs.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from_iter_values(0..5)),
+            Arc::new(vectors),
+            docs,
+        ],
+    )
+    .unwrap();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new([Ok(batch)], schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 3);
+
+    dataset
+        .create_index(
+            &["docs"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    dataset
+        .create_index(
+            &["vector"],
+            IndexType::Vector,
+            None,
+            &VectorIndexParams::ivf_flat(1, MetricType::L2),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let query = match_query("target", Operator::Or);
+    assert_eq!(indexed_ids(&dataset, query.clone()).await, [0, 3]);
+    assert_eq!(postfilter_ids(&dataset, query).await, [0, 3]);
+
+    let query = match_query("target alpha", Operator::And);
+    assert_eq!(indexed_ids(&dataset, query.clone()).await, [0]);
+    assert_eq!(postfilter_ids(&dataset, query).await, [0]);
+
+    let query = match_query("target missing", Operator::And);
+    assert!(indexed_ids(&dataset, query.clone()).await.is_empty());
+    assert!(postfilter_ids(&dataset, query).await.is_empty());
+
+    dataset
+        .create_index(
+            &["docs"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default().base_tokenizer("raw".to_owned()),
+            true,
+        )
+        .await
+        .unwrap();
+    let query = match_query("target", Operator::Or);
+    assert_eq!(indexed_ids(&dataset, query.clone()).await, [3]);
+    assert_eq!(postfilter_ids(&dataset, query).await, [3]);
+
+    dataset
+        .create_index(
+            &["docs"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::code()
+                .split_identifiers(true)
+                .preserve_original(true),
+            true,
+        )
+        .await
+        .unwrap();
+    let query = match_query("targetAlpha", Operator::And);
+    assert_eq!(indexed_ids(&dataset, query.clone()).await, [0]);
+    assert_eq!(postfilter_ids(&dataset, query).await, [0]);
+
+    let fuzzy_query = FullTextSearchQuery::new_query(FtsQuery::Match(
+        MatchQuery::new("targets".to_owned())
+            .with_column(Some("docs".to_owned()))
+            .with_fuzziness(Some(1)),
+    ));
+    let query_vector = Float32Array::from(vec![0.0, 0.0]);
+    let mut scanner = dataset.scan();
+    scanner
+        .nearest("vector", &query_vector, 5)
+        .unwrap()
+        .prefilter(false)
+        .filter_query(QueryFilter::Fts(fuzzy_query))
+        .unwrap();
+    let error = scanner.try_into_batch().await.unwrap_err();
+    assert!(matches!(&error, Error::NotSupported { .. }));
+    assert!(
+        error
+            .to_string()
+            .contains("Fuzzy MatchQuery is not supported when FTS is used as a post-filter"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -1412,7 +1412,7 @@ impl ExecutionPlan for MatchQueryExec {
     }
 }
 
-/// Filters the input, removing rows that do not share tokens with the query
+/// Filters the input according to a match query's token operator.
 #[derive(Debug)]
 pub struct FlatMatchFilterExec {
     dataset: Arc<Dataset>,
@@ -1448,17 +1448,20 @@ fn document_matches_query(
     match operator {
         Operator::Or => has_query_token(text, tokenizer, query_tokens),
         Operator::And => {
-            let mut remaining = query_tokens
-                .into_iter()
-                .map(String::as_str)
+            let mut remaining_positions = (0..query_tokens.len())
+                .map(|index| query_tokens.position(index))
                 .collect::<HashSet<_>>();
-            if remaining.is_empty() {
+            if remaining_positions.is_empty() {
                 return false;
             }
             let mut stream = tokenizer.token_stream_for_doc(text);
             while let Some(token) = stream.next() {
-                remaining.remove(token.text.as_str());
-                if remaining.is_empty() {
+                for index in 0..query_tokens.len() {
+                    if token.text == query_tokens.get_token(index) {
+                        remaining_positions.remove(&query_tokens.position(index));
+                    }
+                }
+                if remaining_positions.is_empty() {
                     return true;
                 }
             }
@@ -1656,6 +1659,12 @@ impl FlatMatchFilterExec {
                 "column not set for MatchQuery {}",
                 query.terms
             )))?;
+        if query.fuzziness != Some(0) {
+            return Err(DataFusionError::NotImplemented(format!(
+                "Fuzzy MatchQuery is not supported when FTS is used as a post-filter: column={}, fuzziness={:?}",
+                column, query.fuzziness
+            )));
+        }
         let document_granularity = resolved_field
             .as_ref()
             .map(|resolved| resolved.document_granularity)


### PR DESCRIPTION
## Summary

- cover `List<Utf8>` and `LargeList<Utf8>` row-document FTS in the vector post-filter path
- align exact post-filter AND matching with indexed query-position semantics, including tokenizer alternatives at the same position
- reject fuzzy match queries in the exact post-filter path instead of silently applying exact-match semantics

## Problem

FTS indexing and flat search accept list-of-string columns, but the vector-search post-filter path previously treated the selected column as a scalar string. A query using `prefilter(false)` therefore failed with `Column <name> is not a string` even though the same FTS query worked through the normal indexed path.

## Implementation after rebasing

While this PR was under review, #7788 added document granularity and centralized nested-field extraction in `ResolvedFtsField`. After rebasing onto that work, the original direct `List`/`LargeList` dispatch is no longer needed: `Scanner::flat_fts_filter` resolves the FTS field, includes the root list column in the take, and `FlatMatchFilterExec` evaluates the row documents produced by the shared extraction path.

This PR keeps the issue-specific cross-path regression coverage on top of that architecture. It also makes exact AND matching consume query positions rather than distinct token text, matching the indexed path when a tokenizer emits multiple alternatives at one position. The explicit fuzzy-query guard remains because the flat post-filter performs token matching and cannot reproduce index-dictionary fuzzy expansion.

The integration test covers both outer list offset types across three fragments and verifies:

- a vector index is used with `prefilter(false)` and FTS runs as `FlatMatchFilterExec`
- indexed FTS and vector post-filter FTS return the same parent rows
- OR and cross-element AND semantics agree with the indexed row-document path
- the `raw` tokenizer uses the same row materialization semantics
- the `code` tokenizer preserves same-position alternatives for AND queries
- null lists, empty lists, and null list elements do not cause failures or false matches
- unsupported fuzzy post-filter queries fail clearly

Fixes #7662.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lance test_fts_list_postfilter_vector_search -- --nocapture`
- `cargo test -p lance document_match_filter_respects_document_boundary -- --nocapture`
- `cargo clippy --all --tests --benches -- -D warnings`

Thanks to @BubbleCal for the clear issue report and suggested integration coverage.
