### PR TITLE
docs: convert ignore doctests to compiling examples

### DIFF
--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -177,7 +177,7 @@ class KMeans:
         for idx in zero_counts.nonzero(as_tuple=False):
             # split the largest cluster and remove empty cluster
             max_idx = torch.argmax(counts).item()
-            # add 1% gassuian noise to the largest centroid
+            # add 1% gaussian noise to the largest centroid
             # do this twice so we effectively split the largest cluster into 2
             # rand_like returns on [0, 1) so we need to shift it to [-0.5, 0.5)
             noise = (torch.rand_like(centroids[idx]) - 0.5) * 0.01 + 1

--- a/rust/lance-core/src/cache/registry.rs
+++ b/rust/lance-core/src/cache/registry.rs
@@ -110,10 +110,18 @@ fn registry_lock_for_test() -> MutexGuard<'static, HashMap<String, BackendBuildF
 ///
 /// Typical usage from a backend crate:
 ///
-/// ```ignore
-/// pub fn register() -> lance_core::Result<()> {
-///     lance_core::cache::register_backend("my_backend", build_my_backend)
+/// ```
+/// # use std::sync::Arc;
+/// # use lance_core::Result;
+/// # use lance_core::cache::{BackendConfig, CacheBackend, MokaCacheBackend, register_backend};
+/// fn build_my_backend(_config: &BackendConfig) -> Result<Arc<dyn CacheBackend>> {
+///     Ok(Arc::new(MokaCacheBackend::with_capacity(1024)))
 /// }
+///
+/// # fn main() -> Result<()> {
+/// register_backend("my-backend", build_my_backend)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn register_backend(kind: &str, build: BackendBuildFn) -> Result<()> {
     let kind = normalize_backend_kind(kind)?;

--- a/rust/lance-datafusion/src/spill.rs
+++ b/rust/lance-datafusion/src/spill.rs
@@ -389,7 +389,7 @@ impl Default for DataLocation {
     }
 }
 
-/// A DataFusion error that be be emitted multiple times. We provide the
+/// A DataFusion error that can be emitted multiple times. We provide the
 /// Original error first, and subsequent conversions provide a copy with a
 /// string representation of the original error.
 #[derive(Debug)]

--- a/rust/lance/src/dataset/mem_wal/util.rs
+++ b/rust/lance/src/dataset/mem_wal/util.rs
@@ -92,7 +92,8 @@ impl<T: Clone + std::fmt::Debug> WatchableOnceCellReader<T> {
 /// optimizing S3 throughput by spreading sequential writes across internal partitions.
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// # use lance::dataset::mem_wal::util::bit_reverse_u64;
 /// // 5 in binary: 000...101
 /// // Reversed:    101...000
 /// assert_eq!(bit_reverse_u64(5), 0xa000000000000000);


### PR DESCRIPTION
`rust/AGENTS.md` asks for doctests that compile a function rather than ```ignore blocks. Neither of these two was checked by anything, and the cache registry example had drifted: it wrapped the call in a `register()` function that does not exist in the crate.

The registry example now builds a real `BackendBuildFn` from `MokaCacheBackend`. It uses `"my-backend"` rather than `"my_backend"` because `normalize_backend_kind` rejects underscores — the underscore spelling fails at runtime, which is what made converting this one worth doing rather than just deleting the `ignore`. Each doctest runs in its own process, so touching the global registry is safe.

Also fixes two typos found nearby: "that be be" in `spill.rs` and "gassuian" in `kmeans.py`.

## Testing

- `cargo test --doc -p lance-core -p lance` — both new doctests run and pass
- `cargo fmt --all -- --check`, `cargo clippy -p lance-core -p lance-datafusion --tests --benches -- -D warnings`
- `ruff format --check` and `ruff check` on the touched Python file