### PR TITLE
feat(dataset): add write_fragment_column and commit_column_writes

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -141,6 +141,7 @@ pub use write::merge_insert::{
 };
 
 use crate::dataset::index::LanceIndexStoreExt;
+pub use write::column_write_error::ColumnWriteError;
 pub use write::update::{UpdateBuilder, UpdateJob};
 #[allow(deprecated)]
 pub use write::{
@@ -3577,9 +3578,9 @@ impl Dataset {
         data: impl Stream<Item = Result<RecordBatch>> + Send,
         schema: &lance_core::datatypes::Schema,
     ) -> Result<transaction::DataReplacementGroup> {
-        let fragment = self.get_fragment(fragment_id as usize).ok_or_else(|| {
-            Error::invalid_input(format!("fragment {fragment_id} not found in dataset"))
-        })?;
+        let fragment = self
+            .get_fragment(fragment_id as usize)
+            .ok_or(ColumnWriteError::FragmentNotFound { fragment_id })?;
         let expected_rows = fragment.physical_rows().await? as u64;
 
         let file_name = format!("{}.lance", fragment::write::generate_random_filename());
@@ -3611,11 +3612,12 @@ impl Dataset {
             if let Err(delete_error) = self.object_store.delete(&path).await {
                 log::warn!("failed to delete staged column file '{path}': {delete_error}");
             }
-            return Err(Error::invalid_input(format!(
-                "column data for fragment {fragment_id} has {} rows but the fragment has {} \
-                 physical rows",
-                summary.num_rows, expected_rows
-            )));
+            return Err(ColumnWriteError::RowCountMismatch {
+                fragment_id,
+                staged_rows: summary.num_rows,
+                physical_rows: expected_rows,
+            }
+            .into());
         }
         let field_ids: Vec<i32> = field_id_mapping
             .iter()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -29,6 +29,7 @@ use lance_core::utils::tracing::{
 use lance_datafusion::projection::ProjectionPlan;
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
+use lance_file::writer::FileWriterOptions;
 use lance_index::{IndexType, progress::IndexBuildProgress};
 use lance_io::object_store::{
     ChainedWrappingObjectStore, LanceNamespaceStorageOptionsProvider, ObjectStore,
@@ -151,6 +152,10 @@ pub use write::{
 pub(crate) const INDICES_DIR: &str = "_indices";
 pub(crate) const DATA_DIR: &str = "data";
 pub(crate) const TRANSACTIONS_DIR: &str = "_transactions";
+/// Schema metadata key stamped on files staged by
+/// [`Dataset::write_fragment_column`]: the dataset version the column data
+/// was prepared against.
+pub(crate) const COLUMN_WRITE_READ_VERSION_METADATA_KEY: &str = "lance:column_write:read_version";
 
 // We default to 6GB for the index cache, since indices are often large but
 // worth caching.
@@ -3553,6 +3558,87 @@ impl Dataset {
         batch_size: Option<u32>,
     ) -> Result<()> {
         schema_evolution::add_columns(self, transforms, read_columns, batch_size).await
+    }
+
+    /// Write new column data for a single fragment as a standalone data file,
+    /// without committing it, and return the
+    /// [`DataReplacementGroup`](transaction::DataReplacementGroup) describing it.
+    ///
+    /// `data` must produce exactly the fragment's physical row count, including
+    /// nulls for rows that are not being populated. Batches are pulled from the
+    /// stream one at a time, so the full column need not be held in memory.
+    ///
+    /// The staged file records `schema` and the dataset version it was
+    /// prepared against; committing validates against that record, not
+    /// caller-supplied copies.
+    pub async fn write_fragment_column(
+        &self,
+        fragment_id: u64,
+        data: impl Stream<Item = Result<RecordBatch>> + Send,
+        schema: &lance_core::datatypes::Schema,
+    ) -> Result<transaction::DataReplacementGroup> {
+        let fragment = self.get_fragment(fragment_id as usize).ok_or_else(|| {
+            Error::invalid_input(format!("fragment {fragment_id} not found in dataset"))
+        })?;
+        let expected_rows = fragment.physical_rows().await? as u64;
+
+        let file_name = format!("{}.lance", fragment::write::generate_random_filename());
+        let path = self.data_dir().join(file_name.as_str());
+
+        let file_version =
+            ConcreteFileVersion::from(self.manifest.data_storage_format.lance_file_version()?);
+
+        let writer = self.object_store.create(&path).await?;
+        let mut file_writer = lance_file::versions::create_writer(
+            file_version,
+            writer,
+            schema.clone(),
+            FileWriterOptions::default(),
+        )?;
+        file_writer.add_schema_metadata(
+            COLUMN_WRITE_READ_VERSION_METADATA_KEY,
+            self.manifest.version.to_string(),
+        );
+
+        let mut data = std::pin::pin!(data);
+        while let Some(batch_result) = data.next().await {
+            let batch = batch_result?;
+            file_writer.write_batch(&batch).await?;
+        }
+        let field_id_mapping = file_writer.field_id_to_column_indices().to_vec();
+        let summary = file_writer.finish().await?;
+        if summary.num_rows != expected_rows {
+            if let Err(delete_error) = self.object_store.delete(&path).await {
+                log::warn!("failed to delete staged column file '{path}': {delete_error}");
+            }
+            return Err(Error::invalid_input(format!(
+                "column data for fragment {fragment_id} has {} rows but the fragment has {} \
+                 physical rows",
+                summary.num_rows, expected_rows
+            )));
+        }
+        let field_ids: Vec<i32> = field_id_mapping
+            .iter()
+            .map(|(field_id, _)| *field_id as i32)
+            .collect();
+        let column_indices: Vec<i32> = field_id_mapping
+            .iter()
+            .map(|(_, column_index)| *column_index as i32)
+            .collect();
+
+        let (major, minor) = file_version.to_data_file_numbers();
+
+        let data_file = DataFile {
+            path: file_name,
+            fields: field_ids.into(),
+            column_indices: column_indices.into(),
+            file_major_version: major,
+            file_minor_version: minor,
+            file_size_bytes: CachedFileSize::new(summary.size_bytes),
+            base_id: None,
+        };
+
+        Ok(transaction::DataReplacementGroup(fragment_id, data_file))
     }
 
     /// Modify columns in the dataset, changing their name, type, or nullability.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5,7 +5,7 @@
 //!
 
 use arrow_array::{RecordBatch, RecordBatchReader};
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Schema as ArrowSchema};
 use byteorder::{ByteOrder, LittleEndian};
 use chrono::{Duration, prelude::*};
 use futures::future::BoxFuture;
@@ -3572,6 +3572,16 @@ impl Dataset {
     /// The staged file records `schema` and the dataset version it was
     /// prepared against; committing validates against that record, not
     /// caller-supplied copies.
+    ///
+    /// Use [`Self::new_column_schema`] to build `schema` for a column that
+    /// does not exist yet; to rewrite one that does, project the field out of
+    /// [`Self::schema`] so it keeps its committed id and contract.
+    ///
+    /// A staged file that is never committed -- because staging failed, or
+    /// because the caller abandoned the write -- is unreferenced by any
+    /// manifest, so `cleanup_old_versions` reclaims it once it ages past the
+    /// unverified-file threshold. Staging failures delete their own file
+    /// immediately rather than waiting for that.
     pub async fn write_fragment_column(
         &self,
         fragment_id: u64,
@@ -3586,10 +3596,37 @@ impl Dataset {
         let file_name = format!("{}.lance", fragment::write::generate_random_filename());
         let path = self.data_dir().join(file_name.as_str());
 
+        match self
+            .stage_column_file(&path, &file_name, fragment_id, expected_rows, data, schema)
+            .await
+        {
+            Ok(data_file) => Ok(transaction::DataReplacementGroup(fragment_id, data_file)),
+            Err(error) => {
+                // Best effort: a write that never finished may have produced
+                // no object at all, and whatever does survive is unreferenced,
+                // so version cleanup reclaims it either way.
+                let _ = self.object_store.delete(&path).await;
+                Err(error)
+            }
+        }
+    }
+
+    /// Write one fragment's column data as a standalone file at `path`,
+    /// leaving the file in place for [`Self::write_fragment_column`] to
+    /// discard if anything here fails.
+    async fn stage_column_file(
+        &self,
+        path: &Path,
+        file_name: &str,
+        fragment_id: u64,
+        expected_rows: u64,
+        data: impl Stream<Item = Result<RecordBatch>> + Send,
+        schema: &lance_core::datatypes::Schema,
+    ) -> Result<DataFile> {
         let file_version =
             ConcreteFileVersion::from(self.manifest.data_storage_format.lance_file_version()?);
 
-        let writer = self.object_store.create(&path).await?;
+        let writer = self.object_store.create(path).await?;
         let mut file_writer = lance_file::versions::create_writer(
             file_version,
             writer,
@@ -3609,9 +3646,6 @@ impl Dataset {
         let field_id_mapping = file_writer.field_id_to_column_indices().to_vec();
         let summary = file_writer.finish().await?;
         if summary.num_rows != expected_rows {
-            if let Err(delete_error) = self.object_store.delete(&path).await {
-                log::warn!("failed to delete staged column file '{path}': {delete_error}");
-            }
             return Err(ColumnWriteError::RowCountMismatch {
                 fragment_id,
                 staged_rows: summary.num_rows,
@@ -3630,17 +3664,65 @@ impl Dataset {
 
         let (major, minor) = file_version.to_data_file_numbers();
 
-        let data_file = DataFile {
-            path: file_name,
+        Ok(DataFile {
+            path: file_name.to_string(),
             fields: field_ids.into(),
             column_indices: column_indices.into(),
             file_major_version: major,
             file_minor_version: minor,
             file_size_bytes: CachedFileSize::new(summary.size_bytes),
             base_id: None,
-        };
+        })
+    }
 
-        Ok(transaction::DataReplacementGroup(fragment_id, data_file))
+    /// Build the schema for staging columns that do not exist in this dataset
+    /// yet, for [`Self::write_fragment_column`].
+    ///
+    /// Field ids are assigned above the dataset's current maximum, nested
+    /// children included, which is the numbering
+    /// [`Self::commit_column_writes`] requires of a new column. Build the
+    /// schema once and stage the same one for every fragment of a column
+    /// write, so all its files agree on the ids.
+    ///
+    /// Rewriting a column that already exists is a different operation: the
+    /// staged file must carry that field's committed id, name, type and
+    /// nullability, so project it out of [`Self::schema`] rather than
+    /// numbering it here. Naming an existing column is therefore an error, as
+    /// is naming a reserved system column.
+    pub fn new_column_schema(
+        &self,
+        columns: &ArrowSchema,
+    ) -> Result<lance_core::datatypes::Schema> {
+        for field in columns.fields() {
+            // The system columns are virtual: they are injected into scan
+            // results at read time and never stored. A stored column sharing
+            // one of those names commits and validates, but then collides
+            // with the injected field and makes projection fail.
+            if lance_core::is_system_column(field.name()) {
+                return Err(ColumnWriteError::ReservedColumnName {
+                    name: field.name().clone(),
+                }
+                .into());
+            }
+            if self.schema().field(field.name()).is_some() {
+                return Err(ColumnWriteError::ColumnAlreadyExists {
+                    name: field.name().clone(),
+                }
+                .into());
+            }
+        }
+        let mut merged = self.schema().merge(columns)?;
+        merged.set_field_id(Some(self.manifest.max_field_id()));
+        let new_names: HashSet<&str> = columns
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect();
+        merged
+            .fields
+            .retain(|f| new_names.contains(f.name.as_str()));
+        merged.metadata = Default::default();
+        Ok(merged)
     }
 
     /// Commit per-fragment column writes from [`Self::write_fragment_column`]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3641,6 +3641,26 @@ impl Dataset {
         Ok(transaction::DataReplacementGroup(fragment_id, data_file))
     }
 
+    /// Commit per-fragment column writes from [`Self::write_fragment_column`]
+    /// as a new dataset version, merging each data file into its fragment and
+    /// extending the schema with the staged columns in one atomic commit.
+    ///
+    /// The staged files are the source of truth: their footers supply the
+    /// column schema and the dataset version the writes were prepared
+    /// against. Columns that already existed at prepare time are incremental
+    /// rewrites (prior coverage in the fragment is tombstoned so the new file
+    /// is authoritative); columns that were new must still be unclaimed at
+    /// commit time. A new non-nullable column must cover every live fragment.
+    /// Every replacement must reference a current fragment; if a concurrent
+    /// operation rewrote one, the commit fails and the caller must recompute.
+    pub async fn commit_column_writes(
+        &mut self,
+        replacements: Vec<transaction::DataReplacementGroup>,
+        transaction_properties: Option<Arc<HashMap<String, String>>>,
+    ) -> Result<()> {
+        write::column_writes::commit_column_writes(self, replacements, transaction_properties).await
+    }
+
     /// Modify columns in the dataset, changing their name, type, or nullability.
     ///
     /// If only changing the name or nullability of a column, this is a zero-copy

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -48,6 +48,7 @@ use lance_file::{LanceEncodingsIo, determine_file_version};
 use lance_io::ReadBatchParams;
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
+use lance_table::format::overlay::TOMBSTONE_FIELD_ID;
 use lance_table::format::{DataFile, DeletionFile, Fragment};
 use lance_table::io::deletion::{deletion_file_path, write_deletion_file};
 use lance_table::rowids::RowIdSequence;
@@ -1418,6 +1419,12 @@ impl FileFragment {
         for data_file in &self.metadata.files {
             let last = -1;
             for field_id in data_file.fields.iter() {
+                // Tombstoned entries mark fields superseded by a later data
+                // file (e.g. an in-place column rewrite) and are valid in any
+                // position, any number of times.
+                if *field_id == TOMBSTONE_FIELD_ID {
+                    continue;
+                }
                 if *field_id <= last {
                     return Err(Error::corrupt_file(
                         self.dataset

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -13,7 +13,7 @@ use crate::dataset::transaction::{DataReplacementGroup, Operation};
 use crate::dataset::{AutoCleanupParams, MergeInsertBuilder, ProjectionRequest, UpdateBuilder};
 use crate::index::DatasetIndexExt;
 use crate::{Dataset, Error};
-use lance_core::ROW_ADDR;
+use lance_core::{ROW_ADDR, datatypes::Schema as LanceSchema};
 use lance_index::IndexType;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
@@ -4291,4 +4291,102 @@ async fn test_merge_insert_target_all_bases() {
     for row in expected_new {
         assert!(all_rows.contains(&row), "missing row {:?}", row);
     }
+}
+
+/// Lance schema for new nullable Int32 columns with fresh sequential field ids.
+fn new_int32_columns_schema(dataset: &Dataset, names: &[&str]) -> LanceSchema {
+    let fields: Vec<ArrowField> = names
+        .iter()
+        .map(|name| ArrowField::new(*name, DataType::Int32, true))
+        .collect();
+    let mut schema = LanceSchema::try_from(&ArrowSchema::new(fields)).unwrap();
+    let base_id = dataset.manifest.max_field_id() + 1;
+    for (offset, field) in schema.fields.iter_mut().enumerate() {
+        field.id = base_id + offset as i32;
+    }
+    schema
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_write_fragment_column_metadata(
+    #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)]
+    data_storage_version: LanceFileVersion,
+) {
+    let batch = arrow_array::record_batch!(("id", Int32, [1, 2])).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+    let dataset = Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            data_storage_version: Some(data_storage_version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // One new column streamed as two batches: the returned DataFile must
+    // record the writer's field/column layout and the dataset's file version.
+    let b1 = arrow_array::record_batch!(("value", Int32, [1])).unwrap();
+    let b2 = arrow_array::record_batch!(("value", Int32, [2])).unwrap();
+    let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let field_id = lance_schema.fields[0].id;
+
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let DataReplacementGroup(replaced_fragment, data_file) = dataset
+        .write_fragment_column(
+            fragment_id,
+            futures::stream::iter([Ok(b1), Ok(b2)]),
+            &lance_schema,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(replaced_fragment, fragment_id);
+    assert_eq!(data_file.fields.as_ref(), &[field_id]);
+    assert_eq!(data_file.fields.len(), data_file.column_indices.len());
+    assert!(data_file.path.ends_with(".lance"));
+    assert_eq!(
+        (data_file.file_major_version, data_file.file_minor_version),
+        ConcreteFileVersion::from(data_storage_version).to_data_file_numbers()
+    );
+}
+
+#[tokio::test]
+async fn test_write_fragment_column_rejects_row_count_mismatch() {
+    let batch = arrow_array::record_batch!(("id", Int32, [1, 2])).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+    let dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+    let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+
+    // Too short and too long: both must be rejected before a commit is possible.
+    for wrong_len in [
+        arrow_array::record_batch!(("value", Int32, [7])).unwrap(),
+        arrow_array::record_batch!(("value", Int32, [7, 8, 9])).unwrap(),
+    ] {
+        let err = dataset
+            .write_fragment_column(
+                fragment_id,
+                futures::stream::iter([Ok(wrong_len)]),
+                &lance_schema,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("physical rows"),
+            "expected row-count mismatch error, got: {err}"
+        );
+    }
+
+    let ok = arrow_array::record_batch!(("value", Int32, [1, 2])).unwrap();
+    let err = dataset
+        .write_fragment_column(99, futures::stream::iter([Ok(ok)]), &lance_schema)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("not found"),
+        "expected missing-fragment error, got: {err}"
+    );
 }

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -4293,6 +4293,64 @@ async fn test_merge_insert_target_all_bases() {
     }
 }
 
+/// Lance schema for new columns described by `column_arrow`, with fresh field
+/// ids (and parent links) assigned after the dataset's current max field id.
+fn new_columns_schema(dataset: &Dataset, column_arrow: &ArrowSchema) -> LanceSchema {
+    let mut merged = dataset.schema().merge(column_arrow).unwrap();
+    merged.set_field_id(Some(dataset.manifest.max_field_id()));
+    let new_names: HashSet<&str> = column_arrow
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    LanceSchema {
+        fields: merged
+            .fields
+            .into_iter()
+            .filter(|f| new_names.contains(f.name.as_str()))
+            .collect(),
+        metadata: Default::default(),
+    }
+}
+
+/// Single-column ("id": Int32 1..=rows) dataset split at `max_rows_per_file`.
+async fn id_dataset(rows: i32, max_rows_per_file: usize) -> Dataset {
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from((1..=rows).collect::<Vec<_>>()))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap()
+}
+
+/// Stage one batch as a fragment's new column data.
+async fn stage_column(
+    dataset: &Dataset,
+    fragment_id: u64,
+    batch: RecordBatch,
+    schema: &LanceSchema,
+) -> DataReplacementGroup {
+    dataset
+        .write_fragment_column(fragment_id, futures::stream::iter([Ok(batch)]), schema)
+        .await
+        .unwrap()
+}
+
 /// Lance schema for new nullable Int32 columns with fresh sequential field ids.
 fn new_int32_columns_schema(dataset: &Dataset, names: &[&str]) -> LanceSchema {
     let fields: Vec<ArrowField> = names
@@ -4355,9 +4413,7 @@ async fn test_write_fragment_column_metadata(
 
 #[tokio::test]
 async fn test_write_fragment_column_rejects_row_count_mismatch() {
-    let batch = arrow_array::record_batch!(("id", Int32, [1, 2])).unwrap();
-    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
-    let dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+    let dataset = id_dataset(2, 1024).await;
     let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
     let fragment_id = dataset.get_fragments()[0].id() as u64;
 
@@ -4388,5 +4444,659 @@ async fn test_write_fragment_column_rejects_row_count_mismatch() {
     assert!(
         err.to_string().contains("not found"),
         "expected missing-fragment error, got: {err}"
+    );
+}
+
+/// A column write computes per-fragment replacements, then a concurrent
+/// compaction rewrites those fragments into new ids before the commit.
+/// `commit_column_writes` must fail rather than commit a column with null
+/// data for the rewritten fragments.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_orphaned_replacements_after_compaction() {
+    // One row per file: two fragments to compact together.
+    let mut dataset = id_dataset(2, 1).await;
+    let orig_frag_ids: Vec<u64> = dataset
+        .get_fragments()
+        .iter()
+        .map(|f| f.id() as u64)
+        .collect();
+    assert_eq!(orig_frag_ids.len(), 2);
+
+    let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let mut replacements = Vec::new();
+    for frag_id in &orig_frag_ids {
+        let out = arrow_array::record_batch!(("value", Int32, [0])).unwrap();
+        replacements.push(stage_column(&dataset, *frag_id, out, &lance_schema).await);
+    }
+
+    compact_files(&mut dataset, CompactionOptions::default(), None)
+        .await
+        .unwrap();
+    let new_frag_ids: Vec<u64> = dataset
+        .get_fragments()
+        .iter()
+        .map(|f| f.id() as u64)
+        .collect();
+    assert!(new_frag_ids.iter().all(|id| !orig_frag_ids.contains(id)));
+
+    let err = dataset
+        .commit_column_writes(replacements, None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no longer in the dataset"),
+        "expected orphaned-replacement error, got: {err}"
+    );
+}
+
+/// Committing a replacement for a column that already exists must not
+/// duplicate the field, and must tombstone the fragment's previous coverage
+/// so the new file is authoritative.
+#[tokio::test]
+async fn test_commit_column_writes_incremental_rewrite_tombstones_old_file() {
+    let mut dataset = id_dataset(2, 1024).await;
+
+    let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let value_id = lance_schema.fields[0].id;
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+
+    for out in [
+        arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap(),
+        arrow_array::record_batch!(("value", Int32, [30, 60])).unwrap(),
+    ] {
+        let replacement = stage_column(&dataset, fragment_id, out, &lance_schema).await;
+        dataset
+            .commit_column_writes(vec![replacement], None)
+            .await
+            .unwrap();
+    }
+    dataset.validate().await.unwrap();
+
+    // The field appears once in the schema and the second write's data wins.
+    let value_fields = dataset
+        .schema()
+        .fields
+        .iter()
+        .filter(|f| f.name == "value")
+        .count();
+    assert_eq!(value_fields, 1);
+    let batch = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["value"].as_primitive::<Int32Type>().values(),
+        &[30, 60]
+    );
+
+    // Exactly one live data file covers the field in the fragment.
+    let covering = dataset.get_fragments()[0]
+        .metadata()
+        .files
+        .iter()
+        .filter(|file| file.fields.contains(&value_id))
+        .count();
+    assert_eq!(covering, 1);
+}
+
+/// Two stale writers derive the same fresh field id from one snapshot. After
+/// the first commits, the second must fail and recompute -- whether it staged
+/// a different column or an identical twin -- instead of replaying stale
+/// bytes over the winner.
+#[rstest]
+#[case::different_field("second_value")]
+#[case::same_field("value")]
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_replacement(#[case] second_name: &str) {
+    let mut ds1 = id_dataset(2, 1024).await;
+    let mut ds2 = ds1.clone();
+
+    let schema1 = new_int32_columns_schema(&ds1, &["value"]);
+    let schema2 = new_int32_columns_schema(&ds2, &[second_name]);
+    assert_eq!(schema1.fields[0].id, schema2.fields[0].id);
+    let fragment_id = ds1.get_fragments()[0].id() as u64;
+
+    let b1 = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
+    let r1 = stage_column(&ds1, fragment_id, b1, &schema1).await;
+    let b2 = RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            second_name,
+            DataType::Int32,
+            true,
+        )])),
+        vec![Arc::new(Int32Array::from(vec![30, 40]))],
+    )
+    .unwrap();
+    let r2 = stage_column(&ds2, fragment_id, b2, &schema2).await;
+
+    ds1.commit_column_writes(vec![r1], None).await.unwrap();
+    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
+    assert!(
+        err.to_string().contains("stale schema"),
+        "expected stale-schema conflict, got: {err}"
+    );
+
+    // The winner's data is intact and the loser's was not applied.
+    ds2.checkout_latest().await.unwrap();
+    let batch = ds2.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["value"].as_primitive::<Int32Type>().values(),
+        &[10, 20]
+    );
+    if second_name != "value" {
+        assert!(ds2.schema().field(second_name).is_none());
+    }
+}
+
+#[tokio::test]
+async fn test_commit_column_writes_applies_multiple_files_per_fragment() {
+    let mut dataset = id_dataset(2, 1024).await;
+
+    // Two columns staged as separate files for the same fragment.
+    let union_schema = new_int32_columns_schema(&dataset, &["first", "second"]);
+    let first_schema = union_schema.project_by_ids(&[union_schema.fields[0].id], true);
+    let second_schema = union_schema.project_by_ids(&[union_schema.fields[1].id], true);
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+
+    let b1 = arrow_array::record_batch!(("first", Int32, [10, 20])).unwrap();
+    let r1 = stage_column(&dataset, fragment_id, b1, &first_schema).await;
+    let b2 = arrow_array::record_batch!(("second", Int32, [30, 40])).unwrap();
+    let r2 = stage_column(&dataset, fragment_id, b2, &second_schema).await;
+
+    dataset
+        .commit_column_writes(vec![r1, r2], None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    let batch = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["first"].as_primitive::<Int32Type>().values(),
+        &[10, 20]
+    );
+    assert_eq!(
+        batch["second"].as_primitive::<Int32Type>().values(),
+        &[30, 40]
+    );
+}
+
+#[tokio::test]
+async fn test_commit_column_writes_rejects_disagreeing_staged_schemas() {
+    // One row per file: two fragments to stage separately.
+    let mut dataset = id_dataset(2, 1).await;
+    let frag_ids: Vec<u64> = dataset
+        .get_fragments()
+        .iter()
+        .map(|f| f.id() as u64)
+        .collect();
+
+    // Stage the same field id as Int32 for one fragment and Float32 for the
+    // other; the footers disagree, so the commit must reject the pair.
+    let int_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let float_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "value",
+        DataType::Float32,
+        true,
+    )]));
+    let mut float_schema = LanceSchema::try_from(float_arrow.as_ref()).unwrap();
+    float_schema.fields[0].id = int_schema.fields[0].id;
+
+    let b1 = arrow_array::record_batch!(("value", Int32, [10])).unwrap();
+    let r1 = stage_column(&dataset, frag_ids[0], b1, &int_schema).await;
+    let b2 = RecordBatch::try_new(
+        float_arrow.clone(),
+        vec![Arc::new(arrow_array::Float32Array::from(vec![1.5]))],
+    )
+    .unwrap();
+    let r2 = stage_column(&dataset, frag_ids[1], b2, &float_schema).await;
+
+    let err = dataset
+        .commit_column_writes(vec![r1, r2], None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("disagree on field id"),
+        "expected staged-schema disagreement error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_commit_column_writes_rejects_nullability_change_on_rewrite() {
+    let mut dataset = id_dataset(2, 1024).await;
+
+    let nullable_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let b = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
+    let replacement = stage_column(&dataset, fragment_id, b, &nullable_schema).await;
+    dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+
+    // Rewrite the same field id and name, but declared non-nullable.
+    let strict_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "value",
+        DataType::Int32,
+        false,
+    )]));
+    let mut strict_schema = LanceSchema::try_from(strict_arrow.as_ref()).unwrap();
+    strict_schema.fields[0].id = nullable_schema.fields[0].id;
+    let b = RecordBatch::try_new(
+        strict_arrow.clone(),
+        vec![Arc::new(Int32Array::from(vec![30, 60]))],
+    )
+    .unwrap();
+    let replacement = stage_column(&dataset, fragment_id, b, &strict_schema).await;
+    let err = dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("conflicts with field id"),
+        "expected field-contract mismatch error, got: {err}"
+    );
+}
+
+#[rstest]
+#[case::int32(vec![ArrowField::new("nv", DataType::Int32, true)])]
+#[case::utf8(vec![ArrowField::new("nv", DataType::Utf8, true)])]
+#[case::fixed_size_list(vec![ArrowField::new(
+    "nv",
+    DataType::FixedSizeList(Arc::new(ArrowField::new("item", DataType::Float32, true)), 4),
+    true,
+)])]
+#[case::struct_flat(vec![ArrowField::new(
+    "nv",
+    DataType::Struct(Fields::from(vec![
+        ArrowField::new("x", DataType::Int32, true),
+        ArrowField::new("y", DataType::Utf8, true),
+    ])),
+    true,
+)])]
+#[case::struct_nested(vec![ArrowField::new(
+    "nv",
+    DataType::Struct(Fields::from(vec![ArrowField::new(
+        "inner",
+        DataType::Struct(Fields::from(vec![ArrowField::new("x", DataType::Int32, true)])),
+        true,
+    )])),
+    true,
+)])]
+#[case::list(vec![ArrowField::new(
+    "nv",
+    DataType::List(Arc::new(ArrowField::new("item", DataType::Int32, true))),
+    true,
+)])]
+#[case::large_binary(vec![ArrowField::new("nv", DataType::LargeBinary, true)])]
+#[case::multi_mixed(vec![
+    ArrowField::new("nv", DataType::Int32, true),
+    ArrowField::new("nv2", DataType::Struct(Fields::from(vec![
+        ArrowField::new("x", DataType::Int32, true),
+    ])), true),
+])]
+#[tokio::test]
+async fn test_write_commit_column_round_trip_schema_zoo(#[case] new_fields: Vec<ArrowField>) {
+    let mut dataset = id_dataset(6, 3).await;
+    assert_eq!(dataset.get_fragments().len(), 2);
+
+    let column_arrow = Arc::new(ArrowSchema::new(new_fields));
+    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
+
+    let mut expected = Vec::new();
+    let mut replacements = Vec::new();
+    for frag in dataset.get_fragments() {
+        let rows = frag.physical_rows().await.unwrap();
+        let data = lance_datagen::rand(&column_arrow)
+            .into_batch_rows(RowCount::from(rows as u64))
+            .unwrap();
+        expected.push(data.clone());
+        replacements.push(
+            dataset
+                .write_fragment_column(
+                    frag.id() as u64,
+                    futures::stream::iter([Ok(data)]),
+                    &column_schema,
+                )
+                .await
+                .unwrap(),
+        );
+    }
+    dataset
+        .commit_column_writes(replacements, None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    // Re-read through a fresh handle so nothing rides on in-memory state.
+    let dataset = dataset
+        .checkout_version(dataset.version().version)
+        .await
+        .unwrap();
+    let names: Vec<&str> = column_arrow
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    let scanned = dataset
+        .scan()
+        .project(&names)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let expected = concat_batches(&column_arrow, &expected).unwrap();
+    assert_eq!(scanned.num_rows(), expected.num_rows());
+    for name in names {
+        assert_eq!(
+            &scanned[name], &expected[name],
+            "column '{name}' round trip"
+        );
+    }
+}
+
+#[rstest]
+#[case::nullable(true)]
+#[case::non_nullable(false)]
+#[tokio::test]
+async fn test_commit_column_writes_concurrent_append(#[case] nullable: bool) {
+    let mut dataset = id_dataset(2, 1024).await;
+
+    let column_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "value",
+        DataType::Int32,
+        nullable,
+    )]));
+    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
+
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let staged = RecordBatch::try_new(
+        column_arrow.clone(),
+        vec![Arc::new(Int32Array::from(vec![10, 20]))],
+    )
+    .unwrap();
+    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
+
+    // An append lands between the write and the commit.
+    let append = arrow_array::record_batch!(("id", Int32, [3])).unwrap();
+    let append_reader = RecordBatchIterator::new(vec![Ok(append.clone())], append.schema());
+    dataset.append(append_reader, None).await.unwrap();
+
+    let result = dataset.commit_column_writes(vec![replacement], None).await;
+    if nullable {
+        // The appended fragment reads null, matching add_columns semantics.
+        result.unwrap();
+        dataset.validate().await.unwrap();
+        let scanned = dataset
+            .scan()
+            .project(&["value"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let values = scanned["value"].as_primitive::<Int32Type>();
+        assert_eq!(scanned.num_rows(), 3);
+        assert!(values.is_null(2));
+    } else {
+        // An uncovered non-nullable column would synthesize invalid nulls.
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("non-nullable column"),
+            "expected coverage error, got: {err}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_commit_column_writes_rewrite_updates_indexed_column_queries() {
+    let batch =
+        arrow_array::record_batch!(("id", Int32, [1, 2]), ("value", Int32, [10, 20])).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+    let mut dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::Scalar,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    // Incrementally rewrite the indexed column.
+    let value_field = dataset.schema().field("value").unwrap().clone();
+    let column_schema = LanceSchema {
+        fields: vec![value_field],
+        metadata: Default::default(),
+    };
+    let column_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "value",
+        DataType::Int32,
+        true,
+    )]));
+    let staged =
+        RecordBatch::try_new(column_arrow, vec![Arc::new(Int32Array::from(vec![30, 60]))]).unwrap();
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
+    dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    // Filtered queries must reflect the rewritten values, not stale index
+    // entries for the replaced data.
+    let hits = dataset
+        .scan()
+        .filter("value = 60")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(hits.num_rows(), 1);
+    let stale = dataset
+        .scan()
+        .filter("value = 20")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(stale.num_rows(), 0, "stale index entries must not surface");
+}
+
+#[tokio::test]
+async fn test_write_fragment_column_covers_physical_rows_with_deletions() {
+    let mut dataset = id_dataset(3, 1024).await;
+    dataset.delete("id = 2").await.unwrap();
+
+    // The staged column must cover physical rows, including deleted ones.
+    let column_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let staged = arrow_array::record_batch!(("value", Int32, [10, 20, 30])).unwrap();
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
+    dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    let scanned = dataset
+        .scan()
+        .project(&["id", "value"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(scanned["id"].as_primitive::<Int32Type>().values(), &[1, 3]);
+    assert_eq!(
+        scanned["value"].as_primitive::<Int32Type>().values(),
+        &[10, 30]
+    );
+}
+
+#[tokio::test]
+async fn test_commit_column_writes_nullable_struct_with_non_nullable_leaf_partial_coverage() {
+    let mut dataset = id_dataset(2, 1).await;
+
+    // Nullable struct with a non-nullable leaf: an uncovered fragment can
+    // read as a null struct, so partial coverage is legal.
+    let leaf = ArrowField::new("x", DataType::Int32, false);
+    let column_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "s",
+        DataType::Struct(Fields::from(vec![leaf.clone()])),
+        true,
+    )]));
+    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
+
+    let staged = RecordBatch::try_new(
+        column_arrow.clone(),
+        vec![Arc::new(StructArray::from(vec![(
+            Arc::new(leaf),
+            Arc::new(Int32Array::from(vec![10])) as ArrayRef,
+        )]))],
+    )
+    .unwrap();
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
+    dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+    dataset.validate().await.unwrap();
+
+    let scanned = dataset
+        .scan()
+        .project(&["s"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(scanned.num_rows(), 2);
+    assert!(!scanned["s"].is_null(0));
+    assert!(
+        scanned["s"].is_null(1),
+        "uncovered fragment reads a null struct"
+    );
+}
+
+/// Two handles rewrite the same existing column from one snapshot. The
+/// loser's staged bytes are bound to the prepare-time backing file, so the
+/// retry fails instead of tombstoning the winner's fresh data.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_existing_column_rewrite() {
+    let mut ds1 = id_dataset(2, 1024).await;
+    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
+    let fragment_id = ds1.get_fragments()[0].id() as u64;
+    let seed = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
+    let replacement = stage_column(&ds1, fragment_id, seed, &column_schema).await;
+    ds1.commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+
+    let mut ds2 = ds1.clone();
+    let b1 = arrow_array::record_batch!(("value", Int32, [30, 40])).unwrap();
+    let r1 = stage_column(&ds1, fragment_id, b1, &column_schema).await;
+    let b2 = arrow_array::record_batch!(("value", Int32, [50, 60])).unwrap();
+    let r2 = stage_column(&ds2, fragment_id, b2, &column_schema).await;
+
+    ds1.commit_column_writes(vec![r1], None).await.unwrap();
+    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("changed since the column was prepared"),
+        "expected stale-rewrite conflict, got: {err}"
+    );
+
+    ds2.checkout_latest().await.unwrap();
+    let batch = ds2.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["value"].as_primitive::<Int32Type>().values(),
+        &[30, 40]
+    );
+}
+
+/// Two handles fill the same still-uncovered fragment of a nullable column.
+/// Absence is part of the prepare-time binding, so the loser's retry fails
+/// instead of tombstoning the winner's fill.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_fill_of_uncovered_fragment() {
+    let mut ds1 = id_dataset(2, 1).await;
+    let frag_ids: Vec<u64> = ds1.get_fragments().iter().map(|f| f.id() as u64).collect();
+
+    // Establish a nullable column covering only the first fragment.
+    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
+    let seed = arrow_array::record_batch!(("value", Int32, [10])).unwrap();
+    let replacement = stage_column(&ds1, frag_ids[0], seed, &column_schema).await;
+    ds1.commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+
+    // Two handles stage a fill for the uncovered second fragment.
+    let mut ds2 = ds1.clone();
+    let b1 = arrow_array::record_batch!(("value", Int32, [30])).unwrap();
+    let r1 = stage_column(&ds1, frag_ids[1], b1, &column_schema).await;
+    let b2 = arrow_array::record_batch!(("value", Int32, [50])).unwrap();
+    let r2 = stage_column(&ds2, frag_ids[1], b2, &column_schema).await;
+
+    ds1.commit_column_writes(vec![r1], None).await.unwrap();
+    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("changed since the column was prepared"),
+        "expected stale-fill conflict, got: {err}"
+    );
+
+    ds2.checkout_latest().await.unwrap();
+    let batch = ds2.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["value"].as_primitive::<Int32Type>().values(),
+        &[10, 30]
+    );
+}
+
+/// A concurrent DataOverlay covering the staged field changes the fragment's
+/// coverage identity without touching its base file. The stale column write
+/// must fail rather than tombstone the overlay winner.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_write_over_concurrent_overlay() {
+    use super::dataset_overlay_index_masking::commit_overlay;
+    use lance_table::format::overlay::OverlayCoverage;
+    use roaring::RoaringBitmap;
+
+    let mut ds1 = id_dataset(2, 1024).await;
+    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
+    let fragment_id = ds1.get_fragments()[0].id() as u64;
+    let seed = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
+    let replacement = stage_column(&ds1, fragment_id, seed, &column_schema).await;
+    ds1.commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap();
+
+    // Stage a stale rewrite, then land a concurrent overlay on the field.
+    let staged = arrow_array::record_batch!(("value", Int32, [50, 50])).unwrap();
+    let stale = stage_column(&ds1, fragment_id, staged, &column_schema).await;
+    let value_id = ds1.schema().field("value").unwrap().id;
+    commit_overlay(
+        ds1.clone(),
+        "value_overlay",
+        fragment_id,
+        &[value_id],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([0u32, 1])),
+        vec![Arc::new(Int32Array::from(vec![30, 30])) as ArrayRef],
+    )
+    .await;
+
+    let err = ds1
+        .commit_column_writes(vec![stale], None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("changed since the column was prepared"),
+        "expected stale-over-overlay conflict, got: {err}"
+    );
+
+    ds1.checkout_latest().await.unwrap();
+    let batch = ds1.scan().try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["value"].as_primitive::<Int32Type>().values(),
+        &[30, 30]
     );
 }

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use std::vec;
@@ -10,7 +10,9 @@ use crate::dataset::ROW_ID;
 use crate::dataset::WriteDestination;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
 use crate::dataset::transaction::{DataReplacementGroup, Operation};
