### PR TITLE
fix(mem-wal): deduplicate IN literals before point lookup

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -57,7 +57,11 @@ struct LsmVectorQuery {
 /// operand order) or `pk IN (lit, …)` — return the literal key values. Any
 /// other shape returns `None`, so the scanner falls through to the general
 /// scan plan. Type coercion is left to the lookup path (an exact-type literal
-/// takes the fast BTree path; a coercible one falls back internally).
+/// takes the fast BTree path; a coercible one falls back internally). IN-list
+/// literals are deduplicated in first-seen order: the lookup path resolves one
+/// row per key, so a repeated literal would emit the same pk row twice (and
+/// could crowd out other keys under a LIMIT), unlike the scan path where IN
+/// is a predicate.
 fn extract_pk_point_keys(filter: &Expr, pk_col: &str) -> Option<Vec<ScalarValue>> {
     match filter {
         Expr::BinaryExpr(b) if matches!(b.op, Operator::Eq) => {
@@ -78,12 +82,18 @@ fn extract_pk_point_keys(filter: &Expr, pk_col: &str) -> Option<Vec<ScalarValue>
             if c.name != pk_col {
                 return None;
             }
-            let mut vals = Vec::with_capacity(in_list.list.len());
+            let mut vals: Vec<ScalarValue> = Vec::with_capacity(in_list.list.len());
             for e in &in_list.list {
                 let Expr::Literal(lit, _) = e else {
                     return None; // a non-literal IN element → not a point lookup
                 };
-                vals.push(lit.clone());
+                // Linear-scan dedup: IN lists are small, and ScalarValue has no
+                // Hash/Eq for all variants. Variant-wise PartialEq keeps
+                // cross-type literals (e.g. Int32 vs Int64) distinct, which the
+                // lookup path requires.
+                if !vals.contains(lit) {
+                    vals.push(lit.clone());
+                }
             }
             (!vals.is_empty()).then_some(vals)
         }
@@ -1975,6 +1985,50 @@ mod tests {
             "pk IN (..) must route"
         );
         assert_eq!(count(plan).await, 2);
+
+        // Duplicate IN literals collapse: each matching row comes back exactly
+        // once, matching the scan path where IN is a predicate (#8195).
+        let plan = scanner()
+            .filter_expr(col("id").in_list(vec![lit(1i32), lit(1i32), lit(3i32)], false))
+            .create_plan()
+            .await
+            .unwrap();
+        assert!(
+            format!("{}", displayable(plan.as_ref()).indent(true)).contains("OneShotStream"),
+            "duplicate pk IN (..) must still route"
+        );
+        assert_eq!(collect_ids(plan).await, vec![1, 3]);
+
+        // Duplicates mixed with an absent key: the present row comes back once.
+        let plan = scanner()
+            .filter_expr(col("id").in_list(vec![lit(1i32), lit(99i32), lit(1i32)], false))
+            .create_plan()
+            .await
+            .unwrap();
+        assert_eq!(collect_ids(plan).await, vec![1]);
+
+        // A NULL literal never matches (same as the scan path) and must not
+        // error or interfere with dedup of the remaining literals.
+        let plan = scanner()
+            .filter_expr(col("id").in_list(
+                vec![lit(ScalarValue::Int32(None)), lit(2i32), lit(2i32)],
+                false,
+            ))
+            .create_plan()
+            .await
+            .unwrap();
+        assert_eq!(collect_ids(plan).await, vec![2]);
+
+        // Duplicates must not crowd out distinct rows under a LIMIT:
+        // IN (1, 1, 2) LIMIT 2 yields both distinct rows, not id=1 twice.
+        let plan = scanner()
+            .filter_expr(col("id").in_list(vec![lit(1i32), lit(1i32), lit(2i32)], false))
+            .limit(Some(2), None)
+            .unwrap()
+            .create_plan()
+            .await
+            .unwrap();
+        assert_eq!(collect_ids(plan).await, vec![1, 2]);
 
         // A range filter is NOT a point lookup → falls through to the scan path.
         let plan = scanner()

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -1902,6 +1902,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_lookup_many_null_key_resolves_as_miss() {
+        let schema = create_pk_schema();
+        let planner = active_planner(&[create_test_batch(&schema, &[10, 20], "v")]);
+        // A NULL key probes the (empty) null positions and resolves as a miss —
+        // same as an absent key: omitted, no error, other keys still found.
+        let keys = [
+            ScalarValue::Int32(None),
+            ScalarValue::Int32(Some(10)),
+            ScalarValue::Int32(None),
+        ];
+        let batch = planner.lookup_many(&keys, None).await.unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(sorted_ids(&batch), vec![10]);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_many_emits_one_row_per_requested_key() {
+        let schema = create_pk_schema();
+        let planner = active_planner(&[create_test_batch(&schema, &[10, 20], "v")]);
+        // The planner contract is per-key ("equivalent to N× lookup"): a
+        // repeated key yields the row once per occurrence. Deduplicating
+        // user-supplied IN literals is the scanner's job, at
+        // `extract_pk_point_keys` — the planner intentionally does not dedup.
+        let keys = [
+            ScalarValue::Int32(Some(20)),
+            ScalarValue::Int32(Some(10)),
+            ScalarValue::Int32(Some(20)),
+        ];
+        let batch = planner.lookup_many(&keys, None).await.unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(sorted_ids(&batch), vec![10, 20, 20]);
+    }
+
+    #[tokio::test]
     async fn test_lookup_many_newest_duplicate() {
         let schema = create_pk_schema();
         // id=5 written twice; the batch get must return the newest ("new_5").


### PR DESCRIPTION
## What is the bug?

The MemWAL point-lookup fast path resolves each `IN`-list literal independently and emits one result row per key, so duplicate literals produce duplicate rows for the same primary key: `WHERE id IN (1, 1, 2)` returns the `id = 1` row twice, and with `LIMIT 2` the duplicate can crowd out the `id = 2` row entirely. The general scan path treats `IN` as a predicate and never duplicates rows, so the fast path diverges from fallback semantics.

Fixes #8195.

## How does this fix it?

Stable-deduplicates the extracted keys in first-seen order at the extraction boundary (`extract_pk_point_keys`), using `ScalarValue`'s variant-wise `PartialEq` via `Vec::contains` — IN lists are small, and `ScalarValue` has no `Hash`/`Eq` for all variants. Variant-wise equality deliberately keeps cross-type literals (e.g. `Int32` vs `Int64`) distinct, because the lookup path coerces them differently.

`extract_pk_point_keys` is the only production extraction path feeding `plan_point_lookup`/`lookup_many` (the single-column-PK fast path in `LsmScanner::plan_scan`), so the planner itself is untouched: its per-key contract (`lookup_many` ≡ N× `lookup`) is intentionally preserved, and all fallback behavior is unchanged — a single `Eq` key is unaffected, negated `IN` (`NOT IN`) still falls back to the general scan, and a non-literal list element still makes extraction return `None`.

Tests (extended existing modules, no new files):
- `builder.rs` — `point_lookup_filter_routes_to_fast_path`: duplicate IN literals still route to the fast path and return each matching row exactly once; duplicates + `LIMIT 2` return both distinct rows (not `id=1` twice); a `NULL` literal still never matches and does not disturb dedup of the rest; duplicates mixed with an absent key return the present row once.
- `point_lookup.rs` — pins the planner's unchanged per-key contract for duplicate keys (`test_lookup_many_emits_one_row_per_requested_key`) and NULL-key miss behavior (`test_lookup_many_null_key_resolves_as_miss`).
- Verified the new builder assertions fail pre-fix: `IN (1, 1, 3)` returned `[1, 1, 3]`.

## Validation

- `cargo test -p lance --lib mem_wal::scanner` — 170 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all --tests --benches -- -D warnings` — clean

Fixes #8195