### PR TITLE
fix(index): handle partial FTS prewarm under cache pressure

### DIFF
--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -23,6 +23,7 @@ use object_store::path::Path;
 use roaring::RoaringBitmap;
 use tokio::sync::OnceCell;
 
+use crate::FtsPrewarmDocumentStatus;
 use crate::scalar::{IndexReader, IndexStore, RowIdRemapper};
 
 use super::index::{DocSet, NUM_TOKEN_COL, dequantize_doc_length, quantize_doc_length};
@@ -644,10 +645,23 @@ impl PartitionDocumentStore {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn query_ready(&self) -> bool {
         match self {
             Self::Legacy(_) => true,
             Self::Modern(docs) => docs.query_ready(),
+        }
+    }
+
+    pub(crate) fn prewarm_status(&self) -> FtsPrewarmDocumentStatus {
+        match self {
+            Self::Legacy(_) => FtsPrewarmDocumentStatus {
+                prewarm_complete: true,
+                scoring_ready: true,
+                reverse_lookup_ready: true,
+                projection_resident: true,
+            },
+            Self::Modern(docs) => docs.prewarm_status(),
         }
     }
 
@@ -754,17 +768,24 @@ impl PartitionDocuments {
         self.resident_address_projection().is_some()
     }
 
+    #[cfg(test)]
     pub(crate) fn query_ready(&self) -> bool {
-        self.prewarm_complete.initialized()
-            && self
+        self.prewarm_status().query_ready()
+    }
+
+    pub(crate) fn prewarm_status(&self) -> FtsPrewarmDocumentStatus {
+        FtsPrewarmDocumentStatus {
+            prewarm_complete: self.prewarm_complete.initialized(),
+            scoring_ready: self
                 .lengths
                 .get()
-                .is_some_and(|lengths| lengths.scoring_ready())
-            && self
+                .is_some_and(|lengths| lengths.scoring_ready()),
+            reverse_lookup_ready: self
                 .projection
                 .get()
-                .is_some_and(|projection| projection.doc_ids_by_address.initialized())
-            && self.projection_resident()
+                .is_some_and(|projection| projection.doc_ids_by_address.initialized()),
+            projection_resident: self.projection_resident(),
+        }
     }
 
     async fn reader(&self) -> Result<Arc<dyn IndexReader>> {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -90,7 +90,9 @@ use crate::scalar::{
     OldIndexDataFilter, RowIdRemapper, ScalarIndex, ScalarIndexParams, SearchResult, TokenQuery,
     UpdateCriteria,
 };
-use crate::{FtsPrewarmOptions, Index};
+use crate::{
+    FtsPrewarmDiagnostics, FtsPrewarmOptions, FtsPrewarmPartitionStatus, FtsPrewarmResult, Index,
+};
 use crate::{prefilter::PreFilter, scalar::inverted::iter::take_fst_keys};
 use std::str::FromStr;
 
@@ -2034,29 +2036,44 @@ fn prewarm_chunk_ranges(
 
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
+        self.prewarm_with_options_result(options).await.map(|_| ())
+    }
+
+    pub async fn prewarm_with_options_result(
+        &self,
+        options: &FtsPrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
         let mut state = self.prewarm_state.lock().await;
         if state.satisfies(options.with_position)
             && (self.is_legacy() || self.document_projections_resident_now())
         {
-            return Ok(());
+            return Ok(FtsPrewarmResult::fully_resident());
         }
         let with_position = options.with_position || state.positions_ready;
         state.query_ready = false;
         state.positions_ready = false;
         self.document_projections_resident
             .store(false, Ordering::Release);
-        self.prewarm_query_state(with_position).await?;
-        state.query_ready = true;
-        state.positions_ready = with_position;
-        Ok(())
+        let result = self
+            .prewarm_query_state(with_position, options.mode.is_best_effort())
+            .await?;
+        if result.fully_resident {
+            state.query_ready = true;
+            state.positions_ready = with_position;
+        }
+        Ok(result)
     }
 
-    async fn prewarm_query_state(&self, with_position: bool) -> Result<()> {
+    async fn prewarm_query_state(
+        &self,
+        with_position: bool,
+        best_effort: bool,
+    ) -> Result<FtsPrewarmResult> {
         let chunk_concurrency = self.store.io_parallelism().max(1);
         let prewarm_started = Instant::now();
         info!(
             partition_count = self.partitions.len(),
-            with_position, chunk_concurrency, "fts index prewarm started"
+            with_position, best_effort, chunk_concurrency, "fts index prewarm started"
         );
         for part in &self.partitions {
             let partition_started = Instant::now();
@@ -2104,25 +2121,50 @@ impl InvertedIndex {
             );
         }
         self.aggregate_corpus_stats().await?;
-        let query_ready = self.partitions.iter().all(|partition| {
-            partition.docs.query_ready()
-                && partition.inverted_list.modern_posting_validation_ready()
-        });
-        if !query_ready {
-            return Err(Error::internal(
-                "FTS prewarm completed without publishing a query-ready document and posting state"
-                    .to_owned(),
-            ));
+        let diagnostics = self.prewarm_diagnostics();
+        if !diagnostics.fully_resident() {
+            if best_effort {
+                warn!(
+                    partition_count = diagnostics.partition_count,
+                    failing_partition_count = diagnostics.failing_partitions.len(),
+                    diagnostics = %diagnostics,
+                    elapsed_ms = prewarm_started.elapsed().as_millis() as u64,
+                    "fts index prewarm finished with partial residency"
+                );
+                return Ok(FtsPrewarmResult::partial(diagnostics));
+            }
+            return Err(Error::internal(diagnostics.to_string()));
         }
         self.document_projections_resident
             .store(true, Ordering::Release);
         info!(
             partition_count = self.partitions.len(),
-            query_ready,
+            query_ready = true,
             elapsed_ms = prewarm_started.elapsed().as_millis() as u64,
             "fts index prewarm finished"
         );
-        Ok(())
+        Ok(FtsPrewarmResult::fully_resident())
+    }
+
+    fn prewarm_diagnostics(&self) -> FtsPrewarmDiagnostics {
+        let failing_partitions = self
+            .partitions
+            .iter()
+            .filter_map(|partition| {
+                let status = FtsPrewarmPartitionStatus {
+                    partition_id: partition.id(),
+                    documents: partition.docs.prewarm_status(),
+                    posting_validation_ready: partition
+                        .inverted_list
+                        .modern_posting_validation_ready(),
+                };
+                (!status.query_ready()).then_some(status)
+            })
+            .collect();
+        FtsPrewarmDiagnostics {
+            partition_count: self.partitions.len(),
+            failing_partitions,
+        }
     }
     /// Search docs match the input text.
     async fn do_search(&self, text: &str) -> Result<RecordBatch> {
@@ -11219,6 +11261,103 @@ mod tests {
         prewarmed_row_ids.sort_unstable();
         assert_eq!(prewarmed_row_ids, expected);
         assert_eq!(prewarmed_scores, cold_scores);
+    }
+
+    #[tokio::test]
+    async fn test_strict_modern_prewarm_fails_when_index_cache_cannot_hold_all_partitions() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let params = InvertedIndexParams::default().format_version(InvertedListFormatVersion::V2);
+        let format_version = params.resolved_format_version();
+        let partition_count = 6_u64;
+        let docs_per_partition = 512_u32;
+
+        for partition_id in 0..partition_count {
+            let mut builder = InnerBuilder::new_with_format_version_and_block_size(
+                partition_id,
+                false,
+                TokenSetFormat::default(),
+                format_version,
+                params.posting_block_size(),
+            );
+            builder.tokens.add(format!("token_{partition_id}"));
+            let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                false,
+                format_version.posting_tail_codec(),
+                params.posting_block_size(),
+            );
+            for doc_id in 0..docs_per_partition {
+                posting.add(doc_id, PositionRecorder::Count(1));
+                builder
+                    .docs
+                    .append(partition_id * 1_000_000 + doc_id as u64, 1);
+            }
+            builder.posting_lists.push(posting);
+            builder.write(store.as_ref()).await.unwrap();
+        }
+        write_test_metadata(&store, (0..partition_count).collect(), params).await;
+
+        let cache = Arc::new(LanceCache::with_backend(Arc::new(
+            QuickCacheBackend::with_capacity(8 * 1024),
+        )));
+        let index = InvertedIndex::load(store, None, cache.as_ref())
+            .await
+            .unwrap();
+
+        let err = index
+            .prewarm_with_options(&FtsPrewarmOptions::default())
+            .await
+            .unwrap_err();
+        let err = err.to_string();
+        assert!(
+            err.contains(
+                "FTS prewarm completed without publishing a query-ready document and posting state"
+            ),
+            "unexpected error: {err}"
+        );
+        assert!(
+            index
+                .partitions
+                .iter()
+                .any(|partition| !partition.docs.query_ready()),
+            "strict prewarm should fail because at least one partition lost query-ready state"
+        );
+        assert!(
+            index
+                .partitions
+                .iter()
+                .all(|partition| partition.inverted_list.modern_posting_validation_ready()),
+            "posting validation should complete; the strict failure should be the final residency postcondition"
+        );
+        assert!(
+            index.partitions.iter().any(|partition| {
+                let docs = partition.docs.modern().unwrap();
+                !docs.projection_resident()
+            }),
+            "at least one modern document projection should be non-resident"
+        );
+
+        let result = index
+            .prewarm_with_options_result(&FtsPrewarmOptions::default().best_effort())
+            .await
+            .unwrap();
+        assert!(!result.fully_resident);
+        let diagnostics = result
+            .diagnostics
+            .expect("best-effort partial prewarm should report diagnostics");
+        assert_eq!(diagnostics.partition_count, partition_count as usize);
+        assert!(!diagnostics.failing_partitions.is_empty());
+        assert!(
+            diagnostics
+                .failing_partitions
+                .iter()
+                .all(|partition| partition.posting_validation_ready),
+            "best-effort should not suppress posting validation failures"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::fmt::Display;
+
 use lance_core::Result;
 
 use lance_table::format::IndexMetadata;
@@ -58,6 +60,9 @@ pub type ScalarIndexCriteria<'a> = IndexCriteria<'a>;
 pub struct FtsPrewarmOptions {
     /// If true, prewarm positions along with posting lists.
     pub with_position: bool,
+    /// Controls whether prewarm requires the full requested FTS working set to
+    /// remain resident when the operation completes.
+    pub mode: FtsPrewarmMode,
 }
 
 impl FtsPrewarmOptions {
@@ -68,6 +73,147 @@ impl FtsPrewarmOptions {
     pub fn with_position(mut self, with_position: bool) -> Self {
         self.with_position = with_position;
         self
+    }
+
+    pub fn with_mode(mut self, mode: FtsPrewarmMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn best_effort(mut self) -> Self {
+        self.mode = FtsPrewarmMode::BestEffort;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FtsPrewarmMode {
+    #[default]
+    Strict,
+    BestEffort,
+}
+
+impl FtsPrewarmMode {
+    pub fn is_best_effort(self) -> bool {
+        matches!(self, Self::BestEffort)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmResult {
+    pub fully_resident: bool,
+    pub diagnostics: Option<FtsPrewarmDiagnostics>,
+}
+
+impl FtsPrewarmResult {
+    pub fn fully_resident() -> Self {
+        Self {
+            fully_resident: true,
+            diagnostics: None,
+        }
+    }
+
+    pub fn partial(diagnostics: FtsPrewarmDiagnostics) -> Self {
+        Self {
+            fully_resident: false,
+            diagnostics: Some(diagnostics),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmDiagnostics {
+    pub partition_count: usize,
+    pub failing_partitions: Vec<FtsPrewarmPartitionStatus>,
+}
+
+impl FtsPrewarmDiagnostics {
+    pub fn fully_resident(&self) -> bool {
+        self.failing_partitions.is_empty()
+    }
+}
+
+impl Display for FtsPrewarmDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FTS prewarm completed without publishing a query-ready document and posting state; \
+             {} of {} partition(s) are not fully resident",
+            self.failing_partitions.len(),
+            self.partition_count
+        )?;
+        if !self.failing_partitions.is_empty() {
+            write!(f, ": ")?;
+            for (index, partition) in self.failing_partitions.iter().enumerate() {
+                if index > 0 {
+                    write!(f, "; ")?;
+                }
+                write!(f, "{partition}")?;
+            }
+        }
+        write!(
+            f,
+            ". Likely cause: index cache pressure or insufficient capacity. \
+             Suggested remediation: increase index-cache capacity, reduce the number of FTS \
+             segments assigned to each executor, or adjust placement/segment sizing."
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmPartitionStatus {
+    pub partition_id: u64,
+    pub documents: FtsPrewarmDocumentStatus,
+    pub posting_validation_ready: bool,
+}
+
+impl FtsPrewarmPartitionStatus {
+    pub fn query_ready(&self) -> bool {
+        self.documents.query_ready() && self.posting_validation_ready
+    }
+}
+
+impl Display for FtsPrewarmPartitionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut missing = Vec::new();
+        if !self.documents.prewarm_complete {
+            missing.push("document prewarm completion");
+        }
+        if !self.documents.scoring_ready {
+            missing.push("scoring lengths/norms");
+        }
+        if !self.documents.reverse_lookup_ready {
+            missing.push("reverse document lookup");
+        }
+        if !self.documents.projection_resident {
+            missing.push("resident row-address projection");
+        }
+        if !self.posting_validation_ready {
+            missing.push("posting validation");
+        }
+        write!(
+            f,
+            "partition {} missing {}",
+            self.partition_id,
+            missing.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FtsPrewarmDocumentStatus {
+    pub prewarm_complete: bool,
+    pub scoring_ready: bool,
+    pub reverse_lookup_ready: bool,
+    pub projection_resident: bool,
+}
+
+impl FtsPrewarmDocumentStatus {
+    pub fn query_ready(&self) -> bool {
+        self.prewarm_complete
+            && self.scoring_ready
+            && self.reverse_lookup_ready
+            && self.projection_resident
     }
 }
 


### PR DESCRIPTION
## Issue

Sophon durable index-cache prewarm can fail for modern FTS indexes when the executor's index cache cannot retain every partition's prewarmed query state at once. Lance currently treats this post-prewarm residency check as a hard correctness failure and returns:

`FTS prewarm completed without publishing a query-ready document and posting state`

That makes a cache-capacity condition look like an execution failure. In practice, the index can still be usable; some warmed document/projection state simply got evicted before the final readiness check completed.

## Root Cause

Modern FTS prewarm loads per-partition document state, scoring state, reverse lookup state, and posting validation state. After warming every partition, Lance checks that all of those pieces are still resident. With a small index cache or many FTS partitions assigned to the same executor, earlier partitions can be evicted while later partitions are warming. The old code returned an error when this happened, which caused Sophon durable prewarm jobs to fail even though the underlying condition was cache pressure rather than a malformed index or failed IO.

## Solution

This adds an explicit FTS prewarm mode:

- `Strict`: preserves the previous behavior and fails if all warmed FTS query state is not fully resident.
- `BestEffort`: prewarms everything it can and returns a partial result with diagnostics instead of failing purely because cache pressure prevented full residency.

The existing `prewarm_with_options` API remains strict-compatible. A new `prewarm_with_options_result` API returns structured residency information for callers that want best-effort behavior and diagnostics.

## Implementation

- Added `FtsPrewarmMode`, `FtsPrewarmResult`, and diagnostic structs in `lance-index`.
- Added per-partition document prewarm status, including scoring readiness, reverse lookup readiness, and resident projection status.
- Reworked modern FTS prewarm final validation to produce partition-level diagnostics.
- Preserved strict-mode failure behavior, but with more actionable detail.
- Added best-effort behavior that logs/returns partial residency diagnostics without treating cache pressure as a hard prewarm failure.
- Added a local repro test with a deliberately tiny index cache: strict mode reproduces the failure, best-effort returns partial diagnostics.

Companion Sophon change wires this into durable PE index-cache prewarm as the default behavior for ENT-2139.