-use crate::dataset::{AutoCleanupParams, MergeInsertBuilder, ProjectionRequest, UpdateBuilder};
+use crate::dataset::{
+    AutoCleanupParams, ColumnWriteError, MergeInsertBuilder, ProjectionRequest, UpdateBuilder,
+};
 use crate::index::DatasetIndexExt;
 use crate::{Dataset, Error};
 use lance_core::{ROW_ADDR, datatypes::Schema as LanceSchema};
@@ -4365,6 +4367,11 @@ fn new_int32_columns_schema(dataset: &Dataset, names: &[&str]) -> LanceSchema {
     schema
 }
 
+/// The returned `DataReplacementGroup` must describe the staged file well
+/// enough to commit it without reopening it: the writer's field-id to
+/// column-index mapping, and the dataset's own file version rather than the
+/// crate default. Streaming the column as several batches must not change
+/// that description.
 #[rstest]
 #[tokio::test]
 async fn test_write_fragment_column_metadata(
@@ -4411,6 +4418,10 @@ async fn test_write_fragment_column_metadata(
     );
 }
 
+/// A staged file must cover the fragment's physical rows exactly. A short
+/// file leaves rows with no value and makes later scans fail; a long one
+/// silently drops its surplus. Both are caught while staging, so a bad file
+/// can never reach a commit, and the file is not left behind.
 #[tokio::test]
 async fn test_write_fragment_column_rejects_row_count_mismatch() {
     let dataset = id_dataset(2, 1024).await;
@@ -4430,10 +4441,10 @@ async fn test_write_fragment_column_rejects_row_count_mismatch() {
             )
             .await
             .unwrap_err();
-        assert!(
-            err.to_string().contains("physical rows"),
-            "expected row-count mismatch error, got: {err}"
-        );
+        assert!(matches!(
+            ColumnWriteError::of(&err),
+            Some(ColumnWriteError::RowCountMismatch { .. })
+        ));
     }
 
     let ok = arrow_array::record_batch!(("value", Int32, [1, 2])).unwrap();
