### PR TITLE
fix(mem-wal): return error instead of panic in validate_index_configs

### DIFF
--- a/rust/lance/src/dataset/mem_wal/index.rs
+++ b/rust/lance/src/dataset/mem_wal/index.rs
@@ -199,9 +199,18 @@ pub fn validate_index_configs(
         // A config whose `field_id` identifies a *different* column would be bound
         // under the wrong identity (e.g. reused as the single-column PK index), so
         // reject any `field_id` that does not name the resolved column.
+        //
+        // The Lance lookup can still miss when the Arrow and Lance schemas
+        // diverge; a fallible API must report that, not panic on it.
         let resolved_field_id = lance_schema
             .field(column)
-            .expect("column resolved in the Arrow schema is present in the Lance schema")
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "index '{}' is configured on column '{}', which is not in the Lance schema",
+                    config.name(),
+                    column,
+                ))
+            })?
             .id;
         if resolved_field_id != config.field_id() {
             return Err(Error::invalid_input(format!(
@@ -1739,6 +1748,39 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The Arrow and Lance schemas normally derive from the same source, but a
+    /// diverged pair — the column resolves in the Arrow schema yet has no Lance
+    /// field — must yield a descriptive error, not a panic (#8194).
+    #[test]
+    fn test_validate_index_configs_column_missing_from_lance_schema() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("extra", DataType::Int32, false),
+        ]));
+        let lance_schema = LanceSchema::try_from(&ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]))
+        .unwrap();
+
+        let config = MemIndexConfig::BTree(BTreeIndexConfig {
+            name: "idx".into(),
+            field_id: 1,
+            column: "extra".into(),
+        });
+        let err = validate_index_configs(&[config], &schema, &lance_schema, &[])
+            .expect_err("a column absent from the Lance schema must be rejected, not panic");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected invalid-input error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("extra"),
+            "error must name the missing column, got {err}"
+        );
     }
 
     /// A composite PK builds an order-preserving encoded key, so its columns must


### PR DESCRIPTION
## What is the bug?

`validate_index_configs` in the MemWAL writer path panics when a configured column resolves in the Arrow schema but is absent from the Lance schema:

```rust
let resolved_field_id = lance_schema
    .field(column)
    .expect("column resolved in the Arrow schema is present in the Lance schema")
    .id;
```

This is a public, fallible API boundary: writer construction surfaces the panic to callers — and across the Python/Java FFI a Rust panic is far worse than a catchable error. Normal writer construction derives both schemas from the same source, so the trigger requires a diverged Arrow/Lance schema pair, but a fallible public API must return a descriptive error rather than panic on any input.

## How does this fix it?

Replaces the `.expect()` with `Error::invalid_input` naming the index config and the column, matching the error style used elsewhere in the same function:

```
index '<name>' is configured on column '<column>', which is not in the Lance schema
```

Adds a regression test (`test_validate_index_configs_column_missing_from_lance_schema`) that builds a mismatched Arrow/Lance schema pair — the column resolves in the Arrow schema but has no Lance field — and asserts a contextual `Err` (both the `InvalidInput` variant and the column name in the message) instead of a panic.

## Validation

- `cargo test -p lance --lib mem_wal::index` — all tests pass, including the new regression test (see run details below)
- `cargo fmt --all` — clean
- `cargo clippy --all --tests --benches -- -D warnings` — clean

Fixes #8194
