### PR TITLE
fix: avoid v2.2 panic for full dictionaries

### DIFF
--- a/rust/lance-arrow/src/scalar.rs
+++ b/rust/lance-arrow/src/scalar.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use arrow_array::{ArrayRef, make_array};
+use arrow_array::{ArrayRef, UInt64Array, make_array};
 use arrow_buffer::Buffer;
-use arrow_data::{ArrayDataBuilder, transform::MutableArrayData};
+use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType};
+use arrow_select::take::take;
 
 use crate::DataTypeExt;
 
@@ -19,10 +20,7 @@ pub fn extract_scalar_value(array: &ArrayRef, idx: usize) -> Result<ArrayRef> {
         ));
     }
 
-    let data = array.to_data();
-    let mut mutable = MutableArrayData::new(vec![&data], /*use_nulls=*/ true, 1);
-    mutable.extend(0, idx, idx + 1);
-    Ok(make_array(mutable.freeze()))
+    take(array.as_ref(), &UInt64Array::from(vec![idx as u64]), None)
 }
 
 fn read_u32(buf: &[u8], offset: &mut usize) -> Result<u32> {
@@ -195,7 +193,10 @@ pub fn try_inline_value(scalar: &ArrayRef) -> Option<Vec<u8>> {
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{BooleanArray, FixedSizeBinaryArray, Int32Array, StringArray, cast::AsArray};
+    use arrow_array::{
+        BooleanArray, DictionaryArray, FixedSizeBinaryArray, Int8Array, Int32Array, StringArray,
+        cast::AsArray, types::Int8Type,
+    };
 
     use super::*;
 
@@ -210,6 +211,24 @@ mod tests {
                 .value(0),
             3
         );
+    }
+
+    #[test]
+    fn test_extract_scalar_value_from_full_dictionary() {
+        let values = Arc::new(StringArray::from(
+            (0..=i8::MAX)
+                .map(|value| format!("value-{value}"))
+                .collect::<Vec<_>>(),
+        ));
+        let keys = Int8Array::from((0..=i8::MAX).collect::<Vec<_>>());
+        let array: ArrayRef = Arc::new(DictionaryArray::<Int8Type>::new(keys, values));
+
+        let scalar = extract_scalar_value(&array, i8::MAX as usize).unwrap();
+
+        let scalar = scalar.as_dictionary::<Int8Type>();
+        assert_eq!(scalar.len(), 1);
+        assert_eq!(scalar.key(0), Some(i8::MAX as usize));
+        assert_eq!(scalar.values().len(), i8::MAX as usize + 1);
     }
 
     #[test]

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -2430,8 +2430,9 @@ mod tests {
     };
 
     use arrow_array::{
-        Int32Array, ListArray, RecordBatch, RecordBatchIterator, UInt32Array,
-        types::{Float64Type, Int32Type},
+        DictionaryArray, Int8Array, Int32Array, ListArray, RecordBatch, RecordBatchIterator,
+        StringArray, UInt32Array,
+        types::{Float64Type, Int8Type, Int32Type},
     };
     use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
@@ -2596,6 +2597,61 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(take, vec![batch.take(&indices).unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn full_int8_dictionary_v2_2_roundtrip() {
+        let fs = FsFixture::default();
+        let values = Arc::new(StringArray::from(
+            (0..=i8::MAX)
+                .map(|value| format!("value-{value}"))
+                .collect::<Vec<_>>(),
+        ));
+        let keys = Int8Array::from((0..=i8::MAX).collect::<Vec<_>>());
+        let dictionary = Arc::new(DictionaryArray::<Int8Type>::new(keys, values));
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "dictionary",
+            DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![dictionary]).unwrap();
+
+        write_lance_file(
+            RecordBatchIterator::new([Ok(batch.clone())], arrow_schema),
+            &fs,
+            ConcreteFileVersion::V2_2,
+            FileWriterOptions::default(),
+        )
+        .await;
+
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &test_cache(),
+            FileReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+        let actual = file_reader
+            .read_stream(
+                lance_io::ReadBatchParams::RangeFull,
+                1024,
+                1,
+                FilterExpression::no_filter(),
+            )
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(actual, vec![batch]);
     }
 
     async fn create_some_file(fs: &FsFixture, version: ConcreteFileVersion) -> WrittenFile {


### PR DESCRIPTION
## Summary

- extract scalar rows with Arrow's dictionary-aware `take` kernel
- cover at-capacity `Int8` dictionary extraction
- verify a v2.2 file round-trip preserves all 128 dictionary values

## Root cause

`MutableArrayData::new` eagerly prepared dictionary concatenation while the v2.2 constant-page probe extracted a candidate scalar. An `Int8` dictionary already using all 128 keys could not represent the extra reservation, so Arrow panicked before the probe could reject dictionary constants.

## Fix

Use Arrow's `take` kernel to copy the selected row. Its dictionary path copies the key while reusing the existing values array, avoiding dictionary growth and preserving the scalar-copy semantics required by supported constant encodings.

## Validation

- `cargo test -p lance-arrow scalar::tests`
- `cargo test -p lance-file full_int8_dictionary_v2_2_roundtrip`
- `cargo fmt --all --check`
- `cargo clippy -p lance-arrow -p lance-file --tests -- -D warnings`

## Note

Supersedes #8219, which carries the same change but on a branch that predates the dependency-advisory fixes on `main`, so its `cargo-deny` job fails on `rkyv 0.8.16` (RUSTSEC-2026-0233/0234/0235). This branch is cut from current `main`, so it picks those up already.

Fixes #8218