### PR TITLE
fix(core)!: stop reusing fragment ids across an overwrite

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5777,8 +5777,8 @@ class LanceOperation:
             The newly written fragments that make up the new dataset. They are
             assigned fresh ids when the operation is committed, continuing from
             the highest id the dataset has ever used, so any id they carry is
-            ignored. A fragment with a deletion file belongs to the dataset being
-            replaced and is rejected: use :class:`LanceOperation.Delete` to commit
+            ignored. Since we reassign fragment ids, a fragment with a deletion
+            file is rejected: use :class:`LanceOperation.Delete` to commit
             deletions, or :class:`LanceOperation.Merge` to change the schema of
             existing fragments.
         initial_bases: list[DatasetBasePath], optional

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5774,7 +5774,13 @@ class LanceOperation:
         new_schema: pyarrow.Schema
             The schema of the new dataset.
         fragments: list[FragmentMetadata]
-            The fragments that make up the new dataset.
+            The newly written fragments that make up the new dataset. They are
+            assigned fresh ids when the operation is committed, continuing from
+            the highest id the dataset has ever used, so any id they carry is
+            ignored. A fragment with a deletion file belongs to the dataset being
+            replaced and is rejected: use :class:`LanceOperation.Delete` to commit
+            deletions, or :class:`LanceOperation.Merge` to change the schema of
+            existing fragments.
         initial_bases: list[DatasetBasePath], optional
             Base paths to register when creating a new dataset (CREATE mode only).
             **Only valid in CREATE mode**. Will raise an error if used with

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2277,8 +2277,13 @@ def test_deletion_file(tmp_path: Path):
     assert re.match(
         "_deletions/0-1-[0-9]{1,32}.arrow", new_fragment.deletion_file.path(0)
     )
-    operation = lance.LanceOperation.Overwrite(table.schema, [new_fragment])
-    dataset = lance.LanceDataset.commit(base_dir, operation)
+    # Delete, not Overwrite: the deletion file belongs to fragment 0 of this
+    # dataset, and an overwrite's fragments are newly written ones that get fresh
+    # ids, which a deletion file cannot follow.
+    operation = lance.LanceOperation.Delete([new_fragment], [], "a < 10")
+    dataset = lance.LanceDataset.commit(
+        base_dir, operation, read_version=dataset.version
+    )
     assert dataset.count_rows() == 90
 
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -5537,48 +5537,64 @@ mod tests {
                 assert_eq!(dataset.count_rows(None).await.unwrap(), 195);
             }
 
-            let fragment = &mut dataset.get_fragment(0).unwrap();
-            let mut updater = fragment.updater(Some(&["i"]), None, None).await.unwrap();
             let new_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
                 "double_i",
                 DataType::Int32,
                 true,
             )]));
-            while let Some(batch) = updater.next().await.unwrap() {
-                let input_col = batch.column_by_name("i").unwrap();
-                let result_col = mul(input_col, &Int32Array::new_scalar(2)).unwrap();
-                let batch = RecordBatch::try_new(
-                    new_schema.clone(),
-                    vec![Arc::new(result_col) as ArrayRef],
-                )
-                .unwrap();
-                updater.update(batch).await.unwrap();
-            }
-            let new_fragment = updater.finish().await.unwrap();
+            // Merge keeps the fragment list intact, so every fragment gets the new
+            // column. Fragment 0 is the one carrying the deletions.
+            let fragment_ids = dataset
+                .manifest
+                .fragments
+                .iter()
+                .map(|f| f.id as usize)
+                .collect::<Vec<_>>();
+            let mut merged_fragments = Vec::new();
+            for fragment_id in fragment_ids {
+                let fragment = &mut dataset.get_fragment(fragment_id).unwrap();
+                let mut updater = fragment.updater(Some(&["i"]), None, None).await.unwrap();
+                while let Some(batch) = updater.next().await.unwrap() {
+                    let input_col = batch.column_by_name("i").unwrap();
+                    let result_col = mul(input_col, &Int32Array::new_scalar(2)).unwrap();
+                    let batch = RecordBatch::try_new(
+                        new_schema.clone(),
+                        vec![Arc::new(result_col) as ArrayRef],
+                    )
+                    .unwrap();
+                    updater.update(batch).await.unwrap();
+                }
+                let new_fragment = updater.finish().await.unwrap();
 
-            assert_eq!(new_fragment.files.len(), 2);
+                assert_eq!(new_fragment.files.len(), 2);
+                merged_fragments.push(new_fragment);
+            }
 
             // Scan again
             let mut full_schema = dataset.schema().merge(new_schema.as_ref()).unwrap();
             full_schema.set_field_id(None);
             let before_version = dataset.version().version;
 
