### PR TITLE
fix: protect shallow-clone sources with permanent GC markers

### DIFF
--- a/docs/src/format/table/branch_tag.md
+++ b/docs/src/format/table/branch_tag.md
@@ -1,9 +1,11 @@
-# Branch and Tag Specification
+# Branch, Tag, and Clone Reference Specification
 
 ## Overview
 
 Lance supports branching and tagging for managing multiple independent version histories and creating named references to specific versions.
 Branches enable parallel development workflows, while tags provide stable named references for important versions.
+Clone pins record that a shallow clone at another URI reads this dataset's files. Cleanup keeps those files while a pin exists.
+All three are stored under `_refs/` at the dataset root.
 
 ## Branching
 
@@ -123,3 +125,67 @@ Each tag file is a JSON file with the following fields:
 | `updatedAt`     | string | Yes      | RFC 3339 timestamp for the latest tag reference update.                 |
 | `manifestSize`  | number |          | Size of the manifest file in bytes. Used for efficient manifest loading. |
 | `metadata`      | object | Yes      | String key/value metadata map. If absent, it is treated as an empty object. |
+
+## Clone Pin
+
+A shallow clone stores its manifest at its own URI but reads the source dataset's data, deletion, and index files in place through `base_paths`.
+The source does not discover clones on its own. Cleanup on the source does not open clone URIs.
+By default, at clone time the source writes a pin under `_refs/clones/` for the cloned version, and the clone stores that pin id in its config under `lance.clone.source_pin_id`.
+A clone of a read-only source may instead rely on a tag the source owner created, in which case no pin is written.
+Cleanup keeps a pinned version's manifest and every file it references, the same way it keeps a tagged version.
+
+Pins are not removed when the clone is created. Remove the pin when the clone is deleted or detached.
+Several clones may each hold a pin on the same version. The version stays retained until the last pin is removed.
+
+Before deleting a version, cleanup writes a per-version marker under `_refs/gc_markers/`, then relists pins and tags.
+If a pin for the current branch incarnation or a tag protects the version, cleanup retains it. Otherwise it deletes the version.
+Tags are rechecked because a clone of a read-only source relies on a tag instead of a pin, and that tag may appear after cleanup's first tag listing.
+Markers stay after the version is deleted so a marked version stays closed to new shallow clones.
+Marker paths and pin `branchId` values use the branch incarnation id, not only the display name.
+A recreated branch with the same name gets a new incarnation and does not inherit prior markers or pins.
+Existing clones keep working through their pins until those pins are unregistered. A later cleanup then deletes the version.
+Deleting a branch is also fenced. Deletion writes an incarnation-wide `deleted` marker, then lists pins and is refused while any pin targets that incarnation.
+The `deleted` marker is never removed. An incarnation whose deletion was requested stays closed to new shallow clones even when the deletion was refused, and deletion can be rerun once the listed pins are unregistered.
+A force delete overrides the refusal and breaks the clones holding those pins.
+Tag-retained clones do not block branch deletion. Deleting the source branch breaks them.
+A pinned shallow clone checks both markers, creates its pin, then checks both again before beginning the commit.
+A tag-retained clone verifies that a tag retains the version and checks both markers without creating a pin.
+
+### Clone Pin Storage
+
+Pins are stored as JSON files under `_refs/clones/` at the dataset root.
+Cleanup markers live under `_refs/gc_markers/<incarnation>/<version>`:
+
+```
+{dataset_root}/
+    _refs/
+        clones/
+            21b1c1b1a4f7f9f0d1e2c3b4a5968778.json
+            8f0e1d2c3b4a5968778091a2b3c4d5e6.json
+        gc_markers/
+            main/
+                1
+                3
+            a1b2c3d4e5f60718293a4b5c6d7e8f90/
+                1
+                deleted
+```
+
+Pins are always stored at the root dataset level, for every branch a clone reads from.
+The pin file name is a random 32-character hexadecimal pin id. The same id is stored on the clone.
+The main branch uses the path segment `main`. Named branches use the leaf UUID of their `BranchIdentifier`.
+Path segments encode `%` as `%25` and `/` as `%2F`.
+Numeric file names fence single versions. The `deleted` file name fences the whole incarnation and is written by branch deletion.
+
+### Clone Pin File Format
+
+Each pin file is a JSON file with the following fields:
+
+| JSON Key    | Type   | Optional | Description                                                                 |
+|-------------|--------|----------|-----------------------------------------------------------------------------|
+| `id`        | string |          | Random pin id. Matches the file stem.                                       |
+| `branch`    | string | Yes      | Display name of the branch that was cloned. Absent means the main branch.   |
+| `branchId`  | string | Yes      | Leaf UUID of the branch incarnation. Absent means main. Used for retention. Required when `branch` is present. Readers reject a named-branch pin without it. |
+| `version`   | number |          | Version of that incarnation that the clone reads from.                      |
+| `createdAt` | string |          | RFC 3339 timestamp for when the pin was created.                            |
+| `cloneUri`  | string | Yes      | URI of the clone dataset, for listing. Not used as the registry key.        |

--- a/docs/src/format/table/branch_tag.md
+++ b/docs/src/format/table/branch_tag.md
@@ -128,28 +128,27 @@ Each tag file is a JSON file with the following fields:
 
 ## Clone Pin
 
-A shallow clone stores its manifest at its own URI but reads the source dataset's data, deletion, and index files in place through `base_paths`.
-The source does not discover clones on its own. Cleanup on the source does not open clone URIs.
-By default, at clone time the source writes a pin under `_refs/clones/` for the cloned version, and the clone stores that pin id in its config under `lance.clone.source_pin_id`.
-A clone of a read-only source may instead rely on a tag the source owner created, in which case no pin is written.
-Cleanup keeps a pinned version's manifest and every file it references, the same way it keeps a tagged version.
+A shallow clone stores its manifest at its own URI and reads the source's data, deletion, and index files in place through `base_paths`.
+Cleanup on the source does not open clone URIs.
+By default the source writes a pin under `_refs/clones/` for the cloned version, and the clone stores that pin id under `lance.clone.source_pin_id`.
+A read-only source may rely on a tag the owner created instead, with no pin written.
+Cleanup keeps a pinned version the same way it keeps a tagged version.
 
-Pins are not removed when the clone is created. Remove the pin when the clone is deleted or detached.
-Several clones may each hold a pin on the same version. The version stays retained until the last pin is removed.
+Remove the pin when the clone is deleted or detached. Several clones may pin the same version. Retention lasts until the last pin is removed.
 
-Before deleting a version, cleanup writes a per-version marker under `_refs/gc_markers/`, then relists pins and tags.
-If a pin for the current branch incarnation or a tag protects the version, cleanup retains it. Otherwise it deletes the version.
-Tags are rechecked because a clone of a read-only source relies on a tag instead of a pin, and that tag may appear after cleanup's first tag listing.
-Markers stay after the version is deleted so a marked version stays closed to new shallow clones.
-Marker paths and pin `branchId` values use the branch incarnation id, not only the display name.
-A recreated branch with the same name gets a new incarnation and does not inherit prior markers or pins.
-Existing clones keep working through their pins until those pins are unregistered. A later cleanup then deletes the version.
-Deleting a branch is also fenced. Deletion writes an incarnation-wide `deleted` marker, then lists pins and is refused while any pin targets that incarnation.
-The `deleted` marker is never removed. An incarnation whose deletion was requested stays closed to new shallow clones even when the deletion was refused, and deletion can be rerun once the listed pins are unregistered.
-A force delete overrides the refusal and breaks the clones holding those pins.
-Tag-retained clones do not block branch deletion. Deleting the source branch breaks them.
-A pinned shallow clone checks both markers, creates its pin, then checks both again before beginning the commit.
-A tag-retained clone verifies that a tag retains the version and checks both markers without creating a pin.
+Before deleting a version, cleanup writes a marker under `_refs/gc_markers/`, then relists pins and tags.
+A pin for the current incarnation or a matching tag retains the version. Otherwise cleanup deletes it.
+Tags are rechecked so a mid-cleanup `require_tag` clone still protects its version.
+Markers stay after deletion, so a marked version stays closed to new shallow clones.
+Marker paths and pin `branchId` values use the branch incarnation id. A recreated branch with the same name gets a new incarnation and does not inherit prior markers or pins.
+Existing clones keep working until their pins are unregistered.
+
+Branch deletion writes an incarnation-wide `deleted` marker, then lists pins and is refused while any pin targets that incarnation.
+The `deleted` marker is never removed. A refused delete leaves the incarnation closed to new shallow clones. Rerun delete after unregistering the listed pins.
+A force delete overrides the refusal and breaks those clones.
+Tag-retained clones do not block branch deletion.
+A pinned clone checks both markers, creates its pin, then checks both again before commit.
+A tag-retained clone verifies the tag and checks both markers without creating a pin.
 
 ### Clone Pin Storage
 

--- a/docs/src/format/table/branch_tag.md
+++ b/docs/src/format/table/branch_tag.md
@@ -147,6 +147,10 @@ Branch deletion writes an incarnation-wide `deleted` marker, then lists pins and
 The `deleted` marker is never removed. A refused delete leaves the incarnation closed to new shallow clones. Rerun delete after unregistering the listed pins.
 A force delete overrides the refusal and breaks those clones.
 Tag-retained clones do not block branch deletion.
+
+Named-branch create, delete, and cleanup hold a short-lived path lease under `_refs/branch_path_leases/<encoded-branch-name>` for their full critical sections.
+The lease serializes those operations so a delete/recreate cannot reuse `tree/{branch}/` paths while cleanup or another mutation is still using them.
+The lease is removed when the operation finishes. If a process crashes, remove the lease file before retrying create, delete, or cleanup.
 A pinned clone checks both markers, creates its pin, then checks both again before commit.
 A tag-retained clone verifies the tag and checks both markers without creating a pin.
 
@@ -161,6 +165,8 @@ Cleanup markers live under `_refs/gc_markers/<incarnation>/<version>`:
         clones/
             21b1c1b1a4f7f9f0d1e2c3b4a5968778.json
             8f0e1d2c3b4a5968778091a2b3c4d5e6.json
+        branch_path_leases/
+            feature%2Fdev
         gc_markers/
             main/
                 1

--- a/docs/src/format/table/layout.md
+++ b/docs/src/format/table/layout.md
@@ -153,7 +153,12 @@ Only the manifest and new data files are stored in the clone location.
 2. Manifest includes base path pointing to source dataset
 3. Original fragments reference source via `base_id: 1`
 4. Subsequent writes reference clone location via `base_id: 0`