@@ -4441,57 +4452,16 @@ async fn test_write_fragment_column_rejects_row_count_mismatch() {
         .write_fragment_column(99, futures::stream::iter([Ok(ok)]), &lance_schema)
         .await
         .unwrap_err();
-    assert!(
-        err.to_string().contains("not found"),
-        "expected missing-fragment error, got: {err}"
-    );
+    assert!(matches!(
+        ColumnWriteError::of(&err),
+        Some(ColumnWriteError::FragmentNotFound { .. })
+    ));
 }
 
-/// A column write computes per-fragment replacements, then a concurrent
-/// compaction rewrites those fragments into new ids before the commit.
-/// `commit_column_writes` must fail rather than commit a column with null
-/// data for the rewritten fragments.
-#[tokio::test]
-async fn test_commit_column_writes_rejects_orphaned_replacements_after_compaction() {
-    // One row per file: two fragments to compact together.
-    let mut dataset = id_dataset(2, 1).await;
-    let orig_frag_ids: Vec<u64> = dataset
-        .get_fragments()
-        .iter()
-        .map(|f| f.id() as u64)
-        .collect();
-    assert_eq!(orig_frag_ids.len(), 2);
-
-    let lance_schema = new_int32_columns_schema(&dataset, &["value"]);
-    let mut replacements = Vec::new();
-    for frag_id in &orig_frag_ids {
-        let out = arrow_array::record_batch!(("value", Int32, [0])).unwrap();
-        replacements.push(stage_column(&dataset, *frag_id, out, &lance_schema).await);
-    }
-
-    compact_files(&mut dataset, CompactionOptions::default(), None)
-        .await
-        .unwrap();
-    let new_frag_ids: Vec<u64> = dataset
-        .get_fragments()
-        .iter()
-        .map(|f| f.id() as u64)
-        .collect();
-    assert!(new_frag_ids.iter().all(|id| !orig_frag_ids.contains(id)));
-
-    let err = dataset
-        .commit_column_writes(replacements, None)
-        .await
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("no longer in the dataset"),
-        "expected orphaned-replacement error, got: {err}"
-    );
-}
-
-/// Committing a replacement for a column that already exists must not
-/// duplicate the field, and must tombstone the fragment's previous coverage
-/// so the new file is authoritative.
+/// Committing a replacement for a column that already exists is an in-place
+/// rewrite, not a second column: the field must still appear once in the
+/// schema, and the fragment's previous coverage must be tombstoned so the new
+/// file is the only one answering for the field.
 #[tokio::test]
 async fn test_commit_column_writes_incremental_rewrite_tombstones_old_file() {
     let mut dataset = id_dataset(2, 1024).await;
@@ -4536,55 +4506,9 @@ async fn test_commit_column_writes_incremental_rewrite_tombstones_old_file() {
     assert_eq!(covering, 1);
 }
 
-/// Two stale writers derive the same fresh field id from one snapshot. After
-/// the first commits, the second must fail and recompute -- whether it staged
-/// a different column or an identical twin -- instead of replaying stale
-/// bytes over the winner.
-#[rstest]
-#[case::different_field("second_value")]
-#[case::same_field("value")]
-#[tokio::test]
-async fn test_commit_column_writes_rejects_stale_replacement(#[case] second_name: &str) {
-    let mut ds1 = id_dataset(2, 1024).await;
-    let mut ds2 = ds1.clone();
-
-    let schema1 = new_int32_columns_schema(&ds1, &["value"]);
-    let schema2 = new_int32_columns_schema(&ds2, &[second_name]);
-    assert_eq!(schema1.fields[0].id, schema2.fields[0].id);
-    let fragment_id = ds1.get_fragments()[0].id() as u64;
-
-    let b1 = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
-    let r1 = stage_column(&ds1, fragment_id, b1, &schema1).await;
-    let b2 = RecordBatch::try_new(
-        Arc::new(ArrowSchema::new(vec![ArrowField::new(
-            second_name,
-            DataType::Int32,
-            true,
-        )])),
-        vec![Arc::new(Int32Array::from(vec![30, 40]))],
-    )
-    .unwrap();
-    let r2 = stage_column(&ds2, fragment_id, b2, &schema2).await;
-
-    ds1.commit_column_writes(vec![r1], None).await.unwrap();
-    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
-    assert!(
-        err.to_string().contains("stale schema"),
-        "expected stale-schema conflict, got: {err}"
-    );
-
-    // The winner's data is intact and the loser's was not applied.
-    ds2.checkout_latest().await.unwrap();
-    let batch = ds2.scan().try_into_batch().await.unwrap();
-    assert_eq!(
-        batch["value"].as_primitive::<Int32Type>().values(),
-        &[10, 20]
-    );
-    if second_name != "value" {
-        assert!(ds2.schema().field(second_name).is_none());
-    }
-}
-
+/// Staging one file per column is a supported way to assemble a multi-column
+/// write, so a fragment with several staged files must apply all of them.
+/// Keeping only the last would publish nulls for every other column.
 #[tokio::test]
 async fn test_commit_column_writes_applies_multiple_files_per_fragment() {
     let mut dataset = id_dataset(2, 1024).await;
@@ -4617,6 +4541,10 @@ async fn test_commit_column_writes_applies_multiple_files_per_fragment() {
     );
 }
 
+/// The staged footers are the source of truth for the column schema, so files
+/// sharing a field id must agree on it. Accepting two fragments staged under
+/// one id with different types would reinterpret one fragment's stored bytes
+/// under the other fragment's type.
 #[tokio::test]
 async fn test_commit_column_writes_rejects_disagreeing_staged_schemas() {
     // One row per file: two fragments to stage separately.
@@ -4651,12 +4579,16 @@ async fn test_commit_column_writes_rejects_disagreeing_staged_schemas() {
         .commit_column_writes(vec![r1, r2], None)
         .await
         .unwrap_err();
-    assert!(
-        err.to_string().contains("disagree on field id"),
-        "expected staged-schema disagreement error, got: {err}"
-    );
+    assert!(matches!(
+        ColumnWriteError::of(&err),
+        Some(ColumnWriteError::StagedSchemasDisagree { .. })
+    ));
 }
 
+/// An in-place rewrite must match the existing field's whole contract, not
+/// just its name and type. Narrowing a committed nullable column to
+/// non-nullable would leave the nulls already stored for other fragments
+/// unreadable under the new declaration.
 #[tokio::test]
 async fn test_commit_column_writes_rejects_nullability_change_on_rewrite() {
     let mut dataset = id_dataset(2, 1024).await;
@@ -4688,10 +4620,10 @@ async fn test_commit_column_writes_rejects_nullability_change_on_rewrite() {
         .commit_column_writes(vec![replacement], None)
         .await
         .unwrap_err();
-    assert!(
-        err.to_string().contains("conflicts with field id"),
-        "expected field-contract mismatch error, got: {err}"
-    );
+    assert!(matches!(
+        ColumnWriteError::of(&err),
+        Some(ColumnWriteError::FieldContractConflict { .. })
+    ));
 }
 
 #[rstest]
@@ -4731,6 +4663,11 @@ async fn test_commit_column_writes_rejects_nullability_change_on_rewrite() {
         ArrowField::new("x", DataType::Int32, true),
     ])), true),
 ])]
