### PR TITLE
refactor: name blob v2 layouts

### DIFF
--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -48,6 +48,83 @@ pub static BLOB_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
 pub static BLOB_DESC_LANCE_FIELD: LazyLock<Field> =
     LazyLock::new(|| Field::try_from(&*BLOB_DESC_FIELD).unwrap());
 
+/// The minimal logical blob v2 fields accepted from writers.
+///
+/// Logical values may also use [`BLOB_V2_LOGICAL_FIELDS`] when an external
+/// object range is present.
+pub static BLOB_V2_LOGICAL_MINIMAL_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
+    Fields::from(vec![
+        ArrowField::new("data", DataType::LargeBinary, true),
+        ArrowField::new("uri", DataType::Utf8, true),
+    ])
+});
+
+/// The complete logical blob v2 fields used for writer input and rewrite output.
+///
+/// `position` and `size` are an optional range within the external object named
+/// by `uri`. They do not describe Lance-managed data, packed, or dedicated
+/// storage.
+pub static BLOB_V2_LOGICAL_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
+    let mut fields = BLOB_V2_LOGICAL_MINIMAL_FIELDS
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    fields.extend([
+        Arc::new(ArrowField::new("position", DataType::UInt64, true)),
+        Arc::new(ArrowField::new("size", DataType::UInt64, true)),
+    ]);
+    Fields::from(fields)
+});
+
+/// The complete logical blob v2 struct type.
+pub static BLOB_V2_LOGICAL_TYPE: LazyLock<DataType> =
+    LazyLock::new(|| DataType::Struct(BLOB_V2_LOGICAL_FIELDS.clone()));
+
+/// Writer-prepared blob v2 fields consumed by the structural encoder.
+///
+/// The populated fields depend on [`BlobKind`]:
+///
+/// - [`BlobKind::Inline`] carries `data`; the encoder derives the stored
+///   `position` and `size` from the out-of-line buffer it creates.
+/// - [`BlobKind::Packed`] carries `blob_id`, `position`, and `blob_size`.
+/// - [`BlobKind::Dedicated`] carries `blob_id` and `blob_size`; its stored
+///   `position` is zero.
+/// - [`BlobKind::External`] carries `uri`, optional `blob_id`, `position`, and
+///   `blob_size`. A zero `blob_size` is resolved to the complete external object
+///   length when read.
+///
+/// `blob_size` is distinct from the logical `size`, which is only an optional
+/// external-object range before preparation. For external blobs, `uri` is
+/// normalized into the stable stored `blob_uri` field.
+pub static BLOB_V2_PREPARED_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
+    Fields::from(vec![
+        ArrowField::new("kind", DataType::UInt8, true),
+        ArrowField::new("data", DataType::LargeBinary, true),
+        ArrowField::new("uri", DataType::Utf8, true),
+        ArrowField::new("blob_id", DataType::UInt32, true),
+        ArrowField::new("blob_size", DataType::UInt64, true),
+        ArrowField::new("position", DataType::UInt64, true),
+    ])
+});
+
+/// The writer-prepared blob v2 struct type.
+pub static BLOB_V2_PREPARED_TYPE: LazyLock<DataType> =
+    LazyLock::new(|| DataType::Struct(BLOB_V2_PREPARED_FIELDS.clone()));
+
+/// Stored blob v2 descriptor fields.
+///
+/// These field names are part of the stable file format. Their meaning depends
+/// on `kind`:
+///
+/// - [`BlobKind::Inline`]: `position` and `size` locate an out-of-line buffer in
+///   the Lance data file.
+/// - [`BlobKind::Packed`]: `blob_id` identifies a shared packed blob file, and
+///   `position` and `size` locate a range within it.
+/// - [`BlobKind::Dedicated`]: `blob_id` identifies a dedicated raw blob file,
+///   `position` is zero, and `size` is the complete file length.
+/// - [`BlobKind::External`]: `blob_uri` and `blob_id` identify the object, while
+///   `position` and `size` select a range. A zero `size` is resolved to the
+///   object's complete length when read.
 pub static BLOB_V2_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
     Fields::from(vec![
         ArrowField::new("kind", DataType::UInt8, false),
@@ -71,25 +148,95 @@ pub static BLOB_V2_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
 pub static BLOB_V2_DESC_LANCE_FIELD: LazyLock<Field> =
     LazyLock::new(|| Field::try_from(&*BLOB_V2_DESC_FIELD).unwrap());
 
-/// Blob v2 user-view struct fields used by internal rewrite paths.
-///
-/// This schema converts the descriptor view back into the write-side view used
-/// by blob compaction.
-pub static BLOB_V2_USER_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
-    Fields::from(vec![
-        ArrowField::new("data", DataType::LargeBinary, true),
-        ArrowField::new("uri", DataType::Utf8, true),
-        ArrowField::new("position", DataType::UInt64, true),
-        ArrowField::new("size", DataType::UInt64, true),
-    ])
-});
+/// The in-memory representation of a blob v2 struct.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlobV2Layout {
+    /// Writer input or rewrite output.
+    ///
+    /// Both the minimal `data, uri` fields and the complete
+    /// `data, uri, position, size` fields have this layout.
+    Logical,
+    /// Kind-aware writer intermediate consumed by the structural encoder.
+    Prepared,
+    /// Stable descriptor stored in Lance files and returned by descriptor scans.
+    Descriptor,
+}
 