-5. Source dataset remains immutable and can be garbage collected independently
+5. By default, the source writes a pin under `_refs/clones/` and the clone stores the pin id in its config. A clone of a read-only source may instead rely on a tag the source owner created, and no pin is written.
+6. The clone commit is refused if the source has a cleanup marker for that version under `_refs/gc_markers/`
+
+The clone reads the source's files in place. Cleanup on the source must keep the version the clone reads, even when no version of the source still references those files.
+Cleanup does not open clone URIs. The pin written at clone time, or the tag it relies on instead, is the record that keeps those files.
+See [Clone Pin](branch_tag.md#clone-pin) for the pin format, cleanup markers, and lifecycle.
 
 ## Dataset Portability
 

--- a/docs/src/format/table/layout.md
+++ b/docs/src/format/table/layout.md
@@ -153,12 +153,12 @@ Only the manifest and new data files are stored in the clone location.
 2. Manifest includes base path pointing to source dataset
 3. Original fragments reference source via `base_id: 1`
 4. Subsequent writes reference clone location via `base_id: 0`
-5. By default, the source writes a pin under `_refs/clones/` and the clone stores the pin id in its config. A clone of a read-only source may instead rely on a tag the source owner created, and no pin is written.
+5. By default the source writes a pin under `_refs/clones/` and the clone stores the pin id in its config. A read-only source may rely on a tag instead, with no pin written.
 6. The clone commit is refused if the source has a cleanup marker for that version under `_refs/gc_markers/`
 
-The clone reads the source's files in place. Cleanup on the source must keep the version the clone reads, even when no version of the source still references those files.
-Cleanup does not open clone URIs. The pin written at clone time, or the tag it relies on instead, is the record that keeps those files.
-See [Clone Pin](branch_tag.md#clone-pin) for the pin format, cleanup markers, and lifecycle.
+The clone reads the source's files in place. Cleanup on the source must keep that version even when no current source version still references those files.
+Cleanup does not open clone URIs. The pin or tag is the retention record.
+See [Clone Pin](branch_tag.md#clone-pin) for format and lifecycle.
 
 ## Dataset Portability
 

--- a/docs/src/guide/tags_and_branches.md
+++ b/docs/src/guide/tags_and_branches.md
@@ -123,3 +123,49 @@ print(ds.branches.list_ordered(order="desc"))
     Branches hold references to data files. Lance ensures that cleanup does not delete files still referenced by any branch.
 
     Delete unused branches to allow their referenced files to be cleaned up by `cleanup_old_versions()`.
+
+## Shallow clones and cleanup on the source
+
+A shallow clone created with `shallow_clone()` does not copy data.
+Its manifest points back at the source dataset and reads the source's data files in place.
+
+By default, `shallow_clone()` creates a pin on the **source** under `_refs/clones/` for the version it clones, and stores the pin id on the clone.
+That keeps `cleanup_old_versions()` on the source from deleting files the clone still reads.
+Cleanup treats pinned versions like tagged versions. It does not open clone URIs.
+Pinned clones need write access to the source so they can create the pin.
+If you only have read access, pass `retention="require_tag"` after the source owner has tagged the version.
+With `require_tag`, the tag must remain for as long as the clone reads source files.
+Removing the tag removes the clone's cleanup protection.
+Before deleting a version, cleanup writes a marker under `_refs/gc_markers/`.
+That marker stays after the version is deleted so `shallow_clone()` cannot reopen it.
+Marker and pin identity use the branch incarnation id, not only the display name, so a recreated branch does not inherit the previous incarnation's markers or pins.
+Existing clones of a marked version keep working until their pins are unregistered.
+
+After deleting or detaching the clone, remove the pin on the source:
+
+```python
+clone = source.shallow_clone("s3://experiments/test-variant", 3)
+pin_id = clone.source_pin_id
+
+# After the clone is gone
+source.clone_pins.unregister(pin_id)
+```
+
+If cleanup marks the version before the clone commit begins, the unused pin is removed.
+If the commit path verifies that no manifest landed, the unused pin is removed.
+If the outcome is unknown, the pin is retained.
+A leaked pin wastes storage. Removing a pin for a live clone can lose data.
+
+Pins also block branch deletion.
+Deleting a branch is refused while shallow-clone pins target it. Unregister the listed pins, then rerun the delete.
+A refused delete leaves the branch closed to new shallow clones. `force_delete_branch` overrides the refusal and breaks the clones holding those pins.
+Tag-retained clones do not block branch deletion. Deleting the source branch breaks clones that rely on a tag, so prefer pinned clones when the source branch may be deleted.
+
+!!! warning
+
+    Shallow clones created before this behavior existed have no pin and are not protected.
+    Re-clone them, or create a tag on the source version they read so cleanup retains it.
+
+    Libraries that predate pins ignore `_refs/clones/` during cleanup and can still delete
+    files a new clone needs. Run cleanup with a library that understands pins, or keep a
+    tag on the source version while older clients may vacuum the source.

--- a/docs/src/guide/tags_and_branches.md
+++ b/docs/src/guide/tags_and_branches.md
@@ -129,19 +129,13 @@ print(ds.branches.list_ordered(order="desc"))
 A shallow clone created with `shallow_clone()` does not copy data.
 Its manifest points back at the source dataset and reads the source's data files in place.
 
-By default, `shallow_clone()` creates a pin on the **source** under `_refs/clones/` for the version it clones, and stores the pin id on the clone.
-That keeps `cleanup_old_versions()` on the source from deleting files the clone still reads.
-Cleanup treats pinned versions like tagged versions. It does not open clone URIs.
-Pinned clones need write access to the source so they can create the pin.
-If you only have read access, pass `retention="require_tag"` after the source owner has tagged the version.
-With `require_tag`, the tag must remain for as long as the clone reads source files.
-Removing the tag removes the clone's cleanup protection.
-Before deleting a version, cleanup writes a marker under `_refs/gc_markers/`.
-That marker stays after the version is deleted so `shallow_clone()` cannot reopen it.
-Marker and pin identity use the branch incarnation id, not only the display name, so a recreated branch does not inherit the previous incarnation's markers or pins.
-Existing clones of a marked version keep working until their pins are unregistered.
+By default, `shallow_clone()` writes a pin under `_refs/clones/` on the source for the cloned version and stores that pin id on the clone.
+`cleanup_old_versions()` on the source keeps pinned versions the same way it keeps tagged versions. It does not open clone URIs.
+Creating a pin needs write access to the source. With read-only access, pass `retention="require_tag"` after the source owner tags the version. Keep that tag for as long as the clone reads source files.
+Cleanup writes a marker under `_refs/gc_markers/` before deleting a version. The marker stays after deletion so `shallow_clone()` cannot reopen that version.
+Markers and pin `branchId` values use the branch incarnation id, so a recreated branch with the same name does not inherit them. Existing clones keep working until their pins are unregistered.
 
-After deleting or detaching the clone, remove the pin on the source:
+Unregister the pin after deleting or detaching the clone:
 
 ```python
 clone = source.shallow_clone("s3://experiments/test-variant", 3)
@@ -151,15 +145,10 @@ pin_id = clone.source_pin_id
 source.clone_pins.unregister(pin_id)
 ```
 
-If cleanup marks the version before the clone commit begins, the unused pin is removed.
-If the commit path verifies that no manifest landed, the unused pin is removed.
-If the outcome is unknown, the pin is retained.
-A leaked pin wastes storage. Removing a pin for a live clone can lose data.
+An unused pin is removed when cleanup marks the version before clone commit starts, or when the commit path verifies no manifest landed. If the commit outcome is unknown, the pin stays. A leaked pin wastes storage. Removing a pin for a live clone can lose data.
 
-Pins also block branch deletion.
-Deleting a branch is refused while shallow-clone pins target it. Unregister the listed pins, then rerun the delete.
-A refused delete leaves the branch closed to new shallow clones. `force_delete_branch` overrides the refusal and breaks the clones holding those pins.
-Tag-retained clones do not block branch deletion. Deleting the source branch breaks clones that rely on a tag, so prefer pinned clones when the source branch may be deleted.
+Pins also block branch deletion. `delete_branch` is refused while pins target that incarnation. Unregister the listed pins, then delete again. A refused delete leaves the incarnation closed to new shallow clones. `force_delete_branch` overrides the refusal and breaks those clones.
+Tag-retained clones do not block branch deletion. Prefer pinned clones when the source branch may be deleted.
 
 !!! warning
 

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -185,6 +185,17 @@ message Transaction {
     string ref_path = 4;
     // if the target dataset is a branch, this is the branch name of the target dataset
     optional string branch_name = 5;
+    // Pin id written on the source under `_refs/clones/{id}.json` for a cross-dataset
+    // shallow clone. Absent for in-dataset branch creation and for deep clones.
+    // Present: the clone stores this id in its config so destroy/detach can remove the pin.
+    optional string source_pin_id = 6;
+    // Leaf UUID of the source branch incarnation resolved for this clone operation.
+    // Set for shallow clones, deep clones, and in-dataset branch creation, all of which
+    // read a source branch during commit. The commit path re-reads the source branch
+    // metadata after its source reads and refuses the commit if the leaf UUID no longer
+    // matches, which means the branch was deleted or recreated under the same name.
+    // Absent for the main branch and for older transactions.
+    optional string source_branch_id = 7;
   }
   
   // Exact set of key hashes for conflict detection.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1021,6 +1021,40 @@ class LanceDataset(pa.dataset.Dataset):
         """
         return Branches(self._ds)
 
+    @property
+    def clone_pins(self) -> "ClonePins":
+        """Source-side pins for shallow clones of this dataset.
+
+        By default, :py:meth:`shallow_clone` creates a pin here and stores the
+        pin id on the clone. Clones using ``retention="require_tag"`` do not
+        create a pin.
+
+        .. warning::
+
+            A pin outlives the clone. After deleting or detaching the clone, remove
+            the pin with :py:meth:`~ClonePins.unregister` using the clone's
+            :py:attr:`source_pin_id`.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            source = lance.dataset("dataset.lance")
+            clone = source.shallow_clone("s3://experiments/variant", 3)
+            pin_id = clone.source_pin_id
+
+            # Once the clone has been deleted
+            source.clone_pins.unregister(pin_id)
+
+        """
+        return ClonePins(self._ds)
+
+    @property
+    def source_pin_id(self) -> Optional[str]:
+        """Pin id this shallow clone holds on its source dataset, if any."""
+        return self._ds.source_pin_id()
+
     def create_branch(
         self,
         branch: str,
@@ -4939,6 +4973,7 @@ class LanceDataset(pa.dataset.Dataset):
         target_path: str | Path,
         reference: int | str | Tuple[Optional[str], Optional[int]],
         storage_options: Optional[Dict[str, str]] = None,
+        retention: str = "pin_source",
         **kwargs,
     ) -> "LanceDataset":
         """
@@ -4960,11 +4995,30 @@ class LanceDataset(pa.dataset.Dataset):
             Object store configuration for the new dataset (e.g., credentials,
             endpoints). If not specified, the storage options of the source dataset
             will be used.
+        retention : {"pin_source", "require_tag"}, default "pin_source"
+            ``"pin_source"`` writes a retention pin on the source so
+            :py:meth:`cleanup_old_versions` keeps the cloned version. Requires write
+            access to the source. ``"require_tag"`` skips the pin and requires that a
+            tag on the source already points at the resolved version. Use
+            ``"require_tag"`` when the source is read-only and the source owner has
+            tagged the version before cloning. With ``"require_tag"``, the tag must
+            remain for the lifetime of the clone. Removing it allows source cleanup
+            to delete files the clone reads.
 
         Returns
         -------
         LanceDataset
             A new LanceDataset representing the shallow-cloned dataset.
+
+        Notes
+        -----
+        The clone reads the source's data files in place. With
+        ``retention="pin_source"``, a pin is created on the source and the pin id is
+        stored on the clone. If the commit fails and the commit path verifies that no
+        manifest landed, the unused pin is removed. If the outcome is unknown, the pin
+        is retained. After deleting or detaching a pinned clone, call
+        ``source.clone_pins.unregister(clone.source_pin_id)``.
+        See :py:attr:`clone_pins`.
         """
         if isinstance(target_path, Path):
             target_uri = os.fspath(target_path)
@@ -4973,7 +5027,7 @@ class LanceDataset(pa.dataset.Dataset):
 
         if storage_options is None:
             storage_options = self._storage_options
-        self._ds.shallow_clone(target_uri, reference, storage_options)
+        self._ds.shallow_clone(target_uri, reference, storage_options, retention)
 
         # Open and return a fresh dataset at the target URI to avoid manual overrides
         return LanceDataset(target_uri, storage_options=storage_options, **kwargs)
@@ -5690,6 +5744,15 @@ class Branch(TypedDict):
     create_at: int
     manifest_size: int
     metadata: Dict[str, str]
+
+
+class ClonePin(TypedDict):
+    id: str
+    branch: Optional[str]
+    branch_id: Optional[str]
+    version: int
+    created_at: datetime
+    clone_uri: Optional[str]
 
 
 class Version(TypedDict):
@@ -7408,6 +7471,44 @@ class Branches:
         Replace metadata for a branch.
         """
         self._ds.replace_branch_metadata(branch, metadata)
+
+
+class ClonePins:
+    """Source-side pins for shallow clones of a dataset."""
+
+    def __init__(self, dataset: _Dataset):
+        self._ds = dataset
+
+    def list(self) -> List[ClonePin]:
+        """
+        List every shallow-clone pin on this dataset.
+
+        Returns
+        -------
+        List[ClonePin]
+            One entry per pin with its id and the branch and version it holds.
+            Cleanup keeps those versions.
+        """
+        return self._ds.clone_pins()
+
+    def unregister(self, pin_id: str) -> None:
+        """
+        Drop the pin with ``pin_id``.
+
+        Call this after the clone has been deleted or detached. Until then the version
+        it pins stays retained. Versions that other pins still hold stay retained.
+
+        Parameters
+        ----------
+        pin_id: str
+            The pin id from :py:attr:`LanceDataset.source_pin_id` on the clone.
+
+        Raises
+        ------
+        ValueError
+            If no pin with that id exists.
+        """
+        self._ds.unregister_clone_pin(pin_id)
 
 
 @dataclass

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4998,12 +4998,10 @@ class LanceDataset(pa.dataset.Dataset):
         retention : {"pin_source", "require_tag"}, default "pin_source"
             ``"pin_source"`` writes a retention pin on the source so
             :py:meth:`cleanup_old_versions` keeps the cloned version. Requires write
-            access to the source. ``"require_tag"`` skips the pin and requires that a
-            tag on the source already points at the resolved version. Use
-            ``"require_tag"`` when the source is read-only and the source owner has
-            tagged the version before cloning. With ``"require_tag"``, the tag must
-            remain for the lifetime of the clone. Removing it allows source cleanup
-            to delete files the clone reads.
+            access to the source. ``"require_tag"`` skips the pin and requires a tag on
+            the source that already points at the resolved version. Use that mode for
+            read-only sources after the owner tags the version. Keep the tag while the
+            clone reads source files.
 
         Returns
         -------
@@ -5014,10 +5012,9 @@ class LanceDataset(pa.dataset.Dataset):
         -----
         The clone reads the source's data files in place. With
         ``retention="pin_source"``, a pin is created on the source and the pin id is
-        stored on the clone. If the commit fails and the commit path verifies that no
-        manifest landed, the unused pin is removed. If the outcome is unknown, the pin
-        is retained. After deleting or detaching a pinned clone, call
-        ``source.clone_pins.unregister(clone.source_pin_id)``.
+        stored on the clone. An unused pin is removed when the commit path verifies no
+        manifest landed. Unknown outcomes keep the pin. After deleting or detaching a
+        pinned clone, call ``source.clone_pins.unregister(clone.source_pin_id)``.
         See :py:attr:`clone_pins`.
         """
         if isinstance(target_path, Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -6230,6 +6230,69 @@ def test_shallow_clone(tmp_path: Path):
     assert lance.dataset(clone_branch_v3).to_table() == table_v3
 
 
+def test_cleanup_on_source_keeps_shallow_clone_files(tmp_path: Path):
+    src_dir = tmp_path / "clone_pin_src"
+    table_v1 = pa.table({"a": [1, 2, 3]})
+    lance.write_dataset(table_v1, src_dir, mode="create")
+
+    ds = lance.dataset(src_dir)
+    clone_dir = tmp_path / "clone_pin_clone"
+    clone = ds.shallow_clone(clone_dir, 1)
+    assert clone.to_table() == table_v1
+
+    pin_id = clone.source_pin_id
+    assert pin_id is not None
+    pins = ds.clone_pins.list()
+    assert len(pins) == 1
+    assert pins[0]["id"] == pin_id
+    assert pins[0]["version"] == 1
+    assert pins[0]["branch"] is None
+    assert pins[0]["branch_id"] is None
+
+    ds = lance.write_dataset(pa.table({"a": [4, 5, 6]}), src_dir, mode="overwrite")
+    ds.cleanup_old_versions(older_than=timedelta(0), delete_unverified=True)
+
+    assert lance.dataset(clone_dir).to_table() == table_v1
+
+    ds.clone_pins.unregister(pin_id)
+    assert ds.clone_pins.list() == []
+    with pytest.raises(ValueError, match="no shallow clone pin"):
+        ds.clone_pins.unregister(pin_id)
+
+
+def test_shallow_clone_require_tag_skips_source_pin(tmp_path: Path):
+    src_dir = tmp_path / "require_tag_src"
+    table = pa.table({"a": [1, 2, 3]})
+    ds = lance.write_dataset(table, src_dir, mode="create")
+    ds.tags.create("v1", 1)
+
+    clone_dir = tmp_path / "require_tag_clone"
+    clone = ds.shallow_clone(clone_dir, 1, retention="require_tag")
+
+    assert clone.to_table() == table
+    assert clone.source_pin_id is None
+    assert ds.clone_pins.list() == []
+
+
+def test_shallow_clone_require_tag_rejects_untagged_version(tmp_path: Path):
+    src_dir = tmp_path / "untagged_src"
+    table = pa.table({"a": [1, 2, 3]})
+    ds = lance.write_dataset(table, src_dir, mode="create")
+
+    with pytest.raises(ValueError, match="needs a tag"):
+        ds.shallow_clone(tmp_path / "untagged_clone", 1, retention="require_tag")
+    assert ds.clone_pins.list() == []
+
+
+def test_shallow_clone_rejects_unknown_retention(tmp_path: Path):
+    src_dir = tmp_path / "bad_retention_src"
+    ds = lance.write_dataset(pa.table({"a": [1]}), src_dir, mode="create")
+
+    with pytest.raises(ValueError, match="retention must be"):
+        ds.shallow_clone(tmp_path / "bad_retention_clone", 1, retention="whatever")
+    assert ds.clone_pins.list() == []
+
+
 def test_branches(tmp_path: Path):
     # Step 1: create branch1 from main → append to branch1 → create branch2 from tag
     base_dir = tmp_path / "test_branches"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2079,13 +2079,14 @@ impl Dataset {
     }
 
     /// Restore the current version
-    #[pyo3(signature = (target_path, reference, storage_options=None))]
+    #[pyo3(signature = (target_path, reference, storage_options=None, retention="pin_source"))]
     fn shallow_clone(
         &mut self,
         py: Python,
         target_path: String,
         reference: Option<Bound<PyAny>>,
         storage_options: Option<HashMap<String, String>>,
+        retention: &str,
     ) -> PyResult<Self> {
         // Perform a shallow clone of the dataset into the target path.
         // `version` can be a version number or a tag name.
@@ -2097,6 +2098,17 @@ impl Dataset {
             ..Default::default()
         });
 
+        let retention = match retention {
+            "pin_source" => lance::dataset::ShallowCloneRetention::PinSource,
+            "require_tag" => lance::dataset::ShallowCloneRetention::RequireTag,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "retention must be 'pin_source' or 'require_tag', got {}",
+                    other
+                )));
+            }
+        };
+
         // Use a mutable clone of the inner dataset for operations that require &mut self
         let mut new_self = self.ds.as_ref().clone();
         let reference = self.transform_ref(reference)?;
@@ -2104,9 +2116,17 @@ impl Dataset {
         let ds = rt()
             .block_on(
                 Some(py),
-                new_self.shallow_clone(&target_path, reference, store_params),
+                new_self.shallow_clone_with_retention(
+                    &target_path,
+                    reference,
+                    store_params,
+                    retention,
+                ),
             )?
-            .map_err(|err: Error| PyIOError::new_err(err.to_string()))?;
+            .map_err(|err: Error| match err {
+                Error::InvalidInput { .. } => PyValueError::new_err(err.to_string()),
+                _ => PyIOError::new_err(err.to_string()),
+            })?;
 
         let uri = ds.uri().to_string();
         Ok(Self {
@@ -2236,6 +2256,41 @@ impl Dataset {
             pytags.set_item(k, dict.into_py_any(py)?)?;
         }
         pytags.into_py_any(py)
+    }
+
+    fn clone_pins(self_: PyRef<'_, Self>) -> PyResult<Py<PyAny>> {
+        let py = self_.py();
+        let clone_pins = rt()
+            .block_on(None, self_.ds.clone_pins().list())?
+            .infer_error()?;
+
+        let py_clone_pins = PyList::empty(py);
+        for pin in clone_pins {
+            let dict = PyDict::new(py);
+            dict.set_item("id", pin.id)?;
+            dict.set_item("branch", pin.branch)?;
+            dict.set_item("branch_id", pin.branch_id)?;
+            dict.set_item("version", pin.version)?;
+            dict.set_item("created_at", pin.created_at)?;
+            dict.set_item("clone_uri", pin.clone_uri)?;
+            py_clone_pins.append(dict)?;
+        }
+        py_clone_pins.into_py_any(py)
+    }
+
+    fn source_pin_id(&self) -> Option<String> {
+        self.ds.source_pin_id().map(|id| id.to_string())
+    }
+
+    fn unregister_clone_pin(&mut self, pin_id: String) -> PyResult<()> {
+        rt().block_on(None, self.ds.as_ref().clone_pins().unregister(&pin_id))?
+            .map_err(|err| match err {
+                Error::RefNotFound { .. } | Error::InvalidInput { .. } => {
+                    PyValueError::new_err(err.to_string())
+                }
+                _ => PyIOError::new_err(err.to_string()),
+            })?;
+        Ok(())
     }
 
     fn get_version(self_: PyRef<'_, Self>, tag: String) -> PyResult<u64> {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3204,27 +3204,21 @@ impl Dataset {
 
     /// Shallow clone the target version into a new dataset at `target_path`.
     ///
-    /// The clone reads the source's data files in place. It does not copy them.
+    /// The clone reads the source's data files in place without copying them.
     ///
-    /// With [`ShallowCloneRetention::PinSource`] (the default via [`Self::shallow_clone`]),
-    /// creates a pin on the source under `_refs/clones/` and stores the pin id on the
-    /// clone so [`Self::cleanup_old_versions`] on the source keeps the cloned version's
-    /// files. Requires write access to the source.
+    /// [`ShallowCloneRetention::PinSource`] writes a pin under `_refs/clones/` and stores
+    /// the pin id on the clone so [`Self::cleanup_old_versions`] keeps those files.
+    /// Requires write access to the source. This is the default via [`Self::shallow_clone`].
     ///
-    /// With [`ShallowCloneRetention::RequireTag`], no source pin is written. A tag on the
-    /// source must already point at the resolved version. Use this when the source is
-    /// read-only and the source owner has tagged the version before cloning. The tag must
-    /// remain while the clone reads source files. Removing it allows cleanup to reclaim
-    /// the cloned version.
+    /// [`ShallowCloneRetention::RequireTag`] skips the pin. A tag on the source must already
+    /// point at the resolved version. Keep that tag while the clone reads source files.
     ///
-    /// If cleanup has marked the version, the clone is refused under either policy.
-    /// When pinning, if cleanup marks the version before the clone commit begins, the
-    /// unused pin is removed. If the clone commit fails and the commit path verified
-    /// that no manifest landed, the unused pin is removed. When the outcome is unknown,
-    /// the pin is kept. A leaked pin wastes storage. Removing a pin for a live clone
-    /// can lose data.
+    /// Cleanup markers refuse the clone under either policy. An unused pin is removed when
+    /// cleanup marks the version before commit starts, or when the commit path verifies no
+    /// manifest landed. Unknown outcomes keep the pin. A leaked pin wastes storage. Removing
+    /// a pin for a live clone can lose data.
     ///
-    /// After deleting or detaching a pinned clone, remove the pin with
+    /// After deleting or detaching a pinned clone, call
     /// `source.clone_pins().unregister(clone.source_pin_id())`.
     pub async fn shallow_clone_with_retention(
         &mut self,
@@ -4380,8 +4374,8 @@ async fn source_version_is_tagged(
 
 /// Create a source pin for a shallow clone after GC-marker checks.
 ///
-/// Checks for a cleanup marker before and after creating the pin. If a marker is present
-/// before commit begins, any unused pin from this attempt is removed. `identifier` must
+/// Checks for a cleanup marker before and after creating the pin. A marker present before
+/// commit begins causes any unused pin from this attempt to be removed. `identifier` must
 /// be `branch`'s current [`refs::BranchIdentifier`], resolved once by the caller.
 pub(crate) async fn create_shallow_clone_pin(
     clone_pins: &ClonePins<'_>,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -562,7 +562,26 @@ impl Dataset {
         version: impl Into<refs::Ref>,
         store_params: Option<ObjectStoreParams>,
     ) -> Result<Self> {
-        let (source_branch, version_number) = self.resolve_reference(version.into()).await?;
+        // Hold the path lease across clone commit and BranchContents write. Named branches
+        // reuse tree/{branch}/, so create must serialize with delete and cleanup.
+        self.branches()
+            .acquire_branch_path_lease(branch, None)
+            .await?;
+        let result = self
+            .create_branch_with_lease_held(branch, version.into(), store_params)
+            .await;
+        self.branches()
+            .finish_branch_path_lease(branch, result)
+            .await
+    }
+
+    async fn create_branch_with_lease_held(
+        &mut self,
+        branch: &str,
+        version: refs::Ref,
+        store_params: Option<ObjectStoreParams>,
+    ) -> Result<Self> {
+        let (source_branch, version_number) = self.resolve_reference(version).await?;
         let source_branch_id = self
             .refs
             .branches()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -66,7 +66,7 @@ use std::num::NonZero;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 pub(crate) mod blob;
 pub(crate) mod branch_location;
@@ -107,7 +107,10 @@ use self::transaction::{Operation, Transaction, TransactionBuilder, UpdateMapEnt
 use self::write::{cleanup_data_fragments, write_fragments_internal};
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::cleanup::{CleanupOperation, CleanupPolicy, CleanupPolicyBuilder};
-use crate::dataset::refs::{BranchContents, BranchIdentifier, Branches, Tags};
+use crate::dataset::refs::{
+    BranchContents, BranchIdentifier, Branches, ClonePins, ResolvedBranch,
+    SOURCE_PIN_ID_CONFIG_KEY, Tags,
+};
 use crate::dataset::sql::SqlQueryBuilder;
 use crate::datatypes::Schema;
 use crate::index::retain_supported_indices;
@@ -248,6 +251,20 @@ pub struct VersionTransaction {
 
     /// The transaction that produced this version, if one was recorded.
     pub transaction: Option<Transaction>,
+}
+
+/// How [`Dataset::shallow_clone`] retains the source version against cleanup.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ShallowCloneRetention {
+    /// Write a source pin so cleanup retains the cloned version.
+    ///
+    /// Requires write access to the source. This is the default.
+    #[default]
+    PinSource,
+    /// Do not write a source pin. Requires a tag on the source that already points at
+    /// the resolved version. Use when the source is read-only and the source owner has
+    /// tagged the version before cloning.
+    RequireTag,
 }
 
 /// Customize read behavior of a dataset.
@@ -486,6 +503,24 @@ impl Dataset {
         self.refs.branches()
     }
 
+    /// Source-side pins for shallow clones of this dataset.
+    ///
+    /// Each pin holds a source version so [`Self::cleanup_old_versions`] keeps the files
+    /// that clone still needs. [`Dataset::shallow_clone`] creates a pin and stores its id
+    /// on the clone. After the clone is deleted or detached, remove the pin with
+    /// [`ClonePins::unregister`].
+    pub fn clone_pins(&self) -> ClonePins<'_> {
+        self.refs.clone_pins()
+    }
+
+    /// Pin id this shallow clone holds on its source dataset, if any.
+    pub fn source_pin_id(&self) -> Option<&str> {
+        self.manifest
+            .config
+            .get(SOURCE_PIN_ID_CONFIG_KEY)
+            .map(|value| value.as_str())
+    }
+
     /// Check out the latest version of the dataset
     pub async fn checkout_latest(&mut self) -> Result<()> {
         let (manifest, manifest_location) = self.latest_manifest().await?;
@@ -528,6 +563,13 @@ impl Dataset {
         store_params: Option<ObjectStoreParams>,
     ) -> Result<Self> {
         let (source_branch, version_number) = self.resolve_reference(version.into()).await?;
+        let source_branch_id = self
+            .refs
+            .branches()
+            .get_identifier(source_branch.as_deref())
+            .await?
+            .branch_id()
+            .map(str::to_owned);
         let branch_location = self.branch_location().find_branch(Some(branch))?;
         let source_location = self
             .branch_location()
@@ -538,6 +580,8 @@ impl Dataset {
             ref_version: version_number,
             ref_path: source_location.uri,
             branch_name: Some(branch.to_string()),
+            source_pin_id: None,
+            source_branch_id,
         };
         let transaction = Transaction::new(version_number, clone_op, None);
 
@@ -562,7 +606,9 @@ impl Dataset {
         self.branches().delete(branch, false).await
     }
 
-    /// Delete the branch even if the BranchContents is not found.
+    /// Delete the branch even if the BranchContents is not found, and even if
+    /// shallow-clone pins still target it. Clones holding those pins lose access
+    /// to branch-local files.
     /// This could be useful when we have zombie branches and want to clean them up immediately.
     pub async fn force_delete_branch(&mut self, branch: &str) -> Result<()> {
         self.branches().delete(branch, true).await
@@ -1416,6 +1462,10 @@ impl Dataset {
     ///
     /// Once a version is removed it can no longer be checked out or restored.  Any data unique
     /// to that version will be lost.
+    ///
+    /// Versions that are tagged, that a descendant branch still reads, or that a shallow-clone
+    /// pin under `_refs/clones/` holds are retained regardless of age, along with the files
+    /// they reference. See [`Self::clone_pins`]. Cleanup does not open clone URIs.
     ///
     /// # Arguments
     ///
@@ -3133,35 +3183,237 @@ impl Dataset {
         Ok(())
     }
 
-    /// Shallow clone the target version into a new dataset at target_path.
-    /// 'target_path': the uri string to clone the dataset into.
-    /// 'version': the version cloned from, could be a version number or tag.
-    /// 'store_params': the object store params to use for the new dataset.
+    /// Shallow clone the target version into a new dataset at `target_path`.
+    ///
+    /// Equivalent to [`Self::shallow_clone_with_retention`] with
+    /// [`ShallowCloneRetention::PinSource`].
     pub async fn shallow_clone(
         &mut self,
         target_path: &str,
         version: impl Into<refs::Ref>,
         store_params: Option<ObjectStoreParams>,
     ) -> Result<Self> {
-        let (ref_name, version_number) = self.resolve_reference(version.into()).await?;
-        let source_location = self.branch_location().find_branch(ref_name.as_deref())?;
+        self.shallow_clone_with_retention(
+            target_path,
+            version,
+            store_params,
+            ShallowCloneRetention::PinSource,
+        )
+        .await
+    }
+
+    /// Shallow clone the target version into a new dataset at `target_path`.
+    ///
+    /// The clone reads the source's data files in place. It does not copy them.
+    ///
+    /// With [`ShallowCloneRetention::PinSource`] (the default via [`Self::shallow_clone`]),
+    /// creates a pin on the source under `_refs/clones/` and stores the pin id on the
+    /// clone so [`Self::cleanup_old_versions`] on the source keeps the cloned version's
+    /// files. Requires write access to the source.
+    ///
+    /// With [`ShallowCloneRetention::RequireTag`], no source pin is written. A tag on the
+    /// source must already point at the resolved version. Use this when the source is
+    /// read-only and the source owner has tagged the version before cloning. The tag must
+    /// remain while the clone reads source files. Removing it allows cleanup to reclaim
+    /// the cloned version.
+    ///
+    /// If cleanup has marked the version, the clone is refused under either policy.
+    /// When pinning, if cleanup marks the version before the clone commit begins, the
+    /// unused pin is removed. If the clone commit fails and the commit path verified
+    /// that no manifest landed, the unused pin is removed. When the outcome is unknown,
+    /// the pin is kept. A leaked pin wastes storage. Removing a pin for a live clone
+    /// can lose data.
+    ///
+    /// After deleting or detaching a pinned clone, remove the pin with
+    /// `source.clone_pins().unregister(clone.source_pin_id())`.
+    pub async fn shallow_clone_with_retention(
+        &mut self,
+        target_path: &str,
+        version: impl Into<refs::Ref>,
+        store_params: Option<ObjectStoreParams>,
+        retention: ShallowCloneRetention,
+    ) -> Result<Self> {
+        let source = self.resolve_shallow_clone_source(version.into()).await?;
+        let store_params =
+            store_params.unwrap_or(self.store_params.as_deref().cloned().unwrap_or_default());
+        // Resolve before pin creation: an error after the pin is written would leak it.
+        let storage_format = self.manifest.data_storage_format.lance_file_version()?;
+
+        // Fail before writing a source pin when the destination is already a dataset.
+        ensure_shallow_clone_target_available(target_path, Some(&store_params)).await?;
+
+        let branch = source.ref_name.as_deref();
+        let source_pin_id = match retention {
+            ShallowCloneRetention::PinSource => Some(
+                create_shallow_clone_pin(
+                    &self.clone_pins(),
+                    branch,
+                    &source.identifier,
+                    source.version,
+                    target_path,
+                )
+                .await?,
+            ),
+            ShallowCloneRetention::RequireTag => {
+                if !source_version_is_tagged(self, branch, source.version).await? {
+                    return Err(Error::invalid_input(format!(
+                        "shallow clone with RequireTag needs a tag on version {} of branch {}; \
+                         create the tag on the source before cloning",
+                        source.version,
+                        branch.unwrap_or(refs::MAIN_BRANCH),
+                    )));
+                }
+                // Still refuse versions cleanup has already closed and branches whose
+                // deletion has been requested. Files may be gone or about to be.
+                ensure_clone_source_not_fenced(
+                    &self.clone_pins(),
+                    branch,
+                    source.identifier.marker_namespace(),
+                    source.version,
+                )
+                .await?;
+                None
+            }
+        };
+
+        // Pin creation can race with branch recreation. Re-check before commit.
+        if let Err(err) =
+            ensure_branch_incarnation_unchanged(&self.refs.branches(), branch, &source.identifier)
+                .await
+        {
+            if let Some(pin_id) = source_pin_id.as_deref()
+                && let Err(unregister_error) = self.clone_pins().unregister(pin_id).await
+            {
+                warn!(
+                    error = %unregister_error,
+                    pin_id,
+                    "failed to remove unused shallow-clone pin"
+                );
+            }
+            return Err(err);
+        }
+
         let clone_op = Operation::Clone {
             is_shallow: true,
-            ref_name,
-            ref_version: version_number,
-            ref_path: source_location.uri,
+            ref_name: source.ref_name.clone(),
+            ref_version: source.version,
+            ref_path: source.location.uri,
             branch_name: None,
+            source_pin_id: source_pin_id.clone(),
+            source_branch_id: source.identifier.branch_id().map(str::to_owned),
         };
-        let transaction = Transaction::new(version_number, clone_op, None);
+        let transaction = Transaction::new(source.version, clone_op, None);
 
         let builder = CommitBuilder::new(WriteDestination::Uri(target_path))
-            .with_store_params(
-                store_params.unwrap_or(self.store_params.as_deref().cloned().unwrap_or_default()),
-            )
+            .with_store_params(store_params.clone())
             .with_object_store(Arc::new(self.object_store.as_ref().clone()))
             .with_commit_handler(self.commit_handler.clone())
-            .with_storage_format(self.manifest.data_storage_format.lance_file_version()?);
-        builder.execute(transaction).await
+            .with_storage_format(storage_format);
+
+        match builder.execute(transaction).await {
+            Ok(dataset) => Ok(dataset),
+            Err(commit_error) => {
+                if let Some(pin_id) = source_pin_id.as_deref() {
+                    self.cleanup_pin_after_failed_clone_commit(pin_id, &commit_error)
+                        .await;
+                }
+                Err(commit_error)
+            }
+        }
+    }
+
+    /// Resolve the version, location, and branch incarnation for a shallow clone together.
+    ///
+    /// Captures the branch incarnation before reading the version on that branch so the
+    /// returned values cannot come from two different incarnations of the same name.
+    async fn resolve_shallow_clone_source(
+        &self,
+        reference: refs::Ref,
+    ) -> Result<ResolvedCloneSource> {
+        match reference {
+            refs::Ref::Tag(tag_name) => {
+                let tag = self.tags().get(tag_name.as_str()).await?;
+                let source = self
+                    .resolve_shallow_clone_source_on_branch(tag.branch, Some(tag.version))
+                    .await?;
+                let tag_again = self.tags().get(tag_name.as_str()).await?;
+                if tag_again.branch != source.ref_name || tag_again.version != source.version {
+                    return Err(Error::RefConflict {
+                        message: format!("tag {} changed during shallow clone", tag_name),
+                    });
+                }
+                ensure_branch_incarnation_unchanged(
+                    &self.refs.branches(),
+                    source.ref_name.as_deref(),
+                    &source.identifier,
+                )
+                .await?;
+                Ok(source)
+            }
+            refs::Ref::VersionNumber(version) => {
+                self.resolve_shallow_clone_source_on_branch(
+                    self.manifest.branch.clone(),
+                    Some(version),
+                )
+                .await
+            }
+            refs::Ref::Version(branch, version) => {
+                self.resolve_shallow_clone_source_on_branch(branch, version)
+                    .await
+            }
+        }
+    }
+
+    async fn resolve_shallow_clone_source_on_branch(
+        &self,
+        ref_name: Option<String>,
+        version: Option<u64>,
+    ) -> Result<ResolvedCloneSource> {
+        let branch = ref_name.as_deref();
+        // Resolve the incarnation first, then the version on that location.
+        let ResolvedBranch {
+            location,
+            identifier,
+        } = self.refs.branches().resolve_branch(branch).await?;
+        let version = if let Some(version) = version {
+            // Confirm the version exists on this incarnation's location before returning.
+            self.commit_handler
+                .resolve_version_location(&location.path, version, &self.object_store.inner)
+                .await?;
+            version
+        } else {
+            self.commit_handler
+                .resolve_latest_location(&location.path, &self.object_store)
+                .await?
+                .version
+        };
+        ensure_branch_incarnation_unchanged(&self.refs.branches(), branch, &identifier).await?;
+        Ok(ResolvedCloneSource {
+            ref_name,
+            version,
+            location,
+            identifier,
+        })
+    }
+
+    /// Remove an unused source pin only when the commit is known not to have landed.
+    ///
+    /// Unknown commit outcomes, timeouts, and commit handlers that may report errors
+    /// after success retain the pin.
+    async fn cleanup_pin_after_failed_clone_commit(&self, pin_id: &str, commit_error: &Error) {
+        let outcome_is_ambiguous = commit_error.is_commit_status_unknown()
+            || matches!(commit_error, Error::Timeout { .. })
+            || self.commit_handler.propagate_commit_error_after_success();
+        if outcome_is_ambiguous {
+            return;
+        }
+        if let Err(error) = self.clone_pins().unregister(pin_id).await {
+            warn!(
+                error = %error,
+                pin_id,
+                "failed to remove unused shallow-clone pin"
+            );
+        }
     }
 
     /// Deep clone the target version into a new dataset at target_path.
@@ -3266,12 +3518,21 @@ impl Dataset {
         // Record a Clone operation and commit via CommitBuilder
         let ref_name = src_ds.manifest.branch.clone();
         let ref_version = src_ds.manifest_location.version;
+        let source_branch_id = src_ds
+            .refs
+            .branches()
+            .get_identifier(ref_name.as_deref())
+            .await?
+            .branch_id()
+            .map(str::to_owned);
         let clone_op = Operation::Clone {
             is_shallow: false,
             ref_name,
             ref_version,
             ref_path: src_ds.uri().to_string(),
             branch_name: None,
+            source_pin_id: None,
+            source_branch_id,
         };
         let txn = Transaction::new(ref_version, clone_op, None);
         let builder = CommitBuilder::new(WriteDestination::Uri(target_path))
@@ -4022,6 +4283,170 @@ pub(crate) async fn write_manifest_file(
             transaction.take().map(|tx| tx.into()),
         )
         .await
+}
+
+/// Version, location, and branch incarnation for one shallow-clone source.
+struct ResolvedCloneSource {
+    ref_name: Option<String>,
+    version: u64,
+    location: BranchLocation,
+    identifier: BranchIdentifier,
+}
+
+fn shallow_clone_marked_for_deletion_error(branch: Option<&str>, version: u64) -> Error {
+    Error::invalid_input(format!(
+        "cannot shallow clone version {} of branch {}: source cleanup has marked it for deletion",
+        version,
+        branch.unwrap_or(refs::MAIN_BRANCH),
+    ))
+}
+
+fn shallow_clone_branch_deleted_error(branch: Option<&str>) -> Error {
+    Error::invalid_input(format!(
+        "cannot shallow clone branch {}: deletion of this branch has been requested",
+        branch.unwrap_or(refs::MAIN_BRANCH),
+    ))
+}
+
+/// Refuse a clone of a version cleanup has fenced, or of a branch whose deletion
+/// has been requested. Both fences are permanent for the incarnation.
+async fn ensure_clone_source_not_fenced(
+    clone_pins: &ClonePins<'_>,
+    branch: Option<&str>,
+    namespace: &str,
+    version: u64,
+) -> Result<()> {
+    if clone_pins
+        .has_gc_marker_in_namespace(namespace, refs::GcMarker::Version(version))
+        .await?
+    {
+        return Err(shallow_clone_marked_for_deletion_error(branch, version));
+    }
+    if branch.is_some()
+        && clone_pins
+            .has_gc_marker_in_namespace(namespace, refs::GcMarker::BranchDeleted)
+            .await?
+    {
+        return Err(shallow_clone_branch_deleted_error(branch));
+    }
+    Ok(())
+}
+
+async fn ensure_shallow_clone_target_available(
+    target_path: &str,
+    store_params: Option<&ObjectStoreParams>,
+) -> Result<()> {
+    let builder = DatasetBuilder::from_uri(target_path).with_read_params(ReadParams {
+        store_options: store_params.cloned(),
+        ..Default::default()
+    });
+    match builder.load().await {
+        Ok(_) => Err(Error::invalid_input(format!(
+            "cannot shallow clone into {}: a dataset already exists at that URI",
+            target_path
+        ))),
+        Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+async fn ensure_branch_incarnation_unchanged(
+    branches: &Branches<'_>,
+    branch: Option<&str>,
+    expected: &BranchIdentifier,
+) -> Result<()> {
+    match branches.matches_identifier(branch, expected).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(Error::RefConflict {
+            message: format!(
+                "branch {} was deleted or recreated during shallow clone",
+                branch.unwrap_or(refs::MAIN_BRANCH),
+            ),
+        }),
+        Err(err) => Err(err),
+    }
+}
+
+async fn source_version_is_tagged(
+    dataset: &Dataset,
+    branch: Option<&str>,
+    version: u64,
+) -> Result<bool> {
+    let tags = dataset.tags().list().await?;
+    Ok(tags
+        .values()
+        .any(|tag| tag.branch.as_deref() == branch && tag.version == version))
+}
+
+/// Create a source pin for a shallow clone after GC-marker checks.
+///
+/// Checks for a cleanup marker before and after creating the pin. If a marker is present
+/// before commit begins, any unused pin from this attempt is removed. `identifier` must
+/// be `branch`'s current [`refs::BranchIdentifier`], resolved once by the caller.
+pub(crate) async fn create_shallow_clone_pin(
+    clone_pins: &ClonePins<'_>,
+    branch: Option<&str>,
+    identifier: &refs::BranchIdentifier,
+    version: u64,
+    clone_uri: &str,
+) -> Result<String> {
+    create_shallow_clone_pin_inner(
+        clone_pins,
+        branch,
+        identifier,
+        version,
+        clone_uri,
+        std::future::ready(Ok(())),
+    )
+    .await
+}
+
+/// Same as [`create_shallow_clone_pin`], with a hook between pin create and the second
+/// marker check. Used only by tests that inject a marker in that window.
+#[cfg(test)]
+pub(crate) async fn create_shallow_clone_pin_with_hook(
+    clone_pins: &ClonePins<'_>,
+    branch: Option<&str>,
+    identifier: &refs::BranchIdentifier,
+    version: u64,
+    clone_uri: &str,
+    after_pin_created: impl std::future::Future<Output = Result<()>>,
+) -> Result<String> {
+    create_shallow_clone_pin_inner(
+        clone_pins,
+        branch,
+        identifier,
+        version,
+        clone_uri,
+        after_pin_created,
+    )
+    .await
+}
+
+async fn create_shallow_clone_pin_inner(
+    clone_pins: &ClonePins<'_>,
+    branch: Option<&str>,
+    identifier: &refs::BranchIdentifier,
+    version: u64,
+    clone_uri: &str,
+    after_pin_created: impl std::future::Future<Output = Result<()>>,
+) -> Result<String> {
+    let namespace = identifier.marker_namespace();
+    ensure_clone_source_not_fenced(clone_pins, branch, namespace, version).await?;
+
+    let pin_id = clone_pins
+        .create_pin(branch, identifier, version, Some(clone_uri))
+        .await?;
+    after_pin_created.await?;
+
+    if let Err(fence_error) =
+        ensure_clone_source_not_fenced(clone_pins, branch, namespace, version).await
+    {
+        clone_pins.unregister(&pin_id).await?;
+        return Err(fence_error);
+    }
+
+    Ok(pin_id)
 }
 
 impl Projectable for Dataset {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -517,15 +517,13 @@ impl<'a> CleanupTask<'a> {
                 .await?
         };
 
-        // Mark delete candidates, then re-check pins and tags. A concurrent clone writes
-        // its pin and refuses to commit when it sees the marker. Markers are never cleared.
-        // An old version once selected by cleanup stays closed to new shallow clones.
+        // Mark candidates, then recheck pins and tags. A concurrent clone that sees the
+        // marker refuses to commit. Markers stay permanently once written.
         inspection = self
             .mark_old_versions_and_retain_protected(inspection, &branch_identifier)
             .await?;
 
-        // Abort if this branch name now maps to a different incarnation. Deleting under
-        // the open dataset path would otherwise touch the recreated branch's files.
+        // Abort if this branch name now maps to a different incarnation.
         self.ensure_cleanup_branch_incarnation(&branch_identifier)
             .await?;
 
@@ -585,9 +583,8 @@ impl<'a> CleanupTask<'a> {
             }
             Err(error) => return Err(error),
         };
-        // Keep the latest version even when old. Keep tagged and clone-pinned versions
-        // regardless of age. Keep manifests newer than the dataset version. Those are
-        // in-progress or added after cleanup started.
+        // Retain the latest version, tagged versions, clone-pinned versions, and
+        // manifests newer than the dataset version.
         let is_latest = self.read_version <= manifest.version;
         let is_tagged = retained.tagged_versions.contains(&manifest.version);
         let is_clone_pinned = retained.clone_pinned_versions.contains(&manifest.version);
@@ -639,9 +636,8 @@ impl<'a> CleanupTask<'a> {
     ///
     /// Markers stay after a version is deleted. Namespaces use branch incarnation
     /// ids so a recreated branch does not inherit markers from an older incarnation.
-    ///
-    /// Tags are relisted because a `RequireTag` clone may begin after the initial
-    /// tag listing.
+    /// Tags are relisted so a `RequireTag` clone that starts mid-cleanup still protects
+    /// its version.
     async fn mark_old_versions_and_retain_protected(
         &self,
         mut inspection: CleanupInspection,
@@ -2068,9 +2064,7 @@ mod tests {
                 num_bytes: 0,
             };
             while let Some(path) = file_stream.try_next().await? {
-                // Cleanup writes permanent GC markers while it deletes. They are
-                // bookkeeping, not dataset content, and would skew the
-                // bytes_removed == before - after assertions.
+                // Exclude GC markers from byte and file counts.
                 if path.location.as_ref().contains("_refs/gc_markers/") {
                     continue;
                 }
@@ -2228,14 +2222,11 @@ mod tests {
         assert_gt!(after_count.num_tx_files, 0);
     }
 
-    // Scan data files. A count from fragment metadata alone survives after those files are
-    // deleted.
     async fn scan_row_count(dataset: &Dataset) -> Result<usize> {
         Ok(dataset.scan().try_into_batch().await?.num_rows())
     }
 
-    // Reachability-only cleanup. delete_unverified drops age-based retention for unreferenced
-    // files. Without it, a clone read updates source file mtimes and the pin goes untested.
+    // delete_unverified=true so retention is reachability-only.
     async fn run_reachability_cleanup(fixture: &MockDatasetFixture) -> Result<RemovalStats> {
         fixture
             .run_cleanup_with_override(
@@ -2269,8 +2260,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Row count from the generator, not a clone read. Reading the clone first updates
-        // the source data file mtime and age-based cleanup would keep it even without a pin.
         let expected_rows: usize = some_batch().map(|batch| batch.unwrap().num_rows()).sum();
         assert_gt!(expected_rows, 0);
         let before_count = fixture.count_files().await.unwrap();
@@ -2365,9 +2354,6 @@ mod tests {
             )
             .await
             .unwrap();
-        // Force-drop the branch so lineage retention does not keep main version 1 and the
-        // pin becomes orphaned. Main cleanup must still ignore it because it carries a
-        // different branch_id.
         source.force_delete_branch("dev").await.unwrap();
 
         fixture.overwrite_some_data().await.unwrap();
@@ -2438,7 +2424,6 @@ mod tests {
             .create_branch_and_load(&mut source, "dev", 1)
             .await
             .unwrap();
-        // Branch-local data, so branch deletion actually removes files the clone reads.
         Dataset::write(
             some_batch(),
             &branch.uri,
@@ -2466,8 +2451,6 @@ mod tests {
         assert!(matches!(error, Error::RefConflict { .. }), "{error:?}");
         assert!(error.to_string().contains("unregister them"), "{error}");
 
-        // The refused delete leaves the fence. The clone keeps working, the
-        // incarnation is closed to new shallow clones.
         let clone = fixture.load_dataset(&clone_uri).await.unwrap();
         assert_eq!(scan_row_count(&clone).await.unwrap(), expected_rows);
         let mut branch = fixture.load_dataset(&branch.uri).await.unwrap();
@@ -2503,8 +2486,6 @@ mod tests {
         let identifier = source.branches().get_identifier(Some("dev")).await.unwrap();
         let clone_pins = source.clone_pins();
 
-        // The fence lands between pin creation and the clone's second check, the way a
-        // concurrent delete_branch writes it after this clone passed the first check.
         let error = create_shallow_clone_pin_with_hook(
             &clone_pins,
             Some("dev"),
@@ -2562,8 +2543,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Force past the pin fence so the old pin survives as an orphan of the
-        // deleted incarnation.
         source.force_delete_branch("dev").await.unwrap();
 
         let mut recreated = fixture
@@ -2659,8 +2638,6 @@ mod tests {
                 .any(|&version| version == 1)
         );
 
-        // Cleanup has marked the version. A concurrent clone writes its pin before the
-        // post-mark pin list. Cleanup retains the version and keeps the marker.
         dataset.clone_pins().write_gc_marker(None, 1).await.unwrap();
         dataset
             .clone_pins()
@@ -2728,8 +2705,6 @@ mod tests {
                 .any(|&version| version == 1)
         );
 
-        // A tag created after this run's first tag listing, the way a RequireTag clone's
-        // tag appears mid-cleanup. The post-mark recheck must see it and retain the version.
         dataset.tags().create("late_tag", 1).await.unwrap();
 
         inspection = cleanup
@@ -2762,7 +2737,6 @@ mod tests {
         let source = fixture.load().await.unwrap();
         assert!(source.clone_pins().has_gc_marker(None, 1).await.unwrap());
 
-        // A later cleanup must not clear the marker for an already-deleted version.
         run_reachability_cleanup(&fixture).await.unwrap();
         let source = fixture.load().await.unwrap();
         assert!(source.clone_pins().has_gc_marker(None, 1).await.unwrap());

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -35,6 +35,7 @@
 
 use super::refs::TagContents;
 use crate::dataset::TRANSACTIONS_DIR;
+use crate::dataset::refs::{BranchIdentifier, GcMarker};
 use crate::{Dataset, utils::temporal::utc_now};
 use chrono::{DateTime, TimeDelta, Utc};
 use dashmap::DashSet;
@@ -53,7 +54,7 @@ use lance_core::{
 use lance_table::{
     format::{IndexMetadata, Manifest},
     io::{
-        commit::ManifestLocation,
+        commit::{ManifestLocation, ManifestNamingScheme},
         deletion::deletion_file_path,
         manifest::{read_manifest, read_manifest_indexes},
     },
@@ -64,7 +65,7 @@ use std::fmt::Debug;
 use std::{
     collections::{HashMap, HashSet},
     future,
-    sync::{Mutex, MutexGuard},
+    sync::Mutex,
     time::Duration,
 };
 use tokio::time::{MissedTickBehavior, interval};
@@ -298,6 +299,18 @@ struct CleanupTask<'a> {
     include_referenced_branches: bool,
 }
 
+/// Versions cleanup keeps regardless of age.
+#[derive(Clone, Debug, Default)]
+struct RetainedVersions {
+    /// Versions retained by tags on the branch being cleaned.
+    tagged_versions: HashSet<u64>,
+    /// Versions retained by shallow-clone pins.
+    ///
+    /// Separate from `tagged_versions` because `error_if_tagged_old_versions` reports only user
+    /// tags. A clone pin is not something the caller is asked to remove first.
+    clone_pinned_versions: HashSet<u64>,
+}
+
 /// Information about the dataset that we learn by inspecting all of the manifests
 #[derive(Clone, Debug, Default)]
 struct CleanupInspection {
@@ -467,7 +480,24 @@ impl<'a> CleanupTask<'a> {
             .map(|tag_content| tag_content.version)
             .collect();
 
-        let mut inspection = self.process_manifests(&tagged_versions).await?;
+        // Use one branch identifier throughout so branch recreation cannot mix
+        // marker and pin namespaces.
+        let branch_identifier = self.dataset.branch_identifier().await?;
+        let clone_pinned_versions: HashSet<u64> = self
+            .dataset
+            .clone_pins()
+            .list()
+            .await?
+            .into_iter()
+            .filter(|pin| pin.branch_id.as_deref() == branch_identifier.branch_id())
+            .map(|pin| pin.version)
+            .collect();
+
+        let retained = RetainedVersions {
+            tagged_versions,
+            clone_pinned_versions,
+        };
+        let mut inspection = self.process_manifests(&retained).await?;
 
         if self.policy.error_if_tagged_old_versions && !inspection.tagged_old_versions.is_empty() {
             return Err(tagged_old_versions_cleanup_error(
@@ -487,6 +517,18 @@ impl<'a> CleanupTask<'a> {
                 .await?
         };
 
+        // Mark delete candidates, then re-check pins and tags. A concurrent clone writes
+        // its pin and refuses to commit when it sees the marker. Markers are never cleared.
+        // An old version once selected by cleanup stays closed to new shallow clones.
+        inspection = self
+            .mark_old_versions_and_retain_protected(inspection, &branch_identifier)
+            .await?;
+
+        // Abort if this branch name now maps to a different incarnation. Deleting under
+        // the open dataset path would otherwise touch the recreated branch's files.
+        self.ensure_cleanup_branch_incarnation(&branch_identifier)
+            .await?;
+
         final_result.merge(
             self.delete_unreferenced_files(inspection).await?,
             candidate_file_limit,
@@ -495,17 +537,14 @@ impl<'a> CleanupTask<'a> {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn process_manifests(
-        &'a self,
-        tagged_versions: &HashSet<u64>,
-    ) -> Result<CleanupInspection> {
+    async fn process_manifests(&'a self, retained: &RetainedVersions) -> Result<CleanupInspection> {
         let inspection = Mutex::new(CleanupInspection::default());
         self.dataset
             .commit_handler
             .list_manifest_locations(&self.dataset.base, &self.dataset.object_store, false)
             .try_filter(|location| future::ready(!self.ignored_manifests.contains(&location.path)))
             .try_for_each_concurrent(self.dataset.object_store.io_parallelism(), |location| {
-                self.process_manifest_file(location, &inspection, tagged_versions)
+                self.process_manifest_file(location, &inspection, retained)
             })
             .await?;
         Ok(inspection.into_inner().unwrap())
@@ -515,7 +554,7 @@ impl<'a> CleanupTask<'a> {
         &self,
         location: ManifestLocation,
         inspection: &Mutex<CleanupInspection>,
-        tagged_versions: &HashSet<u64>,
+        retained: &RetainedVersions,
     ) -> Result<()> {
         // TODO: We can't cleanup invalid manifests.  There is no way to distinguish
         // between an invalid manifest and a temporary I/O error.  It's also not safe
@@ -546,12 +585,14 @@ impl<'a> CleanupTask<'a> {
             }
             Err(error) => return Err(error),
         };
-        // Don't delete the latest version, even if it is old. Don't delete tagged versions,
-        // regardless of age. Don't delete manifests if their version is newer than the dataset
-        // version.  These are either in-progress or newly added since we started.
+        // Keep the latest version even when old. Keep tagged and clone-pinned versions
+        // regardless of age. Keep manifests newer than the dataset version. Those are
+        // in-progress or added after cleanup started.
         let is_latest = self.read_version <= manifest.version;
-        let is_tagged = tagged_versions.contains(&manifest.version);
-        let in_working_set = is_latest || !self.policy.should_clean(&manifest) || is_tagged;
+        let is_tagged = retained.tagged_versions.contains(&manifest.version);
+        let is_clone_pinned = retained.clone_pinned_versions.contains(&manifest.version);
+        let in_working_set =
+            is_latest || !self.policy.should_clean(&manifest) || is_tagged || is_clone_pinned;
         let mut inspection = inspection.lock().unwrap();
 
         // Track tagged old versions in case we want to return a `CleanupError` later.
@@ -566,16 +607,135 @@ impl<'a> CleanupTask<'a> {
                 .old_manifests
                 .insert(location.path.clone(), manifest.version);
         } else {
-            let commit_ts = manifest.timestamp();
-            if let Some(ts) = inspection.earliest_retained_manifest_time {
-                if commit_ts < ts {
-                    inspection.earliest_retained_manifest_time = Some(commit_ts);
-                }
-            } else {
-                inspection.earliest_retained_manifest_time = Some(commit_ts);
-            }
+            Self::note_retained_manifest_time(&mut inspection, &manifest);
         }
         Ok(())
+    }
+
+    /// Abort if the branch was deleted or recreated during cleanup.
+    async fn ensure_cleanup_branch_incarnation(&self, expected: &BranchIdentifier) -> Result<()> {
+        match self
+            .dataset
+            .branches()
+            .matches_identifier(self.dataset.manifest.branch.as_deref(), expected)
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(Error::RefConflict {
+                message: format!(
+                    "branch {} was deleted or recreated during cleanup",
+                    self.dataset
+                        .manifest
+                        .branch
+                        .as_deref()
+                        .unwrap_or(crate::dataset::refs::MAIN_BRANCH),
+                ),
+            }),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Mark old versions, then retain any that a pin or tag protects.
+    ///
+    /// Markers stay after a version is deleted. Namespaces use branch incarnation
+    /// ids so a recreated branch does not inherit markers from an older incarnation.
+    ///
+    /// Tags are relisted because a `RequireTag` clone may begin after the initial
+    /// tag listing.
+    async fn mark_old_versions_and_retain_protected(
+        &self,
+        mut inspection: CleanupInspection,
+        branch_identifier: &BranchIdentifier,
+    ) -> Result<CleanupInspection> {
+        if !self.action.deletes_files() {
+            return Ok(inspection);
+        }
+
+        let branch = self.dataset.manifest.branch.as_deref();
+        let clone_pins = self.dataset.clone_pins();
+        let marker_namespace = branch_identifier.marker_namespace();
+        let versions_to_delete: HashSet<u64> = inspection.old_manifests.values().copied().collect();
+
+        stream::iter(versions_to_delete.iter().copied())
+            .map(Ok)
+            .try_for_each_concurrent(self.dataset.object_store.io_parallelism(), |version| {
+                let clone_pins = &clone_pins;
+                async move {
+                    clone_pins
+                        .write_gc_marker_in_namespace(marker_namespace, GcMarker::Version(version))
+                        .await
+                }
+            })
+            .await?;
+
+        let pinned_versions: HashSet<u64> = clone_pins
+            .list()
+            .await?
+            .into_iter()
+            .filter(|pin| pin.branch_id.as_deref() == branch_identifier.branch_id())
+            .map(|pin| pin.version)
+            .collect();
+        let tagged_versions: HashSet<u64> = self
+            .dataset
+            .tags()
+            .list()
+            .await?
+            .into_values()
+            .filter(|tag| tag.branch.as_deref() == branch)
+            .map(|tag| tag.version)
+            .collect();
+        let protected_versions: HashSet<u64> =
+            pinned_versions.union(&tagged_versions).copied().collect();
+
+        for version in versions_to_delete.intersection(&protected_versions) {
+            self.retain_version(&mut inspection, *version).await?;
+        }
+
+        Ok(inspection)
+    }
+
+    async fn retain_version(&self, inspection: &mut CleanupInspection, version: u64) -> Result<()> {
+        let manifest_paths: Vec<Path> = inspection
+            .old_manifests
+            .iter()
+            .filter(|(_, v)| **v == version)
+            .map(|(path, _)| path.clone())
+            .collect();
+
+        for path in manifest_paths {
+            let filename = path.filename().ok_or_else(|| {
+                Error::internal(format!("manifest path {} has no filename", path))
+            })?;
+            let naming_scheme = ManifestNamingScheme::detect_scheme(filename).ok_or_else(|| {
+                Error::internal(format!("invalid manifest filename: '{}'", filename))
+            })?;
+            let location = ManifestLocation {
+                path: path.clone(),
+                version,
+                size: None,
+                naming_scheme,
+                e_tag: None,
+            };
+            let manifest =
+                read_manifest(&self.dataset.object_store, &location.path, location.size).await?;
+            let indexes =
+                read_manifest_indexes(&self.dataset.object_store, &location, &manifest).await?;
+            self.process_manifest(&manifest, &indexes, true, inspection)?;
+            inspection.old_manifests.remove(&path);
+            Self::note_retained_manifest_time(inspection, &manifest);
+        }
+        Ok(())
+    }
+
+    fn note_retained_manifest_time(inspection: &mut CleanupInspection, manifest: &Manifest) {
+        let commit_ts = manifest.timestamp();
+        if let Some(ts) = inspection.earliest_retained_manifest_time {
+            if commit_ts < ts {
+                inspection.earliest_retained_manifest_time = Some(commit_ts);
+            }
+        } else {
+            inspection.earliest_retained_manifest_time = Some(commit_ts);
+        }
     }
 
     fn process_manifest(
@@ -583,7 +743,7 @@ impl<'a> CleanupTask<'a> {
         manifest: &Manifest,
         indexes: &Vec<IndexMetadata>,
         in_working_set: bool,
-        inspection: &mut MutexGuard<CleanupInspection>,
+        inspection: &mut CleanupInspection,
     ) -> Result<()> {
         // If this part of our working set then update referenced_files.  Otherwise, just mark the
         // file as verified.
@@ -1103,6 +1263,9 @@ impl<'a> CleanupTask<'a> {
 
     // Retain manifests containing files referenced by descendant branches.
     // This protects parent branch files that are still needed by child branches.
+    //
+    // Only the descendant direction is walked. Ancestor-direction retention waits on
+    // merge/rebase, tracked by https://github.com/lance-format/lance/issues/7263.
     async fn retain_branch_lineage_files(
         &self,
         inspection: CleanupInspection,
@@ -1553,6 +1716,7 @@ mod tests {
 
     use super::*;
     use crate::blob::{BlobArrayBuilder, blob_field};
+    use crate::dataset::create_shallow_clone_pin_with_hook;
     use crate::index::DatasetIndexExt;
     use crate::{
         dataset::transaction::{Operation, Transaction},
@@ -1673,6 +1837,14 @@ mod tests {
                 object_store_wrapper: Some(self.mock_store.clone()),
                 ..Default::default()
             }
+        }
+
+        fn sibling_path(&self, name: &str) -> String {
+            let (parent, _) = self
+                .dataset_path
+                .rsplit_once('/')
+                .expect("dataset_path always has a parent directory");
+            format!("{parent}/{name}")
         }
 
         async fn write_data_impl(
@@ -1896,6 +2068,12 @@ mod tests {
                 num_bytes: 0,
             };
             while let Some(path) = file_stream.try_next().await? {
+                // Cleanup writes permanent GC markers while it deletes. They are
+                // bookkeeping, not dataset content, and would skew the
+                // bytes_removed == before - after assertions.
+                if path.location.as_ref().contains("_refs/gc_markers/") {
+                    continue;
+                }
                 file_count.num_bytes += path.size;
                 match path.location.extension() {
                     Some("lance") => file_count.num_data_files += 1,
@@ -2050,6 +2228,637 @@ mod tests {
         assert_gt!(after_count.num_tx_files, 0);
     }
 
+    // Scan data files. A count from fragment metadata alone survives after those files are
+    // deleted.
+    async fn scan_row_count(dataset: &Dataset) -> Result<usize> {
+        Ok(dataset.scan().try_into_batch().await?.num_rows())
+    }
+
+    // Reachability-only cleanup. delete_unverified drops age-based retention for unreferenced
+    // files. Without it, a clone read updates source file mtimes and the pin goes untested.
+    async fn run_reachability_cleanup(fixture: &MockDatasetFixture) -> Result<RemovalStats> {
+        fixture
+            .run_cleanup_with_override(
+                utc_now() - TimeDelta::try_days(8).unwrap(),
+                Some(true),
+                Some(false),
+            )
+            .await
+    }
+
+    async fn create_clone_then_overwrite_source(
+        fixture: &MockDatasetFixture,
+        clone_uri: &str,
+    ) -> Result<()> {
+        fixture.create_some_data().await?;
+        let mut source = fixture.load().await?;
+        let cloned_version = source.version().version;
+        source
+            .shallow_clone(clone_uri, cloned_version, Some(fixture.os_params()))
+            .await?;
+        fixture.overwrite_some_data().await?;
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cleanup_on_source_keeps_shallow_clone_files() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        let clone_uri = fixture.sibling_path("my_clone");
+        create_clone_then_overwrite_source(&fixture, &clone_uri)
+            .await
+            .unwrap();
+
+        // Row count from the generator, not a clone read. Reading the clone first updates
+        // the source data file mtime and age-based cleanup would keep it even without a pin.
+        let expected_rows: usize = some_batch().map(|batch| batch.unwrap().num_rows()).sum();
+        assert_gt!(expected_rows, 0);
+        let before_count = fixture.count_files().await.unwrap();
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+
+        assert_eq!(removed.old_versions, 0);
+        assert_eq!(removed.data_files_removed, 0);
+        assert_eq!(fixture.count_files().await.unwrap(), before_count);
+
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        assert_eq!(scan_row_count(&clone).await.unwrap(), expected_rows);
+    }
+
+    #[tokio::test]
+    async fn cleanup_reclaims_source_files_after_pin_removed() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        let clone_uri = fixture.sibling_path("my_clone");
+        create_clone_then_overwrite_source(&fixture, &clone_uri)
+            .await
+            .unwrap();
+
+        let source = fixture.load().await.unwrap();
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        let pin_id = clone.source_pin_id().unwrap().to_string();
+        source.clone_pins().unregister(&pin_id).await.unwrap();
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        assert!(scan_row_count(&clone).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cleanup_on_source_keeps_version_pinned_by_remaining_clone() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        let first_clone_uri = fixture.sibling_path("first_clone");
+        create_clone_then_overwrite_source(&fixture, &first_clone_uri)
+            .await
+            .unwrap();
+
+        let second_clone_uri = fixture.sibling_path("second_clone");
+        let mut source = fixture.load().await.unwrap();
+        let second = source
+            .shallow_clone(&second_clone_uri, 1, Some(fixture.os_params()))
+            .await
+            .unwrap();
+
+        let first = fixture.load_dataset(&first_clone_uri).await.unwrap();
+        source
+            .clone_pins()
+            .unregister(first.source_pin_id().unwrap())
+            .await
+            .unwrap();
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+
+        assert_eq!(removed.old_versions, 0);
+        assert_eq!(removed.data_files_removed, 0);
+
+        source
+            .clone_pins()
+            .unregister(second.source_pin_id().unwrap())
+            .await
+            .unwrap();
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_ignores_clone_pins_from_other_branches() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+
+        let dev_identifier = source.branches().get_identifier(Some("dev")).await.unwrap();
+        source
+            .clone_pins()
+            .create_pin(
+                Some("dev"),
+                &dev_identifier,
+                1,
+                Some(&fixture.sibling_path("branch_clone")),
+            )
+            .await
+            .unwrap();
+        // Force-drop the branch so lineage retention does not keep main version 1 and the
+        // pin becomes orphaned. Main cleanup must still ignore it because it carries a
+        // different branch_id.
+        source.force_delete_branch("dev").await.unwrap();
+
+        fixture.overwrite_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_on_branch_keeps_shallow_clone_files() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        let mut branch = fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+
+        let clone_uri = fixture.sibling_path("branch_clone");
+        let cloned_version = branch.version().version;
+        let expected_rows = scan_row_count(&branch).await.unwrap();
+        branch
+            .shallow_clone(&clone_uri, cloned_version, Some(fixture.os_params()))
+            .await
+            .unwrap();
+
+        Dataset::write(
+            some_batch(),
+            &branch.uri,
+            Some(WriteParams {
+                store_params: Some(fixture.os_params()),
+                commit_handler: Some(Arc::new(RenameCommitHandler)),
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let branch = fixture.load_dataset(&branch.uri).await.unwrap();
+        let removed = cleanup_old_versions(
+            &branch,
+            CleanupPolicyBuilder::default()
+                .before_timestamp(utc_now() - TimeDelta::try_days(8).unwrap())
+                .delete_unverified(true)
+                .error_if_tagged_old_versions(false)
+                .build(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(removed.old_versions, 0);
+        assert_eq!(removed.data_files_removed, 0);
+
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        assert_eq!(scan_row_count(&clone).await.unwrap(), expected_rows);
+    }
+
+    #[tokio::test]
+    async fn branch_delete_refused_while_clone_pin_exists() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        let branch = fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+        // Branch-local data, so branch deletion actually removes files the clone reads.
+        Dataset::write(
+            some_batch(),
+            &branch.uri,
+            Some(WriteParams {
+                store_params: Some(fixture.os_params()),
+                commit_handler: Some(Arc::new(RenameCommitHandler)),
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let mut branch = fixture.load_dataset(&branch.uri).await.unwrap();
+
+        let clone_uri = fixture.sibling_path("branch_delete_clone");
+        let expected_rows = scan_row_count(&branch).await.unwrap();
+        let cloned_version = branch.version().version;
+        let clone = branch
+            .shallow_clone(&clone_uri, cloned_version, Some(fixture.os_params()))
+            .await
+            .unwrap();
+        let pin_id = clone.source_pin_id().unwrap().to_string();
+
+        let error = source.delete_branch("dev").await.unwrap_err();
+        assert!(matches!(error, Error::RefConflict { .. }), "{error:?}");
+        assert!(error.to_string().contains("unregister them"), "{error}");
+
+        // The refused delete leaves the fence. The clone keeps working, the
+        // incarnation is closed to new shallow clones.
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        assert_eq!(scan_row_count(&clone).await.unwrap(), expected_rows);
+        let mut branch = fixture.load_dataset(&branch.uri).await.unwrap();
+        let blocked = branch
+            .shallow_clone(
+                &fixture.sibling_path("blocked_after_delete"),
+                cloned_version,
+                Some(fixture.os_params()),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            blocked.to_string().contains("deletion of this branch"),
+            "{blocked}"
+        );
+
+        source.clone_pins().unregister(&pin_id).await.unwrap();
+        source.delete_branch("dev").await.unwrap();
+        let clone = fixture.load_dataset(&clone_uri).await.unwrap();
+        assert!(scan_row_count(&clone).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn branch_delete_fence_aborts_pin_created_after_check() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+
+        let identifier = source.branches().get_identifier(Some("dev")).await.unwrap();
+        let clone_pins = source.clone_pins();
+
+        // The fence lands between pin creation and the clone's second check, the way a
+        // concurrent delete_branch writes it after this clone passed the first check.
+        let error = create_shallow_clone_pin_with_hook(
+            &clone_pins,
+            Some("dev"),
+            &identifier,
+            1,
+            &fixture.sibling_path("racing_clone"),
+            async {
+                clone_pins
+                    .write_gc_marker_in_namespace(
+                        identifier.marker_namespace(),
+                        GcMarker::BranchDeleted,
+                    )
+                    .await
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("deletion of this branch"),
+            "{error}"
+        );
+        assert!(
+            clone_pins.list().await.unwrap().is_empty(),
+            "aborted clone must unregister its pin so the rerun delete proceeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn recreated_branch_does_not_inherit_gc_markers_or_pins() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        let branch = fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+        let branch_version = branch.version().version;
+        let old_identifier = source.branches().get_identifier(Some("dev")).await.unwrap();
+        let old_branch_id = old_identifier.branch_id().map(str::to_string);
+
+        source
+            .clone_pins()
+            .write_gc_marker(Some("dev"), branch_version)
+            .await
+            .unwrap();
+        source
+            .clone_pins()
+            .create_pin(
+                Some("dev"),
+                &old_identifier,
+                branch_version,
+                Some(&fixture.sibling_path("old")),
+            )
+            .await
+            .unwrap();
+
+        // Force past the pin fence so the old pin survives as an orphan of the
+        // deleted incarnation.
+        source.force_delete_branch("dev").await.unwrap();
+
+        let mut recreated = fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+        let resolved = source.branches().resolve_branch(Some("dev")).await.unwrap();
+        let new_identifier = resolved.identifier;
+        let new_branch_id = new_identifier.branch_id().map(str::to_string);
+        assert_eq!(resolved.location.branch.as_deref(), Some("dev"));
+        assert_ne!(
+            old_identifier.marker_namespace(),
+            new_identifier.marker_namespace()
+        );
+        assert_ne!(old_branch_id, new_branch_id);
+        assert!(
+            !source
+                .branches()
+                .matches_identifier(Some("dev"), &old_identifier)
+                .await
+                .unwrap()
+        );
+        assert!(
+            source
+                .branches()
+                .matches_identifier(Some("dev"), &new_identifier)
+                .await
+                .unwrap()
+        );
+        assert!(
+            source
+                .clone_pins()
+                .has_gc_marker_in_namespace(
+                    old_identifier.marker_namespace(),
+                    GcMarker::Version(branch_version),
+                )
+                .await
+                .unwrap()
+        );
+        assert!(
+            !source
+                .clone_pins()
+                .has_gc_marker(Some("dev"), branch_version)
+                .await
+                .unwrap()
+        );
+
+        recreated
+            .shallow_clone(
+                &fixture.sibling_path("recreated_branch_clone"),
+                branch_version,
+                Some(fixture.os_params()),
+            )
+            .await
+            .unwrap();
+
+        let pins = source.clone_pins().list().await.unwrap();
+        assert_eq!(
+            pins.iter()
+                .filter(|pin| pin.branch_id == new_branch_id)
+                .count(),
+            1
+        );
+        assert_eq!(
+            pins.iter()
+                .filter(|pin| pin.branch_id == old_branch_id)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_version_when_pin_appears_after_marker() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        fixture.overwrite_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let dataset = fixture.load().await.unwrap();
+        let policy = CleanupPolicyBuilder::default()
+            .before_timestamp(utc_now() - TimeDelta::try_days(8).unwrap())
+            .delete_unverified(true)
+            .error_if_tagged_old_versions(false)
+            .build();
+        let cleanup = CleanupTask::new(&dataset, policy, CleanupAction::Execute);
+
+        let retained = RetainedVersions::default();
+        let mut inspection = cleanup.process_manifests(&retained).await.unwrap();
+        assert!(
+            inspection
+                .old_manifests
+                .values()
+                .any(|&version| version == 1)
+        );
+
+        // Cleanup has marked the version. A concurrent clone writes its pin before the
+        // post-mark pin list. Cleanup retains the version and keeps the marker.
+        dataset.clone_pins().write_gc_marker(None, 1).await.unwrap();
+        dataset
+            .clone_pins()
+            .create_pin(
+                None,
+                &BranchIdentifier::main(),
+                1,
+                Some(&fixture.sibling_path("late_clone")),
+            )
+            .await
+            .unwrap();
+
+        inspection = cleanup
+            .mark_old_versions_and_retain_protected(inspection, &BranchIdentifier::main())
+            .await
+            .unwrap();
+        assert!(
+            !inspection
+                .old_manifests
+                .values()
+                .any(|&version| version == 1)
+        );
+        assert!(dataset.clone_pins().has_gc_marker(None, 1).await.unwrap());
+
+        let removed = cleanup.delete_unreferenced_files(inspection).await.unwrap();
+        assert_eq!(removed.stats.old_versions, 0);
+        assert_eq!(removed.stats.data_files_removed, 0);
+
+        let mut source = fixture.load().await.unwrap();
+        let error = source
+            .shallow_clone(
+                &fixture.sibling_path("closed_clone"),
+                1,
+                Some(fixture.os_params()),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("marked it for deletion"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_version_when_tag_appears_after_initial_listing() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        fixture.overwrite_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let dataset = fixture.load().await.unwrap();
+        let policy = CleanupPolicyBuilder::default()
+            .before_timestamp(utc_now() - TimeDelta::try_days(8).unwrap())
+            .delete_unverified(true)
+            .error_if_tagged_old_versions(false)
+            .build();
+        let cleanup = CleanupTask::new(&dataset, policy, CleanupAction::Execute);
+
+        let retained = RetainedVersions::default();
+        let mut inspection = cleanup.process_manifests(&retained).await.unwrap();
+        assert!(
+            inspection
+                .old_manifests
+                .values()
+                .any(|&version| version == 1)
+        );
+
+        // A tag created after this run's first tag listing, the way a RequireTag clone's
+        // tag appears mid-cleanup. The post-mark recheck must see it and retain the version.
+        dataset.tags().create("late_tag", 1).await.unwrap();
+
+        inspection = cleanup
+            .mark_old_versions_and_retain_protected(inspection, &BranchIdentifier::main())
+            .await
+            .unwrap();
+        assert!(
+            !inspection
+                .old_manifests
+                .values()
+                .any(|&version| version == 1)
+        );
+
+        let removed = cleanup.delete_unreferenced_files(inspection).await.unwrap();
+        assert_eq!(removed.stats.old_versions, 0);
+        assert_eq!(removed.stats.data_files_removed, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_marker_after_deleting_version() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        fixture.overwrite_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+
+        let source = fixture.load().await.unwrap();
+        assert!(source.clone_pins().has_gc_marker(None, 1).await.unwrap());
+
+        // A later cleanup must not clear the marker for an already-deleted version.
+        run_reachability_cleanup(&fixture).await.unwrap();
+        let source = fixture.load().await.unwrap();
+        assert!(source.clone_pins().has_gc_marker(None, 1).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn shallow_clone_rejects_version_marked_for_cleanup() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+
+        source.clone_pins().write_gc_marker(None, 1).await.unwrap();
+
+        let clone_uri = fixture.sibling_path("blocked_clone");
+        let error = source
+            .shallow_clone(&clone_uri, 1, Some(fixture.os_params()))
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("marked it for deletion"),
+            "{error}"
+        );
+        assert!(source.clone_pins().has_gc_marker(None, 1).await.unwrap());
+        assert!(
+            source.clone_pins().list().await.unwrap().is_empty(),
+            "rejected clone must not leave a pin"
+        );
+        assert!(fixture.load_dataset(&clone_uri).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn shallow_clone_removes_pin_when_marker_appears_after_pin_creation() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let source = fixture.load().await.unwrap();
+        let clone_pins = source.clone_pins();
+        let clone_uri = fixture.sibling_path("second_check_clone");
+
+        let error = create_shallow_clone_pin_with_hook(
+            &clone_pins,
+            None,
+            &BranchIdentifier::main(),
+            1,
+            &clone_uri,
+            async {
+                clone_pins.write_gc_marker(None, 1).await?;
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("marked it for deletion"),
+            "{error}"
+        );
+        assert!(clone_pins.has_gc_marker(None, 1).await.unwrap());
+        assert!(
+            clone_pins.list().await.unwrap().is_empty(),
+            "second marker check must unregister the unused pin"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_shallow_clone_does_not_block_later_cleanup() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        let first_clone_uri = fixture.sibling_path("first_clone");
+        create_clone_then_overwrite_source(&fixture, &first_clone_uri)
+            .await
+            .unwrap();
+
+        let mut source = fixture.load().await.unwrap();
+        source.clone_pins().write_gc_marker(None, 1).await.unwrap();
+
+        source
+            .shallow_clone(
+                &fixture.sibling_path("rejected_clone"),
+                1,
+                Some(fixture.os_params()),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(source.clone_pins().list().await.unwrap().len(), 1);
+
+        let first = fixture.load_dataset(&first_clone_uri).await.unwrap();
+        source
+            .clone_pins()
+            .unregister(first.source_pin_id().unwrap())
+            .await
+            .unwrap();
+
+        let removed = run_reachability_cleanup(&fixture).await.unwrap();
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+    }
+
     #[tokio::test]
     async fn cleanup_ignores_old_manifest_removed_after_listing() {
         let fixture = MockDatasetFixture::try_new().unwrap();
@@ -2080,7 +2889,7 @@ mod tests {
             .process_manifest_file(
                 old_manifest,
                 &Mutex::new(CleanupInspection::default()),
-                &HashSet::new(),
+                &RetainedVersions::default(),
             )
             .await
             .unwrap();

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -527,10 +527,33 @@ impl<'a> CleanupTask<'a> {
         self.ensure_cleanup_branch_incarnation(&branch_identifier)
             .await?;
 
-        final_result.merge(
-            self.delete_unreferenced_files(inspection).await?,
-            candidate_file_limit,
-        );
+        // Named branches reuse tree/{name}/ across incarnations. Hold the branch-name
+        // path lease through the destructive phase so create/delete cannot touch those
+        // paths until this cleanup finishes.
+        let lease_branch = self
+            .action
+            .deletes_files()
+            .then(|| self.dataset.manifest.branch.clone())
+            .flatten();
+        let delete_result = if let Some(branch_name) = lease_branch.as_deref() {
+            self.dataset
+                .branches()
+                .acquire_branch_path_lease(branch_name, branch_identifier.branch_id())
+                .await?;
+            let result = async {
+                self.ensure_cleanup_branch_incarnation(&branch_identifier)
+                    .await?;
+                self.delete_unreferenced_files(inspection).await
+            }
+            .await;
+            self.dataset
+                .branches()
+                .finish_branch_path_lease(branch_name, result)
+                .await
+        } else {
+            self.delete_unreferenced_files(inspection).await
+        };
+        final_result.merge(delete_result?, candidate_file_limit);
         Ok(final_result)
     }
 
@@ -2449,7 +2472,7 @@ mod tests {
 
         let error = source.delete_branch("dev").await.unwrap_err();
         assert!(matches!(error, Error::RefConflict { .. }), "{error:?}");
-        assert!(error.to_string().contains("unregister them"), "{error}");
+        assert!(error.to_string().contains("Unregister them"), "{error}");
 
         let clone = fixture.load_dataset(&clone_uri).await.unwrap();
         assert_eq!(scan_row_count(&clone).await.unwrap(), expected_rows);
@@ -2471,6 +2494,99 @@ mod tests {
         source.delete_branch("dev").await.unwrap();
         let clone = fixture.load_dataset(&clone_uri).await.unwrap();
         assert!(scan_row_count(&clone).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn branch_path_lease_blocks_recreate_during_destructive_phase() {
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        let mut source = fixture.load().await.unwrap();
+        let branch = fixture
+            .create_branch_and_load(&mut source, "dev", 1)
+            .await
+            .unwrap();
+        Dataset::write(
+            some_batch(),
+            &branch.uri,
+            Some(WriteParams {
+                store_params: Some(fixture.os_params()),
+                commit_handler: Some(Arc::new(RenameCommitHandler)),
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let branch = fixture.load_dataset(&branch.uri).await.unwrap();
+        let expected_rows = scan_row_count(&branch).await.unwrap();
+        let cleanup = CleanupTask::new(
+            &branch,
+            CleanupPolicyBuilder::default()
+                .before_timestamp(utc_now() - TimeDelta::try_days(8).unwrap())
+                .delete_unverified(true)
+                .error_if_tagged_old_versions(false)
+                .build(),
+            CleanupAction::Execute,
+        );
+        let identifier = branch.branch_identifier().await.unwrap();
+        let inspection = cleanup
+            .process_manifests(&RetainedVersions::default())
+            .await
+            .unwrap();
+        let inspection = cleanup
+            .mark_old_versions_and_retain_protected(inspection, &identifier)
+            .await
+            .unwrap();
+        cleanup
+            .ensure_cleanup_branch_incarnation(&identifier)
+            .await
+            .unwrap();
+        branch
+            .branches()
+            .acquire_branch_path_lease("dev", identifier.branch_id())
+            .await
+            .unwrap();
+        assert!(
+            branch
+                .branches()
+                .has_branch_path_lease("dev")
+                .await
+                .unwrap()
+        );
+
+        let delete_error = source.delete_branch("dev").await.unwrap_err();
+        assert!(
+            matches!(delete_error, Error::RefConflict { .. }),
+            "{delete_error:?}"
+        );
+        assert!(
+            delete_error.to_string().contains("is busy"),
+            "{delete_error}"
+        );
+
+        // Create also acquires the path lease, so recreate is refused while cleanup
+        // holds it even before the "already exists" check.
+        let recreate_error = source.create_branch("dev", 1, None).await.unwrap_err();
+        assert!(
+            matches!(recreate_error, Error::RefConflict { .. }),
+            "{recreate_error:?}"
+        );
+        assert!(
+            recreate_error.to_string().contains("is busy"),
+            "{recreate_error}"
+        );
+
+        let delete_result = cleanup.delete_unreferenced_files(inspection).await;
+        branch
+            .branches()
+            .finish_branch_path_lease("dev", delete_result)
+            .await
+            .unwrap();
+
+        let branch = fixture.load_dataset(&branch.uri).await.unwrap();
+        assert_eq!(scan_row_count(&branch).await.unwrap(), expected_rows);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -596,6 +596,14 @@ impl Branches<'_> {
     pub async fn delete(&self, branch: &str, force: bool) -> Result<()> {
         check_valid_branch(branch)?;
 
+        // Acquire with None, then resolve the incarnation under the lease. A prior
+        // list() could observe a branch that is deleted and recreated before we hold.
+        self.acquire_branch_path_lease(branch, None).await?;
+        let result = self.delete_with_lease_held(branch, force).await;
+        self.finish_branch_path_lease(branch, result).await
+    }
+
+    async fn delete_with_lease_held(&self, branch: &str, force: bool) -> Result<()> {
         let all_branches = self.list().await?;
         let branch_id = all_branches
             .get(branch)
@@ -660,8 +668,88 @@ impl Branches<'_> {
             self.object_store().delete(&branch_file).await?;
         }
 
-        // Clean up branch directories
         self.cleanup_branch_directories(branch).await
+    }
+
+    /// True when a create, delete, or cleanup holds the branch-name path lease.
+    pub(crate) async fn has_branch_path_lease(&self, branch: &str) -> Result<bool> {
+        let root_location = self.refs.root()?;
+        let path = branch_path_lease_path(&root_location.path, branch);
+        self.object_store().exists(&path).await
+    }
+
+    /// Acquire the branch-name path lease for a create, delete, or cleanup critical section.
+    ///
+    /// Keyed by display name, not incarnation id, because recreated branches reuse
+    /// `tree/{branch}/`. `branch_id` is recorded for debugging when known.
+    pub(crate) async fn acquire_branch_path_lease(
+        &self,
+        branch: &str,
+        branch_id: Option<&str>,
+    ) -> Result<()> {
+        check_valid_branch(branch)?;
+        let root_location = self.refs.root()?;
+        let path = branch_path_lease_path(&root_location.path, branch);
+        let body = BranchPathLease {
+            branch_id: branch_id.map(str::to_owned),
+        };
+        match put_if_not_exists(
+            self.object_store(),
+            &path,
+            serde_json::to_vec_pretty(&body)?.as_slice(),
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::AlreadyExists { .. })
+            | Err(ObjectStoreError::Precondition { .. }) => Err(Error::RefConflict {
+                message: format!(
+                    "branch {} is busy with another create, delete, or cleanup. Retry after it \
+                     finishes. If a process crashed, remove _refs/branch_path_leases/{} and retry",
+                    branch,
+                    encode_gc_marker_namespace(branch),
+                ),
+            }),
+            Err(error) => Err(Error::io(format!(
+                "acquiring branch path lease for {}: {}",
+                branch, error
+            ))),
+        }
+    }
+
+    /// Drop the branch-name path lease after the critical section finishes.
+    pub(crate) async fn release_branch_path_lease(&self, branch: &str) -> Result<()> {
+        let root_location = self.refs.root()?;
+        let path = branch_path_lease_path(&root_location.path, branch);
+        match self.object_store().delete(&path).await {
+            Ok(()) => Ok(()),
+            Err(Error::NotFound { .. }) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Release the path lease and prefer a release failure over a silent success.
+    ///
+    /// A successful operation that leaves the lease behind would block the branch name
+    /// until the lease file is removed by hand.
+    pub(crate) async fn finish_branch_path_lease<T>(
+        &self,
+        branch: &str,
+        result: Result<T>,
+    ) -> Result<T> {
+        match (result, self.release_branch_path_lease(branch).await) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(release_err)) => Err(release_err),
+            (Err(err), Ok(())) => Err(err),
+            (Err(err), Err(release_err)) => {
+                log::warn!(
+                    "failed to release branch path lease for {}: {}",
+                    branch,
+                    release_err
+                );
+                Err(err)
+            }
+        }
     }
 
     pub async fn list_ordered(
@@ -1267,6 +1355,26 @@ pub fn clone_pin_path(base_path: &Path, pin_id: &str) -> Path {
 
 pub fn base_gc_markers_path(base_path: &Path) -> Path {
     base_path.clone().join("_refs").join("gc_markers")
+}
+
+pub fn base_branch_path_leases_path(base_path: &Path) -> Path {
+    base_path.clone().join("_refs").join("branch_path_leases")
+}
+
+/// Lease file under `_refs/branch_path_leases/<encoded-branch-name>`.
+///
+/// Held for the full create, delete, or cleanup critical section on that branch name.
+/// Keyed by display name because recreated branches reuse `tree/{branch}/`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BranchPathLease {
+    /// Leaf UUID of the incarnation when known. Absent for create, delete acquire, and main.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    branch_id: Option<String>,
+}
+
+fn branch_path_lease_path(base_path: &Path, branch: &str) -> Path {
+    base_branch_path_leases_path(base_path).join(encode_gc_marker_namespace(branch))
 }
 
 fn encode_gc_marker_namespace(namespace: &str) -> String {

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -672,6 +672,7 @@ impl Branches<'_> {
     }
 
     /// True when a create, delete, or cleanup holds the branch-name path lease.
+    #[cfg(test)]
     pub(crate) async fn has_branch_path_lease(&self, branch: &str) -> Result<bool> {
         let root_location = self.refs.root()?;
         let path = branch_path_lease_path(&root_location.path, branch);

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -611,12 +611,9 @@ impl Branches<'_> {
                 });
             }
 
-            // Fence, then check pins. A clone that pins after this write sees the fence
-            // on its second marker check and aborts, so a pin list taken after the fence
-            // is complete. The fence stays if deletion is refused. The incarnation is
-            // then closed to new shallow clones, and deletion can be rerun once the
-            // listed pins are unregistered. `force` skips the pin refusal with a warning
-            // and breaks the clones holding those pins.
+            // Write BranchDeleted before listing pins. A clone that pins after this
+            // write aborts on its second marker check. The fence stays if deletion is
+            // refused. force skips the pin refusal and breaks those clones.
             let namespace = branch_id.marker_namespace();
             let clone_pins = self.refs.clone_pins();
             clone_pins
@@ -633,7 +630,7 @@ impl Branches<'_> {
                 if !force {
                     return Err(Error::RefConflict {
                         message: format!(
-                            "branch {} has {} shallow-clone pins [{}]; unregister them, then \
+                            "branch {} has {} shallow-clone pins [{}]. Unregister them, then \
                              rerun delete. The branch stays closed to new shallow clones",
                             branch,
                             pin_ids.len(),
@@ -642,7 +639,7 @@ impl Branches<'_> {
                     });
                 }
                 log::warn!(
-                    "force-deleting branch {} despite {} shallow-clone pins [{}]; the \
+                    "force-deleting branch {} despite {} shallow-clone pins [{}]. The \
                      clones holding them will lose access to branch-local files",
                     branch,
                     pin_ids.len(),
@@ -1084,9 +1081,8 @@ pub struct ClonePin {
 impl ClonePin {
     /// Reject pins whose retention identity is incomplete.
     ///
-    /// A named-branch pin without `branch_id` cannot be matched to any branch incarnation.
-    /// Treating it as a main pin would retain the wrong versions, and ignoring it would
-    /// silently drop a clone's protection, so the registry read fails instead.
+    /// A named-branch pin without `branch_id` cannot be matched to a branch incarnation.
+    /// Fail the registry read rather than retain the wrong versions or drop protection.
     fn validate(&self) -> Result<()> {
         if self.branch.is_some() && self.branch_id.is_none() {
             return Err(Error::corrupt_file(

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -3,12 +3,14 @@
 
 use std::ops::Range;
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::stream::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_io::object_store::ObjectStore;
 use lance_table::io::commit::CommitHandler;
 use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, PutMode, PutOptions};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -24,6 +26,9 @@ use std::fmt::Formatter;
 use uuid::Uuid;
 
 pub const MAIN_BRANCH: &str = "main";
+
+/// Config key on a shallow-clone manifest for the source pin id under `_refs/clones/`.
+pub const SOURCE_PIN_ID_CONFIG_KEY: &str = "lance.clone.source_pin_id";
 
 /// Lance Ref
 #[derive(Debug, Clone)]
@@ -111,6 +116,10 @@ impl Refs {
         Branches { refs: self }
     }
 
+    pub fn clone_pins(&self) -> ClonePins<'_> {
+        ClonePins { refs: self }
+    }
+
     pub fn base(&self) -> &Path {
         &self.base_location.path
     }
@@ -129,6 +138,12 @@ pub struct Tags<'a> {
 /// Branches operation
 #[derive(Debug, Clone)]
 pub struct Branches<'a> {
+    refs: &'a Refs,
+}
+
+/// Source-side pins for shallow clones stored at other URIs.
+#[derive(Debug, Clone)]
+pub struct ClonePins<'a> {
     refs: &'a Refs,
 }
 
@@ -433,10 +448,40 @@ impl Branches<'_> {
 
     pub async fn get_identifier(&self, branch: Option<&str>) -> Result<BranchIdentifier> {
         if let Some(branch_name) = branch {
-            let branch_contents = self.get(branch_name).await?;
-            Ok(branch_contents.identifier)
+            Ok(self.get(branch_name).await?.identifier)
         } else {
             Ok(BranchIdentifier::main())
+        }
+    }
+
+    /// Resolve the branch location and incarnation id together.
+    ///
+    /// The location comes from the path layout. The identifier comes from `BranchContents`
+    /// when the branch exists. Callers should keep both values from this result rather than
+    /// resolving them separately.
+    pub(crate) async fn resolve_branch(&self, branch: Option<&str>) -> Result<ResolvedBranch> {
+        let location = self.refs.base_location.find_branch(branch)?;
+        let identifier = if let Some(branch_name) = branch {
+            self.get(branch_name).await?.identifier
+        } else {
+            BranchIdentifier::main()
+        };
+        Ok(ResolvedBranch {
+            location,
+            identifier,
+        })
+    }
+
+    /// True when `branch` still maps to `expected`.
+    pub(crate) async fn matches_identifier(
+        &self,
+        branch: Option<&str>,
+        expected: &BranchIdentifier,
+    ) -> Result<bool> {
+        match self.get_identifier(branch).await {
+            Ok(current) => Ok(current == *expected),
+            Err(Error::RefNotFound { .. }) => Ok(false),
+            Err(err) => Err(err),
         }
     }
 
@@ -565,6 +610,45 @@ impl Branches<'_> {
                     ),
                 });
             }
+
+            // Fence, then check pins. A clone that pins after this write sees the fence
+            // on its second marker check and aborts, so a pin list taken after the fence
+            // is complete. The fence stays if deletion is refused. The incarnation is
+            // then closed to new shallow clones, and deletion can be rerun once the
+            // listed pins are unregistered. `force` skips the pin refusal with a warning
+            // and breaks the clones holding those pins.
+            let namespace = branch_id.marker_namespace();
+            let clone_pins = self.refs.clone_pins();
+            clone_pins
+                .write_gc_marker_in_namespace(namespace, GcMarker::BranchDeleted)
+                .await?;
+            let pin_ids: Vec<String> = clone_pins
+                .list()
+                .await?
+                .into_iter()
+                .filter(|pin| pin.branch_id.as_deref() == branch_id.branch_id())
+                .map(|pin| pin.id)
+                .collect();
+            if !pin_ids.is_empty() {
+                if !force {
+                    return Err(Error::RefConflict {
+                        message: format!(
+                            "branch {} has {} shallow-clone pins [{}]; unregister them, then \
+                             rerun delete. The branch stays closed to new shallow clones",
+                            branch,
+                            pin_ids.len(),
+                            pin_ids.join(", ")
+                        ),
+                    });
+                }
+                log::warn!(
+                    "force-deleting branch {} despite {} shallow-clone pins [{}]; the \
+                     clones holding them will lose access to branch-local files",
+                    branch,
+                    pin_ids.len(),
+                    pin_ids.join(", ")
+                );
+            }
         } else if !force {
             return Err(Error::RefNotFound {
                 message: format!("Branch {} does not exist", branch),
@@ -664,6 +748,218 @@ impl Branches<'_> {
     }
 }
 
+impl ClonePins<'_> {
+    fn object_store(&self) -> &ObjectStore {
+        &self.refs.object_store
+    }
+
+    /// Every shallow-clone pin on this dataset.
+    ///
+    /// Pins live at the root dataset level for every branch.
+    pub async fn list(&self) -> Result<Vec<ClonePin>> {
+        let root_location = self.refs.root()?;
+        let pin_files = match self
+            .object_store()
+            .read_dir(base_clone_pins_path(&root_location.path))
+            .await
+        {
+            Ok(files) => files,
+            Err(err) if err.is_not_found() => return Ok(Vec::new()),
+            Err(err) => return Err(err),
+        };
+
+        let pin_ids: Vec<String> = pin_files
+            .iter()
+            .filter_map(|name| name.strip_suffix(".json"))
+            .map(|name| name.to_string())
+            .collect_vec();
+
+        let root_path = &root_location.path;
+        let concurrency = self.object_store().io_parallelism();
+        futures::stream::iter(pin_ids)
+            .map(|pin_id| async move {
+                let mut pin =
+                    ClonePin::from_path(&clone_pin_path(root_path, &pin_id), self.object_store())
+                        .await?;
+                pin.id = pin_id;
+                pin.validate()?;
+                Ok(pin)
+            })
+            .buffer_unordered(concurrency)
+            .try_collect()
+            .await
+    }
+
+    /// Create a source pin for an already-resolved branch incarnation.
+    ///
+    /// Callers must perform the surrounding cleanup-marker protocol. Callers should
+    /// unregister unused pins when the clone commit clearly did not land. A leaked pin
+    /// wastes storage. Removing a pin for a live clone can lose data.
+    pub(crate) async fn create_pin(
+        &self,
+        branch: Option<&str>,
+        identifier: &BranchIdentifier,
+        version: u64,
+        clone_uri: Option<&str>,
+    ) -> Result<String> {
+        let root_location = self.refs.root()?;
+        let pin_id = Uuid::new_v4().simple().to_string();
+        let pin = ClonePin {
+            id: pin_id.clone(),
+            branch: branch.map(|branch| branch.to_string()),
+            branch_id: identifier.branch_id().map(|id| id.to_string()),
+            version,
+            created_at: utc_now(),
+            clone_uri: clone_uri.map(normalize_clone_uri),
+        };
+        pin.validate()?;
+        let pin_path = clone_pin_path(&root_location.path, &pin_id);
+        let body = serde_json::to_string_pretty(&pin)?;
+
+        match put_if_not_exists(self.object_store(), &pin_path, body.as_bytes()).await {
+            Ok(()) => Ok(pin_id),
+            Err(ObjectStoreError::AlreadyExists { .. })
+            | Err(ObjectStoreError::Precondition { .. }) => Err(Error::RefConflict {
+                message: format!("shallow clone pin {} already exists", pin_id),
+            }),
+            Err(error) => Err(Error::io(format!(
+                "creating shallow-clone source pin {}: {}",
+                pin_id, error
+            ))),
+        }
+    }
+
+    /// Drop the pin with `pin_id`.
+    ///
+    /// Call this after the clone is deleted or no longer reads this dataset. Versions that
+    /// other pins still reference stay retained.
+    pub async fn unregister(&self, pin_id: &str) -> Result<()> {
+        check_valid_pin_id(pin_id)?;
+        let root_location = self.refs.root()?;
+        let pin_path = clone_pin_path(&root_location.path, pin_id);
+
+        if !self.object_store().exists(&pin_path).await? {
+            return Err(Error::RefNotFound {
+                message: format!("no shallow clone pin {}", pin_id),
+            });
+        }
+
+        self.object_store().delete(&pin_path).await
+    }
+
+    /// Mark `version` of `branch`'s current incarnation as selected by cleanup.
+    ///
+    /// Test helper. Production cleanup resolves the branch identifier once and calls
+    /// [`Self::write_gc_marker_in_namespace`].
+    #[cfg(test)]
+    pub(crate) async fn write_gc_marker(&self, branch: Option<&str>, version: u64) -> Result<()> {
+        let identifier = self.refs.branches().get_identifier(branch).await?;
+        self.write_gc_marker_in_namespace(identifier.marker_namespace(), GcMarker::Version(version))
+            .await
+    }
+
+    /// Write a marker under an already-resolved incarnation namespace.
+    pub(crate) async fn write_gc_marker_in_namespace(
+        &self,
+        namespace: &str,
+        marker: GcMarker,
+    ) -> Result<()> {
+        let root_location = self.refs.root()?;
+        let path = gc_marker_path(&root_location.path, namespace, marker);
+        match put_if_not_exists(self.object_store(), &path, b"{}").await {
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::AlreadyExists { .. })
+            | Err(ObjectStoreError::Precondition { .. }) => Ok(()),
+            Err(error) => Err(Error::io(format!(
+                "writing cleanup marker for {} in namespace {}: {}",
+                marker, namespace, error
+            ))),
+        }
+    }
+
+    /// True when cleanup has marked `version` of `branch`'s current incarnation.
+    ///
+    /// Test helper. Production code resolves the branch identifier once per operation
+    /// and calls [`Self::has_gc_marker_in_namespace`].
+    #[cfg(test)]
+    pub(crate) async fn has_gc_marker(&self, branch: Option<&str>, version: u64) -> Result<bool> {
+        let identifier = self.refs.branches().get_identifier(branch).await?;
+        self.has_gc_marker_in_namespace(identifier.marker_namespace(), GcMarker::Version(version))
+            .await
+    }
+
+    /// True when a marker exists under an already-resolved incarnation namespace.
+    pub(crate) async fn has_gc_marker_in_namespace(
+        &self,
+        namespace: &str,
+        marker: GcMarker,
+    ) -> Result<bool> {
+        let root_location = self.refs.root()?;
+        let path = gc_marker_path(&root_location.path, namespace, marker);
+        self.object_store().exists(&path).await
+    }
+}
+
+/// One fence file under `_refs/gc_markers/<incarnation>/`.
+///
+/// Fences are never removed. A fenced target stays closed to new shallow clones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GcMarker {
+    /// Closes one version. Cleanup writes this before deleting the version.
+    Version(u64),
+    /// Closes the whole incarnation. Branch deletion writes this before its pin check,
+    /// so a pin that appears after the check aborts its clone instead of dangling.
+    BranchDeleted,
+}
+
+impl GcMarker {
+    fn file_name(&self) -> String {
+        match self {
+            Self::Version(version) => version.to_string(),
+            // Version file names are numeric, so this name cannot collide with one.
+            Self::BranchDeleted => "deleted".to_string(),
+        }
+    }
+}
+
+impl fmt::Display for GcMarker {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Version(version) => write!(f, "version {}", version),
+            Self::BranchDeleted => write!(f, "branch deletion"),
+        }
+    }
+}
+
+async fn put_if_not_exists(
+    object_store: &ObjectStore,
+    path: &Path,
+    bytes: &[u8],
+) -> std::result::Result<(), ObjectStoreError> {
+    object_store
+        .inner
+        .put_opts(
+            path,
+            Bytes::copy_from_slice(bytes).into(),
+            PutOptions {
+                mode: PutMode::Create,
+                ..Default::default()
+            },
+        )
+        .await
+        .map(|_| ())
+}
+
+fn check_valid_pin_id(pin_id: &str) -> Result<()> {
+    if pin_id.is_empty() || !pin_id.chars().all(|c| c.is_ascii_hexdigit()) || pin_id.len() > 64 {
+        return Err(Error::invalid_input(format!(
+            "invalid shallow clone pin id {}",
+            pin_id
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, PartialEq)]
 struct BranchRelativePath<'a> {
     segments: Vec<&'a str>,
@@ -736,6 +1032,13 @@ pub struct TagContents {
     pub metadata: HashMap<String, String>,
 }
 
+/// Location and incarnation id for one branch, resolved together.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedBranch {
+    pub(crate) location: BranchLocation,
+    pub(crate) identifier: BranchIdentifier,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchContents {
@@ -750,6 +1053,53 @@ pub struct BranchContents {
     /// Missing metadata is deserialized as an empty map.
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+}
+
+/// A pin held on this dataset by a shallow clone stored at another URI.
+///
+/// Cleanup keeps `version` and every file that version references. The clone stores `id` in
+/// its config so destroy or detach can remove the pin. Cleanup does not open the clone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClonePin {
+    /// Random pin id. Also the `_refs/clones/{id}.json` file stem.
+    #[serde(default)]
+    pub id: String,
+    /// Display name of the branch that was cloned. Absent means the main branch.
+    pub branch: Option<String>,
+    /// Leaf UUID of the branch incarnation that was cloned. Absent means main.
+    ///
+    /// Cleanup matches pins by this field so a recreated branch with the same name does
+    /// not inherit retention from an older incarnation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_id: Option<String>,
+    /// Version of that incarnation that the clone's manifest reads from.
+    pub version: u64,
+    pub created_at: DateTime<Utc>,
+    /// Optional clone URI for listing. Not used as the registry key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clone_uri: Option<String>,
+}
+
+impl ClonePin {
+    /// Reject pins whose retention identity is incomplete.
+    ///
+    /// A named-branch pin without `branch_id` cannot be matched to any branch incarnation.
+    /// Treating it as a main pin would retain the wrong versions, and ignoring it would
+    /// silently drop a clone's protection, so the registry read fails instead.
+    fn validate(&self) -> Result<()> {
+        if self.branch.is_some() && self.branch_id.is_none() {
+            return Err(Error::corrupt_file(
+                Path::from(format!("_refs/clones/{}.json", self.id)),
+                format!(
+                    "clone pin {} names branch {} but has no branchId",
+                    self.id,
+                    self.branch.as_deref().unwrap_or_default()
+                ),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -824,6 +1174,19 @@ impl BranchIdentifier {
         }
     }
 
+    /// Leaf UUID of this incarnation, or `None` for main.
+    pub fn branch_id(&self) -> Option<&str> {
+        self.version_mapping.last().map(|(_, uuid)| uuid.as_str())
+    }
+
+    /// Object-store path segment for markers of this incarnation.
+    ///
+    /// Main uses [`MAIN_BRANCH`]. Named branches use their leaf UUID so a recreated branch
+    /// name gets a distinct namespace.
+    pub fn marker_namespace(&self) -> &str {
+        self.branch_id().unwrap_or(MAIN_BRANCH)
+    }
+
     pub fn parse(identifier: &str) -> Result<Self> {
         let parts: Vec<&str> = identifier.split(':').collect();
         if !parts.len().is_multiple_of(2) {
@@ -889,6 +1252,10 @@ pub fn base_branches_contents_path(base_path: &Path) -> Path {
     base_path.clone().join("_refs").join("branches")
 }
 
+pub fn base_clone_pins_path(base_path: &Path) -> Path {
+    base_path.clone().join("_refs").join("clones")
+}
+
 pub fn tag_path(base_path: &Path, branch: &str) -> Path {
     base_tags_path(base_path).join(format!("{}.json", branch))
 }
@@ -896,6 +1263,31 @@ pub fn tag_path(base_path: &Path, branch: &str) -> Path {
 // Note: child will encode '/' to '%2F'
 pub fn branch_contents_path(base_path: &Path, branch: &str) -> Path {
     base_branches_contents_path(base_path).join(format!("{}.json", branch))
+}
+
+pub fn clone_pin_path(base_path: &Path, pin_id: &str) -> Path {
+    base_clone_pins_path(base_path).join(format!("{}.json", pin_id))
+}
+
+pub fn base_gc_markers_path(base_path: &Path) -> Path {
+    base_path.clone().join("_refs").join("gc_markers")
+}
+
+fn encode_gc_marker_namespace(namespace: &str) -> String {
+    // Encode '%' first so a literal "%2F" in a value cannot collide with '/'.
+    namespace.replace('%', "%25").replace('/', "%2F")
+}
+
+fn gc_marker_namespace_path(base_path: &Path, namespace: &str) -> Path {
+    base_gc_markers_path(base_path).join(encode_gc_marker_namespace(namespace))
+}
+
+fn gc_marker_path(base_path: &Path, namespace: &str, marker: GcMarker) -> Path {
+    gc_marker_namespace_path(base_path, namespace).join(marker.file_name())
+}
+
+fn normalize_clone_uri(clone_uri: &str) -> String {
+    clone_uri.trim_end_matches('/').to_string()
 }
 
 pub(crate) fn normalize_branch(branch: Option<&str>) -> String {
@@ -929,6 +1321,12 @@ where
 }
 
 impl TagContents {
+    pub async fn from_path(path: &Path, object_store: &ObjectStore) -> Result<Self> {
+        from_path(path, object_store).await
+    }
+}
+
+impl ClonePin {
     pub async fn from_path(path: &Path, object_store: &ObjectStore) -> Result<Self> {
         from_path(path, object_store).await
     }
@@ -1182,6 +1580,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn gc_marker_paths_encode_percent_before_slash() {
+        let base_path = Path::from("dataset");
+        let slash = gc_marker_path(&base_path, "a/b", GcMarker::Version(1));
+        let encoded_slash = gc_marker_path(&base_path, "a%2Fb", GcMarker::Version(1));
+        assert_eq!(slash, Path::from("dataset/_refs/gc_markers/a%2Fb/1"));
+        assert_eq!(
+            encoded_slash,
+            Path::from("dataset/_refs/gc_markers/a%252Fb/1")
+        );
+        assert_ne!(slash, encoded_slash);
+    }
+
     #[tokio::test]
     async fn test_refs_from_traits() {
         // Test From<u64> for Ref
@@ -1242,6 +1653,43 @@ mod tests {
         let legacy_json = r#"{"parentBranch":"main","parentVersion":42,"createAt":1234567890,"manifestSize":1024}"#;
         let legacy_deserialized: BranchContents = serde_json::from_str(legacy_json).unwrap();
         assert!(legacy_deserialized.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_clone_pin_serialization() {
+        let pin = ClonePin {
+            id: "21b1c1b1a4f7f9f0d1e2c3b4a5968778".to_string(),
+            branch: Some("feature".to_string()),
+            branch_id: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
+            version: 7,
+            created_at: chrono::DateTime::from_timestamp(1_234_567_890, 123_000_000).unwrap(),
+            clone_uri: Some("s3://experiments/test-variant".to_string()),
+        };
+
+        let json = serde_json::to_string(&pin).unwrap();
+        assert!(json.contains("id"));
+        assert!(json.contains("branch"));
+        assert!(json.contains("branchId"));
+        assert!(json.contains("version"));
+        assert!(json.contains("createdAt"));
+        assert!(json.contains("cloneUri"));
+
+        let deserialized: ClonePin = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, pin);
+    }
+
+    #[test]
+    fn named_clone_pin_without_branch_id_fails_validation() {
+        let named = r#"{"id":"21b1c1b1a4f7f9f0d1e2c3b4a5968778","branch":"feature","version":7,"createdAt":"2009-02-13T23:31:30.123Z"}"#;
+        let named_pin: ClonePin = serde_json::from_str(named).unwrap();
+        let error = named_pin.validate().unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }), "{error:?}");
+        assert!(error.to_string().contains("branchId"), "{error}");
+
+        let main = r#"{"id":"21b1c1b1a4f7f9f0d1e2c3b4a5968778","branch":null,"version":7,"createdAt":"2009-02-13T23:31:30.123Z"}"#;
+        let main_pin: ClonePin = serde_json::from_str(main).unwrap();
+        assert!(main_pin.validate().is_ok());
+        assert_eq!(main_pin.branch_id, None);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1928,7 +1928,6 @@ async fn test_shallow_clone_stores_source_pin_id() {
     assert_eq!(pins[0].branch, None);
     assert_eq!(pins[0].clone_uri.as_deref(), Some(clone_uri.as_str()));
 
-    // A second clone gets its own pin.
     let other_uri = format!("{}/other", test_uri);
     let other = source.shallow_clone(&other_uri, 1, None).await.unwrap();
     assert_ne!(other.source_pin_id(), Some(pin_id.as_str()));
@@ -2067,7 +2066,6 @@ async fn test_shallow_clone_rejects_occupied_target_without_pin() {
         .await
         .expect_err("cloning onto an existing dataset should fail");
 
-    // Occupied targets are rejected before a source pin is written.
     let pins = source.clone_pins().list().await.unwrap();
     assert!(pins.is_empty());
 }
@@ -2099,7 +2097,6 @@ async fn test_failed_clone_commit_keeps_pin_when_outcome_is_ambiguous() {
             .unwrap()
     };
 
-    // The commit path verified no manifest landed. The unused pin is removed.
     let pin_id = create_pin().await;
     let definitive = Error::invalid_input("target validation failed");
     source
@@ -2107,7 +2104,6 @@ async fn test_failed_clone_commit_keeps_pin_when_outcome_is_ambiguous() {
         .await;
     assert!(source.clone_pins().list().await.unwrap().is_empty());
 
-    // The commit outcome could not be verified. The pin must stay.
     let pin_id = create_pin().await;
     let unknown = Error::commit_status_unknown_source(1, "response lost".to_string().into());
     source
@@ -2115,7 +2111,6 @@ async fn test_failed_clone_commit_keeps_pin_when_outcome_is_ambiguous() {
         .await;
     assert_eq!(source.clone_pins().list().await.unwrap().len(), 1);
 
-    // A cancelled commit future may still land server side. The pin must stay.
     let timed_out = Error::timeout("commit timed out");
     source
         .cleanup_pin_after_failed_clone_commit(&pin_id, &timed_out)
@@ -2139,7 +2134,6 @@ async fn resolve_shallow_clone_source_matches_resolve_reference() {
     )
     .await
     .unwrap();
-    // Second main version so "latest" differs from version 1.
     Dataset::write(
         gen_batch()
             .col("index", array::step_custom::<Int32Type>(10, 1))
@@ -2197,17 +2191,11 @@ async fn resolve_shallow_clone_source_matches_resolve_reference() {
         );
     }
 
-    // Numeric version on main.
     assert_parity(&source, Ref::VersionNumber(1)).await;
-    // Numeric version on an opened branch.
     assert_parity(&dev, Ref::VersionNumber(1)).await;
-    // Explicit branch and version.
     assert_parity(&source, Ref::Version(Some("dev".to_string()), Some(1))).await;
-    // Explicit branch with latest version.
     assert_parity(&source, Ref::Version(Some("dev".to_string()), None)).await;
-    // Tag on main.
     assert_parity(&source, Ref::Tag("main_tag".to_string())).await;
-    // Tag on a named branch.
     assert_parity(&source, Ref::Tag("dev_tag".to_string())).await;
 }
 

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1905,6 +1905,367 @@ async fn test_shallow_clone_multiple_times(
     validate_dataset(&original, 36, 1, 0).await;
 }
 
+#[tokio::test]
+async fn test_shallow_clone_stores_source_pin_id() {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let clone_uri = format!("{}/clone", test_uri);
+    let clone = source.shallow_clone(&clone_uri, 1, None).await.unwrap();
+
+    let pin_id = clone.source_pin_id().unwrap().to_string();
+    let pins = source.clone_pins().list().await.unwrap();
+    assert_eq!(pins.len(), 1);
+    assert_eq!(pins[0].id, pin_id);
+    assert_eq!(pins[0].version, 1);
+    assert_eq!(pins[0].branch, None);
+    assert_eq!(pins[0].clone_uri.as_deref(), Some(clone_uri.as_str()));
+
+    // A second clone gets its own pin.
+    let other_uri = format!("{}/other", test_uri);
+    let other = source.shallow_clone(&other_uri, 1, None).await.unwrap();
+    assert_ne!(other.source_pin_id(), Some(pin_id.as_str()));
+    assert_eq!(source.clone_pins().list().await.unwrap().len(), 2);
+
+    source.clone_pins().unregister(&pin_id).await.unwrap();
+    assert_eq!(source.clone_pins().list().await.unwrap().len(), 1);
+
+    let error = source.clone_pins().unregister(&pin_id).await.unwrap_err();
+    assert!(matches!(error, Error::RefNotFound { .. }), "{:?}", error);
+}
+
+#[tokio::test]
+async fn test_source_pin_id_survives_clone_update() {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let clone_uri = format!("{}/clone", test_uri);
+    let mut clone = source.shallow_clone(&clone_uri, 1, None).await.unwrap();
+    let pin_id = clone.source_pin_id().unwrap().to_string();
+
+    let append = gen_batch().col("index", array::step::<Int32Type>());
+    clone = Dataset::write(
+        append.into_reader_rows(RowCount::from(5), BatchCount::from(1)),
+        &clone_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(clone.source_pin_id(), Some(pin_id.as_str()));
+
+    let overwrite = gen_batch().col("index", array::step::<Int32Type>());
+    Dataset::write(
+        overwrite.into_reader_rows(RowCount::from(3), BatchCount::from(1)),
+        &clone_uri,
+        Some(WriteParams {
+            mode: WriteMode::Overwrite,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let reopened = Dataset::open(&clone_uri).await.unwrap();
+    assert_eq!(reopened.source_pin_id(), Some(pin_id.as_str()));
+}
+
+#[tokio::test]
+async fn test_shallow_clone_require_tag_skips_source_pin() {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+    source.tags().create("v1", 1).await.unwrap();
+
+    let clone_uri = format!("{}/tagged_clone", test_uri);
+    let clone = source
+        .shallow_clone_with_retention(
+            &clone_uri,
+            1,
+            None,
+            crate::dataset::ShallowCloneRetention::RequireTag,
+        )
+        .await
+        .unwrap();
+
+    assert!(clone.source_pin_id().is_none());
+    assert!(source.clone_pins().list().await.unwrap().is_empty());
+    assert_eq!(clone.count_rows(None).await.unwrap(), 10);
+}
+
+#[tokio::test]
+async fn test_shallow_clone_require_tag_rejects_untagged_version() {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let error = source
+        .shallow_clone_with_retention(
+            &format!("{}/untagged_clone", test_uri),
+            1,
+            None,
+            crate::dataset::ShallowCloneRetention::RequireTag,
+        )
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("needs a tag"));
+    assert!(source.clone_pins().list().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_shallow_clone_rejects_occupied_target_without_pin() {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let occupied_uri = format!("{}/occupied", test_uri);
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    Dataset::write(
+        data.into_reader_rows(RowCount::from(5), BatchCount::from(1)),
+        &occupied_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    source
+        .shallow_clone(&occupied_uri, 1, None)
+        .await
+        .expect_err("cloning onto an existing dataset should fail");
+
+    // Occupied targets are rejected before a source pin is written.
+    let pins = source.clone_pins().list().await.unwrap();
+    assert!(pins.is_empty());
+}
+
+#[tokio::test]
+async fn test_failed_clone_commit_keeps_pin_when_outcome_is_ambiguous() {
+    use crate::dataset::refs::BranchIdentifier;
+
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let create_pin = || async {
+        source
+            .clone_pins()
+            .create_pin(
+                None,
+                &BranchIdentifier::main(),
+                1,
+                Some("memory://unused_clone"),
+            )
+            .await
+            .unwrap()
+    };
+
+    // The commit path verified no manifest landed. The unused pin is removed.
+    let pin_id = create_pin().await;
+    let definitive = Error::invalid_input("target validation failed");
+    source
+        .cleanup_pin_after_failed_clone_commit(&pin_id, &definitive)
+        .await;
+    assert!(source.clone_pins().list().await.unwrap().is_empty());
+
+    // The commit outcome could not be verified. The pin must stay.
+    let pin_id = create_pin().await;
+    let unknown = Error::commit_status_unknown_source(1, "response lost".to_string().into());
+    source
+        .cleanup_pin_after_failed_clone_commit(&pin_id, &unknown)
+        .await;
+    assert_eq!(source.clone_pins().list().await.unwrap().len(), 1);
+
+    // A cancelled commit future may still land server side. The pin must stay.
+    let timed_out = Error::timeout("commit timed out");
+    source
+        .cleanup_pin_after_failed_clone_commit(&pin_id, &timed_out)
+        .await;
+    assert_eq!(source.clone_pins().list().await.unwrap().len(), 1);
+
+    source.clone_pins().unregister(&pin_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn resolve_shallow_clone_source_matches_resolve_reference() {
+    use crate::dataset::refs::Ref;
+    use crate::dataset::write::{WriteMode, WriteParams};
+
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+    // Second main version so "latest" differs from version 1.
+    Dataset::write(
+        gen_batch()
+            .col("index", array::step_custom::<Int32Type>(10, 1))
+            .into_reader_rows(RowCount::from(5), BatchCount::from(1)),
+        &test_uri,
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    source.checkout_latest().await.unwrap();
+
+    let mut dev = source.create_branch("dev", 1, None).await.unwrap();
+    Dataset::write(
+        gen_batch()
+            .col("index", array::step_custom::<Int32Type>(100, 1))
+            .into_reader_rows(RowCount::from(3), BatchCount::from(1)),
+        dev.uri(),
+        Some(WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    dev.checkout_latest().await.unwrap();
+
+    source.tags().create("main_tag", 1).await.unwrap();
+    source.tags().create("dev_tag", ("dev", 2)).await.unwrap();
+
+    async fn assert_parity(dataset: &Dataset, reference: Ref) {
+        let (ref_name, version) = dataset.resolve_reference(reference.clone()).await.unwrap();
+        let source = dataset
+            .resolve_shallow_clone_source(reference)
+            .await
+            .unwrap();
+        assert_eq!(source.ref_name, ref_name);
+        assert_eq!(source.version, version);
+        assert_eq!(
+            source.identifier,
+            dataset
+                .branches()
+                .get_identifier(ref_name.as_deref())
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            source.location,
+            dataset
+                .branch_location()
+                .find_branch(ref_name.as_deref())
+                .unwrap()
+        );
+    }
+
+    // Numeric version on main.
+    assert_parity(&source, Ref::VersionNumber(1)).await;
+    // Numeric version on an opened branch.
+    assert_parity(&dev, Ref::VersionNumber(1)).await;
+    // Explicit branch and version.
+    assert_parity(&source, Ref::Version(Some("dev".to_string()), Some(1))).await;
+    // Explicit branch with latest version.
+    assert_parity(&source, Ref::Version(Some("dev".to_string()), None)).await;
+    // Tag on main.
+    assert_parity(&source, Ref::Tag("main_tag".to_string())).await;
+    // Tag on a named branch.
+    assert_parity(&source, Ref::Tag("dev_tag".to_string())).await;
+}
+
+#[tokio::test]
+async fn clone_commit_rejects_recreated_source_branch() {
+    use crate::dataset::transaction::{Operation, Transaction};
+    use crate::dataset::write::CommitBuilder;
+
+    let test_uri = TempStrDir::default();
+    let data = gen_batch().col("index", array::step::<Int32Type>());
+    let mut source = Dataset::write(
+        data.into_reader_rows(RowCount::from(10), BatchCount::from(1)),
+        &test_uri,
+        None,
+    )
+    .await
+    .unwrap();
+    let branch = source.create_branch("dev", 1, None).await.unwrap();
+    let old_branch_id = source
+        .branches()
+        .get_identifier(Some("dev"))
+        .await
+        .unwrap()
+        .branch_id()
+        .unwrap()
+        .to_string();
+    let branch_uri = branch.uri().to_string();
+    let branch_version = branch.version().version;
+
+    source.delete_branch("dev").await.unwrap();
+    source.create_branch("dev", 1, None).await.unwrap();
+
+    let clone_uri = format!("{}/stale_branch_clone", test_uri.as_str());
+    let error = CommitBuilder::new(WriteDestination::Uri(&clone_uri))
+        .with_object_store(Arc::new(source.object_store.as_ref().clone()))
+        .with_commit_handler(source.commit_handler.clone())
+        .execute(Transaction::new(
+            branch_version,
+            Operation::Clone {
+                is_shallow: true,
+                ref_name: Some("dev".to_string()),
+                ref_version: branch_version,
+                ref_path: branch_uri,
+                branch_name: None,
+                source_pin_id: None,
+                source_branch_id: Some(old_branch_id),
+            },
+            None,
+        ))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, Error::RefConflict { .. }),
+        "expected RefConflict for stale source_branch_id, got {:?}",
+        error
+    );
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_self_dataset_append(

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -469,6 +469,15 @@ pub enum Operation {
         ref_version: u64,
         ref_path: String,
         branch_name: Option<String>,
+        /// Source pin id for a cross-dataset shallow clone. Absent for branches and deep clones.
+        source_pin_id: Option<String>,
+        /// Leaf UUID of the source branch incarnation used by this clone operation.
+        ///
+        /// Set for shallow clones, deep clones, and in-dataset branch creation, all of
+        /// which read a source branch during commit. The commit path verifies it after
+        /// its source reads and refuses the commit on a mismatch. Absent for main and
+        /// for older transactions.
+        source_branch_id: Option<String>,
     },
 
     // Update base paths in the dataset (currently only supports adding new bases).
@@ -558,6 +567,8 @@ impl PartialEq for Operation {
                     ref_version: a_ref_version,
                     ref_path: a_source_path,
                     branch_name: a_branch_name,
+                    source_pin_id: a_source_pin_id,
+                    source_branch_id: a_source_branch_id,
                 },
                 Self::Clone {
                     is_shallow: b_is_shallow,
@@ -565,6 +576,8 @@ impl PartialEq for Operation {
                     ref_version: b_ref_version,
                     ref_path: b_source_path,
                     branch_name: b_branch_name,
+                    source_pin_id: b_source_pin_id,
+                    source_branch_id: b_source_branch_id,
                 },
             ) => {
                 a_is_shallow == b_is_shallow
@@ -572,6 +585,8 @@ impl PartialEq for Operation {
                     && a_ref_version == b_ref_version
                     && a_source_path == b_source_path
                     && a_branch_name == b_branch_name
+                    && a_source_pin_id == b_source_pin_id
+                    && a_source_branch_id == b_source_branch_id
             }
             (
                 Self::Delete {
@@ -3334,12 +3349,16 @@ impl TryFrom<pb::Transaction> for Transaction {
                 ref_version,
                 ref_path,
                 branch_name,
+                source_pin_id,
+                source_branch_id,
             })) => Operation::Clone {
                 is_shallow,
                 ref_name,
                 ref_version,
                 ref_path,
                 branch_name,
+                source_pin_id,
+                source_branch_id,
             },
             Some(pb::transaction::Operation::Delete(pb::transaction::Delete {
                 updated_fragments,
@@ -3707,12 +3726,16 @@ impl From<&Transaction> for pb::Transaction {
                 ref_version,
                 ref_path,
                 branch_name,
+                source_pin_id,
+                source_branch_id,
             } => pb::transaction::Operation::Clone(pb::transaction::Clone {
                 is_shallow: *is_shallow,
                 ref_name: ref_name.clone(),
                 ref_version: *ref_version,
                 ref_path: ref_path.clone(),
                 branch_name: branch_name.clone(),
+                source_pin_id: source_pin_id.clone(),
+                source_branch_id: source_branch_id.clone(),
             }),
             Operation::Delete {
                 updated_fragments,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -341,12 +341,11 @@ pub(crate) async fn write_transaction_file(
 /// `source_branch_id` is the leaf UUID captured when the clone transaction was built.
 /// Absent means main, or an older transaction that did not record the incarnation.
 ///
-/// Call this AFTER every read from the source, not before. A recreated branch reuses
-/// the same manifest paths, so a check before the reads leaves a window where the reads
-/// hit the recreated branch. `Branches::delete` removes the branch contents file
-/// before any branch data is touched, and recreation writes a fresh leaf UUID, so the
-/// expected UUID still being present after the reads proves every read was served by
-/// the expected incarnation.
+/// Call this after every source read completes. A recreated branch reuses the same
+/// manifest paths. Checking before the reads leaves a window where those reads hit the
+/// new incarnation. `Branches::delete` removes the branch contents file before touching
+/// branch data, and recreation writes a fresh leaf UUID. The expected UUID still present
+/// after the reads proves they were served by that incarnation.
 async fn verify_clone_source_branch_incarnation(
     source_store: &ObjectStore,
     source_base_path: &Path,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -44,8 +44,10 @@ use rand::{Rng, rng};
 
 use super::ObjectStore;
 use crate::Dataset;
+use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::cleanup::auto_cleanup_hook;
 use crate::dataset::fragment::FileFragment;
+use crate::dataset::refs::{BranchContents, SOURCE_PIN_ID_CONFIG_KEY, branch_contents_path};
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{
     ManifestWriteConfig, NewTransactionResult, TRANSACTIONS_DIR, load_new_transactions,
@@ -334,6 +336,59 @@ pub(crate) async fn write_transaction_file(
     Ok(file_name)
 }
 
+/// Refuse a clone when the source branch was deleted or recreated after resolution.
+///
+/// `source_branch_id` is the leaf UUID captured when the clone transaction was built.
+/// Absent means main, or an older transaction that did not record the incarnation.
+///
+/// Call this AFTER every read from the source, not before. A recreated branch reuses
+/// the same manifest paths, so a check before the reads leaves a window where the reads
+/// hit the recreated branch. `Branches::delete` removes the branch contents file
+/// before any branch data is touched, and recreation writes a fresh leaf UUID, so the
+/// expected UUID still being present after the reads proves every read was served by
+/// the expected incarnation.
+async fn verify_clone_source_branch_incarnation(
+    source_store: &ObjectStore,
+    source_base_path: &Path,
+    ref_path: &str,
+    ref_name: &Option<String>,
+    source_branch_id: &Option<String>,
+) -> Result<()> {
+    let Some(expected) = source_branch_id.as_deref() else {
+        return Ok(());
+    };
+    let Some(branch_name) = ref_name.as_deref() else {
+        return Err(Error::RefConflict {
+            message: "clone source_branch_id set but source has no branch name".to_string(),
+        });
+    };
+    let location = BranchLocation {
+        path: source_base_path.clone(),
+        uri: ref_path.to_string(),
+        branch: Some(branch_name.to_string()),
+    };
+    let root = location.find_main()?;
+    let branch_file = branch_contents_path(&root.path, branch_name);
+    if !source_store.exists(&branch_file).await? {
+        return Err(Error::RefConflict {
+            message: format!(
+                "branch {} was deleted or recreated during clone",
+                branch_name
+            ),
+        });
+    }
+    let contents = BranchContents::from_path(&branch_file, source_store, branch_name).await?;
+    if contents.identifier.branch_id() != Some(expected) {
+        return Err(Error::RefConflict {
+            message: format!(
+                "branch {} was deleted or recreated during clone",
+                branch_name
+            ),
+        });
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn do_commit_new_dataset(
     object_store: &ObjectStore,
@@ -358,6 +413,8 @@ async fn do_commit_new_dataset(
         ref_version,
         ref_path,
         branch_name,
+        source_pin_id,
+        source_branch_id,
         ..
     } = &transaction.operation
     {
@@ -378,20 +435,25 @@ async fn do_commit_new_dataset(
         )
         .await?;
 
-        if *is_shallow {
+        let manifest_and_indices = if *is_shallow {
             let new_base_id = source_manifest
                 .base_paths
                 .keys()
                 .max()
                 .map(|id| *id + 1)
                 .unwrap_or(0);
-            let new_manifest = source_manifest.shallow_clone(
+            let mut new_manifest = source_manifest.shallow_clone(
                 ref_name.clone(),
                 ref_path.clone(),
                 new_base_id,
                 branch_name.clone(),
                 transaction_file.clone(),
             );
+            if let Some(pin_id) = source_pin_id {
+                new_manifest
+                    .config
+                    .insert(SOURCE_PIN_ID_CONFIG_KEY.to_string(), pin_id.clone());
+            }
 
             let updated_indices = if let Some(index_section_pos) = source_manifest.index_section {
                 let reader = source_store.open(&source_manifest_location.path).await?;
@@ -447,7 +509,20 @@ async fn do_commit_new_dataset(
                     .collect::<Result<Vec<_>>>()?;
             }
             (new_manifest, updated_indices)
-        }
+        };
+
+        // Every source read is done. Verify the source branch still maps to the
+        // incarnation captured at resolution before committing a manifest built
+        // from those reads.
+        verify_clone_source_branch_incarnation(
+            source_store,
+            &source_base_path,
+            ref_path,
+            ref_name,
+            source_branch_id,
+        )
+        .await?;
+        manifest_and_indices
     } else {
         let (manifest, indices) =
             transaction.build_manifest(None, vec![], &transaction_file, write_config)?;


### PR DESCRIPTION
Fixes [#7514](https://github.com/lance-format/lance/issues/7514).

If you shallow-clone dataset A into dataset B, then run `cleanup_old_versions` on A, B can lose the files it still reads through `base_paths`. Same class of bug as Delta's VACUUM-on-shallow-clone-source.

Weston called this out on the issue, where the source doesn't know about external clones. The proposed "drop the URI guard and walk all `base_paths`" path also doesn't fix it, because the clone never shows up in `branches()`. Cleanup can't retain what it can't see.

So this PR registers the clone on the source.

## Fix

`shallow_clone` writes a pin under `_refs/clones/` and stores the pin id on the clone as `lance.clone.source_pin_id`. Cleanup keeps pinned versions the same way it keeps tagged ones.

There's also a race if cleanup and clone run at the same time. Cleanup writes a permanent marker under `_refs/gc_markers/<branch_incarnation>/<version>` before it deletes. Clones check that marker and bail if the version is already marked. Pins and markers use the branch leaf UUID, so deleting and recreating `dev` doesn't pick up the old pins.

If the source is read-only, use `retention="require_tag"` and keep Weston's tag workaround. Older clones with no pin are still unprotected.

```python
source.clone_pins.unregister(clone.source_pin_id)
```

## Testing

- Cleanup keeps shallow-clone files, reclaims after pin removal
- Marker/pin races and marked-version rejection
- Branch delete/recreate doesn't inherit pins or markers
- `require_tag` path
- Stale `source_branch_id` rejected at commit
