### PR TITLE
fix: manifest file walkers miss data-overlay files

### DIFF
--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -547,6 +547,28 @@ impl Fragment {
         }
     }
 
+    /// Every data file this fragment references: the base files plus the data
+    /// file of each overlay.
+    ///
+    /// Prefer this over `files`, which omits overlays.
+    pub fn data_files(&self) -> impl Iterator<Item = &DataFile> + '_ {
+        // Destructured on purpose: a new field here fails to compile until
+        // someone decides whether it references files.
+        let Self {
+            id: _,
+            files,
+            overlays,
+            deletion_file: _,
+            row_id_meta: _,
+            physical_rows: _,
+            last_updated_at_version_meta: _,
+            created_at_version_meta: _,
+        } = self;
+        files
+            .iter()
+            .chain(overlays.iter().map(|overlay| &overlay.data_file))
+    }
+
     pub fn from_json(json: &str) -> Result<Self> {
         let fragment: Self = serde_json::from_str(json)?;
         Ok(fragment)

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -569,6 +569,26 @@ impl Fragment {
             .chain(overlays.iter().map(|overlay| &overlay.data_file))
     }
 
+    /// Mutable counterpart of [`Self::data_files`], for rewriting the fields a
+    /// clone has to normalize (`base_id`) across base and overlay files alike.
+    pub fn data_files_mut(&mut self) -> impl Iterator<Item = &mut DataFile> + '_ {
+        // Destructured for the same reason as `data_files`, and so the two
+        // disjoint field borrows are visible to the borrow checker.
+        let Self {
+            id: _,
+            files,
+            overlays,
+            deletion_file: _,
+            row_id_meta: _,
+            physical_rows: _,
+            last_updated_at_version_meta: _,
+            created_at_version_meta: _,
+        } = self;
+        files
+            .iter_mut()
+            .chain(overlays.iter_mut().map(|overlay| &mut overlay.data_file))
+    }
+
     pub fn from_json(json: &str) -> Result<Self> {
         let fragment: Self = serde_json::from_str(json)?;
         Ok(fragment)

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -550,8 +550,9 @@ impl Fragment {
     /// Every data file this fragment references: the base files plus the data
     /// file of each overlay.
     ///
-    /// Prefer this over `files`, which omits overlays.
-    pub fn data_files(&self) -> impl Iterator<Item = &DataFile> + '_ {
+    /// Prefer this over `files`, which is the base files only and so omits
+    /// overlays.
+    pub fn all_data_files(&self) -> impl Iterator<Item = &DataFile> + '_ {
         // Destructured on purpose: a new field here fails to compile until
         // someone decides whether it references files.
         let Self {
@@ -569,10 +570,10 @@ impl Fragment {
             .chain(overlays.iter().map(|overlay| &overlay.data_file))
     }
 
-    /// Mutable counterpart of [`Self::data_files`], for rewriting the fields a
-    /// clone has to normalize (`base_id`) across base and overlay files alike.
-    pub fn data_files_mut(&mut self) -> impl Iterator<Item = &mut DataFile> + '_ {
-        // Destructured for the same reason as `data_files`, and so the two
+    /// Mutable counterpart of [`Self::all_data_files`], for rewriting the fields
+    /// a clone has to normalize (`base_id`) across base and overlay files alike.
+    pub fn all_data_files_mut(&mut self) -> impl Iterator<Item = &mut DataFile> + '_ {
+        // Destructured for the same reason as `all_data_files`, and so the two
         // disjoint field borrows are visible to the borrow checker.
         let Self {
             id: _,

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -547,12 +547,13 @@ impl Fragment {
         }
     }
 
-    /// Every data file this fragment references: the base files plus the data
-    /// file of each overlay.
+    /// Every Lance-format file this fragment references: the base data files
+    /// plus the data file of each overlay. The fragment's other referenced
+    /// files (deletion files, external row-id files) are not in this format.
     ///
-    /// Prefer this over `files`, which is the base files only and so omits
+    /// Prefer this over `files`, which is the base data files only and so omits
     /// overlays.
-    pub fn all_data_files(&self) -> impl Iterator<Item = &DataFile> + '_ {
+    pub fn referenced_lance_files(&self) -> impl Iterator<Item = &DataFile> + '_ {
         // Destructured on purpose: a new field here fails to compile until
         // someone decides whether it references files.
         let Self {
@@ -570,11 +571,12 @@ impl Fragment {
             .chain(overlays.iter().map(|overlay| &overlay.data_file))
     }
 
-    /// Mutable counterpart of [`Self::all_data_files`], for rewriting the fields
-    /// a clone has to normalize (`base_id`) across base and overlay files alike.
-    pub fn all_data_files_mut(&mut self) -> impl Iterator<Item = &mut DataFile> + '_ {
-        // Destructured for the same reason as `all_data_files`, and so the two
-        // disjoint field borrows are visible to the borrow checker.
+    /// Mutable counterpart of [`Self::referenced_lance_files`], for rewriting
+    /// the fields a clone has to normalize (`base_id`) across base and overlay
+    /// files alike.
+    pub fn referenced_lance_files_mut(&mut self) -> impl Iterator<Item = &mut DataFile> + '_ {
+        // Destructured for the same reason as `referenced_lance_files`, and so
+        // the two disjoint field borrows are visible to the borrow checker.
         let Self {
             id: _,
             files,

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -250,7 +250,7 @@ impl Manifest {
             .iter()
             .map(|fragment| {
                 let mut cloned_fragment = fragment.clone();
-                for file in &mut cloned_fragment.files {
+                for file in cloned_fragment.data_files_mut() {
                     if file.base_id.is_none() {
                         file.base_id = Some(ref_base_id);
                     }
@@ -1114,6 +1114,51 @@ mod tests {
 
     use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
     use lance_core::datatypes::Field;
+
+    /// A shallow clone points every local file at the parent through `base_id`.
+    /// An overlay's data file lives in the parent too, so it needs the same
+    /// stamp; without it the clone looks for the overlay under its own root.
+    #[test]
+    fn shallow_clone_stamps_base_id_on_overlay_files() {
+        use crate::format::overlay::{DataOverlayFile, OverlayCoverage};
+        use roaring::RoaringBitmap;
+
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let mut fragment = Fragment::with_file_legacy(0, "base.lance", &schema, Some(10));
+        fragment.overlays = vec![DataOverlayFile {
+            data_file: DataFile::new_legacy_from_fields("overlay.lance", vec![0], None),
+            coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter([0_u32]))),
+            committed_version: 1,
+        }];
+        let manifest = Manifest::new(
+            schema,
+            Arc::new(vec![fragment]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+
+        let cloned = manifest.shallow_clone(
+            Some("parent".to_string()),
+            "memory://parent".to_string(),
+            7,
+            None,
+            String::new(),
+        );
+
+        let fragment = &cloned.fragments[0];
+        assert_eq!(fragment.files[0].base_id, Some(7));
+        assert_eq!(
+            fragment.overlays[0].data_file.base_id,
+            Some(7),
+            "the overlay's data file resolves against the parent as well"
+        );
+    }
 
     #[test]
     fn old_empty_manifest_recovers_v1_or_current_stable() {

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -250,7 +250,7 @@ impl Manifest {
             .iter()
             .map(|fragment| {
                 let mut cloned_fragment = fragment.clone();
-                for file in cloned_fragment.data_files_mut() {
+                for file in cloned_fragment.all_data_files_mut() {
                     if file.base_id.is_none() {
                         file.base_id = Some(ref_base_id);
                     }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -250,7 +250,7 @@ impl Manifest {
             .iter()
             .map(|fragment| {
                 let mut cloned_fragment = fragment.clone();
-                for file in cloned_fragment.all_data_files_mut() {
+                for file in cloned_fragment.referenced_lance_files_mut() {
                     if file.base_id.is_none() {
                         file.base_id = Some(ref_base_id);
                     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3319,7 +3319,7 @@ impl Dataset {
                     external_file.path
                 )));
             }
-            for data_file in fragment.files.iter() {
+            for data_file in fragment.data_files() {
                 let base_root = if let Some(base_id) = data_file.base_id {
                     let base_path =
                         self.manifest.base_paths.get(&base_id).ok_or_else(|| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3319,7 +3319,7 @@ impl Dataset {
                     external_file.path
                 )));
             }
-            for data_file in fragment.data_files() {
+            for data_file in fragment.all_data_files() {
                 let base_root = if let Some(base_id) = data_file.base_id {
                     let base_path =
                         self.manifest.base_paths.get(&base_id).ok_or_else(|| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3319,7 +3319,7 @@ impl Dataset {
                     external_file.path
                 )));
             }
-            for data_file in fragment.all_data_files() {
+            for data_file in fragment.referenced_lance_files() {
                 let base_root = if let Some(base_id) = data_file.base_id {
                     let base_path =
                         self.manifest.base_paths.get(&base_id).ok_or_else(|| {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -594,7 +594,7 @@ impl<'a> CleanupTask<'a> {
         };
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.files.iter() {
+            for file in fragment.data_files() {
                 let full_data_path = self.dataset.data_dir().clone().join(file.path.as_str());
                 let relative_data_path = remove_prefix(&full_data_path, &self.dataset.base);
                 referenced_files.data_paths.insert(relative_data_path);
@@ -2698,6 +2698,68 @@ mod tests {
         assert_gt!(removed.transaction_files_removed, 0);
         assert_gt!(removed.index_files_removed, 0);
         assert_gt!(removed.deletion_files_removed, 0);
+    }
+
+    /// A keep set built from `fragment.files` alone omits overlay data files, so
+    /// cleanup would delete live data.
+    #[tokio::test]
+    async fn keep_set_covers_referenced_overlay_files() {
+        use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+        use roaring::RoaringBitmap;
+
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+
+        // The overlay file need not exist: the keep set comes from manifest
+        // metadata alone.
+        let mut dataset = fixture.open().await.unwrap();
+        let mut fragments: Vec<_> = dataset
+            .get_fragments()
+            .iter()
+            .map(|f| f.metadata().clone())
+            .collect();
+        let mut overlay_file = fragments[0].files[0].clone();
+        overlay_file.path = "overlay.lance".to_string();
+        fragments[0].overlays = vec![DataOverlayFile {
+            data_file: overlay_file,
+            coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter([0_u32]))),
+            committed_version: dataset.manifest.version,
+        }];
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::Overwrite {
+                fragments,
+                schema: dataset.schema().clone(),
+                config_upsert_values: None,
+                initial_bases: None,
+            },
+            None,
+        );
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let task = CleanupTask::new(
+            &dataset,
+            CleanupPolicyBuilder::default()
+                .before_timestamp(utc_now())
+                .build(),
+            CleanupAction::Execute,
+        );
+        let inspection = task.process_manifests(&HashSet::new()).await.unwrap();
+        let kept: HashSet<&Path> = inspection
+            .referenced_files
+            .data_paths
+            .iter()
+            .chain(inspection.verified_files.data_paths.iter())
+            .collect();
+
+        let overlay_path = Path::from("data/overlay.lance");
+        assert!(
+            kept.contains(&overlay_path),
+            "the overlay's data file must be in the keep set, got {kept:?}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -594,7 +594,7 @@ impl<'a> CleanupTask<'a> {
         };
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.all_data_files() {
+            for file in fragment.referenced_lance_files() {
                 let full_data_path = self.dataset.data_dir().clone().join(file.path.as_str());
                 let relative_data_path = remove_prefix(&full_data_path, &self.dataset.base);
                 referenced_files.data_paths.insert(relative_data_path);
@@ -1147,7 +1147,7 @@ impl<'a> CleanupTask<'a> {
         let mut is_referenced = false;
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.all_data_files() {
+            for file in fragment.referenced_lance_files() {
                 if let Some(base_id) = file.base_id {
                     let base_path = manifest.base_paths.get(&base_id);
                     if let Some(base_path) = base_path

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -594,7 +594,7 @@ impl<'a> CleanupTask<'a> {
         };
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.data_files() {
+            for file in fragment.all_data_files() {
                 let full_data_path = self.dataset.data_dir().clone().join(file.path.as_str());
                 let relative_data_path = remove_prefix(&full_data_path, &self.dataset.base);
                 referenced_files.data_paths.insert(relative_data_path);
@@ -1147,7 +1147,7 @@ impl<'a> CleanupTask<'a> {
         let mut is_referenced = false;
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.data_files() {
+            for file in fragment.all_data_files() {
                 if let Some(base_id) = file.base_id {
                     let base_path = manifest.base_paths.get(&base_id);
                     if let Some(base_path) = base_path

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1147,7 +1147,7 @@ impl<'a> CleanupTask<'a> {
         let mut is_referenced = false;
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.files.iter() {
+            for file in fragment.data_files() {
                 if let Some(base_id) = file.base_id {
                     let base_path = manifest.base_paths.get(&base_id);
                     if let Some(base_path) = base_path
@@ -2698,6 +2698,85 @@ mod tests {
         assert_gt!(removed.transaction_files_removed, 0);
         assert_gt!(removed.index_files_removed, 0);
         assert_gt!(removed.deletion_files_removed, 0);
+    }
+
+    /// A branch reaches its parent's files through `base_id`, and
+    /// `retain_branch_lineage_files` promotes those into the parent's keep set. An
+    /// overlay inherited that way must be promoted too, or the parent deletes a
+    /// file the branch still reads.
+    #[tokio::test]
+    async fn lineage_retention_covers_inherited_overlay_files() {
+        use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+        use roaring::RoaringBitmap;
+
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+
+        // Give the parent an overlay, then branch from it: `shallow_clone` stamps
+        // the overlay's `base_id` so the branch resolves it against the parent.
+        let mut dataset = fixture.open().await.unwrap();
+        let mut fragments: Vec<_> = dataset
+            .get_fragments()
+            .iter()
+            .map(|f| f.metadata().clone())
+            .collect();
+        let mut overlay_file = fragments[0].files[0].clone();
+        overlay_file.path = "overlay.lance".to_string();
+        fragments[0].overlays = vec![DataOverlayFile {
+            data_file: overlay_file,
+            coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter([0_u32]))),
+            committed_version: dataset.manifest.version,
+        }];
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::Overwrite {
+                fragments,
+                schema: dataset.schema().clone(),
+                config_upsert_values: None,
+                initial_bases: None,
+            },
+            None,
+        );
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let branch = fixture
+            .create_branch_and_load(&mut dataset, "child", (None, None))
+            .await
+            .unwrap();
+        let branch_fragments = branch.get_fragments();
+        let inherited = &branch_fragments[0].metadata().overlays[0].data_file;
+        assert!(
+            inherited.base_id.is_some(),
+            "the branch must reach the parent's overlay through base_id"
+        );
+
+        // The parent's cleanup walks the branch's manifest and must promote that
+        // overlay out of `verified_files`.
+        let task = CleanupTask::new(
+            &dataset,
+            CleanupPolicyBuilder::default()
+                .before_timestamp(utc_now())
+                .build(),
+            CleanupAction::Execute,
+        );
+        let inspection = task.process_manifests(&HashSet::new()).await.unwrap();
+        let referenced_branches = task.find_referenced_branches().await.unwrap();
+        let inspection = task
+            .retain_branch_lineage_files(inspection, &referenced_branches, &HashSet::new())
+            .await
+            .unwrap();
+
+        let overlay_path = Path::from("data/overlay.lance");
+        assert!(
+            inspection
+                .referenced_files
+                .data_paths
+                .contains(&overlay_path),
+            "the inherited overlay must be promoted into the parent's keep set"
+        );
     }
 
     /// A keep set built from `fragment.files` alone omits overlay data files, so

--- a/rust/lance/src/dataset/files.rs
+++ b/rust/lance/src/dataset/files.rs
@@ -112,7 +112,7 @@ fn manifest_file_rows<'a>(
     for fragment in manifest.fragments.iter() {
         // Precount with the same accessor as the iterator below, or `exact_size`
         // drifts.
-        files += fragment.all_data_files().count();
+        files += fragment.referenced_lance_files().count();
 
         if fragment.deletion_file.is_some() {
             files += 1;
@@ -120,7 +120,7 @@ fn manifest_file_rows<'a>(
     }
 
     let data_files = manifest.fragments.iter().flat_map(move |fragment| {
-        fragment.all_data_files().map(move |data_file| {
+        fragment.referenced_lance_files().map(move |data_file| {
             let resolved_base = resolve_file_base(manifest, data_file.base_id, base_uri);
             let path = if resolved_base.is_dataset_root {
                 Cow::Owned(format!("{}/{}", DATA_DIR, data_file.path))

--- a/rust/lance/src/dataset/files.rs
+++ b/rust/lance/src/dataset/files.rs
@@ -112,7 +112,7 @@ fn manifest_file_rows<'a>(
     for fragment in manifest.fragments.iter() {
         // Precount with the same accessor as the iterator below, or `exact_size`
         // drifts.
-        files += fragment.data_files().count();
+        files += fragment.all_data_files().count();
 
         if fragment.deletion_file.is_some() {
             files += 1;
@@ -120,7 +120,7 @@ fn manifest_file_rows<'a>(
     }
 
     let data_files = manifest.fragments.iter().flat_map(move |fragment| {
-        fragment.data_files().map(move |data_file| {
+        fragment.all_data_files().map(move |data_file| {
             let resolved_base = resolve_file_base(manifest, data_file.base_id, base_uri);
             let path = if resolved_base.is_dataset_root {
                 Cow::Owned(format!("{}/{}", DATA_DIR, data_file.path))

--- a/rust/lance/src/dataset/files.rs
+++ b/rust/lance/src/dataset/files.rs
@@ -110,7 +110,9 @@ fn manifest_file_rows<'a>(
     };
 
     for fragment in manifest.fragments.iter() {
-        files += fragment.files.len();
+        // Precount with the same accessor as the iterator below, or `exact_size`
+        // drifts.
+        files += fragment.data_files().count();
 
         if fragment.deletion_file.is_some() {
             files += 1;
@@ -118,7 +120,7 @@ fn manifest_file_rows<'a>(
     }
 
     let data_files = manifest.fragments.iter().flat_map(move |fragment| {
-        fragment.files.iter().map(move |data_file| {
+        fragment.data_files().map(move |data_file| {
             let resolved_base = resolve_file_base(manifest, data_file.base_id, base_uri);
             let path = if resolved_base.is_dataset_root {
                 Cow::Owned(format!("{}/{}", DATA_DIR, data_file.path))
@@ -1025,6 +1027,7 @@ mod tests {
     fn test_manifest_file_rows_per_file_base_id() {
         use lance_core::datatypes::{Field as LanceField, Schema as LanceSchema};
         use lance_io::utils::CachedFileSize;
+        use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
         use lance_table::format::{
             BasePath, DataFile, DataStorageFormat, DeletionFile, DeletionFileType, Fragment,
             Manifest,
@@ -1053,7 +1056,13 @@ mod tests {
                 // No base_id -> falls back to the dataset base_uri.
                 mk_file("c.lance", None),
             ],
-            overlays: vec![],
+            // An overlay's data file is reported like any other, and resolves
+            // its own base_id.
+            overlays: vec![DataOverlayFile {
+                data_file: mk_file("d.lance", Some(1)),
+                coverage: OverlayCoverage::Shared(Arc::new(Default::default())),
+                committed_version: 1,
+            }],
             // Deletion files also carry a base_id when they originate from a
             // shallow clone, and must resolve against base_paths too.
             deletion_file: Some(DeletionFile {
@@ -1097,6 +1106,7 @@ mod tests {
         assert_eq!(by_path.get("a.lance"), Some(&"s3://bucket-a/root"));
         assert_eq!(by_path.get("data/b.lance"), Some(&"s3://bucket-b/root"));
         assert_eq!(by_path.get("data/c.lance"), Some(&"memory://main"));
+        assert_eq!(by_path.get("d.lance"), Some(&"s3://bucket-a/root"));
 
         let deletion = rows
             .iter()

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -3251,9 +3251,6 @@ mod tests {
         /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `val` (field 1)
         /// = id * 10, written 6 rows per file (fragments 0 and 1).
         ///
-        /// Uses an in-memory store so the test can write overlay files with a
-        /// store-relative `data/<name>.lance` path and commit against the returned
-        /// dataset directly.
         async fn create_base_dataset(version: LanceFileVersion) -> Dataset {
             let schema = Arc::new(ArrowSchema::new(vec![
                 ArrowField::new("id", DataType::Int32, true),
@@ -3296,7 +3293,9 @@ mod tests {
             let overlay_schema = dataset.schema().project_by_ids(fields, true);
 
             let filename = format!("{name}.lance");
-            let path = Path::from(format!("data/{filename}"));
+            // The manifest records the bare filename; only the physical write is
+            // data-dir qualified.
+            let path = dataset.data_dir().join(filename.as_str());
             let obj_writer = dataset.object_store.create(&path).await.unwrap();
             let file_version = ConcreteFileVersion::from(version);
             let mut writer = lance_file::versions::create_writer(
@@ -3347,6 +3346,80 @@ mod tests {
             )
             .await
             .unwrap()
+        }
+
+        /// `collect_paths` feeds `deep_clone`'s copy loop, so an overlay data file
+        /// it omits is referenced by the clone's manifest but never copied. The
+        /// clone then fails to read the overlaid values.
+        #[tokio::test]
+        async fn deep_clone_copies_overlay_files() {
+            use lance_core::utils::tempfile::TempStdDir;
+
+            let version = LanceFileVersion::Stable;
+            let test_dir = TempStdDir::default();
+            let source_uri = test_dir.join("source").to_str().unwrap().to_string();
+            let clone_uri = test_dir.join("clone").to_str().unwrap().to_string();
+
+            let schema = Arc::new(ArrowSchema::new(vec![
+                ArrowField::new("id", DataType::Int32, true),
+                ArrowField::new("val", DataType::Int32, true),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values(0..6)),
+                    Arc::new(Int32Array::from_iter_values((0..6).map(|v| v * 10))),
+                ],
+            )
+            .unwrap();
+            let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+            let dataset = Dataset::write(
+                reader,
+                &source_uri,
+                Some(WriteParams {
+                    max_rows_per_file: 6,
+                    max_rows_per_group: 6,
+                    data_storage_version: Some(version),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+            // Overlay `val` on offsets 0 and 1 of fragment 0.
+            let mut dataset = commit_overlay(
+                dataset,
+                "overlay0",
+                0,
+                &[1],
+                OverlayCoverage::Shared(Arc::new(bitmap([0, 1]))),
+                vec![i32_array([Some(700), Some(701)])],
+                version,
+            )
+            .await;
+
+            let source_version = dataset.version().version;
+            dataset
+                .tags()
+                .create("clone-me", source_version)
+                .await
+                .unwrap();
+            let cloned = dataset
+                .deep_clone(&clone_uri, "clone-me", None)
+                .await
+                .unwrap();
+
+            let batch = cloned
+                .scan()
+                .try_into_batch()
+                .await
+                .expect("the clone must be readable, including its overlay files");
+            let val = col(&batch, "val");
+            assert_eq!(
+                val.values()[..2],
+                [700, 701],
+                "the clone must return the overlaid values, not the base ones"
+            );
         }
 
         fn full_schema(dataset: &Dataset) -> Schema {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -3422,6 +3422,87 @@ mod tests {
             );
         }
 
+        /// Deep-cloning a shallow clone has to drop every `base_id`, since the
+        /// result owns its files. An overlay whose `base_id` survives points at a
+        /// base the new manifest no longer lists.
+        #[tokio::test]
+        async fn deep_clone_of_shallow_clone_clears_overlay_base_id() {
+            use lance_core::utils::tempfile::TempStdDir;
+
+            let version = LanceFileVersion::Stable;
+            let test_dir = TempStdDir::default();
+            let source_uri = test_dir.join("source").to_str().unwrap().to_string();
+            let shallow_uri = test_dir.join("shallow").to_str().unwrap().to_string();
+            let deep_uri = test_dir.join("deep").to_str().unwrap().to_string();
+
+            let schema = Arc::new(ArrowSchema::new(vec![
+                ArrowField::new("id", DataType::Int32, true),
+                ArrowField::new("val", DataType::Int32, true),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values(0..6)),
+                    Arc::new(Int32Array::from_iter_values((0..6).map(|v| v * 10))),
+                ],
+            )
+            .unwrap();
+            let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+            let dataset = Dataset::write(
+                reader,
+                &source_uri,
+                Some(WriteParams {
+                    max_rows_per_file: 6,
+                    data_storage_version: Some(version),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+            let mut dataset = commit_overlay(
+                dataset,
+                "overlay0",
+                0,
+                &[1],
+                OverlayCoverage::Shared(Arc::new(bitmap([0, 1]))),
+                vec![i32_array([Some(700), Some(701)])],
+                version,
+            )
+            .await;
+
+            let source_version = dataset.version().version;
+            dataset.tags().create("v", source_version).await.unwrap();
+            let mut shallow = dataset
+                .shallow_clone(&shallow_uri, "v", None)
+                .await
+                .unwrap();
+            // The shallow clone reaches the overlay through the parent.
+            assert!(
+                shallow.get_fragments()[0].metadata().overlays[0]
+                    .data_file
+                    .base_id
+                    .is_some(),
+                "the shallow clone must reference the parent's overlay by base_id"
+            );
+
+            let shallow_version = shallow.version().version;
+            shallow.tags().create("v", shallow_version).await.unwrap();
+            let deep = shallow.deep_clone(&deep_uri, "v", None).await.unwrap();
+
+            assert_eq!(
+                deep.get_fragments()[0].metadata().overlays[0]
+                    .data_file
+                    .base_id,
+                None,
+                "a deep clone owns its files, so the overlay must carry no base_id"
+            );
+            assert!(
+                deep.manifest.base_paths.is_empty(),
+                "a deep clone lists no external bases"
+            );
+        }
+
         fn full_schema(dataset: &Dataset) -> Schema {
             dataset.schema().clone()
         }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -821,8 +821,8 @@ pub(crate) async fn cleanup_data_fragments(
     let data_dir = base_dir.clone().join(DATA_DIR);
     let mut skipped_external = 0usize;
     for fragment in fragments {
-        // Deliberately not `data_files()`: callers decide which files belong to
-        // the failed write. `schema_evolution` passes a live fragment whose
+        // Deliberately not `all_data_files()`: callers decide which files belong
+        // to the failed write. `schema_evolution` passes a live fragment whose
         // `files` it narrowed to the newly written ones while leaving `overlays`
         // untouched, so including overlays here would delete live data.
         for file in &fragment.files {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -821,10 +821,11 @@ pub(crate) async fn cleanup_data_fragments(
     let data_dir = base_dir.clone().join(DATA_DIR);
     let mut skipped_external = 0usize;
     for fragment in fragments {
-        // Deliberately not `all_data_files()`: callers decide which files belong
-        // to the failed write. `schema_evolution` passes a live fragment whose
-        // `files` it narrowed to the newly written ones while leaving `overlays`
-        // untouched, so including overlays here would delete live data.
+        // Deliberately not `referenced_lance_files()`: callers decide which
+        // files belong to the failed write. `schema_evolution` passes a live
+        // fragment whose `files` it narrowed to the newly written ones while
+        // leaving `overlays` untouched, so including overlays here would delete
+        // live data.
         for file in &fragment.files {
             let (store, file_dir) = if let Some(base_id) = file.base_id {
                 match target_bases.and_then(|bases| bases.iter().find(|b| b.base_id == base_id)) {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -821,7 +821,7 @@ pub(crate) async fn cleanup_data_fragments(
     let data_dir = base_dir.clone().join(DATA_DIR);
     let mut skipped_external = 0usize;
     for fragment in fragments {
-        for file in &fragment.files {
+        for file in fragment.data_files() {
             let (store, file_dir) = if let Some(base_id) = file.base_id {
                 match target_bases.and_then(|bases| bases.iter().find(|b| b.base_id == base_id)) {
                     Some(base_info) => {
@@ -4013,6 +4013,58 @@ mod tests {
             count_data_files(test_uri),
             0,
             "Local data file should be deleted by cleanup"
+        );
+    }
+
+    /// Cleanup of a failed write must delete overlay data files, not only base
+    /// files.
+    #[tokio::test]
+    async fn test_cleanup_data_fragments_deletes_overlay_files() {
+        use lance_core::utils::tempfile::TempStrDir;
+        use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+        use roaring::RoaringBitmap;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let (object_store, base_dir) =
+            ObjectStore::from_uri_and_params(Default::default(), test_uri, &Default::default())
+                .await
+                .unwrap();
+
+        let data_dir = base_dir.clone().join(DATA_DIR);
+        for name in ["base.lance", "overlay.lance"] {
+            object_store
+                .put(&data_dir.clone().join(name), b"x")
+                .await
+                .unwrap();
+        }
+        assert_eq!(count_data_files(test_uri), 2);
+
+        let fragments = vec![Fragment {
+            id: 0,
+            files: vec![DataFile::new_unstarted(
+                "base.lance",
+                ConcreteFileVersion::V2_1,
+            )],
+            overlays: vec![DataOverlayFile {
+                data_file: DataFile::new_unstarted("overlay.lance", ConcreteFileVersion::V2_1),
+                coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter([0_u32]))),
+                committed_version: 1,
+            }],
+            deletion_file: None,
+            row_id_meta: None,
+            physical_rows: Some(0),
+            created_at_version_meta: None,
+            last_updated_at_version_meta: None,
+        }];
+
+        cleanup_data_fragments(&object_store, &base_dir, None, &fragments).await;
+
+        assert_eq!(
+            count_data_files(test_uri),
+            0,
+            "both the base file and the overlay's data file must be deleted"
         );
     }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -821,7 +821,11 @@ pub(crate) async fn cleanup_data_fragments(
     let data_dir = base_dir.clone().join(DATA_DIR);
     let mut skipped_external = 0usize;
     for fragment in fragments {
-        for file in fragment.data_files() {
+        // Deliberately not `data_files()`: callers decide which files belong to
+        // the failed write. `schema_evolution` passes a live fragment whose
+        // `files` it narrowed to the newly written ones while leaving `overlays`
+        // untouched, so including overlays here would delete live data.
+        for file in &fragment.files {
             let (store, file_dir) = if let Some(base_id) = file.base_id {
                 match target_bases.and_then(|bases| bases.iter().find(|b| b.base_id == base_id)) {
                     Some(base_info) => {
@@ -4013,58 +4017,6 @@ mod tests {
             count_data_files(test_uri),
             0,
             "Local data file should be deleted by cleanup"
-        );
-    }
-
-    /// Cleanup of a failed write must delete overlay data files, not only base
-    /// files.
-    #[tokio::test]
-    async fn test_cleanup_data_fragments_deletes_overlay_files() {
-        use lance_core::utils::tempfile::TempStrDir;
-        use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
-        use roaring::RoaringBitmap;
-
-        let test_dir = TempStrDir::default();
-        let test_uri = test_dir.as_str();
-
-        let (object_store, base_dir) =
-            ObjectStore::from_uri_and_params(Default::default(), test_uri, &Default::default())
-                .await
-                .unwrap();
-
-        let data_dir = base_dir.clone().join(DATA_DIR);
-        for name in ["base.lance", "overlay.lance"] {
-            object_store
-                .put(&data_dir.clone().join(name), b"x")
-                .await
-                .unwrap();
-        }
-        assert_eq!(count_data_files(test_uri), 2);
-
-        let fragments = vec![Fragment {
-            id: 0,
-            files: vec![DataFile::new_unstarted(
-                "base.lance",
-                ConcreteFileVersion::V2_1,
-            )],
-            overlays: vec![DataOverlayFile {
-                data_file: DataFile::new_unstarted("overlay.lance", ConcreteFileVersion::V2_1),
-                coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter([0_u32]))),
-                committed_version: 1,
-            }],
-            deletion_file: None,
-            row_id_meta: None,
-            physical_rows: Some(0),
-            created_at_version_meta: None,
-            last_updated_at_version_meta: None,
-        }];
-
-        cleanup_data_fragments(&object_store, &base_dir, None, &fragments).await;
-
-        assert_eq!(
-            count_data_files(test_uri),
-            0,
-            "both the base file and the overlay's data file must be deleted"
         );
     }
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -421,7 +421,7 @@ async fn do_commit_new_dataset(
                 (!transaction_file.is_empty()).then_some(transaction_file.clone());
             let mut new_frags = new_manifest.fragments.as_ref().clone();
             for f in &mut new_frags {
-                for df in f.data_files_mut() {
+                for df in f.all_data_files_mut() {
                     df.base_id = None;
                 }
                 if let Some(d) = f.deletion_file.as_mut() {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -421,7 +421,7 @@ async fn do_commit_new_dataset(
                 (!transaction_file.is_empty()).then_some(transaction_file.clone());
             let mut new_frags = new_manifest.fragments.as_ref().clone();
             for f in &mut new_frags {
-                for df in &mut f.files {
+                for df in f.data_files_mut() {
                     df.base_id = None;
                 }
                 if let Some(d) = f.deletion_file.as_mut() {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -421,7 +421,7 @@ async fn do_commit_new_dataset(
                 (!transaction_file.is_empty()).then_some(transaction_file.clone());
             let mut new_frags = new_manifest.fragments.as_ref().clone();
             for f in &mut new_frags {
-                for df in f.all_data_files_mut() {
+                for df in f.referenced_lance_files_mut() {
                     df.base_id = None;
                 }
                 if let Some(d) = f.deletion_file.as_mut() {


### PR DESCRIPTION
A fragment references its base files through `files` and its overlay files through `overlays[].data_file`. Six paths read `files` directly and so miss every overlay data file. Three enumerate, and three rewrite or retain.

Enumeration:

- `process_manifest` builds the cleanup keep set, so an overlay old enough to be a deletion candidate is irreversibly deleted from the live dataset.
- `collect_paths` feeds deep clone's copy loop. It copies exactly the paths returned, then commits an `Operation::Clone` whose manifest carries the source fragments verbatim, overlays included, so the clone references files that were never copied and reading it fails with a not-found error.
- `manifest_file_rows` powers `tracked_files`, which under-reports its documented "every file referenced in any manifest" contract. That becomes a deletion risk of its own once its output drives an external cleanup.

Rewriting and retention:

- Shallow clone stamps `base_id` on every local file so the clone resolves it against the parent. Skipping overlays left theirs at `None`, so the clone looked for the overlay under its own root, where it was never written.
- Deep clone clears `base_id` on the same fields. An overlay kept a `base_id` naming a base the new manifest no longer lists.
- Branch lineage retention promotes a path from `verified_files` into `referenced_files` when its `base_id` resolves to the parent's own URI. An overlay a branch inherited never got promoted, so the parent's cleanup deleted a file the branch still reads.

The last two are inseparable. Before this change an inherited overlay carried no `base_id` at all, so retention never examined it; fixing the clone alone would give overlays a `base_id` while retention still skipped them, which is what turns the omission into a deletion.

All six misbehave in any build that can open an overlay-bearing dataset: debug builds unconditionally, release builds only with `LANCE_ENABLE_UNSTABLE_DATA_OVERLAY_FILES` set, since a release reader otherwise refuses the manifest at open and these paths never see one. Within that gate none of them needs a further code change to be reachable.

## The fix

`Fragment::data_files()` yields the base files chained with each overlay's data file, and `data_files_mut()` is its counterpart for the two paths that rewrite `base_id`. Both destructure `Fragment` exhaustively, so a new field fails to compile there until someone decides whether it references files — the prompt that was missing when `overlays` was added in #7535. The mutable one also needs the destructure so the disjoint field borrows are visible to the borrow checker.

`manifest_file_rows` derives its `exact_size` precount from the same accessor. Counting `files.len()` separately would underflow the moment an overlay appeared, since `ExactSize::next` decrements an unsigned counter.

`cleanup_data_fragments` deliberately stays on `files`. It deletes the files a caller hands it, and callers decide which files belong to the failed write: `schema_evolution` clones a live committed fragment and narrows `files` to the newly written ones while leaving `overlays` untouched, so including overlays there would delete live data. The second commit records that reasoning at the loop.

Each converted caller keeps its own `base_id` handling: `collect_paths` resolves it to a base root, `manifest_file_rows` to an external base URI, and `process_manifest` ignores it. Those differ by design, so unifying them is out of scope.

## Tests

Six cases, one per path, each verified to fail with the corresponding accessor reverted to `files`-only:

- `keep_set_covers_referenced_overlay_files` — the keep set contains the overlay path.
- `deep_clone_copies_overlay_files` — the clone returns the overlaid values rather than failing to find the file.
- `test_manifest_file_rows_per_file_base_id` (extended) — the overlay row appears with its own `base_id` resolved.
- `shallow_clone_stamps_base_id_on_overlay_files` — the overlay resolves against the parent.
- `deep_clone_of_shallow_clone_clears_overlay_base_id` — deep-cloning a shallow clone leaves the overlay with no `base_id`.
- `lineage_retention_covers_inherited_overlay_files` — the parent's keep set promotes an overlay its branch inherited. It asserts the branch actually inherited a `base_id` first, so it cannot pass vacuously.

The keep-set and lineage cases assert on `process_manifests` and `retain_branch_lineage_files` output rather than driving cleanup end to end. An end-to-end version cannot reach the deletion decision: `build_listing_stream` passes `earliest_retained_manifest_time` to `read_dir_all`, which lists only files whose mtime predates it, and the test clock does not move real file mtimes, so a file written during the test is never a candidate.

One pre-existing test helper needed a fix to support this: `commit_overlay` wrote through a store-root-relative path that only resolved on an in-memory store, and the clone cases need real stores.

`cargo test -p lance --lib` across `dataset::cleanup`, `dataset::files`, `dataset::fragment`, `dataset::write`, `io::commit`, plus `cargo test -p lance-table --lib format`, all pass. `cargo clippy -p lance -p lance-table --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p lance -p lance-table --no-deps`, and `cargo fmt --all --check` are clean.

## Relation to #8097

This came out of the #8097 discussion, where the suggestion was to factor out the reusable part before rebasing that PR onto it. The overlay drift is an independent defect, so it is split out here rather than mixed into the API discussion. It is not by itself the consolidation asked for there — `Fragment::data_files()` is a fragment-level accessor, and whether that is the "reusable part" or whether `referenced_files` should be rebuilt on `tracked_files`' pipeline is still open. I will follow up on #8097 with that question.