+/// Values written by `write_fragment_column` and published by
+/// `commit_column_writes` must read back unchanged across the type shapes the
+/// file writer handles -- nested structs, lists, fixed-size lists and
+/// variable-length binary -- staged per fragment over a multi-fragment
+/// dataset and read through a fresh handle.
 #[tokio::test]
 async fn test_write_commit_column_round_trip_schema_zoo(#[case] new_fields: Vec<ArrowField>) {
     let mut dataset = id_dataset(6, 3).await;
@@ -4791,58 +4728,10 @@ async fn test_write_commit_column_round_trip_schema_zoo(#[case] new_fields: Vec<
     }
 }
 
-#[rstest]
-#[case::nullable(true)]
-#[case::non_nullable(false)]
-#[tokio::test]
-async fn test_commit_column_writes_concurrent_append(#[case] nullable: bool) {
-    let mut dataset = id_dataset(2, 1024).await;
-
-    let column_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-        "value",
-        DataType::Int32,
-        nullable,
-    )]));
-    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
-
-    let fragment_id = dataset.get_fragments()[0].id() as u64;
-    let staged = RecordBatch::try_new(
-        column_arrow.clone(),
-        vec![Arc::new(Int32Array::from(vec![10, 20]))],
-    )
-    .unwrap();
-    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
-
-    // An append lands between the write and the commit.
-    let append = arrow_array::record_batch!(("id", Int32, [3])).unwrap();
-    let append_reader = RecordBatchIterator::new(vec![Ok(append.clone())], append.schema());
-    dataset.append(append_reader, None).await.unwrap();
-
-    let result = dataset.commit_column_writes(vec![replacement], None).await;
-    if nullable {
-        // The appended fragment reads null, matching add_columns semantics.
-        result.unwrap();
-        dataset.validate().await.unwrap();
-        let scanned = dataset
-            .scan()
-            .project(&["value"])
-            .unwrap()
-            .try_into_batch()
-            .await
-            .unwrap();
-        let values = scanned["value"].as_primitive::<Int32Type>();
-        assert_eq!(scanned.num_rows(), 3);
-        assert!(values.is_null(2));
-    } else {
-        // An uncovered non-nullable column would synthesize invalid nulls.
-        let err = result.unwrap_err();
-        assert!(
-            err.to_string().contains("non-nullable column"),
-            "expected coverage error, got: {err}"
-        );
-    }
-}
-
+/// Rewriting a column in place must not leave a scalar index answering from
+/// the replaced values: the commit tombstones the old coverage, so filtered
+/// queries have to find the new values and must not return phantom hits for
+/// the old ones.
 #[tokio::test]
 async fn test_commit_column_writes_rewrite_updates_indexed_column_queries() {
     let batch =
@@ -4901,6 +4790,10 @@ async fn test_commit_column_writes_rewrite_updates_indexed_column_queries() {
     assert_eq!(stale.num_rows(), 0, "stale index entries must not surface");
 }
 
+/// Staged data is addressed by physical row offset, not by live row, so a
+/// fragment carrying a deletion vector still expects a value for every
+/// physical row. The deleted row's staged value is written and then filtered
+/// out by the deletion vector on read.
 #[tokio::test]
 async fn test_write_fragment_column_covers_physical_rows_with_deletions() {
     let mut dataset = id_dataset(3, 1024).await;
@@ -4931,6 +4824,10 @@ async fn test_write_fragment_column_covers_physical_rows_with_deletions() {
     );
 }
 
+/// A non-nullable leaf inside a nullable struct does not force full coverage.
+/// An uncovered fragment reads the whole struct as null, which never
+/// materializes a null leaf, so partial coverage is legal here -- only a
+/// non-nullable top-level column requires every live fragment to be staged.
 #[tokio::test]
 async fn test_commit_column_writes_nullable_struct_with_non_nullable_leaf_partial_coverage() {
     let mut dataset = id_dataset(2, 1).await;
@@ -4976,127 +4873,369 @@ async fn test_commit_column_writes_nullable_struct_with_non_nullable_leaf_partia
     );
 }
 
-/// Two handles rewrite the same existing column from one snapshot. The
-/// loser's staged bytes are bound to the prepare-time backing file, so the
-/// retry fails instead of tombstoning the winner's fresh data.
-#[tokio::test]
-async fn test_commit_column_writes_rejects_stale_existing_column_rewrite() {
-    let mut ds1 = id_dataset(2, 1024).await;
-    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
-    let fragment_id = ds1.get_fragments()[0].id() as u64;
-    let seed = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
-    let replacement = stage_column(&ds1, fragment_id, seed, &column_schema).await;
-    ds1.commit_column_writes(vec![replacement], None)
-        .await
-        .unwrap();
-
-    let mut ds2 = ds1.clone();
-    let b1 = arrow_array::record_batch!(("value", Int32, [30, 40])).unwrap();
-    let r1 = stage_column(&ds1, fragment_id, b1, &column_schema).await;
-    let b2 = arrow_array::record_batch!(("value", Int32, [50, 60])).unwrap();
-    let r2 = stage_column(&ds2, fragment_id, b2, &column_schema).await;
-
-    ds1.commit_column_writes(vec![r1], None).await.unwrap();
-    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("changed since the column was prepared"),
-        "expected stale-rewrite conflict, got: {err}"
-    );
-
-    ds2.checkout_latest().await.unwrap();
-    let batch = ds2.scan().try_into_batch().await.unwrap();
-    assert_eq!(
-        batch["value"].as_primitive::<Int32Type>().values(),
-        &[30, 40]
-    );
+/// One step in a concurrent column-write scenario.
+///
+/// Handles model independent `Dataset` references racing to commit. Handle 0
+/// is the dataset as created; every higher handle is cloned from handle 0 the
+/// first time a step names it, which is the shared snapshot the writers race
+/// from. Staged replacements accumulate per handle until that handle commits.
+enum Step {
+    /// Stage `values` for fragment `fragment` on `handle`, under column
+    /// `column`. Every staged column takes the same fresh field id, so two
+    /// handles staging different names collide on one id.
+    Stage {
+        handle: usize,
+        fragment: usize,
+        column: &'static str,
+        values: Vec<i32>,
+    },
+    /// Commit everything `handle` has staged.
+    Commit { handle: usize, expect: Expect },
+    /// Append rows, creating a fragment the staged writes do not cover.
+    Append(Vec<i32>),
+    /// Land a `DataOverlay` supplying new values for the staged column,
+    /// changing the fragment's coverage without touching its base file.
+    Overlay { fragment: usize, values: Vec<i32> },
+    /// Compact every fragment, which rewrites them under new ids.
+    Compact,
 }
 
-/// Two handles fill the same still-uncovered fragment of a nullable column.
-/// Absence is part of the prepare-time binding, so the loser's retry fails
-/// instead of tombstoning the winner's fill.
-#[tokio::test]
-async fn test_commit_column_writes_rejects_stale_fill_of_uncovered_fragment() {
-    let mut ds1 = id_dataset(2, 1).await;
-    let frag_ids: Vec<u64> = ds1.get_fragments().iter().map(|f| f.id() as u64).collect();
-
-    // Establish a nullable column covering only the first fragment.
-    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
-    let seed = arrow_array::record_batch!(("value", Int32, [10])).unwrap();
-    let replacement = stage_column(&ds1, frag_ids[0], seed, &column_schema).await;
-    ds1.commit_column_writes(vec![replacement], None)
-        .await
-        .unwrap();
-
-    // Two handles stage a fill for the uncovered second fragment.
-    let mut ds2 = ds1.clone();
-    let b1 = arrow_array::record_batch!(("value", Int32, [30])).unwrap();
-    let r1 = stage_column(&ds1, frag_ids[1], b1, &column_schema).await;
-    let b2 = arrow_array::record_batch!(("value", Int32, [50])).unwrap();
-    let r2 = stage_column(&ds2, frag_ids[1], b2, &column_schema).await;
-
-    ds1.commit_column_writes(vec![r1], None).await.unwrap();
-    let err = ds2.commit_column_writes(vec![r2], None).await.unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("changed since the column was prepared"),
-        "expected stale-fill conflict, got: {err}"
-    );
-
-    ds2.checkout_latest().await.unwrap();
-    let batch = ds2.scan().try_into_batch().await.unwrap();
-    assert_eq!(
-        batch["value"].as_primitive::<Int32Type>().values(),
-        &[10, 30]
-    );
+/// What a [`Step::Commit`] must produce.
+enum Expect {
+    Ok,
+    /// The commit must fail with a [`ColumnWriteError`] the predicate accepts.
+    Err(fn(&ColumnWriteError) -> bool),
 }
 
-/// A concurrent DataOverlay covering the staged field changes the fragment's
-/// coverage identity without touching its base file. The stale column write
-/// must fail rather than tombstone the overlay winner.
-#[tokio::test]
-async fn test_commit_column_writes_rejects_stale_write_over_concurrent_overlay() {
+impl Step {
+    fn stage(handle: usize, fragment: usize, values: Vec<i32>) -> Self {
+        Self::Stage {
+            handle,
+            fragment,
+            column: "value",
+            values,
+        }
+    }
+
+    fn stage_as(handle: usize, fragment: usize, column: &'static str, values: Vec<i32>) -> Self {
+        Self::Stage {
+            handle,
+            fragment,
+            column,
+            values,
+        }
+    }
+
+    fn commit_ok(handle: usize) -> Self {
+        Self::Commit {
+            handle,
+            expect: Expect::Ok,
+        }
+    }
+
+    fn commit_err(handle: usize, accepts: fn(&ColumnWriteError) -> bool) -> Self {
+        Self::Commit {
+            handle,
+            expect: Expect::Err(accepts),
+        }
+    }
+}
+
+/// Run `steps` against a fresh `rows`-row dataset split at `max_rows_per_file`,
+/// then assert the committed "value" column.
+///
+/// `expected` is the column's final contents (`None` entries are nulls), or
+/// `None` if no commit should have introduced the column at all. Either way
+/// the final schema must hold exactly the columns that implies, so a losing
+/// writer's column cannot slip in unnoticed.
+async fn run_column_write_scenario(
+    rows: i32,
+    max_rows_per_file: usize,
+    nullable: bool,
+    steps: Vec<Step>,
+    expected: Option<&[Option<i32>]>,
+) {
     use super::dataset_overlay_index_masking::commit_overlay;
     use lance_table::format::overlay::OverlayCoverage;
     use roaring::RoaringBitmap;
 
-    let mut ds1 = id_dataset(2, 1024).await;
-    let column_schema = new_int32_columns_schema(&ds1, &["value"]);
-    let fragment_id = ds1.get_fragments()[0].id() as u64;
-    let seed = arrow_array::record_batch!(("value", Int32, [10, 20])).unwrap();
-    let replacement = stage_column(&ds1, fragment_id, seed, &column_schema).await;
-    ds1.commit_column_writes(vec![replacement], None)
+    let base = id_dataset(rows, max_rows_per_file).await;
+    // Every staged column claims the same fresh id, whatever its name.
+    let field_id = base.manifest.max_field_id() + 1;
+    let frag_ids: Vec<u64> = base.get_fragments().iter().map(|f| f.id() as u64).collect();
+    let mut handles = vec![base];
+    let mut staged: HashMap<usize, Vec<DataReplacementGroup>> = HashMap::new();
+
+    for step in steps {
+        if let Step::Stage { handle, .. } | Step::Commit { handle, .. } = step {
+            while handles.len() <= handle {
+                let snapshot = handles[0].clone();
+                handles.push(snapshot);
+            }
+        }
+        match step {
+            Step::Stage {
+                handle,
+                fragment,
+                column,
+                values,
+            } => {
+                let arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                    column,
+                    DataType::Int32,
+                    nullable,
+                )]));
+                let mut schema = LanceSchema::try_from(arrow.as_ref()).unwrap();
+                schema.fields[0].id = field_id;
+                let batch =
+                    RecordBatch::try_new(arrow, vec![Arc::new(Int32Array::from(values))]).unwrap();
+                let replacement = handles[handle]
+                    .write_fragment_column(
+                        frag_ids[fragment],
+                        futures::stream::iter([Ok(batch)]),
+                        &schema,
+                    )
+                    .await
+                    .unwrap();
+                staged.entry(handle).or_default().push(replacement);
+            }
+            Step::Commit { handle, expect } => {
+                let replacements = staged.remove(&handle).unwrap_or_default();
+                let result = handles[handle]
+                    .commit_column_writes(replacements, None)
+                    .await;
+                match expect {
+                    Expect::Ok => result.unwrap(),
+                    Expect::Err(accepts) => {
+                        let error = result.unwrap_err();
+                        let cause = ColumnWriteError::of(&error)
+                            .unwrap_or_else(|| panic!("expected a ColumnWriteError, got: {error}"));
+                        assert!(accepts(cause), "unexpected column-write failure: {cause}");
+                    }
+                }
+            }
+            Step::Append(values) => {
+                let arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                    "id",
+                    DataType::Int32,
+                    true,
+                )]));
+                let batch =
+                    RecordBatch::try_new(arrow.clone(), vec![Arc::new(Int32Array::from(values))])
+                        .unwrap();
+                let reader = RecordBatchIterator::new(vec![Ok(batch)], arrow);
+                handles[0].append(reader, None).await.unwrap();
+            }
+            Step::Overlay { fragment, values } => {
+                let coverage = RoaringBitmap::from_iter(0..values.len() as u32);
+                commit_overlay(
+                    handles[0].clone(),
+                    "scenario_overlay",
+                    frag_ids[fragment],
+                    &[field_id],
+                    OverlayCoverage::dense(coverage),
+                    vec![Arc::new(Int32Array::from(values)) as ArrayRef],
+                )
+                .await;
+            }
+            Step::Compact => {
+                compact_files(&mut handles[0], CompactionOptions::default(), None)
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    let mut final_dataset = handles.swap_remove(0);
+    final_dataset.checkout_latest().await.unwrap();
+    let columns: HashSet<&str> = final_dataset
+        .schema()
+        .fields
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    let Some(expected) = expected else {
+        assert_eq!(columns, HashSet::from(["id"]), "no column should be live");
+        return;
+    };
+    assert_eq!(columns, HashSet::from(["id", "value"]));
+    final_dataset.validate().await.unwrap();
+    let batch = final_dataset
+        .scan()
+        .project(&["value"])
+        .unwrap()
+        .try_into_batch()
         .await
         .unwrap();
+    let values = batch["value"].as_primitive::<Int32Type>();
+    let actual: Vec<Option<i32>> = (0..batch.num_rows())
+        .map(|row| (!values.is_null(row)).then(|| values.value(row)))
+        .collect();
+    assert_eq!(actual, expected);
+}
 
