### PR TITLE
chore(deps): allow using newer version of time crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,7 +2653,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -5035,7 +5034,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "time",
  "tokio",
  "tower",
  "tower-http 0.5.2",
@@ -8922,12 +8920,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -8937,15 +8934,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4203,7 +4203,6 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "time",
  "tokio",
  "tower",
  "tower-http 0.5.2",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4493,7 +4493,6 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "time",
  "tokio",
  "tower",
  "tower-http 0.5.2",

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -79,11 +79,6 @@ base64 = { version = "0.22", optional = true }
 aws-sdk-sts = { version = "1.38.0", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-config = { workspace = true, optional = true }
 
-# Pin: time 0.3.48 conflicts with aws-smithy-types (E0119: conflicting `From` impls), which this
-# crate pulls in via the AWS credential vendor. Capping time here forces the workspace resolver to
-# 0.3.47 even for no-lock builds. Not used directly; remove once the upstream conflict is resolved.
-time = "=0.3.47"
-
 # GCP credential vending dependencies (optional, enabled by "credential-vendor-gcp" feature)
 ring = { version = "0.17", optional = true }
 rustls-pki-types = { version = "1", optional = true }


### PR DESCRIPTION
The `time` dependency was pinned to 0.3.47 in https://github.com/lance-format/lance/pull/7222/commits/e090896f87a4cb692d978e9920b3b976d8a4eb10 to mitigate this build error in `aws-smithy-types`:

```console
error[E0119]: conflicting implementations of trait `From<format_description::parse::format_item::HourBase>` for type `<format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/aws-smithy-types-1.4.5/src/timeout.rs:49:1
   |
49 | impl<T> From<T> for CanDisable<T> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: conflicting implementation in crate `time`:
           - impl From<format_description::parse::format_item::HourBase> for <format_description::parse::format_item::HourBase as format_description::parse::format_item::ModifierValue>::Type;
```

But that blocks using `lance` in projects that require features from a newer version of `time`. The conflict was fixed a long time ago by https://github.com/time-rs/time/pull/786.