### PR TITLE
ci: serialize regression benchmark runs

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# These benchmarks mutate shared GCS datasets, so runs must not overlap.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   bench_regress:
     timeout-minutes: 120


### PR DESCRIPTION
The regression benchmark workflow mutates shared GCS datasets. Runs triggered by multiple `main` pushes can overlap, causing restore conflicts and allowing one run's cleanup to delete another run's base manifest.

Serialize the workflow under a single concurrency group while preserving the active run. GitHub keeps only the newest pending run for the group, which avoids building a backlog of long-running benchmarks.

This change addresses only the cross-run dataset race. It does not address the independent `v1_indexed` memory-limit failures in the reported CI run.
