### PR TITLE
fix(docs): stop make help from running the website build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "  make build        - Build documentation (auto-installs deps)"
 	@echo "  make make-full-website  - Assemble the full website from local repo checkouts"
 	@echo "  make clean-full-website - Remove generated website content"
-	@echo "                       Run `make make-full-website` before `make build` or `make serve` for the full multi-repo site"
+	@echo "                       Run 'make make-full-website' before 'make build' or 'make serve' for the full multi-repo site"
 	@echo "                       Override any repo with env vars like LANCE_NAMESPACE_REPO=..., LANCE_SPARK_REPO=..., LANCE_RAY_REPO=..."
 	@echo "  make clean        - Clean build artifacts"
 	@echo "  make check-links  - Check for broken links"


### PR DESCRIPTION
The backticks in the `help` recipe are command substitutions, so `make help` in `docs/` executes `make make-full-website` twice, `make build`, and `make serve` before printing anything. `make-full-website.sh` rewrites `docs/src`, so a command that should only print text mutates the working tree and then starts a dev server.

The substituted output also replaces the text it was meant to render, so the line prints shell command paths instead of the intended hint.

Single-quoting keeps the intended emphasis without invoking anything.

## Testing

Ran `make help` against a copy of the Makefile with `make-full-website.sh`, `clean-full-website.sh` and `uv` replaced by stubs that announce themselves.

Before:

```
  make clean-full-website - Remove generated website content
>>> SIDE EFFECT: make-full-website.sh EXECUTED
>>> SIDE EFFECT: make-full-website.sh EXECUTED
>>> SIDE EFFECT: uv run mkdocs build EXECUTED
>>> SIDE EFFECT: make-full-website.sh EXECUTED
>>> SIDE EFFECT: uv run mkdocs serve EXECUTED
                       Run ./make-full-website.sh before ./make-full-website.sh
uv run mkdocs build or ./make-full-website.sh
uv run mkdocs serve for the full multi-repo site
```

After:

```
  make clean-full-website - Remove generated website content
                       Run 'make make-full-website' before 'make build' or 'make serve' for the full multi-repo site
```

No stub is invoked. `docs/Makefile` is the only Makefile in the tree with backticks in a recipe.