### PR TITLE
feat(compaction): add max source bytes limit

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3146,6 +3146,14 @@ fn convert_java_compaction_options_to_rust(
             &[],
         )?
         .l()?;
+    let max_source_bytes = env
+        .call_method(
+            &java_options,
+            "getMaxSourceBytes",
+            "()Ljava/util/Optional;",
+            &[],
+        )?
+        .l()?;
 
     build_compaction_options(
         env,
@@ -3160,6 +3168,7 @@ fn convert_java_compaction_options_to_rust(
         &compaction_mode,
         &binary_copy_read_batch_bytes,
         &max_source_fragments,
+        Some(&max_source_bytes),
         config,
     )
 }

--- a/java/lance-jni/src/optimize.rs
+++ b/java/lance-jni/src/optimize.rs
@@ -46,6 +46,7 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
     compaction_mode: JObject,                 // Optional<String>
     binary_copy_read_batch_bytes: JObject,    // Optional<Long>
     max_source_fragments: JObject,            // Optional<Long>
+    max_source_bytes: JObject,                // Optional<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -62,7 +63,8 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
             defer_index_remap,
             compaction_mode,
             binary_copy_read_batch_bytes,
-            max_source_fragments
+            max_source_fragments,
+            max_source_bytes
         ),
         JObject::null()
     )
@@ -83,6 +85,7 @@ fn inner_plan_compaction<'local>(
     compaction_mode: JObject,                 // Optional<String>
     binary_copy_read_batch_bytes: JObject,    // Optional<Long>
     max_source_fragments: JObject,            // Optional<Long>
+    max_source_bytes: JObject,                // Optional<Long>
 ) -> Result<JObject<'local>> {
     let config = {
         let dataset =
@@ -102,6 +105,7 @@ fn inner_plan_compaction<'local>(
         &compaction_mode,
         &binary_copy_read_batch_bytes,
         &max_source_fragments,
+        Some(&max_source_bytes),
         &config,
     )?;
 
@@ -188,6 +192,7 @@ fn inner_commit_compaction<'local>(
         &compaction_mode,
         &binary_copy_read_batch_bytes,
         &max_source_fragments,