-    // Stage a stale rewrite, then land a concurrent overlay on the field.
-    let staged = arrow_array::record_batch!(("value", Int32, [50, 50])).unwrap();
-    let stale = stage_column(&ds1, fragment_id, staged, &column_schema).await;
-    let value_id = ds1.schema().field("value").unwrap().id;
-    commit_overlay(
-        ds1.clone(),
-        "value_overlay",
-        fragment_id,
-        &[value_id],
-        OverlayCoverage::dense(RoaringBitmap::from_iter([0u32, 1])),
-        vec![Arc::new(Int32Array::from(vec![30, 30])) as ArrayRef],
+/// A column write stages replacements for every fragment, then a concurrent
+/// compaction rewrites those fragments under new ids. The staged replacements
+/// no longer name live fragments; dropping them silently would publish a
+/// column whose data is all null, so the commit must fail and the caller must
+/// recompute against the new fragments.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_orphaned_replacements_after_compaction() {
+    // One row per file, so there are two fragments to compact together.
+    run_column_write_scenario(
+        2,
+        1,
+        true,
+        vec![
+            Step::stage(0, 0, vec![0]),
+            Step::stage(0, 1, vec![0]),
+            Step::Compact,
+            Step::commit_err(0, |e| {
+                matches!(e, ColumnWriteError::OrphanedReplacements { .. })
+            }),
+        ],
+        None,
     )
     .await;
+}
 
-    let err = ds1
-        .commit_column_writes(vec![stale], None)
-        .await
-        .unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("changed since the column was prepared"),
-        "expected stale-over-overlay conflict, got: {err}"
-    );
+/// Two writers derive the same fresh field id from one snapshot, because both
+/// take `max_field_id() + 1`. Once the first commits, that id belongs to its
+/// column; the second's file was written under the same id but holds different
+/// data, and staged files cannot be renumbered. The loser must fail and
+/// recompute rather than publish its bytes under the winner's id.
+///
+/// Both cases matter: the loser may have staged a differently named column
+/// (a visible collision) or an identical twin (a silent overwrite).
+#[rstest]
+#[case::different_column("second_value")]
+#[case::same_column("value")]
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_replacement(#[case] second_column: &'static str) {
+    run_column_write_scenario(
+        2,
+        1024,
+        true,
+        vec![
+            Step::stage(0, 0, vec![10, 20]),
+            Step::stage_as(1, 0, second_column, vec![30, 40]),
+            Step::commit_ok(0),
+            Step::commit_err(1, |e| matches!(e, ColumnWriteError::StaleSchema { .. })),
+        ],
+        Some(&[Some(10), Some(20)]),
+    )
+    .await;
+}
 
-    ds1.checkout_latest().await.unwrap();
-    let batch = ds1.scan().try_into_batch().await.unwrap();
-    assert_eq!(
-        batch["value"].as_primitive::<Int32Type>().values(),
-        &[30, 30]
-    );
+/// An append lands between staging and committing, so the appended fragment
+/// has no staged data. A nullable column may read null there, matching
+/// `add_columns` semantics. A non-nullable one would have to synthesize nulls
+/// it declares impossible, so that commit must fail instead.
+#[rstest]
+#[case::nullable(true, Some(&[Some(10), Some(20), None][..]))]
+#[case::non_nullable(false, None)]
+#[tokio::test]
+async fn test_commit_column_writes_concurrent_append(
+    #[case] nullable: bool,
+    #[case] expected: Option<&[Option<i32>]>,
+) {
+    let commit = if nullable {
+        Step::commit_ok(0)
+    } else {
+        Step::commit_err(0, |e| {
+            matches!(e, ColumnWriteError::UncoveredNonNullableColumn { .. })
+        })
+    };
+    run_column_write_scenario(
+        2,
+        1024,
+        nullable,
+        vec![
+            Step::stage(0, 0, vec![10, 20]),
+            Step::Append(vec![3]),
+            commit,
+        ],
+        expected,
+    )
+    .await;
+}
+
+/// Two handles rewrite the same existing column from one snapshot. Committing
+/// a rewrite tombstones the fragment's prior coverage, so replaying the
+/// loser's staged bytes would erase the winner's fresh data. Each replacement
+/// is bound to the data file backing the field when it was prepared; the
+/// winner's commit changed that backing, so the loser's retry fails.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_existing_column_rewrite() {
+    run_column_write_scenario(
+        2,
+        1024,
+        true,
+        vec![
+            Step::stage(0, 0, vec![10, 20]),
+            Step::commit_ok(0),
+            Step::stage(0, 0, vec![30, 40]),
+            Step::stage(1, 0, vec![50, 60]),
+            Step::commit_ok(0),
+            Step::commit_err(1, |e| {
+                matches!(e, ColumnWriteError::StaleFragmentData { .. })
+            }),
+        ],
+        Some(&[Some(30), Some(40)]),
+    )
+    .await;
+}
+
+/// The same race on a fragment the column does not cover yet: a nullable
+/// column is committed for the first fragment only, then two handles fill the
+/// second. The prepare-time binding records that the field had no backing
+/// there at all, so the loser is caught by that absence rather than by a
+/// changed file.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_fill_of_uncovered_fragment() {
+    // One row per file, so the seeded column covers only the first fragment.
+    run_column_write_scenario(
+        2,
+        1,
+        true,
+        vec![
+            Step::stage(0, 0, vec![10]),
+            Step::commit_ok(0),
+            Step::stage(0, 1, vec![30]),
+            Step::stage(1, 1, vec![50]),
+            Step::commit_ok(0),
+            Step::commit_err(1, |e| {
+                matches!(e, ColumnWriteError::StaleFragmentData { .. })
+            }),
+        ],
+        Some(&[Some(10), Some(30)]),
+    )
+    .await;
+}
+
+/// A concurrent `DataOverlay` supplies new values for the staged field
+/// without touching the fragment's base file. Committing the stale write
+/// would tombstone that overlay, so the binding covers overlay identity too
+/// and the write must fail; the overlay's values survive.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_stale_write_over_concurrent_overlay() {
+    run_column_write_scenario(
+        2,
+        1024,
+        true,
+        vec![
+            Step::stage(0, 0, vec![10, 20]),
+            Step::commit_ok(0),
+            Step::stage(0, 0, vec![50, 50]),
+            Step::Overlay {
+                fragment: 0,
+                values: vec![30, 30],
+            },
+            Step::commit_err(0, |e| {
+                matches!(e, ColumnWriteError::StaleFragmentData { .. })
+            }),
+        ],
+        Some(&[Some(30), Some(30)]),
+    )
+    .await;
 }

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -4295,26 +4295,6 @@ async fn test_merge_insert_target_all_bases() {
     }
 }
 
-/// Lance schema for new columns described by `column_arrow`, with fresh field
-/// ids (and parent links) assigned after the dataset's current max field id.
-fn new_columns_schema(dataset: &Dataset, column_arrow: &ArrowSchema) -> LanceSchema {
-    let mut merged = dataset.schema().merge(column_arrow).unwrap();
-    merged.set_field_id(Some(dataset.manifest.max_field_id()));
-    let new_names: HashSet<&str> = column_arrow
-        .fields()
-        .iter()
-        .map(|f| f.name().as_str())
-        .collect();
-    LanceSchema {
-        fields: merged
-            .fields
-            .into_iter()
-            .filter(|f| new_names.contains(f.name.as_str()))
-            .collect(),
-        metadata: Default::default(),
-    }
-}
-
 /// Single-column ("id": Int32 1..=rows) dataset split at `max_rows_per_file`.
 async fn id_dataset(rows: i32, max_rows_per_file: usize) -> Dataset {
     let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
@@ -4353,18 +4333,15 @@ async fn stage_column(
         .unwrap()
 }
 
-/// Lance schema for new nullable Int32 columns with fresh sequential field ids.
+/// Staging schema for new nullable Int32 columns, numbered by the dataset.
 fn new_int32_columns_schema(dataset: &Dataset, names: &[&str]) -> LanceSchema {
     let fields: Vec<ArrowField> = names
         .iter()
         .map(|name| ArrowField::new(*name, DataType::Int32, true))
         .collect();
-    let mut schema = LanceSchema::try_from(&ArrowSchema::new(fields)).unwrap();
-    let base_id = dataset.manifest.max_field_id() + 1;
-    for (offset, field) in schema.fields.iter_mut().enumerate() {
-        field.id = base_id + offset as i32;
-    }
-    schema
+    dataset
+        .new_column_schema(&ArrowSchema::new(fields))
+        .unwrap()
 }
 
 /// The returned `DataReplacementGroup` must describe the staged file well
@@ -4674,7 +4651,7 @@ async fn test_write_commit_column_round_trip_schema_zoo(#[case] new_fields: Vec<
     assert_eq!(dataset.get_fragments().len(), 2);
 
     let column_arrow = Arc::new(ArrowSchema::new(new_fields));
-    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
+    let column_schema = dataset.new_column_schema(column_arrow.as_ref()).unwrap();
 
     let mut expected = Vec::new();
     let mut replacements = Vec::new();
@@ -4840,7 +4817,7 @@ async fn test_commit_column_writes_nullable_struct_with_non_nullable_leaf_partia
         DataType::Struct(Fields::from(vec![leaf.clone()])),
         true,
     )]));
-    let column_schema = new_columns_schema(&dataset, column_arrow.as_ref());
+    let column_schema = dataset.new_column_schema(column_arrow.as_ref()).unwrap();
 
     let staged = RecordBatch::try_new(
         column_arrow.clone(),
@@ -4960,8 +4937,20 @@ async fn run_column_write_scenario(
     use roaring::RoaringBitmap;
 
     let base = id_dataset(rows, max_rows_per_file).await;
-    // Every staged column claims the same fresh id, whatever its name.
-    let field_id = base.manifest.max_field_id() + 1;
+    // The dataset numbers new columns, and every handle stages against the
+    // version as created, so each staged column lands on the same fresh id
+    // whatever it is named.
+    let numbering = base.clone();
+    let staging_schema = |column: &str| {
+        numbering
+            .new_column_schema(&ArrowSchema::new(vec![ArrowField::new(
+                column,
+                DataType::Int32,
+                nullable,
+            )]))
+            .unwrap()
+    };
+    let field_id = staging_schema("value").fields[0].id;
     let frag_ids: Vec<u64> = base.get_fragments().iter().map(|f| f.id() as u64).collect();
     let mut handles = vec![base];
     let mut staged: HashMap<usize, Vec<DataReplacementGroup>> = HashMap::new();
@@ -4980,13 +4969,12 @@ async fn run_column_write_scenario(
                 column,
                 values,
             } => {
+                let schema = staging_schema(column);
                 let arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
                     column,
                     DataType::Int32,
                     nullable,
                 )]));
-                let mut schema = LanceSchema::try_from(arrow.as_ref()).unwrap();
-                schema.fields[0].id = field_id;
                 let batch =
                     RecordBatch::try_new(arrow, vec![Arc::new(Int32Array::from(values))]).unwrap();
                 let replacement = handles[handle]
@@ -5238,4 +5226,150 @@ async fn test_commit_column_writes_rejects_stale_write_over_concurrent_overlay()
         Some(&[Some(30), Some(30)]),
     )
     .await;
