### PR TITLE
fix(test): pass stable_row_ids to create_text_dataset call site

### DIFF
--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -2036,7 +2036,7 @@ async fn test_optimize_preserves_fts_overlay_masking() {
     use crate::index::DatasetIndexExt;
     use lance_index::optimize::OptimizeOptions;
 
-    let mut dataset = create_text_dataset().await;
+    let mut dataset = create_text_dataset(false).await;
     build_text_fts_index(&mut dataset).await;
 
     // fragment 0, offset 1 (id=1): "apple banana" -> "cherry mango".


### PR DESCRIPTION
Every Rust CI job on `main` is currently failing to compile the `lance` lib tests with `E0061`. Two PRs that were fine on their own conflicted semantically once both landed: #7975 added a `stable_row_ids: bool` parameter to the `create_text_dataset` test helper and updated the call sites it knew about, while #7924 concurrently added a new call site in `test_optimize_preserves_fts_overlay_masking`. Neither PR saw the other, so the new call site still passes no arguments.

This passes `false`, matching the other non-parameterized tests in the module and preserving the behavior that test had when it was written.
