### PR TITLE
fix(dataset): accept tombstoned field ids when validating a fragment

### DIFF
--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -12,7 +12,7 @@ use lance_io::utils::CachedFileSize;
 use object_store::path::Path;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::overlay::{DataOverlayFile, sort_overlays_newest_last};
+use super::overlay::{DataOverlayFile, TOMBSTONE_FIELD_ID, sort_overlays_newest_last};
 use crate::format::pb;
 
 use crate::rowids::version::{
@@ -182,7 +182,16 @@ impl DataFile {
 
     pub fn validate(&self, base_path: &Path) -> Result<()> {
         if self.is_legacy_file() {
-            if !self.fields.windows(2).all(|w| w[0] < w[1]) {
+            // A tombstone marks a field superseded by a later data file. It is
+            // not a field id, so it carries no ordering; the live ids around it
+            // must still be sorted and distinct.
+            let live: Vec<i32> = self
+                .fields
+                .iter()
+                .copied()
+                .filter(|field| *field != TOMBSTONE_FIELD_ID)
+                .collect();
+            if !live.windows(2).all(|w| w[0] < w[1]) {
                 return Err(Error::corrupt_file(
                     base_path.clone().join(self.path.clone()),
                     "contained unsorted or duplicate field ids",

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -48,6 +48,7 @@ use lance_file::{LanceEncodingsIo, determine_file_version, versions as file_vers
 use lance_io::ReadBatchParams;
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
+use lance_table::format::overlay::TOMBSTONE_FIELD_ID;
 use lance_table::format::{DataFile, DeletionFile, Fragment};
 use lance_table::io::deletion::{deletion_file_path, write_deletion_file};
 use lance_table::rowids::RowIdSequence;
@@ -1407,6 +1408,11 @@ impl FileFragment {
         for data_file in &self.metadata.files {
             let last = -1;
             for field_id in data_file.fields.iter() {
+                // A tombstone marks a field superseded by a later data file.
+                // It is not a field id: it has no ordering and can repeat.
+                if *field_id == TOMBSTONE_FIELD_ID {
+                    continue;
+                }
                 if *field_id <= last {
                     return Err(Error::corrupt_file(
                         self.dataset

--- a/rust/lance/src/dataset/tests/fragment_validate_tombstones.rs
+++ b/rust/lance/src/dataset/tests/fragment_validate_tombstones.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use arrow_array::{RecordBatchIterator, record_batch};
+use lance_file::version::LanceFileVersion;
+use rstest::rstest;
+
+use crate::Dataset;
+use crate::dataset::WriteParams;
+use crate::dataset::fragment::FileFragment;
+
+/// Rewriting a column with `update_columns` tombstones the field in the file
+/// that held it, leaving `-2` behind while a new file answers for it.
+/// Validation has to accept that: a tombstone marks a superseded field, not a
+/// corrupt one. Legacy files are checked by a separate sort rule, so both
+/// storage versions are covered.
+#[rstest]
+#[case::legacy(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_validate_accepts_tombstoned_fields(#[case] version: LanceFileVersion) {
+    let batch = record_batch!(("i", Int32, [1, 2]), ("v", Int64, [10, 20])).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+    let dataset = Arc::new(
+        Dataset::write(
+            reader,
+            "memory://",
+            Some(WriteParams {
+                data_storage_version: Some(version),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let update = record_batch!(("i1", Int32, [1, 2]), ("v", Int64, [99, 99])).unwrap();
+    let right = RecordBatchIterator::new(vec![Ok(update.clone())], update.schema());
+
+    let mut fragment = dataset.get_fragments().into_iter().next().unwrap();
+    let updated = fragment
+        .update_columns_with_offsets(right, "i", "i1")
+        .await
+        .unwrap();
+
+    let layout: Vec<Vec<i32>> = updated
+        .fragment
+        .files
+        .iter()
+        .map(|file| file.fields.as_ref().to_vec())
+        .collect();
+    assert_eq!(layout, vec![vec![0, -2], vec![1]]);
+
+    FileFragment::new(dataset, updated.fragment)
+        .validate()
+        .await
+        .unwrap();
+}

--- a/rust/lance/src/dataset/tests/mod.rs
+++ b/rust/lance/src/dataset/tests/mod.rs
@@ -16,3 +16,4 @@ mod dataset_scanner;
 mod dataset_schema_evolution;
 mod dataset_transactions;
 mod dataset_versioning;
+mod fragment_validate_tombstones;


### PR DESCRIPTION
update_columns rewrites a column by tombstoning the field in the file that held it and writing a new file that answers for it. That leaves -2 entries behind, which the format defines as "superseded", not "corrupt".

FileFragment::validate rejects them: its order check compares each id against a `last` of -1, so any -2 fails outright. A fragment that has been through update_columns therefore cannot be validated even though it reads correctly.