### PR TITLE
fix: remove duplicate LanceFileVersion import in lance-file tests

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -2448,7 +2448,6 @@ mod tests {
         },
         encoder::{EncodedBatch, EncodingOptions, encode_batch},
         format::pb21,
-        version::LanceFileVersion,
     };
     use lance_io::{stream::RecordBatchStream, utils::CachedFileSize};
     use log::debug;


### PR DESCRIPTION
Every Rust CI job on `main` has failed since a2d3047e4 (#8227) with a duplicate-import error:

```
error[E0252]: the name `LanceFileVersion` is defined multiple times
    --> rust/lance-file/src/reader.rs:2462:47
```

`lance-file`'s own `crate::version` module re-exports `LanceFileVersion` from `lance_encoding::version`, and the reader's test module already imported it from there alongside `ConcreteFileVersion`. #8227 added a second import of the same type directly from `lance_encoding::version`, so the test module no longer compiles. Because it is a `#[cfg(test)]` module, a plain build is unaffected and only the test-compiling jobs break — which is all of them, including clippy, where the accompanying unused-import warning is promoted to an error by `-D warnings`.

This PR drops the added import and keeps the crate-local one.
