### PR TITLE
feat(mem-wal): record index catch-up positions and withdraw them on index change

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -346,6 +346,8 @@ What an absent entry means depends on the `FLAG_MEM_WAL_INDEX_CATCHUP` feature b
 - **Without the bit**, a shard absent from `index_catchup` for an index means that index is assumed fully caught up for the shard.
 - **With the bit**, absence means the opposite: the index is *not* known to have caught up, so the shard's SSTables must be retained until some commit records that it has.
 
+A commit records catch-up by attaching an `IndexCatchupAdvance` to the index operation that publishes the work, so the index result and the position recorded for it land together. The advance names the index, the exact segments it expects that index to consist of, the fragments those segments covered when it inspected them, and every fragment live in the table at that moment. The commit fails unless the published segments match all three, which is what ties the recorded generations to an index that actually covers them — nothing maps a generation to the fragments its rows landed in. Fragments appended after the repair's snapshot are a later catch-up gap and are not required.
+
 Setting the bit is one-way. Once SSTables have stopped being served against a recorded catch-up position, reading absence as "caught up" again could drop rows that only those SSTables still hold, so the bit is never cleared as a rollback. Writers must also hold the bit: a writer that does not maintain `index_catchup` can change an index without withdrawing the position recorded for it, leaving a position that no longer describes the index it names.
 
 Shard snapshots, when present, use the following Lance file schema:

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -341,7 +341,12 @@ Important fields:
 - `index_catchup`: per-index coverage progress after data has been compacted into the base table.
 - `snapshot_ts_millis`, `num_shards`, and `inline_snapshots`: optional shard snapshot fields for read optimization.
 
-If a shard is absent from `index_catchup` for an index, that index is assumed to be fully caught up for the shard.
+What an absent entry means depends on the `FLAG_MEM_WAL_INDEX_CATCHUP` feature bit:
+
+- **Without the bit**, a shard absent from `index_catchup` for an index means that index is assumed fully caught up for the shard.
+- **With the bit**, absence means the opposite: the index is *not* known to have caught up, so the shard's SSTables must be retained until some commit records that it has.
+
+Setting the bit is one-way. Once SSTables have stopped being served against a recorded catch-up position, reading absence as "caught up" again could drop rows that only those SSTables still hold, so the bit is never cleared as a rollback. Writers must also hold the bit: a writer that does not maintain `index_catchup` can change an index without withdrawing the position recorded for it, leaving a position that no longer describes the index it names.
 
 Shard snapshots, when present, use the following Lance file schema:
 
@@ -494,7 +499,7 @@ On commit conflict, a compactor reloads the conflicting base-table version:
 The garbage collector may remove obsolete SSTables after:
 
 1. The SSTable has been compacted into the base table.
-2. Every maintained index has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads.
+2. Every index a query may rely on has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads. With `FLAG_MEM_WAL_INDEX_CATCHUP` set, an index absent from `index_catchup` has *not* caught up, so this condition is not met for it.
 3. No retained base-table version needs the SSTable for time travel or consistency.
 
 !!! warning

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -28,7 +28,10 @@ they should return an "unsupported" error on any read or write operation.
 | 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
 | 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | Table config is present in the manifest.                                                                    |
 | 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transactions are recorded in the manifest rather than in a separate transaction file.                       |
+| 64       | `FLAG_UNSTABLE_DATA_OVERLAY_FILES` | Yes          | Yes             | Fragments may carry data overlay files. Unstable: release builds reject it unless explicitly opted in.      |
+| 128      | `FLAG_MEM_WAL_INDEX_CATCHUP`    | Yes             | Yes             | `index_catchup` is maintained on this table, so an index absent from it is *not* caught up. See [MemWAL](mem_wal.md). |
 
 </div>
 