+}
+
+/// However staging fails, it must leave no file behind. Such a file is
+/// unreferenced, so version cleanup reclaims it eventually, but a caller
+/// looping prepare/conflict/recompute would accumulate a full column copy per
+/// attempt until then.
+///
+/// The two cases fail at different points and are guarded differently. A
+/// stream that errors never reaches `finish`, so no object is published and
+/// there is nothing to delete -- this pins that, since a writer that started
+/// publishing eagerly would begin leaking. A row-count mismatch is rejected
+/// after `finish` has published the file, so that one is deleted explicitly.
+#[rstest]
+#[case::stream_error(true)]
+#[case::row_count_mismatch(false)]
+#[tokio::test]
+async fn test_write_fragment_column_deletes_its_file_when_staging_fails(
+    #[case] stream_error: bool,
+) {
+    let dataset = id_dataset(2, 1024).await;
+    let data_dir = dataset.data_dir();
+    let before = dataset
+        .object_store
+        .read_dir(data_dir.clone())
+        .await
+        .unwrap();
+
+    let column_schema = new_int32_columns_schema(&dataset, &["value"]);
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let batches: Vec<Result<RecordBatch, Error>> = if stream_error {
+        vec![Err(Error::invalid_input("stream blew up".to_string()))]
+    } else {
+        // One row short of the fragment's two physical rows.
+        vec![Ok(
+            arrow_array::record_batch!(("value", Int32, [7])).unwrap()
+        )]
+    };
+    dataset
+        .write_fragment_column(fragment_id, futures::stream::iter(batches), &column_schema)
+        .await
+        .unwrap_err();
+
+    let after = dataset.object_store.read_dir(data_dir).await.unwrap();
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "staging left a file behind: {:?}",
+        after
+    );
+}
+
+/// `new_column_schema` numbers a new column above the dataset's current
+/// maximum, nested children included, which is what `commit_column_writes`
+/// requires of a column that does not exist yet.
+#[tokio::test]
+async fn test_new_column_schema_numbers_fields_above_dataset_max() {
+    let dataset = id_dataset(2, 1024).await;
+    let max_before = dataset.manifest.max_field_id();
+
+    let arrow = ArrowSchema::new(vec![ArrowField::new(
+        "s",
+        DataType::Struct(Fields::from(vec![
+            ArrowField::new("x", DataType::Int32, true),
+            ArrowField::new("y", DataType::Utf8, true),
+        ])),
+        true,
+    )]);
+    let schema = dataset.new_column_schema(&arrow).unwrap();
+
+    assert_eq!(schema.fields.len(), 1);
+    let mut ids = vec![schema.fields[0].id];
+    ids.extend(schema.fields[0].children.iter().map(|c| c.id));
+    assert_eq!(ids.len(), 3, "parent and both children must be numbered");
+    assert!(
+        ids.iter().all(|id| *id > max_before),
+        "ids {ids:?} must sit above the dataset max {max_before}"
+    );
+}
+
+/// Numbering a column that already exists would give it a fresh id and stage
+/// bytes the commit cannot match to the live field, so it is rejected and the
+/// caller is pointed at the dataset schema instead.
+#[tokio::test]
+async fn test_new_column_schema_rejects_an_existing_column() {
+    let dataset = id_dataset(2, 1024).await;
+    let arrow = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, true)]);
+
+    let error = dataset.new_column_schema(&arrow).unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::ColumnAlreadyExists { .. })
+    ));
+}
+
+/// The system columns are virtual: the scanner injects them at read time, so a
+/// stored column with one of those names commits and passes `validate`, and
+/// only fails later when a projection sees two fields of that name. Staging
+/// must refuse them up front.
+#[rstest]
+#[case::row_id(ROW_ID)]
+#[case::row_addr(ROW_ADDR)]
+#[tokio::test]
+async fn test_new_column_schema_rejects_reserved_system_columns(#[case] reserved: &str) {
+    let dataset = id_dataset(2, 1024).await;
+    let arrow = ArrowSchema::new(vec![ArrowField::new(reserved, DataType::Int32, true)]);
+
+    let error = dataset.new_column_schema(&arrow).unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::ReservedColumnName { .. })
+    ));
+}
+
+/// The commit boundary has to reject reserved names too. A caller can build a
+/// staging schema by hand and never call `new_column_schema`, so the guard
+/// there alone would leave the collision reachable.
+#[tokio::test]
+async fn test_commit_column_writes_rejects_hand_built_reserved_column() {
+    let mut dataset = id_dataset(2, 1024).await;
+
+    // Bypass new_column_schema entirely, the way a caller assembling its own
+    // staging schema would.
+    let arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        ROW_ID,
+        DataType::Int32,
+        true,
+    )]));
+    let mut column_schema = LanceSchema::try_from(arrow.as_ref()).unwrap();
+    column_schema.fields[0].id = dataset.manifest.max_field_id() + 1;
+
+    let staged = RecordBatch::try_new(arrow, vec![Arc::new(Int32Array::from(vec![7, 8]))]).unwrap();
+    let fragment_id = dataset.get_fragments()[0].id() as u64;
+    let replacement = stage_column(&dataset, fragment_id, staged, &column_schema).await;
+
+    let error = dataset
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::ReservedColumnName { .. })
+    ));
+
+    // The reserved name still projects, which is what the collision broke.
+    dataset.checkout_latest().await.unwrap();
+    assert!(dataset.scan().project(&[ROW_ID]).is_ok());
 }

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -82,7 +82,7 @@ async fn build_age_index(dataset: &mut Dataset) {
 /// Write an overlay file covering `fields` of `fragment_id` with `coverage` and the given
 /// per-field value columns, then commit it as a `DataOverlay` transaction. `name` makes
 /// the overlay file unique.
-async fn commit_overlay(
+pub(super) async fn commit_overlay(
     dataset: Dataset,
     name: &str,
     fragment_id: u64,
@@ -1332,4 +1332,166 @@ async fn bench_index_query_overlay_overhead() {
 
         println!("{num_vec_overlays:>12}  {ann_ms:>10.1}");
     }
+}
+
+/// A stale column write staged against a multi-field base file must not
+/// erase a concurrently committed overlay on the same field.
+#[rstest]
+#[case::address_row_ids(false)]
+#[case::stable_row_ids(true)]
+#[tokio::test]
+async fn test_stale_column_write_rejected_over_concurrent_overlay(#[case] stable_row_ids: bool) {
+    let mut dataset = create_base_dataset_with(stable_row_ids).await;
+    let age_schema = lance_core::datatypes::Schema {
+        fields: vec![dataset.schema().field("age").unwrap().clone()],
+        metadata: Default::default(),
+    };
+    let staged_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "age",
+        DataType::Int32,
+        true,
+    )]));
+    let staged =
+        RecordBatch::try_new(staged_arrow, vec![Arc::new(Int32Array::from(vec![50; 6]))]).unwrap();
+    let stale = dataset
+        .write_fragment_column(0, futures::stream::iter([Ok(staged)]), &age_schema)
+        .await
+        .unwrap();
+
+    let _ = commit_overlay(
+        dataset.clone(),
+        "concurrent_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter(0u32..6)),
+        vec![Arc::new(Int32Array::from(vec![30; 6])) as ArrayRef],
+    )
+    .await;
+
+    let result = dataset.commit_column_writes(vec![stale], None).await;
+    assert!(result.is_err(), "stale write must not erase the overlay");
+    dataset.checkout_latest().await.unwrap();
+    let batch = dataset
+        .scan()
+        .project(&["age"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    use arrow::array::AsArray;
+    let ages = batch["age"].as_primitive::<arrow::datatypes::Int32Type>();
+    assert_eq!(&ages.values()[0..6], &[30; 6]);
+}
+
+/// A concurrent Merge can change an existing overlay's coverage while
+/// keeping its file path. Path-only identity would miss it; the stale
+/// column write must still be rejected.
+#[tokio::test]
+async fn test_stale_column_write_rejected_over_overlay_coverage_change() {
+    let mut stale = commit_overlay(
+        create_base_dataset().await,
+        "same_path_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([0u32])),
+        vec![Arc::new(Int32Array::from(vec![777])) as ArrayRef],
+    )
+    .await;
+    let age_schema = lance_core::datatypes::Schema {
+        fields: vec![stale.schema().field("age").unwrap().clone()],
+        metadata: Default::default(),
+    };
+    let staged_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "age",
+        DataType::Int32,
+        true,
+    )]));
+    let staged =
+        RecordBatch::try_new(staged_arrow, vec![Arc::new(Int32Array::from(vec![50; 6]))]).unwrap();
+    let replacement = stale
+        .write_fragment_column(0, futures::stream::iter([Ok(staged)]), &age_schema)
+        .await
+        .unwrap();
+
+    // Concurrent Merge moves the overlay's coverage from offset 0 to offset 1
+    // without changing its path.
+    let concurrent = stale.clone();
+    let read_version = concurrent.version().version;
+    let schema = concurrent.schema().clone();
+    let mut fragments: Vec<_> = concurrent
+        .get_fragments()
+        .into_iter()
+        .map(|fragment| fragment.metadata().clone())
+        .collect();
+    fragments[0].overlays[0].coverage = OverlayCoverage::dense(RoaringBitmap::from_iter([1u32]));
+    Dataset::commit(
+        WriteDestination::Dataset(Arc::new(concurrent)),
+        Operation::Merge { fragments, schema },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let result = stale.commit_column_writes(vec![replacement], None).await;
+    assert!(
+        result.is_err(),
+        "stale write must not erase the moved overlay coverage"
+    );
+}
+
+/// A concurrent Merge can remap a base file's column indices while keeping
+/// its path. The witness includes the field's routing, so the stale column
+/// write must be rejected.
+#[tokio::test]
+async fn test_stale_column_write_rejected_over_base_mapping_change() {
+    let mut stale = create_base_dataset().await;
+    let age_schema = lance_core::datatypes::Schema {
+        fields: vec![stale.schema().field("age").unwrap().clone()],
+        metadata: Default::default(),
+    };
+    let staged_arrow = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "age",
+        DataType::Int32,
+        true,
+    )]));
+    let staged =
+        RecordBatch::try_new(staged_arrow, vec![Arc::new(Int32Array::from(vec![50; 6]))]).unwrap();
+    let replacement = stale
+        .write_fragment_column(0, futures::stream::iter([Ok(staged)]), &age_schema)
+        .await
+        .unwrap();
+
+    // Concurrent Merge swaps the two-column base file's mapping in place.
+    let concurrent = stale.clone();
+    let read_version = concurrent.version().version;
+    let schema = concurrent.schema().clone();
+    let mut fragments: Vec<_> = concurrent
+        .get_fragments()
+        .into_iter()
+        .map(|fragment| fragment.metadata().clone())
+        .collect();
+    assert_eq!(fragments[0].files[0].fields.as_ref(), &[0, 1]);
+    assert_eq!(fragments[0].files[0].column_indices.as_ref(), &[0, 1]);
+    fragments[0].files[0].column_indices = Arc::from([1, 0]);
+    Dataset::commit(
+        WriteDestination::Dataset(Arc::new(concurrent)),
+        Operation::Merge { fragments, schema },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let result = stale.commit_column_writes(vec![replacement], None).await;
+    assert!(
+        result.is_err(),
+        "stale write must not clobber the remapped base file"
+    );
 }

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -31,7 +31,7 @@ use lance_file::writer::FileWriterOptions;
 use crate::Dataset;
 use crate::dataset::optimize::{CompactionOptions, compact_files, remapping};
 use crate::dataset::transaction::{DataOverlayGroup, Operation};
-use crate::dataset::{WriteDestination, WriteParams};
+use crate::dataset::{ColumnWriteError, WriteDestination, WriteParams};
 use crate::index::vector::VectorIndexParams;
 use crate::index::{CreateIndexBuilder, DatasetIndexExt};
 
@@ -1368,8 +1368,14 @@ async fn test_stale_column_write_rejected_over_concurrent_overlay(#[case] stable
     )
     .await;
 
-    let result = dataset.commit_column_writes(vec![stale], None).await;
-    assert!(result.is_err(), "stale write must not erase the overlay");
+    let error = dataset
+        .commit_column_writes(vec![stale], None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::StaleFragmentData { .. })
+    ));
     dataset.checkout_latest().await.unwrap();
     let batch = dataset
         .scan()
@@ -1436,11 +1442,14 @@ async fn test_stale_column_write_rejected_over_overlay_coverage_change() {
     .await
     .unwrap();
 
-    let result = stale.commit_column_writes(vec![replacement], None).await;
-    assert!(
-        result.is_err(),
-        "stale write must not erase the moved overlay coverage"
-    );
+    let error = stale
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::StaleFragmentData { .. })
+    ));
 }
 
 /// A concurrent Merge can remap a base file's column indices while keeping
@@ -1489,9 +1498,12 @@ async fn test_stale_column_write_rejected_over_base_mapping_change() {
     .await
     .unwrap();
 
-    let result = stale.commit_column_writes(vec![replacement], None).await;
-    assert!(
-        result.is_err(),
-        "stale write must not clobber the remapped base file"
-    );
+    let error = stale
+        .commit_column_writes(vec![replacement], None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        ColumnWriteError::of(&error),
+        Some(ColumnWriteError::StaleFragmentData { .. })
+    ));
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -56,6 +56,7 @@ use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 
+pub(crate) mod column_writes;
 mod commit;
 pub mod delete;
 mod insert;

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -56,6 +56,7 @@ use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 
+pub mod column_write_error;
 pub(crate) mod column_writes;
 mod commit;
 pub mod delete;

--- a/rust/lance/src/dataset/write/column_write_error.rs
+++ b/rust/lance/src/dataset/write/column_write_error.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use lance_core::Error;
+use snafu::Snafu;
+
+/// Why a column write could not be staged or committed.
+///
+/// Returned as the `source` of an [`Error::InvalidInput`]. Recover it with
+/// [`ColumnWriteError::of`] to branch on the failure programmatically; the
+/// message text is for humans and is not a stable interface.
+///
+/// The variants split into three groups. [`Self::FragmentNotFound`] and
+/// [`Self::RowCountMismatch`] come from staging. The staged-file and
+/// prepare-time variants report a commit the caller assembled wrongly. The
+/// freshness variants ([`Self::StaleSchema`], [`Self::StaleFragmentData`],
+/// [`Self::OrphanedReplacements`], [`Self::UncoveredNonNullableColumn`],
+/// [`Self::ReadVersionUnavailable`]) report that the dataset moved under a
+/// prepared write; the column must be recomputed against the current dataset
+/// and staged again.
+#[derive(Debug, Clone, PartialEq, Eq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum ColumnWriteError {
+    #[snafu(display("fragment {fragment_id} not found in dataset"))]
+    FragmentNotFound { fragment_id: u64 },
+
+    #[snafu(display(
+        "column data for fragment {fragment_id} has {staged_rows} rows but the fragment has \
+         {physical_rows} physical rows"
+    ))]
+    RowCountMismatch {
+        fragment_id: u64,
+        staged_rows: u64,
+        physical_rows: u64,
+    },
+
+    #[snafu(display("no column replacements to commit"))]
+    NoReplacements,
+
+    #[snafu(display(
+        "file '{path}' was not staged by write_fragment_column (missing or unparsable \
+         read-version metadata)"
+    ))]
+    NotStaged { path: String },
+
+    #[snafu(display(
+        "staged files span dataset versions {first} and {second}; stage all fragments against \
+         one version"
+    ))]
+    MixedReadVersions { first: u64, second: u64 },
+
+    #[snafu(display(
+        "staged files disagree on field id {field_id}: '{name}' ({data_type}) vs '{other_name}' \
+         ({other_data_type})"
+    ))]
+    StagedSchemasDisagree {
+        field_id: i32,
+        name: String,
+        data_type: String,
+        other_name: String,
+        other_data_type: String,
+    },
+
+    #[snafu(display("staged file '{path}' records no field ids"))]
+    NoStagedFieldIds { path: String },
+
+    #[snafu(display(
+        "staged file '{path}' records field id {field_id}, which is not in its staged schema"
+    ))]
+    StagedFieldNotInSchema { path: String, field_id: i32 },
+
+    #[snafu(display(
+        "fragment {fragment_id} has multiple staged files covering field id {field_id}"
+    ))]
+    DuplicateFieldCoverage { fragment_id: u64, field_id: i32 },
+
+    #[snafu(display(
+        "dataset version {read_version} the columns were staged against is no longer available; \
+         recompute against the current dataset"
+    ))]
+    ReadVersionUnavailable { read_version: u64 },
+
+    #[snafu(display(
+        "fragment {fragment_id} does not exist at dataset version {read_version} the write was \
+         prepared against"
+    ))]
+    FragmentNotInReadVersion { fragment_id: u64, read_version: u64 },
+
+    #[snafu(display(
+        "staged column '{name}' ({data_type}) conflicts with field id {field_id} ('{other_name}', \
+         {other_data_type}) in dataset version {read_version} it was prepared against"
+    ))]
+    FieldContractConflict {
+        field_id: i32,
+        name: String,
+        data_type: String,
+        other_name: String,
+        other_data_type: String,
+        read_version: u64,
+    },
+
+    #[snafu(display(
+        "field id {field_id} ('{name}', {data_type}) was computed against a stale schema; \
+         recompute the column against the current dataset"
+    ))]
+    StaleSchema {
+        field_id: i32,
+        name: String,
+        data_type: String,
+    },
+
+    #[snafu(display(
+        "fragment {fragment_id}'s data for field id {field_id} changed since the column was \
+         prepared; recompute against the current dataset"
+    ))]
+    StaleFragmentData { fragment_id: u64, field_id: i32 },
+
+    #[snafu(display(
+        "column replacements reference fragments {fragment_ids:?}, which are no longer in the \
+         dataset; re-run the column write against the current fragments"
+    ))]
+    OrphanedReplacements { fragment_ids: Vec<u64> },
+
+    #[snafu(display(
+        "non-nullable column '{name}' has no staged data for fragment {fragment_id} (possibly \
+         appended concurrently); stage every live fragment and recommit"
+    ))]
+    UncoveredNonNullableColumn { name: String, fragment_id: u64 },
+}
+
+impl ColumnWriteError {
+    /// Recover the column-write cause behind a [`Dataset::write_fragment_column`]
+    /// or [`Dataset::commit_column_writes`] failure, if `error` came from one.
+    ///
+    /// [`Dataset::write_fragment_column`]: crate::Dataset::write_fragment_column
+    /// [`Dataset::commit_column_writes`]: crate::Dataset::commit_column_writes
+    pub fn of(error: &Error) -> Option<&Self> {
+        match error {
+            Error::InvalidInput { source, .. } => source.downcast_ref(),
+            _ => None,
+        }
+    }
+
+    /// True when the dataset moved under a prepared write. The staged files
+    /// cannot be replayed; recompute the column against the current dataset.
+    pub fn needs_recompute(&self) -> bool {
+        matches!(
+            self,
+            Self::StaleSchema { .. }
+                | Self::StaleFragmentData { .. }
+                | Self::OrphanedReplacements { .. }
+                | Self::UncoveredNonNullableColumn { .. }
+                | Self::ReadVersionUnavailable { .. }
+        )
+    }
+}
+
+impl From<ColumnWriteError> for Error {
+    fn from(error: ColumnWriteError) -> Self {
+        Self::invalid_input_source(Box::new(error))
+    }
+}

