### PR TITLE
fix(index): handle partial FTS prewarm under cache pressure

### DIFF
--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -477,6 +477,45 @@ impl LanceCache {
         self.state.backend.insert(&key, metadata, size, None).await;
     }
 
+    pub async fn get_or_insert_unsized_with_key<K, F, Fut>(
+        &self,
+        cache_key: K,
+        loader: F,
+    ) -> Result<Arc<K::ValueType>>
+    where
+        K: UnsizedCacheKey,
+        K::ValueType: DeepSizeOf + Send + Sync + 'static,
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = Result<Arc<K::ValueType>>> + Send,
+    {
+        let key = self.unsized_key(&cache_key);
+        let state = self.state.clone();
+        let typed_loader = Box::pin(async move {
+            let value = loader().await?;
+            let size = state.entry_size(&value);
+            Ok((Arc::new(value) as CacheEntry, size))
+        });
+
+        let (entry, was_cached) = self
+            .state
+            .backend
+            .get_or_insert(&key, typed_loader, None)
+            .await?;
+        let entry = entry.downcast::<Arc<K::ValueType>>().map_err(|_| {
+            self.state.misses.fetch_add(1, Ordering::Relaxed);
+            Error::io(format!(
+                "cache backend returned a value with the wrong concrete type for unsized key type {:?}",
+                K::stable_type_id()
+            ))
+        })?;
+        if was_cached {
+            self.state.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.state.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(entry.as_ref().clone())
+    }
+
     pub async fn get_unsized_with_key<K>(&self, cache_key: &K) -> Option<Arc<K::ValueType>>
     where
         K: UnsizedCacheKey,

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -127,7 +127,8 @@ use crate::scalar::{
     CreatedIndex, RowIdRemapper, ScalarIndex,
     expression::{FtsQueryParser, ScalarQueryParser},
     registry::{
-        BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+        BasicTrainer, ScalarIndexCacheKey, ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria,
+        TrainingOrdering, TrainingRequest,
     },
 };
 
@@ -324,6 +325,18 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
             )));
         }
         Ok(index as Arc<dyn ScalarIndex>)