+        None,
         &config,
     )?;
     let completed_tasks = import_vec_to_rust(env, &rewrite_results, |env, rewrite_result| {
@@ -286,6 +291,7 @@ fn inner_execute_task<'local>(
         &compaction_mode,
         &binary_copy_read_batch_bytes,
         &max_source_fragments,
+        None,
         &config,
     )?;
     let compaction_task = CompactionTask {
@@ -312,7 +318,7 @@ const REWRITE_RESULT_CLASS: &str = "org/lance/compaction/RewriteResult";
 const REWRITE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/compaction/CompactionMetrics;Ljava/util/List;Ljava/util/List;J[B)V";
 const COMPACTION_OPTIONS_CLASS: &str = "org/lance/compaction/CompactionOptions";
-const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V";
+const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V";
 
 impl IntoJava for &TaskData {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
@@ -377,6 +383,19 @@ impl IntoJava for &CompactionOptions {
         let max_source_fragments =
             to_java_long_obj(env, self.max_source_fragments.map(|v| v as i64))?;
         let max_source_fragments_opt = to_java_optional(env, max_source_fragments)?;
+        let max_source_bytes = self
+            .max_source_bytes
+            .map(|value| {
+                i64::try_from(value).map_err(|_| {
+                    crate::error::Error::runtime_error(format!(
+                        "max_source_bytes {} exceeds Java Long.MAX_VALUE",
+                        value
+                    ))
+                })
+            })
+            .transpose()?;
+        let max_source_bytes = to_java_long_obj(env, max_source_bytes)?;
+        let max_source_bytes_opt = to_java_optional(env, max_source_bytes)?;
 
         Ok(env.new_object(
             COMPACTION_OPTIONS_CLASS,
@@ -393,6 +412,7 @@ impl IntoJava for &CompactionOptions {
                 JValueGen::Object(&compaction_mode_opt),
                 JValueGen::Object(&binary_copy_read_batch_bytes_opt),
                 JValueGen::Object(&max_source_fragments_opt),
+                JValueGen::Object(&max_source_bytes_opt),
             ],
         )?)
     }

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -191,6 +191,7 @@ pub fn build_compaction_options(
     compaction_mode: &JObject,                 // Optional<String>
     binary_copy_read_batch_bytes: &JObject,    // Optional<Long>
     max_source_fragments: &JObject,            // Optional<Long>
+    max_source_bytes: Option<&JObject>,        // Optional<Long>
     config: &std::collections::HashMap<String, String>,
 ) -> Result<CompactionOptions> {
     let mut compaction_options = CompactionOptions::from_dataset_config(config)?;
@@ -233,6 +234,17 @@ pub fn build_compaction_options(
     }
     if let Some(max_source_fragments_val) = env.get_long_opt(max_source_fragments)? {
         compaction_options.max_source_fragments = Some(max_source_fragments_val as usize);
+    }
+    if let Some(max_source_bytes) = max_source_bytes
+        && let Some(max_source_bytes_val) = env.get_long_opt(max_source_bytes)?
+    {
+        compaction_options.max_source_bytes =
+            Some(u64::try_from(max_source_bytes_val).map_err(|_| {
+                Error::input_error(format!(
+                    "max_source_bytes must be non-negative, got {}",
+                    max_source_bytes_val
+                ))
+            })?);
     }
 
     Ok(compaction_options)

--- a/java/src/main/java/org/lance/compaction/Compaction.java
+++ b/java/src/main/java/org/lance/compaction/Compaction.java
@@ -44,7 +44,8 @@ public class Compaction {
         compactionOptions.getDeferIndexRemap(),
         compactionOptions.getCompactionMode(),
         compactionOptions.getBinaryCopyReadBatchBytes(),
-        compactionOptions.getMaxSourceFragments());
+        compactionOptions.getMaxSourceFragments(),
+        compactionOptions.getMaxSourceBytes());
   }
 
   public static CompactionMetrics commitCompaction(
@@ -95,5 +96,6 @@ public class Compaction {
       Optional<Boolean> deferIndexRemap,
       Optional<String> compactionMode,
       Optional<Long> binaryCopyReadBatchBytes,
-      Optional<Long> maxSourceFragments);
+      Optional<Long> maxSourceFragments,
+      Optional<Long> maxSourceBytes);
 }

--- a/java/src/main/java/org/lance/compaction/CompactionOptions.java
+++ b/java/src/main/java/org/lance/compaction/CompactionOptions.java
@@ -40,6 +40,7 @@ public class CompactionOptions implements Serializable {
   private Optional<CompactionMode> compactionMode;
   private Optional<Long> binaryCopyReadBatchBytes;
   private Optional<Long> maxSourceFragments;
+  private Optional<Long> maxSourceBytes;
 
   private CompactionOptions(
       Optional<Long> targetRowsPerFragment,
@@ -52,7 +53,8 @@ public class CompactionOptions implements Serializable {
       Optional<Boolean> deferIndexRemap,
       Optional<CompactionMode> compactionMode,
       Optional<Long> binaryCopyReadBatchBytes,
-      Optional<Long> maxSourceFragments) {
+      Optional<Long> maxSourceFragments,
+      Optional<Long> maxSourceBytes) {
     this.targetRowsPerFragment = targetRowsPerFragment;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
@@ -64,6 +66,7 @@ public class CompactionOptions implements Serializable {
     this.compactionMode = compactionMode;
     this.binaryCopyReadBatchBytes = binaryCopyReadBatchBytes;
     this.maxSourceFragments = maxSourceFragments;
+    this.maxSourceBytes = maxSourceBytes;
   }
 
   public Optional<Boolean> getDeferIndexRemap() {
@@ -81,6 +84,10 @@ public class CompactionOptions implements Serializable {
 
   public Optional<Long> getMaxSourceFragments() {
     return maxSourceFragments;
+  }
+
+  public Optional<Long> getMaxSourceBytes() {
+    return maxSourceBytes;
   }
 
   public Optional<Boolean> getMaterializeDeletions() {
@@ -129,6 +136,7 @@ public class CompactionOptions implements Serializable {
         .add("compactionMode", compactionMode.orElse(null))
         .add("binaryCopyReadBatchBytes", binaryCopyReadBatchBytes.orElse(null))
         .add("maxSourceFragments", maxSourceFragments.orElse(null))
+        .add("maxSourceBytes", maxSourceBytes.orElse(null))
         .toString();
   }
 
@@ -144,6 +152,7 @@ public class CompactionOptions implements Serializable {
     output.writeObject(compactionMode.map(CompactionMode::getValue).orElse(null));
     output.writeObject(binaryCopyReadBatchBytes.orElse(null));
     output.writeObject(maxSourceFragments.orElse(null));
+    output.writeObject(maxSourceBytes.orElse(null));
   }
 
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
@@ -167,6 +176,7 @@ public class CompactionOptions implements Serializable {
     }
     this.binaryCopyReadBatchBytes = Optional.ofNullable((Long) input.readObject());
     this.maxSourceFragments = Optional.ofNullable((Long) input.readObject());
+    this.maxSourceBytes = Optional.ofNullable((Long) input.readObject());
   }
 
   /** Builder for CompactionOptions. */
@@ -182,6 +192,7 @@ public class CompactionOptions implements Serializable {
     private Optional<CompactionMode> compactionMode = Optional.empty();
     private Optional<Long> binaryCopyReadBatchBytes = Optional.empty();
     private Optional<Long> maxSourceFragments = Optional.empty();
+    private Optional<Long> maxSourceBytes = Optional.empty();
 
     private Builder() {}
 
@@ -245,6 +256,19 @@ public class CompactionOptions implements Serializable {
       return this;
     }
 
+    /**
+     * Maximum physical size of source data files in one compaction task. Candidate fragments are
+     * split at fragment boundaries so tasks stay within this limit whenever possible. A single
+     * oversized fragment, or the minimum group needed for compaction to make progress, may exceed
+     * it. The size includes base and overlay data files, but excludes deletion files and indices.
+     * This option is not supported for datasets with blob v2 columns because blob sidecar sizes are
+     * not recorded in the manifest.
+     */
+    public Builder withMaxSourceBytes(long maxSourceBytes) {
+      this.maxSourceBytes = Optional.of(maxSourceBytes);
+      return this;
+    }
+
     public CompactionOptions build() {
       return new CompactionOptions(
           targetRowsPerFragment,
@@ -257,7 +281,8 @@ public class CompactionOptions implements Serializable {
           deferIndexRemap,
           compactionMode,
           binaryCopyReadBatchBytes,
-          maxSourceFragments);
+          maxSourceFragments,
+          maxSourceBytes);
     }
   }
 }

--- a/java/src/test/java/org/lance/CompactionTest.java
+++ b/java/src/test/java/org/lance/CompactionTest.java
@@ -49,11 +49,18 @@ public class CompactionTest {
       testDataset.write(1, 10).close();
       try (Dataset dataset = testDataset.write(2, 10)) {
         CompactionOptions compactionOptions =
-            CompactionOptions.builder().withTargetRowsPerFragment(100).withNumThreads(1).build();
+            CompactionOptions.builder()
+                .withTargetRowsPerFragment(100)
+                .withNumThreads(1)
+                .withMaxSourceBytes(Long.MAX_VALUE)
+                .build();
         CompactionPlan compactionPlan = Compaction.planCompaction(dataset, compactionOptions);
 
         // will plan to compact two fragments into one.
         assertEquals(1, compactionPlan.getCompactionTasks().size());
+        assertEquals(
+            Long.MAX_VALUE,
+            compactionPlan.getCompactionOptions().getMaxSourceBytes().orElseThrow());
         CompactionTask task = compactionPlan.getCompactionTasks().get(0);
         assertEquals(2, task.getTaskData().getFragments().size());
 

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -1710,6 +1710,7 @@ public class DatasetTest {
                 .withNumThreads(1)
                 .withBatchSize(5)
                 .withDeferIndexRemap(false)
+                .withMaxSourceBytes(1024 * 1024)
                 .build();
 
         dataset2.compact(allOptions);
@@ -1734,6 +1735,7 @@ public class DatasetTest {
         assertTrue(allOptions.getBatchSize().isPresent());
         assertEquals(5, allOptions.getBatchSize().get().intValue());
         assertFalse(allOptions.getDeferIndexRemap().get());
+        assertEquals(1024 * 1024, allOptions.getMaxSourceBytes().get().intValue());
       }
     }
   }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7071,6 +7071,7 @@ class DatasetOptimizer:
         ] = None,
         binary_copy_read_batch_bytes: Optional[int] = None,
         max_source_fragments: Optional[int] = None,
+        max_source_bytes: Optional[int] = None,
     ) -> CompactionMetrics:
         """Compacts small files in the dataset, reducing total number of files.
 
@@ -7102,7 +7103,8 @@ class DatasetOptimizer:
         ``lance.compaction.batch_size``,
         ``lance.compaction.compaction_mode``,
         ``lance.compaction.binary_copy_read_batch_bytes``,
-        ``lance.compaction.max_source_fragments``.
+        ``lance.compaction.max_source_fragments``,
+        ``lance.compaction.max_source_bytes``.
 
         Parameters
         ----------
@@ -7161,6 +7163,16 @@ class DatasetOptimizer:
             exceed this limit, allowing compaction to proceed incrementally.
             Fragments are processed oldest first. If not specified, uses the
             manifest config value, or applies no limit.
+        max_source_bytes: int, optional
+            Maximum physical size of source data files in one compaction task.
+            Candidate fragments are split at fragment boundaries so tasks stay
+            within this limit whenever possible. A single oversized fragment,
+            or the minimum group needed for compaction to make progress, may
+            exceed it. The size includes base and overlay data files, but
+            excludes deletion files and indices. If not specified, uses the
+            manifest config value and otherwise forms tasks based on rows only.
+            This option is not supported for datasets with blob v2 columns
+            because blob sidecar sizes are not recorded in the manifest.
 
         Returns
         -------
@@ -7185,6 +7197,7 @@ class DatasetOptimizer:
                 compaction_mode=compaction_mode,
                 binary_copy_read_batch_bytes=binary_copy_read_batch_bytes,
                 max_source_fragments=max_source_fragments,
+                max_source_bytes=max_source_bytes,
             ).items()
             if v is not None
         }

--- a/python/python/lance/optimize.py
+++ b/python/python/lance/optimize.py
@@ -13,7 +13,7 @@ from .lance import RewriteResult as RewriteResult
 # from .lance import CompactionPlan as CompactionPlan
 
 
-class CompactionOptions(TypedDict):
+class CompactionOptions(TypedDict, total=False):
     """Options for compaction."""
 
     target_rows_per_fragment: Optional[int]
@@ -96,4 +96,15 @@ class CompactionOptions(TypedDict):
     allowing for incremental compaction (e.g., compact 20 fragments at a
     time). Fragments are processed oldest first.
     (default: None, no limit)
+    """
+    max_source_bytes: Optional[int]
+    """
+    Maximum physical size of source data files in one compaction task.
+    Candidate fragments are split at fragment boundaries so tasks stay within
+    this limit whenever possible. A single oversized fragment, or the minimum
+    group needed for compaction to make progress, may exceed it. The size
+    includes base and overlay data files, but excludes deletion files and
+    indices. This option is not supported for datasets with blob v2 columns
+    because blob sidecar sizes are not recorded in the manifest.
+    (default: None, task formation is based on rows only)
     """

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 from lance.lance import Compaction
-from lance.optimize import RewriteResult
+from lance.optimize import CompactionOptions, RewriteResult
 from lance.vector import vec_to_table
 
 
@@ -54,6 +54,38 @@ def test_compact_files_max_source_fragments(tmp_path: Path):
     assert metrics.fragments_removed == 4
     assert metrics.fragments_added == 1
     assert len(dataset.get_fragments()) == 7
+
+
+def test_compact_files_max_source_bytes(tmp_path: Path):
+    rows_per_fragment = 256 * 1024
+    dataset = lance.write_dataset(
+        pa.table({"a": pa.nulls(10 * rows_per_fragment)}),
+        tmp_path / "dataset",
+        max_rows_per_file=rows_per_fragment,
+    )
+
+    metrics = dataset.optimize.compact_files(
+        target_rows_per_fragment=10 * rows_per_fragment,
+        max_source_bytes=1,
+        num_threads=1,
+    )
+    # The byte limit splits task formation but still allows the minimum useful
+    # two-fragment groups to exceed the limit and make progress.
+    assert metrics.fragments_removed == 10
+    assert metrics.fragments_added == 5
+    assert len(dataset.get_fragments()) == 5
+
+    metrics = dataset.optimize.compact_files(
+        target_rows_per_fragment=10 * rows_per_fragment,
+        max_source_bytes=1024**4,
+        num_threads=1,
+    )
+    assert metrics.fragments_removed == 5
+    assert metrics.fragments_added == 1
+
+
+def test_compaction_options_keys_are_optional():
+    assert "max_source_bytes" in CompactionOptions.__optional_keys__
 
 
 def test_blob_compaction(tmp_path: Path):

--- a/python/src/dataset/optimize.rs
+++ b/python/src/dataset/optimize.rs
@@ -76,6 +76,9 @@ fn parse_compaction_options(
             "max_source_fragments" => {
                 opts.max_source_fragments = value.extract()?;
             }
+            "max_source_bytes" => {
+                opts.max_source_bytes = value.extract()?;
+            }
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "Invalid compaction option: {}",

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -84,6 +84,7 @@ use lance_core::utils::row_addr_remap::{GroupInput, RowAddrRemap};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::Cursor;
+use std::num::NonZero;
 use std::ops::{AddAssign, Range};
 use std::sync::Arc;
 
@@ -116,7 +117,7 @@ use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::utils::tracing::{DATASET_COMPACTING_EVENT, TRACE_DATASET_EVENTS};
 use lance_index::frag_reuse::{FRAG_REUSE_INDEX_NAME, FragReuseGroup};
 use lance_index::is_system_index;
-use lance_table::format::{Fragment, RowIdMeta};
+use lance_table::format::{DataFile, Fragment, RowIdMeta};
 use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
@@ -262,6 +263,16 @@ pub struct CompactionOptions {
     /// fragments at a time).
     /// Defaults to `None` (no limit, all eligible fragments are compacted).
     pub max_source_fragments: Option<usize>,
+    /// Maximum physical size in bytes of source data files in one compaction
+    /// task. Candidate fragments are split at fragment boundaries so tasks stay
+    /// within this limit whenever possible. A single oversized fragment, or the
+    /// minimum group needed for compaction to make progress, may exceed it. The
+    /// size includes base and overlay data files, but excludes deletion files and
+    /// indices. This option is not supported for datasets with blob v2 columns
+    /// because blob sidecar sizes are not recorded in the manifest.
+    ///
+    /// Defaults to `None` (task formation is based on rows only).
+    pub max_source_bytes: Option<u64>,
     /// Maximum number of data overlay files a fragment may carry before it is
     /// fully compacted. When set, any fragment with more than this many overlays
     /// is rewritten into a fresh fragment with its overlays (and deletions)
@@ -300,6 +311,7 @@ impl Default for CompactionOptions {
             enable_binary_copy_force: false,
             binary_copy_read_batch_bytes: Some(16 * 1024 * 1024),
             max_source_fragments: None,
+            max_source_bytes: None,
             max_overlays_per_fragment: Some(10),
             transaction_properties: None,
         }
@@ -327,6 +339,7 @@ impl CompactionOptions {
     /// - `lance.compaction.compaction_mode`
     /// - `lance.compaction.binary_copy_read_batch_bytes`
     /// - `lance.compaction.max_source_fragments`
+    /// - `lance.compaction.max_source_bytes`
     /// - `lance.compaction.max_overlays_per_fragment`
     pub fn from_dataset_config(config: &HashMap<String, String>) -> Result<Self> {
         let mut opts = Self::default();
@@ -432,6 +445,14 @@ impl CompactionOptions {
                 }
                 "max_source_fragments" => {
                     self.max_source_fragments = Some(value.parse().map_err(|_| {
+                        Error::invalid_input(format!(
+                            "Invalid value for {}: '{}' (expected a non-negative integer)",
+                            key, value
+                        ))
+                    })?);
+                }
+                "max_source_bytes" => {
+                    self.max_source_bytes = Some(value.parse().map_err(|_| {
                         Error::invalid_input(format!(
                             "Invalid value for {}: '{}' (expected a non-negative integer)",
                             key, value
@@ -701,6 +722,18 @@ impl CompactionPlanner for DefaultCompactionPlanner {
             ));
         }
 
+        if self.options.max_source_bytes.is_some()
+            && dataset
+                .schema()
+                .fields_pre_order()
+                .any(|field| field.is_blob_v2())
+        {
+            return Err(Error::not_supported(
+                "max_source_bytes is not supported for datasets with blob v2 columns because blob sidecar sizes are not recorded in the manifest"
+                    .to_string(),
+            ));
+        }
+
         // get_fragments should be returning fragments in sorted order (by id)
         // and fragment ids should be unique
         let fragments = dataset.get_fragments();
@@ -806,27 +839,25 @@ impl CompactionPlanner for DefaultCompactionPlanner {
             candidate_bins.push(bin);
         }
 
-        let all_tasks: Vec<TaskData> = candidate_bins
-            .into_iter()
-            .filter(|bin| !bin.is_noop())
-            .flat_map(|bin| bin.split_for_size(self.options.target_rows_per_fragment))
-            .map(|bin| TaskData {
-                fragments: bin.fragments,
-            })
-            .collect();
+        let mut all_tasks = Vec::new();
+        for bin in candidate_bins.into_iter().filter(|bin| !bin.is_noop()) {
+            let source_size_bins = if let Some(max_source_bytes) = self.options.max_source_bytes {
+                let source_bytes = source_bytes_by_fragment(dataset, &bin.fragments).await?;
+                bin.split_for_source_bytes(max_source_bytes, &source_bytes)?
+            } else {
+                vec![bin]
+            };
+            all_tasks.extend(
+                source_size_bins
+                    .into_iter()
+                    .flat_map(|bin| bin.split_for_size(self.options.target_rows_per_fragment))
+                    .map(|bin| TaskData {
+                        fragments: bin.fragments,
+                    }),
+            );
+        }
 
-        let tasks = if let Some(max_frags) = self.options.max_source_fragments {
-            let mut total_frags = 0;
-            all_tasks
-                .into_iter()
-                .take_while(|task| {
-                    total_frags += task.fragments.len();
-                    total_frags <= max_frags
-                })
-                .collect()
-        } else {
-            all_tasks
-        };
+        let tasks = limit_tasks_by_source_fragments(all_tasks, &self.options)?;
 
         let mut compaction_plan =
             CompactionPlan::new(dataset.manifest.version, self.options.clone());
@@ -834,6 +865,132 @@ impl CompactionPlanner for DefaultCompactionPlanner {
 
         Ok(compaction_plan)
     }
+}
+
+async fn data_file_size_bytes(dataset: &Dataset, data_file: &DataFile) -> Result<u64> {
+    if let Some(size) = data_file.file_size_bytes.get() {
+        return Ok(size.get());
+    }
+
+    let object_store = dataset.object_store_for_data_file(data_file).await?;
+    let data_dir = dataset.data_file_dir_for_base(data_file.base_id)?;
+    let path = data_dir.join(data_file.path.as_str());
+    let size = object_store.size(&path).await?;
+    let size = NonZero::new(size).ok_or_else(|| {
+        Error::internal(format!(
+            "Source data file '{}' has size 0 while planning compaction",
+            path
+        ))
+    })?;
+    data_file.file_size_bytes.set(size);
+    Ok(size.get())
+}
+
+async fn source_bytes_by_fragment(dataset: &Dataset, fragments: &[Fragment]) -> Result<Vec<u64>> {
+    let num_data_files = fragments
+        .iter()
+        .try_fold(0_usize, |total, fragment| {
+            total
+                .checked_add(fragment.files.len())?
+                .checked_add(fragment.overlays.len())
+        })
+        .ok_or_else(|| {
+            Error::internal("Source data file count overflowed usize while planning compaction")
+        })?;
+    let mut unknown_data_files = Vec::with_capacity(num_data_files);
+    for fragment in fragments {
+        for data_file in fragment
+            .files
+            .iter()
+            .chain(fragment.overlays.iter().map(|overlay| &overlay.data_file))
+        {
+            if data_file.file_size_bytes.get().is_none() {
+                unknown_data_files.push(data_file);
+            }
+        }
+    }
+
+    let mut unknown_data_files = unknown_data_files.into_iter();
+    let mut sizes = futures::stream::FuturesUnordered::new();
+    let size_parallelism = dataset.object_store.as_ref().io_parallelism().max(1);
+    for _ in 0..size_parallelism {
+        if let Some(data_file) = unknown_data_files.next() {
+            sizes.push(data_file_size_bytes(dataset, data_file));
+        } else {
+            break;
+        }
+    }
+    while sizes.try_next().await?.is_some() {
+        if let Some(data_file) = unknown_data_files.next() {
+            sizes.push(data_file_size_bytes(dataset, data_file));
+        }
+    }
+
+    fragments
+        .iter()
+        .map(|fragment| {
+            fragment
+                .files
+                .iter()
+                .chain(fragment.overlays.iter().map(|overlay| &overlay.data_file))
+                .try_fold(0_u64, |total, data_file| {
+                    let size = data_file.file_size_bytes.get().ok_or_else(|| {
+                        Error::internal(format!(
+                            "Source data file '{}' still has unknown size after metadata lookup",
+                            data_file.path
+                        ))
+                    })?;
+                    total.checked_add(size.get()).ok_or_else(|| {
+                        Error::internal(
+                            "Source data file sizes overflowed u64 while planning compaction",
+                        )
+                    })
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+async fn task_source_bytes(dataset: &Dataset, task: &TaskData) -> Result<u64> {
+    source_bytes_by_fragment(dataset, &task.fragments)
+        .await?
+        .into_iter()
+        .try_fold(0_u64, |total, size| {
+            total.checked_add(size).ok_or_else(|| {
+                Error::internal("Source data file sizes overflowed u64 while planning compaction")
+            })
+        })
+}
+
+fn limit_tasks_by_source_fragments(
+    all_tasks: Vec<TaskData>,
+    options: &CompactionOptions,
+) -> Result<Vec<TaskData>> {
+    if options.max_source_fragments.is_none() {
+        return Ok(all_tasks);
+    }
+
+    let mut tasks = Vec::with_capacity(all_tasks.len());
+    let mut total_fragments = 0_usize;
+
+    for task in all_tasks {
+        let next_total_fragments = total_fragments
+            .checked_add(task.fragments.len())
+            .ok_or_else(|| {
+                Error::internal("Source fragment count overflowed usize while planning compaction")
+            })?;
+        if options
+            .max_source_fragments
+            .is_some_and(|max| next_total_fragments > max)
+        {
+            break;
+        }
+
+        total_fragments = next_total_fragments;
+        tasks.push(task);
+    }
+
+    Ok(tasks)
 }
 
 /// Compacts the files in the dataset without reordering them.
@@ -1464,6 +1621,66 @@ impl CandidateBin {
             }
         }
 
+        self.split_at_lengths(split_lengths)
+    }
+
+    /// Split at fragment boundaries so each useful bin stays within the source
+    /// byte limit whenever possible. A single oversized fragment, or the minimum
+    /// group needed to avoid a no-op, remains together so compaction can make
+    /// progress.
+    fn split_for_source_bytes(
+        self,
+        max_source_bytes: u64,
+        source_bytes: &[u64],
+    ) -> Result<Vec<Self>> {
+        if source_bytes.len() != self.fragments.len() {
+            return Err(Error::internal(format!(
+                "Source byte count length {} did not match candidate fragment count {}",
+                source_bytes.len(),
+                self.fragments.len()
+            )));
+        }
+
+        let mut split_lengths = Vec::new();
+        let mut current_start = 0_usize;
+        let mut current_len = 0_usize;
+        let mut current_bytes = 0_u64;
+
+        for source_bytes in source_bytes {
+            let next_bytes = current_bytes.checked_add(*source_bytes).ok_or_else(|| {
+                Error::internal("Source data file sizes overflowed u64 while planning compaction")
+            })?;
+            let current_is_noop = current_len == 1
+                && matches!(
+                    self.candidacy[current_start],
+                    CompactionCandidacy::CompactWithNeighbors
+                );
+            if current_len > 0 && next_bytes > max_source_bytes && !current_is_noop {
+                split_lengths.push(current_len);
+                current_start += current_len;
+                current_len = 0;
+                current_bytes = 0;
+            }
+
+            current_bytes = current_bytes.checked_add(*source_bytes).ok_or_else(|| {
+                Error::internal("Source data file sizes overflowed u64 while planning compaction")
+            })?;
+            current_len += 1;
+        }
+
+        let remainder_is_noop = current_len == 1
+            && matches!(
+                self.candidacy[current_start],
+                CompactionCandidacy::CompactWithNeighbors
+            );
+        if remainder_is_noop {
+            split_lengths.pop();
+        }
+
+        Ok(self.split_at_lengths(split_lengths))
+    }
+
+    fn split_at_lengths(self, split_lengths: Vec<usize>) -> Vec<Self> {
         if split_lengths.is_empty() {
             return vec![self];
         }
@@ -2378,7 +2595,7 @@ mod tests {
         assert!(!single_bin.is_noop());
 
         let big_bin = CandidateBin {
-            fragments: std::iter::repeat_n(fragment, 8).collect(),
+            fragments: std::iter::repeat_n(fragment.clone(), 8).collect(),
             pos_range: 0..8,
             candidacy: std::iter::repeat_n(CompactionCandidacy::CompactItself, 8).collect(),
             row_counts: vec![100, 400, 200, 200, 400, 300, 300, 100],
@@ -2419,6 +2636,48 @@ mod tests {
         assert_eq!(split[0].pos_range, 0..1);
         assert_eq!(split[1].pos_range, 1..2);
         assert_eq!(split[2].pos_range, 2..3);
+
+        let byte_split_bin = CandidateBin {
+            fragments: std::iter::repeat_n(fragment.clone(), 6).collect(),
+            pos_range: 0..6,
+            candidacy: std::iter::repeat_n(CompactionCandidacy::CompactWithNeighbors, 6).collect(),
+            row_counts: vec![100; 6],
+            indices: vec![],
+        };
+        let split = byte_split_bin
+            .split_for_source_bytes(100, &[80, 20, 90, 10, 60, 40])
+            .unwrap();
+        assert_eq!(split.len(), 3);
+        assert_eq!(split[0].pos_range, 0..2);
+        assert_eq!(split[1].pos_range, 2..4);
+        assert_eq!(split[2].pos_range, 4..6);
+
+        let oversized_bin = CandidateBin {
+            fragments: std::iter::repeat_n(fragment.clone(), 2).collect(),
+            pos_range: 0..2,
+            candidacy: std::iter::repeat_n(CompactionCandidacy::CompactItself, 2).collect(),
+            row_counts: vec![100; 2],
+            indices: vec![],
+        };
+        let split = oversized_bin
+            .split_for_source_bytes(100, &[150, 40])
+            .unwrap();
+        assert_eq!(split.len(), 2);
+        assert_eq!(split[0].pos_range, 0..1);
+        assert_eq!(split[1].pos_range, 1..2);
+
+        let minimum_useful_bin = CandidateBin {
+            fragments: std::iter::repeat_n(fragment, 2).collect(),
+            pos_range: 0..2,
+            candidacy: std::iter::repeat_n(CompactionCandidacy::CompactWithNeighbors, 2).collect(),
+            row_counts: vec![100; 2],
+            indices: vec![],
+        };
+        let split = minimum_useful_bin
+            .split_for_source_bytes(100, &[80, 80])
+            .unwrap();
+        assert_eq!(split.len(), 1);
+        assert_eq!(split[0].pos_range, 0..2);
     }
 
     fn sample_data() -> RecordBatch {
@@ -6755,6 +7014,10 @@ mod tests {
                 "lance.compaction.index_remap_mode".to_string(),
                 "compact".to_string(),
             ),
+            (
+                "lance.compaction.max_source_bytes".to_string(),
+                "10737418240".to_string(),
+            ),
         ]);
 
         let opts = CompactionOptions::from_dataset_config(&config).unwrap();
@@ -6768,6 +7031,7 @@ mod tests {
         assert_eq!(opts.io_buffer_size, Some(1_073_741_824));
         assert_eq!(opts.compaction_mode, Some(CompactionMode::TryBinaryCopy));
         assert_eq!(opts.binary_copy_read_batch_bytes, Some(8_388_608));
+        assert_eq!(opts.max_source_bytes, Some(10_737_418_240));
         // A non-default value proves the config string was actually parsed.
         assert_eq!(opts.index_remap_mode, IndexRemapMode::Compact);
     }
@@ -6793,6 +7057,7 @@ mod tests {
         assert_eq!(opts.index_remap_mode, IndexRemapMode::Direct);
         assert_eq!(opts.batch_size, defaults.batch_size);
         assert_eq!(opts.compaction_mode, defaults.compaction_mode);
+        assert_eq!(opts.max_source_bytes, defaults.max_source_bytes);
         assert_eq!(
             opts.binary_copy_read_batch_bytes,
             defaults.binary_copy_read_batch_bytes
@@ -6955,7 +7220,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_max_source_fragments() {
+    async fn test_max_source_limits() {
         let test_dir = TempStrDir::default();
         let test_uri = &test_dir;
 
@@ -7003,6 +7268,112 @@ mod tests {
             "need multiple tasks to test bounding, got {}",
             plan_all.num_tasks()
         );
+
+        let first_task_bytes = task_source_bytes(&dataset, &plan_all.tasks()[0])
+            .await
+            .unwrap();
+        assert!(first_task_bytes > 0);
+
+        let mut task_with_overlay = plan_all.tasks()[0].clone();
+        let overlay_data_file = task_with_overlay.fragments[0].files[0].clone();
+        let overlay_bytes = overlay_data_file.file_size_bytes.get().unwrap().get();
+        task_with_overlay.fragments[0]
+            .overlays
+            .push(DataOverlayFile {
+                data_file: overlay_data_file,
+                coverage: OverlayCoverage::dense(RoaringBitmap::new()),
+                committed_version: dataset.version().version,
+            });
+        assert_eq!(
+            task_source_bytes(&dataset, &task_with_overlay)
+                .await
+                .unwrap(),
+            first_task_bytes + overlay_bytes
+        );
+
+        let all_source_fragments = plan_all
+            .tasks()
+            .iter()
+            .flat_map(|task| task.fragments.iter().cloned())
+            .collect::<Vec<_>>();
+        let source_bytes = source_bytes_by_fragment(&dataset, &all_source_fragments)
+            .await
+            .unwrap();
+        let two_fragment_bytes = source_bytes[0] + source_bytes[1];
+
+        // The byte limit participates in task formation instead of truncating
+        // the plan. All eligible fragments remain covered by smaller tasks.
+        let opts_bytes_bounded = CompactionOptions {
+            target_rows_per_fragment: 250,
+            max_source_bytes: Some(two_fragment_bytes),
+            ..Default::default()
+        };
+        let plan_bytes_bounded = plan_compaction(&dataset, &opts_bytes_bounded)
+            .await
+            .unwrap();
+        assert_eq!(
+            plan_bytes_bounded
+                .tasks()
+                .iter()
+                .map(|task| task.fragments.len())
+                .sum::<usize>(),
+            10
+        );
+        assert!(plan_bytes_bounded.num_tasks() > plan_all.num_tasks());
+        for task in plan_bytes_bounded.tasks() {
+            assert!(task_source_bytes(&dataset, task).await.unwrap() <= two_fragment_bytes);
+        }
+
+        let plan_both_bounded = plan_compaction(
+            &dataset,
+            &CompactionOptions {
+                target_rows_per_fragment: 250,
+                max_source_fragments: Some(4),
+                max_source_bytes: Some(two_fragment_bytes),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            plan_both_bounded
+                .tasks()
+                .iter()
+                .map(|task| task.fragments.len())
+                .sum::<usize>(),
+            4
+        );
+        for task in plan_both_bounded.tasks() {
+            assert!(task_source_bytes(&dataset, task).await.unwrap() <= two_fragment_bytes);
+        }
+
+        // File size metadata may be unknown. Planning falls back to object-store
+        // metadata and caches the resolved sizes on the task.
+        let mut uncached_task = plan_all.tasks()[0].clone();
+        for fragment in &mut uncached_task.fragments {
+            for data_file in fragment.files.iter_mut().chain(
+                fragment
+                    .overlays
+                    .iter_mut()
+                    .map(|overlay| &mut overlay.data_file),
+            ) {
+                data_file.file_size_bytes = CachedFileSize::unknown();
+            }
+        }
+        assert_eq!(
+            task_source_bytes(&dataset, &uncached_task).await.unwrap(),
+            first_task_bytes
+        );
+        assert!(uncached_task.fragments.iter().all(|fragment| {
+            fragment
+                .files
+                .iter()
+                .all(|file| file.file_size_bytes.get().is_some())
+                && fragment
+                    .overlays
+                    .iter()
+                    .all(|overlay| overlay.data_file.file_size_bytes.get().is_some())
+        }));
 
         // Plan with max_source_fragments=4 should include tasks covering <= 4
         // source fragments
@@ -7804,6 +8175,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(dataset.get_fragments().len(), 3);
+
+        let error = plan_compaction(
+            &dataset,
+            &CompactionOptions {
+                target_rows_per_fragment: 1024 * 1024,
+                max_source_bytes: Some(u64::MAX),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, Error::NotSupported { .. }));
+        assert!(error.to_string().contains("blob v2"));
 
         compact_files(
             &mut dataset,
@@ -8655,7 +9039,6 @@ mod tests {
     use arrow_array::record_batch;
     use lance_file::writer::FileWriterOptions;
     use lance_io::utils::CachedFileSize;
-    use lance_table::format::DataFile;
     use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
     use std::collections::BTreeMap;
 


### PR DESCRIPTION
## What changed

- Add `max_source_bytes` to compaction options across Rust, Python, and Java.
- Use exact physical sizes of base and overlay data files when forming compaction tasks.
- Split candidate bins at fragment boundaries so each task stays under the byte limit whenever possible.
- Preserve forward progress when a single fragment, or the minimum useful fragment group, exceeds the limit.
- Keep `max_source_fragments` as the incremental plan-level cap.
- Reject `max_source_bytes` for Blob v2 datasets instead of silently undercounting sidecar storage.

## Why

Fragment counts are a poor proxy for compaction work because fragment sizes can differ by orders of magnitude. A physical source-byte limit produces more balanced compaction tasks without truncating the overall plan.

## User impact

Setting `max_source_bytes` now controls task formation. All eligible fragments remain represented in the plan, while task input sizes are bounded at fragment boundaries. Base and overlay data files are counted; deletion files and indices are excluded.

## Validation

- `cargo fmt --all`
- `cargo test -p lance test_candidate_bin`
- `cargo test -p lance test_max_source_limits`
- `cargo test -p lance test_compact_blob_v2_packed_and_dedicated`
- `cargo clippy -p lance --tests -- -D warnings`
- `uv run make build`
- `uv run pytest python/tests/test_optimize.py -k 'max_source_bytes or compaction_options_keys_are_optional'`
- `uv run ruff check python/lance/dataset.py python/lance/optimize.py python/tests/test_optimize.py`
- `uv run ruff format --check python/lance/dataset.py python/lance/optimize.py python/tests/test_optimize.py`
- `./mvnw -Dtest=CompactionTest test`