--- a/rust/lance/src/dataset/write/column_write_error.rs
+++ b/rust/lance/src/dataset/write/column_write_error.rs
@@ -25,6 +25,15 @@ pub enum ColumnWriteError {
     FragmentNotFound { fragment_id: u64 },
 
     #[snafu(display(
+        "column '{name}' already exists; project it out of the dataset schema to rewrite it \
+         rather than numbering it as a new column"
+    ))]
+    ColumnAlreadyExists { name: String },
+
+    #[snafu(display("column '{name}' is a reserved name and cannot be used in a Lance dataset"))]
+    ReservedColumnName { name: String },
+
+    #[snafu(display(
         "column data for fragment {fragment_id} has {staged_rows} rows but the fragment has \
          {physical_rows} physical rows"
     ))]

--- a/rust/lance/src/dataset/write/column_writes.rs
+++ b/rust/lance/src/dataset/write/column_writes.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use futures::{StreamExt, TryStreamExt};
+use lance_core::Result;
 use lance_core::datatypes::{Field, NullabilityComparison, Schema, SchemaCompareOptions};
-use lance_core::{Error, Result};
 use lance_encoding::decoder::DecoderPlugins;
 use lance_file::reader::FileReader;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
@@ -17,6 +17,7 @@ use lance_table::format::{DataFile, Fragment};
 use roaring::RoaringBitmap;
 
 use super::CommitBuilder;
+use super::column_write_error::ColumnWriteError;
 use super::retry::{RetryConfig, RetryExecutor, execute_with_retry};
 use crate::Dataset;
 use crate::dataset::COLUMN_WRITE_READ_VERSION_METADATA_KEY;
@@ -33,9 +34,7 @@ pub async fn commit_column_writes(
     transaction_properties: Option<Arc<HashMap<String, String>>>,
 ) -> Result<()> {
     if replacements.is_empty() {
-        return Err(Error::invalid_input(
-            "no column replacements to commit".to_string(),
-        ));
+        return Err(ColumnWriteError::NoReplacements.into());
     }
 
     let staged_schemas = read_staged_schemas(ds, &replacements).await?;
@@ -120,29 +119,19 @@ async fn plan_column_writes(
         let stamped = schema
             .metadata
             .get(COLUMN_WRITE_READ_VERSION_METADATA_KEY)
-            .ok_or_else(|| {
-                Error::invalid_input(format!(
-                    "file '{}' was not staged by write_fragment_column (missing read-version \
-                     metadata)",
-                    file.path
-                ))
-            })?
-            .parse::<u64>()
-            .map_err(|parse_error| {
-                Error::invalid_input(format!(
-                    "file '{}' has an unparsable read-version stamp: {}",
-                    file.path, parse_error
-                ))
+            .and_then(|stamp| stamp.parse::<u64>().ok())
+            .ok_or_else(|| ColumnWriteError::NotStaged {
+                path: file.path.clone(),
             })?;
         match read_version {
             None => read_version = Some(stamped),
             Some(prev) if prev == stamped => {}
             Some(prev) => {
-                return Err(Error::invalid_input(format!(
-                    "staged files span dataset versions {} and {}; stage all fragments against \
-                     one version",
-                    prev, stamped
-                )));
+                return Err(ColumnWriteError::MixedReadVersions {
+                    first: prev,
+                    second: stamped,
+                }
+                .into());
             }
         }
     }
@@ -157,14 +146,14 @@ async fn plan_column_writes(
                 None => new_columns.push(field.clone()),
                 Some(existing) if fields_match(existing, field) => {}
                 Some(existing) => {
-                    return Err(Error::invalid_input(format!(
-                        "staged files disagree on field id {}: '{}' ({}) vs '{}' ({})",
-                        field.id,
-                        existing.name,
-                        existing.data_type(),
-                        field.name,
-                        field.data_type(),
-                    )));
+                    return Err(ColumnWriteError::StagedSchemasDisagree {
+                        field_id: field.id,
+                        name: existing.name.clone(),
+                        data_type: existing.data_type().to_string(),
+                        other_name: field.name.clone(),
+                        other_data_type: field.data_type().to_string(),
+                    }
+                    .into());
                 }
             }
         }
@@ -180,24 +169,26 @@ async fn plan_column_writes(
             collect_field_ids(field, &mut subtree_ids);
         }
         if file.fields.is_empty() {
-            return Err(Error::invalid_input(format!(
-                "staged file '{}' records no field ids",
-                file.path
-            )));
+            return Err(ColumnWriteError::NoStagedFieldIds {
+                path: file.path.clone(),
+            }
+            .into());
         }
         let recorded = recorded_by_fragment.entry(*frag_id).or_default();
         for field_id in file.fields.iter() {
             if !subtree_ids.contains(field_id) {
-                return Err(Error::invalid_input(format!(
-                    "staged file '{}' records field id {}, which is not in its staged schema",
-                    file.path, field_id
-                )));
+                return Err(ColumnWriteError::StagedFieldNotInSchema {
+                    path: file.path.clone(),
+                    field_id: *field_id,
+                }
+                .into());
             }
             if !recorded.insert(*field_id) {
-                return Err(Error::invalid_input(format!(
-                    "fragment {} has multiple staged files covering field id {}",
-                    frag_id, field_id
-                )));
+                return Err(ColumnWriteError::DuplicateFieldCoverage {
+                    fragment_id: *frag_id,
+                    field_id: *field_id,
+                }
+                .into());
             }
         }
         covered_by_fragment
@@ -209,13 +200,10 @@ async fn plan_column_writes(
     // Classify each staged column against the schema it was prepared under.
     // Ids that were already this exact field are incremental rewrites; ids
     // that were absent must still be unclaimed at commit time.
-    let prepare_dataset = ds.checkout_version(read_version).await.map_err(|error| {
-        Error::invalid_input(format!(
-            "dataset version {} the columns were staged against is no longer available; \
-             recompute against the current dataset: {}",
-            read_version, error
-        ))
-    })?;
+    let prepare_dataset = ds
+        .checkout_version(read_version)
+        .await
+        .map_err(|_| ColumnWriteError::ReadVersionUnavailable { read_version })?;
     let prepare_schema = prepare_dataset.schema();
     let mut preexisting_field_ids = HashSet::new();
     for field in &new_columns {
@@ -225,16 +213,15 @@ async fn plan_column_writes(
                 preexisting_field_ids.insert(field.id);
             }
             Some(existing) => {
-                return Err(Error::schema(format!(
-                    "staged column '{}' ({}) conflicts with field id {} ('{}', {}) in dataset \
-                     version {} it was prepared against",
-                    field.name,
-                    field.data_type(),
-                    field.id,
-                    existing.name,
-                    existing.data_type(),
+                return Err(ColumnWriteError::FieldContractConflict {
+                    field_id: field.id,
+                    name: field.name.clone(),
+                    data_type: field.data_type().to_string(),
+                    other_name: existing.name.clone(),
+                    other_data_type: existing.data_type().to_string(),
                     read_version,
-                )));
+                }
+                .into());
             }
         }
     }
@@ -250,10 +237,11 @@ async fn plan_column_writes(
     let mut prepare_backing: HashMap<u64, Vec<(i32, FieldBacking)>> = HashMap::new();
     for DataReplacementGroup(frag_id, file) in replacements {
         let Some(prepare_fragment) = prepare_fragments.get(frag_id) else {
-            return Err(Error::invalid_input(format!(
-                "fragment {} does not exist at dataset version {} the write was prepared against",
-                frag_id, read_version
-            )));
+            return Err(ColumnWriteError::FragmentNotInReadVersion {
+                fragment_id: *frag_id,
+                read_version,
+            }
+            .into());
         };
         let bindings = prepare_backing.entry(*frag_id).or_default();
         for field_id in file.fields.iter() {
@@ -328,13 +316,12 @@ impl RetryExecutor for CommitColumnWritesJob {
                 // changed, or a field dropped). Staged files cannot be
                 // renumbered; replaying them would clobber the winner.
                 _ => {
-                    return Err(Error::schema(format!(
-                        "field id {} ('{}', {}) was computed against a stale schema; recompute \
-                         the column against the current dataset",
-                        field.id,
-                        field.name,
-                        field.data_type(),
-                    )));
+                    return Err(ColumnWriteError::StaleSchema {
+                        field_id: field.id,
+                        name: field.name.clone(),
+                        data_type: field.data_type().to_string(),
+                    }
+                    .into());
                 }
             }
         }
@@ -355,11 +342,11 @@ impl RetryExecutor for CommitColumnWritesJob {
                     .get(&frag_id)
                     .is_some_and(|ids| ids.contains(&field.id));
                 if !covered {
-                    return Err(Error::invalid_input(format!(
-                        "non-nullable column '{}' has no staged data for fragment {} (possibly \
-                         appended concurrently); stage every live fragment and recommit",
-                        field.name, frag_id
-                    )));
+                    return Err(ColumnWriteError::UncoveredNonNullableColumn {
+                        name: field.name.clone(),
+                        fragment_id: frag_id,
+                    }
+                    .into());
                 }
             }
         }
@@ -377,11 +364,11 @@ impl RetryExecutor for CommitColumnWritesJob {
                 if let Some(bindings) = self.plan.prepare_backing.get(&frag_id) {
                     for (field_id, prepare_state) in bindings {
                         if field_backing(&metadata, *field_id) != *prepare_state {
-                            return Err(Error::schema(format!(
-                                "fragment {}'s data for field id {} changed since the column \
-                                 was prepared; recompute against the current dataset",
-                                frag_id, field_id
-                            )));
+                            return Err(ColumnWriteError::StaleFragmentData {
+                                fragment_id: frag_id,
+                                field_id: *field_id,
+                            }
+                            .into());
                         }
                     }
                 }
@@ -398,10 +385,7 @@ impl RetryExecutor for CommitColumnWritesJob {
         if !orphaned.is_empty() {
             let mut ids: Vec<u64> = orphaned.into_iter().collect();
             ids.sort_unstable();
-            return Err(Error::invalid_input(format!(
-                "column replacements reference fragments {ids:?}, which are no longer in the \
-                 dataset; re-run the column write against the current fragments"
-            )));
+            return Err(ColumnWriteError::OrphanedReplacements { fragment_ids: ids }.into());
         }
 
         let operation = Operation::Merge { fragments, schema };

--- a/rust/lance/src/dataset/write/column_writes.rs
+++ b/rust/lance/src/dataset/write/column_writes.rs
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use futures::{StreamExt, TryStreamExt};
+use lance_core::datatypes::{Field, NullabilityComparison, Schema, SchemaCompareOptions};
+use lance_core::{Error, Result};
+use lance_encoding::decoder::DecoderPlugins;
+use lance_file::reader::FileReader;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_table::format::overlay::{
+    DataOverlayFile, OverlayCoverage, TOMBSTONE_FIELD_ID, tombstone_overlay_fields,
+};
+use lance_table::format::{DataFile, Fragment};
+use roaring::RoaringBitmap;
+
+use super::CommitBuilder;
+use super::retry::{RetryConfig, RetryExecutor, execute_with_retry};
+use crate::Dataset;
+use crate::dataset::COLUMN_WRITE_READ_VERSION_METADATA_KEY;
+use crate::dataset::transaction::{DataReplacementGroup, Operation, Transaction};
+
+/// See [`Dataset::commit_column_writes`].
+///
+/// The staged files are the source of truth: each file's footer carries the
+/// column schema it was written with and the dataset version it was prepared
+/// against, and the commit is validated against those records.
+pub async fn commit_column_writes(
+    ds: &mut Dataset,
+    replacements: Vec<DataReplacementGroup>,
+    transaction_properties: Option<Arc<HashMap<String, String>>>,
+) -> Result<()> {
+    if replacements.is_empty() {
+        return Err(Error::invalid_input(
+            "no column replacements to commit".to_string(),
+        ));
+    }
+
+    let staged_schemas = read_staged_schemas(ds, &replacements).await?;
+    let plan = plan_column_writes(ds, &replacements, &staged_schemas).await?;
+
+    let dataset = Arc::new(ds.clone());
+    let job = CommitColumnWritesJob {
+        dataset: dataset.clone(),
+        replacements: Arc::new(replacements),
+        plan: Arc::new(plan),
+        transaction_properties,
+    };
+    let new_dataset = execute_with_retry(job, dataset, RetryConfig::default()).await?;
+    *ds = Arc::try_unwrap(new_dataset).unwrap_or_else(|arc| (*arc).clone());
+    Ok(())
+}
+
+/// Read every staged file's footer schema, in `replacements` order.
+async fn read_staged_schemas(
+    ds: &Dataset,
+    replacements: &[DataReplacementGroup],
+) -> Result<Vec<Schema>> {
+    let scheduler = ScanScheduler::new(
+        ds.object_store.clone(),
+        SchedulerConfig::max_bandwidth(&ds.object_store),
+    );
+    // A column write stages one file per fragment, so this fans out over the
+    // whole dataset; `buffered` keeps the schemas aligned with `replacements`.
+    futures::stream::iter(replacements)
+        .map(|DataReplacementGroup(_, file)| read_staged_schema(ds, &scheduler, file))
+        .buffered(ds.object_store.io_parallelism())
+        .try_collect()
+        .await
+}
+
+/// Read one staged file's footer schema.
+async fn read_staged_schema(
+    ds: &Dataset,
+    scheduler: &Arc<ScanScheduler>,
+    file: &DataFile,
+) -> Result<Schema> {
+    let path = ds.data_dir().join(file.path.as_str());
+    let file_scheduler = scheduler.open_file(&path, &file.file_size_bytes).await?;
+    let reader = FileReader::try_open(
+        file_scheduler,
+        None,
+        Arc::<DecoderPlugins>::default(),
+        &ds.metadata_cache.file_metadata_cache(&path),
+        ds.file_reader_options.clone().unwrap_or_default(),
+    )
+    .await?;
+    Ok(reader.schema().as_ref().clone())
+}
+
+/// The staged columns' union schema, which of them already existed at
+/// prepare time, and which top-level columns each fragment covers.
+struct ColumnWritePlan {
+    new_columns: Vec<Field>,
+    preexisting_field_ids: HashSet<i32>,
+    covered_by_fragment: HashMap<u64, HashSet<i32>>,
+    /// Each staged field's complete prepare-time coverage identity on its
+    /// target fragment. A replacement is only current while that exact
+    /// state holds, absence included.
+    ///
+    /// Row count is deliberately not part of this identity: a fragment id's
+    /// physical row count is immutable, so staged files sized at prepare time
+    /// still fit at commit time. Operations that change a fragment's row count
+    /// give it a new id (compaction, merge insert), which the orphan check
+    /// catches instead, and `merge_fragments_valid` rejects any Merge that
+    /// tries to resize a fragment in place.
+    prepare_backing: HashMap<u64, Vec<(i32, FieldBacking)>>,
+}
+
+async fn plan_column_writes(
+    ds: &Dataset,
+    replacements: &[DataReplacementGroup],
+    staged_schemas: &[Schema],
+) -> Result<ColumnWritePlan> {
+    // All staged files must be prepared against one dataset version.
+    let mut read_version: Option<u64> = None;
+    for (DataReplacementGroup(_, file), schema) in replacements.iter().zip(staged_schemas) {
+        let stamped = schema
+            .metadata
+            .get(COLUMN_WRITE_READ_VERSION_METADATA_KEY)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "file '{}' was not staged by write_fragment_column (missing read-version \
+                     metadata)",
+                    file.path
+                ))
+            })?
+            .parse::<u64>()
+            .map_err(|parse_error| {
+                Error::invalid_input(format!(
+                    "file '{}' has an unparsable read-version stamp: {}",
+                    file.path, parse_error
+                ))
+            })?;
+        match read_version {
+            None => read_version = Some(stamped),
+            Some(prev) if prev == stamped => {}
+            Some(prev) => {
+                return Err(Error::invalid_input(format!(
+                    "staged files span dataset versions {} and {}; stage all fragments against \
+                     one version",
+                    prev, stamped
+                )));
+            }
+        }
+    }
+    let read_version = read_version.expect("replacements are non-empty");
+
+    // Union the staged top-level columns; files sharing a field id must agree
+    // on its full recursive schema.
+    let mut new_columns: Vec<Field> = Vec::new();
+    for schema in staged_schemas {
+        for field in &schema.fields {
+            match new_columns.iter().find(|f| f.id == field.id) {
+                None => new_columns.push(field.clone()),
+                Some(existing) if fields_match(existing, field) => {}
+                Some(existing) => {
+                    return Err(Error::invalid_input(format!(
+                        "staged files disagree on field id {}: '{}' ({}) vs '{}' ({})",
+                        field.id,
+                        existing.name,
+                        existing.data_type(),
+                        field.name,
+                        field.data_type(),
+                    )));
+                }
+            }
+        }
+    }
+
+    // Recorded field ids must come from the file's own staged schema, and a
+    // fragment's files must cover disjoint ids.
+    let mut covered_by_fragment: HashMap<u64, HashSet<i32>> = HashMap::new();
+    let mut recorded_by_fragment: HashMap<u64, HashSet<i32>> = HashMap::new();
+    for (DataReplacementGroup(frag_id, file), schema) in replacements.iter().zip(staged_schemas) {
+        let mut subtree_ids = HashSet::new();
+        for field in &schema.fields {
+            collect_field_ids(field, &mut subtree_ids);
+        }
+        if file.fields.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "staged file '{}' records no field ids",
+                file.path
+            )));
+        }
+        let recorded = recorded_by_fragment.entry(*frag_id).or_default();
+        for field_id in file.fields.iter() {
+            if !subtree_ids.contains(field_id) {
+                return Err(Error::invalid_input(format!(
+                    "staged file '{}' records field id {}, which is not in its staged schema",
+                    file.path, field_id
+                )));
+            }
+            if !recorded.insert(*field_id) {
+                return Err(Error::invalid_input(format!(
+                    "fragment {} has multiple staged files covering field id {}",
+                    frag_id, field_id
+                )));
+            }
+        }
+        covered_by_fragment
+            .entry(*frag_id)
+            .or_default()
+            .extend(schema.fields.iter().map(|field| field.id));
+    }
+
+    // Classify each staged column against the schema it was prepared under.
+    // Ids that were already this exact field are incremental rewrites; ids
+    // that were absent must still be unclaimed at commit time.
+    let prepare_dataset = ds.checkout_version(read_version).await.map_err(|error| {
+        Error::invalid_input(format!(
+            "dataset version {} the columns were staged against is no longer available; \
+             recompute against the current dataset: {}",
+            read_version, error
+        ))
+    })?;
+    let prepare_schema = prepare_dataset.schema();
+    let mut preexisting_field_ids = HashSet::new();
+    for field in &new_columns {
+        match prepare_schema.field_by_id(field.id) {
+            None => {}
+            Some(existing) if fields_match(existing, field) => {
+                preexisting_field_ids.insert(field.id);
+            }
+            Some(existing) => {
+                return Err(Error::schema(format!(
+                    "staged column '{}' ({}) conflicts with field id {} ('{}', {}) in dataset \
+                     version {} it was prepared against",
+                    field.name,
+                    field.data_type(),
+                    field.id,
+                    existing.name,
+                    existing.data_type(),
+                    read_version,
+                )));
+            }
+        }
+    }
+
+    // Record which file backs each rewritten field at prepare time; a
+    // concurrent rewrite of the same field changes that backing, and the
+    // staged bytes must then be recomputed rather than replayed.
+    let prepare_fragments: HashMap<u64, Fragment> = prepare_dataset
+        .get_fragments()
+        .into_iter()
+        .map(|frag| (frag.id() as u64, frag.metadata().clone()))
+        .collect();
+    let mut prepare_backing: HashMap<u64, Vec<(i32, FieldBacking)>> = HashMap::new();
+    for DataReplacementGroup(frag_id, file) in replacements {
+        let Some(prepare_fragment) = prepare_fragments.get(frag_id) else {
+            return Err(Error::invalid_input(format!(
+                "fragment {} does not exist at dataset version {} the write was prepared against",
+                frag_id, read_version
+            )));
+        };
+        let bindings = prepare_backing.entry(*frag_id).or_default();
+        for field_id in file.fields.iter() {
+            bindings.push((*field_id, field_backing(prepare_fragment, *field_id)));
+        }
+    }
+
+    Ok(ColumnWritePlan {
+        new_columns,
+        preexisting_field_ids,
+        covered_by_fragment,
+        prepare_backing,
+    })
+}
+
+/// Full recursive field-contract comparison: names, types, nullability, and
+/// field ids, at every level.
+fn fields_match(a: &Field, b: &Field) -> bool {
+    let a_schema = Schema {
+        fields: vec![a.clone()],
+        metadata: HashMap::new(),
+    };
+    let b_schema = Schema {
+        fields: vec![b.clone()],
+        metadata: HashMap::new(),
+    };
+    let options = SchemaCompareOptions {
+        compare_field_ids: true,
+        compare_nullability: NullabilityComparison::Strict,
+        ..Default::default()
+    };
+    a_schema.check_compatible(&b_schema, &options).is_ok()
+}
+
+fn collect_field_ids(field: &Field, ids: &mut HashSet<i32>) {
+    ids.insert(field.id);
+    for child in &field.children {
+        collect_field_ids(child, ids);
+    }
+}
+
+#[derive(Clone)]
+struct CommitColumnWritesJob {
+    dataset: Arc<Dataset>,
+    replacements: Arc<Vec<DataReplacementGroup>>,
+    plan: Arc<ColumnWritePlan>,
+    transaction_properties: Option<Arc<HashMap<String, String>>>,
+}
+
+impl RetryExecutor for CommitColumnWritesJob {
+    type Data = Transaction;
+    type Result = Arc<Dataset>;
+
+    /// Build the Merge transaction against the job's current dataset version.
+    /// Re-run on each retry so a concurrent commit's data files are preserved.
+    async fn execute_impl(&self) -> Result<Self::Data> {
+        let mut replacement_map: HashMap<u64, Vec<&DataFile>> = HashMap::new();
+        for DataReplacementGroup(frag_id, file) in self.replacements.iter() {
+            replacement_map.entry(*frag_id).or_default().push(file);
+        }
+
+        let mut schema = self.dataset.schema().clone();
+        for field in &self.plan.new_columns {
+            let was_preexisting = self.plan.preexisting_field_ids.contains(&field.id);
+            match schema.field_by_id(field.id) {
+                None if !was_preexisting => schema.fields.push(field.clone()),
+                // Rewrite of a column that existed when the write was
+                // prepared: the occupant must still match the full contract.
+                Some(existing) if was_preexisting && fields_match(existing, field) => {}
+                // The schema moved underneath the prepared write (a
+                // formerly-new id claimed concurrently, a rewrite target
+                // changed, or a field dropped). Staged files cannot be
+                // renumbered; replaying them would clobber the winner.
+                _ => {
+                    return Err(Error::schema(format!(
+                        "field id {} ('{}', {}) was computed against a stale schema; recompute \
+                         the column against the current dataset",
+                        field.id,
+                        field.name,
+                        field.data_type(),
+                    )));
+                }
+            }
+        }
+
+        // A new non-nullable column must cover every live fragment; an
+        // uncovered one (e.g. appended concurrently) would synthesize
+        // invalid nulls. Uncovered nullable columns read as null.
+        let live_fragments = self.dataset.get_fragments();
+        for field in &self.plan.new_columns {
+            if self.plan.preexisting_field_ids.contains(&field.id) || field.nullable {
+                continue;
+            }
+            for frag in &live_fragments {
+                let frag_id = frag.id() as u64;
+                let covered = self
+                    .plan
+                    .covered_by_fragment
+                    .get(&frag_id)
+                    .is_some_and(|ids| ids.contains(&field.id));
+                if !covered {
+                    return Err(Error::invalid_input(format!(
+                        "non-nullable column '{}' has no staged data for fragment {} (possibly \
+                         appended concurrently); stage every live fragment and recommit",
+                        field.name, frag_id
+                    )));
+                }
+            }
+        }
+
+        let mut orphaned: HashSet<u64> = replacement_map.keys().copied().collect();
+        let mut fragments = Vec::with_capacity(live_fragments.len());
+        for frag in live_fragments {
+            let frag_id = frag.id() as u64;
+            let mut metadata = frag.metadata().clone();
+            if let Some(data_files) = replacement_map.get(&frag_id) {
+                orphaned.remove(&frag_id);
+                // A rewritten field must still be backed by the file it had
+                // at prepare time; a different backing means a concurrent
+                // rewrite won and the staged bytes are stale.
+                if let Some(bindings) = self.plan.prepare_backing.get(&frag_id) {
+                    for (field_id, prepare_state) in bindings {
+                        if field_backing(&metadata, *field_id) != *prepare_state {
+                            return Err(Error::schema(format!(
+                                "fragment {}'s data for field id {} changed since the column \
+                                 was prepared; recompute against the current dataset",
+                                frag_id, field_id
+                            )));
+                        }
+                    }
+                }
+                for data_file in data_files {
+                    replace_column_coverage(&mut metadata, data_file);
+                }
+            }
+            fragments.push(metadata);
+        }
+
+        // An orphaned replacement (its fragment was rewritten, e.g. by
+        // compaction) would otherwise be dropped silently, committing a
+        // column with missing (null) data.
+        if !orphaned.is_empty() {
+            let mut ids: Vec<u64> = orphaned.into_iter().collect();
+            ids.sort_unstable();
+            return Err(Error::invalid_input(format!(
+                "column replacements reference fragments {ids:?}, which are no longer in the \
+                 dataset; re-run the column write against the current fragments"
+            )));
+        }
+
+        let operation = Operation::Merge { fragments, schema };
+        let mut transaction = Transaction::new(self.dataset.manifest.version, operation, None);
+        transaction.transaction_properties = self.transaction_properties.clone();
+        Ok(transaction)
+    }
+
+    async fn commit(&self, dataset: Arc<Dataset>, transaction: Self::Data) -> Result<Self::Result> {
+        CommitBuilder::new(dataset)
+            .execute(transaction)
+            .await
+            .map(Arc::new)
+    }
+
+    fn update_dataset(&mut self, dataset: Arc<Dataset>) {
+        self.dataset = dataset;
+    }
+}
+
+/// A field's complete coverage identity on a fragment: the base data file
+/// backing it (None: uncovered) and the overlays covering it, in order.
+#[derive(Clone, PartialEq)]
+struct FieldBacking {
+    base: Option<DataFileWitness>,
+    overlays: Vec<OverlayBacking>,
+}
+
+/// A data file's identity projected to one field: everything a reader uses
+/// to locate and decode the field's values. `file_size_bytes` is a cache
+/// hint and excluded. Paths alone are not identity; a commit can change the
+/// routing under the same path.
+#[derive(Clone, PartialEq)]
+struct DataFileWitness {
+    path: String,
+    base_id: Option<u32>,
+    file_major_version: u32,
+    file_minor_version: u32,
+    column_index: Option<i32>,
+}
+
+fn field_data_file_witness(file: &DataFile, field_id: i32) -> Option<DataFileWitness> {
+    let position = file.fields.iter().position(|id| *id == field_id)?;
+    Some(DataFileWitness {
+        path: file.path.clone(),
+        base_id: file.base_id,
+        file_major_version: file.file_major_version,
+        file_minor_version: file.file_minor_version,
+        column_index: file.column_indices.get(position).copied(),
+    })
+}
+
+/// One overlay's identity projected to a single field: its data-file witness,
+/// committed version, and the coverage bitmap that applies to the field.
+#[derive(Clone, PartialEq)]
+struct OverlayBacking {
+    file: DataFileWitness,
+    committed_version: u64,
+    coverage: Arc<RoaringBitmap>,
+}
+
+fn field_overlay_backing(overlay: &DataOverlayFile, field_id: i32) -> Option<OverlayBacking> {
+    let position = overlay
+        .data_file
+        .fields
+        .iter()
+        .position(|id| *id == field_id)?;
+    let coverage = match &overlay.coverage {
+        OverlayCoverage::Shared(bitmap) => bitmap.clone(),
+        OverlayCoverage::PerField(bitmaps) => bitmaps.get(position)?.clone(),
+    };
+    Some(OverlayBacking {
+        file: field_data_file_witness(&overlay.data_file, field_id)?,
+        committed_version: overlay.committed_version,
+        coverage,
+    })
+}
+
+fn field_backing(fragment: &Fragment, field_id: i32) -> FieldBacking {
+    let base = fragment
+        .files
+        .iter()
+        .find_map(|file| field_data_file_witness(file, field_id));
+    let overlays = fragment
+        .overlays
+        .iter()
+        .filter_map(|overlay| field_overlay_backing(overlay, field_id))
+        .collect();
+    FieldBacking { base, overlays }
+}
+
+/// Make `data_file` the fragment's authoritative coverage of its fields:
+/// tombstone them in existing files and overlays (the update-columns idiom),
+/// drop fully tombstoned files, and append `data_file`.
+fn replace_column_coverage(fragment: &mut Fragment, data_file: &DataFile) {
+    let replaced: HashSet<i32> = data_file.fields.iter().copied().collect();
+    for file in &mut fragment.files {
+        file.fields = file
+            .fields
+            .iter()
+            .map(|field| {
+                if replaced.contains(field) {
+                    TOMBSTONE_FIELD_ID
+                } else {
+                    *field
+                }
+            })
+            .collect::<Vec<_>>()
+            .into();
+    }
+    fragment
+        .files
+        .retain(|file| file.fields.iter().any(|&field| field != TOMBSTONE_FIELD_ID));
+    let replaced_u32: Vec<u32> = replaced
+        .iter()
+        .filter(|&&field| field >= 0)
+        .map(|&field| field as u32)
+        .collect();
+    tombstone_overlay_fields(&mut fragment.overlays, &replaced_u32);
+    fragment.files.push(data_file.clone());
+}

