### PR TITLE
fix(mem-wal): reject stale SSTable compaction progress

### DIFF
--- a/java/src/main/java/org/lance/merge/MergeInsertParams.java
+++ b/java/src/main/java/org/lance/merge/MergeInsertParams.java
@@ -248,7 +248,13 @@ public class MergeInsertParams {
    * Mark MemWAL SSTables as compacted into the base table.
    *
    * <p>Use this when merge insert compacts MemWAL SSTables. It updates MemWAL compaction progress
-   * to prevent the same SSTables from being compacted again.
+   * to prevent the same SSTables from being compacted again, in the same commit as the data.
+   *
+   * <p><b>For multi-pass compaction, call this only on the final successful data-changing pass.</b>
+   * Intermediate passes must not carry compaction progress. Lance cannot tell whether a caller has
+   * another pass planned, so it cannot enforce this: if a delete pass carried the marker and the
+   * process then died before the matching upsert, the recorded progress would claim rows were
+   * copied in that never were.
    *
    * @param sstables the SSTables being compacted
    * @return This MergeInsertParams instance

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -750,6 +750,14 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         """Mark MemWAL SSTables as compacted into the base table.
 
         Call this before executing merge_insert when it compacts MemWAL SSTables.
+        The progress is recorded in the same commit as the data.
+
+        For multi-pass compaction, call this only on the final successful
+        data-changing pass. Intermediate passes must not carry compaction
+        progress. Lance cannot tell whether a caller has another pass planned,
+        so it cannot enforce this: if a delete pass carried the marker and the
+        process then died before the matching upsert, the recorded progress
+        would claim rows were copied in that never were.
 
         Parameters
         ----------

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -668,6 +668,13 @@ impl MergeInsertBuilder {
     ///
     /// This updates `compacted_sstables` in the MemWAL index atomically with
     /// the data commit.
+    ///
+    /// **For multi-pass compaction, call this only on the final successful
+    /// data-changing pass.** Intermediate passes must not carry compaction
+    /// progress. Lance cannot tell whether a caller has another pass planned,
+    /// so it cannot enforce this: if a delete pass carried the marker and the
+    /// process then died before the matching upsert, the recorded generation
+    /// would claim rows were copied in that never were.
     pub fn mark_sstables_as_compacted(&mut self, sstables: Vec<CompactedSsTable>) -> &mut Self {
         self.params.compacted_sstables.extend(sstables);
         self

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -13,6 +13,7 @@
 //! - Load the MemWAL index
 //! - Update compacted SSTables (called during merge-insert commits)
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use lance_core::{Error, Result};
@@ -47,10 +48,19 @@ pub(crate) fn open_mem_wal_index(index: IndexMetadata) -> Result<Arc<MemWalIndex
 
 /// Update `compacted_sstables` in the MemWAL index.
 ///
-/// This is called during merge-insert commits to atomically record which
-/// SSTables have been compacted into the base table.
+/// Called from the final data-changing merge-insert commit for a compaction
+/// target, so the rows and the generation that describes them publish
+/// together.
+///
+/// A proposed generation must be **strictly greater** than the one the latest
+/// state records for that shard, and a stale one fails the whole transaction.
+/// Accepting it while keeping the larger marker would publish that worker's row
+/// mutations under a generation it did not produce, and anything reading only
+/// the marker could then stop serving SSTables whose rows were never inserted.
+///
+/// Every other `MemWalIndexDetails` field is carried through untouched.
 pub(crate) fn update_mem_wal_index_compacted_sstables(
-    indices: &mut Vec<IndexMetadata>,
+    indices: &mut [IndexMetadata],
     dataset_version: u64,
     new_compacted_sstables: Vec<CompactedSsTable>,
 ) -> Result<()> {
@@ -58,44 +68,64 @@ pub(crate) fn update_mem_wal_index_compacted_sstables(
         return Ok(());
     }
 
+    let mut seen_shards = HashSet::with_capacity(new_compacted_sstables.len());
+    for sstable in &new_compacted_sstables {
+        if !seen_shards.insert(sstable.shard_id) {
+            return Err(Error::invalid_input(format!(
+                "Duplicate shard {} in one SSTable compaction update; each shard \
+                 may advance at most once per transaction",
+                sstable.shard_id
+            )));
+        }
+    }
+
+    // Default details would describe a table with no MemWAL shards at all, so
+    // the recorded generation would name a shard nothing can corroborate.
+    // Refuse instead of inventing metadata.
     let pos = indices
         .iter()
-        .position(|idx| idx.name == MEM_WAL_INDEX_NAME);
+        .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
+        .ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Cannot record SSTable compaction progress: the {} system index \
+                 does not exist on this table",
+                MEM_WAL_INDEX_NAME
+            ))
+        })?;
 
-    let new_meta = if let Some(pos) = pos {
-        let current_meta = indices.remove(pos);
-        let mut details = load_mem_wal_index_details(current_meta)?;
+    // Validated against a copy so a rejected update leaves `indices` exactly as
+    // the caller passed it.
+    let mut details = load_mem_wal_index_details(indices[pos].clone())?;
 
-        // Update compacted_sstables - for each shard, keep the higher generation
-        for new_sstable in new_compacted_sstables {
-            if let Some(existing) = details
-                .compacted_sstables
-                .iter_mut()
-                .find(|sstable| sstable.shard_id == new_sstable.shard_id)
-            {
-                if new_sstable.generation > existing.generation {
-                    existing.generation = new_sstable.generation;
-                }
-            } else {
-                details.compacted_sstables.push(new_sstable);
+    for new_sstable in new_compacted_sstables {
+        match details
+            .compacted_sstables
+            .iter_mut()
+            .find(|sstable| sstable.shard_id == new_sstable.shard_id)
+        {
+            Some(existing) if new_sstable.generation <= existing.generation => {
+                return Err(Error::invalid_input(format!(
+                    "Stale SSTable compaction for shard {}: proposed generation {} \
+                     is not greater than the recorded generation {}",
+                    new_sstable.shard_id, new_sstable.generation, existing.generation
+                )));
             }
+            Some(existing) => existing.generation = new_sstable.generation,
+            None => details.compacted_sstables.push(new_sstable),
         }
+    }
 
-        new_mem_wal_index_meta(dataset_version, details)?
-    } else {
-        // Create a MemWAL index containing only compaction progress.
-        let details = MemWalIndexDetails {
-            compacted_sstables: new_compacted_sstables,
-            ..Default::default()
-        };
-        new_mem_wal_index_meta(dataset_version, details)?
-    };
-
-    indices.push(new_meta);
+    // Replaced in place so the index list keeps its order.
+    indices[pos] = new_mem_wal_index_meta(dataset_version, details)?;
     Ok(())
 }
 
 /// Create a new MemWAL index metadata entry.
+///
+/// A fresh UUID is minted on every rewrite, including metadata-only updates.
+/// The decoded-details cache is keyed on that UUID, so the change of identity
+/// is what invalidates it; holding the UUID steady would leave a warmed reader
+/// answering with the state from before the update.
 pub(crate) fn new_mem_wal_index_meta(
     dataset_version: u64,
     details: MemWalIndexDetails,
@@ -121,6 +151,7 @@ pub(crate) fn new_mem_wal_index_meta(
 mod tests {
     use super::*;
 
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::index::DatasetIndexExt;
@@ -153,11 +184,34 @@ mod tests {
             .unwrap()
     }
 
+    /// A dataset with `__lance_mem_wal` already installed, as MemWAL
+    /// initialization leaves it. Recording compaction progress requires the
+    /// system index to exist, so any test that commits progress needs this
+    /// rather than a bare [`test_dataset`].
+    async fn test_dataset_with_mem_wal() -> crate::Dataset {
+        let dataset = test_dataset().await;
+        let mem_wal_index =
+            new_mem_wal_index_meta(dataset.manifest.version, MemWalIndexDetails::default())
+                .unwrap();
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![mem_wal_index],
+                removed_indices: vec![],
+            },
+            None,
+        );
+        CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap()
+    }
+
     /// Test that UpdateMemWalState with lower generation than committed fails without retry.
     /// Per spec: If committed_generation >= to_commit_generation, abort without retry.
     #[tokio::test]
     async fn test_update_mem_wal_state_conflict_lower_generation_no_retry() {
-        let dataset = test_dataset().await;
+        let dataset = test_dataset_with_mem_wal().await;
         let shard = Uuid::new_v4();
 
         // First commit UpdateMemWalState with generation 10
@@ -194,7 +248,7 @@ mod tests {
     /// Test that UpdateMemWalState with equal generation as committed fails without retry.
     #[tokio::test]
     async fn test_update_mem_wal_state_conflict_equal_generation_no_retry() {
-        let dataset = test_dataset().await;
+        let dataset = test_dataset_with_mem_wal().await;
         let shard = Uuid::new_v4();
 
         // First commit UpdateMemWalState with generation 10
@@ -231,7 +285,7 @@ mod tests {
     /// Per spec: If committed_generation < to_commit_generation, retry is allowed.
     #[tokio::test]
     async fn test_update_mem_wal_state_conflict_higher_generation_retryable() {
-        let dataset = test_dataset().await;
+        let dataset = test_dataset_with_mem_wal().await;
         let shard = Uuid::new_v4();
 
         // First commit UpdateMemWalState with generation 5
@@ -268,7 +322,7 @@ mod tests {
     /// Test that UpdateMemWalState on different shards don't conflict.
     #[tokio::test]
     async fn test_update_mem_wal_state_different_shards_no_conflict() {
-        let dataset = test_dataset().await;
+        let dataset = test_dataset_with_mem_wal().await;
         let shard1 = Uuid::new_v4();
         let shard2 = Uuid::new_v4();
 
@@ -320,7 +374,7 @@ mod tests {
     /// The compacted_sstables from UpdateMemWalState should be included in CreateIndex.
     #[tokio::test]
     async fn test_create_index_rebase_against_update_mem_wal_state() {
-        let dataset = test_dataset().await;
+        let dataset = test_dataset_with_mem_wal().await;
         let shard = Uuid::new_v4();
 
         // First commit UpdateMemWalState with generation 10
@@ -420,73 +474,295 @@ mod tests {
         );
     }
 
+    /// One `__lance_mem_wal` entry carrying `details`, as a real table has.
+    fn indices_with(details: MemWalIndexDetails) -> Vec<IndexMetadata> {
+        vec![new_mem_wal_index_meta(1, details).unwrap()]
+    }
+
+    fn compacted_generation(indices: &[IndexMetadata], shard: Uuid) -> Option<u64> {
+        load_mem_wal_index_details(indices[0].clone())
+            .unwrap()
+            .compacted_sstables
+            .iter()
+            .find(|sstable| sstable.shard_id == shard)
+            .map(|sstable| sstable.generation)
+    }
+
     #[test]
     fn test_update_compacted_sstables() {
-        let mut indices = Vec::new();
         let shard1 = Uuid::new_v4();
         let shard2 = Uuid::new_v4();
+        let mut indices = indices_with(MemWalIndexDetails::default());
 
-        // First update - creates new index
         update_mem_wal_index_compacted_sstables(
             &mut indices,
             1,
             vec![CompactedSsTable::new(shard1, 5)],
         )
         .unwrap();
-
         assert_eq!(indices.len(), 1);
-        let details = load_mem_wal_index_details(indices[0].clone()).unwrap();
-        assert_eq!(details.compacted_sstables.len(), 1);
-        assert_eq!(details.compacted_sstables[0].shard_id, shard1);
-        assert_eq!(details.compacted_sstables[0].generation, 5);
+        assert_eq!(compacted_generation(&indices, shard1), Some(5));
 
-        // Second update - updates existing shard
+        // Advancing an existing shard.
         update_mem_wal_index_compacted_sstables(
             &mut indices,
             2,
             vec![CompactedSsTable::new(shard1, 10)],
         )
         .unwrap();
+        assert_eq!(compacted_generation(&indices, shard1), Some(10));
 
-        assert_eq!(indices.len(), 1);
-        let details = load_mem_wal_index_details(indices[0].clone()).unwrap();
-        assert_eq!(details.compacted_sstables.len(), 1);
-        assert_eq!(details.compacted_sstables[0].generation, 10);
-
-        // Third update - adds new shard
+        // A second shard is independent.
         update_mem_wal_index_compacted_sstables(
             &mut indices,
             3,
             vec![CompactedSsTable::new(shard2, 3)],
         )
         .unwrap();
+        assert_eq!(compacted_generation(&indices, shard1), Some(10));
+        assert_eq!(compacted_generation(&indices, shard2), Some(3));
+    }
 
-        assert_eq!(indices.len(), 1);
-        let details = load_mem_wal_index_details(indices[0].clone()).unwrap();
-        assert_eq!(details.compacted_sstables.len(), 2);
+    /// A stale proposal must fail the whole transaction: accepting it while
+    /// keeping generation 10 would publish the stale worker's rows under a
+    /// marker they did not produce.
+    #[test]
+    fn a_lower_generation_rejects_the_whole_update() {
+        let shard = Uuid::new_v4();
+        let mut indices = indices_with(MemWalIndexDetails {
+            compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+            ..Default::default()
+        });
+        let before = indices.clone();
 
-        // Fourth update - lower generation should not update
+        let err = update_mem_wal_index_compacted_sstables(
+            &mut indices,
+            2,
+            vec![CompactedSsTable::new(shard, 8)],
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Stale SSTable compaction"),
+            "{err}"
+        );
+        assert_eq!(
+            indices[0].uuid, before[0].uuid,
+            "a rejected update must leave the index list untouched"
+        );
+        assert_eq!(compacted_generation(&indices, shard), Some(10));
+    }
+
+    /// Equal is also refused: it proves nothing new, and accepting it would let
+    /// a retry publish a second set of row mutations under the same marker.
+    #[test]
+    fn an_equal_generation_rejects() {
+        let shard = Uuid::new_v4();
+        let mut indices = indices_with(MemWalIndexDetails {
+            compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+            ..Default::default()
+        });
+
+        let err = update_mem_wal_index_compacted_sstables(
+            &mut indices,
+            2,
+            vec![CompactedSsTable::new(shard, 10)],
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Stale SSTable compaction"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_shards_in_one_update_reject() {
+        let shard = Uuid::new_v4();
+        let mut indices = indices_with(MemWalIndexDetails::default());
+
+        let err = update_mem_wal_index_compacted_sstables(
+            &mut indices,
+            1,
+            vec![
+                CompactedSsTable::new(shard, 5),
+                CompactedSsTable::new(shard, 6),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("Duplicate shard"), "{err}");
+    }
+
+    /// Absent metadata must not be materialized: default details describe a
+    /// table with no MemWAL shards, so the recorded generation would name a
+    /// shard nothing can corroborate.
+    #[test]
+    fn a_missing_mem_wal_index_rejects() {
+        let mut indices: Vec<IndexMetadata> = Vec::new();
+
+        let err = update_mem_wal_index_compacted_sstables(
+            &mut indices,
+            1,
+            vec![CompactedSsTable::new(Uuid::new_v4(), 5)],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("does not exist"), "{err}");
+        assert!(indices.is_empty(), "nothing should have been created");
+    }
+
+    /// Recording progress replaces the entry where it sits, so the index list
+    /// keeps its order.
+    #[test]
+    fn recording_progress_keeps_the_system_index_position() {
+        let shard = Uuid::new_v4();
+        let mut indices = indices_with(MemWalIndexDetails::default());
+        // A neighbour to prove the entry is replaced in place, not moved.
+        indices.push(IndexMetadata {
+            name: "other_index".to_string(),
+            ..indices[0].clone()
+        });
         update_mem_wal_index_compacted_sstables(
             &mut indices,
-            4,
-            vec![CompactedSsTable::new(shard1, 8)], // lower than 10
+            2,
+            vec![CompactedSsTable::new(shard, 5)],
         )
         .unwrap();
 
-        let details = load_mem_wal_index_details(indices[0].clone()).unwrap();
-        let shard1_sstable = details
-            .compacted_sstables
-            .iter()
-            .find(|sstable| sstable.shard_id == shard1)
+        assert_eq!(indices[0].name, MEM_WAL_INDEX_NAME);
+        assert_eq!(indices[1].name, "other_index");
+    }
+
+    /// Recording progress must not disturb any other saved MemWAL field.
+    #[test]
+    fn recording_progress_preserves_unrelated_mem_wal_state() {
+        let shard = Uuid::new_v4();
+        let other_shard = Uuid::new_v4();
+        let mut writer_config_defaults = HashMap::new();
+        writer_config_defaults.insert("target_size".to_string(), "64MB".to_string());
+        let details = MemWalIndexDetails {
+            snapshot_ts_millis: 12_345,
+            num_shards: 4,
+            maintained_indexes: vec!["vector_idx".to_string()],
+            compacted_sstables: vec![CompactedSsTable::new(other_shard, 7)],
+            writer_config_defaults: writer_config_defaults.clone(),
+            ..Default::default()
+        };
+        let mut indices = indices_with(details);
+
+        update_mem_wal_index_compacted_sstables(
+            &mut indices,
+            2,
+            vec![CompactedSsTable::new(shard, 5)],
+        )
+        .unwrap();
+
+        let after = load_mem_wal_index_details(indices[0].clone()).unwrap();
+        assert_eq!(after.snapshot_ts_millis, 12_345);
+        assert_eq!(after.num_shards, 4);
+        assert_eq!(after.maintained_indexes, vec!["vector_idx".to_string()]);
+        assert_eq!(after.writer_config_defaults, writer_config_defaults);
+        // The untouched shard keeps its generation.
+        assert_eq!(compacted_generation(&indices, other_shard), Some(7));
+    }
+
+    /// The hole this guards is a worker that refreshed to HEAD before
+    /// submitting: there is no intervening transaction, so the conflict
+    /// resolver sees nothing to reject and only apply-time validation stands
+    /// between a stale generation and a published commit.
+    ///
+    /// The row mutation is the point: were the stale generation accepted, this
+    /// commit would add a fragment while the recorded generation stayed at 10,
+    /// so the rows and the number describing them would disagree.
+    #[tokio::test]
+    async fn a_stale_generation_against_latest_head_publishes_nothing() {
+        use lance_table::format::Fragment;
+
+        let shard = Uuid::new_v4();
+        let dataset = test_dataset_with_mem_wal().await;
+        let version = dataset.manifest.version;
+
+        // Record generation 10.
+        let dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(Transaction::new(
+                version,
+                Operation::UpdateMemWalState {
+                    compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                },
+                None,
+            ))
+            .await
             .unwrap();
-        assert_eq!(shard1_sstable.generation, 10); // Should still be 10
+
+        let version_before = dataset.manifest.version;
+        let fragments_before = dataset.get_fragments().len();
+
+        // Built against the LATEST version, so there is nothing stale for the
+        // conflict resolver to catch, and carrying a real row mutation.
+        let stale = Transaction::new(
+            version_before,
+            Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![],
+                new_fragments: vec![Fragment::new(999)],
+                fields_modified: vec![],
+                compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: None,
+                inserted_rows_filter: None,
+                updated_fragment_offsets: None,
+            },
+            None,
+        );
+        let mut dataset = dataset;
+        let result = CommitBuilder::new(Arc::new(dataset.clone()))
+            .execute(stale)
+            .await;
+
+        // Asserting the reason, not just the failure: the commit must be
+        // refused by apply-time generation validation, not by something
+        // incidental about the fragment.
+        let err = result.expect_err("a stale generation must fail the whole commit");
+        assert!(
+            err.to_string().contains("Stale SSTable compaction"),
+            "expected stale-generation rejection, got {err}"
+        );
+
+        // Neither the marker nor the fragment may have been published.
+        dataset.checkout_latest().await.unwrap();
+        let latest = dataset;
+        assert_eq!(
+            latest.manifest.version, version_before,
+            "no new table version may be published"
+        );
+        assert_eq!(
+            latest.get_fragments().len(),
+            fragments_before,
+            "the row mutation must not be published"
+        );
+        let details = load_mem_wal_index_details(
+            latest
+                .load_indices()
+                .await
+                .unwrap()
+                .iter()
+                .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                .unwrap()
+                .clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            details.compacted_sstables[0].generation, 10,
+            "the recorded generation must be unchanged"
+        );
     }
 
     #[test]
     fn test_empty_compacted_sstables_noop() {
         let mut indices = Vec::new();
 
-        // Empty update should be a no-op
+        // Empty update should be a no-op, even with no MemWAL index present.
         update_mem_wal_index_compacted_sstables(&mut indices, 1, vec![]).unwrap();
 
         assert!(indices.is_empty());
@@ -502,7 +778,7 @@ mod tests {
         use lance_index::IndexType;
         use lance_index::scalar::ScalarIndexParams;
 
-        let mut dataset = test_dataset().await;
+        let mut dataset = test_dataset_with_mem_wal().await;
 
         // A real user index that describe_indices must keep returning.
         dataset

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1944,10 +1944,12 @@ impl<'a> TransactionRebase<'a> {
                     .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
                     .unwrap();
 
-                let current_meta = new_indices.remove(pos);
-                let mut details = load_mem_wal_index_details(current_meta)?;
+                let mut details = load_mem_wal_index_details(new_indices[pos].clone())?;
 
-                // Reconcile conflicting compacted_sstables by keeping each shard's higher generation.
+                // Reconcile conflicting compacted_sstables by keeping each shard's higher
+                // generation. Both sides are already-committed facts here, so the higher one
+                // is correct; rejecting a stale proposal is the job of apply-time validation
+                // against the latest state, which runs after this rebase.
                 // We own self so we can consume conflicting_mem_wal_compacted_sstables directly
                 for new_sstable in self.conflicting_mem_wal_compacted_sstables {
                     if let Some(existing) = details
@@ -1963,8 +1965,8 @@ impl<'a> TransactionRebase<'a> {
                     }
                 }
 
-                let new_meta = new_mem_wal_index_meta(dataset.manifest.version, details)?;
-                new_indices.push(new_meta);
+                // Replaced in place so the index list keeps its order.
+                new_indices[pos] = new_mem_wal_index_meta(dataset.manifest.version, details)?;
             }
 
             for singleton_name in [FRAG_REUSE_INDEX_NAME, MEM_WAL_INDEX_NAME] {


### PR DESCRIPTION
## The bug

When a compaction job records how far it has got for a shard, Lance kept whichever generation number was larger — the one already saved, or the one being written. A job arriving late with an old number therefore got success back, and its number was quietly ignored.

The damage is that the job's **rows still get written**. The table then holds one job's rows labelled with a different job's progress number. Anything that trusts that number to decide an SSTable has been fully copied in can discard rows that were never copied.

Now an old or equal number fails the entire commit, so the rows and the number describing them either both land or neither does.

## Four more problems in the same function

- **A table with no `__lance_mem_wal` index got one invented.** Lance created empty metadata and recorded progress into it, naming a shard the table has no other record of. It now returns an error instead. This applies to every table, not just ones using the new behaviour: recording progress for a table that has no MemWAL shards is meaningless either way.
- **The index entry was pulled out of the list before the update was checked**, so any error left the caller holding a list with the system index missing.
- **The entry was appended at the end afterwards**, reordering the index list on every single update.
- **The entry was rebuilt from constants each time**, which generated a new UUID and a new creation time. Nothing about the index changed except its saved numbers, yet it looked newly created after every compaction, and any `IndexMetadata` field not listed in that constructor would be silently dropped. There is now a helper that clones the existing entry and replaces only `dataset_version` and `index_details`, used here and in the conflict resolver, which had the same problems. The constructor that mints a UUID and creation time is kept for genuinely new indexes.

Listing the same shard twice in one update is also rejected — a shard may move forward at most once per commit.

## What stays untouched

Every other saved MemWAL field is copied through unchanged.

The conflict resolver still keeps the larger number when rebasing, deliberately. Both numbers there are already committed facts, and rejecting a stale one is the job of the check against latest state, which runs after the rebase.

## The multi-pass rule is the caller's

`mark_sstables_as_compacted` now documents that a multi-pass compaction must attach progress only to its final successful data-changing pass. Lance cannot enforce this — it cannot tell whether the caller has another pass planned — so the contract is stated on the public method and enforcement belongs to the compaction worker. If a delete pass carried the marker and the process died before the matching upsert, the recorded generation would claim rows were copied in that never were.

## Tests

Ten new tests, each covering one thing: a lower number fails and leaves the list untouched; an equal number fails; a repeated shard fails; a missing system index fails and creates nothing; recording progress keeps the UUID and the list order; and unrelated saved MemWAL state survives.

The important one is `a_stale_generation_against_latest_head_publishes_nothing`, which covers the case the conflict resolver cannot: a worker that refreshed to HEAD before submitting, so there is no intervening transaction to inspect and only apply-time validation stands in the way. It commits a real row mutation together with a stale generation and then asserts that the commit was refused *for that reason*, that no new table version appeared, that the fragment was not published, and that the recorded generation is unchanged. Under the previous behaviour that commit succeeded.

Six existing tests relied on the invent-an-index behaviour this removes. They now start from a table that already has the system index, which is what MemWAL setup actually leaves behind.

`cargo test -p lance --lib` — 2725 pass, 0 fail. `cargo fmt --check` clean. `cargo clippy --no-deps` finds nothing new; the 7 `single_range_in_vec_init` errors it reports are in untouched code and appear identically on the base commit.