-Flags with bit values 32 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values 256 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -411,6 +411,7 @@ fn convert_to_java_operation_inner<'local>(
         Operation::CreateIndex {
             new_indices,
             removed_indices,
+            ..
         } => {
             let java_new_indices = export_vec(env, &new_indices)?;
             let java_removed_indices = export_vec(env, &removed_indices)?;
@@ -1332,6 +1333,7 @@ fn convert_to_rust_operation(
             return Ok(Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances: Vec::new(),
             });
         }
         _ => unimplemented!(),

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -694,7 +694,7 @@ message IndexCatchupProgress {
   //
   // An absent shard means "fully caught up" ONLY on a legacy table. On a table
   // with the MemWAL safe-retirement feature bit set it means *unknown*: this
-  // index has proved nothing for that shard, so its SSTables must be retained
+  // index has recorded no catch-up for that shard, so its SSTables must be retained
   // and a repair scheduled. The manifest feature bit, not this message, selects
   // which reading applies.
   repeated CompactedSsTable caught_up_generations = 2;
@@ -764,10 +764,10 @@ message MemWalIndexDetails {
   //
   // An index absent from this list is "fully caught up" ONLY on a legacy table.
   // With the MemWAL safe-retirement feature bit set, absence means the index has
-  // proved no coverage, so the SSTables it would need stay live until a repair
+  // recorded no catch-up, so the SSTables it would need stay live until a repair
   // records it. Only the dedicated WAL index-repair path may add entries here;
   // ordinary index operations have their entry removed automatically when they
-  // change an index, since they do not prove what the new index covers.
+  // change an index, since they do not report what the new index covers.
   repeated IndexCatchupProgress index_catchup = 10;
 
   // Default ShardWriter configuration values for this MemWAL index.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -693,7 +693,7 @@ message IndexCatchupProgress {
   // Per-shard progress: the generation up to which this index covers.
   //
   // An absent shard means "fully caught up" ONLY on a legacy table. On a table
-  // with the MemWAL safe-retirement feature bit set it means *unknown*: this
+  // with the MemWAL index-catchup feature bit set it means *unknown*: this
   // index has recorded no catch-up for that shard, so its SSTables must be retained
   // and a repair scheduled. The manifest feature bit, not this message, selects
   // which reading applies.
@@ -763,7 +763,7 @@ message MemWalIndexDetails {
   // scanning unindexed data in the base table.
   //
   // An index absent from this list is "fully caught up" ONLY on a legacy table.
-  // With the MemWAL safe-retirement feature bit set, absence means the index has
+  // With the MemWAL index-catchup feature bit set, absence means the index has
   // recorded no catch-up, so the SSTables it would need stay live until a repair
   // records it. Only the dedicated WAL index-repair path may add entries here;
   // ordinary index operations have their entry removed automatically when they

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -118,6 +118,13 @@ message Manifest {
   // * 1 << 6: data overlay files are present (see DataOverlayFile). Readers that do
   //   not understand overlays must refuse the dataset, since ignoring an overlay
   //   would silently return stale base values.
+  // * 1 << 7: index_catchup is maintained on this table, so an index absent from
+  //   it is *not* caught up rather than fully caught up (see MemWalIndexDetails).
+  //   Readers that do not understand it must refuse the dataset, since reading
+  //   absence as caught up could answer from an index missing rows that only the
+  //   MemWAL SSTables still hold. Writers must refuse it too: one that does not
+  //   maintain index_catchup can change an index without withdrawing the
+  //   position recorded for it. Setting it is one-way.
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -691,8 +691,12 @@ message IndexCatchupProgress {
   string index_name = 1;
 
   // Per-shard progress: the generation up to which this index covers.
-  // If a shard is not present, the index is assumed to be fully caught up
-  // (i.e., caught_up_generation >= compacted_generation for that shard).
+  //
+  // An absent shard means "fully caught up" ONLY on a legacy table. On a table
+  // with the MemWAL safe-retirement feature bit set it means *unknown*: this
+  // index has proved nothing for that shard, so its SSTables must be retained
+  // and a repair scheduled. The manifest feature bit, not this message, selects
+  // which reading applies.
   repeated CompactedSsTable caught_up_generations = 2;
 }
 
@@ -758,7 +762,12 @@ message MemWalIndexDetails {
   // readers should use SSTable indexes for the gap instead of
   // scanning unindexed data in the base table.
   //
-  // If an index is not present in this list, it is assumed to be fully caught up.
+  // An index absent from this list is "fully caught up" ONLY on a legacy table.
+  // With the MemWAL safe-retirement feature bit set, absence means the index has
+  // proved no coverage, so the SSTables it would need stay live until a repair
+  // records it. Only the dedicated WAL index-repair path may add entries here;
+  // ordinary index operations have their entry removed automatically when they
+  // change an index, since they do not prove what the new index covers.
   repeated IndexCatchupProgress index_catchup = 10;
 
   // Default ShardWriter configuration values for this MemWAL index.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -81,6 +81,31 @@ message Transaction {
   message CreateIndex {
     repeated IndexMetadata new_indices = 1;
     repeated IndexMetadata removed_indices = 2;
+
+    // Proof that one logical index now covers named per-shard compaction
+    // generations, published in the same commit as the index change it
+    // describes.
+    message IndexCatchupAdvance {
+      // One user-visible logical index, possibly backed by several segments.
+      string index_name = 1;
+
+      // Exact final physical segment UUID set expected after this operation.
+      // Ordering has no meaning; duplicates are rejected. The commit fails if
+      // the segments actually present differ, so a repair cannot claim
+      // coverage for an index that something else replaced underneath it.
+      repeated UUID expected_index_segment_uuids = 2;
+
+      // Compaction numbers captured when the repair job opened the table.
+      // Recording only these, rather than whatever is current at commit time,
+      // keeps the claim to what the job actually indexed.
+      repeated CompactedSsTable caught_up_generations = 3;
+    }
+
+    // Empty for every ordinary index operation, which is why an ordinary
+    // create, reindex, append, or remap conservatively loses whatever coverage
+    // its index had proved. Empty means "this operation proves no new
+    // coverage"; it never means "inherit what the previous index proved".
+    repeated IndexCatchupAdvance mem_wal_index_catchup_advances = 3;
   }
 
   // An operation that rewrites but does not change the data in the table. These
@@ -355,6 +380,14 @@ message Transaction {
   message UpdateMemWalState {
     // SSTables being marked as compacted.
     repeated CompactedSsTable compacted_sstables = 1;
+
+    // Presence with true requests the one-way migration to safe retirement.
+    // False is invalid; absence is an ordinary progress update.
+    //
+    // The migration is one-way because returning to legacy semantics — where a
+    // missing coverage entry reads as "fully caught up" — is unsafe once any
+    // SSTable has been retired against proved coverage.
+    optional bool activate_safe_retirement = 2;
   }
 
   // An operation that updates base paths in the dataset.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -101,9 +101,10 @@ message Transaction {
       repeated CompactedSsTable caught_up_generations = 3;
     }
 
-    // Empty for every ordinary index operation, which is why an ordinary
-    // create, reindex, append, or remap conservatively loses whatever coverage
-    // its index had recorded. Empty means "this operation reports no new
+    // Empty for every ordinary index operation. Creating, reindexing,
+    // appending to, or remapping an index changes it without saying how far it
+    // has caught up, so that index's index_catchup entry is removed and a later
+    // repair records a fresh one. Empty means "this operation reports no new
     // coverage"; it never means "inherit the previous index's catch-up".
     repeated IndexCatchupAdvance mem_wal_index_catchup_advances = 3;
   }

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -82,7 +82,7 @@ message Transaction {
     repeated IndexMetadata new_indices = 1;
     repeated IndexMetadata removed_indices = 2;
 
-    // Proof that one logical index now covers named per-shard compaction
+    // Records that one logical index now covers named per-shard compaction
     // generations, published in the same commit as the index change it
     // describes.
     message IndexCatchupAdvance {
@@ -103,8 +103,8 @@ message Transaction {
 
     // Empty for every ordinary index operation, which is why an ordinary
     // create, reindex, append, or remap conservatively loses whatever coverage
-    // its index had proved. Empty means "this operation proves no new
-    // coverage"; it never means "inherit what the previous index proved".
+    // its index had recorded. Empty means "this operation reports no new
+    // coverage"; it never means "inherit the previous index's catch-up".
     repeated IndexCatchupAdvance mem_wal_index_catchup_advances = 3;
   }
 
@@ -386,7 +386,7 @@ message Transaction {
     //
     // The migration is one-way because returning to legacy semantics — where a
     // missing coverage entry reads as "fully caught up" — is unsafe once any
-    // SSTable has been retired against proved coverage.
+    // SSTable has been retired against a recorded catch-up position.
     optional bool activate_safe_retirement = 2;
   }
 

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -99,6 +99,13 @@ message Transaction {
       // Recording only these, rather than whatever is current at commit time,
       // keeps the claim to what the job actually indexed.
       repeated CompactedSsTable caught_up_generations = 3;
+
+      // Serialized roaring bitmap: the fragments the named segments covered
+      // when the repair inspected them. UUIDs alone are not a fence -- an
+      // operation can prune a segment's fragment bitmap while keeping its
+      // UUID, so a claim made before the prune would still match. The commit
+      // fails unless the published segments cover exactly these fragments.
+      bytes expected_fragment_bitmap = 4;
     }
 
     // Empty for every ordinary index operation. Creating, reindexing,

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -106,6 +106,15 @@ message Transaction {
       // UUID, so a claim made before the prune would still match. The commit
       // fails unless the published segments cover exactly these fragments.
       bytes expected_fragment_bitmap = 4;
+
+      // Serialized roaring bitmap: every fragment live in the table when the
+      // repair inspected it. The index must cover all of them, which is what
+      // ties the claim to the generations it names -- there is no mapping from
+      // a generation to the fragments its rows landed in, so covering the whole
+      // inspected table is how the repair shows it covered those rows.
+      // Fragments appended after that snapshot are a later catch-up gap and are
+      // not required.
+      bytes inspected_fragments = 5;
     }
 
     // Empty for every ordinary index operation. Creating, reindexing,

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -382,13 +382,13 @@ message Transaction {
     // SSTables being marked as compacted.
     repeated CompactedSsTable compacted_sstables = 1;
 
-    // Presence with true requests the one-way migration to safe retirement.
+    // Presence with true requests the one-way migration to required catch-up.
     // False is invalid; absence is an ordinary progress update.
     //
     // The migration is one-way because returning to legacy semantics — where a
     // missing coverage entry reads as "fully caught up" — is unsafe once any
     // SSTable has been retired against a recorded catch-up position.
-    optional bool activate_safe_retirement = 2;
+    optional bool require_index_catchup = 2;
   }
 
   // An operation that updates base paths in the dataset.

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -474,6 +474,7 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                 let op = Operation::CreateIndex {
                     new_indices,
                     removed_indices,
+                    mem_wal_index_catchup_advances: Vec::new(),
                 };
                 Ok(Self(op))
             }
@@ -689,6 +690,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                ..
             } => {
                 let new_indices_py = export_vec(py, new_indices.as_slice())?;
                 let removed_indices_py = export_vec(py, removed_indices.as_slice())?;

--- a/rust/lance-index/src/optimize.rs
+++ b/rust/lance-index/src/optimize.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use lance_table::system_index::mem_wal::CompactedSsTable;
+
 use crate::progress::{IndexBuildProgress, noop_progress};
 
 /// Options for optimizing all indices.
@@ -48,6 +50,17 @@ pub struct OptimizeOptions {
 
     /// Progress callback for index building during optimization.
     pub progress: Arc<dyn IndexBuildProgress>,
+
+    /// Per-shard MemWAL compaction generations to record as caught up for every
+    /// index this call optimizes.
+    ///
+    /// Only the generations are supplied: the advance must also name the exact
+    /// segments it describes, and those do not exist until the merge runs, so
+    /// `optimize_indices` binds them to what it publishes. Recording them in the
+    /// same commit as the index work is what keeps the two from disagreeing.
+    ///
+    /// Empty for ordinary index maintenance, which records no catch-up.
+    pub mem_wal_index_catchup: Vec<CompactedSsTable>,
 }
 
 impl Default for OptimizeOptions {
@@ -58,6 +71,7 @@ impl Default for OptimizeOptions {
             retrain: false,
             transaction_properties: None,
             progress: noop_progress(),
+            mem_wal_index_catchup: Vec::new(),
         }
     }
 }
@@ -65,6 +79,12 @@ impl Default for OptimizeOptions {
 impl OptimizeOptions {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Record `generations` as caught up for every index this call optimizes.
+    pub fn mem_wal_index_catchup(mut self, generations: Vec<CompactedSsTable>) -> Self {
+        self.mem_wal_index_catchup = generations;
+        self
     }
 
     pub fn merge(num: usize) -> Self {

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -2506,6 +2506,7 @@ impl DirectoryNamespace {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                ..
             } if new_indices.is_empty() && !removed_indices.is_empty() => "DropIndex".to_string(),
             _ => transaction.operation.to_string(),
         }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -56,15 +56,6 @@ pub fn apply_feature_flags(
     enable_stable_row_id: bool,
     disable_transaction_file: bool,
 ) -> Result<()> {
-    // Preserved rather than derived: this bit depends on the `__lance_mem_wal`
-    // index details, and a manifest carries only a byte offset to its index
-    // section, not the indices themselves. Whoever holds the final index list
-    // sets it; every other recomputation must leave it alone, or an unrelated
-    // transaction would silently downgrade the table to legacy semantics.
-    // Clearing it is an explicit MemWAL disable, never a side effect.
-    let mem_wal_index_catchup = (manifest.reader_feature_flags | manifest.writer_feature_flags)
-        & FLAG_MEM_WAL_INDEX_CATCHUP;
-
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -123,9 +114,37 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
 
-    manifest.reader_feature_flags |= mem_wal_index_catchup;
-    manifest.writer_feature_flags |= mem_wal_index_catchup;
     Ok(())
+}
+
+/// Carry [`FLAG_MEM_WAL_INDEX_CATCHUP`] from the manifest a new one is derived
+/// from.
+///
+/// This bit cannot be derived like the others: it depends on the
+/// `__lance_mem_wal` index details, and a manifest carries only a byte offset to
+/// its index section. It also cannot be preserved inside
+/// [`apply_feature_flags`], which sees only the destination -- and
+/// `Manifest::new_from_previous` zeroes both feature words before that runs, so
+/// reading them there always yields zero and every ordinary commit would
+/// silently downgrade the table to legacy semantics.
+///
+/// A half-set state is refused rather than normalized: one bit set means a
+/// legacy reader or a legacy writer is still permitted, which is neither mode.
+pub fn inherit_mem_wal_index_catchup(destination: &mut Manifest, source: &Manifest) -> Result<()> {
+    let reader = source.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+    let writer = source.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+    match (reader, writer) {
+        (false, false) => Ok(()),
+        (true, true) => {
+            destination.reader_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
+            destination.writer_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
+            Ok(())
+        }
+        _ => Err(Error::invalid_input(
+            "Manifest has only one of the MemWAL index-catchup reader and writer \
+             feature bits set, so its catch-up semantics are undefined",
+        )),
+    }
 }
 
 /// Whether this build understands data overlay files: always in debug builds,
@@ -337,7 +356,63 @@ mod tests {
     /// it, or a later transaction would silently downgrade the table to legacy
     /// semantics and a reader would treat missing coverage as complete.
     #[test]
-    fn an_unrelated_recomputation_preserves_the_mem_wal_bit() {
+    fn inheriting_carries_the_mem_wal_bit_from_the_source() {
+        let mut source = empty_manifest();
+        source.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+        source.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+        // What `Manifest::new_from_previous` hands us: both words zeroed.
+        let mut destination = empty_manifest();
+
+        inherit_mem_wal_index_catchup(&mut destination, &source).unwrap();
+
+        assert_ne!(
+            destination.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+        assert_ne!(
+            destination.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+    }
+
+    #[test]
+    fn inheriting_refuses_a_half_set_source() {
+        for (reader, writer) in [
+            (FLAG_MEM_WAL_INDEX_CATCHUP, 0),
+            (0, FLAG_MEM_WAL_INDEX_CATCHUP),
+        ] {
+            let mut source = empty_manifest();
+            source.reader_feature_flags = reader;
+            source.writer_feature_flags = writer;
+            let mut destination = empty_manifest();
+
+            let err = inherit_mem_wal_index_catchup(&mut destination, &source).unwrap_err();
+
+            assert!(err.to_string().contains("only one of"), "{err}");
+        }
+    }
+
+    #[test]
+    fn apply_feature_flags_does_not_carry_the_mem_wal_bit() {
+        // It only ever sees the destination, whose words are already zeroed, so
+        // inheriting is `inherit_mem_wal_index_catchup`'s job, not its own.
+        let mut manifest = empty_manifest();
+        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+        manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+
+        assert_eq!(
+            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+        assert_eq!(
+            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+    }
+
+    fn empty_manifest() -> Manifest {
         use crate::format::DataStorageFormat;
         use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
         use lance_core::datatypes::Schema;
@@ -345,25 +420,12 @@ mod tests {
         use std::sync::Arc;
 
         let arrow_schema = ArrowSchema::new(vec![ArrowField::new("i", DataType::Int32, false)]);
-        let mut manifest = Manifest::new(
+        Manifest::new(
             Schema::try_from(&arrow_schema).unwrap(),
             Arc::new(vec![]),
             DataStorageFormat::default(),
             HashMap::new(),
-        );
-        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-        manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-
-        apply_feature_flags(&mut manifest, false, false).unwrap();
-
-        assert_ne!(
-            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-        assert_ne!(
-            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
+        )
     }
 
     /// A build that does not know the bit must refuse the table rather than

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -30,21 +30,21 @@ pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
 /// unless [`ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV`] is set, which lets benchmarks opt in.
 /// Debug builds always understand it so tests exercise the path.
 pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
-/// MemWAL SSTables are retired only against a recorded index catch-up position.
+/// `index_catchup` is maintained on this table, so a missing entry means the
+/// index is *not* caught up rather than fully caught up.
 ///
 /// A reader without this bit would read a missing `index_catchup` entry as
 /// "fully caught up" and could answer an index-only query without the SSTables
 /// holding the newest rows. A writer without it would change an index without
 /// invalidating the catch-up position recorded for that index, leaving a stale
-/// position behind.
-/// Both must refuse the table.
-pub const FLAG_MEM_WAL_SAFE_RETIREMENT: u64 = 128;
+/// position behind. Both must refuse the table.
+pub const FLAG_MEM_WAL_INDEX_CATCHUP: u64 = 128;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 256;
 
 // This build only understands flags below the unknown boundary, so a bit
 // allocated at or above it would be refused by the very readers meant to use it.
-const _: () = assert!(FLAG_MEM_WAL_SAFE_RETIREMENT < FLAG_UNKNOWN);
+const _: () = assert!(FLAG_MEM_WAL_INDEX_CATCHUP < FLAG_UNKNOWN);
 
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.
@@ -62,8 +62,8 @@ pub fn apply_feature_flags(
     // sets it; every other recomputation must leave it alone, or an unrelated
     // transaction would silently downgrade the table to legacy semantics.
     // Clearing it is an explicit MemWAL disable, never a side effect.
-    let mem_wal_safe_retirement = (manifest.reader_feature_flags | manifest.writer_feature_flags)
-        & FLAG_MEM_WAL_SAFE_RETIREMENT;
+    let mem_wal_index_catchup = (manifest.reader_feature_flags | manifest.writer_feature_flags)
+        & FLAG_MEM_WAL_INDEX_CATCHUP;
 
     // Reset flags
     manifest.reader_feature_flags = 0;
@@ -123,8 +123,8 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
 
-    manifest.reader_feature_flags |= mem_wal_safe_retirement;
-    manifest.writer_feature_flags |= mem_wal_safe_retirement;
+    manifest.reader_feature_flags |= mem_wal_index_catchup;
+    manifest.writer_feature_flags |= mem_wal_index_catchup;
     Ok(())
 }
 
@@ -351,17 +351,17 @@ mod tests {
             DataStorageFormat::default(),
             HashMap::new(),
         );
-        manifest.reader_feature_flags = FLAG_MEM_WAL_SAFE_RETIREMENT;
-        manifest.writer_feature_flags = FLAG_MEM_WAL_SAFE_RETIREMENT;
+        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+        manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
 
         apply_feature_flags(&mut manifest, false, false).unwrap();
 
         assert_ne!(
-            manifest.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT,
+            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
             0
         );
         assert_ne!(
-            manifest.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT,
+            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
             0
         );
     }
@@ -370,8 +370,8 @@ mod tests {
     /// continue with legacy semantics.
     #[test]
     fn the_mem_wal_bit_is_below_the_unknown_boundary() {
-        assert!(can_read_dataset(FLAG_MEM_WAL_SAFE_RETIREMENT));
-        assert!(can_write_dataset(FLAG_MEM_WAL_SAFE_RETIREMENT));
+        assert!(can_read_dataset(FLAG_MEM_WAL_INDEX_CATCHUP));
+        assert!(can_write_dataset(FLAG_MEM_WAL_INDEX_CATCHUP));
         // The next bit up is still unknown, so allocating this one did not
         // silently widen what this build claims to understand.
         assert!(!can_read_dataset(FLAG_UNKNOWN));

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -30,12 +30,13 @@ pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
 /// unless [`ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV`] is set, which lets benchmarks opt in.
 /// Debug builds always understand it so tests exercise the path.
 pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
-/// MemWAL SSTables are retired only against proved index coverage.
+/// MemWAL SSTables are retired only against a recorded index catch-up position.
 ///
 /// A reader without this bit would read a missing `index_catchup` entry as
 /// "fully caught up" and could answer an index-only query without the SSTables
 /// holding the newest rows. A writer without it would change an index without
-/// invalidating the coverage that index had proved, leaving stale proof behind.
+/// invalidating the catch-up position recorded for that index, leaving a stale
+/// position behind.
 /// Both must refuse the table.
 pub const FLAG_MEM_WAL_SAFE_RETIREMENT: u64 = 128;
 /// The first bit that is unknown as a feature flag

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -56,6 +56,26 @@ pub fn apply_feature_flags(
     enable_stable_row_id: bool,
     disable_transaction_file: bool,
 ) -> Result<()> {
+    // Carried across the reset. This bit is not derivable from the manifest --
+    // it depends on the `__lance_mem_wal` index details, which a manifest only
+    // points at -- and this function runs twice per commit: once in
+    // `build_manifest` and again in `write_manifest_file`. Dropping it here
+    // would clear it immediately before the write, so an activated table would
+    // report success and stay legacy.
+    //
+    // Only a consistent state carries: one bit set is neither mode, and
+    // `inherit_mem_wal_index_catchup` refuses it at the boundary where a
+    // manifest is derived from another. Reaching here half-set means the
+    // manifest was already written that way, so leave it for the reader check
+    // rather than silently completing it.
+    let mem_wal_index_catchup = if manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
+        && manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
+    {
+        FLAG_MEM_WAL_INDEX_CATCHUP
+    } else {
+        0
+    };
+
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -114,19 +134,20 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
 
+    manifest.reader_feature_flags |= mem_wal_index_catchup;
+    manifest.writer_feature_flags |= mem_wal_index_catchup;
+
     Ok(())
 }
 
 /// Carry [`FLAG_MEM_WAL_INDEX_CATCHUP`] from the manifest a new one is derived
 /// from.
 ///
-/// This bit cannot be derived like the others: it depends on the
-/// `__lance_mem_wal` index details, and a manifest carries only a byte offset to
-/// its index section. It also cannot be preserved inside
-/// [`apply_feature_flags`], which sees only the destination -- and
-/// `Manifest::new_from_previous` zeroes both feature words before that runs, so
-/// reading them there always yields zero and every ordinary commit would
-/// silently downgrade the table to legacy semantics.
+/// [`apply_feature_flags`] carries this bit across its own reset, but it only
+/// ever sees one manifest. It cannot help where a *new* manifest is derived from
+/// an existing one -- `Manifest::new_from_previous` and `shallow_clone` both
+/// zero the feature words -- because the destination starts with nothing to
+/// carry. That transition is this function's job.
 ///
 /// A half-set state is refused rather than normalized: one bit set means a
 /// legacy reader or a legacy writer is still permitted, which is neither mode.
@@ -189,6 +210,24 @@ pub fn can_write_dataset(writer_flags: u64) -> bool {
 
 pub fn has_deprecated_v2_feature_flag(writer_flags: u64) -> bool {
     writer_flags & FLAG_USE_V2_FORMAT_DEPRECATED != 0
+}
+
+/// Refuse a manifest whose MemWAL index-catchup bits disagree.
+///
+/// One word set and the other not is neither mode: it would let a legacy reader
+/// or a legacy writer through on a table where the other half is enforcing. The
+/// commit path refuses to *produce* this, so seeing it on read means the
+/// manifest was written by something that did not.
+pub fn validate_mem_wal_index_catchup_flags(manifest: &Manifest) -> Result<()> {
+    let reader = manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+    let writer = manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+    if reader != writer {
+        return Err(Error::invalid_input(
+            "Manifest has only one of the MemWAL index-catchup reader and writer \
+             feature bits set, so its catch-up semantics are undefined",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -393,12 +432,31 @@ mod tests {
     }
 
     #[test]
-    fn apply_feature_flags_does_not_carry_the_mem_wal_bit() {
-        // It only ever sees the destination, whose words are already zeroed, so
-        // inheriting is `inherit_mem_wal_index_catchup`'s job, not its own.
+    fn apply_feature_flags_carries_the_mem_wal_bit_across_its_reset() {
+        // It runs twice per commit -- `build_manifest` and `write_manifest_file`
+        // -- so dropping the bit here would clear it immediately before the
+        // write, and an activated table would report success and stay legacy.
         let mut manifest = empty_manifest();
         manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
         manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+
+        assert_ne!(
+            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+        assert_ne!(
+            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0
+        );
+    }
+
+    #[test]
+    fn apply_feature_flags_drops_a_half_set_mem_wal_bit() {
+        // Neither mode, so leave it for the reader check rather than completing it.
+        let mut manifest = empty_manifest();
+        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
 
         apply_feature_flags(&mut manifest, false, false).unwrap();
 

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -30,8 +30,20 @@ pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
 /// unless [`ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV`] is set, which lets benchmarks opt in.
 /// Debug builds always understand it so tests exercise the path.
 pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
+/// MemWAL SSTables are retired only against proved index coverage.
+///
+/// A reader without this bit would read a missing `index_catchup` entry as
+/// "fully caught up" and could answer an index-only query without the SSTables
+/// holding the newest rows. A writer without it would change an index without
+/// invalidating the coverage that index had proved, leaving stale proof behind.
+/// Both must refuse the table.
+pub const FLAG_MEM_WAL_SAFE_RETIREMENT: u64 = 128;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 128;
+pub const FLAG_UNKNOWN: u64 = 256;
+
+// This build only understands flags below the unknown boundary, so a bit
+// allocated at or above it would be refused by the very readers meant to use it.
+const _: () = assert!(FLAG_MEM_WAL_SAFE_RETIREMENT < FLAG_UNKNOWN);
 
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.
@@ -43,6 +55,15 @@ pub fn apply_feature_flags(
     enable_stable_row_id: bool,
     disable_transaction_file: bool,
 ) -> Result<()> {
+    // Preserved rather than derived: this bit depends on the `__lance_mem_wal`
+    // index details, and a manifest carries only a byte offset to its index
+    // section, not the indices themselves. Whoever holds the final index list
+    // sets it; every other recomputation must leave it alone, or an unrelated
+    // transaction would silently downgrade the table to legacy semantics.
+    // Clearing it is an explicit MemWAL disable, never a side effect.
+    let mem_wal_safe_retirement = (manifest.reader_feature_flags | manifest.writer_feature_flags)
+        & FLAG_MEM_WAL_SAFE_RETIREMENT;
+
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -100,6 +121,9 @@ pub fn apply_feature_flags(
     if disable_transaction_file {
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
+
+    manifest.reader_feature_flags |= mem_wal_safe_retirement;
+    manifest.writer_feature_flags |= mem_wal_safe_retirement;
     Ok(())
 }
 
@@ -304,5 +328,51 @@ mod tests {
             multi_base_manifest.writer_feature_flags & FLAG_BASE_PATHS,
             0
         );
+    }
+
+    /// The MemWAL bit depends on the `__lance_mem_wal` index details, which a
+    /// manifest cannot see — it holds only a byte offset to its index section.
+    /// So an unrelated recomputation must preserve the bit rather than derive
+    /// it, or a later transaction would silently downgrade the table to legacy
+    /// semantics and a reader would treat missing coverage as complete.
+    #[test]
+    fn an_unrelated_recomputation_preserves_the_mem_wal_bit() {
+        use crate::format::DataStorageFormat;
+        use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("i", DataType::Int32, false)]);
+        let mut manifest = Manifest::new(
+            Schema::try_from(&arrow_schema).unwrap(),
+            Arc::new(vec![]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+        manifest.reader_feature_flags = FLAG_MEM_WAL_SAFE_RETIREMENT;
+        manifest.writer_feature_flags = FLAG_MEM_WAL_SAFE_RETIREMENT;
+
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+
+        assert_ne!(
+            manifest.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT,
+            0
+        );
+        assert_ne!(
+            manifest.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT,
+            0
+        );
+    }
+
+    /// A build that does not know the bit must refuse the table rather than
+    /// continue with legacy semantics.
+    #[test]
+    fn the_mem_wal_bit_is_below_the_unknown_boundary() {
+        assert!(can_read_dataset(FLAG_MEM_WAL_SAFE_RETIREMENT));
+        assert!(can_write_dataset(FLAG_MEM_WAL_SAFE_RETIREMENT));
+        // The next bit up is still unknown, so allocating this one did not
+        // silently widen what this build claims to understand.
+        assert!(!can_read_dataset(FLAG_UNKNOWN));
     }
 }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -18,6 +18,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use super::Fragment;
+use crate::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
 use crate::feature_flags::{FLAG_STABLE_ROW_IDS, has_deprecated_v2_feature_flag};
 use crate::format::fragment::DataFileFieldInterner;
 use crate::format::pb;
@@ -275,8 +276,11 @@ impl Manifest {
             index_section: None, // These will be set on commit
             timestamp_nanos: self.timestamp_nanos,
             tag: None,
-            reader_feature_flags: 0, // These will be set on commit
-            writer_feature_flags: 0, // These will be set on commit
+            // Not derivable from the manifest, so it would be lost like any
+            // other zeroed word -- and a clone of a table that requires index
+            // catch-up would silently come back as legacy.
+            reader_feature_flags: self.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            writer_feature_flags: self.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
             max_fragment_id: self.max_fragment_id,
             transaction_file: Some(transaction_file),
             transaction_section: None,

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -428,7 +428,7 @@ impl MemWalIndex {
     /// A missing `index_catchup` entry is read here as "fully caught up". That
     /// is only correct for a table without the safe-retirement feature bit. On
     /// an activated table a missing entry means *unknown*: the index has not
-    /// proved anything, so its SSTables must be retained and a repair
+    /// recorded anything, so its SSTables must be retained and a repair
     /// scheduled. This accessor cannot see the manifest, so it cannot make that
     /// distinction -- callers must select the semantics from the feature bit,
     /// and the name says which one they get here.

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -422,13 +422,21 @@ impl MemWalIndex {
             .and_then(|icp| icp.caught_up_generation_for_shard(shard_id))
     }
 
-    /// Check if an index is fully caught up for a shard.
-    /// Returns true if the index covers all compacted data for the shard.
-    pub fn is_index_caught_up(&self, index_name: &str, shard_id: &Uuid) -> bool {
+    /// Whether an index covers all compacted data for a shard, under **legacy**
+    /// semantics.
+    ///
+    /// A missing `index_catchup` entry is read here as "fully caught up". That
+    /// is only correct for a table without the safe-retirement feature bit. On
+    /// an activated table a missing entry means *unknown*: the index has not
+    /// proved anything, so its SSTables must be retained and a repair
+    /// scheduled. This accessor cannot see the manifest, so it cannot make that
+    /// distinction -- callers must select the semantics from the feature bit,
+    /// and the name says which one they get here.
+    pub fn is_index_caught_up_legacy(&self, index_name: &str, shard_id: &Uuid) -> bool {
         let compacted_gen = self.compacted_generation_for_shard(shard_id).unwrap_or(0);
         let caught_up_gen = self.index_caught_up_generation(index_name, shard_id);
 
-        // If not tracked in index_catchup, assumed fully caught up
+        // Missing means "caught up" only because this is the legacy reading.
         caught_up_gen.is_none_or(|generation| generation >= compacted_gen)
     }
 }

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -426,7 +426,7 @@ impl MemWalIndex {
     /// semantics.
     ///
     /// A missing `index_catchup` entry is read here as "fully caught up". That
-    /// is only correct for a table without the safe-retirement feature bit. On
+    /// is only correct for a table without the index-catchup feature bit. On
     /// an activated table a missing entry means *unknown*: the index has not
     /// recorded anything, so its SSTables must be retained and a repair
     /// scheduled. This accessor cannot see the manifest, so it cannot make that

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -128,7 +128,9 @@ pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
-use lance_table::feature_flags::{apply_feature_flags, can_read_dataset};
+use lance_table::feature_flags::{
+    apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
+};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
@@ -716,6 +718,8 @@ impl Dataset {
         } else {
             read_struct(object_reader.as_ref(), offset).await
         }?;
+
+        validate_mem_wal_index_catchup_flags(&manifest)?;
 
         if !can_read_dataset(manifest.reader_feature_flags) {
             let message = format!(

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -3050,6 +3050,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index_a.clone(), index_b.clone()],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -3068,6 +3069,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index_c.clone()],
                 removed_indices: vec![index_a.clone()],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -2943,6 +2943,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![referenced_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -3148,6 +3149,7 @@ mod tests {
                     Operation::CreateIndex {
                         new_indices: vec![old_index.clone()],
                         removed_indices: vec![],
+                        mem_wal_index_catchup_advances: Vec::new(),
                     },
                     None,
                 ),
@@ -3166,6 +3168,7 @@ mod tests {
                     Operation::CreateIndex {
                         new_indices: vec![current_index],
                         removed_indices: vec![old_index],
+                        mem_wal_index_catchup_advances: Vec::new(),
                     },
                     None,
                 ),

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -237,6 +237,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![frag_reuse_index],
                 removed_indices: Vec::new(),
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -107,6 +107,7 @@ pub async fn cleanup_frag_reuse_index(dataset: &mut Dataset) -> lance_core::Resu
         Operation::CreateIndex {
             new_indices: vec![new_index_meta],
             removed_indices: vec![frag_reuse_index_meta.clone()],
+            mem_wal_index_catchup_advances: Vec::new(),
         },
         None,
     );

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -486,6 +486,20 @@ pub trait DatasetMemWalExt {
         Ok(None)
     }
 
+    /// Switch this table to safe SSTable retirement.
+    ///
+    /// Until this is called, a missing index-coverage entry reads as "fully
+    /// caught up". Afterwards it reads as "not proved", so an SSTable is served
+    /// until some commit shows the indexes contain its rows.
+    ///
+    /// One-way: there is no matching deactivate, because a table that has
+    /// already retired SSTables against proved coverage cannot go back to
+    /// treating missing coverage as caught up. Calling it on an already-active
+    /// table succeeds and changes nothing.
+    async fn activate_mem_wal_safe_retirement(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// List current MemWAL shard IDs from object storage directory listing.
     async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {
         Ok(Vec::new())
@@ -564,6 +578,28 @@ impl DatasetMemWalExt for Dataset {
         };
 
         load_mem_wal_index_details(index_meta).map(Some)
+    }
+
+    async fn activate_mem_wal_safe_retirement(&self) -> Result<()> {
+        if self.load_index_by_name(MEM_WAL_INDEX_NAME).await?.is_none() {
+            return Err(Error::invalid_input(
+                "Cannot activate MemWAL safe retirement: MemWAL is not initialized on \
+                 this dataset.",
+            ));
+        }
+
+        let transaction = Transaction::new(
+            self.manifest.version,
+            Operation::UpdateMemWalState {
+                compacted_sstables: Vec::new(),
+                activate_safe_retirement: true,
+            },
+            None,
+        );
+        CommitBuilder::new(Arc::new(self.clone()))
+            .execute(transaction)
+            .await?;
+        Ok(())
     }
 
     async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -486,7 +486,7 @@ pub trait DatasetMemWalExt {
         Ok(None)
     }
 
-    /// Switch this table to safe SSTable retirement.
+    /// Require a recorded index catch-up before an SSTable stops being served.
     ///
     /// Until this is called, a missing index-coverage entry reads as "fully
     /// caught up". Afterwards it reads as "not caught up", so an SSTable is served
@@ -496,7 +496,7 @@ pub trait DatasetMemWalExt {
     /// already retired SSTables against a recorded catch-up cannot go back to
     /// treating missing coverage as caught up. Calling it on an already-active
     /// table succeeds and changes nothing.
-    async fn activate_mem_wal_safe_retirement(&self) -> Result<()> {
+    async fn require_mem_wal_index_catchup(&self) -> Result<()> {
         Ok(())
     }
 
@@ -580,10 +580,10 @@ impl DatasetMemWalExt for Dataset {
         load_mem_wal_index_details(index_meta).map(Some)
     }
 
-    async fn activate_mem_wal_safe_retirement(&self) -> Result<()> {
+    async fn require_mem_wal_index_catchup(&self) -> Result<()> {
         if self.load_index_by_name(MEM_WAL_INDEX_NAME).await?.is_none() {
             return Err(Error::invalid_input(
-                "Cannot activate MemWAL safe retirement: MemWAL is not initialized on \
+                "Cannot require MemWAL index catch-up: MemWAL is not initialized on \
                  this dataset.",
             ));
         }
@@ -592,7 +592,7 @@ impl DatasetMemWalExt for Dataset {
             self.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: Vec::new(),
-                activate_safe_retirement: true,
+                require_index_catchup: true,
             },
             None,
         );

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -496,7 +496,7 @@ pub trait DatasetMemWalExt {
     /// already retired SSTables against a recorded catch-up cannot go back to
     /// treating missing coverage as caught up. Calling it on an already-active
     /// table succeeds and changes nothing.
-    async fn require_mem_wal_index_catchup(&self) -> Result<()> {
+    async fn require_mem_wal_index_catchup(&mut self) -> Result<()> {
         Ok(())
     }
 
@@ -580,7 +580,7 @@ impl DatasetMemWalExt for Dataset {
         load_mem_wal_index_details(index_meta).map(Some)
     }
 
-    async fn require_mem_wal_index_catchup(&self) -> Result<()> {
+    async fn require_mem_wal_index_catchup(&mut self) -> Result<()> {
         if self.load_index_by_name(MEM_WAL_INDEX_NAME).await?.is_none() {
             return Err(Error::invalid_input(
                 "Cannot require MemWAL index catch-up: MemWAL is not initialized on \
@@ -596,7 +596,9 @@ impl DatasetMemWalExt for Dataset {
             },
             None,
         );
-        CommitBuilder::new(Arc::new(self.clone()))
+        // Assigned back: leaving the receiver on the pre-activation manifest
+        // would report success while `self` still reads as legacy.
+        *self = CommitBuilder::new(Arc::new(self.clone()))
             .execute(transaction)
             .await?;
         Ok(())

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -240,6 +240,7 @@ impl<'a> InitializeMemWalBuilder<'a> {
             Operation::CreateIndex {
                 new_indices: vec![index_meta],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -489,11 +489,11 @@ pub trait DatasetMemWalExt {
     /// Switch this table to safe SSTable retirement.
     ///
     /// Until this is called, a missing index-coverage entry reads as "fully
-    /// caught up". Afterwards it reads as "not proved", so an SSTable is served
+    /// caught up". Afterwards it reads as "not caught up", so an SSTable is served
     /// until some commit shows the indexes contain its rows.
     ///
     /// One-way: there is no matching deactivate, because a table that has
-    /// already retired SSTables against proved coverage cannot go back to
+    /// already retired SSTables against a recorded catch-up cannot go back to
     /// treating missing coverage as caught up. Calling it on an already-active
     /// table succeeds and changes nothing.
     async fn activate_mem_wal_safe_retirement(&self) -> Result<()> {

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -381,6 +381,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         Operation::CreateIndex {
             new_indices: vec![new_index_meta],
             removed_indices: vec![curr_index_meta],
+            mem_wal_index_catchup_advances: Vec::new(),
         },
         None,
     );

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -35,7 +35,7 @@ use lance_index::mem_wal::{CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX
 use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{
-    FLAG_MEM_WAL_SAFE_RETIREMENT, FLAG_STABLE_ROW_IDS, apply_feature_flags,
+    FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, apply_feature_flags,
 };
 use lance_table::rowids::read_row_ids;
 use lance_table::{
@@ -575,12 +575,12 @@ pub enum Operation {
     /// SSTables have been compacted into the base table.
     UpdateMemWalState {
         compacted_sstables: Vec<CompactedSsTable>,
-        /// Requests the one-way migration to safe retirement.
+        /// Requests the one-way migration to required index catch-up.
         ///
         /// One-way because returning to legacy semantics — where a missing
         /// coverage entry reads as "fully caught up" — is unsafe once any
         /// SSTable has been retired against a recorded catch-up position.
-        activate_safe_retirement: bool,
+        require_index_catchup: bool,
     },
 
     /// Clone a dataset.
@@ -1377,11 +1377,11 @@ impl PartialEq for Operation {
             (
                 Self::UpdateMemWalState {
                     compacted_sstables: a_compacted,
-                    activate_safe_retirement: a_activate,
+                    require_index_catchup: a_activate,
                 },
                 Self::UpdateMemWalState {
                     compacted_sstables: b_compacted,
-                    activate_safe_retirement: b_activate,
+                    require_index_catchup: b_activate,
                 },
             ) => compare_vec(a_compacted, b_compacted) && a_activate == b_activate,
             (Self::Clone { .. }, Self::Append { .. }) => {
@@ -1929,21 +1929,18 @@ impl Transaction {
         Ok((manifest, indices))
     }
 
-    /// Turn on safe retirement for a table that has never had it.
+    /// Require index catch-up on a table that has never required it.
     ///
     /// One-way, because returning to legacy semantics -- where a missing
     /// coverage entry reads as "fully caught up" -- is unsafe once any SSTable
     /// has been retired against a recorded catch-up position.
-    fn activate_safe_retirement(
-        final_indices: &mut [IndexMetadata],
-        new_version: u64,
-    ) -> Result<()> {
+    fn require_index_catchup(final_indices: &mut [IndexMetadata], new_version: u64) -> Result<()> {
         let Some(pos) = final_indices
             .iter()
             .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
         else {
             return Err(Error::invalid_input(format!(
-                "Cannot activate MemWAL safe retirement: the {} system index does \
+                "Cannot require MemWAL index catch-up: the {} system index does \
                  not exist on this table",
                 MEM_WAL_INDEX_NAME
             )));
@@ -1958,7 +1955,7 @@ impl Transaction {
         // them must be drained through an explicit migration instead.
         if !details.compacted_sstables.is_empty() {
             return Err(Error::invalid_input(
-                "Cannot activate MemWAL safe retirement: the table already records \
+                "Cannot require MemWAL index catch-up: the table already records \
                  SSTable compaction progress from the beta protocol, which cannot \
                  be validated. Drain or reset the table first.",
             ));
@@ -2008,7 +2005,7 @@ impl Transaction {
     /// here rather than in each caller so an ordinary index job cannot forget it
     /// and leave a stale catch-up position behind.
     ///
-    /// Dropping coverage is only conservative under safe retirement, where a
+    /// Dropping coverage is only conservative once catch-up is required, where a
     /// missing entry means "not caught up" and the SSTables stay. A legacy table
     /// reads a missing entry as "fully caught up", so this leaves legacy
     /// progress untouched rather than making the table look more covered.
@@ -2017,15 +2014,15 @@ impl Transaction {
         final_fragments: &[Fragment],
         segments_before: &LogicalIndexSegments,
         advances: &[IndexCatchupAdvance],
-        safe_retirement_enabled: bool,
+        index_catchup_required: bool,
         coverage_only_operation: bool,
         new_version: u64,
     ) -> Result<()> {
-        if !safe_retirement_enabled {
+        if !index_catchup_required {
             if !advances.is_empty() {
                 return Err(Error::invalid_input(
-                    "Index coverage can only be advanced on a table with MemWAL safe \
-                     retirement enabled",
+                    "Index coverage can only be advanced on a table that requires MemWAL \
+                     index catch-up",
                 ));
             }
             return Ok(());
@@ -2346,10 +2343,10 @@ impl Transaction {
 
         // Both words must agree: a reader that keeps legacy semantics would read a
         // missing entry as "fully caught up", so a half-set state is not safe mode.
-        let safe_retirement_enabled = current_manifest
+        let index_catchup_required = current_manifest
             .map(|m| {
-                m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0
-                    && m.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0
+                m.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
+                    && m.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
             })
             .unwrap_or(false);
 
@@ -2357,7 +2354,7 @@ impl Transaction {
         // be compared against what each logical index looked like going in. Only
         // tables in safe mode maintain coverage, so every other commit -- and the
         // segment clones this costs -- pays nothing.
-        let mem_wal_segments_before = (safe_retirement_enabled
+        let mem_wal_segments_before = (index_catchup_required
             && final_indices
                 .iter()
                 .any(|idx| idx.name == MEM_WAL_INDEX_NAME))
@@ -3030,7 +3027,7 @@ impl Transaction {
                 &final_fragments,
                 mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
                 advances,
-                safe_retirement_enabled,
+                index_catchup_required,
                 coverage_only_operation,
                 new_version,
             )?;
@@ -3083,19 +3080,19 @@ impl Transaction {
         // Set after apply_feature_flags, which resets both flag words: activation
         // is the one place the bit is turned on, and it must survive that reset.
         if let Operation::UpdateMemWalState {
-            activate_safe_retirement: true,
+            require_index_catchup: true,
             ..
         } = &self.operation
         {
             let reader_set = current_manifest
-                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
+                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0)
                 .unwrap_or(false);
             let writer_set = current_manifest
-                .map(|m| m.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
+                .map(|m| m.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0)
                 .unwrap_or(false);
             match (reader_set, writer_set) {
                 (false, false) => {
-                    Self::activate_safe_retirement(&mut final_indices, new_version)?;
+                    Self::require_index_catchup(&mut final_indices, new_version)?;
                 }
                 // Already active. A retry whose first attempt landed but lost its
                 // response must not clear coverage repaired since, so this keeps
@@ -3103,14 +3100,14 @@ impl Transaction {
                 (true, true) => {}
                 _ => {
                     return Err(Error::invalid_input(
-                        "Cannot activate MemWAL safe retirement: the table has only one \
-                         of the reader and writer feature bits set, so its retirement \
+                        "Cannot require MemWAL index catch-up: the table has only one of \
+                         the reader and writer feature bits set, so its catch-up \
                          semantics are undefined",
                     ));
                 }
             }
-            manifest.reader_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
-            manifest.writer_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
+            manifest.reader_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
+            manifest.writer_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
         }
 
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
@@ -4196,7 +4193,7 @@ impl TryFrom<pb::Transaction> for Transaction {
             Some(pb::transaction::Operation::UpdateMemWalState(
                 pb::transaction::UpdateMemWalState {
                     compacted_sstables,
-                    activate_safe_retirement,
+                    require_index_catchup,
                 },
             )) => Operation::UpdateMemWalState {
                 compacted_sstables: compacted_sstables
@@ -4206,11 +4203,11 @@ impl TryFrom<pb::Transaction> for Transaction {
                 // Absent is an ordinary progress update. Explicit `false` is
                 // refused rather than read as absent, so a caller cannot express
                 // "deactivate" -- the migration is one-way.
-                activate_safe_retirement: match activate_safe_retirement {
+                require_index_catchup: match require_index_catchup {
                     Some(false) => {
                         return Err(Error::invalid_input(
-                            "activate_safe_retirement cannot be false: MemWAL safe \
-                             retirement cannot be turned off once activated",
+                            "require_index_catchup cannot be false: MemWAL index catch-up \
+                             cannot stop being required once it is",
                         ));
                     }
                     other => other.unwrap_or(false),
@@ -4519,7 +4516,7 @@ impl From<&Transaction> for pb::Transaction {
             }
             Operation::UpdateMemWalState {
                 compacted_sstables,
-                activate_safe_retirement,
+                require_index_catchup,
             } => {
                 pb::transaction::Operation::UpdateMemWalState(pb::transaction::UpdateMemWalState {
                     compacted_sstables: compacted_sstables
@@ -4528,7 +4525,7 @@ impl From<&Transaction> for pb::Transaction {
                         .collect::<Vec<_>>(),
                     // Written only when requesting activation, so an ordinary
                     // progress update stays byte-identical to before.
-                    activate_safe_retirement: activate_safe_retirement.then_some(true),
+                    require_index_catchup: require_index_catchup.then_some(true),
                 })
             }
             Operation::UpdateBases { new_bases } => {
@@ -7685,14 +7682,14 @@ mod tests {
             final_indices: &mut [IndexMetadata],
             segments_before: &LogicalIndexSegments,
             advances: &[IndexCatchupAdvance],
-            safe_retirement_enabled: bool,
+            index_catchup_required: bool,
         ) -> Result<()> {
             Transaction::apply_mem_wal_index_coverage(
                 final_indices,
                 &[],
                 segments_before,
                 advances,
-                safe_retirement_enabled,
+                index_catchup_required,
                 false,
                 2,
             )
@@ -7900,7 +7897,7 @@ mod tests {
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], false)
                 .unwrap_err();
 
-            assert!(err.to_string().contains("safe retirement"), "{err}");
+            assert!(err.to_string().contains("index catch-up"), "{err}");
         }
 
         #[test]
@@ -7988,21 +7985,21 @@ mod tests {
                 ..Default::default()
             })];
 
-            let err = Transaction::activate_safe_retirement(&mut indices, 2).unwrap_err();
+            let err = Transaction::require_index_catchup(&mut indices, 2).unwrap_err();
 
             assert!(err.to_string().contains("beta protocol"), "{err}");
         }
 
         #[test]
         fn activation_requires_the_mem_wal_index() {
-            let err = Transaction::activate_safe_retirement(&mut [], 2).unwrap_err();
+            let err = Transaction::require_index_catchup(&mut [], 2).unwrap_err();
             assert!(err.to_string().contains("does not exist"), "{err}");
         }
 
         #[test]
         fn activation_accepts_a_clean_table() {
             let mut indices = vec![mem_wal_index(MemWalIndexDetails::default())];
-            Transaction::activate_safe_retirement(&mut indices, 2).unwrap();
+            Transaction::require_index_catchup(&mut indices, 2).unwrap();
         }
 
         #[test]
@@ -8285,7 +8282,7 @@ mod tests {
                 ..Default::default()
             })];
 
-            Transaction::activate_safe_retirement(&mut indices, 2).unwrap();
+            Transaction::require_index_catchup(&mut indices, 2).unwrap();
 
             // Beta coverage was written under rules this protocol does not
             // enforce, so keeping it would let the first trim run without a catch-up check.

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -444,10 +444,11 @@ pub enum Operation {
         removed_indices: Vec<IndexMetadata>,
         /// MemWAL index catch-up this operation reports, if any.
         ///
-        /// Empty for every ordinary index operation. An ordinary create,
-        /// reindex, append, or remap therefore loses whatever coverage its
-        /// index had recorded, and the agent schedules a repair — conservative,
-        /// but it can never make an uncovered index look covered.
+        /// Empty for every ordinary index operation. Creating, reindexing,
+        /// appending to, or remapping an index changes it without saying how far
+        /// it has caught up, so that index's `index_catchup` entry is removed and
+        /// a later repair records a fresh one. Conservative, but it can never
+        /// leave a lagging index looking caught up.
         mem_wal_index_catchup_advances: Vec<IndexCatchupAdvance>,
     },
     /// Data is rewritten but *not* modified. This is used for things like

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2229,9 +2229,14 @@ impl Transaction {
         Ok(())
     }
 
-    /// Require a coverage-only advance to name an index that spans every live
-    /// fragment. Such a commit publishes no index work of its own, so without
-    /// this an incomplete or untrained index could be handed a coverage claim.
+    /// Reject a coverage-only advance whose target index cannot back any claim.
+    ///
+    /// Such a commit publishes no index work of its own, so an untrained or
+    /// empty index would otherwise be handed a coverage claim. What it does
+    /// *not* check is that the index spans the whole table: the claim is only
+    /// about generations already compacted, and fragments appended since are a
+    /// later catch-up gap. Requiring full coverage would fail every repair on a
+    /// table still taking writes.
     fn validate_coverage_only_target(
         index_name: &str,
         segments: &[IndexMetadata],
@@ -2248,14 +2253,13 @@ impl Transaction {
             };
             covered |= bitmap;
         }
-        // `covered` is already clipped to the live set, so equality means the
-        // index spans all of it.
-        if &covered != live_fragments {
+        // An index covering nothing that still exists has indexed nothing a
+        // reader could use, so it cannot stand in for the SSTables.
+        if covered.is_empty() && !live_fragments.is_empty() {
             return Err(Error::invalid_input(format!(
-                "Cannot advance coverage for index {}: it covers {} of the {} live \
-                 fragments, so it cannot stand in for the SSTables",
+                "Cannot advance coverage for index {}: it covers none of the {} live \
+                 fragments",
                 index_name,
-                covered.len(),
                 live_fragments.len()
             )));
         }
@@ -8153,10 +8157,13 @@ mod tests {
         }
 
         #[test]
-        fn a_coverage_only_advance_requires_the_index_to_span_the_table() {
+        fn a_coverage_only_advance_survives_a_concurrent_append() {
             let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
             let before = table(shard, 10, "vec_idx", 5, uuid);
             let mut after = before.clone();
+            // The index spans the table the repair read; fragment 1 landed while
+            // the repair ran. A table still taking writes always looks like this,
+            // and the claim is only about generations already compacted.
             after[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32]));
 
             let advance = IndexCatchupAdvance {
@@ -8165,6 +8172,37 @@ mod tests {
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
             };
             let fragments = vec![Fragment::new(0), Fragment::new(1)];
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &fragments,
+                &segments_before(&before),
+                &[advance],
+                true,
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert_eq!(
+                coverage_for(&after, "vec_idx"),
+                Some(vec![CompactedSsTable::new(shard, 9)])
+            );
+        }
+
+        #[test]
+        fn a_coverage_only_advance_rejects_an_index_covering_nothing_live() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            // Declared but never trained, or covering only fragments since gone.
+            after[0].fragment_bitmap = Some(RoaringBitmap::new());
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+            };
+            let fragments = vec![Fragment::new(0)];
             let err = Transaction::apply_mem_wal_index_coverage(
                 &mut after,
                 &fragments,
@@ -8176,7 +8214,7 @@ mod tests {
             )
             .unwrap_err();
 
-            assert!(err.to_string().contains("live fragments"), "{err}");
+            assert!(err.to_string().contains("covers none"), "{err}");
         }
 
         #[test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -36,7 +36,7 @@ use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{
     FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, apply_feature_flags,
-    inherit_mem_wal_index_catchup,
+    inherit_mem_wal_index_catchup, validate_mem_wal_index_catchup_flags,
 };
 use lance_table::rowids::read_row_ids;
 use lance_table::{
@@ -1973,6 +1973,10 @@ impl Transaction {
             .resolve_version_location(base_path, version, &object_store.inner)
             .await?;
         let mut manifest = read_manifest(object_store, &location.path, location.size).await?;
+        // Read below the reader validation boundary, so nothing else refuses a
+        // half-set manifest here: the flag reset would quietly drop the lone bit
+        // and republish an undefined state as legacy.
+        validate_mem_wal_index_catchup_flags(&manifest)?;
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
         manifest.transaction_file = Some(tx_path.to_string());
         let indices = read_manifest_indexes(object_store, &location, &manifest).await?;
@@ -2172,7 +2176,7 @@ impl Transaction {
                 })
                 .collect();
             // The first thing to check when SSTables stop becoming trimmable.
-            log::debug!(
+            log::info!(
                 "MemWAL index catch-up invalidated at version {new_version} for {dropped:?}: \
                  these indices changed without reporting how far they caught up"
             );

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1919,10 +1919,6 @@ impl Transaction {
         Ok((manifest, indices))
     }
 
-    /// Create a new manifest from the current manifest and the transaction.
-    ///
-    /// `current_manifest` should only be None if the dataset does not yet exist.
-
     /// Preconditions for the one-way migration to safe retirement.
     ///
     /// Activation is one-way because returning to legacy semantics -- where a
@@ -1994,7 +1990,7 @@ impl Transaction {
     /// Dropping coverage is always safe -- missing coverage schedules a repair
     /// and retains SSTables. Wrongly *keeping* it is not.
     fn apply_mem_wal_index_coverage(
-        final_indices: &mut Vec<IndexMetadata>,
+        final_indices: &mut [IndexMetadata],
         segments_before: &LogicalIndexSegments,
         advances: &[IndexCatchupAdvance],
         safe_retirement_enabled: bool,
@@ -2028,10 +2024,11 @@ impl Transaction {
 
         // Nothing has ever been compacted, so no index can be behind and there is
         // no coverage to invalidate. Bail before doing any work.
-        if details.compacted_sstables.is_empty() && details.index_catchup.is_empty() {
-            if advances.is_empty() {
-                return Ok(());
-            }
+        if details.compacted_sstables.is_empty()
+            && details.index_catchup.is_empty()
+            && advances.is_empty()
+        {
+            return Ok(());
         }
 
         // --- invalidate coverage the transaction changed but did not prove ---
@@ -2172,6 +2169,9 @@ impl Transaction {
         Ok(())
     }
 
+    /// Create a new manifest from the current manifest and the transaction.
+    ///
+    /// `current_manifest` should only be None if the dataset does not yet exist.
     pub(crate) fn build_manifest(
         &self,
         current_manifest: Option<&Manifest>,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -8567,6 +8567,50 @@ mod tests {
             assert!(err.to_string().contains("covers none"), "{err}");
         }
 
+        /// An ordinary index job on a table that requires catch-up must still
+        /// commit -- it loses the coverage entry, it is never refused.
+        #[test]
+        fn an_ordinary_index_job_is_never_blocked() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4());
+
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
+
+            assert_eq!(coverage_for(&after, "vec_idx"), None, "coverage dropped");
+        }
+
+        /// A table with no MemWAL system index never reaches the protocol, so an
+        /// index job on an ordinary table is untouched by any of this.
+        #[test]
+        fn a_table_without_mem_wal_is_untouched() {
+            let uuid = Uuid::new_v4();
+            let before = vec![user_index("vec_idx", uuid)];
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4());
+            let expected = after.clone();
+
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
+
+            assert_eq!(after, expected, "index list must be byte-identical");
+        }
+
+        /// A MemWAL table that has not been migrated keeps legacy behaviour: an
+        /// index job neither loses coverage nor is refused.
+        #[test]
+        fn a_legacy_mem_wal_table_is_untouched_by_an_index_job() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4());
+            let expected = after.clone();
+
+            apply_coverage(&mut after, &segments_before(&before), &[], false).unwrap();
+
+            assert_eq!(after, expected, "index list must be byte-identical");
+        }
+
         #[test]
         fn index_catchup_advance_round_trips_through_protobuf() {
             let advance = IndexCatchupAdvance {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -36,6 +36,7 @@ use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{
     FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, apply_feature_flags,
+    inherit_mem_wal_index_catchup,
 };
 use lance_table::rowids::read_row_ids;
 use lance_table::{
@@ -353,6 +354,13 @@ pub struct IndexCatchupAdvance {
     /// Only these are recorded, never whatever is current at commit time: the
     /// claim must not exceed what the job actually indexed.
     pub caught_up_generations: Vec<CompactedSsTable>,
+    /// The fragments the named segments covered when the repair inspected them.
+    ///
+    /// UUIDs alone are not a fence: an operation can prune a segment's fragment
+    /// bitmap while keeping its UUID, so a claim made before the prune would
+    /// still match afterwards. The commit fails unless the segments it publishes
+    /// cover exactly these fragments.
+    pub expected_fragment_bitmap: RoaringBitmap,
 }
 
 // Hand-written because `Uuid` does not implement `DeepSizeOf`; it is a fixed
@@ -379,6 +387,16 @@ impl From<&IndexCatchupAdvance> for pb::transaction::create_index::IndexCatchupA
                 .iter()
                 .map(pb::CompactedSsTable::from)
                 .collect(),
+            expected_fragment_bitmap: {
+                let mut bytes =
+                    Vec::with_capacity(advance.expected_fragment_bitmap.serialized_size());
+                // Writing to a Vec cannot fail.
+                advance
+                    .expected_fragment_bitmap
+                    .serialize_into(&mut bytes)
+                    .expect("serializing a roaring bitmap into a Vec cannot fail");
+                bytes
+            },
         }
     }
 }
@@ -387,8 +405,8 @@ impl TryFrom<pb::transaction::create_index::IndexCatchupAdvance> for IndexCatchu
     type Error = Error;
 
     fn try_from(advance: pb::transaction::create_index::IndexCatchupAdvance) -> Result<Self> {
+        let index_name = advance.index_name;
         Ok(Self {
-            index_name: advance.index_name,
             expected_index_segment_uuids: advance
                 .expected_index_segment_uuids
                 .iter()
@@ -399,6 +417,15 @@ impl TryFrom<pb::transaction::create_index::IndexCatchupAdvance> for IndexCatchu
                 .into_iter()
                 .map(CompactedSsTable::try_from)
                 .collect::<Result<_>>()?,
+            expected_fragment_bitmap: RoaringBitmap::deserialize_from(
+                advance.expected_fragment_bitmap.as_slice(),
+            )
+            .map_err(|err| {
+                Error::invalid_input(format!(
+                    "Could not decode expected_fragment_bitmap for index {index_name}: {err}"
+                ))
+            })?,
+            index_name,
         })
     }
 }
@@ -1926,6 +1953,19 @@ impl Transaction {
         manifest.max_fragment_id = manifest
             .max_fragment_id
             .max(current_manifest.max_fragment_id);
+        // Restoring a version from before catch-up was required must not take the
+        // table back to legacy semantics: SSTables may already have stopped being
+        // served against a recorded position. The restored coverage map is then
+        // read strictly, so a missing entry retains SSTables until a repair
+        // rebuilds it.
+        if current_manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0 {
+            log::info!(
+                "Restoring version {version} onto a table that requires MemWAL index \
+                 catch-up; the bit is kept and the restored catch-up state is read \
+                 strictly, so SSTables are retained until a repair rebuilds it"
+            );
+        }
+        inherit_mem_wal_index_catchup(&mut manifest, current_manifest)?;
         Ok((manifest, indices))
     }
 
@@ -2015,7 +2055,7 @@ impl Transaction {
         segments_before: &LogicalIndexSegments,
         advances: &[IndexCatchupAdvance],
         index_catchup_required: bool,
-        coverage_only_operation: bool,
+        indices_published: &HashSet<&str>,
         new_version: u64,
     ) -> Result<()> {
         if !index_catchup_required {
@@ -2090,12 +2130,27 @@ impl Transaction {
             }
         });
 
+        if details.index_catchup.len() < catchup_before.len() {
+            let dropped: Vec<&str> = catchup_before
+                .iter()
+                .map(|entry| entry.index_name.as_str())
+                .filter(|name| {
+                    !details
+                        .index_catchup
+                        .iter()
+                        .any(|kept| kept.index_name == *name)
+                })
+                .collect();
+            // The first thing to check when SSTables stop becoming trimmable.
+            log::debug!(
+                "MemWAL index catch-up invalidated at version {new_version} for {dropped:?}: \
+                 these indices changed without reporting how far they caught up"
+            );
+        }
+
         // --- validate and apply each advance ---
 
-        // A coverage-only commit publishes no index work, so nothing else in the
-        // transaction shows the named index is usable against the current table.
-        let live_fragments: Option<RoaringBitmap> =
-            coverage_only_operation.then(|| final_fragments.iter().map(|f| f.id as u32).collect());
+        let live_fragments: RoaringBitmap = final_fragments.iter().map(|f| f.id as u32).collect();
 
         let mut seen_names = HashSet::with_capacity(advances.len());
         for advance in advances {
@@ -2139,8 +2194,39 @@ impl Transaction {
                 )));
             }
 
-            if let Some(live) = live_fragments.as_ref() {
-                Self::validate_coverage_only_target(&advance.index_name, segments, live)?;
+            // UUIDs alone are not a fence: pruning narrows a segment's fragment
+            // bitmap without changing its UUID, so an advance made before the
+            // prune would still match the UUID set afterwards.
+            let mut published = RoaringBitmap::new();
+            for segment in segments {
+                let Some(bitmap) = segment.fragment_bitmap.as_ref() else {
+                    return Err(Error::invalid_input(format!(
+                        "Cannot advance coverage for index {}: segment {} does not \
+                         record which fragments it covers",
+                        advance.index_name, segment.uuid
+                    )));
+                };
+                published |= bitmap;
+            }
+            if published != advance.expected_fragment_bitmap {
+                return Err(Error::invalid_input(format!(
+                    "Index {} does not cover the fragments this coverage advance \
+                     expects: expected {:?}, found {:?}",
+                    advance.index_name,
+                    advance.expected_fragment_bitmap.iter().collect::<Vec<_>>(),
+                    published.iter().collect::<Vec<_>>()
+                )));
+            }
+
+            // Decided per advance, not per transaction: publishing an index in the
+            // same commit says nothing about a *different* index named by another
+            // advance, which still has to stand on its own metadata.
+            if !indices_published.contains(advance.index_name.as_str()) {
+                Self::validate_coverage_only_target(
+                    &advance.index_name,
+                    segments,
+                    &live_fragments,
+                )?;
             }
 
             let mut seen_shards = HashSet::with_capacity(advance.caught_up_generations.len());
@@ -3008,16 +3094,21 @@ impl Transaction {
             } => mem_wal_index_catchup_advances,
             _ => &[],
         };
-        // A coverage-only commit publishes no index work of its own, so the named
-        // index has to be checked against the table before its claim is recorded.
-        let coverage_only_operation = matches!(
-            &self.operation,
+        // The logical indices this commit publishes work for. An advance naming
+        // one of them is backed by the metadata landing alongside it; an advance
+        // naming any other index has to stand on that index's own metadata.
+        let indices_published: HashSet<&str> = match &self.operation {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
                 ..
-            } if new_indices.is_empty() && removed_indices.is_empty()
-        );
+            } => new_indices
+                .iter()
+                .chain(removed_indices.iter())
+                .map(|idx| idx.name.as_str())
+                .collect(),
+            _ => HashSet::new(),
+        };
         // Advances are also routed in when the table carries no system index, so a
         // coverage claim on such a table is rejected rather than silently dropped.
         if mem_wal_segments_before.is_some() || !advances.is_empty() {
@@ -3028,7 +3119,7 @@ impl Transaction {
                 mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
                 advances,
                 index_catchup_required,
-                coverage_only_operation,
+                &indices_published,
                 new_version,
             )?;
         }
@@ -3077,6 +3168,13 @@ impl Transaction {
                 config.disable_transaction_file,
             )?;
         }
+        // Carried from the manifest this one is derived from. `new_from_previous`
+        // zeroes both feature words, so `apply_feature_flags` cannot see the
+        // previous state and every ordinary commit would otherwise drop the bit.
+        if let Some(current_manifest) = current_manifest {
+            inherit_mem_wal_index_catchup(&mut manifest, current_manifest)?;
+        }
+
         // Set after apply_feature_flags, which resets both flag words: activation
         // is the one place the bit is turned on, and it must survive that reset.
         if let Operation::UpdateMemWalState {
@@ -3093,6 +3191,11 @@ impl Transaction {
             match (reader_set, writer_set) {
                 (false, false) => {
                     Self::require_index_catchup(&mut final_indices, new_version)?;
+                    log::info!(
+                        "MemWAL index catch-up is now required at version {new_version}; a \
+                         missing catch-up entry means an index is behind, not caught up. \
+                         This is one-way."
+                    );
                 }
                 // Already active. A retry whose first attempt landed but lost its
                 // response must not clear coverage repaired since, so this keeps
@@ -7649,7 +7752,7 @@ mod tests {
                 name: name.to_string(),
                 fields: vec![0],
                 dataset_version: 1,
-                fragment_bitmap: None,
+                fragment_bitmap: Some(RoaringBitmap::from_iter([0u32])),
                 index_details: None,
                 index_version: 0,
                 created_at: None,
@@ -7690,9 +7793,22 @@ mod tests {
                 segments_before,
                 advances,
                 index_catchup_required,
-                false,
+                &HashSet::new(),
                 2,
             )
+        }
+
+        /// The fragments `name`'s segments cover here -- what a repair that
+        /// inspected this state would put in its advance.
+        fn covered_by(indices: &[IndexMetadata], name: &str) -> RoaringBitmap {
+            indices
+                .iter()
+                .filter(|idx| idx.name == name)
+                .filter_map(|idx| idx.fragment_bitmap.clone())
+                .fold(RoaringBitmap::new(), |mut acc, bitmap| {
+                    acc |= bitmap;
+                    acc
+                })
         }
 
         fn coverage_for(indices: &[IndexMetadata], name: &str) -> Option<Vec<CompactedSsTable>> {
@@ -7812,6 +7928,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![rebuilt],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -7831,6 +7948,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![Uuid::new_v4()], // what the repair built
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7853,6 +7971,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7873,6 +7992,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7893,6 +8013,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], false)
                 .unwrap_err();
@@ -7909,6 +8030,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &LogicalIndexSegments::new(), &[advance], true)
                 .unwrap_err();
@@ -7926,6 +8048,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(
                 &mut after,
@@ -7951,6 +8074,7 @@ mod tests {
                     CompactedSsTable::new(shard, 9),
                     CompactedSsTable::new(shard, 10),
                 ],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7968,6 +8092,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid, uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -8068,6 +8193,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8091,6 +8217,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 6)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8125,6 +8252,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![rebuilt],
                 caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8167,6 +8295,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let fragments = vec![Fragment::new(0), Fragment::new(1)];
             Transaction::apply_mem_wal_index_coverage(
@@ -8175,7 +8304,7 @@ mod tests {
                 &segments_before(&before),
                 &[advance],
                 true,
-                true,
+                &HashSet::new(),
                 2,
             )
             .unwrap();
@@ -8198,6 +8327,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let fragments = vec![Fragment::new(0)];
             let err = Transaction::apply_mem_wal_index_coverage(
@@ -8206,7 +8336,7 @@ mod tests {
                 &segments_before(&before),
                 &[advance],
                 true,
-                true,
+                &HashSet::new(),
                 2,
             )
             .unwrap_err();
@@ -8225,6 +8355,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let fragments = vec![Fragment::new(0), Fragment::new(1)];
             Transaction::apply_mem_wal_index_coverage(
@@ -8233,7 +8364,7 @@ mod tests {
                 &segments_before(&before),
                 &[advance],
                 true,
-                true,
+                &HashSet::new(),
                 2,
             )
             .unwrap();
@@ -8255,6 +8386,7 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: covered_by(&after, "vec_idx"),
             };
             let fragments = vec![Fragment::new(0)];
             let err = Transaction::apply_mem_wal_index_coverage(
@@ -8263,7 +8395,7 @@ mod tests {
                 &segments_before(&before),
                 &[advance],
                 true,
-                true,
+                &HashSet::new(),
                 2,
             )
             .unwrap_err();
@@ -8289,6 +8421,152 @@ mod tests {
             assert!(details_of(&indices).index_catchup.is_empty());
         }
 
+        /// F1: the real commit path, not `apply_feature_flags` in isolation.
+        /// `Manifest::new_from_previous` zeroes both feature words, so a helper
+        /// that reads them back sees nothing to preserve.
+        #[test]
+        fn an_ordinary_commit_keeps_the_feature_bit() {
+            let mut current = sample_manifest_with_fragments(0..1);
+            current.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+            current.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
+
+            let transaction = Transaction::new(
+                current.version,
+                Operation::UpdateConfig {
+                    config_updates: None,
+                    table_metadata_updates: None,
+                    schema_metadata_updates: None,
+                    field_metadata_updates: HashMap::new(),
+                },
+                None,
+            );
+            let (next, _) = transaction
+                .build_manifest(
+                    Some(&current),
+                    vec![mem_wal_index(MemWalIndexDetails::default())],
+                    "txn",
+                    &ManifestWriteConfig::default(),
+                )
+                .unwrap();
+
+            assert_ne!(next.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP, 0);
+            assert_ne!(next.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP, 0);
+        }
+
+        /// F2: one bit set means a legacy reader or a legacy writer is still
+        /// permitted, which is neither mode. Refused, not normalized to both.
+        #[test]
+        fn a_half_set_feature_bit_is_refused() {
+            for (reader, writer) in [
+                (FLAG_MEM_WAL_INDEX_CATCHUP, 0),
+                (0, FLAG_MEM_WAL_INDEX_CATCHUP),
+            ] {
+                let mut current = sample_manifest_with_fragments(0..1);
+                current.reader_feature_flags = reader;
+                current.writer_feature_flags = writer;
+
+                let transaction = Transaction::new(
+                    current.version,
+                    Operation::UpdateConfig {
+                        config_updates: None,
+                        table_metadata_updates: None,
+                        schema_metadata_updates: None,
+                        field_metadata_updates: HashMap::new(),
+                    },
+                    None,
+                );
+                let err = transaction
+                    .build_manifest(
+                        Some(&current),
+                        vec![mem_wal_index(MemWalIndexDetails::default())],
+                        "txn",
+                        &ManifestWriteConfig::default(),
+                    )
+                    .unwrap_err();
+
+                assert!(err.to_string().contains("only one of"), "{err}");
+            }
+        }
+
+        /// F3: pruning narrows a segment's fragment bitmap without changing its
+        /// UUID, so the UUID set alone cannot fence the advance.
+        #[test]
+        fn an_advance_whose_target_was_pruned_rejects() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let mut before = table(shard, 10, "vec_idx", 3, uuid);
+            before[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32, 1]));
+            let mut after = before.clone();
+
+            // What the repair inspected, before anything pruned it.
+            let inspected = covered_by(&after, "vec_idx");
+
+            Transaction::prune_updated_fields_from_indices(&mut after, &[Fragment::new(1)], &[0]);
+            assert_eq!(
+                after[0].fragment_bitmap,
+                Some(RoaringBitmap::from_iter([0u32])),
+                "precondition: the prune narrowed the segment but kept its UUID"
+            );
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+                expected_fragment_bitmap: inspected,
+            };
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
+
+            assert!(
+                err.to_string().contains("does not cover the fragments"),
+                "{err}"
+            );
+        }
+
+        /// F4: publishing one index says nothing about a different index named
+        /// by another advance in the same commit.
+        #[test]
+        fn work_on_one_index_does_not_excuse_another() {
+            let shard = Uuid::new_v4();
+            let target_uuid = Uuid::new_v4();
+            let mut target = user_index("idx_a", target_uuid);
+            // Declared but never trained: covers nothing that still exists.
+            target.fragment_bitmap = Some(RoaringBitmap::new());
+            let mut after = vec![
+                target,
+                user_index("idx_b", Uuid::new_v4()),
+                mem_wal_index(MemWalIndexDetails {
+                    compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                    index_catchup: vec![IndexCatchupProgress::new(
+                        "idx_a".to_string(),
+                        vec![CompactedSsTable::new(shard, 3)],
+                    )],
+                    ..Default::default()
+                }),
+            ];
+            let before = after.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "idx_a".to_string(),
+                expected_index_segment_uuids: vec![target_uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+                expected_fragment_bitmap: RoaringBitmap::new(),
+            };
+            // The commit publishes idx_b; idx_a still has to stand on its own.
+            let published: HashSet<&str> = ["idx_b"].into_iter().collect();
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &[Fragment::new(0)],
+                &segments_before(&before),
+                &[advance],
+                true,
+                &published,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("covers none"), "{err}");
+        }
+
         #[test]
         fn index_catchup_advance_round_trips_through_protobuf() {
             let advance = IndexCatchupAdvance {
@@ -8298,6 +8576,7 @@ mod tests {
                     CompactedSsTable::new(Uuid::new_v4(), 3),
                     CompactedSsTable::new(Uuid::new_v4(), 9),
                 ],
+                expected_fragment_bitmap: RoaringBitmap::from_iter([0u32, 7, 42]),
             };
 
             let encoded = pb::transaction::create_index::IndexCatchupAdvance::from(&advance);

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -17,7 +17,9 @@ use super::write::merge_insert::inserted_rows::KeyExistenceFilter;
 use crate::dataset::overlay::collect_overlay_stale_frags;
 use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
 use crate::index::index_results_are_row_addrs;
-use crate::index::mem_wal::update_mem_wal_index_compacted_sstables;
+use crate::index::mem_wal::{
+    load_mem_wal_index_details, new_mem_wal_index_meta, update_mem_wal_index_compacted_sstables,
+};
 use crate::utils::temporal::timestamp_to_nanos;
 use lance_core::datatypes::{
     LANCE_UNENFORCED_CLUSTERING_KEY_POSITION, LANCE_UNENFORCED_PRIMARY_KEY,
@@ -29,10 +31,12 @@ use lance_file::{
     datatypes::Fields,
     version::{ConcreteFileVersion, LanceFileVersion},
 };
-use lance_index::mem_wal::CompactedSsTable;
+use lance_index::mem_wal::{CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX_NAME};
 use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
-use lance_table::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
+use lance_table::feature_flags::{
+    FLAG_MEM_WAL_SAFE_RETIREMENT, FLAG_STABLE_ROW_IDS, apply_feature_flags,
+};
 use lance_table::rowids::read_row_ids;
 use lance_table::{
     format::{
@@ -51,7 +55,7 @@ use object_store::path::Path;
 use roaring::RoaringBitmap;
 use std::cmp::Ordering;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 use uuid::Uuid;
@@ -321,6 +325,79 @@ pub struct UpdateMap {
     pub replace: bool,
 }
 
+/// Non-system logical index name -> its sorted physical segment UUIDs.
+type LogicalIndexSegments = BTreeMap<String, Vec<Uuid>>;
+
+/// Proof that one logical index covers named per-shard compaction generations.
+///
+/// Supplied only by the WAL index-repair worker, and published in the same
+/// commit as the index change it describes so the index result and the coverage
+/// it proves can never disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexCatchupAdvance {
+    /// One user-visible logical index, possibly backed by several segments.
+    pub index_name: String,
+    /// Exact final physical segment UUID set expected after this operation.
+    ///
+    /// The commit fails unless the segments actually present match exactly, so
+    /// a repair cannot claim coverage for an index that something else replaced
+    /// while it was running.
+    pub expected_index_segment_uuids: Vec<Uuid>,
+    /// Compaction numbers captured when the repair job opened the table.
+    ///
+    /// Only these are recorded, never whatever is current at commit time: the
+    /// claim must not exceed what the job actually indexed.
+    pub caught_up_generations: Vec<CompactedSsTable>,
+}
+
+// Hand-written because `Uuid` does not implement `DeepSizeOf`; it is a fixed
+// 16 bytes with no heap allocation, like `CompactedSsTable`'s own impl.
+impl DeepSizeOf for IndexCatchupAdvance {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.index_name.deep_size_of_children(context)
+            + self.expected_index_segment_uuids.capacity() * std::mem::size_of::<Uuid>()
+            + self.caught_up_generations.deep_size_of_children(context)
+    }
+}
+
+impl From<&IndexCatchupAdvance> for pb::transaction::create_index::IndexCatchupAdvance {
+    fn from(advance: &IndexCatchupAdvance) -> Self {
+        Self {
+            index_name: advance.index_name.clone(),
+            expected_index_segment_uuids: advance
+                .expected_index_segment_uuids
+                .iter()
+                .map(pb::Uuid::from)
+                .collect(),
+            caught_up_generations: advance
+                .caught_up_generations
+                .iter()
+                .map(pb::CompactedSsTable::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::transaction::create_index::IndexCatchupAdvance> for IndexCatchupAdvance {
+    type Error = Error;
+
+    fn try_from(advance: pb::transaction::create_index::IndexCatchupAdvance) -> Result<Self> {
+        Ok(Self {
+            index_name: advance.index_name,
+            expected_index_segment_uuids: advance
+                .expected_index_segment_uuids
+                .iter()
+                .map(Uuid::try_from)
+                .collect::<Result<_>>()?,
+            caught_up_generations: advance
+                .caught_up_generations
+                .into_iter()
+                .map(CompactedSsTable::try_from)
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
 /// An operation on a dataset.
 #[derive(Debug, Clone, DeepSizeOf)]
 pub enum Operation {
@@ -360,6 +437,13 @@ pub enum Operation {
         new_indices: Vec<IndexMetadata>,
         /// The indices that have been modified.
         removed_indices: Vec<IndexMetadata>,
+        /// MemWAL coverage this operation proves, if any.
+        ///
+        /// Empty for every ordinary index operation. An ordinary create,
+        /// reindex, append, or remap therefore loses whatever coverage its
+        /// index had proved, and the agent schedules a repair — conservative,
+        /// but it can never make an uncovered index look covered.
+        mem_wal_index_catchup_advances: Vec<IndexCatchupAdvance>,
     },
     /// Data is rewritten but *not* modified. This is used for things like
     /// compaction or re-ordering. Contains the old fragments and the new
@@ -485,6 +569,12 @@ pub enum Operation {
     /// SSTables have been compacted into the base table.
     UpdateMemWalState {
         compacted_sstables: Vec<CompactedSsTable>,
+        /// Requests the one-way migration to safe retirement.
+        ///
+        /// One-way because returning to legacy semantics — where a missing
+        /// coverage entry reads as "fully caught up" — is unsafe once any
+        /// SSTable has been retired against proved coverage.
+        activate_safe_retirement: bool,
     },
 
     /// Clone a dataset.
@@ -637,10 +727,12 @@ impl PartialEq for Operation {
                 Self::CreateIndex {
                     new_indices: a_new,
                     removed_indices: a_removed,
+                    ..
                 },
                 Self::CreateIndex {
                     new_indices: b_new,
                     removed_indices: b_removed,
+                    ..
                 },
             ) => compare_vec(a_new, b_new) && compare_vec(a_removed, b_removed),
             (
@@ -1275,9 +1367,11 @@ impl PartialEq for Operation {
             (
                 Self::UpdateMemWalState {
                     compacted_sstables: a_compacted,
+                    ..
                 },
                 Self::UpdateMemWalState {
                     compacted_sstables: b_compacted,
+                    ..
                 },
             ) => compare_vec(a_compacted, b_compacted),
             (Self::Clone { .. }, Self::Append { .. }) => {
@@ -1828,6 +1922,256 @@ impl Transaction {
     /// Create a new manifest from the current manifest and the transaction.
     ///
     /// `current_manifest` should only be None if the dataset does not yet exist.
+
+    /// Preconditions for the one-way migration to safe retirement.
+    ///
+    /// Activation is one-way because returning to legacy semantics -- where a
+    /// missing coverage entry reads as "fully caught up" -- is unsafe once any
+    /// SSTable has been retired against proved coverage. Repeating a successful
+    /// activation is an idempotent no-op, which matters when the first commit
+    /// landed but its response was lost: the retry must not clear coverage
+    /// repaired since.
+    fn validate_safe_retirement_activation(final_indices: &[IndexMetadata]) -> Result<()> {
+        let Some(mem_wal) = final_indices
+            .iter()
+            .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+        else {
+            return Err(Error::invalid_input(format!(
+                "Cannot activate MemWAL safe retirement: the {} system index does \
+                 not exist on this table",
+                MEM_WAL_INDEX_NAME
+            )));
+        };
+
+        let details = load_mem_wal_index_details(mem_wal.clone())?;
+
+        // The beta protocol wrote compaction progress that was never an active
+        // retirement proof, and Lance cannot check those numbers against WAL
+        // shard manifests. Trusting them would let the first trim after
+        // activation delete SSTables no commit copied in, so a table carrying
+        // them must be drained through an explicit migration instead.
+        if !details.compacted_sstables.is_empty() {
+            return Err(Error::invalid_input(
+                "Cannot activate MemWAL safe retirement: the table already records \
+                 SSTable compaction progress from the beta protocol, which cannot \
+                 be validated. Drain or reset the table first.",
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Every non-system logical index, mapped to its sorted segment UUIDs.
+    ///
+    /// A logical index may be backed by several physical segments. Lance mints a
+    /// fresh UUID whenever a segment is written, so the complete sorted set is a
+    /// faithful identity for "is this the same physical index" -- unlike any one
+    /// arbitrarily chosen segment.
+    ///
+    /// Built once per side, so the comparison below is a map lookup per coverage
+    /// entry rather than a scan of the whole index list.
+    fn logical_index_segments(indices: &[IndexMetadata]) -> LogicalIndexSegments {
+        let mut by_name: LogicalIndexSegments = BTreeMap::new();
+        for idx in indices.iter().filter(|idx| !is_system_index(idx)) {
+            by_name.entry(idx.name.clone()).or_default().push(idx.uuid);
+        }
+        for uuids in by_name.values_mut() {
+            uuids.sort_unstable();
+        }
+        by_name
+    }
+
+    /// Apply MemWAL index-coverage rules once the final index list is known.
+    ///
+    /// Coverage records that a base-table index contains the rows a compaction
+    /// copied in, and the WAL pod retires SSTables against it. So any index
+    /// change that this transaction does not explicitly prove must drop the
+    /// coverage that index had: an ordinary create, reindex, append, replacement
+    /// or remap carries no advance and is therefore conservative. The rule lives
+    /// here rather than in each caller so an ordinary index job cannot forget it
+    /// and leave stale proof behind.
+    ///
+    /// Dropping coverage is always safe -- missing coverage schedules a repair
+    /// and retains SSTables. Wrongly *keeping* it is not.
+    fn apply_mem_wal_index_coverage(
+        final_indices: &mut Vec<IndexMetadata>,
+        segments_before: &LogicalIndexSegments,
+        advances: &[IndexCatchupAdvance],
+        safe_retirement_enabled: bool,
+        new_version: u64,
+    ) -> Result<()> {
+        if !advances.is_empty() && !safe_retirement_enabled {
+            return Err(Error::invalid_input(
+                "Index coverage can only be advanced on a table with MemWAL safe \
+                 retirement enabled",
+            ));
+        }
+
+        let Some(pos) = final_indices
+            .iter()
+            .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
+        else {
+            // The system index went away with this transaction (MemWAL disable,
+            // or an overwrite). There is no coverage left to maintain, but a
+            // claim about it is a contradiction.
+            if !advances.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "Cannot advance index coverage: the {} system index is not \
+                     present in the resulting index list",
+                    MEM_WAL_INDEX_NAME
+                )));
+            }
+            return Ok(());
+        };
+
+        let mut details = load_mem_wal_index_details(final_indices[pos].clone())?;
+
+        // Nothing has ever been compacted, so no index can be behind and there is
+        // no coverage to invalidate. Bail before doing any work.
+        if details.compacted_sstables.is_empty() && details.index_catchup.is_empty() {
+            if advances.is_empty() {
+                return Ok(());
+            }
+        }
+
+        // --- invalidate coverage the transaction changed but did not prove ---
+
+        let segments_after = Self::logical_index_segments(final_indices);
+        let advanced_names: HashSet<&str> =
+            advances.iter().map(|a| a.index_name.as_str()).collect();
+
+        details.index_catchup.retain(|entry| {
+            // A name this transaction proves is rebuilt below from the advance.
+            if advanced_names.contains(entry.index_name.as_str()) {
+                return false;
+            }
+            match (
+                segments_before.get(&entry.index_name),
+                segments_after.get(&entry.index_name),
+            ) {
+                // Dropped index: coverage no longer gates anything.
+                (_, None) => false,
+                // Present before and after: keep only if physically unchanged.
+                (Some(before), Some(after)) => before == after,
+                // Absent before, present now: a brand-new index proves nothing.
+                (None, Some(_)) => false,
+            }
+        });
+
+        if advances.is_empty() {
+            final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
+            return Ok(());
+        }
+
+        // --- validate and apply each advance ---
+
+        let mut seen_names = HashSet::with_capacity(advances.len());
+        for advance in advances {
+            if !seen_names.insert(advance.index_name.as_str()) {
+                return Err(Error::invalid_input(format!(
+                    "Duplicate index name {} in index-coverage advances; each \
+                     logical index may advance at most once per transaction",
+                    advance.index_name
+                )));
+            }
+
+            let mut expected = advance.expected_index_segment_uuids.clone();
+            expected.sort_unstable();
+            let deduped = expected.len();
+            expected.dedup();
+            if expected.len() != deduped {
+                return Err(Error::invalid_input(format!(
+                    "Duplicate expected segment UUID for index {}",
+                    advance.index_name
+                )));
+            }
+
+            let actual = segments_after
+                .get(&advance.index_name)
+                .cloned()
+                .unwrap_or_default();
+            if actual.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "Cannot advance coverage for index {}: it is not present in \
+                     the resulting index list",
+                    advance.index_name
+                )));
+            }
+            // Exact equality, so a repair cannot claim coverage for an index that
+            // a concurrent reindex or replacement changed underneath it.
+            if actual != expected {
+                return Err(Error::invalid_input(format!(
+                    "Index {} does not match the segments this coverage advance \
+                     expects: expected {:?}, found {:?}",
+                    advance.index_name, expected, actual
+                )));
+            }
+
+            let mut seen_shards = HashSet::with_capacity(advance.caught_up_generations.len());
+            for proposed in &advance.caught_up_generations {
+                if !seen_shards.insert(proposed.shard_id) {
+                    return Err(Error::invalid_input(format!(
+                        "Duplicate shard {} in the coverage advance for index {}",
+                        proposed.shard_id, advance.index_name
+                    )));
+                }
+
+                // Coverage can never exceed what has actually been compacted;
+                // otherwise the WAL pod would retire SSTables no commit copied in.
+                let compacted = details
+                    .compacted_sstables
+                    .iter()
+                    .find(|sstable| sstable.shard_id == proposed.shard_id)
+                    .map(|sstable| sstable.generation);
+                match compacted {
+                    Some(compacted) if proposed.generation <= compacted => {}
+                    Some(compacted) => {
+                        return Err(Error::invalid_input(format!(
+                            "Coverage for index {} shard {} claims generation {} but \
+                             only {} has been compacted into the base table",
+                            advance.index_name, proposed.shard_id, proposed.generation, compacted
+                        )));
+                    }
+                    None => {
+                        return Err(Error::invalid_input(format!(
+                            "Coverage for index {} names shard {}, which has no \
+                             recorded compaction progress",
+                            advance.index_name, proposed.shard_id
+                        )));
+                    }
+                }
+            }
+
+            // Built fresh, so the entry publishes exactly what the advance proves.
+            // Per-shard max() keeps a duplicate or reordered retry from lowering
+            // coverage.
+            let mut merged: Vec<CompactedSsTable> = Vec::new();
+            for proposed in &advance.caught_up_generations {
+                match merged
+                    .iter_mut()
+                    .find(|existing| existing.shard_id == proposed.shard_id)
+                {
+                    Some(existing) => {
+                        existing.generation = existing.generation.max(proposed.generation)
+                    }
+                    None => merged.push(proposed.clone()),
+                }
+            }
+            merged.sort_unstable_by_key(|sstable| sstable.shard_id);
+            details.index_catchup.push(IndexCatchupProgress::new(
+                advance.index_name.clone(),
+                merged,
+            ));
+        }
+
+        details
+            .index_catchup
+            .sort_by(|a, b| a.index_name.cmp(&b.index_name));
+
+        final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
+        Ok(())
+    }
+
     pub(crate) fn build_manifest(
         &self,
         current_manifest: Option<&Manifest>,
@@ -1902,6 +2246,15 @@ impl Transaction {
             .unwrap_or(0);
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
+
+        // Snapshot taken before the operation rewrites the list, so coverage can
+        // be compared against what each logical index looked like going in.
+        // Only tables carrying the system index can have coverage to invalidate,
+        // so every other commit pays nothing for this.
+        let mem_wal_segments_before = final_indices
+            .iter()
+            .any(|idx| idx.name == MEM_WAL_INDEX_NAME)
+            .then(|| Self::logical_index_segments(&final_indices));
 
         let mut next_row_id = {
             // Only use row ids if the feature flag is set already or
@@ -2219,6 +2572,7 @@ impl Transaction {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                ..
             } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
                 let removed_uuids = removed_indices
@@ -2502,7 +2856,9 @@ impl Transaction {
                     final_fragments.push(fragment);
                 }
             }
-            Operation::UpdateMemWalState { compacted_sstables } => {
+            Operation::UpdateMemWalState {
+                compacted_sstables, ..
+            } => {
                 update_mem_wal_index_compacted_sstables(
                     &mut final_indices,
                     new_version,
@@ -2537,6 +2893,29 @@ impl Transaction {
             (None, Some(false)) => Some(LanceFileVersion::V2_0),
             (None, None) => None,
         };
+
+        // Applied once the final index list is known, so it sees exactly the
+        // indices this commit publishes rather than what any one operation arm
+        // intended.
+        if let Some(segments_before) = mem_wal_segments_before.as_ref() {
+            let safe_retirement_enabled = current_manifest
+                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
+                .unwrap_or(false);
+            let advances: &[IndexCatchupAdvance] = match &self.operation {
+                Operation::CreateIndex {
+                    mem_wal_index_catchup_advances,
+                    ..
+                } => mem_wal_index_catchup_advances,
+                _ => &[],
+            };
+            Self::apply_mem_wal_index_coverage(
+                &mut final_indices,
+                segments_before,
+                advances,
+                safe_retirement_enabled,
+                new_version,
+            )?;
+        }
 
         let mut manifest = if let Some(current_manifest) = current_manifest {
             // OVERWRITE with initial_bases on existing dataset is not allowed (caught by validation)
@@ -2582,6 +2961,18 @@ impl Transaction {
                 config.disable_transaction_file,
             )?;
         }
+        // Set after apply_feature_flags, which resets both flag words: activation
+        // is the one place the bit is turned on, and it must survive that reset.
+        if let Operation::UpdateMemWalState {
+            activate_safe_retirement: true,
+            ..
+        } = &self.operation
+        {
+            Self::validate_safe_retirement_activation(&final_indices)?;
+            manifest.reader_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
+            manifest.writer_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
+        }
+
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
 
         manifest.update_max_fragment_id();
@@ -3483,6 +3874,7 @@ impl TryFrom<pb::Transaction> for Transaction {
             Some(pb::transaction::Operation::CreateIndex(pb::transaction::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances,
             })) => Operation::CreateIndex {
                 new_indices: new_indices
                     .into_iter()
@@ -3491,6 +3883,10 @@ impl TryFrom<pb::Transaction> for Transaction {
                 removed_indices: removed_indices
                     .into_iter()
                     .map(IndexMetadata::try_from)
+                    .collect::<Result<_>>()?,
+                mem_wal_index_catchup_advances: mem_wal_index_catchup_advances
+                    .into_iter()
+                    .map(IndexCatchupAdvance::try_from)
                     .collect::<Result<_>>()?,
             },
             Some(pb::transaction::Operation::Merge(pb::transaction::Merge {
@@ -3658,12 +4054,19 @@ impl TryFrom<pb::Transaction> for Transaction {
                     .collect::<Result<Vec<_>>>()?,
             },
             Some(pb::transaction::Operation::UpdateMemWalState(
-                pb::transaction::UpdateMemWalState { compacted_sstables },
+                pb::transaction::UpdateMemWalState {
+                    compacted_sstables,
+                    activate_safe_retirement,
+                },
             )) => Operation::UpdateMemWalState {
                 compacted_sstables: compacted_sstables
                     .into_iter()
-                    .map(|m| CompactedSsTable::try_from(m).unwrap())
-                    .collect(),
+                    .map(CompactedSsTable::try_from)
+                    .collect::<Result<_>>()?,
+                // Absent is an ordinary progress update. Explicit `false` is
+                // rejected at apply time rather than silently read as absent,
+                // so a caller cannot express "deactivate".
+                activate_safe_retirement: activate_safe_retirement.unwrap_or(false),
             },
             Some(pb::transaction::Operation::UpdateBases(pb::transaction::UpdateBases {
                 new_bases,
@@ -3847,11 +4250,16 @@ impl From<&Transaction> for pb::Transaction {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances,
             } => pb::transaction::Operation::CreateIndex(pb::transaction::CreateIndex {
                 new_indices: new_indices.iter().map(pb::IndexMetadata::from).collect(),
                 removed_indices: removed_indices
                     .iter()
                     .map(pb::IndexMetadata::from)
+                    .collect(),
+                mem_wal_index_catchup_advances: mem_wal_index_catchup_advances
+                    .iter()
+                    .map(pb::transaction::create_index::IndexCatchupAdvance::from)
                     .collect(),
             }),
             Operation::Merge {
@@ -3961,12 +4369,18 @@ impl From<&Transaction> for pb::Transaction {
                         .collect(),
                 })
             }
-            Operation::UpdateMemWalState { compacted_sstables } => {
+            Operation::UpdateMemWalState {
+                compacted_sstables,
+                activate_safe_retirement,
+            } => {
                 pb::transaction::Operation::UpdateMemWalState(pb::transaction::UpdateMemWalState {
                     compacted_sstables: compacted_sstables
                         .iter()
                         .map(pb::CompactedSsTable::from)
                         .collect::<Vec<_>>(),
+                    // Written only when requesting activation, so an ordinary
+                    // progress update stays byte-identical to before.
+                    activate_safe_retirement: activate_safe_retirement.then_some(true),
                 })
             }
             Operation::UpdateBases { new_bases } => {
@@ -4443,6 +4857,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![third_index.clone()],
                 removed_indices: vec![second_index.clone()],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -4478,6 +4893,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![first_index.clone(), third_index.clone()],
                 removed_indices: vec![second_index.clone()],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -7073,6 +7489,431 @@ mod tests {
                 matches!(txn.operation, Operation::Merge { preserves_nullability, .. } if preserves_nullability == encoded),
                 "encoded={encoded:?}"
             );
+        }
+    }
+
+    mod mem_wal_index_coverage {
+        use super::*;
+        use lance_index::mem_wal::{
+            CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX_NAME, MemWalIndexDetails,
+        };
+
+        fn user_index(name: &str, uuid: Uuid) -> IndexMetadata {
+            IndexMetadata {
+                uuid,
+                name: name.to_string(),
+                fields: vec![0],
+                dataset_version: 1,
+                fragment_bitmap: None,
+                index_details: None,
+                index_version: 0,
+                created_at: None,
+                base_id: None,
+                files: None,
+            }
+        }
+
+        fn mem_wal_index(details: MemWalIndexDetails) -> IndexMetadata {
+            crate::index::mem_wal::new_mem_wal_index_meta(1, details).unwrap()
+        }
+
+        fn details_of(indices: &[IndexMetadata]) -> MemWalIndexDetails {
+            let meta = indices
+                .iter()
+                .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                .expect("mem wal index present");
+            load_mem_wal_index_details(meta.clone()).unwrap()
+        }
+
+        /// Same helper the production path uses, so tests exercise the real
+        /// before/after comparison rather than a parallel implementation.
+        fn segments_before(indices: &[IndexMetadata]) -> LogicalIndexSegments {
+            Transaction::logical_index_segments(indices)
+        }
+
+        fn coverage_for(indices: &[IndexMetadata], name: &str) -> Option<Vec<CompactedSsTable>> {
+            details_of(indices)
+                .index_catchup
+                .into_iter()
+                .find(|entry| entry.index_name == name)
+                .map(|entry| entry.caught_up_generations)
+        }
+
+        /// shard with `compacted` recorded, and `name` covered through `covered`
+        fn table(
+            shard: Uuid,
+            compacted: u64,
+            name: &str,
+            covered: u64,
+            idx_uuid: Uuid,
+        ) -> Vec<IndexMetadata> {
+            vec![
+                user_index(name, idx_uuid),
+                mem_wal_index(MemWalIndexDetails {
+                    compacted_sstables: vec![CompactedSsTable::new(shard, compacted)],
+                    index_catchup: vec![IndexCatchupProgress::new(
+                        name.to_string(),
+                        vec![CompactedSsTable::new(shard, covered)],
+                    )],
+                    ..Default::default()
+                }),
+            ]
+        }
+
+        #[test]
+        fn an_untouched_index_keeps_its_coverage() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 10, uuid);
+            let mut after = before.clone();
+
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[],
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert_eq!(
+                coverage_for(&after, "vec_idx").unwrap()[0].generation,
+                10,
+                "an index this transaction did not touch must keep its proof"
+            );
+        }
+
+        /// An ordinary reindex/append/replacement mints new segment UUIDs and
+        /// supplies no advance, so its old proof must not survive.
+        #[test]
+        fn a_changed_index_loses_its_coverage() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 10, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4()); // rebuilt
+
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[],
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert!(
+                coverage_for(&after, "vec_idx").is_none(),
+                "a rebuilt index must not inherit the previous index's proof"
+            );
+        }
+
+        #[test]
+        fn a_dropped_index_loses_its_coverage() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 10, uuid);
+            let mut after = vec![before[1].clone()]; // user index dropped
+
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[],
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert!(coverage_for(&after, "vec_idx").is_none());
+        }
+
+        #[test]
+        fn changing_one_index_preserves_another() {
+            let (shard, a, b) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+            let mut before = table(shard, 10, "idx_a", 10, a);
+            before.insert(1, user_index("idx_b", b));
+            let details = MemWalIndexDetails {
+                compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                index_catchup: vec![
+                    IndexCatchupProgress::new(
+                        "idx_a".to_string(),
+                        vec![CompactedSsTable::new(shard, 10)],
+                    ),
+                    IndexCatchupProgress::new(
+                        "idx_b".to_string(),
+                        vec![CompactedSsTable::new(shard, 7)],
+                    ),
+                ],
+                ..Default::default()
+            };
+            let before: Vec<IndexMetadata> = vec![
+                user_index("idx_a", a),
+                user_index("idx_b", b),
+                mem_wal_index(details),
+            ];
+            let mut after = before.clone();
+            after[0] = user_index("idx_a", Uuid::new_v4()); // only idx_a rebuilt
+
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[],
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert!(coverage_for(&after, "idx_a").is_none());
+            assert_eq!(coverage_for(&after, "idx_b").unwrap()[0].generation, 7);
+        }
+
+        #[test]
+        fn an_advance_publishes_the_coverage_it_proves() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+            let rebuilt = Uuid::new_v4();
+            after[0] = user_index("vec_idx", rebuilt);
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![rebuilt],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+            };
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert_eq!(coverage_for(&after, "vec_idx").unwrap()[0].generation, 10);
+        }
+
+        /// The segment set is the fence against a concurrent reindex: if the
+        /// index is not the one the repair built, the claim is refused.
+        #[test]
+        fn an_advance_whose_segments_do_not_match_rejects() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4()); // someone else rebuilt it
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![Uuid::new_v4()], // what the repair built
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string().contains("does not match the segments"),
+                "{err}"
+            );
+        }
+
+        /// Coverage above what was compacted would let the WAL pod retire
+        /// SSTables no commit copied into the base table.
+        #[test]
+        fn coverage_above_compacted_progress_rejects() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 5, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string().contains("only 5 has been compacted"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn coverage_for_an_uncompacted_shard_rejects() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 5, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string().contains("no recorded compaction progress"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn an_advance_on_a_legacy_table_rejects() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                false,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string()
+                    .contains("safe \n                 retirement")
+                    || err.to_string().contains("safe retirement"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn duplicate_index_names_in_one_transaction_reject() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance.clone(), advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("Duplicate index name"), "{err}");
+        }
+
+        #[test]
+        fn duplicate_shards_in_one_advance_reject() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![
+                    CompactedSsTable::new(shard, 9),
+                    CompactedSsTable::new(shard, 10),
+                ],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("Duplicate shard"), "{err}");
+        }
+
+        #[test]
+        fn duplicate_expected_segment_uuids_reject() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 3, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid, uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before(&before),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string().contains("Duplicate expected segment"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn activation_rejects_pre_existing_beta_compaction_progress() {
+            let indices = vec![mem_wal_index(MemWalIndexDetails {
+                compacted_sstables: vec![CompactedSsTable::new(Uuid::new_v4(), 4)],
+                ..Default::default()
+            })];
+
+            let err = Transaction::validate_safe_retirement_activation(&indices).unwrap_err();
+
+            assert!(err.to_string().contains("beta protocol"), "{err}");
+        }
+
+        #[test]
+        fn activation_requires_the_mem_wal_index() {
+            let err = Transaction::validate_safe_retirement_activation(&[]).unwrap_err();
+            assert!(err.to_string().contains("does not exist"), "{err}");
+        }
+
+        #[test]
+        fn activation_accepts_a_clean_table() {
+            let indices = vec![mem_wal_index(MemWalIndexDetails::default())];
+            Transaction::validate_safe_retirement_activation(&indices).unwrap();
+        }
+
+        #[test]
+        fn index_catchup_advance_round_trips_through_protobuf() {
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![Uuid::new_v4(), Uuid::new_v4()],
+                caught_up_generations: vec![
+                    CompactedSsTable::new(Uuid::new_v4(), 3),
+                    CompactedSsTable::new(Uuid::new_v4(), 9),
+                ],
+            };
+
+            let encoded = pb::transaction::create_index::IndexCatchupAdvance::from(&advance);
+            let decoded = IndexCatchupAdvance::try_from(encoded).unwrap();
+
+            assert_eq!(decoded, advance);
         }
     }
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2074,9 +2074,9 @@ impl Transaction {
 
             let mut expected = advance.expected_index_segment_uuids.clone();
             expected.sort_unstable();
-            let deduped = expected.len();
+            let before_dedup = expected.len();
             expected.dedup();
-            if expected.len() != deduped {
+            if expected.len() != before_dedup {
                 return Err(Error::invalid_input(format!(
                     "Duplicate expected segment UUID for index {}",
                     advance.index_name
@@ -2897,20 +2897,23 @@ impl Transaction {
         // Applied once the final index list is known, so it sees exactly the
         // indices this commit publishes rather than what any one operation arm
         // intended.
-        if let Some(segments_before) = mem_wal_segments_before.as_ref() {
+        let advances: &[IndexCatchupAdvance] = match &self.operation {
+            Operation::CreateIndex {
+                mem_wal_index_catchup_advances,
+                ..
+            } => mem_wal_index_catchup_advances,
+            _ => &[],
+        };
+        // Advances are also routed in when the table carries no system index, so a
+        // coverage claim on such a table is rejected rather than silently dropped.
+        if mem_wal_segments_before.is_some() || !advances.is_empty() {
             let safe_retirement_enabled = current_manifest
                 .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
                 .unwrap_or(false);
-            let advances: &[IndexCatchupAdvance] = match &self.operation {
-                Operation::CreateIndex {
-                    mem_wal_index_catchup_advances,
-                    ..
-                } => mem_wal_index_catchup_advances,
-                _ => &[],
-            };
+            let empty_segments = LogicalIndexSegments::new();
             Self::apply_mem_wal_index_coverage(
                 &mut final_indices,
-                segments_before,
+                mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
                 advances,
                 safe_retirement_enabled,
                 new_version,
@@ -7792,12 +7795,29 @@ mod tests {
             )
             .unwrap_err();
 
-            assert!(
-                err.to_string()
-                    .contains("safe \n                 retirement")
-                    || err.to_string().contains("safe retirement"),
-                "{err}"
-            );
+            assert!(err.to_string().contains("safe retirement"), "{err}");
+        }
+
+        #[test]
+        fn an_advance_on_a_table_without_the_system_index_rejects() {
+            let uuid = Uuid::new_v4();
+            let mut after = vec![user_index("vec_idx", uuid)];
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 10)],
+            };
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &LogicalIndexSegments::new(),
+                &[advance],
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("is not present"), "{err}");
         }
 
         #[test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -333,11 +333,11 @@ pub struct UpdateMap {
 /// base fragments.
 type LogicalIndexSegments = BTreeMap<String, Vec<IndexMetadata>>;
 
-/// Proof that one logical index covers named per-shard compaction generations.
+/// Records that one logical index covers named per-shard compaction generations.
 ///
 /// Supplied only by the WAL index-repair worker, and published in the same
 /// commit as the index change it describes so the index result and the coverage
-/// it proves can never disagree.
+/// it reports can never disagree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexCatchupAdvance {
     /// One user-visible logical index, possibly backed by several segments.
@@ -442,11 +442,11 @@ pub enum Operation {
         new_indices: Vec<IndexMetadata>,
         /// The indices that have been modified.
         removed_indices: Vec<IndexMetadata>,
-        /// MemWAL coverage this operation proves, if any.
+        /// MemWAL index catch-up this operation reports, if any.
         ///
         /// Empty for every ordinary index operation. An ordinary create,
         /// reindex, append, or remap therefore loses whatever coverage its
-        /// index had proved, and the agent schedules a repair — conservative,
+        /// index had recorded, and the agent schedules a repair — conservative,
         /// but it can never make an uncovered index look covered.
         mem_wal_index_catchup_advances: Vec<IndexCatchupAdvance>,
     },
@@ -578,7 +578,7 @@ pub enum Operation {
         ///
         /// One-way because returning to legacy semantics — where a missing
         /// coverage entry reads as "fully caught up" — is unsafe once any
-        /// SSTable has been retired against proved coverage.
+        /// SSTable has been retired against a recorded catch-up position.
         activate_safe_retirement: bool,
     },
 
@@ -1932,7 +1932,7 @@ impl Transaction {
     ///
     /// One-way, because returning to legacy semantics -- where a missing
     /// coverage entry reads as "fully caught up" -- is unsafe once any SSTable
-    /// has been retired against proved coverage.
+    /// has been retired against a recorded catch-up position.
     fn activate_safe_retirement(
         final_indices: &mut [IndexMetadata],
         new_version: u64,
@@ -1951,7 +1951,7 @@ impl Transaction {
         let mut details = load_mem_wal_index_details(final_indices[pos].clone())?;
 
         // The beta protocol wrote compaction progress that was never an active
-        // retirement proof, and Lance cannot check those numbers against WAL
+        // retirement record, and Lance cannot check those numbers against WAL
         // shard manifests. Trusting them would let the first trim after
         // activation delete SSTables no commit copied in, so a table carrying
         // them must be drained through an explicit migration instead.
@@ -1964,7 +1964,7 @@ impl Transaction {
         }
 
         // Beta coverage was written under rules this protocol does not enforce,
-        // so it is not proof. Left in place, a later compaction would find it
+        // so it is not trustworthy. Left in place, a later compaction would find it
         // already satisfied and could retire an SSTable that no index covers.
         if details.index_catchup.is_empty() {
             return Ok(());
@@ -2001,14 +2001,14 @@ impl Transaction {
     ///
     /// Coverage records that a base-table index contains the rows a compaction
     /// copied in, and the WAL pod retires SSTables against it. So any index
-    /// change this transaction does not explicitly prove must drop that
+    /// change this transaction does not explicitly report must drop that
     /// index's coverage: an ordinary create, reindex, append, replacement or
     /// remap carries no advance and is therefore conservative. The rule lives
     /// here rather than in each caller so an ordinary index job cannot forget it
-    /// and leave stale proof behind.
+    /// and leave a stale catch-up position behind.
     ///
     /// Dropping coverage is only conservative under safe retirement, where a
-    /// missing entry means "not proved" and the SSTables stay. A legacy table
+    /// missing entry means "not caught up" and the SSTables stay. A legacy table
     /// reads a missing entry as "fully caught up", so this leaves legacy
     /// progress untouched rather than making the table look more covered.
     fn apply_mem_wal_index_coverage(
@@ -2061,7 +2061,7 @@ impl Transaction {
         let segments_after = Self::logical_index_segments(final_indices);
         let advanced_names: HashSet<&str> =
             advances.iter().map(|a| a.index_name.as_str()).collect();
-        // Kept so an advance can merge onto what the index already proved, and so
+        // Kept so an advance can merge onto what the index already recorded, and so
         // an unchanged result can skip rewriting the system index entirely.
         let catchup_before = details.index_catchup.clone();
 
@@ -2072,10 +2072,10 @@ impl Transaction {
             )
         };
 
-        // --- invalidate coverage the transaction changed but did not prove ---
+        // --- invalidate coverage the transaction changed but did not report ---
 
         details.index_catchup.retain(|entry| {
-            // A name this transaction proves is rebuilt below from the advance.
+            // A name this transaction reports is rebuilt below from the advance.
             if advanced_names.contains(entry.index_name.as_str()) {
                 return false;
             }
@@ -2087,7 +2087,7 @@ impl Transaction {
                 (_, None) => false,
                 // Present before and after: keep only if physically unchanged.
                 (Some(before), Some(after)) => before == after,
-                // Absent before, present now: a brand-new index proves nothing.
+                // Absent before, present now: a brand-new index has no catch-up position.
                 (None, Some(_)) => false,
             }
         });
@@ -2181,10 +2181,10 @@ impl Transaction {
             }
 
             // Shards this advance does not name keep the generation they already
-            // proved, so repairing one shard does not erase another and two
+            // recorded, so repairing one shard does not erase another and two
             // repairs on different shards do not overwrite each other. Only an
-            // index that is physically unchanged may carry its old proof forward;
-            // otherwise it was proved against an index that no longer exists.
+            // index that is physically unchanged may carry its old position forward;
+            // otherwise it was recorded against an index that no longer exists.
             let mut merged = if index_unchanged(&advance.index_name) {
                 catchup_before
                     .iter()
@@ -7733,12 +7733,12 @@ mod tests {
             assert_eq!(
                 coverage_for(&after, "vec_idx").unwrap()[0].generation,
                 10,
-                "an index this transaction did not touch must keep its proof"
+                "an index this transaction did not touch must keep its catch-up position"
             );
         }
 
         /// An ordinary reindex/append/replacement mints new segment UUIDs and
-        /// supplies no advance, so its old proof must not survive.
+        /// supplies no advance, so its old catch-up position must not survive.
         #[test]
         fn a_changed_index_loses_its_coverage() {
             let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
@@ -7750,7 +7750,7 @@ mod tests {
 
             assert!(
                 coverage_for(&after, "vec_idx").is_none(),
-                "a rebuilt index must not inherit the previous index's proof"
+                "a rebuilt index must not inherit the previous index's catch-up position"
             );
         }
 
@@ -7799,7 +7799,7 @@ mod tests {
         }
 
         #[test]
-        fn an_advance_publishes_the_coverage_it_proves() {
+        fn an_advance_publishes_the_catch_up_it_reports() {
             let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
             let before = table(shard, 10, "vec_idx", 3, uuid);
             let mut after = before.clone();
@@ -8126,7 +8126,7 @@ mod tests {
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
-            // Shard B was proved against the index this commit replaced.
+            // Shard B was recorded against the index this commit replaced.
             assert_eq!(
                 coverage_for(&after, "vec_idx"),
                 Some(vec![CompactedSsTable::new(shard_a, 9)])
@@ -8249,7 +8249,7 @@ mod tests {
             Transaction::activate_safe_retirement(&mut indices, 2).unwrap();
 
             // Beta coverage was written under rules this protocol does not
-            // enforce, so keeping it would let the first trim run unproved.
+            // enforce, so keeping it would let the first trim run without a catch-up check.
             assert!(details_of(&indices).index_catchup.is_empty());
         }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -325,8 +325,13 @@ pub struct UpdateMap {
     pub replace: bool,
 }
 
-/// Non-system logical index name -> its sorted physical segment UUIDs.
-type LogicalIndexSegments = BTreeMap<String, Vec<Uuid>>;
+/// Non-system logical index name -> its physical segments, ordered by UUID.
+///
+/// Whole segment metadata rather than UUIDs alone: operations such as `Rewrite`
+/// prune a segment's fragment bitmap while keeping its UUID, so a UUID-only
+/// comparison would keep coverage for an index that no longer spans the same
+/// base fragments.
+type LogicalIndexSegments = BTreeMap<String, Vec<IndexMetadata>>;
 
 /// Proof that one logical index covers named per-shard compaction generations.
 ///
@@ -727,14 +732,18 @@ impl PartialEq for Operation {
                 Self::CreateIndex {
                     new_indices: a_new,
                     removed_indices: a_removed,
-                    ..
+                    mem_wal_index_catchup_advances: a_advances,
                 },
                 Self::CreateIndex {
                     new_indices: b_new,
                     removed_indices: b_removed,
-                    ..
+                    mem_wal_index_catchup_advances: b_advances,
                 },
-            ) => compare_vec(a_new, b_new) && compare_vec(a_removed, b_removed),
+            ) => {
+                compare_vec(a_new, b_new)
+                    && compare_vec(a_removed, b_removed)
+                    && compare_vec(a_advances, b_advances)
+            }
             (
                 Self::Rewrite {
                     groups: a_groups,
@@ -1367,13 +1376,13 @@ impl PartialEq for Operation {
             (
                 Self::UpdateMemWalState {
                     compacted_sstables: a_compacted,
-                    ..
+                    activate_safe_retirement: a_activate,
                 },
                 Self::UpdateMemWalState {
                     compacted_sstables: b_compacted,
-                    ..
+                    activate_safe_retirement: b_activate,
                 },
-            ) => compare_vec(a_compacted, b_compacted),
+            ) => compare_vec(a_compacted, b_compacted) && a_activate == b_activate,
             (Self::Clone { .. }, Self::Append { .. }) => {
                 std::mem::discriminant(self) == std::mem::discriminant(other)
             }
@@ -1919,18 +1928,18 @@ impl Transaction {
         Ok((manifest, indices))
     }
 
-    /// Preconditions for the one-way migration to safe retirement.
+    /// Turn on safe retirement for a table that has never had it.
     ///
-    /// Activation is one-way because returning to legacy semantics -- where a
-    /// missing coverage entry reads as "fully caught up" -- is unsafe once any
-    /// SSTable has been retired against proved coverage. Repeating a successful
-    /// activation is an idempotent no-op, which matters when the first commit
-    /// landed but its response was lost: the retry must not clear coverage
-    /// repaired since.
-    fn validate_safe_retirement_activation(final_indices: &[IndexMetadata]) -> Result<()> {
-        let Some(mem_wal) = final_indices
+    /// One-way, because returning to legacy semantics -- where a missing
+    /// coverage entry reads as "fully caught up" -- is unsafe once any SSTable
+    /// has been retired against proved coverage.
+    fn activate_safe_retirement(
+        final_indices: &mut [IndexMetadata],
+        new_version: u64,
+    ) -> Result<()> {
+        let Some(pos) = final_indices
             .iter()
-            .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+            .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
         else {
             return Err(Error::invalid_input(format!(
                 "Cannot activate MemWAL safe retirement: the {} system index does \
@@ -1939,7 +1948,7 @@ impl Transaction {
             )));
         };
 
-        let details = load_mem_wal_index_details(mem_wal.clone())?;
+        let mut details = load_mem_wal_index_details(final_indices[pos].clone())?;
 
         // The beta protocol wrote compaction progress that was never an active
         // retirement proof, and Lance cannot check those numbers against WAL
@@ -1954,6 +1963,14 @@ impl Transaction {
             ));
         }
 
+        // Beta coverage was written under rules this protocol does not enforce,
+        // so it is not proof. Left in place, a later compaction would find it
+        // already satisfied and could retire an SSTable that no index covers.
+        if details.index_catchup.is_empty() {
+            return Ok(());
+        }
+        details.index_catchup.clear();
+        final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
         Ok(())
     }
 
@@ -1969,10 +1986,13 @@ impl Transaction {
     fn logical_index_segments(indices: &[IndexMetadata]) -> LogicalIndexSegments {
         let mut by_name: LogicalIndexSegments = BTreeMap::new();
         for idx in indices.iter().filter(|idx| !is_system_index(idx)) {
-            by_name.entry(idx.name.clone()).or_default().push(idx.uuid);
+            by_name
+                .entry(idx.name.clone())
+                .or_default()
+                .push(idx.clone());
         }
-        for uuids in by_name.values_mut() {
-            uuids.sort_unstable();
+        for segments in by_name.values_mut() {
+            segments.sort_unstable_by_key(|segment| segment.uuid);
         }
         by_name
     }
@@ -1981,26 +2001,33 @@ impl Transaction {
     ///
     /// Coverage records that a base-table index contains the rows a compaction
     /// copied in, and the WAL pod retires SSTables against it. So any index
-    /// change that this transaction does not explicitly prove must drop the
-    /// coverage that index had: an ordinary create, reindex, append, replacement
-    /// or remap carries no advance and is therefore conservative. The rule lives
+    /// change this transaction does not explicitly prove must drop that
+    /// index's coverage: an ordinary create, reindex, append, replacement or
+    /// remap carries no advance and is therefore conservative. The rule lives
     /// here rather than in each caller so an ordinary index job cannot forget it
     /// and leave stale proof behind.
     ///
-    /// Dropping coverage is always safe -- missing coverage schedules a repair
-    /// and retains SSTables. Wrongly *keeping* it is not.
+    /// Dropping coverage is only conservative under safe retirement, where a
+    /// missing entry means "not proved" and the SSTables stay. A legacy table
+    /// reads a missing entry as "fully caught up", so this leaves legacy
+    /// progress untouched rather than making the table look more covered.
     fn apply_mem_wal_index_coverage(
         final_indices: &mut [IndexMetadata],
+        final_fragments: &[Fragment],
         segments_before: &LogicalIndexSegments,
         advances: &[IndexCatchupAdvance],
         safe_retirement_enabled: bool,
+        coverage_only_operation: bool,
         new_version: u64,
     ) -> Result<()> {
-        if !advances.is_empty() && !safe_retirement_enabled {
-            return Err(Error::invalid_input(
-                "Index coverage can only be advanced on a table with MemWAL safe \
-                 retirement enabled",
-            ));
+        if !safe_retirement_enabled {
+            if !advances.is_empty() {
+                return Err(Error::invalid_input(
+                    "Index coverage can only be advanced on a table with MemWAL safe \
+                     retirement enabled",
+                ));
+            }
+            return Ok(());
         }
 
         let Some(pos) = final_indices
@@ -2031,11 +2058,21 @@ impl Transaction {
             return Ok(());
         }
 
-        // --- invalidate coverage the transaction changed but did not prove ---
-
         let segments_after = Self::logical_index_segments(final_indices);
         let advanced_names: HashSet<&str> =
             advances.iter().map(|a| a.index_name.as_str()).collect();
+        // Kept so an advance can merge onto what the index already proved, and so
+        // an unchanged result can skip rewriting the system index entirely.
+        let catchup_before = details.index_catchup.clone();
+
+        let index_unchanged = |name: &str| {
+            matches!(
+                (segments_before.get(name), segments_after.get(name)),
+                (Some(before), Some(after)) if before == after
+            )
+        };
+
+        // --- invalidate coverage the transaction changed but did not prove ---
 
         details.index_catchup.retain(|entry| {
             // A name this transaction proves is rebuilt below from the advance.
@@ -2055,12 +2092,12 @@ impl Transaction {
             }
         });
 
-        if advances.is_empty() {
-            final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
-            return Ok(());
-        }
-
         // --- validate and apply each advance ---
+
+        // A coverage-only commit publishes no index work, so nothing else in the
+        // transaction shows the named index is usable against the current table.
+        let live_fragments: Option<RoaringBitmap> =
+            coverage_only_operation.then(|| final_fragments.iter().map(|f| f.id as u32).collect());
 
         let mut seen_names = HashSet::with_capacity(advances.len());
         for advance in advances {
@@ -2083,17 +2120,17 @@ impl Transaction {
                 )));
             }
 
-            let actual = segments_after
-                .get(&advance.index_name)
-                .cloned()
-                .unwrap_or_default();
-            if actual.is_empty() {
-                return Err(Error::invalid_input(format!(
-                    "Cannot advance coverage for index {}: it is not present in \
-                     the resulting index list",
-                    advance.index_name
-                )));
-            }
+            let segments = match segments_after.get(&advance.index_name) {
+                Some(segments) => segments.as_slice(),
+                None => {
+                    return Err(Error::invalid_input(format!(
+                        "Cannot advance coverage for index {}: it is not present in \
+                         the resulting index list",
+                        advance.index_name
+                    )));
+                }
+            };
+            let actual: Vec<Uuid> = segments.iter().map(|segment| segment.uuid).collect();
             // Exact equality, so a repair cannot claim coverage for an index that
             // a concurrent reindex or replacement changed underneath it.
             if actual != expected {
@@ -2102,6 +2139,10 @@ impl Transaction {
                      expects: expected {:?}, found {:?}",
                     advance.index_name, expected, actual
                 )));
+            }
+
+            if let Some(live) = live_fragments.as_ref() {
+                Self::validate_coverage_only_target(&advance.index_name, segments, live)?;
             }
 
             let mut seen_shards = HashSet::with_capacity(advance.caught_up_generations.len());
@@ -2114,7 +2155,7 @@ impl Transaction {
                 }
 
                 // Coverage can never exceed what has actually been compacted;
-                // otherwise the WAL pod would retire SSTables no commit copied in.
+                // otherwise SSTables would be retired that no commit copied in.
                 let compacted = details
                     .compacted_sstables
                     .iter()
@@ -2139,10 +2180,21 @@ impl Transaction {
                 }
             }
 
-            // Built fresh, so the entry publishes exactly what the advance proves.
-            // Per-shard max() keeps a duplicate or reordered retry from lowering
-            // coverage.
-            let mut merged: Vec<CompactedSsTable> = Vec::new();
+            // Shards this advance does not name keep the generation they already
+            // proved, so repairing one shard does not erase another and two
+            // repairs on different shards do not overwrite each other. Only an
+            // index that is physically unchanged may carry its old proof forward;
+            // otherwise it was proved against an index that no longer exists.
+            let mut merged = if index_unchanged(&advance.index_name) {
+                catchup_before
+                    .iter()
+                    .find(|entry| entry.index_name == advance.index_name)
+                    .map(|entry| entry.caught_up_generations.clone())
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            // Per-shard max, so a delayed or reordered retry cannot lower coverage.
             for proposed in &advance.caught_up_generations {
                 match merged
                     .iter_mut()
@@ -2165,7 +2217,47 @@ impl Transaction {
             .index_catchup
             .sort_by(|a, b| a.index_name.cmp(&b.index_name));
 
+        // Every commit on a table that has ever compacted reaches this point, so
+        // rewriting the entry unconditionally would mint a new UUID and drop the
+        // decoded-details cache on unrelated high-volume commits.
+        if details.index_catchup == catchup_before {
+            return Ok(());
+        }
+
         final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
+        Ok(())
+    }
+
+    /// Require a coverage-only advance to name an index that spans every live
+    /// fragment. Such a commit publishes no index work of its own, so without
+    /// this an incomplete or untrained index could be handed a coverage claim.
+    fn validate_coverage_only_target(
+        index_name: &str,
+        segments: &[IndexMetadata],
+        live_fragments: &RoaringBitmap,
+    ) -> Result<()> {
+        let mut covered = RoaringBitmap::new();
+        for segment in segments {
+            let Some(bitmap) = segment.effective_fragment_bitmap(live_fragments) else {
+                return Err(Error::invalid_input(format!(
+                    "Cannot advance coverage for index {}: segment {} does not record \
+                     which fragments it covers",
+                    index_name, segment.uuid
+                )));
+            };
+            covered |= bitmap;
+        }
+        // `covered` is already clipped to the live set, so equality means the
+        // index spans all of it.
+        if &covered != live_fragments {
+            return Err(Error::invalid_input(format!(
+                "Cannot advance coverage for index {}: it covers {} of the {} live \
+                 fragments, so it cannot stand in for the SSTables",
+                index_name,
+                covered.len(),
+                live_fragments.len()
+            )));
+        }
         Ok(())
     }
 
@@ -2247,14 +2339,24 @@ impl Transaction {
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
 
+        // Both words must agree: a reader that keeps legacy semantics would read a
+        // missing entry as "fully caught up", so a half-set state is not safe mode.
+        let safe_retirement_enabled = current_manifest
+            .map(|m| {
+                m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0
+                    && m.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0
+            })
+            .unwrap_or(false);
+
         // Snapshot taken before the operation rewrites the list, so coverage can
-        // be compared against what each logical index looked like going in.
-        // Only tables carrying the system index can have coverage to invalidate,
-        // so every other commit pays nothing for this.
-        let mem_wal_segments_before = final_indices
-            .iter()
-            .any(|idx| idx.name == MEM_WAL_INDEX_NAME)
-            .then(|| Self::logical_index_segments(&final_indices));
+        // be compared against what each logical index looked like going in. Only
+        // tables in safe mode maintain coverage, so every other commit -- and the
+        // segment clones this costs -- pays nothing.
+        let mem_wal_segments_before = (safe_retirement_enabled
+            && final_indices
+                .iter()
+                .any(|idx| idx.name == MEM_WAL_INDEX_NAME))
+        .then(|| Self::logical_index_segments(&final_indices));
 
         let mut next_row_id = {
             // Only use row ids if the feature flag is set already or
@@ -2904,18 +3006,27 @@ impl Transaction {
             } => mem_wal_index_catchup_advances,
             _ => &[],
         };
+        // A coverage-only commit publishes no index work of its own, so the named
+        // index has to be checked against the table before its claim is recorded.
+        let coverage_only_operation = matches!(
+            &self.operation,
+            Operation::CreateIndex {
+                new_indices,
+                removed_indices,
+                ..
+            } if new_indices.is_empty() && removed_indices.is_empty()
+        );
         // Advances are also routed in when the table carries no system index, so a
         // coverage claim on such a table is rejected rather than silently dropped.
         if mem_wal_segments_before.is_some() || !advances.is_empty() {
-            let safe_retirement_enabled = current_manifest
-                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
-                .unwrap_or(false);
             let empty_segments = LogicalIndexSegments::new();
             Self::apply_mem_wal_index_coverage(
                 &mut final_indices,
+                &final_fragments,
                 mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
                 advances,
                 safe_retirement_enabled,
+                coverage_only_operation,
                 new_version,
             )?;
         }
@@ -2971,7 +3082,28 @@ impl Transaction {
             ..
         } = &self.operation
         {
-            Self::validate_safe_retirement_activation(&final_indices)?;
+            let reader_set = current_manifest
+                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
+                .unwrap_or(false);
+            let writer_set = current_manifest
+                .map(|m| m.writer_feature_flags & FLAG_MEM_WAL_SAFE_RETIREMENT != 0)
+                .unwrap_or(false);
+            match (reader_set, writer_set) {
+                (false, false) => {
+                    Self::activate_safe_retirement(&mut final_indices, new_version)?;
+                }
+                // Already active. A retry whose first attempt landed but lost its
+                // response must not clear coverage repaired since, so this keeps
+                // every recorded generation.
+                (true, true) => {}
+                _ => {
+                    return Err(Error::invalid_input(
+                        "Cannot activate MemWAL safe retirement: the table has only one \
+                         of the reader and writer feature bits set, so its retirement \
+                         semantics are undefined",
+                    ));
+                }
+            }
             manifest.reader_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
             manifest.writer_feature_flags |= FLAG_MEM_WAL_SAFE_RETIREMENT;
         }
@@ -4067,9 +4199,17 @@ impl TryFrom<pb::Transaction> for Transaction {
                     .map(CompactedSsTable::try_from)
                     .collect::<Result<_>>()?,
                 // Absent is an ordinary progress update. Explicit `false` is
-                // rejected at apply time rather than silently read as absent,
-                // so a caller cannot express "deactivate".
-                activate_safe_retirement: activate_safe_retirement.unwrap_or(false),
+                // refused rather than read as absent, so a caller cannot express
+                // "deactivate" -- the migration is one-way.
+                activate_safe_retirement: match activate_safe_retirement {
+                    Some(false) => {
+                        return Err(Error::invalid_input(
+                            "activate_safe_retirement cannot be false: MemWAL safe \
+                             retirement cannot be turned off once activated",
+                        ));
+                    }
+                    other => other.unwrap_or(false),
+                },
             },
             Some(pb::transaction::Operation::UpdateBases(pb::transaction::UpdateBases {
                 new_bases,
@@ -7534,6 +7674,25 @@ mod tests {
             Transaction::logical_index_segments(indices)
         }
 
+        /// Drives the production path, defaulting the arguments a test is not
+        /// exercising: no fragments and an operation that publishes index work.
+        fn apply_coverage(
+            final_indices: &mut [IndexMetadata],
+            segments_before: &LogicalIndexSegments,
+            advances: &[IndexCatchupAdvance],
+            safe_retirement_enabled: bool,
+        ) -> Result<()> {
+            Transaction::apply_mem_wal_index_coverage(
+                final_indices,
+                &[],
+                segments_before,
+                advances,
+                safe_retirement_enabled,
+                false,
+                2,
+            )
+        }
+
         fn coverage_for(indices: &[IndexMetadata], name: &str) -> Option<Vec<CompactedSsTable>> {
             details_of(indices)
                 .index_catchup
@@ -7569,14 +7728,7 @@ mod tests {
             let before = table(shard, 10, "vec_idx", 10, uuid);
             let mut after = before.clone();
 
-            Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[],
-                true,
-                2,
-            )
-            .unwrap();
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
 
             assert_eq!(
                 coverage_for(&after, "vec_idx").unwrap()[0].generation,
@@ -7594,14 +7746,7 @@ mod tests {
             let mut after = before.clone();
             after[0] = user_index("vec_idx", Uuid::new_v4()); // rebuilt
 
-            Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[],
-                true,
-                2,
-            )
-            .unwrap();
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
 
             assert!(
                 coverage_for(&after, "vec_idx").is_none(),
@@ -7615,14 +7760,7 @@ mod tests {
             let before = table(shard, 10, "vec_idx", 10, uuid);
             let mut after = vec![before[1].clone()]; // user index dropped
 
-            Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[],
-                true,
-                2,
-            )
-            .unwrap();
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
 
             assert!(coverage_for(&after, "vec_idx").is_none());
         }
@@ -7654,14 +7792,7 @@ mod tests {
             let mut after = before.clone();
             after[0] = user_index("idx_a", Uuid::new_v4()); // only idx_a rebuilt
 
-            Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[],
-                true,
-                2,
-            )
-            .unwrap();
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
 
             assert!(coverage_for(&after, "idx_a").is_none());
             assert_eq!(coverage_for(&after, "idx_b").unwrap()[0].generation, 7);
@@ -7680,14 +7811,7 @@ mod tests {
                 expected_index_segment_uuids: vec![rebuilt],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
             };
-            Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap();
+            apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
             assert_eq!(coverage_for(&after, "vec_idx").unwrap()[0].generation, 10);
         }
@@ -7706,14 +7830,8 @@ mod tests {
                 expected_index_segment_uuids: vec![Uuid::new_v4()], // what the repair built
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
             assert!(
                 err.to_string().contains("does not match the segments"),
@@ -7734,14 +7852,8 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
             assert!(
                 err.to_string().contains("only 5 has been compacted"),
@@ -7760,14 +7872,8 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
             assert!(
                 err.to_string().contains("no recorded compaction progress"),
@@ -7786,14 +7892,8 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                false,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], false)
+                .unwrap_err();
 
             assert!(err.to_string().contains("safe retirement"), "{err}");
         }
@@ -7808,14 +7908,8 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 10)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &LogicalIndexSegments::new(),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &LogicalIndexSegments::new(), &[advance], true)
+                .unwrap_err();
 
             assert!(err.to_string().contains("is not present"), "{err}");
         }
@@ -7831,12 +7925,11 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
+            let err = apply_coverage(
                 &mut after,
                 &segments_before(&before),
                 &[advance.clone(), advance],
                 true,
-                2,
             )
             .unwrap_err();
 
@@ -7857,14 +7950,8 @@ mod tests {
                     CompactedSsTable::new(shard, 10),
                 ],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
             assert!(err.to_string().contains("Duplicate shard"), "{err}");
         }
@@ -7880,14 +7967,8 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid, uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
             };
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &segments_before(&before),
-                &[advance],
-                true,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
             assert!(
                 err.to_string().contains("Duplicate expected segment"),
@@ -7897,26 +7978,279 @@ mod tests {
 
         #[test]
         fn activation_rejects_pre_existing_beta_compaction_progress() {
-            let indices = vec![mem_wal_index(MemWalIndexDetails {
+            let mut indices = vec![mem_wal_index(MemWalIndexDetails {
                 compacted_sstables: vec![CompactedSsTable::new(Uuid::new_v4(), 4)],
                 ..Default::default()
             })];
 
-            let err = Transaction::validate_safe_retirement_activation(&indices).unwrap_err();
+            let err = Transaction::activate_safe_retirement(&mut indices, 2).unwrap_err();
 
             assert!(err.to_string().contains("beta protocol"), "{err}");
         }
 
         #[test]
         fn activation_requires_the_mem_wal_index() {
-            let err = Transaction::validate_safe_retirement_activation(&[]).unwrap_err();
+            let err = Transaction::activate_safe_retirement(&mut [], 2).unwrap_err();
             assert!(err.to_string().contains("does not exist"), "{err}");
         }
 
         #[test]
         fn activation_accepts_a_clean_table() {
-            let indices = vec![mem_wal_index(MemWalIndexDetails::default())];
-            Transaction::validate_safe_retirement_activation(&indices).unwrap();
+            let mut indices = vec![mem_wal_index(MemWalIndexDetails::default())];
+            Transaction::activate_safe_retirement(&mut indices, 2).unwrap();
+        }
+
+        #[test]
+        fn a_legacy_table_keeps_its_coverage_when_an_index_changes() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4());
+
+            apply_coverage(&mut after, &segments_before(&before), &[], false).unwrap();
+
+            // Legacy readers treat a missing entry as fully caught up, so removing
+            // this one would widen coverage from 5 to the compacted 10.
+            assert_eq!(
+                coverage_for(&after, "vec_idx"),
+                Some(vec![CompactedSsTable::new(shard, 5)])
+            );
+        }
+
+        #[test]
+        fn a_changed_index_loses_its_coverage_in_safe_mode() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0] = user_index("vec_idx", Uuid::new_v4());
+
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
+
+            assert_eq!(coverage_for(&after, "vec_idx"), None);
+        }
+
+        #[test]
+        fn a_pruned_fragment_bitmap_loses_coverage_even_though_the_uuid_is_the_same() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let mut before = table(shard, 10, "vec_idx", 5, uuid);
+            before[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32, 1]));
+            let mut after = before.clone();
+            // What Rewrite does: same segment, fewer base fragments.
+            after[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32]));
+
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
+
+            assert_eq!(coverage_for(&after, "vec_idx"), None);
+        }
+
+        #[test]
+        fn an_advance_keeps_the_shards_it_does_not_name() {
+            let (shard_a, shard_b, uuid) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+            let before = vec![
+                user_index("vec_idx", uuid),
+                mem_wal_index(MemWalIndexDetails {
+                    compacted_sstables: vec![
+                        CompactedSsTable::new(shard_a, 10),
+                        CompactedSsTable::new(shard_b, 10),
+                    ],
+                    index_catchup: vec![IndexCatchupProgress::new(
+                        "vec_idx".to_string(),
+                        vec![CompactedSsTable::new(shard_b, 7)],
+                    )],
+                    ..Default::default()
+                }),
+            ];
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
+            };
+            apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
+
+            let mut coverage = coverage_for(&after, "vec_idx").unwrap();
+            coverage.sort_unstable_by_key(|sstable| sstable.shard_id);
+            let mut expected = vec![
+                CompactedSsTable::new(shard_a, 9),
+                CompactedSsTable::new(shard_b, 7),
+            ];
+            expected.sort_unstable_by_key(|sstable| sstable.shard_id);
+            assert_eq!(coverage, expected);
+        }
+
+        #[test]
+        fn a_late_advance_cannot_lower_recorded_coverage() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 9, uuid);
+            let mut after = before.clone();
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 6)],
+            };
+            apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
+
+            assert_eq!(
+                coverage_for(&after, "vec_idx"),
+                Some(vec![CompactedSsTable::new(shard, 9)])
+            );
+        }
+
+        #[test]
+        fn a_changed_index_does_not_carry_its_old_shards_into_an_advance() {
+            let (shard_a, shard_b, uuid) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+            let before = vec![
+                user_index("vec_idx", uuid),
+                mem_wal_index(MemWalIndexDetails {
+                    compacted_sstables: vec![
+                        CompactedSsTable::new(shard_a, 10),
+                        CompactedSsTable::new(shard_b, 10),
+                    ],
+                    index_catchup: vec![IndexCatchupProgress::new(
+                        "vec_idx".to_string(),
+                        vec![CompactedSsTable::new(shard_b, 7)],
+                    )],
+                    ..Default::default()
+                }),
+            ];
+            let mut after = before.clone();
+            let rebuilt = Uuid::new_v4();
+            after[0] = user_index("vec_idx", rebuilt);
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![rebuilt],
+                caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
+            };
+            apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
+
+            // Shard B was proved against the index this commit replaced.
+            assert_eq!(
+                coverage_for(&after, "vec_idx"),
+                Some(vec![CompactedSsTable::new(shard_a, 9)])
+            );
+        }
+
+        #[test]
+        fn an_unchanged_commit_does_not_rewrite_the_system_index() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+
+            apply_coverage(&mut after, &segments_before(&before), &[], true).unwrap();
+
+            let system_index = |indices: &[IndexMetadata]| {
+                indices
+                    .iter()
+                    .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                    .unwrap()
+                    .uuid
+            };
+            assert_eq!(system_index(&after), system_index(&before));
+        }
+
+        #[test]
+        fn a_coverage_only_advance_requires_the_index_to_span_the_table() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32]));
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+            };
+            let fragments = vec![Fragment::new(0), Fragment::new(1)];
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &fragments,
+                &segments_before(&before),
+                &[advance],
+                true,
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("live fragments"), "{err}");
+        }
+
+        #[test]
+        fn a_coverage_only_advance_accepts_an_index_that_spans_the_table() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0].fragment_bitmap = Some(RoaringBitmap::from_iter([0u32, 1]));
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+            };
+            let fragments = vec![Fragment::new(0), Fragment::new(1)];
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &fragments,
+                &segments_before(&before),
+                &[advance],
+                true,
+                true,
+                2,
+            )
+            .unwrap();
+
+            assert_eq!(
+                coverage_for(&after, "vec_idx"),
+                Some(vec![CompactedSsTable::new(shard, 9)])
+            );
+        }
+
+        #[test]
+        fn a_coverage_only_advance_rejects_an_index_with_no_fragment_bitmap() {
+            let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
+            let before = table(shard, 10, "vec_idx", 5, uuid);
+            let mut after = before.clone();
+            after[0].fragment_bitmap = None;
+
+            let advance = IndexCatchupAdvance {
+                index_name: "vec_idx".to_string(),
+                expected_index_segment_uuids: vec![uuid],
+                caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
+            };
+            let fragments = vec![Fragment::new(0)];
+            let err = Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &fragments,
+                &segments_before(&before),
+                &[advance],
+                true,
+                true,
+                2,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("which fragments"), "{err}");
+        }
+
+        #[test]
+        fn activation_clears_beta_coverage() {
+            let shard = Uuid::new_v4();
+            let mut indices = vec![mem_wal_index(MemWalIndexDetails {
+                index_catchup: vec![IndexCatchupProgress::new(
+                    "vec_idx".to_string(),
+                    vec![CompactedSsTable::new(shard, 100)],
+                )],
+                ..Default::default()
+            })];
+
+            Transaction::activate_safe_retirement(&mut indices, 2).unwrap();
+
+            // Beta coverage was written under rules this protocol does not
+            // enforce, so keeping it would let the first trim run unproved.
+            assert!(details_of(&indices).index_catchup.is_empty());
         }
 
         #[test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -361,6 +361,14 @@ pub struct IndexCatchupAdvance {
     /// still match afterwards. The commit fails unless the segments it publishes
     /// cover exactly these fragments.
     pub expected_fragment_bitmap: RoaringBitmap,
+    /// Every fragment live in the table when the repair inspected it.
+    ///
+    /// The index must cover all of them. That is what ties the claim to the
+    /// generations it names: nothing records which fragments a generation's rows
+    /// landed in, so covering the whole inspected table is how the repair shows
+    /// it covered those rows. Fragments appended after the snapshot are a later
+    /// catch-up gap and are not required.
+    pub inspected_fragments: RoaringBitmap,
 }
 
 // Hand-written because `Uuid` does not implement `DeepSizeOf`; it is a fixed
@@ -370,6 +378,8 @@ impl DeepSizeOf for IndexCatchupAdvance {
         self.index_name.deep_size_of_children(context)
             + self.expected_index_segment_uuids.capacity() * std::mem::size_of::<Uuid>()
             + self.caught_up_generations.deep_size_of_children(context)
+            + self.expected_fragment_bitmap.serialized_size()
+            + self.inspected_fragments.serialized_size()
     }
 }
 
@@ -387,6 +397,14 @@ impl From<&IndexCatchupAdvance> for pb::transaction::create_index::IndexCatchupA
                 .iter()
                 .map(pb::CompactedSsTable::from)
                 .collect(),
+            inspected_fragments: {
+                let mut bytes = Vec::with_capacity(advance.inspected_fragments.serialized_size());
+                advance
+                    .inspected_fragments
+                    .serialize_into(&mut bytes)
+                    .expect("serializing a roaring bitmap into a Vec cannot fail");
+                bytes
+            },
             expected_fragment_bitmap: {
                 let mut bytes =
                     Vec::with_capacity(advance.expected_fragment_bitmap.serialized_size());
@@ -423,6 +441,14 @@ impl TryFrom<pb::transaction::create_index::IndexCatchupAdvance> for IndexCatchu
             .map_err(|err| {
                 Error::invalid_input(format!(
                     "Could not decode expected_fragment_bitmap for index {index_name}: {err}"
+                ))
+            })?,
+            inspected_fragments: RoaringBitmap::deserialize_from(
+                advance.inspected_fragments.as_slice(),
+            )
+            .map_err(|err| {
+                Error::invalid_input(format!(
+                    "Could not decode inspected_fragments for index {index_name}: {err}"
                 ))
             })?,
             index_name,
@@ -1953,17 +1979,23 @@ impl Transaction {
         manifest.max_fragment_id = manifest
             .max_fragment_id
             .max(current_manifest.max_fragment_id);
-        // Restoring a version from before catch-up was required must not take the
-        // table back to legacy semantics: SSTables may already have stopped being
-        // served against a recorded position. The restored coverage map is then
-        // read strictly, so a missing entry retains SSTables until a repair
-        // rebuilds it.
-        if current_manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0 {
-            log::info!(
-                "Restoring version {version} onto a table that requires MemWAL index \
-                 catch-up; the bit is kept and the restored catch-up state is read \
-                 strictly, so SSTables are retained until a repair rebuilds it"
-            );
+        // A version from before catch-up was required carries MemWAL state this
+        // protocol never validated -- catch-up values activation deliberately
+        // cleared, or compaction progress it deliberately refused to trust.
+        // Keeping the bit would republish those as if this protocol had recorded
+        // them. Refuse instead: sanitizing is not possible here, because both
+        // fields would have to be re-derived from data Lance cannot see.
+        let current_requires = current_manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP
+            != 0
+            || current_manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+        let restored_requires = manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
+            && manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
+        if current_requires && !restored_requires {
+            return Err(Error::invalid_input(format!(
+                "Cannot restore version {version}: this table requires MemWAL index \
+                 catch-up and that version predates it, so its recorded catch-up and \
+                 compaction progress were never validated by this protocol"
+            )));
         }
         inherit_mem_wal_index_catchup(&mut manifest, current_manifest)?;
         Ok((manifest, indices))
@@ -2051,11 +2083,9 @@ impl Transaction {
     /// progress untouched rather than making the table look more covered.
     fn apply_mem_wal_index_coverage(
         final_indices: &mut [IndexMetadata],
-        final_fragments: &[Fragment],
         segments_before: &LogicalIndexSegments,
         advances: &[IndexCatchupAdvance],
         index_catchup_required: bool,
-        indices_published: &HashSet<&str>,
         new_version: u64,
     ) -> Result<()> {
         if !index_catchup_required {
@@ -2150,8 +2180,6 @@ impl Transaction {
 
         // --- validate and apply each advance ---
 
-        let live_fragments: RoaringBitmap = final_fragments.iter().map(|f| f.id as u32).collect();
-
         let mut seen_names = HashSet::with_capacity(advances.len());
         for advance in advances {
             if !seen_names.insert(advance.index_name.as_str()) {
@@ -2218,15 +2246,21 @@ impl Transaction {
                 )));
             }
 
-            // Decided per advance, not per transaction: publishing an index in the
-            // same commit says nothing about a *different* index named by another
-            // advance, which still has to stand on its own metadata.
-            if !indices_published.contains(advance.index_name.as_str()) {
-                Self::validate_coverage_only_target(
-                    &advance.index_name,
-                    segments,
-                    &live_fragments,
-                )?;
+            // Nothing records which fragments a generation's rows landed in, so
+            // the claim is tied to its generations by requiring the index to
+            // cover the whole table as the repair saw it. Fragments appended
+            // since are a later gap. Applied to every advance: publishing one
+            // index says nothing about another index this commit also names, and
+            // removing a segment is not evidence of anything.
+            let missing = &advance.inspected_fragments - &published;
+            if !missing.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "Cannot advance catch-up for index {}: it does not cover {} of the \
+                     {} fragments live when the repair inspected the table",
+                    advance.index_name,
+                    missing.len(),
+                    advance.inspected_fragments.len()
+                )));
             }
 
             let mut seen_shards = HashSet::with_capacity(advance.caught_up_generations.len());
@@ -2309,43 +2343,6 @@ impl Transaction {
         }
 
         final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
-        Ok(())
-    }
-
-    /// Reject a coverage-only advance whose target index cannot back any claim.
-    ///
-    /// Such a commit publishes no index work of its own, so an untrained or
-    /// empty index would otherwise be handed a coverage claim. What it does
-    /// *not* check is that the index spans the whole table: the claim is only
-    /// about generations already compacted, and fragments appended since are a
-    /// later catch-up gap. Requiring full coverage would fail every repair on a
-    /// table still taking writes.
-    fn validate_coverage_only_target(
-        index_name: &str,
-        segments: &[IndexMetadata],
-        live_fragments: &RoaringBitmap,
-    ) -> Result<()> {
-        let mut covered = RoaringBitmap::new();
-        for segment in segments {
-            let Some(bitmap) = segment.effective_fragment_bitmap(live_fragments) else {
-                return Err(Error::invalid_input(format!(
-                    "Cannot advance coverage for index {}: segment {} does not record \
-                     which fragments it covers",
-                    index_name, segment.uuid
-                )));
-            };
-            covered |= bitmap;
-        }
-        // An index covering nothing that still exists has indexed nothing a
-        // reader could use, so it cannot stand in for the SSTables.
-        if covered.is_empty() && !live_fragments.is_empty() {
-            return Err(Error::invalid_input(format!(
-                "Cannot advance coverage for index {}: it covers none of the {} live \
-                 fragments",
-                index_name,
-                live_fragments.len()
-            )));
-        }
         Ok(())
     }
 
@@ -3094,32 +3091,15 @@ impl Transaction {
             } => mem_wal_index_catchup_advances,
             _ => &[],
         };
-        // The logical indices this commit publishes work for. An advance naming
-        // one of them is backed by the metadata landing alongside it; an advance
-        // naming any other index has to stand on that index's own metadata.
-        let indices_published: HashSet<&str> = match &self.operation {
-            Operation::CreateIndex {
-                new_indices,
-                removed_indices,
-                ..
-            } => new_indices
-                .iter()
-                .chain(removed_indices.iter())
-                .map(|idx| idx.name.as_str())
-                .collect(),
-            _ => HashSet::new(),
-        };
         // Advances are also routed in when the table carries no system index, so a
         // coverage claim on such a table is rejected rather than silently dropped.
         if mem_wal_segments_before.is_some() || !advances.is_empty() {
             let empty_segments = LogicalIndexSegments::new();
             Self::apply_mem_wal_index_coverage(
                 &mut final_indices,
-                &final_fragments,
                 mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
                 advances,
                 index_catchup_required,
-                &indices_published,
                 new_version,
             )?;
         }
@@ -7789,11 +7769,9 @@ mod tests {
         ) -> Result<()> {
             Transaction::apply_mem_wal_index_coverage(
                 final_indices,
-                &[],
                 segments_before,
                 advances,
                 index_catchup_required,
-                &HashSet::new(),
                 2,
             )
         }
@@ -7929,6 +7907,7 @@ mod tests {
                 expected_index_segment_uuids: vec![rebuilt],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -7949,6 +7928,7 @@ mod tests {
                 expected_index_segment_uuids: vec![Uuid::new_v4()], // what the repair built
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7972,6 +7952,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -7993,6 +7974,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -8014,6 +7996,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], false)
                 .unwrap_err();
@@ -8031,6 +8014,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(Uuid::new_v4(), 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &LogicalIndexSegments::new(), &[advance], true)
                 .unwrap_err();
@@ -8049,6 +8033,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(
                 &mut after,
@@ -8075,6 +8060,7 @@ mod tests {
                     CompactedSsTable::new(shard, 10),
                 ],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -8093,6 +8079,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid, uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -8194,6 +8181,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8218,6 +8206,7 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 6)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8253,6 +8242,7 @@ mod tests {
                 expected_index_segment_uuids: vec![rebuilt],
                 caught_up_generations: vec![CompactedSsTable::new(shard_a, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
             apply_coverage(&mut after, &segments_before(&before), &[advance], true).unwrap();
 
@@ -8296,15 +8286,13 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
-            let fragments = vec![Fragment::new(0), Fragment::new(1)];
             Transaction::apply_mem_wal_index_coverage(
                 &mut after,
-                &fragments,
                 &segments_before(&before),
                 &[advance],
                 true,
-                &HashSet::new(),
                 2,
             )
             .unwrap();
@@ -8316,11 +8304,11 @@ mod tests {
         }
 
         #[test]
-        fn a_coverage_only_advance_rejects_an_index_covering_nothing_live() {
+        fn an_untrained_target_cannot_back_a_claim() {
             let (shard, uuid) = (Uuid::new_v4(), Uuid::new_v4());
             let before = table(shard, 10, "vec_idx", 5, uuid);
             let mut after = before.clone();
-            // Declared but never trained, or covering only fragments since gone.
+            // Declared but never trained: covers nothing.
             after[0].fragment_bitmap = Some(RoaringBitmap::new());
 
             let advance = IndexCatchupAdvance {
@@ -8328,20 +8316,13 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                // The repair inspected a table that had a fragment.
+                inspected_fragments: RoaringBitmap::from_iter([0u32]),
             };
-            let fragments = vec![Fragment::new(0)];
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &fragments,
-                &segments_before(&before),
-                &[advance],
-                true,
-                &HashSet::new(),
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
-            assert!(err.to_string().contains("covers none"), "{err}");
+            assert!(err.to_string().contains("does not cover"), "{err}");
         }
 
         #[test]
@@ -8356,15 +8337,13 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
-            let fragments = vec![Fragment::new(0), Fragment::new(1)];
             Transaction::apply_mem_wal_index_coverage(
                 &mut after,
-                &fragments,
                 &segments_before(&before),
                 &[advance],
                 true,
-                &HashSet::new(),
                 2,
             )
             .unwrap();
@@ -8387,15 +8366,13 @@ mod tests {
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: covered_by(&after, "vec_idx"),
+                inspected_fragments: covered_by(&after, "vec_idx"),
             };
-            let fragments = vec![Fragment::new(0)];
             let err = Transaction::apply_mem_wal_index_coverage(
                 &mut after,
-                &fragments,
                 &segments_before(&before),
                 &[advance],
                 true,
-                &HashSet::new(),
                 2,
             )
             .unwrap_err();
@@ -8511,7 +8488,8 @@ mod tests {
                 index_name: "vec_idx".to_string(),
                 expected_index_segment_uuids: vec![uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 10)],
-                expected_fragment_bitmap: inspected,
+                expected_fragment_bitmap: inspected.clone(),
+                inspected_fragments: inspected,
             };
             let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
                 .unwrap_err();
@@ -8550,21 +8528,15 @@ mod tests {
                 expected_index_segment_uuids: vec![target_uuid],
                 caught_up_generations: vec![CompactedSsTable::new(shard, 9)],
                 expected_fragment_bitmap: RoaringBitmap::new(),
+                // The repair saw a table with one fragment; idx_a covers none of
+                // it. Publishing idx_b in the same commit is no evidence for
+                // idx_a.
+                inspected_fragments: RoaringBitmap::from_iter([0u32]),
             };
-            // The commit publishes idx_b; idx_a still has to stand on its own.
-            let published: HashSet<&str> = ["idx_b"].into_iter().collect();
-            let err = Transaction::apply_mem_wal_index_coverage(
-                &mut after,
-                &[Fragment::new(0)],
-                &segments_before(&before),
-                &[advance],
-                true,
-                &published,
-                2,
-            )
-            .unwrap_err();
+            let err = apply_coverage(&mut after, &segments_before(&before), &[advance], true)
+                .unwrap_err();
 
-            assert!(err.to_string().contains("covers none"), "{err}");
+            assert!(err.to_string().contains("does not cover"), "{err}");
         }
 
         /// An ordinary index job on a table that requires catch-up must still
@@ -8621,6 +8593,7 @@ mod tests {
                     CompactedSsTable::new(Uuid::new_v4(), 9),
                 ],
                 expected_fragment_bitmap: RoaringBitmap::from_iter([0u32, 7, 42]),
+                inspected_fragments: RoaringBitmap::from_iter([0u32, 7, 42]),
             };
 
             let encoded = pb::transaction::create_index::IndexCatchupAdvance::from(&advance);

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1434,14 +1434,15 @@ impl IndexDescription for IndexDescriptionImpl {
     }
 }
 
-/// Describe, for each index this commit republishes, the segments it will
-/// consist of afterwards and the catch-up generations to record for it.
+/// Describe, for each named index, the segments it will consist of after this
+/// commit and the catch-up generations to record for it.
 ///
 /// Built here rather than by the caller: an advance must name the exact segments
 /// it describes, and those do not exist until the merge runs. The final segment
 /// set for a name is what survives the `CreateIndex` apply -- the existing
 /// segments this commit neither removes nor replaces, plus the ones it adds.
 fn build_index_catchup_advances(
+    names: &[String],
     existing: &[IndexMetadata],
     new_indices: &[IndexMetadata],
     removed_indices: &[IndexMetadata],
@@ -1454,9 +1455,11 @@ fn build_index_catchup_advances(
         .map(|idx| idx.uuid)
         .collect();
 
-    new_indices
+    // Driven by the requested names, not by what was rebuilt: an index that
+    // already covered everything produces no new segment, and that is exactly
+    // the repair that most needs to record its catch-up.
+    names
         .iter()
-        .map(|added| &added.name)
         .unique()
         .map(|name| {
             let segments: Vec<&IndexMetadata> = existing
@@ -1550,18 +1553,6 @@ impl DatasetIndexExt for Dataset {
     }
 
     async fn drop_index(&mut self, name: &str) -> Result<()> {
-        // The MemWAL system index holds the compaction progress and index
-        // coverage the WAL pod retires SSTables against. Dropping it through the
-        // ordinary index API would erase that catch-up while the SSTables it
-        // describes are already gone, so it is refused here; disabling MemWAL is
-        // a dedicated operation.
-        if name == MEM_WAL_INDEX_NAME {
-            return Err(Error::invalid_input(format!(
-                "{} is a system index and cannot be dropped through drop_index",
-                MEM_WAL_INDEX_NAME
-            )));
-        }
-
         let indices = self.load_indices_by_name(name).await?;
         if indices.is_empty() {
             return Err(Error::index_not_found(format!("name={}", name)));
@@ -2189,18 +2180,63 @@ impl DatasetIndexExt for Dataset {
             new_indices.push(new_idx);
         }
 
-        if new_indices.is_empty() {
-            return Ok(());
-        }
-
         // Built here rather than by the caller: an advance must name the exact
         // segments it describes, and those only exist now. Recording it in this
         // commit is what keeps the index result and its catch-up from
         // disagreeing.
+        //
+        // Built *before* the no-work early return below. A repair whose index
+        // already covers every fragment has nothing to rebuild, and that is the
+        // ordinary case after a remap: coverage was dropped because the segment
+        // changed, while the index still spans the table. Returning early there
+        // would leave catch-up missing forever and the repair rescheduling
+        // itself.
         let mem_wal_index_catchup_advances = if options.mem_wal_index_catchup.is_empty() {
             Vec::new()
         } else {
+            let Some(names) = options.index_names.as_ref().filter(|n| !n.is_empty()) else {
+                return Err(Error::invalid_input(
+                    "optimize_indices: index_names must name the indices to record \
+                     catch-up for; recording it for every index on the table is \
+                     never what a repair means",
+                ));
+            };
+            // The caller may only claim what the version it read had already
+            // compacted. Anything compacted since landed in fragments this call
+            // never inspected, so its rows are not covered by the index being
+            // published.
+            let details = indices
+                .iter()
+                .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                .map(|idx| crate::index::mem_wal::load_mem_wal_index_details(idx.clone()))
+                .transpose()?
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "optimize_indices: cannot record catch-up, the {} system \
+                         index does not exist on this table",
+                        MEM_WAL_INDEX_NAME
+                    ))
+                })?;
+            for proposed in &options.mem_wal_index_catchup {
+                let inspected = details
+                    .compacted_sstables
+                    .iter()
+                    .find(|sstable| sstable.shard_id == proposed.shard_id)
+                    .map(|sstable| sstable.generation);
+                if inspected.is_none_or(|inspected| proposed.generation > inspected) {
+                    return Err(Error::invalid_input(format!(
+                        "optimize_indices: cannot record catch-up to generation {} for \
+                         shard {}: the version this call read had compacted {}",
+                        proposed.generation,
+                        proposed.shard_id,
+                        inspected
+                            .map(|g| g.to_string())
+                            .unwrap_or_else(|| "nothing".to_string())
+                    )));
+                }
+            }
             build_index_catchup_advances(
+                names,
                 &indices,
                 &new_indices,
                 &removed_indices,
@@ -2215,6 +2251,10 @@ impl DatasetIndexExt for Dataset {
                     .collect(),
             )
         };
+
+        if new_indices.is_empty() && mem_wal_index_catchup_advances.is_empty() {
+            return Ok(());
+        }
 
         let transaction = TransactionBuilder::new(
             self.manifest.version,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1500,6 +1500,18 @@ impl DatasetIndexExt for Dataset {
     }
 
     async fn drop_index(&mut self, name: &str) -> Result<()> {
+        // The MemWAL system index holds the compaction progress and index
+        // coverage the WAL pod retires SSTables against. Dropping it through the
+        // ordinary index API would erase that proof while the SSTables it
+        // describes are already gone, so it is refused here; disabling MemWAL is
+        // a dedicated operation.
+        if name == MEM_WAL_INDEX_NAME {
+            return Err(Error::invalid_input(format!(
+                "{} is a system index and cannot be dropped through drop_index",
+                MEM_WAL_INDEX_NAME
+            )));
+        }
+
         let indices = self.load_indices_by_name(name).await?;
         if indices.is_empty() {
             return Err(Error::index_not_found(format!("name={}", name)));

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1510,6 +1510,7 @@ impl DatasetIndexExt for Dataset {
             Operation::CreateIndex {
                 new_indices: vec![],
                 removed_indices: indices.clone(),
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -1992,6 +1993,7 @@ impl DatasetIndexExt for Dataset {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -2133,6 +2135,7 @@ impl DatasetIndexExt for Dataset {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances: Vec::new(),
             },
         )
         .transaction_properties(options.transaction_properties.clone())
@@ -8058,6 +8061,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: legacy,
                 removed_indices: current,
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -89,7 +89,9 @@ use self::vector::remap_vector_index;
 use crate::dataset::index::LanceIndexStoreExt;
 use crate::dataset::optimize::RemappedIndex;
 use crate::dataset::optimize::remapping::RemapResult;
-use crate::dataset::transaction::{Operation, Transaction, TransactionBuilder};
+use crate::dataset::transaction::{
+    IndexCatchupAdvance, Operation, Transaction, TransactionBuilder,
+};
 pub use crate::index::api::{DatasetIndexExt, IndexSegment, IntoIndexSegment};
 use crate::index::frag_reuse::{load_frag_reuse_index_details, open_frag_reuse_index};
 use crate::index::mem_wal::open_mem_wal_index;
@@ -100,6 +102,7 @@ use crate::session::index_caches::{FragReuseIndexKey, IndexMetadataKey, write_in
 use crate::{Error, Result, dataset::Dataset};
 pub use create::CreateIndexBuilder;
 pub use lance_index::IndexDescription;
+use lance_table::system_index::mem_wal::CompactedSsTable;
 
 fn validate_segment_metadata(index_name: &str, segments: &[IndexMetadata]) -> Result<()> {
     if segments.is_empty() {
@@ -1431,6 +1434,53 @@ impl IndexDescription for IndexDescriptionImpl {
     }
 }
 
+/// Describe, for each index this commit republishes, the segments it will
+/// consist of afterwards and the catch-up generations to record for it.
+///
+/// Built here rather than by the caller: an advance must name the exact segments
+/// it describes, and those do not exist until the merge runs. The final segment
+/// set for a name is what survives the `CreateIndex` apply -- the existing
+/// segments this commit neither removes nor replaces, plus the ones it adds.
+fn build_index_catchup_advances(
+    existing: &[IndexMetadata],
+    new_indices: &[IndexMetadata],
+    removed_indices: &[IndexMetadata],
+    generations: &[CompactedSsTable],
+    inspected_fragments: &RoaringBitmap,
+) -> Vec<IndexCatchupAdvance> {
+    let replaced: HashSet<Uuid> = removed_indices
+        .iter()
+        .chain(new_indices.iter())
+        .map(|idx| idx.uuid)
+        .collect();
+
+    new_indices
+        .iter()
+        .map(|added| &added.name)
+        .unique()
+        .map(|name| {
+            let segments: Vec<&IndexMetadata> = existing
+                .iter()
+                .filter(|idx| &idx.name == name && !replaced.contains(&idx.uuid))
+                .chain(new_indices.iter().filter(|idx| &idx.name == name))
+                .collect();
+            let mut expected_fragment_bitmap = RoaringBitmap::new();
+            for segment in &segments {
+                if let Some(bitmap) = segment.fragment_bitmap.as_ref() {
+                    expected_fragment_bitmap |= bitmap;
+                }
+            }
+            IndexCatchupAdvance {
+                index_name: name.clone(),
+                expected_index_segment_uuids: segments.iter().map(|s| s.uuid).collect(),
+                caught_up_generations: generations.to_vec(),
+                expected_fragment_bitmap,
+                inspected_fragments: inspected_fragments.clone(),
+            }
+        })
+        .collect()
+}
+
 #[async_trait]
 impl DatasetIndexExt for Dataset {
     type IndexBuilder<'a> = CreateIndexBuilder<'a>;
@@ -2081,6 +2131,7 @@ impl DatasetIndexExt for Dataset {
     }
 
     #[instrument(skip_all)]
+
     async fn optimize_indices(&mut self, options: &OptimizeOptions) -> Result<()> {
         let dataset = Arc::new(self.clone());
         let indices = self.load_indices().await?;
@@ -2142,12 +2193,35 @@ impl DatasetIndexExt for Dataset {
             return Ok(());
         }
 
+        // Built here rather than by the caller: an advance must name the exact
+        // segments it describes, and those only exist now. Recording it in this
+        // commit is what keeps the index result and its catch-up from
+        // disagreeing.
+        let mem_wal_index_catchup_advances = if options.mem_wal_index_catchup.is_empty() {
+            Vec::new()
+        } else {
+            build_index_catchup_advances(
+                &indices,
+                &new_indices,
+                &removed_indices,
+                &options.mem_wal_index_catchup,
+                // The table as this call read it; anything appended since is a
+                // later catch-up gap, not something these generations claim.
+                &self
+                    .manifest
+                    .fragments
+                    .iter()
+                    .map(|f| f.id as u32)
+                    .collect(),
+            )
+        };
+
         let transaction = TransactionBuilder::new(
             self.manifest.version,
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
-                mem_wal_index_catchup_advances: Vec::new(),
+                mem_wal_index_catchup_advances,
             },
         )
         .transaction_properties(options.transaction_properties.clone())

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1502,7 +1502,7 @@ impl DatasetIndexExt for Dataset {
     async fn drop_index(&mut self, name: &str) -> Result<()> {
         // The MemWAL system index holds the compaction progress and index
         // coverage the WAL pod retires SSTables against. Dropping it through the
-        // ordinary index API would erase that proof while the SSTables it
+        // ordinary index API would erase that catch-up while the SSTables it
         // describes are already gone, so it is refused here; disabling MemWAL is
         // a dedicated operation.
         if name == MEM_WAL_INDEX_NAME {

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -644,6 +644,7 @@ impl<'a> CreateIndexBuilder<'a> {
             Operation::CreateIndex {
                 new_indices: vec![new_idx],
                 removed_indices,
+                mem_wal_index_catchup_advances: Vec::new(),
             },
         )
         .transaction_properties(self.transaction_properties.clone())
@@ -786,6 +787,7 @@ impl<'a> CreateIndexBuilder<'a> {
                 Operation::CreateIndex {
                     new_indices,
                     removed_indices,
+                    mem_wal_index_catchup_advances: Vec::new(),
                 },
             )
             .transaction_properties(self.transaction_properties.clone())
@@ -860,6 +862,7 @@ impl<'a> CreateIndexBuilder<'a> {
             Operation::CreateIndex {
                 new_indices,
                 removed_indices,
+                mem_wal_index_catchup_advances: Vec::new(),
             },
         )
         .transaction_properties(self.transaction_properties.clone())

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -702,6 +702,7 @@ mod tests {
                 version,
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                    activate_safe_retirement: false,
                 },
                 None,
             ))
@@ -767,7 +768,6 @@ mod tests {
         .unwrap();
         assert_eq!(
             details.compacted_sstables[0].generation, 10,
-            "the recorded generation must be unchanged"
             "the recorded generation must be unchanged"
         );
     }

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -220,7 +220,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -235,7 +235,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -259,7 +259,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -273,7 +273,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -298,7 +298,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -313,7 +313,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -338,7 +338,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -353,7 +353,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -391,7 +391,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -474,7 +474,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -702,7 +702,7 @@ mod tests {
                 version,
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                    activate_safe_retirement: false,
+                    require_index_catchup: false,
                 },
                 None,
             ))
@@ -835,7 +835,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 1)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -487,6 +487,107 @@ mod tests {
         );
     }
 
+    /// The bit must survive being written and read back, not just
+    /// `build_manifest`. `apply_feature_flags` runs a second time inside
+    /// `write_manifest_file`, so a version of this that stops at the in-memory
+    /// manifest passes while the stored table stays legacy.
+    #[tokio::test]
+    async fn required_catch_up_survives_a_persisted_round_trip() {
+        use crate::dataset::mem_wal::DatasetMemWalExt;
+        use lance_table::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
+
+        // A real directory, not `memory://`: reopening by URI builds a fresh
+        // store registry, and the point of this test is to read back what was
+        // actually written.
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let write_params = WriteParams {
+            max_rows_per_file: 10,
+            ..Default::default()
+        };
+        let data = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+        let dataset = InsertBuilder::new(uri)
+            .with_params(&write_params)
+            .execute(vec![data])
+            .await
+            .unwrap();
+
+        // Install the system index, then require catch-up.
+        let mem_wal_index =
+            new_mem_wal_index_meta(dataset.manifest.version, MemWalIndexDetails::default())
+                .unwrap();
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![mem_wal_index],
+                removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
+            },
+            None,
+        );
+        let mut dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap();
+        dataset.require_mem_wal_index_catchup().await.unwrap();
+
+        let reopened = crate::dataset::builder::DatasetBuilder::from_uri(uri)
+            .load()
+            .await
+            .unwrap();
+        assert_ne!(
+            reopened.manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0,
+            "activation did not reach storage"
+        );
+        assert_ne!(
+            reopened.manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0,
+            "activation did not reach storage"
+        );
+
+        // An ordinary commit must not walk it back.
+        let txn = Transaction::new(
+            reopened.manifest.version,
+            Operation::UpdateConfig {
+                config_updates: Some(crate::dataset::transaction::UpdateMap {
+                    update_entries: vec![crate::dataset::transaction::UpdateMapEntry {
+                        key: "k".to_string(),
+                        value: Some("v".to_string()),
+                    }],
+                    replace: false,
+                }),
+                table_metadata_updates: None,
+                schema_metadata_updates: None,
+                field_metadata_updates: HashMap::new(),
+            },
+            None,
+        );
+        CommitBuilder::new(Arc::new(reopened))
+            .execute(txn)
+            .await
+            .unwrap();
+
+        let reopened = crate::dataset::builder::DatasetBuilder::from_uri(uri)
+            .load()
+            .await
+            .unwrap();
+        assert_ne!(
+            reopened.manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0,
+            "an ordinary commit downgraded the stored table"
+        );
+        assert_ne!(
+            reopened.manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            0,
+            "an ordinary commit downgraded the stored table"
+        );
+    }
+
     /// One `__lance_mem_wal` entry carrying `details`, as a real table has.
     fn indices_with(details: MemWalIndexDetails) -> Vec<IndexMetadata> {
         vec![new_mem_wal_index_meta(1, details).unwrap()]

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(compacted_generation(&indices, shard), Some(10));
     }
 
-    /// Equal is also refused: it proves nothing new, and accepting it would let
+    /// Equal is also refused: it reports nothing new, and accepting it would let
     /// a retry publish a second set of row mutations under the same marker.
     #[test]
     fn an_equal_generation_rejects() {
@@ -631,7 +631,7 @@ mod tests {
     fn recording_progress_keeps_the_system_index_position() {
         let shard = Uuid::new_v4();
         let mut indices = indices_with(MemWalIndexDetails::default());
-        // A neighbour to prove the entry is replaced in place, not moved.
+        // A neighbour to show the entry is replaced in place, not moved.
         indices.push(IndexMetadata {
             name: "other_index".to_string(),
             ..indices[0].clone()
@@ -772,7 +772,7 @@ mod tests {
         );
     }
 
-    /// The system index holds the proof the WAL pod retires SSTables against.
+    /// The system index holds the catch-up positions the WAL pod retires SSTables against.
     /// Erasing it through the ordinary index API would leave the table claiming
     /// nothing was ever compacted while the SSTables are already gone.
     #[tokio::test]

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -768,6 +768,30 @@ mod tests {
         assert_eq!(
             details.compacted_sstables[0].generation, 10,
             "the recorded generation must be unchanged"
+            "the recorded generation must be unchanged"
+        );
+    }
+
+    /// The system index holds the proof the WAL pod retires SSTables against.
+    /// Erasing it through the ordinary index API would leave the table claiming
+    /// nothing was ever compacted while the SSTables are already gone.
+    #[tokio::test]
+    async fn the_mem_wal_system_index_cannot_be_dropped_through_drop_index() {
+        use crate::index::DatasetIndexExt;
+
+        let mut dataset = test_dataset_with_mem_wal().await;
+
+        let err = dataset.drop_index(MEM_WAL_INDEX_NAME).await.unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("system index and cannot be dropped"),
+            "{err}"
+        );
+        let indices = dataset.load_indices().await.unwrap();
+        assert!(
+            indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME),
+            "the system index must survive the refused drop"
         );
     }
 

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -198,6 +198,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![mem_wal_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -219,6 +220,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -233,6 +235,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -256,6 +259,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -269,6 +273,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -293,6 +298,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -307,6 +313,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -331,6 +338,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -345,6 +353,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -382,6 +391,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -403,6 +413,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![mem_wal_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -449,6 +460,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![mem_wal_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -462,6 +474,7 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -798,6 +811,7 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 1)],
+                activate_safe_retirement: false,
             },
             None,
         );

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -588,6 +588,129 @@ mod tests {
         );
     }
 
+    /// The ordinary case after a remap: the index still spans the table, so a
+    /// repair has nothing to rebuild. It must still record its catch-up, or the
+    /// agent reschedules the same repair forever and the SSTables never retire.
+    #[tokio::test]
+    async fn a_repair_with_no_index_work_still_records_catch_up() {
+        use crate::dataset::mem_wal::DatasetMemWalExt;
+        use lance_index::optimize::OptimizeOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let data = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+        let mut dataset = InsertBuilder::new(uri).execute(vec![data]).await.unwrap();
+        let scalar_params = lance_index::scalar::ScalarIndexParams::for_builtin(
+            lance_index::scalar::BuiltinIndexType::BTree,
+        );
+        dataset
+            .create_index(
+                &["a"],
+                lance_index::IndexType::BTree,
+                Some("a_idx".to_string()),
+                &scalar_params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // A MemWAL table that has compacted through generation 7 and requires
+        // catch-up, with no catch-up recorded for the index yet.
+        let shard = Uuid::new_v4();
+        let mem_wal_index =
+            new_mem_wal_index_meta(dataset.manifest.version, MemWalIndexDetails::default())
+                .unwrap();
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![mem_wal_index],
+                removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
+            },
+            None,
+        );
+        let mut dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap();
+        // Activation refuses a table already carrying compaction progress, so
+        // the progress lands after it.
+        dataset.require_mem_wal_index_catchup().await.unwrap();
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::UpdateMemWalState {
+                compacted_sstables: vec![CompactedSsTable::new(shard, 7)],
+                require_index_catchup: false,
+            },
+            None,
+        );
+        let mut dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap();
+
+        // The index already covers every fragment, so this rebuilds nothing.
+        dataset
+            .optimize_indices(
+                &OptimizeOptions::append()
+                    .index_names(vec!["a_idx".to_string()])
+                    .mem_wal_index_catchup(vec![CompactedSsTable::new(shard, 7)]),
+            )
+            .await
+            .unwrap();
+
+        let recorded = dataset
+            .mem_wal_index_details()
+            .await
+            .unwrap()
+            .unwrap()
+            .index_catchup
+            .into_iter()
+            .find(|entry| entry.index_name == "a_idx")
+            .expect("a repair that rebuilt nothing still has to record its catch-up");
+        assert_eq!(
+            recorded.caught_up_generations,
+            vec![CompactedSsTable::new(shard, 7)]
+        );
+    }
+
+    /// A claim may not exceed what the version this call read had compacted:
+    /// anything compacted since is in fragments this call never inspected.
+    #[tokio::test]
+    async fn a_claim_beyond_the_inspected_compaction_is_refused() {
+        use lance_index::optimize::OptimizeOptions;
+
+        let dataset = test_dataset_with_mem_wal().await;
+        let shard = Uuid::new_v4();
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::UpdateMemWalState {
+                compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                require_index_catchup: false,
+            },
+            None,
+        );
+        let mut dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap();
+
+        let err = dataset
+            .optimize_indices(
+                &OptimizeOptions::append()
+                    .index_names(vec!["a_idx".to_string()])
+                    .mem_wal_index_catchup(vec![CompactedSsTable::new(shard, 10)]),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("had compacted 5"), "{err}");
+    }
+
     /// One `__lance_mem_wal` entry carrying `details`, as a real table has.
     fn indices_with(details: MemWalIndexDetails) -> Vec<IndexMetadata> {
         vec![new_mem_wal_index_meta(1, details).unwrap()]
@@ -876,25 +999,6 @@ mod tests {
     /// The system index holds the catch-up positions the WAL pod retires SSTables against.
     /// Erasing it through the ordinary index API would leave the table claiming
     /// nothing was ever compacted while the SSTables are already gone.
-    #[tokio::test]
-    async fn the_mem_wal_system_index_cannot_be_dropped_through_drop_index() {
-        use crate::index::DatasetIndexExt;
-
-        let mut dataset = test_dataset_with_mem_wal().await;
-
-        let err = dataset.drop_index(MEM_WAL_INDEX_NAME).await.unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("system index and cannot be dropped"),
-            "{err}"
-        );
-        let indices = dataset.load_indices().await.unwrap();
-        assert!(
-            indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME),
-            "the system index must survive the refused drop"
-        );
-    }
 
     #[test]
     fn test_empty_compacted_sstables_noop() {

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1961,6 +1961,7 @@ pub async fn initialize_vector_index(
         Operation::CreateIndex {
             new_indices: vec![new_idx],
             removed_indices: vec![],
+            mem_wal_index_catchup_advances: Vec::new(),
         },
         None,
     );

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -5426,6 +5426,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index_meta.clone()],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -5523,6 +5524,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![new_index_meta],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -5577,6 +5577,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![new_meta],
                 removed_indices: vec![old_meta.clone()],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -599,6 +599,7 @@ impl<'a> TransactionRebase<'a> {
                 }
                 Operation::UpdateMemWalState {
                     compacted_sstables: other_compacted_sstables,
+                    ..
                 } => self.check_compacted_sstables_conflict(
                     other_compacted_sstables,
                     self_compacted_sstables,
@@ -780,6 +781,7 @@ impl<'a> TransactionRebase<'a> {
                 }
                 Operation::UpdateMemWalState {
                     compacted_sstables: other_compacted_sstables,
+                    ..
                 } => {
                     // CreateIndex of MemWalIndex is compatible with UpdateMemWalState
                     // as they can be rebased on each other
@@ -1517,11 +1519,13 @@ impl<'a> TransactionRebase<'a> {
     ) -> Result<()> {
         if let Operation::UpdateMemWalState {
             compacted_sstables: self_compacted_sstables,
+            activate_safe_retirement: false,
         } = &self.transaction.operation
         {
             match &other_transaction.operation {
                 Operation::UpdateMemWalState {
                     compacted_sstables: other_compacted_sstables,
+                    ..
                 } => {
                     // Two UpdateMemWalState transactions conflict if they're updating
                     // the same shard's compacted SSTable
@@ -1923,9 +1927,16 @@ impl<'a> TransactionRebase<'a> {
     }
 
     async fn finish_create_index(mut self, dataset: &Dataset) -> Result<Transaction> {
+        // `mem_wal_index_catchup_advances` is deliberately carried through the
+        // rebase untouched: it names the exact segment set the repair expects,
+        // and apply-time validation re-checks that against the rebased final
+        // index list. If an ordinary reindex won the race, the expected set no
+        // longer matches and the repair fails rather than claiming coverage for
+        // an index it did not build.
         if let Operation::CreateIndex {
             new_indices,
             removed_indices,
+            ..
         } = &mut self.transaction.operation
         {
             // Handle FRAG_REUSE_INDEX rebasing
@@ -2712,6 +2723,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index0.clone()],
                 removed_indices: vec![index0.clone()],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             Operation::Delete {
                 updated_fragments: vec![fragment0.clone()],
@@ -2855,6 +2867,7 @@ mod tests {
                 Operation::CreateIndex {
                     new_indices: vec![index0.clone()],
                     removed_indices: vec![index0],
+                    mem_wal_index_catchup_advances: Vec::new(),
                 },
                 // Conflicts with row-id-changing operations and same-name CreateIndex.
                 [
@@ -3275,6 +3288,7 @@ mod tests {
                 Operation::CreateIndex {
                     new_indices: vec![],
                     removed_indices: vec![],
+                    mem_wal_index_catchup_advances: Vec::new(),
                 },
                 Compatible,
             ),
@@ -3339,6 +3353,7 @@ mod tests {
             (
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![],
+                    activate_safe_retirement: false,
                 },
                 NotCompatible,
             ),
@@ -3782,6 +3797,7 @@ mod tests {
                 Operation::CreateIndex {
                     new_indices: vec![index],
                     removed_indices: vec![],
+                    mem_wal_index_catchup_advances: Vec::new(),
                 },
                 None,
             ),
@@ -3843,6 +3859,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index0.clone()],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -3863,6 +3880,7 @@ mod tests {
                     ..index0
                 }],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -3871,6 +3889,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![index1],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -3899,6 +3918,7 @@ mod tests {
                         files: None,
                     }],
                     removed_indices: vec![],
+                    mem_wal_index_catchup_advances: Vec::new(),
                 },
                 None,
             ),
@@ -3965,6 +3985,7 @@ mod tests {
                     Operation::CreateIndex {
                         new_indices: vec![ngram_index(covered_fragment)],
                         removed_indices: vec![],
+                        mem_wal_index_catchup_advances: Vec::new(),
                     },
                     None,
                 ),
@@ -4663,6 +4684,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4671,6 +4693,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4701,6 +4724,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4709,6 +4733,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4740,6 +4765,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4748,6 +4774,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4779,6 +4806,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4787,6 +4815,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4828,6 +4857,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![mem_wal_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -4837,6 +4867,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4862,6 +4893,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 15)],
+                activate_safe_retirement: false,
             },
             None,
         );
@@ -4899,6 +4931,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![mem_wal_index],
                 removed_indices: vec![],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
             None,
         );
@@ -4908,6 +4941,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
+                activate_safe_retirement: false,
             },
             None,
         );

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -3355,7 +3355,7 @@ mod tests {
             (
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![],
-                    activate_safe_retirement: false,
+                    require_index_catchup: false,
                 },
                 NotCompatible,
             ),
@@ -4686,7 +4686,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4695,7 +4695,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4726,7 +4726,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4735,7 +4735,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4767,7 +4767,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4776,7 +4776,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4808,7 +4808,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4817,7 +4817,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4869,7 +4869,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4895,7 +4895,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 15)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );
@@ -4943,7 +4943,7 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                activate_safe_retirement: false,
+                require_index_catchup: false,
             },
             None,
         );

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -72,19 +72,6 @@ fn supplies_values(operation: &Operation) -> bool {
     )
 }
 
-/// Whether this operation publishes MemWAL compaction progress.
-fn operation_advances_compaction(operation: &Operation) -> bool {
-    match operation {
-        Operation::Update {
-            compacted_sstables, ..
-        }
-        | Operation::UpdateMemWalState {
-            compacted_sstables, ..
-        } => !compacted_sstables.is_empty(),
-        _ => false,
-    }
-}
-
 impl<'a> TransactionRebase<'a> {
     pub async fn try_new(
         dataset: &Dataset,
@@ -633,21 +620,9 @@ impl<'a> TransactionRebase<'a> {
         if let Operation::CreateIndex {
             new_indices,
             removed_indices,
-            mem_wal_index_catchup_advances,
+            ..
         } = &mut self.transaction.operation
         {
-            // A coverage advance describes the table as the repair inspected it.
-            // If the commit it rebases over moved compaction progress, rows from
-            // the newly compacted generations landed in fragments the repair
-            // never saw, and its claim would cover generations its index does
-            // not. Nothing here can re-derive that, so refuse and let the repair
-            // re-plan against the newer state.
-            if !mem_wal_index_catchup_advances.is_empty()
-                && operation_advances_compaction(&other_transaction.operation)
-            {
-                return Err(self.retryable_conflict_err(other_transaction, other_version));
-            }
-
             match &other_transaction.operation {
                 Operation::Append { .. }
                 | Operation::Clone { .. }

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -72,6 +72,19 @@ fn supplies_values(operation: &Operation) -> bool {
     )
 }
 
+/// Whether this operation publishes MemWAL compaction progress.
+fn operation_advances_compaction(operation: &Operation) -> bool {
+    match operation {
+        Operation::Update {
+            compacted_sstables, ..
+        }
+        | Operation::UpdateMemWalState {
+            compacted_sstables, ..
+        } => !compacted_sstables.is_empty(),
+        _ => false,
+    }
+}
+
 impl<'a> TransactionRebase<'a> {
     pub async fn try_new(
         dataset: &Dataset,
@@ -620,9 +633,21 @@ impl<'a> TransactionRebase<'a> {
         if let Operation::CreateIndex {
             new_indices,
             removed_indices,
-            ..
+            mem_wal_index_catchup_advances,
         } = &mut self.transaction.operation
         {
+            // A coverage advance describes the table as the repair inspected it.
+            // If the commit it rebases over moved compaction progress, rows from
+            // the newly compacted generations landed in fragments the repair
+            // never saw, and its claim would cover generations its index does
+            // not. Nothing here can re-derive that, so refuse and let the repair
+            // re-plan against the newer state.
+            if !mem_wal_index_catchup_advances.is_empty()
+                && operation_advances_compaction(&other_transaction.operation)
+            {
+                return Err(self.retryable_conflict_err(other_transaction, other_version));
+            }
+
             match &other_transaction.operation {
                 Operation::Append { .. }
                 | Operation::Clone { .. }

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1517,9 +1517,11 @@ impl<'a> TransactionRebase<'a> {
         other_transaction: &Transaction,
         other_version: u64,
     ) -> Result<()> {
+        // Activation rebases like any other MemWAL state update; its preconditions
+        // are re-checked against the rebased index list when the commit applies.
         if let Operation::UpdateMemWalState {
             compacted_sstables: self_compacted_sstables,
-            activate_safe_retirement: false,
+            ..
         } = &self.transaction.operation
         {
             match &other_transaction.operation {

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -3628,6 +3628,7 @@ mod tests {
             Operation::CreateIndex {
                 new_indices: vec![legacy_index_meta],
                 removed_indices: vec![index_meta],
+                mem_wal_index_catchup_advances: Vec::new(),
             },
         )
         .build();


### PR DESCRIPTION
MemWAL SSTables may only stop being served once every index a query relies on is known to contain the compacted rows. This adds the recorded protocol and the commit-time enforcement that keeps those catch-up positions honest.

Nothing consumes it yet: the read side is lancedb#3780, and no table sets the bit until something explicitly asks for it.

## Feature bit

`FLAG_MEM_WAL_INDEX_CATCHUP` (128, moving `FLAG_UNKNOWN` to 256), in both the reader and writer words. Without it a missing `index_catchup` entry reads as "fully caught up"; with it, as "not caught up". A writer needs it too, since one that doesn't maintain `index_catchup` can change an index without withdrawing the position recorded for it. A half-set state is refused rather than completed — one bit set means a legacy reader or writer is still permitted, which is neither mode.

The bit isn't derivable from a manifest, and it's dropped at two different kinds of boundary, so keeping it takes two things:

- `apply_feature_flags` resets both words and runs **twice per commit** (`build_manifest`, then `write_manifest_file`), so it carries the bit across its own reset — the same way that file already handles `FLAG_STABLE_ROW_IDS`.
- `new_from_previous`, `shallow_clone` and restore each derive a manifest whose words start zeroed, so there's nothing there to carry. `inherit_mem_wal_index_catchup` moves it from the source.

## Coverage advance

`CreateIndex` gains `IndexCatchupAdvance`: one logical index, the exact segment set expected, and the per-shard generations captured when the repair opened the table. Publishing it on the index operation means the index result and its catch-up land in one commit and can't disagree.

It also declares two things about the moment of inspection:

- **the fragments those segments covered** — UUIDs alone aren't a fence, since pruning narrows a bitmap while keeping the UUID;
- **every fragment live in the table**, which the index must cover. Nothing maps a generation to the fragments its rows landed in, so covering the inspected table is what ties the claim to the generations it names. Fragments appended since are a later gap, which is what keeps a repair committable on a table still taking writes.

A claim also may not exceed what the version the repair read had already compacted, checked where the advance is built.

## Central invalidation

Runs once the final index list is known, so it sees what the commit publishes rather than what an operation arm intended.

| Logical index | Result |
|---|---|
| unchanged | keeps its position |
| dropped | loses it |
| changed, no advance | loses it |
| changed, with a matching advance | invalidated, then re-recorded |

Only on a table that requires catch-up. On a legacy table a missing entry means "caught up", so removing one there would *widen* coverage.

"Unchanged" compares whole segment metadata, not UUIDs: `Rewrite` prunes a bitmap while keeping the UUID. Ordinary create, reindex, append, replacement and remap therefore lose their position conservatively — they may well cover the rows, but they don't say so.

An advance merges onto what the index already recorded: unnamed shards keep their generation, named ones take the higher of the two. So repairing one shard can't erase another, and a delayed retry can't move a position backward. An index that changed carries nothing forward.

Commits that change nothing leave the system index alone, so unrelated commits don't mint a UUID and drop the decoded-details cache.

## Activation

`UpdateMemWalState` gains a one-way `require_index_catchup`. It refuses a table carrying beta-protocol compaction progress, which this protocol never validated, and clears any beta `index_catchup` for the same reason. Restoring an activated table to a pre-migration version is refused on the same grounds. Repeating the call is a true no-op that keeps every recorded generation. An explicit `false` is refused, so no caller can express "deactivate".

`Dataset::require_mem_wal_index_catchup` is the entry point. `OptimizeOptions::mem_wal_index_catchup` is how a repair records catch-up alongside the index work it publishes — the advance is built there, since a caller can't name segments that don't exist yet, and it's recorded even when the index needed no rebuilding. Initializing MemWAL deliberately does *not* activate: a table stays on legacy semantics until something can actually repair coverage.

## Scope

Lance stores and validates positions; it does not decide which SSTables may be retired. There is deliberately no trim-eligibility helper — that belongs to the component that owns the SSTables.

## Tests

36 in the coverage module, 19 in `index::mem_wal`, covering invalidation, advance validation, activation, and the protobuf round trip. Every test for a fix here was confirmed to fail against the unfixed code.

Two matter more than the rest. A **persisted round trip** — activate, reopen from storage, commit, reopen — because testing `build_manifest` alone is what let the feature bit be cleared by the second `apply_feature_flags` twice over. And three that pin that nothing else changes: a table with no MemWAL index, a MemWAL table that hasn't migrated, and an ordinary index job on one that has, which loses its position but still commits. With no advances the coverage code has no error path, so an ordinary index job can never be blocked.

`cargo test -p lance --lib` — 2881 passed; `-p lance-table` — 180. `cargo fmt --all --check` clean. Clippy as CI runs it reports no new findings.

## Format spec

`versioning.md` listed bits only through 16 and said 32 and above are unknown, though 32 and 64 already exist; 128 is now documented alongside them. `mem_wal.md` said an absent `index_catchup` entry always means caught up; it now states both readings, which bit selects them, and what an advance must declare.

## Known limitations

**Positions are dropped more often than strictly necessary.** A remap preserves what an index covers but changes its metadata, so the entry goes and a repair re-records it. Deliberate: the alternative is a list of known-narrowing paths that a later operation could silently fail to join.

**An honest map is not on its own enough to retire an SSTable.** Invalidation stops the *next* retirement from acting on a withdrawn position; it cannot undo one that already happened. Closing that needs a guard at commit time or a margin on the retirement side, and belongs with the component that owns the SSTables.