-/// Blob v2 user-view struct type used by internal rewrite paths.
-///
-/// This schema converts the descriptor view back into the write-side view used
-/// by blob compaction.
-pub static BLOB_V2_USER_TYPE: LazyLock<DataType> =
-    LazyLock::new(|| DataType::Struct(BLOB_V2_USER_FIELDS.clone()));
+impl BlobV2Layout {
+    /// Classify blob v2 child fields by name, type, order, and layout-specific
+    /// nullability requirements.
+    ///
+    /// Child metadata is not part of the representation. The complete logical
+    /// layout also accepts non-nullable `position` and `size` fields, matching
+    /// the existing writer-input contract. Descriptor child nullability is
+    /// ignored because it changed across released schemas; row nullness has
+    /// been represented by either parent struct validity or a nullable `kind`
+    /// child.
+    pub fn classify(fields: &Fields) -> Option<Self> {
+        if logical_blob_v2_fields_match(fields) {
+            Some(Self::Logical)
+        } else if blob_v2_fields_match(fields, &BLOB_V2_PREPARED_FIELDS, true) {
+            Some(Self::Prepared)
+        } else if blob_v2_fields_match(fields, &BLOB_V2_DESC_FIELDS, false) {
+            Some(Self::Descriptor)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for BlobV2Layout {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Logical => write!(f, "logical"),
+            Self::Prepared => write!(f, "prepared"),
+            Self::Descriptor => write!(f, "descriptor"),
+        }
+    }
+}
+
+fn blob_v2_field_matches(
+    actual: &ArrowField,
+    expected: &ArrowField,
+    compare_nullability: bool,
+) -> bool {
+    actual.name() == expected.name()
+        && actual.data_type() == expected.data_type()
+        && (!compare_nullability || actual.is_nullable() == expected.is_nullable())
+}
+
+fn blob_v2_fields_match(actual: &Fields, expected: &Fields, compare_nullability: bool) -> bool {
+    actual.len() == expected.len()
+        && actual
+            .iter()
+            .zip(expected.iter())
+            .all(|(actual, expected)| {
+                blob_v2_field_matches(actual.as_ref(), expected.as_ref(), compare_nullability)
+            })
+}
+
+fn logical_blob_v2_fields_match(fields: &Fields) -> bool {
+    if blob_v2_fields_match(fields, &BLOB_V2_LOGICAL_MINIMAL_FIELDS, true) {
+        return true;
+    }
+    fields.len() == BLOB_V2_LOGICAL_FIELDS.len()
+        && fields
+            .iter()
+            .zip(BLOB_V2_LOGICAL_FIELDS.iter())
+            .enumerate()
+            .all(|(index, (actual, expected))| {
+                blob_v2_field_matches(actual.as_ref(), expected.as_ref(), index < 2)
+            })
+}
+
+/// Deprecated name for [`BLOB_V2_LOGICAL_FIELDS`].
+#[deprecated(note = "use BLOB_V2_LOGICAL_FIELDS")]
+pub use self::BLOB_V2_LOGICAL_FIELDS as BLOB_V2_USER_FIELDS;
+
+/// Deprecated name for [`BLOB_V2_LOGICAL_TYPE`].
+#[deprecated(note = "use BLOB_V2_LOGICAL_TYPE")]
+pub use self::BLOB_V2_LOGICAL_TYPE as BLOB_V2_USER_TYPE;
 
 pub const BLOB_LOGICAL_TYPE: &str = "blob";
 
@@ -460,5 +607,81 @@ impl TryFrom<u8> for BlobKind {
                 format!("Unknown blob kind {other:?}").into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_blob_v2_layouts() {
+        assert_eq!(
+            BlobV2Layout::classify(&BLOB_V2_LOGICAL_MINIMAL_FIELDS),
+            Some(BlobV2Layout::Logical)
+        );
+        assert_eq!(
+            BlobV2Layout::classify(&BLOB_V2_LOGICAL_FIELDS),
+            Some(BlobV2Layout::Logical)
+        );
+        assert_eq!(
+            BlobV2Layout::classify(&BLOB_V2_PREPARED_FIELDS),
+            Some(BlobV2Layout::Prepared)
+        );
+        assert_eq!(
+            BlobV2Layout::classify(&BLOB_V2_DESC_FIELDS),
+            Some(BlobV2Layout::Descriptor)
+        );
+    }
+
+    #[test]
+    fn test_classify_blob_v2_layout_uses_structural_contract() {
+        let logical_with_required_range = Fields::from(vec![
+            ArrowField::new("data", DataType::LargeBinary, true),
+            ArrowField::new("uri", DataType::Utf8, true),
+            ArrowField::new("position", DataType::UInt64, false),
+            ArrowField::new("size", DataType::UInt64, false),
+        ]);
+        assert_eq!(
+            BlobV2Layout::classify(&logical_with_required_range),
+            Some(BlobV2Layout::Logical)
+        );
+
+        let prepared_with_child_metadata =
+            Fields::from(
+                BLOB_V2_PREPARED_FIELDS
+                    .iter()
+                    .map(|field| {
+                        Arc::new(field.as_ref().clone().with_metadata(HashMap::from([(
+                            "source".to_string(),
+                            "test".to_string(),
+                        )])))
+                    })
+                    .collect::<Vec<_>>(),
+            );
+        assert_eq!(
+            BlobV2Layout::classify(&prepared_with_child_metadata),
+            Some(BlobV2Layout::Prepared)
+        );
+
+        let nullable_descriptor = Fields::from(
+            BLOB_V2_DESC_FIELDS
+                .iter()
+                .map(|field| Arc::new(field.as_ref().clone().with_nullable(true)))
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            BlobV2Layout::classify(&nullable_descriptor),
+            Some(BlobV2Layout::Descriptor)
+        );
+
+        let malformed_descriptor = Fields::from(vec![
+            ArrowField::new("kind", DataType::UInt8, false),
+            ArrowField::new("position", DataType::UInt64, false),
+            ArrowField::new("size", DataType::UInt32, false),
+            ArrowField::new("blob_id", DataType::UInt32, false),
+            ArrowField::new("blob_uri", DataType::Utf8, false),
+        ]);
+        assert_eq!(BlobV2Layout::classify(&malformed_descriptor), None);
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -13,7 +13,9 @@ use arrow_buffer::Buffer;
 use arrow_schema::{DataType, Field as ArrowField, Fields};
 use futures::{FutureExt, future::BoxFuture};
 use lance_core::{
-    Error, Result, datatypes::BLOB_V2_DESC_FIELDS, datatypes::Field, error::LanceOptionExt,
+    Error, Result,
+    datatypes::{BLOB_V2_DESC_FIELDS, BlobV2Layout, Field},
+    error::LanceOptionExt,
 };
 
 use crate::{
@@ -259,7 +261,27 @@ impl FieldEncoder for BlobV2StructuralEncoder {
         row_number: u64,
         num_rows: u64,
     ) -> Result<Vec<EncodeTask>> {
-        let struct_arr = array.as_struct();
+        let struct_arr = array
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .ok_or_else(|| {
+                Error::invalid_input_source(
+                    format!(
+                        "Blob v2 encoder expected StructArray, got {}",
+                        array.data_type()
+                    )
+                    .into(),
+                )
+            })?;
+        if BlobV2Layout::classify(struct_arr.fields()) != Some(BlobV2Layout::Prepared) {
+            let actual = BlobV2Layout::classify(struct_arr.fields())
+                .map(|layout| layout.to_string())
+                .unwrap_or_else(|| format!("unrecognized ({:?})", struct_arr.fields()));
+            return Err(Error::invalid_input_source(
+                format!("Blob v2 encoder expected prepared array layout, got {actual} layout")
+                    .into(),
+            ));
+        }
 
         let kind_col = struct_arr
             .column_by_name("kind")
@@ -429,6 +451,7 @@ mod tests {
         ArrayRef, LargeBinaryArray, StringArray, StructArray, UInt8Array, UInt32Array, UInt64Array,
     };
     use arrow_schema::{DataType, Field as ArrowField};
+    use lance_core::datatypes::BLOB_V2_LOGICAL_MINIMAL_FIELDS;
 
     #[test]
     fn test_blob_encoder_creation() {
@@ -446,6 +469,51 @@ mod tests {
             create_test_field_encoder(strategy.as_ref(), &field, &mut column_index, &options);
 
         assert!(encoder.is_ok());
+    }
+
+    #[test]
+    fn test_blob_v2_encoder_rejects_logical_array_layout() {
+        let field = Field::try_from(
+            ArrowField::new(
+                "blob_field",
+                DataType::Struct(BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone()),
+                true,
+            )
+            .with_metadata(HashMap::from([(
+                lance_arrow::ARROW_EXT_NAME_KEY.to_string(),
+                lance_arrow::BLOB_V2_EXT_NAME.to_string(),
+            )])),
+        )
+        .unwrap();
+        let mut column_index = ColumnIndexSequence::default();
+        let options = EncodingOptions::default();
+        let strategy = test_encoding_strategy(TestEncoding::StructuralU32);
+        let mut encoder =
+            create_test_field_encoder(strategy.as_ref(), &field, &mut column_index, &options)
+                .unwrap();
+        let array = Arc::new(
+            StructArray::try_new(
+                BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone(),
+                vec![
+                    Arc::new(LargeBinaryArray::from(vec![Some(b"payload".as_ref())])) as ArrayRef,
+                    Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+                ],
+                None,
+            )
+            .unwrap(),
+        ) as ArrayRef;
+        let mut external_buffers = OutOfLineBuffers::new(0, 8);
+        let Err(error) =
+            encoder.maybe_encode(array, &mut external_buffers, RepDefBuilder::default(), 0, 1)
+        else {
+            panic!("logical array layout unexpectedly reached the descriptor encoder");
+        };
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("expected prepared array layout, got logical layout")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/blob.rs
+++ b/rust/lance/src/blob.rs
@@ -4,7 +4,7 @@
 //! Builders and file-level writer helpers for Lance blob v2 columns.
 //!
 //! Logical blob input uses `Struct<data: LargeBinary?, uri: Utf8?>`. File-level blob
-//! descriptors use a physical writer-side struct with `kind`, `blob_id`, and range fields.
+//! preparation produces a kind-aware writer intermediate with `blob_id` and range fields.
 
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
@@ -21,14 +21,17 @@ use arrow_array::{
     types::{UInt8Type, UInt32Type, UInt64Type},
 };
 use arrow_buffer::NullBufferBuilder;
-use arrow_schema::{DataType, Field, Fields};
+use arrow_schema::{DataType, Field};
 use bytes::Bytes;
 use lance_arrow::{
     ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
     BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_V2_EXT_NAME, FieldExt,
 };
 use lance_core::{
-    datatypes::{BlobKind, Field as LanceField, Schema as LanceSchema},
+    datatypes::{
+        BLOB_V2_LOGICAL_MINIMAL_FIELDS, BLOB_V2_PREPARED_FIELDS, BLOB_V2_PREPARED_TYPE, BlobKind,
+        BlobV2Layout, Field as LanceField, Schema as LanceSchema,
+    },
     utils::blob::blob_path,
 };
 use lance_io::{
@@ -112,27 +115,10 @@ pub fn blob_field_with_options(name: &str, nullable: bool, options: BlobFieldOpt
     }
     Field::new(
         name,
-        DataType::Struct(
-            vec![
-                Field::new("data", DataType::LargeBinary, true),
-                Field::new("uri", DataType::Utf8, true),
-            ]
-            .into(),
-        ),
+        DataType::Struct(BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone()),
         nullable,
     )
     .with_metadata(metadata)
-}
-
-fn prepared_blob_child_fields() -> Fields {
-    Fields::from(vec![
-        Field::new("kind", DataType::UInt8, true),
-        Field::new("data", DataType::LargeBinary, true),
-        Field::new("uri", DataType::Utf8, true),
-        Field::new("blob_id", DataType::UInt32, true),
-        Field::new("blob_size", DataType::UInt64, true),
-        Field::new("position", DataType::UInt64, true),
-    ])
 }
 
 fn prepared_blob_field_with_metadata(
@@ -140,97 +126,68 @@ fn prepared_blob_field_with_metadata(
     nullable: bool,
     metadata: HashMap<String, String>,
 ) -> Field {
-    Field::new(
-        name,
-        DataType::Struct(prepared_blob_child_fields()),
-        nullable,
-    )
-    .with_metadata(metadata)
+    Field::new(name, BLOB_V2_PREPARED_TYPE.clone(), nullable).with_metadata(metadata)
 }
 
 fn logical_blob_lance_children() -> Result<Vec<LanceField>> {
-    [
-        Field::new("data", DataType::LargeBinary, true),
-        Field::new("uri", DataType::Utf8, true),
-    ]
-    .iter()
-    .map(LanceField::try_from)
-    .collect()
+    BLOB_V2_LOGICAL_MINIMAL_FIELDS
+        .iter()
+        .map(|field| LanceField::try_from(field.as_ref()))
+        .collect()
 }
 
-fn field_matches(field: &Field, name: &str, data_type: &DataType, nullable: bool) -> bool {
-    field.name() == name && field.data_type() == data_type && field.is_nullable() == nullable
+pub(crate) fn blob_v2_layout(field: &Field) -> Option<BlobV2Layout> {
+    if !field.is_blob_v2() {
+        return None;
+    }
+    let DataType::Struct(fields) = field.data_type() else {
+        return None;
+    };
+    BlobV2Layout::classify(fields)
 }
 
-fn blob_v2_shape_error(field: &Field) -> Error {
+pub(crate) fn blob_v2_shape_error(field: &Field, expected: &[BlobV2Layout]) -> Error {
+    let expected = expected
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" or ");
+    let actual = match field.data_type() {
+        DataType::Struct(fields) => BlobV2Layout::classify(fields)
+            .map(|layout| format!("{layout} layout"))
+            .unwrap_or_else(|| format!("unrecognized layout {fields:?}")),
+        data_type => format!("non-struct type {data_type}"),
+    };
     Error::invalid_input(format!(
-        "Blob v2 field '{}' must use either logical struct<data: LargeBinary?, uri: Utf8?> \
-         with optional position/size UInt64 fields or prepared struct<kind: UInt8?, data: \
-         LargeBinary?, uri: Utf8?, blob_id: UInt32?, blob_size: UInt64?, position: UInt64?>",
-        field.name()
+        "Blob v2 field '{}' has {actual}; expected {expected} layout",
+        field.name(),
     ))
 }
 
-/// Returns true when `field` is the writer-side prepared blob v2 struct.
-pub(crate) fn is_prepared_blob_v2_field(field: &Field) -> bool {
-    if !field.is_blob_v2() {
-        return false;
-    }
-    let DataType::Struct(fields) = field.data_type() else {
-        return false;
-    };
-    let expected = prepared_blob_child_fields();
-    fields.len() == expected.len()
-        && fields
-            .iter()
-            .zip(expected.iter())
-            .all(|(actual, expected)| actual.as_ref() == expected.as_ref())
-}
-
-/// Returns true when `field` is the logical blob v2 input struct.
-pub(crate) fn is_logical_blob_v2_field(field: &Field) -> bool {
-    if !field.is_blob_v2() {
-        return false;
-    }
-    let DataType::Struct(fields) = field.data_type() else {
-        return false;
-    };
-    match fields.len() {
-        2 => {
-            field_matches(fields[0].as_ref(), "data", &DataType::LargeBinary, true)
-                && field_matches(fields[1].as_ref(), "uri", &DataType::Utf8, true)
-        }
-        4 => {
-            field_matches(fields[0].as_ref(), "data", &DataType::LargeBinary, true)
-                && field_matches(fields[1].as_ref(), "uri", &DataType::Utf8, true)
-                && fields[2].name() == "position"
-                && fields[2].data_type() == &DataType::UInt64
-                && fields[3].name() == "size"
-                && fields[3].data_type() == &DataType::UInt64
-        }
-        _ => false,
-    }
-}
-
-fn normalize_prepared_blob_lance_field(field: &LanceField) -> Result<LanceField> {
+fn prepared_to_logical_blob_lance_field(field: &LanceField) -> Result<LanceField> {
     if field.is_blob_v2() {
         let arrow_field = Field::from(field);
-        if is_prepared_blob_v2_field(&arrow_field) {
-            let mut normalized = field.clone();
-            let mut logical_children = logical_blob_lance_children()?;
-            for (logical_child, prepared_child) in
-                logical_children.iter_mut().zip(field.children.iter())
-            {
-                logical_child.id = prepared_child.id;
-                logical_child.parent_id = field.id;
+        match blob_v2_layout(&arrow_field) {
+            Some(BlobV2Layout::Prepared) => {
+                let mut normalized = field.clone();
+                let mut logical_children = logical_blob_lance_children()?;
+                for (logical_child, prepared_child) in
+                    logical_children.iter_mut().zip(field.children.iter())
+                {
+                    logical_child.id = prepared_child.id;
+                    logical_child.parent_id = field.id;
+                }
+                normalized.children = logical_children;
+                return Ok(normalized);
             }
-            normalized.children = logical_children;
-            return Ok(normalized);
+            Some(BlobV2Layout::Logical) => return Ok(field.clone()),
+            _ => {
+                return Err(blob_v2_shape_error(
+                    &arrow_field,
+                    &[BlobV2Layout::Logical, BlobV2Layout::Prepared],
+                ));
+            }
         }
-        if is_logical_blob_v2_field(&arrow_field) {
-            return Ok(field.clone());
-        }
-        return Err(blob_v2_shape_error(&arrow_field));
     }
 
     if field.children.is_empty() {
@@ -240,7 +197,7 @@ fn normalize_prepared_blob_lance_field(field: &LanceField) -> Result<LanceField>
     let normalized_children = field
         .children
         .iter()
-        .map(normalize_prepared_blob_lance_field)
+        .map(prepared_to_logical_blob_lance_field)
         .collect::<Result<Vec<_>>>()?;
 
     Ok(LanceField {
@@ -249,11 +206,11 @@ fn normalize_prepared_blob_lance_field(field: &LanceField) -> Result<LanceField>
     })
 }
 
-pub(crate) fn normalize_prepared_blob_schema(schema: &LanceSchema) -> Result<LanceSchema> {
+pub(crate) fn prepared_to_logical_blob_schema(schema: &LanceSchema) -> Result<LanceSchema> {
     let fields = schema
         .fields
         .iter()
-        .map(normalize_prepared_blob_lance_field)
+        .map(prepared_to_logical_blob_lance_field)
         .collect::<Result<Vec<_>>>()?;
     Ok(LanceSchema {
         fields,
@@ -331,14 +288,23 @@ fn validate_range(offset: u64, size: u64, object_size: u64, label: &str) -> Resu
 }
 
 fn validate_prepared_blob_value_array(field: &Field, array: &ArrayRef) -> Result<()> {
-    if !is_prepared_blob_v2_field(field) {
-        return Err(blob_v2_shape_error(field));
+    if blob_v2_layout(field) != Some(BlobV2Layout::Prepared) {
+        return Err(blob_v2_shape_error(field, &[BlobV2Layout::Prepared]));
     }
 
     let struct_arr = array
         .as_any()
         .downcast_ref::<StructArray>()
         .ok_or_else(|| Error::invalid_input("Prepared blob column was not a struct array"))?;
+    if BlobV2Layout::classify(struct_arr.fields()) != Some(BlobV2Layout::Prepared) {
+        let actual = BlobV2Layout::classify(struct_arr.fields())
+            .map(|layout| layout.to_string())
+            .unwrap_or_else(|| format!("unrecognized ({:?})", struct_arr.fields()));
+        return Err(Error::invalid_input(format!(
+            "Prepared blob column '{}' has {actual} array layout; expected prepared layout",
+            field.name()
+        )));
+    }
     let kind_col = struct_arr
         .column_by_name("kind")
         .ok_or_else(|| Error::invalid_input("Prepared blob struct missing `kind` field"))?
@@ -465,7 +431,7 @@ pub struct BlobRange {
     pub size: u64,
 }
 
-/// A physical blob descriptor row.
+/// A kind-aware row used to build the writer-prepared blob representation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlobDescriptor {
     /// A null blob row.
@@ -489,19 +455,22 @@ pub enum BlobDescriptor {
     },
 }
 
-/// A physical blob descriptor column ready to be included in a [`RecordBatch`](arrow_array::RecordBatch).
+/// A writer-prepared blob column ready to be included in a [`RecordBatch`](arrow_array::RecordBatch).
+///
+/// Despite the legacy type name, its Arrow representation is
+/// [`BlobV2Layout::Prepared`], not the descriptor stored in a Lance file.
 pub struct BlobDescriptorColumn {
     field: Field,
     array: ArrayRef,
 }
 
 impl BlobDescriptorColumn {
-    /// Return the Arrow field for the descriptor column.
+    /// Return the Arrow field for the prepared column.
     pub fn field(&self) -> &Field {
         &self.field
     }
 
-    /// Return the Arrow array for the descriptor column.
+    /// Return the Arrow array for the prepared column.
     pub fn array(&self) -> &ArrayRef {
         &self.array
     }
@@ -512,9 +481,9 @@ impl BlobDescriptorColumn {
     }
 }
 
-/// Builds physical blob descriptors for one blob v2 column.
+/// Builds the writer-prepared representation for one blob v2 column.
 ///
-/// This builder only produces the writer-side descriptor struct array. It does not allocate blob ids,
+/// This builder only produces the writer-prepared struct array. It does not allocate blob ids,
 /// choose sidecar paths, write blob objects, or commit data files.
 pub struct BlobDescriptorArrayBuilder {
     field: Field,
@@ -606,12 +575,12 @@ impl BlobDescriptorArrayBuilder {
         self.push(BlobDescriptor::Null)
     }
 
-    /// Return the descriptor Arrow field for this blob column.
+    /// Return the prepared Arrow field for this blob column.
     pub fn field(&self) -> &Field {
         &self.field
     }
 
-    /// Finish this column and return the writer-side descriptor struct array.
+    /// Finish this column and return the writer-prepared struct array.
     pub fn finish(self) -> Result<BlobDescriptorColumn> {
         let mut kind_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(self.values.len());
         let mut data_builder = LargeBinaryBuilder::with_capacity(self.values.len(), 0);
@@ -682,7 +651,7 @@ impl BlobDescriptorArrayBuilder {
         }
 
         let array = Arc::new(StructArray::try_new(
-            prepared_blob_child_fields(),
+            BLOB_V2_PREPARED_FIELDS.clone(),
             vec![
                 Arc::new(kind_builder.finish()),
                 Arc::new(data_builder.finish()),
@@ -1057,11 +1026,7 @@ impl BlobArrayBuilder {
         let validity = self.validity.finish();
 
         let struct_array = StructArray::try_new(
-            vec![
-                Field::new("data", DataType::LargeBinary, true),
-                Field::new("uri", DataType::Utf8, true),
-            ]
-            .into(),
+            BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone(),
             vec![data as ArrayRef, uri as ArrayRef],
             validity,
         )?;
@@ -1265,7 +1230,7 @@ mod tests {
         writer.push_null().unwrap();
 
         let column = writer.finish().unwrap();
-        assert!(is_prepared_blob_v2_field(column.field()));
+        assert_eq!(blob_v2_layout(column.field()), Some(BlobV2Layout::Prepared));
         let struct_arr = column.array().as_struct();
         let kinds = struct_arr
             .column_by_name("kind")
@@ -1307,7 +1272,7 @@ mod tests {
         ] {
             let array = Arc::new(
                 StructArray::try_new(
-                    prepared_blob_child_fields(),
+                    BLOB_V2_PREPARED_FIELDS.clone(),
                     vec![
                         Arc::new(arrow_array::UInt8Array::from(vec![kind as u8])) as ArrayRef,
                         Arc::new(arrow_array::LargeBinaryArray::from_iter([None::<&[u8]>])),
@@ -1327,7 +1292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_prepared_blob_schema_preserves_non_blob_fields() {
+    fn test_prepared_to_logical_blob_schema_preserves_non_blob_fields() {
         let mut metadata = HashMap::new();
         metadata.insert(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string());
         let prepared_field = prepared_blob_field_with_metadata("blob", true, metadata);
@@ -1344,7 +1309,7 @@ mod tests {
         let dictionary_values = Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef;
         schema.fields[0].set_dictionary_values(&dictionary_values);
 
-        let normalized = normalize_prepared_blob_schema(&schema).unwrap();
+        let normalized = prepared_to_logical_blob_schema(&schema).unwrap();
 
         assert_eq!(normalized.fields[0].id, 42);
         assert_eq!(

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2272,15 +2272,15 @@ impl Dataset {
         fn field_names_match(
             fields: &[lance_core::datatypes::Field],
             start: usize,
-            names: &[&str],
+            expected: &arrow_schema::Fields,
         ) -> bool {
             fields
-                .get(start..start + names.len())
+                .get(start..start + expected.len())
                 .is_some_and(|candidate| {
                     candidate
                         .iter()
-                        .zip(names)
-                        .all(|(field, name)| field.name == *name)
+                        .zip(expected.iter())
+                        .all(|(field, expected)| field.name == expected.name().as_str())
                 })
         }
 
@@ -2288,14 +2288,10 @@ impl Dataset {
             fields: &[lance_core::datatypes::Field],
             start: usize,
         ) -> usize {
-            const BLOB_V2_DESCRIPTOR_FIELDS: &[&str] =
-                &["kind", "position", "size", "blob_id", "blob_uri"];
-            const BLOB_V1_DESCRIPTOR_FIELDS: &[&str] = &["position", "size"];
-
-            if field_names_match(fields, start, BLOB_V2_DESCRIPTOR_FIELDS) {
-                BLOB_V2_DESCRIPTOR_FIELDS.len()
-            } else if field_names_match(fields, start, BLOB_V1_DESCRIPTOR_FIELDS) {
-                BLOB_V1_DESCRIPTOR_FIELDS.len()
+            if field_names_match(fields, start, &lance_core::datatypes::BLOB_V2_DESC_FIELDS) {
+                lance_core::datatypes::BLOB_V2_DESC_FIELDS.len()
+            } else if field_names_match(fields, start, &lance_core::datatypes::BLOB_DESC_FIELDS) {
+                lance_core::datatypes::BLOB_DESC_FIELDS.len()
             } else {
                 0
             }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -36,10 +36,13 @@ use super::write::ExternalBlobMode;
 use super::{Dataset, ProjectionRequest};
 use crate::blob::{
     BlobDescriptor, BlobDescriptorArrayBuilder, BlobIdAllocator, BlobRange, PackedBlobWriter,
-    is_logical_blob_v2_field, is_prepared_blob_v2_field, validate_prepared_blob_array,
+    blob_v2_layout, blob_v2_shape_error, validate_prepared_blob_array,
 };
 use arrow_array::StructArray;
-use lance_core::datatypes::{BlobKind, BlobVersion, Field as LanceField, Schema, parse_field_path};
+use lance_core::datatypes::{
+    BLOB_DESC_FIELDS, BlobKind, BlobV2Layout, BlobVersion, Field as LanceField, Schema,
+    parse_field_path,
+};
 use lance_core::utils::blob::blob_path;
 use lance_core::{Error, ROW_ADDR, Result, utils::address::RowAddress};
 use lance_io::traits::Reader;
@@ -334,37 +337,32 @@ enum BlobPreprocessFieldKind {
 impl BlobPreprocessField {
     fn new(field: &ArrowField) -> Result<Self> {
         if field.is_blob_v2() {
-            if is_prepared_blob_v2_field(field) {
-                return Ok(Self {
+            return match blob_v2_layout(field) {
+                Some(BlobV2Layout::Prepared) => Ok(Self {
                     kind: BlobPreprocessFieldKind::Passthrough,
-                });
-            }
-            if !is_logical_blob_v2_field(field) {
-                return Err(Error::invalid_input(format!(
-                    "Blob v2 field '{}' must use either logical struct<data: LargeBinary?, \
-                     uri: Utf8?> with optional position/size UInt64 fields or prepared \
-                     struct<kind: UInt8?, data: LargeBinary?, uri: Utf8?, blob_id: UInt32?, \
-                     blob_size: UInt64?, position: UInt64?>",
-                    field.name()
-                )));
-            }
-            return Ok(Self {
-                kind: BlobPreprocessFieldKind::BlobV2 {
-                    inline_threshold: blob_inline_threshold_from_metadata(
-                        field.metadata(),
-                        field.name(),
-                    )?,
-                    dedicated_threshold: blob_dedicated_threshold_from_metadata(
-                        field.metadata(),
-                        field.name(),
-                    )?,
-                    pack_file_threshold: blob_pack_file_threshold_from_metadata(
-                        field.metadata(),
-                        field.name(),
-                    )?,
-                    writer_metadata: field.metadata().clone(),
-                },
-            });
+                }),
+                Some(BlobV2Layout::Logical) => Ok(Self {
+                    kind: BlobPreprocessFieldKind::BlobV2 {
+                        inline_threshold: blob_inline_threshold_from_metadata(
+                            field.metadata(),
+                            field.name(),
+                        )?,
+                        dedicated_threshold: blob_dedicated_threshold_from_metadata(
+                            field.metadata(),
+                            field.name(),
+                        )?,
+                        pack_file_threshold: blob_pack_file_threshold_from_metadata(
+                            field.metadata(),
+                            field.name(),
+                        )?,
+                        writer_metadata: field.metadata().clone(),
+                    },
+                }),
+                _ => Err(blob_v2_shape_error(
+                    field,
+                    &[BlobV2Layout::Logical, BlobV2Layout::Prepared],
+                )),
+            };
         }
 
         if let ArrowDataType::Struct(children) = field.data_type() {
@@ -648,7 +646,7 @@ impl BlobPreprocessor {
         field: &'a Arc<ArrowField>,
     ) -> BoxFuture<'a, Result<(ArrayRef, Arc<ArrowField>)>> {
         async move {
-            if is_prepared_blob_v2_field(field.as_ref()) {
+            if blob_v2_layout(field.as_ref()) == Some(BlobV2Layout::Prepared) {
                 validate_prepared_blob_array(field.as_ref(), &array)?;
                 return Ok((array, field.clone()));
             }
@@ -661,7 +659,7 @@ impl BlobPreprocessor {
                     pack_file_threshold,
                     writer_metadata,
                 } => {
-                    self.preprocess_blob_array(
+                    self.logical_to_prepared_blob_array(
                         array,
                         field.as_ref(),
                         *inline_threshold,
@@ -817,7 +815,7 @@ impl BlobPreprocessor {
         Ok((Arc::new(list_array), field))
     }
 
-    async fn preprocess_blob_array(
+    async fn logical_to_prepared_blob_array(
         &mut self,
         array: ArrayRef,
         field: &ArrowField,
@@ -830,6 +828,15 @@ impl BlobPreprocessor {
             .as_any()
             .downcast_ref::<StructArray>()
             .ok_or_else(|| Error::invalid_input("Blob column was not a struct array"))?;
+        if BlobV2Layout::classify(struct_arr.fields()) != Some(BlobV2Layout::Logical) {
+            let actual = BlobV2Layout::classify(struct_arr.fields())
+                .map(|layout| layout.to_string())
+                .unwrap_or_else(|| format!("unrecognized ({:?})", struct_arr.fields()));
+            return Err(Error::invalid_input(format!(
+                "Blob v2 field '{}' has {actual} array layout; expected logical layout before preparation",
+                field.name()
+            )));
+        }
 
         let data_col = struct_arr
             .column_by_name("data")
@@ -2889,23 +2896,29 @@ fn leaf_descriptor_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a
     Ok(current)
 }
 
+fn blob_descriptor_fields_match(
+    actual: &arrow_schema::Fields,
+    expected: &arrow_schema::Fields,
+) -> bool {
+    actual.len() == expected.len()
+        && actual
+            .iter()
+            .zip(expected.iter())
+            .all(|(actual, expected)| {
+                actual.name() == expected.name() && actual.data_type() == expected.data_type()
+            })
+}
+
 fn blob_version_from_descriptions(descriptions: &StructArray) -> Result<BlobVersion> {
     let fields = descriptions.fields();
-    if fields.len() == 2 && fields[0].name() == "position" && fields[1].name() == "size" {
+    if blob_descriptor_fields_match(fields, &BLOB_DESC_FIELDS) {
         return Ok(BlobVersion::V1);
     }
-    if fields.len() == 5
-        && fields[0].name() == "kind"
-        && fields[1].name() == "position"
-        && fields[2].name() == "size"
-        && fields[3].name() == "blob_id"
-        && fields[4].name() == "blob_uri"
-    {
+    if BlobV2Layout::classify(fields) == Some(BlobV2Layout::Descriptor) {
         return Ok(BlobVersion::V2);
     }
     Err(Error::invalid_input_source(format!(
-        "Unrecognized blob descriptions schema: expected v1 (position,size) or v2 (kind,position,size,blob_id,blob_uri) but got {:?}",
-        fields.iter().map(|f| f.name().as_str()).collect::<Vec<_>>(),
+        "Unrecognized blob descriptions schema: expected v1 descriptor or v2 descriptor layout but got {fields:?}",
     )
     .into()))
 }
@@ -3701,9 +3714,10 @@ mod tests {
 
     use super::{
         BlobEntry, BlobFile, BlobRangeRequest, BlobReadRange, BlobSource, ExternalBaseCandidate,
-        ExternalBaseResolver, ReadBlobsExecution, collect_blob_files_v1, data_file_key_from_path,
-        execute_blob_entries, execute_blob_read_batches_stream, execute_blob_read_plan,
-        plan_blob_read_batches, plan_blob_read_plans,
+        ExternalBaseResolver, ReadBlobsExecution, blob_version_from_descriptions,
+        collect_blob_files_v1, data_file_key_from_path, execute_blob_entries,
+        execute_blob_read_batches_stream, execute_blob_read_plan, plan_blob_read_batches,
+        plan_blob_read_plans,
     };
     use crate::{
         Dataset,
@@ -3726,6 +3740,37 @@ mod tests {
         _test_dir: TempDir,
         dataset: Arc<Dataset>,
         expected: Vec<u8>,
+    }
+
+    #[test]
+    fn test_blob_version_rejects_malformed_v2_descriptor_layout() {
+        let descriptions = StructArray::try_new(
+            vec![
+                Field::new("kind", DataType::UInt8, false),
+                Field::new("position", DataType::UInt64, false),
+                Field::new("size", DataType::UInt32, false),
+                Field::new("blob_id", DataType::UInt32, false),
+                Field::new("blob_uri", DataType::Utf8, false),
+            ]
+            .into(),
+            vec![
+                Arc::new(UInt8Array::from(vec![BlobKind::Inline as u8])),
+                Arc::new(UInt64Array::from(vec![0])),
+                Arc::new(UInt32Array::from(vec![0])),
+                Arc::new(UInt32Array::from(vec![0])),
+                Arc::new(StringArray::from(vec![""])),
+            ],
+            None,
+        )
+        .unwrap();
+
+        let error = blob_version_from_descriptions(&descriptions).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("expected v1 descriptor or v2 descriptor layout")
+        );
     }
 
     fn nested_blob_v2_batch(blob_array: ArrayRef) -> (Arc<Schema>, RecordBatch) {

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -111,7 +111,9 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::{StreamExt, TryStreamExt};
 use lance_core::Error;
-use lance_core::datatypes::{BlobHandling, BlobKind};
+use lance_core::datatypes::{
+    BLOB_V2_LOGICAL_FIELDS, BLOB_V2_LOGICAL_TYPE, BlobHandling, BlobKind, BlobV2Layout,
+};
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::utils::tracing::{DATASET_COMPACTING_EVENT, TRACE_DATASET_EVENTS};
 use lance_index::frag_reuse::{FRAG_REUSE_INDEX_NAME, FragReuseGroup};
@@ -989,6 +991,14 @@ struct BlobV2Descriptor<'a> {
 impl<'a> BlobV2Descriptor<'a> {
     /// Extract the 5 descriptor arrays from a blob v2 descriptor struct array.
     fn try_from_struct(struct_arr: &'a StructArray, column_name: &str) -> Result<Self> {
+        if BlobV2Layout::classify(struct_arr.fields()) != Some(BlobV2Layout::Descriptor) {
+            let actual = BlobV2Layout::classify(struct_arr.fields())
+                .map(|layout| layout.to_string())
+                .unwrap_or_else(|| format!("unrecognized ({:?})", struct_arr.fields()));
+            return Err(Error::invalid_input(format!(
+                "Blob v2 column '{column_name}' has {actual} layout; expected descriptor layout before conversion to logical"
+            )));
+        }
         let kind_col = struct_arr
             .column_by_name("kind")
             .ok_or_else(|| {
@@ -1086,11 +1096,11 @@ fn classify_rows(
     })
 }
 
-/// Build a blob v2 user-view struct array from classification and descriptor.
+/// Convert a blob v2 descriptor into the logical writer representation.
 ///
 /// Reads blob data lazily using row addresses to avoid materializing all blob
 /// payloads in memory at once.
-async fn build_user_view_struct(
+async fn descriptor_to_logical_blob_array(
     dataset: &Arc<Dataset>,
     descriptor: &BlobV2Descriptor<'_>,
     classification: &RowClassification,
@@ -1165,7 +1175,7 @@ async fn build_user_view_struct(
     }
 
     Ok(StructArray::try_new(
-        lance_core::datatypes::BLOB_V2_USER_FIELDS.clone(),
+        BLOB_V2_LOGICAL_FIELDS.clone(),
         vec![
             Arc::new(data_builder.finish()),
             Arc::new(uri_builder.finish()),
@@ -1229,13 +1239,28 @@ pub(crate) async fn transform_blob_v2_batch(
                 ))
             })?;
 
-        // Merge-insert may supply a blob v2 value directly from the source.
-        // Those values are already in the writer's user view and do not refer
-        // to a row in the target dataset, unlike descriptor values from scans.
-        if struct_arr.column_by_name("kind").is_none() {
-            new_columns.push(batch.column(col_idx).clone());
-            new_fields.push(field.clone());
-            continue;
+        match BlobV2Layout::classify(struct_arr.fields()) {
+            // Merge-insert may supply a logical blob v2 value directly from the
+            // source. It does not refer to a row in the target dataset.
+            Some(BlobV2Layout::Logical) => {
+                new_columns.push(batch.column(col_idx).clone());
+                new_fields.push(field.clone());
+                continue;
+            }
+            Some(BlobV2Layout::Descriptor) => {}
+            Some(actual) => {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 column '{}' has {actual} layout; expected logical or descriptor layout during compaction",
+                    field.name()
+                )));
+            }
+            None => {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 column '{}' has unrecognized layout {:?}; expected logical or descriptor layout during compaction",
+                    field.name(),
+                    struct_arr.fields()
+                )));
+            }
         }
 
         let column_name = field.name();
@@ -1243,7 +1268,7 @@ pub(crate) async fn transform_blob_v2_batch(
         let classification = classify_rows(struct_arr, &descriptor, row_addrs, column_name)?;
         let num_rows = struct_arr.len();
 
-        let new_struct = build_user_view_struct(
+        let new_struct = descriptor_to_logical_blob_array(
             dataset,
             &descriptor,
             &classification,
@@ -1263,7 +1288,7 @@ pub(crate) async fn transform_blob_v2_batch(
         new_fields.push(Arc::new(
             arrow_schema::Field::new(
                 field.name(),
-                lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
+                BLOB_V2_LOGICAL_TYPE.clone(),
                 field.is_nullable(),
             )
             .with_metadata(logical_field.metadata().clone()),
@@ -1697,7 +1722,7 @@ async fn rewrite_files(
                         fields.push(Arc::new(
                             arrow_schema::Field::new(
                                 field.name(),
-                                lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
+                                BLOB_V2_LOGICAL_TYPE.clone(),
                                 field.is_nullable(),
                             )
                             .with_metadata(logical_field.metadata().clone()),

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -40,7 +40,7 @@ use std::sync::atomic::AtomicUsize;
 use tracing::{info, instrument};
 
 use crate::Dataset;
-use crate::blob::normalize_prepared_blob_schema;
+use crate::blob::prepared_to_logical_blob_schema;
 use crate::dataset::blob::{
     BlobPreprocessor, ExternalBaseCandidate, ExternalBaseResolver,
     blob_dedicated_threshold_from_metadata, blob_inline_threshold_from_metadata,
@@ -1301,7 +1301,7 @@ pub async fn write_fragments_internal(
     // Make sure the max rows per group is not larger than the max rows per file
     params.max_rows_per_group = std::cmp::min(params.max_rows_per_group, params.max_rows_per_file);
     validate_external_blob_write_params(&params)?;
-    let normalized_converted_schema = normalize_prepared_blob_schema(&converted_schema)?;
+    let normalized_converted_schema = prepared_to_logical_blob_schema(&converted_schema)?;
 
     let (schema, storage_version) = if let Some(dataset) = dataset {
         match params.mode {

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -19,7 +19,7 @@ use lance_table::io::commit::CommitHandler;
 use object_store::path::Path;
 
 use crate::Dataset;
-use crate::blob::normalize_prepared_blob_schema;
+use crate::blob::prepared_to_logical_blob_schema;
 use crate::dataset::ReadParams;
 use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::transaction::{Operation, Transaction, TransactionBuilder};
@@ -324,7 +324,7 @@ impl<'a> InsertBuilder<'a> {
                 ..Default::default()
             };
 
-            let normalized_data_schema = normalize_prepared_blob_schema(data_schema)?;
+            let normalized_data_schema = prepared_to_logical_blob_schema(data_schema)?;
             normalized_data_schema.check_compatible(dataset.schema(), &schema_cmp_opts)?;
         }
 

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -19,7 +19,10 @@ use datafusion::{
 };
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 use futures::{StreamExt, stream};
-use lance_core::{Error, ROW_ADDR, ROW_ID};
+use lance_core::{
+    Error, ROW_ADDR, ROW_ID,
+    datatypes::{BLOB_V2_LOGICAL_TYPE, BlobV2Layout},
+};
 use lance_table::format::RowIdMeta;
 use roaring::RoaringTreemap;
 
@@ -49,46 +52,58 @@ use crate::{
 
 use super::apply_deletions;
 
-fn blob_v2_user_view_schema(
+fn descriptor_to_logical_blob_schema(
     input_schema: arrow_schema::SchemaRef,
     dataset_schema: &lance_core::datatypes::Schema,
-) -> arrow_schema::SchemaRef {
+) -> lance_core::Result<arrow_schema::SchemaRef> {
     let fields = input_schema
         .fields()
         .iter()
-        .map(|field| {
+        .map(|field| -> lance_core::Result<_> {
             let Some(dataset_field) = dataset_schema
                 .field(field.name())
                 .filter(|dataset_field| dataset_field.is_blob_v2())
             else {
-                return field.clone();
+                return Ok(field.clone());
             };
-            let is_descriptor = matches!(
-                field.data_type(),
-                arrow_schema::DataType::Struct(fields)
-                    if fields.iter().any(|child| child.name() == "kind")
-            );
-            if !is_descriptor {
-                return field.clone();
-            }
-            let logical_field = arrow_schema::Field::from(dataset_field);
-            Arc::new(
-                arrow_schema::Field::new(
+            let arrow_schema::DataType::Struct(fields) = field.data_type() else {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 merge input '{}' has non-struct type {}; expected logical or descriptor layout",
                     field.name(),
-                    lance_core::datatypes::BLOB_V2_USER_TYPE.clone(),
-                    field.is_nullable(),
-                )
-                .with_metadata(logical_field.metadata().clone()),
-            )
+                    field.data_type()
+                )));
+            };
+            match BlobV2Layout::classify(fields) {
+                Some(BlobV2Layout::Logical) => Ok(field.clone()),
+                Some(BlobV2Layout::Descriptor) => {
+                    let logical_field = arrow_schema::Field::from(dataset_field);
+                    Ok(Arc::new(
+                        arrow_schema::Field::new(
+                            field.name(),
+                            BLOB_V2_LOGICAL_TYPE.clone(),
+                            field.is_nullable(),
+                        )
+                        .with_metadata(logical_field.metadata().clone()),
+                    ))
+                }
+                Some(actual) => Err(Error::invalid_input(format!(
+                    "Blob v2 merge input '{}' has {actual} layout; expected logical or descriptor layout",
+                    field.name()
+                ))),
+                None => Err(Error::invalid_input(format!(
+                    "Blob v2 merge input '{}' has unrecognized layout {fields:?}; expected logical or descriptor layout",
+                    field.name()
+                ))),
+            }
         })
-        .collect::<Vec<_>>();
-    Arc::new(arrow_schema::Schema::new_with_metadata(
+        .collect::<lance_core::Result<Vec<_>>>()?;
+    Ok(Arc::new(arrow_schema::Schema::new_with_metadata(
         fields
             .iter()
             .map(|field| field.as_ref().clone())
             .collect::<Vec<_>>(),
         input_schema.metadata().clone(),
-    ))
+    )))
 }
 
 /// Shared state for merge insert operations to simplify lock management
@@ -913,7 +928,9 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
             .any(|field| field.is_blob_v2());
         let input_stream = if has_blob_v2_columns {
             let input_schema = input_stream.schema();
-            let output_schema = blob_v2_user_view_schema(input_schema, self.dataset.schema());
+            let output_schema =
+                descriptor_to_logical_blob_schema(input_schema, self.dataset.schema())
+                    .map_err(|error| DataFusionError::External(Box::new(error)))?;
             let dataset = self.dataset.clone();
             let dataset_schema = self.dataset.schema().clone();
             let transformed = input_stream.then(move |batch_result| {
@@ -1125,6 +1142,27 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
 mod tests {
     use super::*;
     use arrow_array::UInt64Array;
+
+    #[test]
+    fn test_descriptor_to_logical_blob_schema_rejects_prepared_layout() {
+        let logical_field = crate::blob::blob_field("blob", true);
+        let dataset_schema =
+            lance_core::datatypes::Schema::try_from(&Schema::new(vec![logical_field.clone()]))
+                .unwrap();
+        let prepared_field = arrow_schema::Field::new(
+            "blob",
+            lance_core::datatypes::BLOB_V2_PREPARED_TYPE.clone(),
+            true,
+        )
+        .with_metadata(logical_field.metadata().clone());
+        let input_schema = Arc::new(Schema::new(vec![prepared_field]));
+
+        let error = descriptor_to_logical_blob_schema(input_schema, &dataset_schema).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains(
+            "Blob v2 merge input 'blob' has prepared layout; expected logical or descriptor layout"
+        ));
+    }
 
     #[test]
     fn test_merge_state_duplicate_rowid_detection_fail() {


### PR DESCRIPTION
Blob V2 columns move through logical, writer-prepared, and stored descriptor struct layouts, but each path previously identified them with its own field probe. This left representation assumptions implicit and allowed mismatches to fail several layers after the boundary.

This centralizes the layout definitions and classifier in `lance-core`, unifies logical and user-view terminology, and makes conversions validate their expected source layout. Stable on-disk descriptor fields remain unchanged, with the `BlobKind`-dependent semantics documented explicitly.

Closes #8201