-            let op = Operation::Overwrite {
-                fragments: vec![new_fragment],
+            let op = Operation::Merge {
+                fragments: merged_fragments,
                 schema: full_schema.clone(),
-                config_upsert_values: None,
-                initial_bases: None,
             };
 
-            let dataset =
-                Dataset::commit(test_uri, op, None, None, None, Default::default(), false)
-                    .await
-                    .unwrap();
+            let dataset = Dataset::commit(
+                test_uri,
+                op,
+                Some(before_version),
+                None,
+                None,
+                Default::default(),
+                false,
+            )
+            .await
+            .unwrap();
 
-            // We only kept the first fragment of 40 rows
             assert_eq!(
                 dataset.count_rows(None).await.unwrap(),
-                if with_delete { 35 } else { 40 }
+                if with_delete { 195 } else { 200 }
             );
             assert_eq!(dataset.version().version, before_version + 1);
             dataset.validate().await.unwrap();

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -459,6 +459,9 @@ mod test {
 
         // Overwriting should NOT reset the row id counter.
         assert_eq!(dataset.manifest().next_row_id, 2 * num_rows);
+        // Nor the fragment id counter: ids are a high water mark, so the
+        // overwritten fragment cannot alias the one it replaced.
+        assert_eq!(dataset.manifest.fragments[0].id, 1);
 
         let index = get_row_id_index(&dataset).await.unwrap().unwrap();
         assert!(index.get(0).is_none());

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2187,9 +2187,10 @@ async fn overwrite_dataset(
 
     let fragments = dataset.get_fragments();
     assert_eq!(fragments.len(), 1);
-    // Fragment ids reset after overwrite.
-    assert_eq!(fragments[0].id(), 0);
-    assert_eq!(dataset.manifest.max_fragment_id(), Some(0));
+    // Fragment ids continue from the dataset's high water mark after an
+    // overwrite; they are never reused.
+    assert_eq!(fragments[0].id(), 1);
+    assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
 
     let actual_ds = Dataset::open(&test_uri).await.unwrap();
     assert_eq!(actual_ds.version().version, 2);

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -22,6 +22,7 @@ use lance_file::version::LanceFileVersion;
 use mock_instant::thread_local::MockClock;
 
 use crate::dataset::refs::branch_contents_path;
+use crate::utils::test::copy_test_data_to_tmp;
 use futures::TryStreamExt;
 use lance_core::Error;
 use object_store::path::Path;
@@ -634,6 +635,146 @@ async fn test_fragment_id_never_reset() {
     assert_eq!(dataset.get_fragments()[0].id(), 3);
     assert_eq!(dataset.get_fragments()[1].id(), 4);
     assert_eq!(dataset.manifest.max_fragment_id(), Some(4));
+}
+
+#[tokio::test]
+async fn test_overwrite_does_not_reuse_fragment_ids() {
+    // An overwrite replaces every fragment, but the ids it hands out must still
+    // continue from the dataset's high water mark: an id that named one set of
+    // rows must never name another.
+    let test_dir = TempStrDir::default();
+    let write = |mode: WriteMode, rows: u64| {
+        let reader = gen_batch()
+            .col("i", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(rows), BatchCount::from(1));
+        let params = WriteParams {
+            mode,
+            max_rows_per_file: 10,
+            ..Default::default()
+        };
+        Dataset::write(reader, test_dir.as_str(), Some(params))
+    };
+    let fragment_ids = |dataset: &Dataset| {
+        dataset
+            .get_fragments()
+            .iter()
+            .map(|f| f.id())
+            .collect::<Vec<_>>()
+    };
+
+    let dataset = write(WriteMode::Create, 30).await.unwrap();
+    assert_eq!(fragment_ids(&dataset), vec![0, 1, 2]);
+
+    let dataset = write(WriteMode::Overwrite, 20).await.unwrap();
+    assert_eq!(fragment_ids(&dataset), vec![3, 4]);
+    assert_eq!(dataset.manifest.max_fragment_id(), Some(4));
+
+    let dataset = write(WriteMode::Append, 10).await.unwrap();
+    assert_eq!(fragment_ids(&dataset), vec![3, 4, 5]);
+}
+
+#[tokio::test]
+async fn test_overwrite_rejects_fragment_with_deletion_file() {
+    // A deletion file's path embeds the fragment id, so it cannot follow its
+    // fragment to the fresh id an overwrite assigns. Such a fragment belongs to
+    // the dataset being replaced, so the operation is rejected rather than
+    // silently losing the deletions.
+    let test_dir = TempStrDir::default();
+    let reader = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+    let mut dataset = Dataset::write(reader, test_dir.as_str(), None)
+        .await
+        .unwrap();
+    dataset.delete("i < 3").await.unwrap();
+
+    let fragment = dataset.manifest.fragments[0].clone();
+    assert!(fragment.deletion_file.is_some());
+    let schema = dataset.schema().clone();
+    let read_version = dataset.manifest.version;
+
+    let err = CommitBuilder::new(Arc::new(dataset))
+        .execute(Transaction::new(
+            read_version,
+            Operation::Overwrite {
+                fragments: vec![fragment],
+                schema,
+                config_upsert_values: None,
+                initial_bases: None,
+            },
+            None,
+        ))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidInput { .. }),
+        "expected invalid input, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("must be newly written"),
+        "unexpected message: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_commit_rejects_duplicate_fragment_ids() {
+    // Append honors an id a fragment arrives with, so a caller can still hand in
+    // one that an existing fragment already uses. Committing that would leave two
+    // fragments sharing everything keyed by the id.
+    let test_dir = TempStrDir::default();
+    let write = |mode: WriteMode| {
+        let reader = gen_batch()
+            .col("i", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+        let params = WriteParams {
+            mode,
+            max_rows_per_file: 5,
+            ..Default::default()
+        };
+        Dataset::write(reader, test_dir.as_str(), Some(params))
+    };
+    let dataset = write(WriteMode::Create).await.unwrap();
+    let existing = dataset.manifest.fragments[1].clone();
+    assert_eq!(existing.id, 1);
+
+    let err = CommitBuilder::new(Arc::new(dataset))
+        .execute(Transaction::new(
+            1,
+            Operation::Append {
+                fragments: vec![existing],
+            },
+            None,
+        ))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("two fragments with id 1"),
+        "unexpected message: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_commit_on_dataset_with_mixed_file_versions() {
+    // A v0.16 dataset that has both v1 and v2 files also has two fragments with
+    // id 1, because the id allocation of that era could hand out an id a caller
+    // had already supplied. The mixture is the more actionable diagnosis, so the
+    // duplicate check must not preempt it.
+    let test_dir = copy_test_data_to_tmp("v0.16.0/wrong_data_version_no_fix.lance").unwrap();
+    let mut dataset = Dataset::open(&test_dir.path_str()).await.unwrap();
+    let ids = dataset
+        .manifest
+        .fragments
+        .iter()
+        .map(|f| f.id)
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec![0, 1, 1, 2]);
+
+    let err = dataset.delete("false").await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("The dataset contains a mixture of file versions"),
+        "unexpected message: {err}"
+    );
 }
 
 /// create_branch and shallow_clone must read the SOURCE ref's chain, not the

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
 
@@ -673,8 +674,14 @@ async fn test_overwrite_does_not_reuse_fragment_ids() {
     assert_eq!(fragment_ids(&dataset), vec![3, 4, 5]);
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_overwrite_rejects_fragment_with_deletion_file() {
+async fn test_overwrite_rejects_fragment_with_deletion_file(
+    // Every form of the operation must be rejected: upserting config alongside
+    // the overwrite does not make renumbering the fragment any safer.
+    #[values(None, Some(HashMap::from([("key".to_string(), "value".to_string())])))]
+    config_upsert_values: Option<HashMap<String, String>>,
+) {
     // A deletion file's path embeds the fragment id, so it cannot follow its
     // fragment to the fresh id an overwrite assigns. Such a fragment belongs to
     // the dataset being replaced, so the operation is rejected rather than
@@ -699,7 +706,7 @@ async fn test_overwrite_rejects_fragment_with_deletion_file() {
             Operation::Overwrite {
                 fragments: vec![fragment],
                 schema,
-                config_upsert_values: None,
+                config_upsert_values,
                 initial_bases: None,
             },
             None,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -340,10 +340,13 @@ pub enum Operation {
     ///
     /// The fragments are newly written ones and are assigned fresh ids at commit
     /// time, continuing from the dataset's highest id ever used; the ids they
-    /// arrive with are ignored. A fragment carrying a deletion file therefore
-    /// belongs to the dataset being replaced and is rejected: use [`Self::Delete`]
-    /// to commit deletions, or [`Self::Merge`] to change the schema of existing
-    /// fragments.
+    /// arrive with are ignored.
+    ///
+    /// A fragment carrying a deletion file is rejected. A deletion file's path
+    /// embeds the fragment id, so it cannot follow its fragment to the new id:
+    /// minting a fragment and giving it a deletion file are mutually exclusive in
+    /// one transaction. Use [`Self::Delete`] to commit deletions against existing
+    /// fragments, or [`Self::Merge`] to change their schema.
     Overwrite {
         fragments: Vec<Fragment>,
         schema: Schema,
@@ -4009,10 +4012,7 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
             schema_fragments_valid(Some(manifest), schema, fragments)
         }
         Operation::Overwrite {
-            fragments,
-            schema,
-            config_upsert_values: None,
-            initial_bases: _,
+            fragments, schema, ..
         } => {
             overwrite_fragments_valid(fragments)?;
             // Pass None for manifest because Overwrite replaces all fragments.

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -42,6 +42,7 @@ use lance_table::{
     },
     io::{
         commit::CommitHandler,
+        deletion::relative_deletion_file_path,
         manifest::{read_manifest, read_manifest_indexes},
     },
     rowids::{RowIdSequence, segment::U64Segment, version::build_version_meta, write_row_ids},
@@ -336,6 +337,13 @@ pub enum Operation {
     },
     /// Overwrite the entire dataset with the given fragments. This is also
     /// used when initially creating a table.
+    ///
+    /// The fragments are newly written ones and are assigned fresh ids at commit
+    /// time, continuing from the dataset's highest id ever used; the ids they
+    /// arrive with are ignored. A fragment carrying a deletion file therefore
+    /// belongs to the dataset being replaced and is rejected: use [`Self::Delete`]
+    /// to commit deletions, or [`Self::Merge`] to change the schema of existing
+    /// fragments.
     Overwrite {
         fragments: Vec<Fragment>,
         schema: Schema,
@@ -1852,14 +1860,14 @@ impl Transaction {
             }
         };
 
-        let mut fragment_id = if matches!(self.operation, Operation::Overwrite { .. }) {
-            0
-        } else {
-            current_manifest
-                .and_then(|m| m.max_fragment_id())
-                .map(|id| id + 1)
-                .unwrap_or(0)
-        };
+        // Fragment ids are a high water mark for the whole dataset history: an id
+        // must never name two different sets of rows, or per-fragment state keyed
+        // by id (caches, deletion files, row addresses) can be attributed to the
+        // wrong rows.
+        let mut fragment_id = current_manifest
+            .and_then(|m| m.max_fragment_id())
+            .map(|id| id + 1)
+            .unwrap_or(0);
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
 
@@ -2089,9 +2097,16 @@ impl Transaction {
                 }
             }
             Operation::Overwrite { fragments, .. } => {
-                let mut new_fragments =
-                    Self::fragments_with_ids(fragments.clone(), &mut fragment_id)
-                        .collect::<Vec<_>>();
+                // Every fragment in an overwrite is newly written, so all of them
+                // take fresh ids regardless of the id they arrive with. Fragments
+                // carried over from the dataset being replaced are rejected by
+                // `validate_operation`, which is what makes ignoring the incoming
+                // id safe here.
+                let mut new_fragments = fragments.clone();
+                for fragment in new_fragments.iter_mut() {
+                    fragment.id = fragment_id;
+                    fragment_id += 1;
+                }
                 if let Some(next_row_id) = &mut next_row_id {
                     Self::assign_row_ids(next_row_id, new_fragments.as_mut_slice())?;
                     // Add version metadata for all new fragments
@@ -3966,6 +3981,7 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
             },
         ) => {
             // Validate here because we are going to return early.
+            overwrite_fragments_valid(fragments)?;
             schema_fragments_valid(None, schema, fragments)?;
 
             return Ok(());
@@ -3998,6 +4014,7 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
             config_upsert_values: None,
             initial_bases: _,
         } => {
+            overwrite_fragments_valid(fragments)?;
             // Pass None for manifest because Overwrite replaces all fragments.
             // The old manifest's storage format is irrelevant for validating
             // the new fragments (e.g., LEGACY→STABLE transitions).
@@ -4013,6 +4030,25 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
         }
         _ => Ok(()),
     }
+}
+
+// An overwrite's fragments are newly written, so they are given fresh ids at
+// commit time. A deletion file cannot come along for that ride: its path embeds
+// the fragment id, so renumbering the fragment would orphan the deletion vector
+// and silently resurrect deleted rows.
+fn overwrite_fragments_valid(fragments: &[Fragment]) -> Result<()> {
+    for fragment in fragments {
+        if let Some(deletion_file) = &fragment.deletion_file {
+            return Err(Error::invalid_input(format!(
+                "Overwrite fragments must be newly written, but fragment {} carries \
+                 deletion file {}. Use Delete to commit deletions against existing \
+                 fragments, or Merge to change their schema.",
+                fragment.id,
+                relative_deletion_file_path(fragment.id, deletion_file)
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn schema_fragments_valid(

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -691,6 +691,26 @@ fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
     Ok(())
 }
 
+/// Reject a manifest in which two fragments share an id. Per-fragment state is
+/// keyed by fragment id — deletion file paths, cached row id sequences, row
+/// addresses — so a duplicate makes it ambiguous which rows that state describes.
+///
+/// Runs after the legacy fixups above, so a dataset that needs a rollback for some
+/// other reason is diagnosed with that first. Relies on `build_manifest` leaving
+/// the fragments sorted by id.
+fn check_fragment_ids(manifest: &Manifest) -> Result<()> {
+    if let Some(pair) = manifest.fragments.windows(2).find(|p| p[0].id == p[1].id) {
+        return Err(Error::invalid_input(format!(
+            "The commit would produce two fragments with id {}. Fragment ids must be \
+             unique. Datasets written by Lance 0.16 and earlier may already contain \
+             duplicate ids; those have to be rewritten, or rolled back to a version \
+             without the duplicate.",
+            pair[0].id
+        )));
+    }
+    Ok(())
+}
+
 fn check_column_indices(manifest: &Manifest) -> Result<()> {
     let data_storage_version = manifest.data_storage_format.lance_file_version()?;
     if data_storage_version < LanceFileVersion::V2_1 {
@@ -1116,6 +1136,7 @@ pub(crate) async fn do_commit_detached_transaction(
         fix_schema(&mut manifest)?;
         check_storage_version(&mut manifest)?;
         check_column_indices(&manifest)?;
+        check_fragment_ids(&manifest)?;
         migrate_indices(dataset, &mut indices).await?;
 
         // Try to commit the manifest
@@ -1435,6 +1456,7 @@ pub(crate) async fn commit_transaction(
 
         check_storage_version(&mut manifest)?;
         check_column_indices(&manifest)?;
+        check_fragment_ids(&manifest)?;
 
         migrate_indices(&dataset, &mut indices).await?;
 


### PR DESCRIPTION
Independent of #8078, which fixes the same #8075 symptom at the cache layer; whichever lands second will hit a one-line conflict on the fragment id assertion in `test_row_ids_overwrite`.

Overwriting a dataset restarted fragment id allocation at 0, so the fragments an overwrite wrote took ids that earlier generations of the dataset had already used. Anything keyed by fragment id — cached row id sequences, deletion files, row addresses — can then be attributed to rows it was never written for. #8075 was one instance: readers sharing a `Session` across an overwrite were served the previous generation's row id sequence for the reused id.

Overwrite now allocates ids from the dataset's high water mark, like every other operation. This is the invariant discussion #5540 asks for — a fragment id must never name two different sets of rows over a dataset's history — and #5554 already established it for restore.

An overwrite's fragments are newly written by definition, so every one of them takes a fresh id and the id it arrives with is ignored. That sidesteps the ambiguity that makes this change awkward otherwise: id 0 doubles as "no id assigned yet", so for a payload that mixed new and carried-over fragments there would be no way to tell which is which.

A deletion file is the one thing that cannot follow its fragment to a new id, because its path embeds the fragment id (`_deletions/{fragment_id}-{read_version}-{id}`). A fragment carrying one therefore belongs to the dataset being replaced, and such an operation is now rejected with an error pointing at `Delete` (to commit deletions against existing fragments) or `Merge` (to change their schema). Everything else survives renumbering: data files and overlays carry explicit paths, and row id sequences are resolved through the fragment's current id.

Two in-repo tests took that shortcut and move to the operation that models what they do: the Rust `test_append_new_columns` now commits with `Merge` (which is what `add_columns` uses in production), and Python's `test_deletion_file` with `Delete`.

Commits that would leave two fragments sharing an id are also rejected now, which nothing checked before. `Append` still honors an id a fragment arrives with, so a caller can hand in one that is already taken — that is how the checked-in `test_data/v0.16.0/wrong_data_version_no_fix.lance` fixture ended up with fragment ids `[0, 1, 1, 2]`: its creating transaction passed `[0, 1, 2, 0]` and the counter handed the last one the 1 that was already in use. The check runs after the legacy manifest fixups, so a dataset that needs a rollback for some other reason still gets that diagnosis first (that fixture reports its mixture of file versions, as before).

## Not included

`lance-namespace-impls` has its own copy of this id assignment for the internal manifest dataset (`ManifestNamespace::manifest_from_overwrite_transaction`), which builds a manifest directly rather than going through `Transaction::build_manifest`. It still restarts at 0 and is left alone here.

The ambiguity around id 0 goes away for good once a transaction type distinguishes existing fragments from newly minted ones; the rejection above is the interim guard rather than the end state.

## Breaking changes

Fragment ids no longer restart at 0 after an overwrite — the first fragment an overwrite writes takes the next id after the dataset's highest ever used. Code that assumes a specific id afterwards (e.g. `dataset.get_fragment(0)`) needs to read the ids from the manifest instead.

Committing an `Overwrite` whose fragments carry a deletion file now fails instead of silently reusing ids. Use `Delete` or `Merge` instead.

Datasets that already contain duplicate fragment ids — Lance 0.16 and earlier could write them — can still be read, but can no longer be committed to. They have to be rewritten, or rolled back to a version without the duplicate.

Addresses discussion #5540.