+    }
+
+    async fn get_or_insert_in_cache(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        _frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+        cache: &LanceCache,
+        load: ScalarIndexLoad<'_>,
+    ) -> Result<Arc<dyn ScalarIndex>> {
+        cache
+            .get_or_insert_unsized_with_key(ScalarIndexCacheKey, || load)
+            .await
     }
 
     fn details_as_json(&self, details: &prost_types::Any) -> Result<serde_json::Value> {

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -23,6 +23,7 @@ use object_store::path::Path;
 use roaring::RoaringBitmap;
 use tokio::sync::OnceCell;
 
+use crate::FtsPrewarmDocumentStatus;
 use crate::scalar::{IndexReader, IndexStore, RowIdRemapper};
 
 use super::index::{
@@ -655,10 +656,23 @@ impl PartitionDocumentStore {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn query_ready(&self) -> bool {
         match self {
             Self::Legacy(_) => true,
             Self::Modern(docs) => docs.query_ready(),
+        }
+    }
+
+    pub(crate) fn prewarm_status(&self) -> FtsPrewarmDocumentStatus {
+        match self {
+            Self::Legacy(_) => FtsPrewarmDocumentStatus {
+                prewarm_complete: true,
+                scoring_ready: true,
+                reverse_lookup_ready: true,
+                projection_resident: true,
+            },
+            Self::Modern(docs) => docs.prewarm_status(),
         }
     }
 
@@ -773,17 +787,24 @@ impl PartitionDocuments {
         self.resident_address_projection().is_some()
     }
 
+    #[cfg(test)]
     pub(crate) fn query_ready(&self) -> bool {
-        self.prewarm_complete.initialized()
-            && self
+        self.prewarm_status().query_ready()
+    }
+
+    pub(crate) fn prewarm_status(&self) -> FtsPrewarmDocumentStatus {
+        FtsPrewarmDocumentStatus {
+            prewarm_complete: self.prewarm_complete.initialized(),
+            scoring_ready: self
                 .lengths
                 .get()
-                .is_some_and(|lengths| lengths.scoring_ready())
-            && self
+                .is_some_and(|lengths| lengths.scoring_ready()),
+            reverse_lookup_ready: self
                 .projection
                 .get()
-                .is_some_and(|projection| projection.doc_ids_by_address.initialized())
-            && self.projection_resident()
+                .is_some_and(|projection| projection.doc_ids_by_address.initialized()),
+            projection_resident: self.projection_resident(),
+        }
     }
 
     async fn reader(&self) -> Result<Arc<dyn IndexReader>> {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -90,7 +90,9 @@ use crate::scalar::{
     OldIndexDataFilter, RowIdRemapper, ScalarIndex, ScalarIndexParams, SearchResult, TokenQuery,
     UpdateCriteria,
 };
-use crate::{FtsPrewarmOptions, Index};
+use crate::{
+    FtsPrewarmDiagnostics, FtsPrewarmOptions, FtsPrewarmPartitionStatus, FtsPrewarmResult, Index,
+};
 use crate::{prefilter::PreFilter, scalar::inverted::iter::take_fst_keys};
 use std::str::FromStr;
 
@@ -2136,29 +2138,47 @@ fn prewarm_chunk_ranges(
 
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
+        self.prewarm_with_options_result(options).await.map(|_| ())
+    }
+
+    pub async fn prewarm_with_options_result(
+        &self,
+        options: &FtsPrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
         let mut state = self.prewarm_state.lock().await;
         if state.satisfies(options.with_position)
-            && (self.is_legacy() || self.document_projections_resident_now())
+            && self
+                .prewarm_diagnostics(options.with_position)
+                .await
+                .fully_resident()
         {
-            return Ok(());
+            return Ok(FtsPrewarmResult::fully_resident());
         }
         let with_position = options.with_position || state.positions_ready;
         state.query_ready = false;
         state.positions_ready = false;
         self.document_projections_resident
             .store(false, Ordering::Release);
-        self.prewarm_query_state(with_position).await?;
-        state.query_ready = true;
-        state.positions_ready = with_position;
-        Ok(())
+        let result = self
+            .prewarm_query_state(with_position, options.mode.is_best_effort())
+            .await?;
+        if result.fully_resident {
+            state.query_ready = true;
+            state.positions_ready = with_position;
+        }
+        Ok(result)
     }
 
-    async fn prewarm_query_state(&self, with_position: bool) -> Result<()> {
+    async fn prewarm_query_state(
+        &self,
+        with_position: bool,
+        best_effort: bool,
+    ) -> Result<FtsPrewarmResult> {
         let chunk_concurrency = self.store.io_parallelism().max(1);
         let prewarm_started = Instant::now();
         info!(
             partition_count = self.partitions.len(),
-            with_position, chunk_concurrency, "fts index prewarm started"
+            with_position, best_effort, chunk_concurrency, "fts index prewarm started"
         );
         for part in &self.partitions {
             let partition_started = Instant::now();
@@ -2206,25 +2226,65 @@ impl InvertedIndex {
             );
         }
         self.aggregate_corpus_stats().await?;
-        let query_ready = self.partitions.iter().all(|partition| {
-            partition.docs.query_ready()
-                && partition.inverted_list.modern_posting_validation_ready()
-        });
-        if !query_ready {
-            return Err(Error::internal(
-                "FTS prewarm completed without publishing a query-ready document and posting state"
-                    .to_owned(),
-            ));
+        let diagnostics = self.prewarm_diagnostics(with_position).await;
+        if !diagnostics.fully_resident() {
+            if best_effort {
+                warn!(
+                    partition_count = diagnostics.partition_count,
+                    failing_partition_count = diagnostics.failing_partitions.len(),
+                    diagnostics = %diagnostics,
+                    elapsed_ms = prewarm_started.elapsed().as_millis() as u64,
+                    "fts index prewarm finished with partial residency"
+                );
+                return Ok(FtsPrewarmResult::partial(diagnostics));
+            }
+            return Err(Error::internal(diagnostics.to_string()));
         }
         self.document_projections_resident
             .store(true, Ordering::Release);
         info!(
             partition_count = self.partitions.len(),
-            query_ready,
+            query_ready = true,
             elapsed_ms = prewarm_started.elapsed().as_millis() as u64,
             "fts index prewarm finished"
         );
-        Ok(())
+        Ok(FtsPrewarmResult::fully_resident())
+    }
+
+    pub async fn prewarm_residency_result(&self, with_position: bool) -> FtsPrewarmResult {
+        let diagnostics = self.prewarm_diagnostics(with_position).await;
+        if diagnostics.fully_resident() {
+            FtsPrewarmResult::fully_resident()
+        } else {
+            FtsPrewarmResult::partial(diagnostics)
+        }
+    }
+
+    async fn prewarm_diagnostics(&self, with_position: bool) -> FtsPrewarmDiagnostics {
+        let statuses = futures::future::join_all(self.partitions.iter().map(|partition| async {
+            let (posting_resident, position_resident) = partition
+                .inverted_list
+                .prewarm_residency_status(with_position)
+                .await;
+            FtsPrewarmPartitionStatus {
+                segment_id: None,
+                partition_id: partition.id(),
+                documents: partition.docs.prewarm_status(),
+                posting_validation_ready: partition.inverted_list.modern_posting_validation_ready(),
+                posting_resident,
+                position_resident,
+            }
+        }))
+        .await;
+        let failing_partitions = statuses
+            .into_iter()
+            .filter(|status| !status.query_ready())
+            .collect();
+        FtsPrewarmDiagnostics {
+            partition_count: self.partitions.len(),
+            failing_segments: Vec::new(),
+            failing_partitions,
+        }
     }
     /// Search docs match the input text.
     async fn do_search(&self, text: &str) -> Result<RecordBatch> {
@@ -4082,6 +4142,59 @@ impl PostingListReader {
                 .store(true, Ordering::Release);
         }
         ready
+    }
+
+    async fn prewarm_residency_status(&self, with_position: bool) -> (bool, Option<bool>) {
+        let postings_resident = self.postings_resident_now().await;
+        let positions_resident = if with_position {
+            Some(self.positions_resident_now().await)
+        } else {
+            None
+        };
+        (postings_resident, positions_resident)
+    }
+
+    async fn postings_resident_now(&self) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        let mut seen_groups = BTreeSet::new();
+        for token_id in 0..self.len() as u32 {
+            if let Some((start, end)) = self.group_range_for_token(token_id) {
+                if seen_groups.insert((start, end))
+                    && self
+                        .index_cache
+                        .get_with_key(&posting_list_group_cache_key(start, end, self.has_impacts))
+                        .await
+                        .is_none()
+                {
+                    return false;
+                }
+            } else if self
+                .index_cache
+                .get_with_key(&posting_list_cache_key(token_id, self.has_impacts))
+                .await
+                .is_none()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    async fn positions_resident_now(&self) -> bool {
+        for token_id in 0..self.len() as u32 {
+            if self
+                .index_cache
+                .get_with_key(&PositionKey { token_id })
+                .await
+                .is_none()
+            {
+                return false;
+            }
+        }
+        true
     }
 
     /// Map a token id to its cache group's row range `[start, end)`, or `None`
@@ -8847,11 +8960,16 @@ fn phrase_query_text(query: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use crate::scalar::inverted::document_tokenizer::DocType;
+    use async_trait::async_trait;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
     use futures::stream;
-    use lance_core::cache::{LanceCache, QuickCacheBackend};
+    use lance_core::cache::{
+        CacheBackend, CacheCodec, CacheEntry, InternalCacheKey, LanceCache, QuickCacheBackend,
+    };
     use lance_core::utils::tempfile::TempObjDir;
     use lance_io::object_store::ObjectStore;
+    use std::future::Future;
+    use std::pin::Pin;
 
     use crate::metrics::{LocalMetricsCollector, NoOpMetricsCollector};
     use crate::prefilter::NoFilter;
@@ -8883,6 +9001,79 @@ mod tests {
     use lance_tokenizer::{Language, SimpleTokenizer, StopWordFilter, TextAnalyzer};
 
     use super::*;
+
+    #[derive(Debug)]
+    struct RejectPositionsCacheBackend {
+        inner: QuickCacheBackend,
+    }
+
+    impl RejectPositionsCacheBackend {
+        fn new(capacity: usize) -> Self {
+            Self {
+                inner: QuickCacheBackend::with_capacity(capacity),
+            }
+        }
+
+        fn rejects(codec: Option<&CacheCodec>) -> bool {
+            codec.is_some_and(|codec| codec.type_id() == "lance.fts.Positions")
+        }
+    }
+
+    #[async_trait]
+    impl CacheBackend for RejectPositionsCacheBackend {
+        async fn get(
+            &self,
+            key: &InternalCacheKey,
+            codec: Option<CacheCodec>,
+        ) -> Option<CacheEntry> {
+            self.inner.get(key, codec).await
+        }
+
+        async fn insert(
+            &self,
+            key: &InternalCacheKey,
+            entry: CacheEntry,
+            size_bytes: usize,
+            codec: Option<CacheCodec>,
+        ) {
+            if Self::rejects(codec.as_ref()) {
+                return;
+            }
+            self.inner.insert(key, entry, size_bytes, codec).await;
+        }
+
+        async fn get_or_insert<'a>(
+            &self,
+            key: &InternalCacheKey,
+            loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
+            codec: Option<CacheCodec>,
+        ) -> Result<(CacheEntry, bool)> {
+            if Self::rejects(codec.as_ref()) {
+                return loader.await.map(|(entry, _)| (entry, false));
+            }
+            self.inner.get_or_insert(key, loader, codec).await
+        }
+
+        async fn clear(&self) {
+            self.inner.clear().await;
+        }
+
+        async fn num_entries(&self) -> usize {
+            self.inner.num_entries().await
+        }
+
+        async fn size_bytes(&self) -> usize {
+            self.inner.size_bytes().await
+        }
+
+        fn approx_num_entries(&self) -> usize {
+            self.inner.approx_num_entries()
+        }
+
+        fn approx_size_bytes(&self) -> usize {
+            self.inner.approx_size_bytes()
+        }
+    }
 
     #[test]
     fn address_read_concurrency_respects_payload_budget() {
@@ -11415,6 +11606,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_best_effort_prewarm_reports_missing_requested_positions() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let params = InvertedIndexParams::default()
+            .with_position(true)
+            .format_version(InvertedListFormatVersion::V2);
+        let format_version = params.resolved_format_version();
+        let mut builder = InnerBuilder::new_with_format_version_and_block_size(
+            0,
+            true,
+            TokenSetFormat::default(),
+            format_version,
+            params.posting_block_size(),
+        );
+        builder.tokens.add("alpha".to_owned());
+        builder.tokens.add("beta".to_owned());
+        for token_id in 0..2 {
+            let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                true,
+                format_version.posting_tail_codec(),
+                params.posting_block_size(),
+            );
+            posting.add(0, PositionRecorder::Position(vec![token_id].into()));
+            builder.posting_lists.push(posting);
+        }
+        builder.docs.append(100, 2);
+        builder.write(store.as_ref()).await.unwrap();
+        write_test_metadata(&store, vec![0], params).await;
+
+        let cache = Arc::new(LanceCache::with_backend(Arc::new(
+            RejectPositionsCacheBackend::new(1 << 20),
+        )));
+        let index = InvertedIndex::load(store, None, cache.as_ref())
+            .await
+            .unwrap();
+
+        let result = index
+            .prewarm_with_options_result(
+                &FtsPrewarmOptions::new().with_position(true).best_effort(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.fully_resident,
+            "prewarm must not report full residency when requested positions were rejected"
+        );
+        let diagnostics = result
+            .diagnostics
+            .expect("missing requested positions should produce diagnostics");
+        assert_eq!(diagnostics.partition_count, 1);
+        assert_eq!(diagnostics.failing_partitions.len(), 1);
+        let partition = &diagnostics.failing_partitions[0];
+        assert!(partition.documents.query_ready());
+        assert!(partition.posting_validation_ready);
+        assert!(partition.posting_resident);
+        assert_eq!(partition.position_resident, Some(false));
+    }
+
+    #[tokio::test]
     async fn test_prewarm_with_v2_positions_preserves_shared_stream_codec() {
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
@@ -11810,6 +12065,99 @@ mod tests {
         prewarmed_row_ids.sort_unstable();
         assert_eq!(prewarmed_row_ids, expected);
         assert_eq!(prewarmed_scores, cold_scores);
+    }
+
+    #[tokio::test]
+    async fn test_strict_modern_prewarm_fails_when_index_cache_cannot_hold_all_partitions() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let params = InvertedIndexParams::default().format_version(InvertedListFormatVersion::V2);
+        let format_version = params.resolved_format_version();
+        let partition_count = 6_u64;
+        let docs_per_partition = 512_u32;
+
+        for partition_id in 0..partition_count {
+            let mut builder = InnerBuilder::new_with_format_version_and_block_size(
+                partition_id,
+                false,
+                TokenSetFormat::default(),
+                format_version,
+                params.posting_block_size(),
+            );
+            builder.tokens.add(format!("token_{partition_id}"));
+            let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                false,
+                format_version.posting_tail_codec(),
+                params.posting_block_size(),
+            );
+            for doc_id in 0..docs_per_partition {
+                posting.add(doc_id, PositionRecorder::Count(1));
+                builder
+                    .docs
+                    .append(partition_id * 1_000_000 + doc_id as u64, 1);
+            }
+            builder.posting_lists.push(posting);
+            builder.write(store.as_ref()).await.unwrap();
+        }
+        write_test_metadata(&store, (0..partition_count).collect(), params).await;
+
+        let cache = Arc::new(LanceCache::with_backend(Arc::new(
+            QuickCacheBackend::with_capacity(8 * 1024),
+        )));
+        let index = InvertedIndex::load(store, None, cache.as_ref())
+            .await
+            .unwrap();
+
+        let err = index
+            .prewarm_with_options(&FtsPrewarmOptions::default())
+            .await
+            .unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains("partition(s) are not fully resident"));
+        assert!(err.contains("resident row-address projection"));
+        assert!(
+            index
+                .partitions
+                .iter()
+                .any(|partition| !partition.docs.query_ready()),
+            "strict prewarm should fail because at least one partition lost query-ready state"
+        );
+        assert!(
+            index
+                .partitions
+                .iter()
+                .all(|partition| partition.inverted_list.modern_posting_validation_ready()),
+            "posting validation should complete; the strict failure should be the final residency postcondition"
+        );
+        assert!(
+            index.partitions.iter().any(|partition| {
+                let docs = partition.docs.modern().unwrap();
+                !docs.projection_resident()
+            }),
+            "at least one modern document projection should be non-resident"
+        );
+
+        let result = index
+            .prewarm_with_options_result(&FtsPrewarmOptions::default().best_effort())
+            .await
+            .unwrap();
+        assert!(!result.fully_resident);
+        let diagnostics = result
+            .diagnostics
+            .expect("best-effort partial prewarm should report diagnostics");
+        assert_eq!(diagnostics.partition_count, partition_count as usize);
+        assert!(!diagnostics.failing_partitions.is_empty());
+        assert!(
+            diagnostics
+                .failing_partitions
+                .iter()
+                .all(|partition| partition.posting_validation_ready),
+            "best-effort should not suppress posting validation failures"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::fmt::Display;
+
 use lance_core::Result;
 
 use lance_table::format::IndexMetadata;
@@ -71,6 +73,9 @@ pub type ScalarIndexCriteria<'a> = IndexCriteria<'a>;
 pub struct FtsPrewarmOptions {
     /// If true, prewarm positions along with posting lists.
     pub with_position: bool,
+    /// Controls whether prewarm requires the full requested FTS working set to
+    /// remain resident when the operation completes.
+    pub mode: FtsPrewarmMode,
 }
 
 impl FtsPrewarmOptions {
@@ -81,6 +86,207 @@ impl FtsPrewarmOptions {
     pub fn with_position(mut self, with_position: bool) -> Self {
         self.with_position = with_position;
         self
+    }
+
+    pub fn with_mode(mut self, mode: FtsPrewarmMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn best_effort(mut self) -> Self {
+        self.mode = FtsPrewarmMode::BestEffort;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FtsPrewarmMode {
+    #[default]
+    Strict,
+    BestEffort,
+}
+
+impl FtsPrewarmMode {
+    pub fn is_best_effort(self) -> bool {
+        matches!(self, Self::BestEffort)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmResult {
+    pub fully_resident: bool,
+    pub diagnostics: Option<FtsPrewarmDiagnostics>,
+}
+
+impl FtsPrewarmResult {
+    pub fn fully_resident() -> Self {
+        Self {
+            fully_resident: true,
+            diagnostics: None,
+        }
+    }
+
+    pub fn partial(diagnostics: FtsPrewarmDiagnostics) -> Self {
+        Self {
+            fully_resident: false,
+            diagnostics: Some(diagnostics),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmDiagnostics {
+    pub partition_count: usize,
+    pub failing_segments: Vec<FtsPrewarmSegmentStatus>,
+    pub failing_partitions: Vec<FtsPrewarmPartitionStatus>,
+}
+
+impl FtsPrewarmDiagnostics {
+    pub fn fully_resident(&self) -> bool {
+        self.failing_segments.is_empty() && self.failing_partitions.is_empty()
+    }
+}
+
+impl Display for FtsPrewarmDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FTS prewarm completed without publishing query-ready scalar container, document, and posting state; \
+             {} segment(s) and {} of {} partition(s) are not fully resident",
+            self.failing_segments.len(),
+            self.failing_partitions.len(),
+            self.partition_count
+        )?;
+        if !self.failing_segments.is_empty() || !self.failing_partitions.is_empty() {
+            write!(f, ": ")?;
+            let mut first = true;
+            for segment in &self.failing_segments {
+                if !first {
+                    write!(f, "; ")?;
+                }
+                first = false;
+                write!(f, "{segment}")?;
+            }
+            for partition in &self.failing_partitions {
+                if !first {
+                    write!(f, "; ")?;
+                }
+                first = false;
+                write!(f, "{partition}")?;
+            }
+        }
+        write!(
+            f,
+            ". Likely cause: index cache pressure or insufficient capacity. \
+             Suggested remediation: increase index-cache capacity, reduce the number of FTS \
+             segments assigned to each executor, or adjust placement/segment sizing."
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmSegmentStatus {
+    pub segment_id: String,
+    pub scalar_index_container_resident: bool,
+    pub scalar_index_container_matches_prewarmed: bool,
+}
+
+impl FtsPrewarmSegmentStatus {
+    pub fn query_ready(&self) -> bool {
+        self.scalar_index_container_resident && self.scalar_index_container_matches_prewarmed
+    }
+}
+
+impl Display for FtsPrewarmSegmentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut missing = Vec::new();
+        if !self.scalar_index_container_resident {
+            missing.push("resident scalar index container");
+        }
+        if !self.scalar_index_container_matches_prewarmed {
+            missing.push("stable scalar index container identity");
+        }
+        write!(
+            f,
+            "segment {} missing {}",
+            self.segment_id,
+            missing.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FtsPrewarmPartitionStatus {
+    pub segment_id: Option<String>,
+    pub partition_id: u64,
+    pub documents: FtsPrewarmDocumentStatus,
+    pub posting_validation_ready: bool,
+    pub posting_resident: bool,
+    pub position_resident: Option<bool>,
+}
+
+impl FtsPrewarmPartitionStatus {
+    pub fn query_ready(&self) -> bool {
+        self.documents.query_ready()
+            && self.posting_validation_ready
+            && self.posting_resident
+            && self.position_resident.unwrap_or(true)
+    }
+}
+
+impl Display for FtsPrewarmPartitionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut missing = Vec::new();
+        if !self.documents.prewarm_complete {
+            missing.push("document prewarm completion");
+        }
+        if !self.documents.scoring_ready {
+            missing.push("scoring lengths/norms");
+        }
+        if !self.documents.reverse_lookup_ready {
+            missing.push("reverse document lookup");
+        }
+        if !self.documents.projection_resident {
+            missing.push("resident row-address projection");
+        }
+        if !self.posting_validation_ready {
+            missing.push("posting validation");
+        }
+        if !self.posting_resident {
+            missing.push("resident posting lists");
+        }
+        if self.position_resident == Some(false) {
+            missing.push("resident positions");
+        }
+        let segment = self
+            .segment_id
+            .as_deref()
+            .map(|segment_id| format!("segment {segment_id} "))
+            .unwrap_or_default();
+        write!(
+            f,
+            "{}partition {} missing {}",
+            segment,
+            self.partition_id,
+            missing.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FtsPrewarmDocumentStatus {
+    pub prewarm_complete: bool,
+    pub scoring_ready: bool,
+    pub reverse_lookup_ready: bool,
+    pub projection_resident: bool,
+}
+
+impl FtsPrewarmDocumentStatus {
+    pub fn query_ready(&self) -> bool {
+        self.prewarm_complete
+            && self.scoring_ready
+            && self.reverse_lookup_ready
+            && self.projection_resident
     }
 }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::vec;
 
@@ -29,7 +32,9 @@ use arrow_schema::{
     DataType, Field as ArrowField, Field, Fields as ArrowFields, Schema as ArrowSchema,
 };
 use lance_arrow::ARROW_EXT_NAME_KEY;
-use lance_core::cache::LanceCache;
+use lance_core::cache::{
+    CacheBackend, CacheCodec, CacheEntry, InternalCacheKey, LanceCache, QuickCacheBackend,
+};
 use lance_core::utils::tempfile::TempStrDir;
 use lance_datafusion::exec::ExecutionSummaryCounts;
 use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
@@ -41,12 +46,12 @@ use lance_index::metrics::{
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
-use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
     DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
     query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
+use lance_index::scalar::{FullTextSearchQuery, ScalarIndex};
 use lance_index::{FtsPrewarmOptions, PrewarmOptions};
 use lance_index::{IndexType, scalar::ScalarIndexParams, vector::DIST_COL};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
@@ -3014,6 +3019,290 @@ async fn test_prewarm_index_with_position_validation() {
     assert_contains!(
         err,
         "FTS prewarm options are only supported for inverted indices"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_best_effort_prewarm_result_reports_dataset_partial_residency() {
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    drop(tmpdir);
+
+    let doc_col: Arc<dyn Array> = Arc::new(GenericStringArray::<i32>::from_iter_values(
+        (0..4096).map(|row| format!("cache pressure token {row}")),
+    ));
+    let ids = UInt64Array::from_iter_values(0..doc_col.len() as u64);
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("doc", doc_col.data_type().to_owned(), true),
+            arrow_schema::Field::new("id", DataType::UInt64, false),
+        ])
+        .into(),
+        vec![Arc::new(doc_col) as ArrayRef, Arc::new(ids) as ArrayRef],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(batches, &uri, None).await.unwrap();
+    dataset
+        .create_index(
+            &["doc"],
+            IndexType::Inverted,
+            Some("fts_idx".to_owned()),
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let session = Arc::new(Session::with_index_cache_backend(
+        Arc::new(QuickCacheBackend::with_capacity(8 * 1024)),
+        8 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    let dataset = DatasetBuilder::from_uri(&uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap();
+    let options = PrewarmOptions::Fts(FtsPrewarmOptions::default().best_effort());
+
+    dataset
+        .prewarm_index_with_options("fts_idx", &options)
+        .await
+        .unwrap();
+    let result = dataset
+        .prewarm_index_with_options_result("fts_idx", &options)
+        .await
+        .unwrap();
+
+    assert!(
+        !result.fully_resident,
+        "tiny cache should make best-effort dataset prewarm report partial residency"
+    );
+    let diagnostics = result
+        .diagnostics
+        .expect("partial dataset prewarm should return aggregate diagnostics");
+    assert!(diagnostics.partition_count > 0);
+    assert!(!diagnostics.failing_segments.is_empty() || !diagnostics.failing_partitions.is_empty());
+    assert!(
+        diagnostics
+            .failing_partitions
+            .iter()
+            .all(|partition| partition.segment_id.is_some()),
+        "dataset aggregation should attach segment ids to partition diagnostics"
+    );
+}
+
+#[derive(Debug)]
+struct SingleScalarContainerCacheBackend {
+    inner: QuickCacheBackend,
+    scalar_container_inserts: AtomicUsize,
+}
+
+impl SingleScalarContainerCacheBackend {
+    fn new(capacity: usize) -> Self {
+        Self {
+            inner: QuickCacheBackend::with_capacity(capacity),
+            scalar_container_inserts: AtomicUsize::new(0),
+        }
+    }
+
+    fn rejects_scalar_container(entry: &CacheEntry, codec: Option<&CacheCodec>) -> bool {
+        codec.is_none() && entry.as_ref().is::<Arc<dyn ScalarIndex>>()
+    }
+}
+
+#[async_trait::async_trait]
+impl CacheBackend for SingleScalarContainerCacheBackend {
+    async fn get(&self, key: &InternalCacheKey, codec: Option<CacheCodec>) -> Option<CacheEntry> {
+        self.inner.get(key, codec).await
+    }
+
+    async fn insert(
+        &self,
+        key: &InternalCacheKey,
+        entry: CacheEntry,
+        size_bytes: usize,
+        codec: Option<CacheCodec>,
+    ) {
+        if Self::rejects_scalar_container(&entry, codec.as_ref())
+            && self
+                .scalar_container_inserts
+                .fetch_add(1, Ordering::Relaxed)
+                > 0
+        {
+            return;
+        }
+        self.inner.insert(key, entry, size_bytes, codec).await;
+    }
+
+    async fn get_or_insert<'a>(
+        &self,
+        key: &InternalCacheKey,
+        loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
+        codec: Option<CacheCodec>,
+    ) -> Result<(CacheEntry, bool)> {
+        if codec.is_none() {
+            if let Some(entry) = self.inner.get(key, None).await {
+                return Ok((entry, true));
+            }
+            let (entry, size_bytes) = loader.await?;
+            if Self::rejects_scalar_container(&entry, None)
+                && self
+                    .scalar_container_inserts
+                    .fetch_add(1, Ordering::Relaxed)
+                    > 0
+            {
+                return Ok((entry, false));
+            }
+            self.inner
+                .insert(key, entry.clone(), size_bytes, codec)
+                .await;
+            return Ok((entry, false));
+        }
+        self.inner.get_or_insert(key, loader, codec).await
+    }
+
+    async fn clear(&self) {
+        self.inner.clear().await;
+    }
+
+    async fn num_entries(&self) -> usize {
+        self.inner.num_entries().await
+    }
+
+    async fn size_bytes(&self) -> usize {
+        self.inner.size_bytes().await
+    }
+
+    fn approx_num_entries(&self) -> usize {
+        self.inner.approx_num_entries()
+    }
+
+    fn approx_size_bytes(&self) -> usize {
+        self.inner.approx_size_bytes()
+    }
+}
+
+async fn two_segment_fts_dataset(uri: &str) -> Dataset {
+    let schema = Arc::new(arrow_schema::Schema::new(vec![
+        arrow_schema::Field::new("doc", DataType::Utf8, true),
+        arrow_schema::Field::new("id", DataType::UInt64, false),
+    ]));
+    let make_batch = |fragment: u64| {
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(GenericStringArray::<i32>::from_iter_values(
+                    (0..32u64).map(|row| format!("segment {fragment} token {row}")),
+                )) as ArrayRef,
+                Arc::new(UInt64Array::from_iter_values(
+                    (0..32u64).map(|row| fragment * 32 + row),
+                )) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    };
+
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![make_batch(0)].into_iter().map(Ok), schema.clone()),
+        uri,
+        None,
+    )
+    .await
+    .unwrap();
+    dataset
+        .create_index(
+            &["doc"],
+            IndexType::Inverted,
+            Some("fts_idx".to_owned()),
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![make_batch(1)].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+    dataset
+        .optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    assert_eq!(
+        dataset.load_indices_by_name("fts_idx").await.unwrap().len(),
+        2
+    );
+    dataset
+}
+
+async fn open_with_single_scalar_container_cache(uri: &str) -> Dataset {
+    let session = Arc::new(Session::with_index_cache_backend(
+        Arc::new(SingleScalarContainerCacheBackend::new(128 * 1024 * 1024)),
+        128 * 1024 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    DatasetBuilder::from_uri(uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_fts_best_effort_prewarm_reports_missing_scalar_container() {
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    two_segment_fts_dataset(&uri).await;
+    let dataset = open_with_single_scalar_container_cache(&uri).await;
+    let options = PrewarmOptions::Fts(FtsPrewarmOptions::default().best_effort());
+
+    let result = dataset
+        .prewarm_index_with_options_result("fts_idx", &options)
+        .await
+        .unwrap();
+
+    assert!(
+        !result.fully_resident,
+        "dataset prewarm must be partial when a selected segment's scalar index \
+         container is not cache-resident"
+    );
+    let diagnostics = result
+        .diagnostics
+        .expect("missing scalar container should produce aggregate diagnostics");
+    assert_eq!(
+        diagnostics.failing_segments.len(),
+        1,
+        "only the rejected scalar container should be reported as missing"
+    );
+    assert!(
+        diagnostics.failing_partitions.is_empty(),
+        "a missing scalar container should not be represented as a partition failure"
+    );
+    let failure = &diagnostics.failing_segments[0];
+    assert!(!failure.scalar_index_container_resident);
+    assert!(!failure.scalar_index_container_matches_prewarmed);
+}
+
+#[tokio::test]
+async fn test_fts_strict_prewarm_fails_missing_scalar_container() {
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    two_segment_fts_dataset(&uri).await;
+    let dataset = open_with_single_scalar_container_cache(&uri).await;
+    let options = PrewarmOptions::Fts(FtsPrewarmOptions::default());
+
+    let err = dataset
+        .prewarm_index_with_options_result("fts_idx", &options)
+        .await
+        .expect_err("strict prewarm should fail after final scalar-container audit");
+    assert!(
+        err.to_string().contains("resident scalar index container"),
+        "strict error should describe the missing scalar container: {err}"
     );
 }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -42,7 +42,10 @@ use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::quantizer::Quantization;
 use lance_index::vector::sq::ScalarQuantizer;
 use lance_index::vector::v3::subindex::IvfSubIndex;
-use lance_index::{INDEX_FILE_NAME, Index, IndexType, PrewarmOptions, pb, vector::VectorIndex};
+use lance_index::{
+    FtsPrewarmDiagnostics, FtsPrewarmOptions, FtsPrewarmResult, FtsPrewarmSegmentStatus,
+    INDEX_FILE_NAME, Index, IndexType, PrewarmOptions, pb, vector::VectorIndex,
+};
 use lance_index::{
     IndexCriteria, is_system_index,
     metrics::{MetricsCollector, NoOpMetricsCollector},
@@ -352,6 +355,117 @@ async fn prewarm_opened_index(
     }
 }
 
+struct SegmentPrewarmResult {
+    partition_count: usize,
+}
+
+struct OpenedSegmentPrewarmResult {
+    index_uuid: Uuid,
+    index: Arc<dyn Index>,
+    partition_count: usize,
+}
+
+async fn prewarm_opened_index_result(
+    index: Arc<dyn Index>,
+    options: &PrewarmOptions,
+) -> Result<SegmentPrewarmResult> {
+    match options {
+        PrewarmOptions::Fts(fts_options) => {
+            let inverted = index
+                .as_any()
+                .downcast_ref::<InvertedIndex>()
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "FTS prewarm options are only supported for inverted indices, got {:?}",
+                        index.index_type()
+                    ))
+                })?;
+            inverted.prewarm_with_options_result(fts_options).await?;
+            Ok(SegmentPrewarmResult {
+                partition_count: inverted.partition_count(),
+            })
+        }
+        _ => Err(Error::not_supported(
+            "unsupported prewarm options for this lance version".to_owned(),
+        )),
+    }
+}
+
+async fn aggregate_fts_prewarm_results(
+    dataset: &Dataset,
+    segment_results: Vec<OpenedSegmentPrewarmResult>,
+    options: Option<&PrewarmOptions>,
+) -> Result<FtsPrewarmResult> {
+    let partition_count = segment_results
+        .iter()
+        .map(|result| result.partition_count)
+        .sum();
+    let mut failing_segments = Vec::new();
+    let mut failing_partitions = Vec::new();
+    let mut best_effort = false;
+
+    for segment in segment_results {
+        let segment_id = segment.index_uuid.to_string();
+        let prewarmed_inverted = segment.index.as_any().downcast_ref::<InvertedIndex>();
+        let Some(fts_options) = (match options {
+            Some(PrewarmOptions::Fts(fts_options)) => Some(fts_options.clone()),
+            None if prewarmed_inverted.is_some() => Some(FtsPrewarmOptions::default()),
+            _ => None,
+        }) else {
+            continue;
+        };
+        best_effort |= fts_options.mode.is_best_effort();
+
+        let cached_index =
+            scalar::cached_scalar_index_container(dataset, &segment.index_uuid).await;
+        let cached_inverted = cached_index
+            .as_ref()
+            .and_then(|index| index.as_any().downcast_ref::<InvertedIndex>());
+        let container_resident = cached_inverted.is_some();
+        let container_matches_prewarmed = match (prewarmed_inverted, cached_inverted) {
+            (Some(prewarmed), Some(cached)) => std::ptr::addr_eq(prewarmed, cached),
+            _ => false,
+        };
+
+        if !container_resident || !container_matches_prewarmed {
+            failing_segments.push(FtsPrewarmSegmentStatus {
+                segment_id: segment_id.clone(),
+                scalar_index_container_resident: container_resident,
+                scalar_index_container_matches_prewarmed: container_matches_prewarmed,
+            });
+        }
+
+        if let Some(cached_inverted) = cached_inverted
+            && let Some(mut diagnostics) = cached_inverted
+                .prewarm_residency_result(fts_options.with_position)
+                .await
+                .diagnostics
+        {
+            failing_segments.append(&mut diagnostics.failing_segments);
+            failing_partitions.extend(diagnostics.failing_partitions.drain(..).map(
+                |mut partition| {
+                    partition.segment_id = Some(segment_id.clone());
+                    partition
+                },
+            ));
+        }
+    }
+
+    let diagnostics = FtsPrewarmDiagnostics {
+        partition_count,
+        failing_segments,
+        failing_partitions,
+    };
+
+    if diagnostics.fully_resident() {
+        Ok(FtsPrewarmResult::fully_resident())
+    } else if best_effort {
+        Ok(FtsPrewarmResult::partial(diagnostics))
+    } else {
+        Err(Error::internal(diagnostics.to_string()))
+    }
+}
+
 fn total_index_segment_size_bytes(indices: &[IndexMetadata]) -> Option<u64> {
     let mut total = 0u64;
     for index_meta in indices {
@@ -379,7 +493,7 @@ async fn prewarm_index_segments_by_metadata(
     options: Option<&PrewarmOptions>,
     available_segment_count: usize,
     requested_segment_count: Option<usize>,
-) -> Result<()> {
+) -> Result<FtsPrewarmResult> {
     let request_started = Instant::now();
     let selected_segment_count = indices.len();
     let selected_size_bytes = total_index_segment_size_bytes(&indices);
@@ -446,16 +560,34 @@ async fn prewarm_index_segments_by_metadata(
             }
         };
 
-        if let Err(err) = prewarm_opened_index(index, options).await {
-            warn!(
-                index_name = name,
-                %index_uuid,
-                error = %err,
-                elapsed_ms = segment_started.elapsed().as_millis() as u64,
-                "prewarm index segment failed"
-            );
-            return Err(err);
-        }
+        let segment_result = match options {
+            Some(options) => match prewarm_opened_index_result(index.clone(), options).await {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!(
+                        index_name = name,
+                        %index_uuid,
+                        error = %err,
+                        elapsed_ms = segment_started.elapsed().as_millis() as u64,
+                        "prewarm index segment failed"
+                    );
+                    return Err(err);
+                }
+            },
+            None => {
+                if let Err(err) = prewarm_opened_index(index.clone(), None).await {
+                    warn!(
+                        index_name = name,
+                        %index_uuid,
+                        error = %err,
+                        elapsed_ms = segment_started.elapsed().as_millis() as u64,
+                        "prewarm index segment failed"
+                    );
+                    return Err(err);
+                }
+                SegmentPrewarmResult { partition_count: 0 }
+            }
+        };
 
         info!(
             index_name = name,
@@ -463,16 +595,22 @@ async fn prewarm_index_segments_by_metadata(
             elapsed_ms = segment_started.elapsed().as_millis() as u64,
             "prewarm index segment finished"
         );
-        Ok(())
+        Ok(OpenedSegmentPrewarmResult {
+            index_uuid,
+            index,
+            partition_count: segment_result.partition_count,
+        })
     }))
     .await;
 
     match result {
-        Ok(_) => {
+        Ok(segment_results) => {
             let cache_stats_after = dataset.session.index_cache_stats().await;
+            let result = aggregate_fts_prewarm_results(dataset, segment_results, options).await?;
             info!(
                 index_name = name,
                 selected_segment_count,
+                fts_fully_resident = result.fully_resident,
                 index_cache_entries_after = cache_stats_after.num_entries,
                 index_cache_entries_delta = cache_size_delta(
                     cache_stats_after.num_entries,
@@ -484,7 +622,7 @@ async fn prewarm_index_segments_by_metadata(
                 elapsed_ms = request_started.elapsed().as_millis() as u64,
                 "prewarm index segments finished"
             );
-            Ok(())
+            Ok(result)
         }
         Err(err) => {
             let cache_stats_after = dataset.session.index_cache_stats().await;
@@ -1391,9 +1529,20 @@ impl DatasetIndexExt for Dataset {
         let available_segment_count = indices.len();
         prewarm_index_segments_by_metadata(self, name, indices, None, available_segment_count, None)
             .await
+            .map(|_| ())
     }
 
     async fn prewarm_index_with_options(&self, name: &str, options: &PrewarmOptions) -> Result<()> {
+        self.prewarm_index_with_options_result(name, options)
+            .await
+            .map(|_| ())
+    }
+
+    async fn prewarm_index_with_options_result(
+        &self,
+        name: &str,
+        options: &PrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
         let indices = self.load_indices_by_name(name).await?;
         if indices.is_empty() {
             return Err(Error::index_not_found(format!("name={}", name)));
@@ -1428,6 +1577,7 @@ impl DatasetIndexExt for Dataset {
             Some(segment_ids.len()),
         )
         .await
+        .map(|_| ())
     }
 
     async fn prewarm_index_segments_with_options(
@@ -1436,6 +1586,17 @@ impl DatasetIndexExt for Dataset {
         segment_ids: &[Uuid],
         options: &PrewarmOptions,
     ) -> Result<()> {
+        self.prewarm_index_segments_with_options_result(name, segment_ids, options)
+            .await
+            .map(|_| ())
+    }
+
+    async fn prewarm_index_segments_with_options_result(
+        &self,
+        name: &str,
+        segment_ids: &[Uuid],
+        options: &PrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
         let indices = self.load_indices_by_name(name).await?;
         if indices.is_empty() {
             return Err(Error::index_not_found(format!("name={}", name)));

--- a/rust/lance/src/index/api.rs
+++ b/rust/lance/src/index/api.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
-use lance_index::{IndexParams, IndexType, PrewarmOptions, optimize::OptimizeOptions};
+use lance_index::{
+    FtsPrewarmResult, IndexParams, IndexType, PrewarmOptions, optimize::OptimizeOptions,
+};
 use lance_table::format::IndexMetadata;
 use roaring::RoaringBitmap;
 use uuid::Uuid;
@@ -202,6 +204,17 @@ pub trait DatasetIndexExt {
         ))
     }
 
+    /// Prewarm an index by name with additional options and return the structured outcome.
+    async fn prewarm_index_with_options_result(
+        &self,
+        _name: &str,
+        _options: &PrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
+        Err(Error::not_supported(
+            "prewarm result reports are not supported by this dataset implementation".to_owned(),
+        ))
+    }
+
     /// Prewarm selected physical segments of an index by name.
     async fn prewarm_index_segments(&self, _name: &str, _segment_ids: &[Uuid]) -> Result<()> {
         Err(Error::not_supported(
@@ -218,6 +231,18 @@ pub trait DatasetIndexExt {
     ) -> Result<()> {
         Err(Error::not_supported(
             "prewarm options are not supported by this dataset implementation".to_owned(),
+        ))
+    }
+
+    /// Prewarm selected physical segments with options and return the structured outcome.
+    async fn prewarm_index_segments_with_options_result(
+        &self,
+        _name: &str,
+        _segment_ids: &[Uuid],
+        _options: &PrewarmOptions,
+    ) -> Result<FtsPrewarmResult> {
+        Err(Error::not_supported(
+            "prewarm result reports are not supported by this dataset implementation".to_owned(),
         ))
     }
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -52,7 +52,8 @@ use lance_index::scalar::label_list::{
     LABEL_LIST_NULLS_METADATA_KEY, LABEL_LIST_NULLS_MIN_VERSION,
 };
 use lance_index::scalar::registry::{
-    ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, VALUE_COLUMN_NAME,
+    ScalarIndexCacheKey, ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+    VALUE_COLUMN_NAME,
 };
 use lance_index::scalar::{BuiltinIndexType, CreatedIndex, InvertedIndexParams};
 use lance_index::scalar::{
@@ -578,6 +579,17 @@ pub async fn open_scalar_index(
     plugin
         .get_or_insert_in_cache(index_store, frag_reuse_index, &index_cache, load)
         .await
+}
+
+pub(crate) async fn cached_scalar_index_container(
+    dataset: &Dataset,
+    uuid: &Uuid,
+) -> Option<Arc<dyn ScalarIndex>> {
+    let frag_reuse_uuid = dataset.frag_reuse_index_uuid().await;
+    let index_cache = dataset
+        .index_cache
+        .for_index(uuid, frag_reuse_uuid.as_ref());
+    index_cache.get_unsized_with_key(&ScalarIndexCacheKey).await
 }
 
 pub(crate) async fn infer_scalar_index_details(


### PR DESCRIPTION
## Summary

Adds an explicit best-effort mode for modern FTS index prewarm when cache pressure prevents all warmed query state from remaining resident at the end of the operation.

## Details

- Keeps strict prewarm behavior as the default.
- Adds structured FTS prewarm results with full-residency status and partition-level diagnostics.
- Lets best-effort prewarm return partial residency diagnostics instead of failing solely on the final residency check.
- Improves strict-mode failure diagnostics so cache pressure is easier to identify.
- Adds coverage for an undersized-cache case where strict mode fails and best-effort mode reports a partial result.