### PR TITLE
fix(ci): run full-fragment merge_insert benchmarks on v2 only

### DIFF
--- a/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
+++ b/python/python/ci_benchmarks/benchmarks/test_merge_insert.py
@@ -367,6 +367,11 @@ def test_upsert_unindexed_baseline(benchmark, narrow: Target, num_rows: int) -> 
 ROW_FRACTIONS = [0.001, 0.01, 0.1, 1.0]
 FRACTION_IDS = ["0.1pct", "1pct", "10pct", "100pct"]
 
+# The projection sweeps only need the two ends of that range: one fraction where
+# the updater interleaves and one where it rewrites whole column files.
+PROJECTION_FRACTIONS = [0.01, 1.0]
+PROJECTION_FRACTION_IDS = ["1pct", "100pct"]
+
 # Isolates the two pressures a partial-column update can exert: field count
 # (scalar columns, cheap per field) and byte volume (the vector column).
 PROJECTIONS = {
@@ -381,6 +386,24 @@ def _wide_rounds(fraction: float) -> int:
     # A full-fragment update rewrites every column file it touches, which for
     # the vector column is ~1 GB per round.
     return 1 if fraction == 1.0 else 3
+
+
+def wide_plan_cases(fractions: Sequence[float], ids: Sequence[str]):
+    """``(fraction, plan)`` cases, minus the ones v1 cannot execute.
+
+    At ``fraction == 1.0`` the source covers every row of the target, and the
+    legacy path builds its hash join on the source side: it asks for the whole
+    source at once -- ~1 GB once the 256-dim vector column is projected --
+    against a 150 MiB pool, and fails with "Resources exhausted". That is the
+    same limitation that keeps ``test_upsert_source_equals_target`` v2-only, so
+    the full-fragment shapes report a v2 number only. The 10pct fraction still
+    gives a v1-vs-v2 write-amplification comparison at fragment scale.
+    """
+    return [
+        pytest.param(fraction, plan, id=f"{fraction_id}-{plan}")
+        for fraction, fraction_id in zip(fractions, ids)
+        for plan in (["v2_hash"] if fraction == 1.0 else PLANS)
+    ]
 
 
 def update_subset(
@@ -399,8 +422,7 @@ def update_subset(
     return job
 
 
-@pytest.mark.parametrize("plan", PLANS)
-@pytest.mark.parametrize("fraction", ROW_FRACTIONS, ids=FRACTION_IDS)
+@pytest.mark.parametrize("fraction,plan", wide_plan_cases(ROW_FRACTIONS, FRACTION_IDS))
 def test_update_subset_row_fraction(
     benchmark, wide: Target, fraction: float, plan: str
 ) -> None:
@@ -420,8 +442,9 @@ def test_update_subset_row_fraction(
     )
 
 
-@pytest.mark.parametrize("plan", PLANS)
-@pytest.mark.parametrize("fraction", [0.01, 1.0], ids=["1pct", "100pct"])
+@pytest.mark.parametrize(
+    "fraction,plan", wide_plan_cases(PROJECTION_FRACTIONS, PROJECTION_FRACTION_IDS)
+)
 @pytest.mark.parametrize("projection", list(PROJECTIONS), ids=list(PROJECTIONS))
 def test_update_subset_projection(
     benchmark, wide: Target, projection: str, fraction: float, plan: str
@@ -438,8 +461,9 @@ def test_update_subset_projection(
     )
 
 
-@pytest.mark.parametrize("plan", PLANS)
-@pytest.mark.parametrize("fraction", [0.01, 1.0], ids=["1pct", "100pct"])
+@pytest.mark.parametrize(
+    "fraction,plan", wide_plan_cases(PROJECTION_FRACTIONS, PROJECTION_FRACTION_IDS)
+)
 def test_upsert_wide_full_schema(
     benchmark, wide: Target, fraction: float, plan: str
 ) -> None:
@@ -714,8 +738,7 @@ def test_io_mem_upsert_ratio(
 
 
 @pytest.mark.io_memory_benchmark()
-@pytest.mark.parametrize("plan", PLANS)
-@pytest.mark.parametrize("fraction", ROW_FRACTIONS, ids=FRACTION_IDS)
+@pytest.mark.parametrize("fraction,plan", wide_plan_cases(ROW_FRACTIONS, FRACTION_IDS))
 def test_io_mem_update_subset_row_fraction(
     io_mem_benchmark, wide: Target, fraction: float, plan: str
 ) -> None:


### PR DESCRIPTION
The `Run Regression Benchmarks` job has failed on every push to `main` since the merge_insert benchmark suite landed in #8052. Seven cases fail with `Resources exhausted`, all of them the `100pct-v1_indexed` shapes against the wide target.

`merge_insert` has two execution paths, and the wide benchmarks are parametrized on both. The legacy indexed path builds its hash join on the source side, so at the `100pct` row fraction — where the source covers all 1M rows of the wide target — it asks for the entire source at once. That is 137 MB for a single scalar column and about 1.3 GB once the 256-dim vector column is projected, against a 150 MB pool, so the operation cannot run at all.

This is a known limitation rather than a new one: #8052 described it and already kept `test_upsert_source_equals_target` on the v2 path for exactly this reason. It was missed for the wide benchmarks because they were verified locally against a scaled-down 20K-row target, where a full-fraction source still fits in the pool.

This PR applies the same exclusion to the wide sweeps, so full-fragment shapes report a v2 number only. The `10pct` fraction still gives a v1-vs-v2 write-amplification comparison at fragment scale, which is what the write-path group is there to measure.

Every retained case keeps the test id it has today, so the benchmark history in Bencher stays continuous rather than restarting under new names.

## Not included

Teaching the legacy indexed path to handle a source the size of its target. Its source-side hash join, and the unbounded replay buffer that feeds it, would both need to change; that is a performance change to a legacy path rather than a CI fix.

## Testing

`.github/workflows/ci-benchmarks.yml` runs only on `workflow_dispatch` and on push to `main`, so PR CI does not exercise any of this. Verified locally instead that the collected case set drops exactly the seven failing `100pct-v1_indexed` cases and that every remaining case keeps a byte-identical test id.