--- a/rust/lance/src/dataset/write/column_writes.rs
+++ b/rust/lance/src/dataset/write/column_writes.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use futures::{StreamExt, TryStreamExt};
-use lance_core::Result;
 use lance_core::datatypes::{Field, NullabilityComparison, Schema, SchemaCompareOptions};
+use lance_core::{Result, is_system_column};
 use lance_encoding::decoder::DecoderPlugins;
 use lance_file::reader::FileReader;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
@@ -156,6 +156,20 @@ async fn plan_column_writes(
                     .into());
                 }
             }
+        }
+    }
+
+    // The system columns are virtual, injected into scan results at read time
+    // and never stored, so a stored column with one of those names commits and
+    // validates but then collides with the injected field and breaks
+    // projection. `new_column_schema` rejects them, but a caller can build a
+    // staging schema by hand, so the commit boundary must reject them too.
+    for field in &new_columns {
+        if is_system_column(&field.name) {
+            return Err(ColumnWriteError::ReservedColumnName {
+                name: field.name.clone(),
+            }
+            .into());
         }
     }
 


### PR DESCRIPTION
Two-step API for writing a column's data to existing fragments:

- `write_fragment_column` writes one fragment's new column data as a
  standalone uncommitted data file and returns its `DataReplacementGroup`.
  The batch stream must match the fragment's physical row count.
- `commit_column_writes` publishes the accumulated replacements and the
  extended schema in one atomic Merge, tombstoning prior coverage of the
  replaced fields. Commit conflicts retry via the standard retry executor;
  a fragment rewritten or a field id reassigned concurrently fails the
  commit instead of publishing stale data.