### PR TITLE
fix(index): accept "RQ" when parsing QuantizationType

### DIFF
--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -81,7 +81,9 @@ impl FromStr for QuantizationType {
             "FLATBIN" => Ok(Self::FlatBin),
             "PQ" => Ok(Self::Product),
             "SQ" => Ok(Self::Scalar),
-            "RABIT" => Ok(Self::Rabit),
+            // `Display` writes "RQ"; "RABIT" is accepted for headers written
+            // before this variant round-tripped.
+            "RQ" | "RABIT" => Ok(Self::Rabit),
             _ => Err(Error::index(format!("Unknown quantization type: {}", s))),
         }
     }
@@ -383,5 +385,36 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
             None,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// `IvfIndexState` persists the quantization type with `Display` and reads
+    /// it back with `FromStr`, so the two must agree for every variant.
+    #[rstest]
+    #[case::flat(QuantizationType::Flat)]
+    #[case::flat_bin(QuantizationType::FlatBin)]
+    #[case::product(QuantizationType::Product)]
+    #[case::scalar(QuantizationType::Scalar)]
+    #[case::rabit(QuantizationType::Rabit)]
+    fn test_display_from_str_round_trip(#[case] quantization_type: QuantizationType) {
+        let encoded = quantization_type.to_string();
+        assert_eq!(
+            encoded.parse::<QuantizationType>().unwrap(),
+            quantization_type,
+            "{encoded} did not round-trip"
+        );
+    }
+
+    #[test]
+    fn test_from_str_accepts_legacy_rabit_spelling() {
+        assert_eq!(
+            "RABIT".parse::<QuantizationType>().unwrap(),
+            QuantizationType::Rabit
+        );
     }
 }


### PR DESCRIPTION
Display writes `"RQ"` for `QuantizationType::Rabit` but `FromStr` only accepted `"RABIT"`, so the two never round-tripped.

`IvfIndexState::serialize` stores the quantization type with `to_string()`; `deserialize` reads it back with `parse::<QuantizationType>()`. For an IVF_RQ index that parse always failed, and since `CacheCodec::deserialize` turns a body error into `CacheDecode::Miss`, the failure was silent — the index just never reused its serialized state.

`Display` has to keep emitting `"RQ"`: `index_type_string` builds `IVF_{quantization_type}` and `IndexType::try_from` expects `"IVF_RQ"`. So the fix belongs on the `FromStr` side. `"RABIT"` stays accepted for headers already on disk.

The existing round-trip coverage missed this because `test_ivf_index_state_roundtrip` hardcodes `QuantizationType::Flat` and the `test_prewarm_and_query_with_serializing_backend` cases are PQ and HNSW_SQ only. The new `#[rstest]` covers every variant.

## Testing

- `cargo test -p lance-index --lib vector::quantizer` — 6 pass; `case_5_rabit` fails without the one-line fix
- `cargo test -p lance-index --lib vector::` — 331 pass
- `cargo fmt --all -- --check`, `cargo clippy -p lance-index --tests --benches -- -D warnings`