### PR TITLE
fix: add fallback case for SIMD_SUPPORT

### DIFF
--- a/rust/lance-core/src/utils/cpu.rs
+++ b/rust/lance-core/src/utils/cpu.rs
@@ -210,6 +210,14 @@ pub static SIMD_SUPPORT: LazyLock<SimdSupport> = LazyLock::new(|| {
             SimdSupport::None
         }
     }
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        target_arch = "loongarch64"
+    )))]
+    {
+        SimdSupport::None
+    }
 });
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Without this, lance-core does not compile successfully for architectures other than aarch64, x86_64, loongarch64.

```console
error[E0308]: mismatched types
   --> rust/lance-core/src/utils/cpu.rs:161:67
    |
161 |   pub static SIMD_SUPPORT: LazyLock<SimdSupport> = LazyLock::new(|| {
    |  ___________________________________________________________________^
162 | |     #[cfg(all(target_arch = "aarch64", any(target_os = "ios", target_os = "tvos")))]
...   |
213 | | });
    | |_^ expected `SimdSupport`, found `()`
```

Repro: `cargo check --target=riscv64gc-unknown-linux-gnu --config='target.riscv64gc-unknown-linux-gnu.zstd.buildscript=""'`