### PR TITLE
feat(encoding): compress v2.3 mini-block offsets

### DIFF
--- a/docs/src/format/file/encoding.md
+++ b/docs/src/format/file/encoding.md
@@ -587,6 +587,7 @@ on a per-value basis. We use ☑️ to mark a technique that is applied on a per
 | Constant        | ✅ (2.1)              | ❓                       | ❓                         |
 | Range           | ✅ (2.3)              | ❌                       | ❌                         |
 | Delta           | ✅ (2.3)              | ❌                       | ❌                         |
+| Dictionary      | ✅ (2.3)              | ❌                       | ❌                         |
 | Bitpacking      | ✅ (2.1)              | ❓                       | ✅ (2.1)                   |
 | Fsst            | ❓                    | ✅ (2.1)                 | ✅ (2.1)                   |
 | Rle             | ✅ (2.2)              | ❌                       | ✅ (2.1)                   |
@@ -638,6 +639,21 @@ has one, and readers reconstruct values with checked prefix sums.
 ```protobuf
 %%% proto.message.Delta %%%
 ```
+
+### Block Dictionary
+
+A block dictionary represents unsigned `u32` or `u64` values with a `u32` indices child and a dictionary-items
+child. Both children are concrete block codecs. When either child has a payload, the outer payload is framed as:
+
+```text
+u64 indices_payload_bytes
+u64 items_payload_bytes
+indices payload
+dictionary-items payload
+```
+
+A metadata-only child has a zero framed length. If both children are metadata-only, the dictionary itself has no
+payload. Readers validate the frame boundaries, child widths and cardinalities, and every dictionary index.
 
 ### Bitpacking
 

--- a/docs/src/format/file/encoding.md
+++ b/docs/src/format/file/encoding.md
@@ -585,6 +585,8 @@ on a per-value basis. We use ☑️ to mark a technique that is applied on a per
 | Flat            | ✅ (2.1)              | ✅ (2.1)                 | ✅ (2.1)                   |
 | Variable        | ✅ (2.1)              | ✅ (2.1)                 | ✅ (2.1)                   |
 | Constant        | ✅ (2.1)              | ❓                       | ❓                         |
+| Range           | ✅ (2.3)              | ❌                       | ❌                         |
+| Delta           | ✅ (2.3)              | ❌                       | ❌                         |
 | Bitpacking      | ✅ (2.1)              | ❓                       | ✅ (2.1)                   |
 | Fsst            | ❓                    | ✅ (2.1)                 | ✅ (2.1)                   |
 | Rle             | ✅ (2.2)              | ❌                       | ✅ (2.1)                   |
@@ -616,6 +618,26 @@ we have passed.
 Constant compression is currently only utilized in a few specialized scenarios such as all-null arrays.
 
 This will likely change in future versions.
+
+### Range
+
+Range is a metadata-only block encoding for unsigned `u32` and `u64` arithmetic sequences. It stores the first
+value and a positive step; the containing block supplies the number of values. Readers compute value `i` as
+`start + step * i` and reject invalid widths or arithmetic overflow.
+
+```protobuf
+%%% proto.message.Range %%%
+```
+
+### Delta
+
+Delta encodes a non-decreasing unsigned `u32` or `u64` sequence as its first value and the `n - 1` adjacent
+differences. The differences are represented by a child block codec. Delta has a payload exactly when its child
+has one, and readers reconstruct values with checked prefix sums.
+
+```protobuf
+%%% proto.message.Delta %%%
+```
 
 ### Bitpacking
 

--- a/protos/encodings_v2_1.proto
+++ b/protos/encodings_v2_1.proto
@@ -426,6 +426,39 @@ message Constant {
   optional bytes value = 1;
 }
 
+// A metadata-only arithmetic sequence of unsigned fixed-width values.
+//
+// The value at index i is `start + step * i`. The container supplies the
+// number of values. Writers use this encoding only when step is positive and
+// the final value fits in the declared bit width.
+//
+// The input is a u32 or u64 fixed-width data block.
+// There is no output buffer.
+message Range {
+  // The width of each decompressed value. Must be 32 or 64.
+  uint64 uncompressed_bits_per_value = 1;
+  // The first value in the sequence.
+  uint64 start = 2;
+  // The positive difference between adjacent values.
+  uint64 step = 3;
+}
+
+// A non-decreasing unsigned fixed-width sequence represented by its first
+// value and the differences between adjacent values.
+//
+// The child contains one fewer value than the input. The container supplies
+// the input cardinality. Delta has a payload exactly when its child has one.
+//
+// The input is a u32 or u64 fixed-width data block.
+message Delta {
+  // The width of each decompressed value. Must be 32 or 64.
+  uint64 uncompressed_bits_per_value = 1;
+  // The first uncompressed value.
+  uint64 base = 2;
+  // Compression applied to the adjacent differences.
+  CompressiveEncoding deltas = 3;
+}
+
 // A compression scheme in which a single fixed-width block is "packed" into
 // a smaller fixed-width block values where each value has fewer bits.
 //
@@ -631,5 +664,7 @@ message CompressiveEncoding {
         FixedSizeList fixed_size_list = 11;
         PackedStruct packed_struct = 12;
         VariablePackedStruct variable_packed_struct = 13;
+        Range range = 14;
+        Delta delta = 15;
     }
 }

--- a/rust/lance-encoding/benches/common/mod.rs
+++ b/rust/lance-encoding/benches/common/mod.rs
@@ -26,7 +26,6 @@ use lance_encoding::{
         },
     },
     encodings::logical::primitive::{fullzip::PerValueCompressor, miniblock::MiniBlockCompressor},
-    format::pb21::CompressiveEncoding,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,7 +140,7 @@ impl CompressionStrategy for BenchCompressionStrategy {
         &self,
         field: &Field,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+    ) -> Result<Box<dyn BlockCompressor>> {
         let params = self.field_params(field);
         if self.encoding == BenchEncoding::StructuralU32
             && let Some(compressor) = try_fixed_u8_rle_block(data, &params)?

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -651,7 +651,7 @@ where
 #[cfg(feature = "bitpacking")]
 fn typed_view_unchunk(buffer: LanceBuffer, uncompressed_bits: u64, num_values: u64) -> DataBlock {
     InlineBitpacking::new(uncompressed_bits)
-        .decompress(buffer, num_values)
+        .decompress(Some(buffer), num_values)
         .unwrap()
 }
 

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -61,10 +61,7 @@ use crate::{
             value::{ValueDecompressor, ValueEncoder},
         },
     },
-    format::{
-        ProtobufUtils21,
-        pb21::{CompressiveEncoding, compressive_encoding::Compression},
-    },
+    format::pb21::{CompressiveEncoding, compressive_encoding::Compression},
     statistics::{GetStat, Stat},
 };
 
@@ -98,11 +95,11 @@ const RLE_BLOCK_HEADER_BYTES: u128 = std::mem::size_of::<u64>() as u128;
 /// required (e.g. when encoding metadata buffers like a dictionary or for encoding rep/def
 /// mini-block chunks)
 pub trait BlockCompressor: std::fmt::Debug + Send + Sync {
-    /// Compress the data into a single buffer
+    /// Compress the data into zero or one buffers and describe the codec used.
     ///
-    /// Also returns a description of the compression that can be used to decompress
-    /// when reading the data back
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer>;
+    /// `None` represents a metadata-only codec. `Some` represents a physical
+    /// payload, including a zero-byte payload.
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)>;
 }
 
 /// A trait to pick which compression to use for given data
@@ -118,12 +115,12 @@ pub trait BlockCompressor: std::fmt::Debug + Send + Sync {
 ///   used for narrow data types (both fixed and variable length) where we can
 ///   fit many values into an 16KiB block.
 pub trait CompressionStrategy: Send + Sync + std::fmt::Debug {
-    /// Create a block compressor for the given data
+    /// Create a block compressor for the given data.
     fn create_block_compressor(
         &self,
         field: &Field,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)>;
+    ) -> Result<Box<dyn BlockCompressor>>;
 
     /// Create a per-value compressor for the given data
     fn create_per_value(
@@ -138,6 +135,19 @@ pub trait CompressionStrategy: Send + Sync + std::fmt::Debug {
         field: &Field,
         data: &DataBlock,
     ) -> Result<Box<dyn MiniBlockCompressor>>;
+}
+
+pub(crate) fn compress_required_block(
+    strategy: &dyn CompressionStrategy,
+    field: &Field,
+    data: DataBlock,
+) -> Result<(LanceBuffer, CompressiveEncoding)> {
+    let compressor = strategy.create_block_compressor(field, &data)?;
+    let (payload, encoding) = compressor.compress(data)?;
+    let payload = payload.ok_or_else(|| {
+        Error::internal("Required block compressor selected a metadata-only codec".to_string())
+    })?;
+    Ok((payload, encoding))
 }
 
 fn try_bss_for_mini_block(
@@ -269,7 +279,7 @@ fn try_rle_for_block_with_width(
     params: &CompressionFieldParams,
     run_length_width: RunLengthWidth,
     rle_payload_bytes: u128,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
     let bits = data.bits_per_value;
     if !matches!(bits, 8 | 16 | 32 | 64) {
         return Ok(None);
@@ -305,18 +315,15 @@ fn try_rle_for_block_with_width(
         }
     }
 
-    let compressor = Box::new(RleEncoder::with_run_length_width(run_length_width));
-    let encoding = ProtobufUtils21::rle(
-        ProtobufUtils21::flat(bits, None),
-        ProtobufUtils21::flat(run_length_width.bits_per_value(), None),
-    );
-    Ok(Some((compressor, encoding)))
+    Ok(Some(Box::new(RleEncoder::with_run_length_width(
+        run_length_width,
+    ))))
 }
 
 fn try_fixed_u8_rle_for_block(
     data: &FixedWidthDataBlock,
     params: &CompressionFieldParams,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
     if !matches!(data.bits_per_value, 8 | 16 | 32 | 64) {
         return Ok(None);
     }
@@ -327,7 +334,7 @@ fn try_fixed_u8_rle_for_block(
 fn try_variable_rle_for_block(
     data: &FixedWidthDataBlock,
     params: &CompressionFieldParams,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
     if !matches!(data.bits_per_value, 8 | 16 | 32 | 64) {
         return Ok(None);
     }
@@ -410,9 +417,7 @@ fn estimate_inline_bitpacking_bytes(data: &FixedWidthDataBlock) -> Option<u64> {
     u64::try_from(estimated_bytes).ok()
 }
 
-fn try_bitpack_for_block(
-    data: &FixedWidthDataBlock,
-) -> Option<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+fn try_bitpack_for_block(data: &FixedWidthDataBlock) -> Option<Box<dyn BlockCompressor>> {
     let bits = data.bits_per_value;
     if !matches!(bits, 8 | 16 | 32 | 64) {
         return None;
@@ -430,16 +435,9 @@ fn try_bitpack_for_block(
     }
 
     if data.num_values <= 1024 {
-        let compressor = Box::new(InlineBitpacking::new(bits));
-        let encoding = ProtobufUtils21::inline_bitpacking(bits, None);
-        Some((compressor, encoding))
+        Some(Box::new(InlineBitpacking::new(bits)))
     } else {
-        let compressor = Box::new(OutOfLineBitpacking::new(max_bit_width, bits));
-        let encoding = ProtobufUtils21::out_of_line_bitpacking(
-            bits,
-            ProtobufUtils21::flat(max_bit_width, None),
-        );
-        Some((compressor, encoding))
+        Some(Box::new(OutOfLineBitpacking::new(max_bit_width, bits)))
     }
 }
 
@@ -818,7 +816,7 @@ pub fn try_variable_width_per_value(
 pub fn try_fixed_u8_rle_block(
     data: &DataBlock,
     params: &CompressionFieldParams,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
     let DataBlock::FixedWidth(data) = data else {
         return Ok(None);
     };
@@ -829,7 +827,7 @@ pub fn try_fixed_u8_rle_block(
 pub fn try_variable_rle_block(
     data: &DataBlock,
     params: &CompressionFieldParams,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
     let DataBlock::FixedWidth(data) = data else {
         return Ok(None);
     };
@@ -837,9 +835,7 @@ pub fn try_variable_rle_block(
 }
 
 /// Select block bitpacking for applicable fixed-width values.
-pub fn try_bitpacking_block(
-    data: &DataBlock,
-) -> Option<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+pub fn try_bitpacking_block(data: &DataBlock) -> Option<Box<dyn BlockCompressor>> {
     let DataBlock::FixedWidth(data) = data else {
         return None;
     };
@@ -850,35 +846,22 @@ pub fn try_bitpacking_block(
 pub fn try_general_block(
     data: &DataBlock,
     params: &CompressionFieldParams,
-) -> Result<Option<(Box<dyn BlockCompressor>, CompressiveEncoding)>> {
-    let Some((compressor, config)) = try_general_compression(params, data)? else {
+) -> Result<Option<Box<dyn BlockCompressor>>> {
+    let Some((compressor, _config)) = try_general_compression(params, data)? else {
         return Ok(None);
     };
-    let inner = match data {
-        DataBlock::FixedWidth(data) => ProtobufUtils21::flat(data.bits_per_value, None),
-        DataBlock::VariableWidth(data) => ProtobufUtils21::variable(
-            ProtobufUtils21::flat(data.bits_per_offset as u64, None),
-            None,
-        ),
-        _ => return Ok(None),
-    };
-    Ok(Some((compressor, ProtobufUtils21::wrapped(config, inner)?)))
+    Ok(Some(compressor))
 }
 
 /// Store fixed- and variable-width block values without block compression.
-pub fn try_raw_block(data: &DataBlock) -> Option<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+pub fn try_raw_block(data: &DataBlock) -> Option<Box<dyn BlockCompressor>> {
     match data {
-        DataBlock::FixedWidth(data) => Some((
-            Box::new(ValueEncoder::default()) as Box<dyn BlockCompressor>,
-            ProtobufUtils21::flat(data.bits_per_value, None),
-        )),
-        DataBlock::VariableWidth(data) => Some((
-            Box::new(VariableEncoder::default()) as Box<dyn BlockCompressor>,
-            ProtobufUtils21::variable(
-                ProtobufUtils21::flat(data.bits_per_offset as u64, None),
-                None,
-            ),
-        )),
+        DataBlock::FixedWidth(_) => {
+            Some(Box::new(ValueEncoder::default()) as Box<dyn BlockCompressor>)
+        }
+        DataBlock::VariableWidth(_) => {
+            Some(Box::new(VariableEncoder::default()) as Box<dyn BlockCompressor>)
+        }
         _ => None,
     }
 }
@@ -922,7 +905,23 @@ pub trait VariablePerValueDecompressor: std::fmt::Debug + Send + Sync {
 }
 
 pub trait BlockDecompressor: std::fmt::Debug + Send + Sync {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock>;
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock>;
+
+    /// Whether this codec consumes one payload buffer.
+    fn requires_payload(&self) -> bool {
+        true
+    }
+}
+
+pub(crate) fn require_block_payload(data: Option<LanceBuffer>, codec: &str) -> Result<LanceBuffer> {
+    data.ok_or_else(|| Error::invalid_input(format!("{codec} requires one payload")))
+}
+
+pub(crate) fn require_no_block_payload(data: Option<LanceBuffer>, codec: &str) -> Result<()> {
+    if data.is_some() {
+        return Err(Error::invalid_input(format!("{codec} expects no payload")));
+    }
+    Ok(())
 }
 
 pub trait DecompressionStrategy: std::fmt::Debug + Send + Sync {
@@ -1389,6 +1388,16 @@ mod tests {
         strategy(TestEncoding::StructuralU16, params)
     }
 
+    fn selected_block_codec(
+        strategy: &Arc<dyn CompressionStrategy>,
+        field: &Field,
+        data: &DataBlock,
+    ) -> (Box<dyn BlockCompressor>, CompressiveEncoding) {
+        let compressor = strategy.create_block_compressor(field, data).unwrap();
+        let (_, encoding) = compressor.compress(data.clone()).unwrap();
+        (compressor, encoding)
+    }
+
     fn miniblock_context() -> MiniBlockCompressionContext {
         MiniBlockCompressionContext::new(0, true, true)
     }
@@ -1643,7 +1652,7 @@ mod tests {
         block.compute_stat();
         let data = DataBlock::FixedWidth(block);
 
-        let (compressor, _encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let compressor = strategy.create_block_compressor(&field, &data).unwrap();
         let debug_str = format!("{:?}", compressor);
         assert!(
             debug_str.contains("OutOfLineBitpacking"),
@@ -1665,7 +1674,7 @@ mod tests {
         block.compute_stat();
         let data = DataBlock::FixedWidth(block);
 
-        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let (compressor, encoding) = selected_block_codec(&strategy, &field, &data);
 
         assert!(format!("{compressor:?}").contains("ValueEncoder"));
         assert!(matches!(
@@ -1693,7 +1702,7 @@ mod tests {
         block.compute_stat();
         let data = DataBlock::FixedWidth(block);
 
-        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let (compressor, encoding) = selected_block_codec(&strategy, &field, &data);
         let debug_str = format!("{compressor:?}");
         assert!(
             debug_str.contains("OutOfLineBitpacking"),
@@ -2492,17 +2501,16 @@ mod tests {
         let expected_num_values = expected_block.num_values;
         let num_values = expected_num_values;
 
-        let (compressor, encoding) = strategy
+        let compressor = strategy
             .create_block_compressor(&field, &data)
             .expect("general compression should be selected");
+        let (compressed_buffer, encoding) = compressor
+            .compress(data.clone())
+            .expect("write path general compression should succeed");
         match encoding.compression.as_ref() {
             Some(Compression::General(_)) => {}
             other => panic!("expected general compression, got {:?}", other),
         }
-
-        let compressed_buffer = compressor
-            .compress(data.clone())
-            .expect("write path general compression should succeed");
 
         let decompressor = DefaultDecompressionStrategy::default()
             .create_block_decompressor(&encoding)
@@ -2538,9 +2546,10 @@ mod tests {
         let field = create_test_field("dict_values", DataType::FixedSizeBinary(3));
         let data = create_fixed_width_block(24, 1024);
 
-        let (_compressor, encoding) = strategy
+        let compressor = strategy
             .create_block_compressor(&field, &data)
             .expect("block compressor selection should succeed");
+        let (_, encoding) = compressor.compress(data).unwrap();
 
         assert!(
             !matches!(encoding.compression.as_ref(), Some(Compression::General(_))),
@@ -2568,9 +2577,10 @@ mod tests {
             "test requires block size above automatic general compression threshold"
         );
 
-        let (_compressor, encoding) = strategy
+        let compressor = strategy
             .create_block_compressor(&field, &data)
             .expect("block compressor selection should succeed");
+        let (_, encoding) = compressor.compress(data).unwrap();
 
         assert!(
             !matches!(encoding.compression.as_ref(), Some(Compression::General(_))),
@@ -2592,10 +2602,9 @@ mod tests {
         let data = DataBlock::FixedWidth(block);
 
         let strategy = strategy(TestEncoding::StructuralSparse, CompressionParams::new());
-        let (compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let compressor = strategy.create_block_compressor(&field, &data).unwrap();
+        let (compressed, encoding) = compressor.compress(data).unwrap();
         assert_eq!(rle_run_length_bits(&encoding), 32);
-
-        let compressed = compressor.compress(data).unwrap();
         let decompressor = DefaultDecompressionStrategy::default()
             .create_block_decompressor(&encoding)
             .unwrap();
@@ -2626,7 +2635,8 @@ mod tests {
         let data = DataBlock::FixedWidth(block);
 
         let strategy = strategy(TestEncoding::StructuralU32, CompressionParams::new());
-        let (_compressor, encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let compressor = strategy.create_block_compressor(&field, &data).unwrap();
+        let (_, encoding) = compressor.compress(data).unwrap();
         assert_eq!(rle_run_length_bits(&encoding), 8);
     }
 
@@ -2656,7 +2666,7 @@ mod tests {
 
         let strategy = strategy(TestEncoding::StructuralU32, CompressionParams::new());
 
-        let (compressor, _) = strategy
+        let compressor = strategy
             .create_block_compressor(&field, &data_block)
             .unwrap();
 
@@ -2690,7 +2700,7 @@ mod tests {
 
         let strategy = strategy(TestEncoding::StructuralU16, CompressionParams::new());
 
-        let (compressor, _) = strategy
+        let compressor = strategy
             .create_block_compressor(&field, &data_block)
             .unwrap();
 

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -42,13 +42,17 @@ use crate::{
             byte_stream_split::{
                 ByteStreamSplitDecompressor, ByteStreamSplitEncoder, should_use_bss,
             },
-            constant::ConstantDecompressor,
+            constant::{ConstantBlockDecompressor, ConstantDecompressor},
             delta::DeltaDecompressor,
+            dictionary::BlockDictionaryDecompressor,
             fsst::{
                 FsstMiniBlockDecompressor, FsstMiniBlockEncoder, FsstPerValueDecompressor,
                 FsstPerValueEncoder,
             },
-            general::{GeneralMiniBlockCompressor, GeneralMiniBlockDecompressor},
+            general::{
+                FixedWidthGeneralBlockDecompressor, GeneralMiniBlockCompressor,
+                GeneralMiniBlockDecompressor,
+            },
             packed::{
                 PackedStructFixedWidthMiniBlockDecompressor,
                 PackedStructFixedWidthMiniBlockEncoder, PackedStructVariablePerValueDecompressor,
@@ -57,8 +61,8 @@ use crate::{
             },
             range::RangeDecompressor,
             rle::{
-                RleChildDecompressor, RleDecompressor, RleEncoder, RunLengthWidth,
-                rle_encoded_size, select_run_length_width,
+                BlockRleDecompressor, BlockRleRunCount, RleChildDecompressor, RleDecompressor,
+                RleEncoder, RunLengthWidth, rle_encoded_size, select_run_length_width,
             },
             value::{ValueDecompressor, ValueEncoder},
         },
@@ -1195,81 +1199,283 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 Ok(Box::new(general_decompressor))
             }
             Compression::Rle(rle) => Ok(Box::new(create_rle_decompressor(rle, self)?)),
-            Compression::Range(range) => {
-                if !matches!(range.uncompressed_bits_per_value, 32 | 64) {
-                    return Err(Error::invalid_input(format!(
-                        "Range only supports 32 or 64-bit values, got {}",
-                        range.uncompressed_bits_per_value
-                    )));
-                }
-                if range.uncompressed_bits_per_value == 32 && range.start > u32::MAX as u64 {
-                    return Err(Error::invalid_input(format!(
-                        "Range start {} exceeds u32::MAX",
-                        range.start
-                    )));
-                }
-                if range.step == 0 {
-                    return Err(Error::invalid_input("Range step must be positive"));
-                }
-                Ok(Box::new(RangeDecompressor::new(
-                    range.uncompressed_bits_per_value,
-                    range.start,
-                    range.step,
-                )))
-            }
-            Compression::Delta(delta) => {
-                let bits_per_value = delta.uncompressed_bits_per_value;
-                if !matches!(bits_per_value, 32 | 64) {
-                    return Err(Error::invalid_input(format!(
-                        "Delta only supports 32 or 64-bit values, got {bits_per_value}"
-                    )));
-                }
-                if bits_per_value == 32 && delta.base > u32::MAX as u64 {
-                    return Err(Error::invalid_input(format!(
-                        "Delta base {} exceeds u32::MAX",
-                        delta.base
-                    )));
-                }
-                let child = delta.deltas.as_deref().ok_or_else(|| {
-                    Error::invalid_input("Delta is missing its deltas child encoding")
-                })?;
-                let child_bits = match child.compression.as_ref() {
-                    Some(Compression::Flat(flat)) => flat.bits_per_value,
-                    Some(Compression::Range(range)) => range.uncompressed_bits_per_value,
-                    Some(Compression::InlineBitpacking(bitpacking)) => {
-                        bitpacking.uncompressed_bits_per_value
-                    }
-                    Some(Compression::OutOfLineBitpacking(bitpacking)) => {
-                        bitpacking.uncompressed_bits_per_value
-                    }
-                    Some(other) => {
-                        return Err(Error::invalid_input(format!(
-                            "Delta does not support a {} child",
-                            compression_name(other)
-                        )));
-                    }
-                    None => {
-                        return Err(Error::invalid_input(
-                            "Delta child is missing its compression variant",
-                        ));
-                    }
-                };
-                if child_bits != bits_per_value {
-                    return Err(Error::invalid_input(format!(
-                        "Delta child declares {child_bits}-bit values, expected {bits_per_value}"
-                    )));
-                }
-                let child = self.create_block_decompressor(child)?;
-                Ok(Box::new(DeltaDecompressor::new(
-                    bits_per_value,
-                    delta.base,
-                    child,
-                )))
-            }
+            Compression::Range(range) => create_fixed_width_block_decompressor(
+                description,
+                range.uncompressed_bits_per_value,
+            ),
+            Compression::Delta(delta) => create_fixed_width_block_decompressor(
+                description,
+                delta.uncompressed_bits_per_value,
+            ),
             _ => todo!(),
         }
     }
 }
+
+/// Builds the bounded decoder tree used by generic unsigned block sequences.
+///
+/// This is intentionally separate from [`DecompressionStrategy::create_block_decompressor`]:
+/// stable 2.1/2.2 block readers keep their existing grammar and framing, while
+/// the 2.3 offset container opts into this typed grammar explicitly.
+pub(crate) fn create_fixed_width_block_decompressor(
+    description: &CompressiveEncoding,
+    expected_bits_per_value: u64,
+) -> Result<Box<dyn BlockDecompressor>> {
+    if !matches!(expected_bits_per_value, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Generic block decoding only supports 32 or 64-bit values, got {expected_bits_per_value}"
+        )));
+    }
+    create_fixed_width_block_decompressor_inner(description, expected_bits_per_value, true)
+}
+
+fn create_fixed_width_block_decompressor_inner(
+    description: &CompressiveEncoding,
+    expected_bits_per_value: u64,
+    allow_composite: bool,
+) -> Result<Box<dyn BlockDecompressor>> {
+    let compression = description
+        .compression
+        .as_ref()
+        .ok_or_else(|| Error::invalid_input("Block encoding is missing its compression variant"))?;
+    match compression {
+        Compression::Flat(flat) => {
+            if flat.bits_per_value != expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Flat declares {}-bit values, expected {expected_bits_per_value}",
+                    flat.bits_per_value
+                )));
+            }
+            if flat.data.is_some() {
+                return Err(Error::invalid_input(
+                    "Generic block Flat cannot contain buffer compression",
+                ));
+            }
+            Ok(Box::new(ValueDecompressor::from_flat(flat)))
+        }
+        Compression::Constant(constant) => {
+            let value = decode_fixed_width_constant(constant, expected_bits_per_value)?;
+            Ok(Box::new(ConstantBlockDecompressor::new(
+                expected_bits_per_value,
+                value,
+            )))
+        }
+        Compression::Range(range) => {
+            if range.uncompressed_bits_per_value != expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Range declares {}-bit values, expected {expected_bits_per_value}",
+                    range.uncompressed_bits_per_value
+                )));
+            }
+            Ok(Box::new(RangeDecompressor::new(
+                expected_bits_per_value,
+                range.start,
+                range.step,
+            )))
+        }
+        Compression::InlineBitpacking(bitpacking) => {
+            if bitpacking.uncompressed_bits_per_value != expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Inline bitpacking declares {}-bit values, expected {expected_bits_per_value}",
+                    bitpacking.uncompressed_bits_per_value
+                )));
+            }
+            #[cfg(feature = "bitpacking")]
+            {
+                Ok(Box::new(InlineBitpacking::from_description(bitpacking)))
+            }
+            #[cfg(not(feature = "bitpacking"))]
+            {
+                Err(Error::not_supported_source(
+                    "this runtime was not built with bitpacking support".into(),
+                ))
+            }
+        }
+        Compression::OutOfLineBitpacking(bitpacking) => {
+            if bitpacking.uncompressed_bits_per_value != expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Out-of-line bitpacking declares {}-bit values, expected {expected_bits_per_value}",
+                    bitpacking.uncompressed_bits_per_value
+                )));
+            }
+            let values = bitpacking.values.as_deref().ok_or_else(|| {
+                Error::invalid_input("Out-of-line bitpacking is missing its values encoding")
+            })?;
+            let compressed_bits = match values.compression.as_ref() {
+                Some(Compression::Flat(flat)) if flat.data.is_none() => flat.bits_per_value,
+                _ => {
+                    return Err(Error::invalid_input(
+                        "Out-of-line bitpacking values must use plain Flat encoding",
+                    ));
+                }
+            };
+            if compressed_bits == 0 || compressed_bits >= expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Out-of-line bitpacking width {compressed_bits} is invalid for {expected_bits_per_value}-bit values"
+                )));
+            }
+            #[cfg(feature = "bitpacking")]
+            {
+                Ok(Box::new(OutOfLineBitpacking::new(
+                    compressed_bits,
+                    expected_bits_per_value,
+                )))
+            }
+            #[cfg(not(feature = "bitpacking"))]
+            {
+                Err(Error::not_supported_source(
+                    "this runtime was not built with bitpacking support".into(),
+                ))
+            }
+        }
+        Compression::Delta(delta) if allow_composite => {
+            if delta.uncompressed_bits_per_value != expected_bits_per_value {
+                return Err(Error::invalid_input(format!(
+                    "Delta declares {}-bit values, expected {expected_bits_per_value}",
+                    delta.uncompressed_bits_per_value
+                )));
+            }
+            let child = delta.deltas.as_deref().ok_or_else(|| {
+                Error::invalid_input("Delta is missing its deltas child encoding")
+            })?;
+            let child =
+                create_fixed_width_block_decompressor_inner(child, expected_bits_per_value, false)?;
+            Ok(Box::new(DeltaDecompressor::new(
+                expected_bits_per_value,
+                delta.base,
+                child,
+            )))
+        }
+        Compression::General(general) if allow_composite => {
+            let child = general.values.as_deref().ok_or_else(|| {
+                Error::invalid_input("General block compression is missing its values encoding")
+            })?;
+            if !matches!(
+                child.compression.as_ref(),
+                Some(Compression::Flat(flat))
+                    if flat.bits_per_value == expected_bits_per_value && flat.data.is_none()
+            ) {
+                return Err(Error::invalid_input(
+                    "Generic General compression must wrap plain Flat values",
+                ));
+            }
+            let child =
+                create_fixed_width_block_decompressor_inner(child, expected_bits_per_value, false)?;
+            let compression = general.compression.as_ref().ok_or_else(|| {
+                Error::invalid_input("General block compression is missing its compression config")
+            })?;
+            let scheme = compression.scheme().try_into()?;
+            let config = CompressionConfig::new(scheme, compression.level);
+            Ok(Box::new(FixedWidthGeneralBlockDecompressor::new(
+                child,
+                config,
+                expected_bits_per_value,
+            )))
+        }
+        Compression::Rle(rle) if allow_composite => {
+            let values = rle.values.as_deref().ok_or_else(|| {
+                Error::invalid_input("RLE compression is missing its values encoding")
+            })?;
+            let run_lengths = rle.run_lengths.as_deref().ok_or_else(|| {
+                Error::invalid_input("RLE compression is missing its run-length encoding")
+            })?;
+            let run_count = match run_lengths.compression.as_ref() {
+                Some(Compression::Constant(constant)) => {
+                    BlockRleRunCount::ConstantRunLength(decode_fixed_width_constant(constant, 32)?)
+                }
+                Some(Compression::Range(range)) if range.uncompressed_bits_per_value == 32 => {
+                    BlockRleRunCount::RangeRunLengths {
+                        start: range.start,
+                        step: range.step,
+                    }
+                }
+                _ if matches!(values.compression.as_ref(), Some(Compression::Flat(flat)) if flat.bits_per_value == expected_bits_per_value && flat.data.is_none()) => {
+                    BlockRleRunCount::FlatValues
+                }
+                _ if matches!(run_lengths.compression.as_ref(), Some(Compression::Flat(flat)) if flat.bits_per_value == 32 && flat.data.is_none()) => {
+                    BlockRleRunCount::FlatRunLengths
+                }
+                _ => {
+                    return Err(Error::invalid_input(
+                        "RLE requires metadata run lengths or one plain Flat child to recover the run count",
+                    ));
+                }
+            };
+            let values = create_fixed_width_block_decompressor_inner(
+                values,
+                expected_bits_per_value,
+                false,
+            )?;
+            let run_lengths = create_fixed_width_block_decompressor_inner(run_lengths, 32, false)?;
+            Ok(Box::new(BlockRleDecompressor::try_new(
+                expected_bits_per_value,
+                values,
+                run_lengths,
+                run_count,
+            )?))
+        }
+        Compression::Dictionary(dictionary) if allow_composite => {
+            let indices = dictionary.indices.as_deref().ok_or_else(|| {
+                Error::invalid_input("Dictionary is missing its indices encoding")
+            })?;
+            let items = dictionary
+                .items
+                .as_deref()
+                .ok_or_else(|| Error::invalid_input("Dictionary is missing its items encoding"))?;
+            let indices = create_fixed_width_block_decompressor_inner(indices, 32, false)?;
+            let items =
+                create_fixed_width_block_decompressor_inner(items, expected_bits_per_value, false)?;
+            Ok(Box::new(BlockDictionaryDecompressor::try_new(
+                expected_bits_per_value,
+                dictionary.num_dictionary_items,
+                indices,
+                items,
+            )?))
+        }
+        other => Err(Error::invalid_input(format!(
+            "{} is not allowed at this position in a generic block encoding",
+            compression_name(other)
+        ))),
+    }
+}
+
+fn decode_fixed_width_constant(
+    constant: &crate::format::pb21::Constant,
+    bits_per_value: u64,
+) -> Result<u64> {
+    let value = constant
+        .value
+        .as_ref()
+        .ok_or_else(|| Error::invalid_input("Typed Constant is missing its scalar value"))?;
+    let expected_bytes = usize::try_from(bits_per_value / 8)
+        .map_err(|_| Error::invalid_input("Constant scalar width does not fit usize"))?;
+    if value.len() != expected_bytes {
+        return Err(Error::invalid_input(format!(
+            "Constant scalar has {} bytes, expected {expected_bytes}",
+            value.len()
+        )));
+    }
+    Ok(match bits_per_value {
+        32 => u64::from(u32::from_le_bytes(
+            value
+                .as_ref()
+                .try_into()
+                .expect("constant width was checked"),
+        )),
+        64 => u64::from_le_bytes(
+            value
+                .as_ref()
+                .try_into()
+                .expect("constant width was checked"),
+        ),
+        _ => {
+            return Err(Error::invalid_input(format!(
+                "Constant only supports 32 or 64-bit values, got {bits_per_value}"
+            )));
+        }
+    })
+}
+
 pub(crate) fn create_rle_decompressor(
     rle: &crate::format::pb21::Rle,
     decompression_strategy: &dyn DecompressionStrategy,
@@ -2783,6 +2989,73 @@ mod tests {
         assert!(
             !debug_str.contains("RleEncoder"),
             "RLE should not be used for V2.1"
+        );
+    }
+
+    #[test]
+    fn generic_block_rle_round_trips_metadata_children() {
+        use crate::encodings::physical::{
+            constant::ConstantEncoder, range::RangeEncoder, rle::BlockRleEncoder,
+        };
+
+        let values = vec![10_u64, 10, 20, 20, 30, 30];
+        let block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(values.clone()),
+            num_values: values.len() as u64,
+            block_info: BlockInfo::default(),
+        });
+        let encoder = BlockRleEncoder::try_new(
+            64,
+            Box::new(RangeEncoder::new(64, 10, 10)),
+            Box::new(ConstantEncoder::new(32, 2)),
+        )
+        .unwrap();
+        let (payload, encoding) = encoder.compress(block).unwrap();
+        assert!(payload.is_none());
+
+        let decoder = create_fixed_width_block_decompressor(&encoding, 64).unwrap();
+        let decoded = decoder.decompress(None, values.len() as u64).unwrap();
+        assert_eq!(
+            decoded
+                .as_fixed_width()
+                .unwrap()
+                .data
+                .borrow_to_typed_slice::<u64>()
+                .as_ref(),
+            values
+        );
+    }
+
+    #[test]
+    fn generic_block_dictionary_uses_the_typed_decoder_tree() {
+        use crate::encodings::physical::{dictionary::BlockDictionaryEncoder, value::ValueEncoder};
+
+        let values = vec![10_u64, 20, 10, 20];
+        let block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(values.clone()),
+            num_values: values.len() as u64,
+            block_info: BlockInfo::default(),
+        });
+        let encoder = BlockDictionaryEncoder::try_new(
+            64,
+            Arc::from([10, 20]),
+            Box::new(ValueEncoder::default()),
+            Box::new(ValueEncoder::default()),
+        )
+        .unwrap();
+        let (payload, encoding) = encoder.compress(block).unwrap();
+        let decoder = create_fixed_width_block_decompressor(&encoding, 64).unwrap();
+        let decoded = decoder.decompress(payload, values.len() as u64).unwrap();
+        assert_eq!(
+            decoded
+                .as_fixed_width()
+                .unwrap()
+                .data
+                .borrow_to_typed_slice::<u64>()
+                .as_ref(),
+            values
         );
     }
 }

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -43,6 +43,7 @@ use crate::{
                 ByteStreamSplitDecompressor, ByteStreamSplitEncoder, should_use_bss,
             },
             constant::ConstantDecompressor,
+            delta::DeltaDecompressor,
             fsst::{
                 FsstMiniBlockDecompressor, FsstMiniBlockEncoder, FsstPerValueDecompressor,
                 FsstPerValueEncoder,
@@ -54,6 +55,7 @@ use crate::{
                 PackedStructVariablePerValueEncoder, VariablePackedStructFieldDecoder,
                 VariablePackedStructFieldKind,
             },
+            range::RangeDecompressor,
             rle::{
                 RleChildDecompressor, RleDecompressor, RleEncoder, RunLengthWidth,
                 rle_encoded_size, select_run_length_width,
@@ -1193,6 +1195,77 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 Ok(Box::new(general_decompressor))
             }
             Compression::Rle(rle) => Ok(Box::new(create_rle_decompressor(rle, self)?)),
+            Compression::Range(range) => {
+                if !matches!(range.uncompressed_bits_per_value, 32 | 64) {
+                    return Err(Error::invalid_input(format!(
+                        "Range only supports 32 or 64-bit values, got {}",
+                        range.uncompressed_bits_per_value
+                    )));
+                }
+                if range.uncompressed_bits_per_value == 32 && range.start > u32::MAX as u64 {
+                    return Err(Error::invalid_input(format!(
+                        "Range start {} exceeds u32::MAX",
+                        range.start
+                    )));
+                }
+                if range.step == 0 {
+                    return Err(Error::invalid_input("Range step must be positive"));
+                }
+                Ok(Box::new(RangeDecompressor::new(
+                    range.uncompressed_bits_per_value,
+                    range.start,
+                    range.step,
+                )))
+            }
+            Compression::Delta(delta) => {
+                let bits_per_value = delta.uncompressed_bits_per_value;
+                if !matches!(bits_per_value, 32 | 64) {
+                    return Err(Error::invalid_input(format!(
+                        "Delta only supports 32 or 64-bit values, got {bits_per_value}"
+                    )));
+                }
+                if bits_per_value == 32 && delta.base > u32::MAX as u64 {
+                    return Err(Error::invalid_input(format!(
+                        "Delta base {} exceeds u32::MAX",
+                        delta.base
+                    )));
+                }
+                let child = delta.deltas.as_deref().ok_or_else(|| {
+                    Error::invalid_input("Delta is missing its deltas child encoding")
+                })?;
+                let child_bits = match child.compression.as_ref() {
+                    Some(Compression::Flat(flat)) => flat.bits_per_value,
+                    Some(Compression::Range(range)) => range.uncompressed_bits_per_value,
+                    Some(Compression::InlineBitpacking(bitpacking)) => {
+                        bitpacking.uncompressed_bits_per_value
+                    }
+                    Some(Compression::OutOfLineBitpacking(bitpacking)) => {
+                        bitpacking.uncompressed_bits_per_value
+                    }
+                    Some(other) => {
+                        return Err(Error::invalid_input(format!(
+                            "Delta does not support a {} child",
+                            compression_name(other)
+                        )));
+                    }
+                    None => {
+                        return Err(Error::invalid_input(
+                            "Delta child is missing its compression variant",
+                        ));
+                    }
+                };
+                if child_bits != bits_per_value {
+                    return Err(Error::invalid_input(format!(
+                        "Delta child declares {child_bits}-bit values, expected {bits_per_value}"
+                    )));
+                }
+                let child = self.create_block_decompressor(child)?;
+                Ok(Box::new(DeltaDecompressor::new(
+                    bits_per_value,
+                    delta.base,
+                    child,
+                )))
+            }
             _ => todo!(),
         }
     }
@@ -1365,6 +1438,8 @@ fn compression_name(compression: &Compression) -> &'static str {
         Compression::FixedSizeList(_) => "fixed-size list",
         Compression::VariablePackedStruct(_) => "variable packed struct",
         Compression::Rle(_) => "rle",
+        Compression::Range(_) => "range",
+        Compression::Delta(_) => "delta",
     }
 }
 

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -658,6 +658,24 @@ pub fn try_variable_width_miniblock(
     data: &DataBlock,
     params: &CompressionFieldParams,
 ) -> Result<Option<Box<dyn MiniBlockCompressor>>> {
+    try_variable_width_miniblock_impl(field, data, params, false)
+}
+
+/// Encode variable-width miniblocks whose offset chunks may use generic block codecs.
+pub fn try_variable_width_miniblock_with_generic_offsets(
+    field: &Field,
+    data: &DataBlock,
+    params: &CompressionFieldParams,
+) -> Result<Option<Box<dyn MiniBlockCompressor>>> {
+    try_variable_width_miniblock_impl(field, data, params, true)
+}
+
+fn try_variable_width_miniblock_impl(
+    field: &Field,
+    data: &DataBlock,
+    params: &CompressionFieldParams,
+    allow_generic_offsets: bool,
+) -> Result<Option<Box<dyn MiniBlockCompressor>>> {
     let DataBlock::VariableWidth(data) = data else {
         return Ok(None);
     };
@@ -672,9 +690,14 @@ pub fn try_variable_width_miniblock(
     let data_size = data.expect_single_stat::<UInt64Type>(Stat::DataSize);
     let max_len = data.expect_single_stat::<UInt64Type>(Stat::MaxLength);
     if compression == Some("none") {
-        return Ok(Some(Box::new(BinaryMiniBlockEncoder::new(
-            params.minichunk_size,
-        ))));
+        return Ok(Some(if allow_generic_offsets {
+            Box::new(BinaryMiniBlockEncoder::with_generic_offsets(
+                params.minichunk_size,
+                params.clone(),
+            ))
+        } else {
+            Box::new(BinaryMiniBlockEncoder::new(params.minichunk_size))
+        }));
     }
 
     let use_fsst = compression == Some("fsst")
@@ -684,6 +707,14 @@ pub fn try_variable_width_miniblock(
             && data_size >= FSST_LEAST_INPUT_SIZE as u64);
     let mut encoder: Box<dyn MiniBlockCompressor> = if use_fsst {
         Box::new(FsstMiniBlockEncoder::new(params.minichunk_size))
+    } else if allow_generic_offsets && compression.is_none() {
+        // An explicit general codec wraps the first mini-block buffer. Generic
+        // offsets may add a leading offset buffer, so keep the legacy container
+        // to preserve which bytes the override compresses.
+        Box::new(BinaryMiniBlockEncoder::with_generic_offsets(
+            params.minichunk_size,
+            params.clone(),
+        ))
     } else {
         Box::new(BinaryMiniBlockEncoder::new(params.minichunk_size))
     };
@@ -962,7 +993,10 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
         description: &CompressiveEncoding,
         decompression_strategy: &dyn DecompressionStrategy,
     ) -> Result<Box<dyn MiniBlockDecompressor>> {
-        match description.compression.as_ref().unwrap() {
+        let compression = description.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Mini-block encoding is missing its compression variant")
+        })?;
+        match compression {
             Compression::Flat(flat) => Ok(Box::new(ValueDecompressor::from_flat(flat))),
             #[cfg(feature = "bitpacking")]
             Compression::InlineBitpacking(description) => {
@@ -972,24 +1006,14 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
             Compression::InlineBitpacking(_) => Err(Error::not_supported_source(
                 "this runtime was not built with bitpacking support".into(),
             )),
-            Compression::Variable(variable) => {
-                let Compression::Flat(offsets) = variable
-                    .offsets
-                    .as_ref()
-                    .unwrap()
-                    .compression
-                    .as_ref()
-                    .unwrap()
-                else {
-                    panic!("Variable compression only supports flat offsets")
-                };
-                Ok(Box::new(BinaryMiniBlockDecompressor::new(
-                    offsets.bits_per_value as u8,
-                )))
-            }
+            Compression::Variable(variable) => Ok(Box::new(
+                BinaryMiniBlockDecompressor::from_variable(variable)?,
+            )),
             Compression::Fsst(description) => {
                 let inner_decompressor = decompression_strategy.create_miniblock_decompressor(
-                    description.values.as_ref().unwrap(),
+                    description.values.as_ref().ok_or_else(|| {
+                        Error::invalid_input("FSST mini-block encoding is missing its values codec")
+                    })?,
                     decompression_strategy,
                 )?;
                 Ok(Box::new(FsstMiniBlockDecompressor::new(
@@ -1013,10 +1037,18 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 decompression_strategy,
             )?)),
             Compression::ByteStreamSplit(bss) => {
-                let Compression::Flat(values) =
-                    bss.values.as_ref().unwrap().compression.as_ref().unwrap()
+                let values = bss.values.as_ref().ok_or_else(|| {
+                    Error::invalid_input("ByteStreamSplit encoding is missing its values codec")
+                })?;
+                let Compression::Flat(values) = values.compression.as_ref().ok_or_else(|| {
+                    Error::invalid_input(
+                        "ByteStreamSplit values codec is missing its compression variant",
+                    )
+                })?
                 else {
-                    panic!("ByteStreamSplit compression only supports flat values")
+                    return Err(Error::invalid_input(
+                        "ByteStreamSplit compression only supports Flat values",
+                    ));
                 };
                 Ok(Box::new(ByteStreamSplitDecompressor::new(
                     values.bits_per_value as usize,
@@ -1045,7 +1077,13 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                     compression_config,
                 )))
             }
-            _ => todo!(),
+            other => Err(Error::not_supported_source(
+                format!(
+                    "{} is not supported for mini-block decompression",
+                    compression_name(other)
+                )
+                .into(),
+            )),
         }
     }
 
@@ -1053,7 +1091,10 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
         &self,
         description: &CompressiveEncoding,
     ) -> Result<Box<dyn FixedPerValueDecompressor>> {
-        match description.compression.as_ref().unwrap() {
+        let compression = description.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Fixed per-value encoding is missing its compression variant")
+        })?;
+        match compression {
             Compression::Constant(constant) => Ok(Box::new(ConstantDecompressor::new(
                 constant
                     .value
@@ -1062,7 +1103,13 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
             ))),
             Compression::Flat(flat) => Ok(Box::new(ValueDecompressor::from_flat(flat))),
             Compression::FixedSizeList(fsl) => Ok(Box::new(ValueDecompressor::from_fsl(fsl))),
-            _ => todo!("fixed-per-value decompressor for {:?}", description),
+            other => Err(Error::not_supported_source(
+                format!(
+                    "{} is not supported for fixed per-value decompression",
+                    compression_name(other)
+                )
+                .into(),
+            )),
         }
     }
 
@@ -1070,19 +1117,30 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
         &self,
         description: &CompressiveEncoding,
     ) -> Result<Box<dyn VariablePerValueDecompressor>> {
-        match description.compression.as_ref().unwrap() {
+        let compression = description.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Variable per-value encoding is missing its compression variant")
+        })?;
+        match compression {
             Compression::Variable(variable) => {
-                let Compression::Flat(offsets) = variable
-                    .offsets
-                    .as_ref()
-                    .unwrap()
-                    .compression
-                    .as_ref()
-                    .unwrap()
+                let offsets = variable.offsets.as_ref().ok_or_else(|| {
+                    Error::invalid_input("Variable per-value encoding is missing offsets")
+                })?;
+                let Compression::Flat(offsets) = offsets.compression.as_ref().ok_or_else(|| {
+                    Error::invalid_input(
+                        "Variable per-value offsets are missing a compression variant",
+                    )
+                })?
                 else {
-                    panic!("Variable compression only supports flat offsets")
+                    return Err(Error::invalid_input(
+                        "Variable per-value compression only supports Flat offsets",
+                    ));
                 };
-                assert!(offsets.bits_per_value < u8::MAX as u64);
+                if offsets.bits_per_value >= u8::MAX as u64 {
+                    return Err(Error::invalid_input(format!(
+                        "Variable per-value offset width {} does not fit u8",
+                        offsets.bits_per_value
+                    )));
+                }
                 Ok(Box::new(VariableDecoder::default()))
             }
             Compression::Fsst(fsst) => Ok(Box::new(FsstPerValueDecompressor::new(
@@ -1132,7 +1190,13 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                     fields,
                 )))
             }
-            _ => todo!("variable-per-value decompressor for {:?}", description),
+            other => Err(Error::not_supported_source(
+                format!(
+                    "{} is not supported for variable per-value decompression",
+                    compression_name(other)
+                )
+                .into(),
+            )),
         }
     }
 
@@ -1140,7 +1204,10 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
         &self,
         description: &CompressiveEncoding,
     ) -> Result<Box<dyn BlockDecompressor>> {
-        match description.compression.as_ref().unwrap() {
+        let compression = description.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Block encoding is missing its compression variant")
+        })?;
+        match compression {
             Compression::InlineBitpacking(inline_bitpacking) => Ok(Box::new(
                 InlineBitpacking::from_description(inline_bitpacking),
             )),
@@ -1157,15 +1224,14 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 Ok(Box::new(ValueDecompressor::from_fsl(fsl.as_ref())))
             }
             Compression::OutOfLineBitpacking(out_of_line) => {
-                // Extract the compressed bit width from the values encoding
-                let compressed_bit_width = match out_of_line
-                    .values
-                    .as_ref()
-                    .unwrap()
-                    .compression
-                    .as_ref()
-                    .unwrap()
-                {
+                let values = out_of_line.values.as_ref().ok_or_else(|| {
+                    Error::invalid_input("OutOfLineBitpacking is missing its values encoding")
+                })?;
+                let compressed_bit_width = match values.compression.as_ref().ok_or_else(|| {
+                    Error::invalid_input(
+                        "OutOfLineBitpacking values are missing a compression variant",
+                    )
+                })? {
                     Compression::Flat(flat) => flat.bits_per_value,
                     _ => {
                         return Err(Error::invalid_input_source(
@@ -1207,9 +1273,72 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                 description,
                 delta.uncompressed_bits_per_value,
             ),
-            _ => todo!(),
+            other => Err(Error::not_supported_source(
+                format!(
+                    "{} is not supported for block decompression",
+                    compression_name(other)
+                )
+                .into(),
+            )),
         }
     }
+}
+
+pub(crate) fn infer_fixed_width_block_bits(description: &CompressiveEncoding) -> Result<u64> {
+    fn infer(description: &CompressiveEncoding, depth: u8) -> Result<u64> {
+        if depth > 2 {
+            return Err(Error::invalid_input(
+                "Generic block encoding exceeds the supported nesting depth",
+            ));
+        }
+        let compression = description.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Block encoding is missing its compression variant")
+        })?;
+        match compression {
+            Compression::Flat(flat) => Ok(flat.bits_per_value),
+            Compression::Constant(constant) => constant
+                .value
+                .as_ref()
+                .map(|value| value.len() as u64 * 8)
+                .ok_or_else(|| Error::invalid_input("Typed Constant is missing its scalar value")),
+            Compression::Range(range) => Ok(range.uncompressed_bits_per_value),
+            Compression::Delta(delta) => Ok(delta.uncompressed_bits_per_value),
+            Compression::InlineBitpacking(bitpacking) => Ok(bitpacking.uncompressed_bits_per_value),
+            Compression::OutOfLineBitpacking(bitpacking) => {
+                Ok(bitpacking.uncompressed_bits_per_value)
+            }
+            Compression::General(general) => infer(
+                general.values.as_deref().ok_or_else(|| {
+                    Error::invalid_input("General block compression is missing its values encoding")
+                })?,
+                depth + 1,
+            ),
+            Compression::Rle(rle) => infer(
+                rle.values.as_deref().ok_or_else(|| {
+                    Error::invalid_input("RLE compression is missing its values encoding")
+                })?,
+                depth + 1,
+            ),
+            Compression::Dictionary(dictionary) => infer(
+                dictionary.items.as_deref().ok_or_else(|| {
+                    Error::invalid_input("Dictionary is missing its items encoding")
+                })?,
+                depth + 1,
+            ),
+            other => Err(Error::invalid_input(format!(
+                "Cannot infer fixed-width output from {}",
+                compression_name(other)
+            ))),
+        }
+    }
+
+    let bits = infer(description, 0)?;
+    if !matches!(bits, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Generic block offsets require 32 or 64-bit values, got {bits}"
+        )));
+    }
+    Ok(bits)
 }
 
 /// Builds the bounded decoder tree used by generic unsigned block sequences.
@@ -1279,6 +1408,11 @@ fn create_fixed_width_block_decompressor_inner(
                     "Inline bitpacking declares {}-bit values, expected {expected_bits_per_value}",
                     bitpacking.uncompressed_bits_per_value
                 )));
+            }
+            if bitpacking.values.is_some() {
+                return Err(Error::invalid_input(
+                    "Generic Inline bitpacking cannot contain buffer compression",
+                ));
             }
             #[cfg(feature = "bitpacking")]
             {
@@ -3057,5 +3191,27 @@ mod tests {
                 .as_ref(),
             values
         );
+    }
+
+    #[test]
+    fn decompressor_dispatch_rejects_missing_variants() {
+        let strategy = DefaultDecompressionStrategy::default();
+        let missing = CompressiveEncoding::default();
+        assert!(
+            strategy
+                .create_miniblock_decompressor(&missing, &strategy)
+                .is_err()
+        );
+        assert!(
+            strategy
+                .create_fixed_per_value_decompressor(&missing)
+                .is_err()
+        );
+        assert!(
+            strategy
+                .create_variable_per_value_decompressor(&missing)
+                .is_err()
+        );
+        assert!(strategy.create_block_decompressor(&missing).is_err());
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -7020,19 +7020,20 @@ mod tests {
         FixedPerValueDecompressor, FixedWidthDataBlock, FixedWidthDictionaryEncoding,
         FullZipCacheableState, FullZipDecodeDetails, FullZipDecodeTaskItem, FullZipReadSource,
         FullZipRepIndexDetails, FullZipScheduler, LazyLevels, LevelCodec, LevelCursor, LevelPlan,
-        MiniBlockChunk, MiniBlockChunkIndex, MiniBlockCompressed, MiniblockChunkSize,
-        PerValueDataBlock, PerValueDecompressor, PreambleAction, RunEndsBuilder, RunPosition,
-        RunStorage, StructuralPageScheduler, VariableFullZipDecoder, dense_levels_from_block,
-        validate_complex_all_null_levels,
+        MiniBlockChunk, MiniBlockChunkIndex, MiniBlockCompressed, MiniBlockScheduler,
+        MiniblockChunkSize, PerValueDataBlock, PerValueDecompressor, PreambleAction,
+        RunEndsBuilder, RunPosition, RunStorage, StructuralPageScheduler, VariableFullZipDecoder,
+        dense_levels_from_block, validate_complex_all_null_levels,
     };
+    use crate::EncodingsIo;
     use crate::buffer::LanceBuffer;
     use crate::compression::{
         BlockCompressor, DefaultDecompressionStrategy, MiniBlockDecompressor,
     };
     use crate::constants::{
-        COMPRESSION_LEVEL_META_KEY, COMPRESSION_META_KEY, DICT_VALUES_COMPRESSION_LEVEL_META_KEY,
-        DICT_VALUES_COMPRESSION_META_KEY, STRUCTURAL_ENCODING_META_KEY,
-        STRUCTURAL_ENCODING_MINIBLOCK,
+        COMPRESSION_LEVEL_META_KEY, COMPRESSION_META_KEY, DICT_DIVISOR_META_KEY,
+        DICT_VALUES_COMPRESSION_LEVEL_META_KEY, DICT_VALUES_COMPRESSION_META_KEY,
+        STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_MINIBLOCK,
     };
     use crate::data::BlockInfo;
     use crate::decoder::{PageEncoding, StructuralFieldDecoder};
@@ -7055,8 +7056,14 @@ mod tests {
     };
     use arrow_buffer::ScalarBuffer;
     use arrow_schema::{DataType, Field as ArrowField};
+    use futures::{FutureExt, future::BoxFuture};
+    use prost::Message;
     use std::collections::HashMap;
-    use std::{collections::VecDeque, sync::Arc};
+    use std::{
+        collections::VecDeque,
+        ops::Range,
+        sync::{Arc, Mutex},
+    };
 
     #[test]
     fn test_is_narrow() {
@@ -9433,6 +9440,194 @@ mod tests {
             pages.push(task.await.unwrap());
         }
         pages.into_iter().next().unwrap()
+    }
+
+    fn variable_offset_test_field() -> arrow_schema::Field {
+        arrow_schema::Field::new("c", DataType::Utf8, false).with_metadata(HashMap::from([
+            (
+                STRUCTURAL_ENCODING_META_KEY.to_string(),
+                STRUCTURAL_ENCODING_MINIBLOCK.to_string(),
+            ),
+            (COMPRESSION_META_KEY.to_string(), "none".to_string()),
+            (DICT_DIVISOR_META_KEY.to_string(), "100000".to_string()),
+        ]))
+    }
+
+    fn variable_offset_test_array(lengths: &[usize], num_rows: usize) -> ArrayRef {
+        Arc::new(StringArray::from_iter_values((0..num_rows).map(|index| {
+            let length = lengths[index % lengths.len()];
+            format!("{index:04x}{}", "x".repeat(length - 4))
+        })))
+    }
+
+    fn miniblock_layout(page: &crate::encoder::EncodedPage) -> &pb21::MiniBlockLayout {
+        let PageEncoding::Structural(layout) = &page.description else {
+            panic!("expected structural page encoding");
+        };
+        let Some(pb21::page_layout::Layout::MiniBlockLayout(layout)) = layout.layout.as_ref()
+        else {
+            panic!("expected mini-block page layout");
+        };
+        layout
+    }
+
+    fn variable_offset_compression(
+        page: &crate::encoder::EncodedPage,
+    ) -> &pb21::compressive_encoding::Compression {
+        let value_encoding = miniblock_layout(page).value_compression.as_ref().unwrap();
+        let Compression::Variable(variable) = value_encoding.compression.as_ref().unwrap() else {
+            panic!("expected Variable value compression");
+        };
+        variable
+            .offsets
+            .as_deref()
+            .and_then(|offsets| offsets.compression.as_ref())
+            .unwrap()
+    }
+
+    fn variable_value_wire_bytes(page: &crate::encoder::EncodedPage) -> usize {
+        miniblock_layout(page)
+            .value_compression
+            .as_ref()
+            .unwrap()
+            .encoded_len()
+            + page.data.iter().map(LanceBuffer::len).sum::<usize>()
+    }
+
+    #[derive(Debug)]
+    struct RecordingScheduler {
+        data: Bytes,
+        requests: Mutex<Vec<Vec<Range<u64>>>>,
+    }
+
+    impl RecordingScheduler {
+        fn take_requests(&self) -> Vec<Vec<Range<u64>>> {
+            std::mem::take(&mut *self.requests.lock().unwrap())
+        }
+    }
+
+    impl EncodingsIo for RecordingScheduler {
+        fn submit_request(
+            &self,
+            ranges: Vec<Range<u64>>,
+            _priority: u64,
+        ) -> BoxFuture<'static, lance_core::Result<Vec<Bytes>>> {
+            self.requests.lock().unwrap().push(ranges.clone());
+            let data = ranges
+                .into_iter()
+                .map(|range| self.data.slice(range.start as usize..range.end as usize))
+                .collect();
+            std::future::ready(Ok(data)).boxed()
+        }
+    }
+
+    async fn miniblock_take_request_shape(page: &crate::encoder::EncodedPage) -> [usize; 6] {
+        let mut position = 0_u64;
+        let buffer_offsets_and_sizes = page
+            .data
+            .iter()
+            .map(|buffer| {
+                let size = buffer.len() as u64;
+                let descriptor = (position, size);
+                position += size;
+                descriptor
+            })
+            .collect::<Vec<_>>();
+        let mut bytes = Vec::with_capacity(position as usize);
+        for buffer in &page.data {
+            bytes.extend_from_slice(buffer);
+        }
+
+        let recorder = Arc::new(RecordingScheduler {
+            data: Bytes::from(bytes),
+            requests: Mutex::new(Vec::new()),
+        });
+        let io: Arc<dyn EncodingsIo> = recorder.clone();
+        let decompression = DefaultDecompressionStrategy::default();
+        let mut cold = MiniBlockScheduler::try_new(
+            &buffer_offsets_and_sizes,
+            0,
+            page.num_rows,
+            miniblock_layout(page),
+            &decompression,
+        )
+        .unwrap();
+        let cached = cold.initialize(&io).await.unwrap();
+        let initialize_requests = recorder.take_requests();
+
+        let cold_tasks = cold.schedule_ranges(&[123..124], &io).unwrap();
+        let cold_requests = recorder.take_requests();
+        for task in cold_tasks {
+            task.decoder_fut.await.unwrap();
+        }
+
+        let mut warm = MiniBlockScheduler::try_new(
+            &buffer_offsets_and_sizes,
+            0,
+            page.num_rows,
+            miniblock_layout(page),
+            &decompression,
+        )
+        .unwrap();
+        warm.load(&cached);
+        let warm_tasks = warm.schedule_ranges(&[123..124], &io).unwrap();
+        let warm_requests = recorder.take_requests();
+        for task in warm_tasks {
+            task.decoder_fut.await.unwrap();
+        }
+
+        [
+            initialize_requests.len(),
+            initialize_requests.iter().map(Vec::len).sum(),
+            cold_requests.len(),
+            cold_requests.iter().map(Vec::len).sum(),
+            warm_requests.len(),
+            warm_requests.iter().map(Vec::len).sum(),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_v2_3_generic_offsets_preserve_legacy_and_take_io() {
+        let array = variable_offset_test_array(&[4, 10, 5, 8], 10_000);
+        let v2_1 = encode_first_page(
+            variable_offset_test_field(),
+            array.clone(),
+            TestEncoding::StructuralU16,
+        )
+        .await;
+        let v2_2 = encode_first_page(
+            variable_offset_test_field(),
+            array.clone(),
+            TestEncoding::StructuralU32,
+        )
+        .await;
+        let v2_3 = encode_first_page(
+            variable_offset_test_field(),
+            array,
+            TestEncoding::StructuralSparse,
+        )
+        .await;
+
+        assert!(matches!(
+            variable_offset_compression(&v2_1),
+            Compression::Flat(_)
+        ));
+        assert!(matches!(
+            variable_offset_compression(&v2_2),
+            Compression::Flat(_)
+        ));
+        assert!(matches!(
+            variable_offset_compression(&v2_3),
+            Compression::Delta(_)
+        ));
+        assert!(variable_value_wire_bytes(&v2_3) < variable_value_wire_bytes(&v2_2));
+        assert_eq!(miniblock_layout(&v2_2).num_buffers, 1);
+        assert_eq!(miniblock_layout(&v2_3).num_buffers, 2);
+
+        let legacy_requests = miniblock_take_request_shape(&v2_2).await;
+        let generic_requests = miniblock_take_request_shape(&v2_3).await;
+        assert_eq!(legacy_requests, [1, 1, 1, 1, 1, 1]);
+        assert_eq!(generic_requests, legacy_requests);
     }
 
     #[tokio::test]

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -45,7 +45,7 @@ use crate::utils::bytepack::ByteUnpacker;
 use crate::{
     compression::{
         BlockDecompressor, CompressionStrategy, DecompressionStrategy, MiniBlockDecompressor,
-        create_rle_decompressor,
+        compress_required_block, create_rle_decompressor,
     },
     data::{AllNullDataBlock, DataBlock, VariableWidthBlock},
     utils::bytepack::BytepackedIntegerEncoder,
@@ -192,7 +192,7 @@ impl DecodeMiniBlockTask {
         levels: LanceBuffer,
         num_levels: u16,
     ) -> Result<ScalarBuffer<u16>> {
-        let rep = rep_decompressor.decompress(levels, num_levels as u64)?;
+        let rep = rep_decompressor.decompress(Some(levels), num_levels as u64)?;
         let rep = rep.as_fixed_width().unwrap();
         debug_assert_eq!(rep.num_values, num_levels as u64);
         debug_assert_eq!(rep.bits_per_value, 16);
@@ -1569,7 +1569,7 @@ impl StructuralPageScheduler for ComplexAllNullScheduler {
                     }
                     LevelCodec::Block(decompressor) => {
                         let frame = LanceBuffer::from_bytes(compressed_bytes, 1);
-                        let decompressed = decompressor.decompress(frame, num_values)?;
+                        let decompressed = decompressor.decompress(Some(frame), num_values)?;
                         dense_levels_from_block(decompressed, num_values, level_type)
                     }
                 }
@@ -2624,7 +2624,10 @@ impl StructuralPageScheduler for MiniBlockScheduler {
             let dictionary = if let Some(ref mut dictionary) = self.dictionary {
                 let dictionary_data = dictionary_bytes.unwrap();
                 Some(Arc::new(dictionary.dictionary_decompressor.decompress(
-                    LanceBuffer::from_bytes(dictionary_data, dictionary.dictionary_data_alignment),
+                    Some(LanceBuffer::from_bytes(
+                        dictionary_data,
+                        dictionary.dictionary_data_alignment,
+                    )),
                     dictionary.num_dictionary_items,
                 )?))
             } else {
@@ -5020,8 +5023,9 @@ impl PrimitiveStructuralEncoder {
         let levels_block = DataBlock::FixedWidth(fixed_width_block);
         let levels_field = Field::new_arrow("", DataType::UInt16, false)?;
         // Pick a block compressor
-        let (compressor, compressor_desc) =
+        let compressor =
             compression_strategy.create_block_compressor(&levels_field, &levels_block)?;
+        let mut compressor_desc = None;
         // Compress blocks of levels (sized according to the chunks)
         let mut level_chunks = Vec::with_capacity(chunks.len());
         let mut values_counter = 0;
@@ -5091,7 +5095,22 @@ impl PrimitiveStructuralEncoder {
             };
             chunk_fixed_width.compute_stat();
             let chunk_levels_block = DataBlock::FixedWidth(chunk_fixed_width);
-            let compressed_levels = compressor.compress(chunk_levels_block)?;
+            let (compressed_levels, chunk_compressor_desc) =
+                compressor.compress(chunk_levels_block)?;
+            if let Some(compressor_desc) = compressor_desc.as_ref() {
+                if compressor_desc != &chunk_compressor_desc {
+                    return Err(Error::internal(
+                        "Rep/def block compressor changed encoding between chunks".to_string(),
+                    ));
+                }
+            } else {
+                compressor_desc = Some(chunk_compressor_desc);
+            }
+            let compressed_levels = compressed_levels.ok_or_else(|| {
+                Error::internal(
+                    "Rep/def block compressor selected a metadata-only codec".to_string(),
+                )
+            })?;
             let num_levels = u16::try_from(num_chunk_levels).map_err(|_| {
                 Error::invalid_input_source(
                     format!(
@@ -5116,7 +5135,9 @@ impl PrimitiveStructuralEncoder {
         };
         Ok(CompressedLevels {
             data: level_chunks,
-            compression: compressor_desc,
+            compression: compressor_desc.ok_or_else(|| {
+                Error::internal("Rep/def compression produced no chunks".to_string())
+            })?,
             rep_index,
         })
     }
@@ -5152,9 +5173,8 @@ impl PrimitiveStructuralEncoder {
 
         let levels_block = DataBlock::FixedWidth(fixed_width_block);
         let levels_field = Field::new_arrow("", DataType::UInt16, false)?;
-        let (compressor, encoding) =
-            compression_strategy.create_block_compressor(&levels_field, &levels_block)?;
-        let compressed_buffer = compressor.compress(levels_block)?;
+        let (compressed_buffer, encoding) =
+            compress_required_block(compression_strategy, &levels_field, levels_block)?;
         Ok((compressed_buffer, encoding))
     }
 
@@ -5540,9 +5560,8 @@ impl PrimitiveStructuralEncoder {
             let num_dictionary_items = dictionary_data.num_values();
             let dict_values_field = Self::build_dict_values_compressor_field(field)?;
 
-            let (compressor, dictionary_encoding) = compression_strategy
-                .create_block_compressor(&dict_values_field, &dictionary_data)?;
-            let dictionary_buffer = compressor.compress(dictionary_data)?;
+            let (dictionary_buffer, dictionary_encoding) =
+                compress_required_block(compression_strategy, &dict_values_field, dictionary_data)?;
 
             data.push(dictionary_buffer);
             if let Some(rep_index) = rep_index {
@@ -9648,7 +9667,7 @@ mod tests {
             .create_block_decompressor(&encoding)
             .unwrap();
         let decompressed = decompressor
-            .decompress(compressed_buf, values.len() as u64)
+            .decompress(Some(compressed_buf), values.len() as u64)
             .unwrap();
         let decompressed_fixed_width = decompressed.as_fixed_width().unwrap();
         assert_eq!(decompressed_fixed_width.num_values, values.len() as u64);
@@ -9736,6 +9755,8 @@ mod tests {
             block_info: BlockInfo::new(),
         });
         BlockCompressor::compress(&RleEncoder::with_run_length_width(run_length_width), block)
+            .unwrap()
+            .0
             .unwrap()
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive/miniblock.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/miniblock.rs
@@ -75,6 +75,18 @@ impl MiniBlockCompressionContext {
             allow_generic_offsets,
         }
     }
+
+    pub(crate) fn chunk_header_bytes(self, value_buffers: u64) -> u64 {
+        let value_buffer_size_bytes = if self.support_large_chunk { 4 } else { 2 };
+        2_u64
+            .saturating_add(self.common_chunk_buffers.saturating_mul(2))
+            .saturating_add(value_buffers.saturating_mul(value_buffer_size_bytes))
+            .next_multiple_of(8)
+    }
+
+    pub(crate) fn allows_generic_offsets(self) -> bool {
+        self.allow_generic_offsets
+    }
 }
 
 /// Describes the size of a mini-block chunk of data

--- a/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
@@ -1388,8 +1388,10 @@ impl SparseStructuralScheduler {
                             .filter_map(|field| field.value.as_ref()),
                     );
                 }
+                Compression::Delta(delta) => stack.extend(delta.deltas.as_deref()),
                 Compression::Flat(_)
                 | Compression::Constant(_)
+                | Compression::Range(_)
                 | Compression::InlineBitpacking(_) => {}
             }
         }
@@ -1537,6 +1539,8 @@ impl SparseStructuralScheduler {
             Compression::Constant(_)
             | Compression::OutOfLineBitpacking(_)
             | Compression::Dictionary(_)
+            | Compression::Range(_)
+            | Compression::Delta(_)
             | Compression::VariablePackedStruct(_) => Err(Error::invalid_input_source(
                 "Sparse value compression uses an unsupported mini-block encoding".into(),
             )),

--- a/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/sparse.rs
@@ -2645,7 +2645,7 @@ impl SparseStructuralScheduler {
     ) -> Result<Vec<u64>> {
         Self::validate_structural_buffer_headers(encoding, &data, label)?;
         let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            decompressor.decompress(LanceBuffer::from_bytes(data, 1), num_values)
+            decompressor.decompress(Some(LanceBuffer::from_bytes(data, 1)), num_values)
         }))
         .map_err(|_| {
             Error::invalid_input_source(

--- a/rust/lance-encoding/src/encodings/logical/primitive/sparse/writer.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/sparse/writer.rs
@@ -10,7 +10,7 @@ use lance_core::{Error, Result, datatypes::Field, utils::bit::pad_bytes};
 
 use crate::{
     buffer::LanceBuffer,
-    compression::CompressionStrategy,
+    compression::{CompressionStrategy, compress_required_block},
     data::{BlockInfo, DataBlock, FixedWidthDataBlock},
     decoder::PageEncoding,
     encoder::EncodedPage,
@@ -593,8 +593,7 @@ fn encode_u64_values(
     });
     block.compute_stat();
     let field = Field::new_arrow("", arrow_schema::DataType::UInt64, false)?;
-    let (compressor, encoding) = compression_strategy.create_block_compressor(&field, &block)?;
-    Ok((compressor.compress(block)?, encoding))
+    compress_required_block(compression_strategy, &field, block)
 }
 
 fn positions_to_deltas(positions: &[u64], label: &str) -> Result<Vec<u64>> {

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -1,14 +1,63 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use arrow_buffer::{ArrowNativeType, ScalarBuffer};
+use lance_core::{Error, Result};
+
+use crate::data::FixedWidthDataBlock;
+
 pub mod binary;
 #[cfg(feature = "bitpacking")]
 pub mod bitpacking;
 pub mod block;
 pub mod byte_stream_split;
 pub mod constant;
+pub mod delta;
 pub mod fsst;
 pub mod general;
 pub mod packed;
+pub mod range;
 pub mod rle;
 pub mod value;
+
+pub(crate) fn try_vec_with_capacity<T>(num_values: u64, label: &str) -> Result<Vec<T>> {
+    let capacity = usize::try_from(num_values)
+        .map_err(|_| Error::invalid_input(format!("{label} cardinality does not fit usize")))?;
+    let output_bytes = capacity
+        .checked_mul(std::mem::size_of::<T>())
+        .ok_or_else(|| Error::invalid_input(format!("{label} byte length overflows usize")))?;
+    if output_bytes > isize::MAX as usize {
+        return Err(Error::invalid_input(format!(
+            "{label} byte length {output_bytes} exceeds isize::MAX"
+        )));
+    }
+    let mut values = Vec::new();
+    values.try_reserve_exact(capacity).map_err(|error| {
+        Error::invalid_input(format!(
+            "{label} could not reserve {capacity} values ({output_bytes} bytes): {error}"
+        ))
+    })?;
+    Ok(values)
+}
+
+pub(crate) fn checked_fixed_values<T: ArrowNativeType>(
+    data: &FixedWidthDataBlock,
+    label: &str,
+) -> Result<ScalarBuffer<T>> {
+    let expected = usize::try_from(data.num_values)
+        .ok()
+        .and_then(|len| len.checked_mul(std::mem::size_of::<T>()))
+        .ok_or_else(|| Error::invalid_input(format!("{label} byte length overflows usize")))?;
+    if expected > isize::MAX as usize {
+        return Err(Error::invalid_input(format!(
+            "{label} byte length {expected} exceeds isize::MAX"
+        )));
+    }
+    if data.data.len() != expected {
+        return Err(Error::invalid_input(format!(
+            "{label} has {} bytes, expected {expected}",
+            data.data.len()
+        )));
+    }
+    Ok(data.data.borrow_to_typed_slice::<T>())
+}

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -13,6 +13,7 @@ pub mod block;
 pub mod byte_stream_split;
 pub mod constant;
 pub mod delta;
+pub mod dictionary;
 pub mod fsst;
 pub mod general;
 pub mod packed;

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -15,6 +15,7 @@ use core::panic;
 
 use crate::compression::{
     BlockCompressor, BlockDecompressor, MiniBlockDecompressor, VariablePerValueDecompressor,
+    require_block_payload,
 };
 
 use crate::buffer::LanceBuffer;
@@ -453,7 +454,15 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
 pub struct VariableEncoder {}
 
 impl BlockCompressor for VariableEncoder {
-    fn compress(&self, mut data: DataBlock) -> Result<LanceBuffer> {
+    fn compress(&self, mut data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let bits_per_offset = match &data {
+            DataBlock::VariableWidth(data) => data.bits_per_offset,
+            _ => {
+                return Err(Error::invalid_input(
+                    "BinaryBlockEncoder requires a variable-width block",
+                ));
+            }
+        };
         match data {
             DataBlock::VariableWidth(ref mut variable_width_data) => {
                 match variable_width_data.bits_per_offset {
@@ -505,18 +514,23 @@ impl BlockCompressor for VariableEncoder {
                         output.extend_from_slice(&variable_width_data.data);
                         Ok(LanceBuffer::from(output))
                     }
-                    _ => {
-                        panic!(
-                            "BinaryBlockEncoder does not work with {} bits per offset VariableWidth DataBlock.",
-                            variable_width_data.bits_per_offset
-                        );
-                    }
+                    _ => Err(Error::invalid_input(format!(
+                        "BinaryBlockEncoder does not support {}-bit offsets",
+                        variable_width_data.bits_per_offset
+                    ))),
                 }
             }
-            _ => {
-                panic!("BinaryBlockEncoder can only work with Variable Width DataBlock.");
-            }
+            _ => unreachable!("variable-width input was validated above"),
         }
+        .map(|payload| {
+            (
+                Some(payload),
+                ProtobufUtils21::variable(
+                    ProtobufUtils21::flat(bits_per_offset as u64, None),
+                    None,
+                ),
+            )
+        })
     }
 }
 
@@ -547,7 +561,8 @@ impl VariablePerValueDecompressor for VariableDecoder {
 pub struct BinaryBlockDecompressor {}
 
 impl BlockDecompressor for BinaryBlockDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "Binary block")?;
         // In older (not quite stable) versions we stored the bits per offset as a single byte and then the num_values
         // as four bytes.  However, this led to alignment problems and was wasteful since we already store the num_values
         // in higher layers.
@@ -1251,7 +1266,9 @@ mod tests {
         });
         BlockCompressor::compress(&super::VariableEncoder::default(), block)
             .unwrap()
+            .0
             .as_ref()
+            .unwrap()
             .to_vec()
     }
 
@@ -1280,7 +1297,7 @@ mod tests {
             .copy_from_slice(&mutated_offset_value.to_le_bytes()[..bytes_per_offset]);
 
         let block = super::BinaryBlockDecompressor::default()
-            .decompress(LanceBuffer::from(encoded), 3)
+            .decompress(Some(LanceBuffer::from(encoded)), 3)
             .unwrap();
         let data_type = match bits_per_offset {
             32 => DataType::Binary,
@@ -1302,7 +1319,7 @@ mod tests {
         let mut encoded = encoded_binary_block(32);
         encoded[8..12].copy_from_slice(&5_u32.to_le_bytes());
         let err = decompressor
-            .decompress(LanceBuffer::from(encoded), 3)
+            .decompress(Some(LanceBuffer::from(encoded)), 3)
             .unwrap_err();
         assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
         assert!(err.to_string().contains("first offset"), "{err}");
@@ -1310,14 +1327,14 @@ mod tests {
         // The offsets region must hold exactly num_values + 1 offsets.
         let encoded = encoded_binary_block(32);
         let err = decompressor
-            .decompress(LanceBuffer::from(encoded), 4)
+            .decompress(Some(LanceBuffer::from(encoded)), 4)
             .unwrap_err();
         assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
         assert!(err.to_string().contains("offset bytes"), "{err}");
 
         // A block too small to hold its header is rejected, not a panic.
         let err = decompressor
-            .decompress(LanceBuffer::from(vec![0_u8; 2]), 1)
+            .decompress(Some(LanceBuffer::from(vec![0_u8; 2])), 1)
             .unwrap_err();
         assert!(matches!(err, Error::CorruptFile { .. }), "{err:?}");
         assert!(err.to_string().contains("too small"), "{err}");

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -11,20 +11,22 @@
 
 use arrow_array::OffsetSizeTrait;
 use byteorder::{ByteOrder, LittleEndian};
-use core::panic;
+use prost::Message;
 
 use crate::compression::{
     BlockCompressor, BlockDecompressor, MiniBlockDecompressor, VariablePerValueDecompressor,
-    require_block_payload,
+    create_fixed_width_block_decompressor, infer_fixed_width_block_bits, require_block_payload,
 };
 
 use crate::buffer::LanceBuffer;
-use crate::data::{BlockInfo, DataBlock, VariableWidthBlock};
+use crate::compression_config::CompressionFieldParams;
+use crate::data::{BlockInfo, DataBlock, FixedWidthDataBlock, VariableWidthBlock};
 use crate::encodings::logical::primitive::fullzip::{PerValueCompressor, PerValueDataBlock};
 use crate::encodings::logical::primitive::miniblock::{
     MAX_MINIBLOCK_VALUES, MiniBlockChunk, MiniBlockCompressed, MiniBlockCompressionContext,
     MiniBlockCompressor,
 };
+use crate::encodings::physical::checked_fixed_values;
 use crate::format::pb21::CompressiveEncoding;
 use crate::format::pb21::compressive_encoding::Compression;
 use crate::format::{ProtobufUtils21, pb21};
@@ -32,18 +34,21 @@ use crate::format::{ProtobufUtils21, pb21};
 use lance_core::utils::bit::pad_bytes_to;
 use lance_core::{Error, Result};
 
-#[allow(dead_code)]
 mod offsets;
+
+use offsets::{BlockCost, OffsetBlockCodec, select_offset_block_codec};
 
 #[derive(Debug)]
 pub struct BinaryMiniBlockEncoder {
     minichunk_size: i64,
+    generic_offsets: Option<CompressionFieldParams>,
 }
 
 impl Default for BinaryMiniBlockEncoder {
     fn default() -> Self {
         Self {
             minichunk_size: *AIM_MINICHUNK_SIZE,
+            generic_offsets: None,
         }
     }
 }
@@ -56,6 +61,31 @@ pub static AIM_MINICHUNK_SIZE: std::sync::LazyLock<i64> = std::sync::LazyLock::n
         .parse::<i64>()
         .unwrap_or(DEFAULT_AIM_MINICHUNK_SIZE)
 });
+
+#[derive(Debug, Clone, Copy)]
+struct BinaryChunkRange {
+    start_offset_index: usize,
+    end_offset_index: usize,
+}
+
+fn binary_chunk_ranges<N: OffsetSizeTrait>(
+    offsets: &[N],
+    minichunk_size: i64,
+) -> Vec<BinaryChunkRange> {
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    loop {
+        let end = search_next_offset_idx(offsets, start, minichunk_size);
+        ranges.push(BinaryChunkRange {
+            start_offset_index: start,
+            end_offset_index: end,
+        });
+        if end == offsets.len() - 1 {
+            return ranges;
+        }
+        start = end;
+    }
+}
 
 // Make it to support both u32 and u64
 fn chunk_offsets<N: OffsetSizeTrait>(
@@ -204,47 +234,277 @@ fn search_next_offset_idx<N: OffsetSizeTrait>(
     last_offset_idx + num_values
 }
 
+fn validate_variable_offsets<N: OffsetSizeTrait>(
+    offsets: &[N],
+    num_values: u64,
+    data_len: usize,
+) -> Result<()> {
+    let expected_offsets = usize::try_from(num_values)
+        .ok()
+        .and_then(|num_values| num_values.checked_add(1))
+        .ok_or_else(|| Error::invalid_input("Variable-width offset count overflows usize"))?;
+    if offsets.len() != expected_offsets {
+        return Err(Error::invalid_input(format!(
+            "Variable-width block has {} offsets, expected {expected_offsets}",
+            offsets.len()
+        )));
+    }
+    let mut previous = None;
+    for (index, offset) in offsets.iter().enumerate() {
+        let offset = offset.to_usize().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Variable-width offset at index {index} is negative or does not fit usize"
+            ))
+        })?;
+        if previous.is_some_and(|previous| offset < previous) {
+            return Err(Error::invalid_input(format!(
+                "Variable-width offsets decrease at index {index}"
+            )));
+        }
+        previous = Some(offset);
+    }
+    if offsets[0].to_usize() != Some(0) {
+        return Err(Error::invalid_input(
+            "Variable-width offsets must start at zero",
+        ));
+    }
+    if previous != Some(data_len) {
+        return Err(Error::invalid_input(format!(
+            "Final variable-width offset {:?} does not equal {data_len} data bytes",
+            previous
+        )));
+    }
+    Ok(())
+}
+
+fn chunk_value_range<N: OffsetSizeTrait>(
+    offsets: &[N],
+    range: BinaryChunkRange,
+) -> Result<std::ops::Range<usize>> {
+    let start = offsets[range.start_offset_index]
+        .to_usize()
+        .ok_or_else(|| Error::invalid_input("Variable chunk start offset does not fit usize"))?;
+    let end = offsets[range.end_offset_index]
+        .to_usize()
+        .ok_or_else(|| Error::invalid_input("Variable chunk end offset does not fit usize"))?;
+    if start > end {
+        return Err(Error::invalid_input(
+            "Variable chunk offsets are decreasing",
+        ));
+    }
+    Ok(start..end)
+}
+
+fn serialized_variable_cost(
+    compressed: &MiniBlockCompressed,
+    encoding: &CompressiveEncoding,
+    context: MiniBlockCompressionContext,
+) -> u64 {
+    compressed
+        .chunks
+        .iter()
+        .fold(encoding.encoded_len() as u64, |total, chunk| {
+            chunk.buffer_sizes.iter().fold(
+                total.saturating_add(context.chunk_header_bytes(chunk.buffer_sizes.len() as u64)),
+                |total, size| total.saturating_add(u64::from(*size).next_multiple_of(8)),
+            )
+        })
+}
+
+fn build_generic_chunks<N: OffsetSizeTrait>(
+    data: &VariableWidthBlock,
+    offsets: &[N],
+    ranges: &[BinaryChunkRange],
+    codec: &OffsetBlockCodec,
+) -> Result<(MiniBlockCompressed, CompressiveEncoding)> {
+    let bytes_per_offset = (data.bits_per_offset / 8) as usize;
+    let mut offset_data = Vec::new();
+    let mut value_data = Vec::new();
+    let mut chunks = Vec::with_capacity(ranges.len());
+    let mut actual_encoding = None;
+
+    for (index, range) in ranges.iter().enumerate() {
+        let num_offsets = range.end_offset_index - range.start_offset_index + 1;
+        let offset_start = range
+            .start_offset_index
+            .checked_mul(bytes_per_offset)
+            .ok_or_else(|| Error::invalid_input("Offset chunk start overflows usize"))?;
+        let offset_bytes = num_offsets
+            .checked_mul(bytes_per_offset)
+            .ok_or_else(|| Error::invalid_input("Offset chunk size overflows usize"))?;
+        let offset_block = FixedWidthDataBlock {
+            bits_per_value: data.bits_per_offset as u64,
+            data: data.offsets.slice_with_length(offset_start, offset_bytes),
+            num_values: num_offsets as u64,
+            block_info: BlockInfo::default(),
+        };
+        let (payload, encoding) = codec.compress(offset_block)?;
+        if actual_encoding
+            .as_ref()
+            .is_some_and(|actual| actual != &encoding)
+        {
+            return Err(Error::internal(format!(
+                "Offset codec produced inconsistent descriptors for chunk {index}"
+            )));
+        }
+        actual_encoding.get_or_insert(encoding);
+
+        let value_range = chunk_value_range(offsets, *range)?;
+        let value_bytes = data.data.get(value_range.clone()).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Variable chunk range {}..{} exceeds {} bytes",
+                value_range.start,
+                value_range.end,
+                data.data.len()
+            ))
+        })?;
+        let mut buffer_sizes = Vec::with_capacity(1 + usize::from(codec.has_payload()));
+        if let Some(payload) = payload {
+            buffer_sizes.push(
+                u32::try_from(payload.len())
+                    .map_err(|_| Error::invalid_input("Offset payload exceeds u32::MAX bytes"))?,
+            );
+            offset_data.extend_from_slice(&payload);
+        }
+        buffer_sizes.push(
+            u32::try_from(value_bytes.len()).map_err(|_| {
+                Error::invalid_input("Variable value payload exceeds u32::MAX bytes")
+            })?,
+        );
+        value_data.extend_from_slice(value_bytes);
+        let num_values = range.end_offset_index - range.start_offset_index;
+        chunks.push(MiniBlockChunk {
+            log_num_values: if index + 1 == ranges.len() {
+                0
+            } else {
+                num_values.trailing_zeros() as u8
+            },
+            buffer_sizes,
+        });
+    }
+
+    let mut buffers = Vec::with_capacity(1 + usize::from(codec.has_payload()));
+    if codec.has_payload() {
+        buffers.push(LanceBuffer::from(offset_data));
+    }
+    buffers.push(LanceBuffer::from(value_data));
+    let offsets_encoding = actual_encoding.ok_or_else(|| {
+        Error::internal("Variable-width page did not contain an offset chunk".to_string())
+    })?;
+    Ok((
+        MiniBlockCompressed {
+            data: buffers,
+            chunks,
+            num_values: data.num_values,
+        },
+        ProtobufUtils21::variable(offsets_encoding, None),
+    ))
+}
+
 impl BinaryMiniBlockEncoder {
     pub fn new(minichunk_size: Option<i64>) -> Self {
         Self {
             minichunk_size: minichunk_size.unwrap_or(*AIM_MINICHUNK_SIZE),
+            generic_offsets: None,
+        }
+    }
+
+    pub fn with_generic_offsets(
+        minichunk_size: Option<i64>,
+        field_params: CompressionFieldParams,
+    ) -> Self {
+        Self {
+            minichunk_size: minichunk_size.unwrap_or(*AIM_MINICHUNK_SIZE),
+            generic_offsets: Some(field_params),
         }
     }
 
     // put binary data into chunks, every chunk is less than or equal to `minichunk_size`.
     // In each chunk, offsets are put first then followed by binary bytes data, each chunk is padded to 8 bytes.
     // the offsets in the chunk points to the bytes offset in this chunk.
-    fn chunk_data(&self, data: VariableWidthBlock) -> (MiniBlockCompressed, CompressiveEncoding) {
-        // TODO: Support compression of offsets
-        // TODO: Support general compression of data
+    fn chunk_data(
+        &self,
+        data: VariableWidthBlock,
+        context: MiniBlockCompressionContext,
+    ) -> Result<(MiniBlockCompressed, CompressiveEncoding)> {
         match data.bits_per_offset {
             32 => {
-                let offsets = data.offsets.borrow_to_typed_slice::<i32>();
-                let (buffers, chunks) =
-                    chunk_offsets(offsets.as_ref(), &data.data, 4, self.minichunk_size);
-                (
-                    MiniBlockCompressed {
-                        data: buffers,
-                        chunks,
-                        num_values: data.num_values,
-                    },
-                    ProtobufUtils21::variable(ProtobufUtils21::flat(32, None), None),
-                )
+                let offsets_buffer = data.offsets.clone();
+                let offsets = offsets_buffer.borrow_to_typed_slice::<i32>();
+                self.chunk_typed_data(offsets.as_ref(), data, 4, context)
             }
             64 => {
-                let offsets = data.offsets.borrow_to_typed_slice::<i64>();
-                let (buffers, chunks) =
-                    chunk_offsets(offsets.as_ref(), &data.data, 8, self.minichunk_size);
-                (
-                    MiniBlockCompressed {
-                        data: buffers,
-                        chunks,
-                        num_values: data.num_values,
-                    },
-                    ProtobufUtils21::variable(ProtobufUtils21::flat(64, None), None),
-                )
+                let offsets_buffer = data.offsets.clone();
+                let offsets = offsets_buffer.borrow_to_typed_slice::<i64>();
+                self.chunk_typed_data(offsets.as_ref(), data, 8, context)
             }
-            _ => panic!("Unsupported bits_per_offset={}", data.bits_per_offset),
+            _ => Err(Error::invalid_input(format!(
+                "Unsupported bits_per_offset={}",
+                data.bits_per_offset
+            ))),
+        }
+    }
+
+    fn chunk_typed_data<N: OffsetSizeTrait>(
+        &self,
+        offsets: &[N],
+        data: VariableWidthBlock,
+        legacy_alignment: usize,
+        context: MiniBlockCompressionContext,
+    ) -> Result<(MiniBlockCompressed, CompressiveEncoding)> {
+        validate_variable_offsets(offsets, data.num_values, data.data.len())?;
+        let bits_per_offset = data.bits_per_offset as u64;
+        let legacy_encoding =
+            ProtobufUtils21::variable(ProtobufUtils21::flat(bits_per_offset, None), None);
+        let (legacy_buffers, legacy_chunks) =
+            chunk_offsets(offsets, &data.data, legacy_alignment, self.minichunk_size);
+        let legacy = MiniBlockCompressed {
+            data: legacy_buffers,
+            chunks: legacy_chunks,
+            num_values: data.num_values,
+        };
+        let Some(field_params) = self
+            .generic_offsets
+            .as_ref()
+            .filter(|_| context.allows_generic_offsets())
+        else {
+            return Ok((legacy, legacy_encoding));
+        };
+
+        let ranges = binary_chunk_ranges(offsets, self.minichunk_size);
+        let member_ranges = ranges
+            .iter()
+            .map(|range| range.start_offset_index..range.end_offset_index + 1)
+            .collect::<Vec<_>>();
+        let offsets_block = FixedWidthDataBlock {
+            bits_per_value: bits_per_offset,
+            data: data.offsets.clone(),
+            num_values: offsets.len() as u64,
+            block_info: BlockInfo::default(),
+        };
+        let extra_payload_header = context
+            .chunk_header_bytes(2)
+            .saturating_sub(context.chunk_header_bytes(1));
+        let codec = select_offset_block_codec(
+            &offsets_block,
+            &member_ranges,
+            field_params,
+            BlockCost::new(extra_payload_header, 8),
+        )?;
+        if matches!(
+            codec.expected_encoding().compression.as_ref(),
+            Some(Compression::Flat(_))
+        ) {
+            return Ok((legacy, legacy_encoding));
+        }
+
+        let (generic, generic_encoding) = build_generic_chunks(&data, offsets, &ranges, &codec)?;
+        if serialized_variable_cost(&generic, &generic_encoding, context)
+            < serialized_variable_cost(&legacy, &legacy_encoding, context)
+        {
+            Ok((generic, generic_encoding))
+        } else {
+            Ok((legacy, legacy_encoding))
         }
     }
 }
@@ -252,11 +512,11 @@ impl BinaryMiniBlockEncoder {
 impl MiniBlockCompressor for BinaryMiniBlockEncoder {
     fn compress(
         &self,
-        _context: MiniBlockCompressionContext,
+        context: MiniBlockCompressionContext,
         data: DataBlock,
     ) -> Result<(MiniBlockCompressed, CompressiveEncoding)> {
         match data {
-            DataBlock::VariableWidth(variable_width) => Ok(self.chunk_data(variable_width)),
+            DataBlock::VariableWidth(variable_width) => self.chunk_data(variable_width, context),
             _ => Err(Error::invalid_input_source(
                 format!(
                     "Cannot compress a data block of type {} with BinaryMiniBlockEncoder",
@@ -270,31 +530,173 @@ impl MiniBlockCompressor for BinaryMiniBlockEncoder {
 
 #[derive(Debug)]
 pub struct BinaryMiniBlockDecompressor {
-    bits_per_offset: u8,
+    layout: BinaryMiniBlockLayout,
+}
+
+#[derive(Debug)]
+enum BinaryMiniBlockLayout {
+    Legacy {
+        bits_per_offset: u8,
+    },
+    Generic {
+        bits_per_offset: u8,
+        offsets: Box<dyn BlockDecompressor>,
+        offsets_have_payload: bool,
+    },
 }
 
 impl BinaryMiniBlockDecompressor {
-    pub fn new(bits_per_offset: u8) -> Self {
-        assert!(bits_per_offset == 32 || bits_per_offset == 64);
-        Self { bits_per_offset }
+    pub fn new(bits_per_offset: u8) -> Result<Self> {
+        if !matches!(bits_per_offset, 32 | 64) {
+            return Err(Error::invalid_input(format!(
+                "Binary mini-block offsets require 32 or 64 bits, got {bits_per_offset}"
+            )));
+        }
+        Ok(Self {
+            layout: BinaryMiniBlockLayout::Legacy { bits_per_offset },
+        })
     }
 
-    pub fn from_variable(variable: &pb21::Variable) -> Self {
-        if let Compression::Flat(flat) = variable
-            .offsets
-            .as_ref()
-            .unwrap()
-            .compression
-            .as_ref()
-            .unwrap()
-        {
-            Self {
-                bits_per_offset: flat.bits_per_value as u8,
-            }
-        } else {
-            panic!("Unsupported offsets compression: {:?}", variable.offsets);
+    pub fn from_variable(variable: &pb21::Variable) -> Result<Self> {
+        if variable.values.is_some() {
+            return Err(Error::invalid_input(
+                "Binary mini-block Variable encoding cannot contain a values codec",
+            ));
         }
+        let offsets = variable.offsets.as_deref().ok_or_else(|| {
+            Error::invalid_input("Binary mini-block Variable encoding is missing offsets")
+        })?;
+        let compression = offsets.compression.as_ref().ok_or_else(|| {
+            Error::invalid_input("Binary mini-block offsets are missing a compression variant")
+        })?;
+        if let Compression::Flat(flat) = compression {
+            if flat.data.is_some() || !matches!(flat.bits_per_value, 32 | 64) {
+                return Err(Error::invalid_input(format!(
+                    "Legacy binary mini-block offsets require plain 32 or 64-bit Flat encoding, got {} bits",
+                    flat.bits_per_value
+                )));
+            }
+            return Self::new(flat.bits_per_value as u8);
+        }
+
+        let bits_per_offset = infer_fixed_width_block_bits(offsets)?;
+        let offsets = create_fixed_width_block_decompressor(offsets, bits_per_offset)?;
+        let offsets_have_payload = offsets.requires_payload();
+        Ok(Self {
+            layout: BinaryMiniBlockLayout::Generic {
+                bits_per_offset: bits_per_offset as u8,
+                offsets,
+                offsets_have_payload,
+            },
+        })
     }
+}
+
+fn decode_generic_binary_miniblock(
+    bits_per_offset: u8,
+    offsets: &dyn BlockDecompressor,
+    offsets_have_payload: bool,
+    data: Vec<LanceBuffer>,
+    num_values: u64,
+) -> Result<DataBlock> {
+    let expected_buffers = 1 + usize::from(offsets_have_payload);
+    if data.len() != expected_buffers {
+        return Err(Error::corrupt_file_named(
+            "binary mini-block",
+            format!(
+                "generic chunk has {} buffers, expected {expected_buffers}",
+                data.len()
+            ),
+        ));
+    }
+    let mut buffers = data.into_iter();
+    let offset_payload =
+        offsets_have_payload.then(|| buffers.next().expect("buffer count was checked"));
+    let values = buffers.next().expect("buffer count was checked");
+    let num_offsets = num_values.checked_add(1).ok_or_else(|| {
+        Error::corrupt_file_named(
+            "binary mini-block",
+            format!("cannot decode offsets for {num_values} values"),
+        )
+    })?;
+    let decoded = offsets.decompress(offset_payload, num_offsets)?;
+    let DataBlock::FixedWidth(offsets) = decoded else {
+        return Err(Error::corrupt_file_named(
+            "binary mini-block",
+            "generic offset codec did not produce fixed-width offsets",
+        ));
+    };
+    if offsets.bits_per_value != u64::from(bits_per_offset) || offsets.num_values != num_offsets {
+        return Err(Error::corrupt_file_named(
+            "binary mini-block",
+            format!(
+                "generic offset codec produced {} {}-bit offsets, expected {num_offsets} {bits_per_offset}-bit offsets",
+                offsets.num_values, offsets.bits_per_value
+            ),
+        ));
+    }
+
+    match bits_per_offset {
+        32 => {
+            let typed = checked_fixed_values::<u32>(&offsets, "Binary mini-block offsets")?;
+            let mut previous = 0_u32;
+            for (position, &offset) in typed.iter().enumerate() {
+                if (position == 0 && offset != 0) || offset < previous || offset > i32::MAX as u32 {
+                    return Err(Error::corrupt_file_named(
+                        "binary mini-block",
+                        format!("invalid 32-bit generic offset {offset} at position {position}"),
+                    ));
+                }
+                previous = offset;
+            }
+            if previous as usize != values.len() {
+                return Err(Error::corrupt_file_named(
+                    "binary mini-block",
+                    format!(
+                        "final generic offset {previous} does not equal the {}-byte value buffer",
+                        values.len()
+                    ),
+                ));
+            }
+        }
+        64 => {
+            let typed = checked_fixed_values::<u64>(&offsets, "Binary mini-block offsets")?;
+            let mut previous = 0_u64;
+            for (position, &offset) in typed.iter().enumerate() {
+                if (position == 0 && offset != 0) || offset < previous || offset > i64::MAX as u64 {
+                    return Err(Error::corrupt_file_named(
+                        "binary mini-block",
+                        format!("invalid 64-bit generic offset {offset} at position {position}"),
+                    ));
+                }
+                previous = offset;
+            }
+            let value_len = u64::try_from(values.len()).map_err(|_| {
+                Error::corrupt_file_named(
+                    "binary mini-block",
+                    "value buffer length does not fit u64",
+                )
+            })?;
+            if previous != value_len {
+                return Err(Error::corrupt_file_named(
+                    "binary mini-block",
+                    format!(
+                        "final generic offset {previous} does not equal the {}-byte value buffer",
+                        values.len()
+                    ),
+                ));
+            }
+        }
+        _ => unreachable!("generic offset width was validated during decoder construction"),
+    }
+
+    Ok(DataBlock::VariableWidth(VariableWidthBlock {
+        data: values,
+        offsets: offsets.data,
+        bits_per_offset,
+        num_values,
+        block_info: BlockInfo::new(),
+    }))
 }
 
 /// Cold path: pinpoint why the chunk-relative offsets of a binary mini-block
@@ -332,10 +734,31 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
     // read.  The monotonicity check rides along the existing rebase loop (the
     // `&=` accumulation keeps it branchless) so validation adds no extra pass.
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
-        assert_eq!(data.len(), 1);
-        let data = data.into_iter().next().unwrap();
+        let bits_per_offset = match &self.layout {
+            BinaryMiniBlockLayout::Legacy { bits_per_offset } => *bits_per_offset,
+            BinaryMiniBlockLayout::Generic {
+                bits_per_offset,
+                offsets,
+                offsets_have_payload,
+            } => {
+                return decode_generic_binary_miniblock(
+                    *bits_per_offset,
+                    offsets.as_ref(),
+                    *offsets_have_payload,
+                    data,
+                    num_values,
+                );
+            }
+        };
+        if data.len() != 1 {
+            return Err(Error::corrupt_file_named(
+                "binary mini-block",
+                format!("legacy chunk has {} buffers, expected 1", data.len()),
+            ));
+        }
+        let data = data.into_iter().next().expect("buffer count was checked");
 
-        let bytes_per_offset = self.bits_per_offset as usize / 8;
+        let bytes_per_offset = bits_per_offset as usize / 8;
         if !data.len().is_multiple_of(bytes_per_offset) {
             return Err(Error::corrupt_file_named(
                 "binary mini-block",
@@ -380,7 +803,7 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
             )
         };
 
-        if self.bits_per_offset == 64 {
+        if bits_per_offset == 64 {
             let offsets_buffer = data.borrow_to_typed_slice::<u64>();
             let offsets = &offsets_buffer.as_ref()[..num_offsets];
 
@@ -719,20 +1142,29 @@ impl BlockDecompressor for BinaryBlockDecompressor {
 
 #[cfg(test)]
 mod tests {
+    use super::{BinaryMiniBlockDecompressor, BinaryMiniBlockEncoder};
     use arrow_array::{
         ArrayRef, StringArray,
         builder::{LargeStringBuilder, StringBuilder},
     };
     use arrow_schema::{DataType, Field};
+    use lance_core::{Error, Result};
 
     use crate::{
         buffer::LanceBuffer,
+        compression::MiniBlockDecompressor,
+        compression_config::CompressionFieldParams,
         constants::{
-            COMPRESSION_META_KEY, STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY,
-            STRUCTURAL_ENCODING_MINIBLOCK,
+            COMPRESSION_META_KEY, DICT_DIVISOR_META_KEY, STRUCTURAL_ENCODING_FULLZIP,
+            STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_MINIBLOCK,
         },
         data::{BlockInfo, DataBlock, VariableWidthBlock},
-        testing::check_specific_random,
+        encodings::logical::primitive::miniblock::{
+            MiniBlockCompressed, MiniBlockCompressionContext, MiniBlockCompressor,
+        },
+        format::pb21::compressive_encoding::Compression,
+        format::{ProtobufUtils21, pb21, pb21::CompressiveEncoding},
+        testing::{TestEncoding, check_specific_random},
     };
     use rstest::rstest;
     use std::{collections::HashMap, sync::Arc, vec};
@@ -740,6 +1172,293 @@ mod tests {
     use crate::testing::{
         FnArrayGeneratorProvider, TestCases, check_basic_random, check_round_trip_encoding_of_data,
     };
+
+    fn miniblock_context() -> MiniBlockCompressionContext {
+        MiniBlockCompressionContext::new(0, true, true)
+    }
+
+    fn variable_block_u32(lengths: &[usize]) -> VariableWidthBlock {
+        let mut offsets = Vec::with_capacity(lengths.len() + 1);
+        let mut data = Vec::new();
+        offsets.push(0_i32);
+        for (index, length) in lengths.iter().copied().enumerate() {
+            data.extend(std::iter::repeat_n((index % 251) as u8, length));
+            offsets.push(i32::try_from(data.len()).unwrap());
+        }
+        VariableWidthBlock {
+            data: LanceBuffer::from(data),
+            offsets: LanceBuffer::reinterpret_vec(offsets),
+            bits_per_offset: 32,
+            num_values: lengths.len() as u64,
+            block_info: BlockInfo::default(),
+        }
+    }
+
+    fn decode_binary_miniblocks(
+        compressed: MiniBlockCompressed,
+        encoding: &CompressiveEncoding,
+    ) -> Result<Vec<VariableWidthBlock>> {
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            return Err(Error::invalid_input("expected Variable encoding"));
+        };
+        let decoder = BinaryMiniBlockDecompressor::from_variable(variable)?;
+        let mut buffer_offsets = vec![0_usize; compressed.data.len()];
+        let mut values_seen = 0_u64;
+        let mut decoded = Vec::with_capacity(compressed.chunks.len());
+        for chunk in compressed.chunks {
+            let num_values = chunk.num_values(values_seen, compressed.num_values);
+            values_seen += num_values;
+            let buffers = chunk
+                .buffer_sizes
+                .iter()
+                .zip(compressed.data.iter().zip(&mut buffer_offsets))
+                .map(|(size, (buffer, offset))| {
+                    let size = *size as usize;
+                    let chunk = buffer.slice_with_length(*offset, size);
+                    *offset += size;
+                    chunk
+                })
+                .collect();
+            let DataBlock::VariableWidth(block) = decoder.decompress(buffers, num_values)? else {
+                return Err(Error::internal(
+                    "Binary mini-block decoded a non-variable block".to_string(),
+                ));
+            };
+            decoded.push(block);
+        }
+        Ok(decoded)
+    }
+
+    fn assert_decoded_value_lengths(decoded: &[VariableWidthBlock], expected: &[usize]) {
+        let actual = decoded
+            .iter()
+            .flat_map(|block| {
+                let offsets = block.offsets.borrow_to_typed_slice::<i32>();
+                offsets
+                    .windows(2)
+                    .map(|pair| (pair[1] - pair[0]) as usize)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn generic_offsets_use_range_across_chunks() {
+        let lengths = vec![3_usize; 2_048];
+        let encoder = BinaryMiniBlockEncoder::with_generic_offsets(
+            Some(256),
+            CompressionFieldParams::default(),
+        );
+        let (compressed, encoding) = encoder
+            .compress(
+                miniblock_context(),
+                DataBlock::VariableWidth(variable_block_u32(&lengths)),
+            )
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Range(_))
+        ));
+        assert_eq!(compressed.data.len(), 1);
+        assert!(compressed.chunks.len() > 1);
+        assert!(
+            compressed
+                .chunks
+                .iter()
+                .all(|chunk| chunk.buffer_sizes.len() == 1)
+        );
+        let decoded = decode_binary_miniblocks(compressed, &encoding).unwrap();
+        assert_decoded_value_lengths(&decoded, &lengths);
+    }
+
+    #[test]
+    fn generic_offsets_use_delta_payload() {
+        let lengths = (0..4_096)
+            .map(|index| [1_usize, 7, 2, 5][index % 4])
+            .collect::<Vec<_>>();
+        let encoder = BinaryMiniBlockEncoder::with_generic_offsets(
+            Some(1_024),
+            CompressionFieldParams::default(),
+        );
+        let (compressed, encoding) = encoder
+            .compress(
+                miniblock_context(),
+                DataBlock::VariableWidth(variable_block_u32(&lengths)),
+            )
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Delta(_))
+        ));
+        assert_eq!(compressed.data.len(), 2);
+        assert!(
+            compressed
+                .chunks
+                .iter()
+                .all(|chunk| chunk.buffer_sizes.len() == 2)
+        );
+        let decoded = decode_binary_miniblocks(compressed, &encoding).unwrap();
+        assert_decoded_value_lengths(&decoded, &lengths);
+    }
+
+    #[test]
+    fn generic_offsets_support_constant_and_u64_range() {
+        let encoder = BinaryMiniBlockEncoder::with_generic_offsets(
+            Some(256),
+            CompressionFieldParams::default(),
+        );
+        let empty_lengths = vec![0_usize; 1_024];
+        let (compressed, encoding) = encoder
+            .compress(
+                miniblock_context(),
+                DataBlock::VariableWidth(variable_block_u32(&empty_lengths)),
+            )
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Constant(_))
+        ));
+        let decoded = decode_binary_miniblocks(compressed, &encoding).unwrap();
+        assert_decoded_value_lengths(&decoded, &empty_lengths);
+
+        let num_values = 512_usize;
+        let block = VariableWidthBlock {
+            data: LanceBuffer::from(vec![1_u8; num_values * 2]),
+            offsets: LanceBuffer::reinterpret_vec(
+                (0..=num_values)
+                    .map(|index| (index * 2) as i64)
+                    .collect::<Vec<_>>(),
+            ),
+            bits_per_offset: 64,
+            num_values: num_values as u64,
+            block_info: BlockInfo::default(),
+        };
+        let (compressed, encoding) = encoder
+            .compress(miniblock_context(), DataBlock::VariableWidth(block))
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Range(_))
+        ));
+        let decoded = decode_binary_miniblocks(compressed, &encoding).unwrap();
+        assert!(decoded.iter().all(|block| block.bits_per_offset == 64));
+    }
+
+    #[test]
+    fn binary_miniblock_preserves_legacy_wire_and_fallible_generic_reader() {
+        assert!(BinaryMiniBlockDecompressor::new(16).is_err());
+        let encoder = BinaryMiniBlockEncoder::new(Some(4_096));
+        let (compressed, encoding) = encoder
+            .compress(
+                miniblock_context(),
+                DataBlock::VariableWidth(variable_block_u32(&[3, 3])),
+            )
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Flat(_))
+        ));
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&12_i32.to_le_bytes());
+        expected.extend_from_slice(&15_i32.to_le_bytes());
+        expected.extend_from_slice(&18_i32.to_le_bytes());
+        expected.extend_from_slice(&[0, 0, 0, 1, 1, 1]);
+        expected.extend_from_slice(&[72, 72]);
+        assert_eq!(compressed.chunks[0].buffer_sizes, [20]);
+        assert_eq!(compressed.data[0].as_ref(), expected);
+
+        let generic_encoder = BinaryMiniBlockEncoder::with_generic_offsets(
+            Some(4_096),
+            CompressionFieldParams::default(),
+        );
+        let (_, encoding) = generic_encoder
+            .compress(
+                miniblock_context(),
+                DataBlock::VariableWidth(variable_block_u32(&[1, 7, 2, 5])),
+            )
+            .unwrap();
+        let Some(Compression::Variable(variable)) = encoding.compression.as_ref() else {
+            panic!("expected Variable encoding");
+        };
+        assert!(matches!(
+            variable
+                .offsets
+                .as_deref()
+                .and_then(|offsets| offsets.compression.as_ref()),
+            Some(Compression::Flat(_))
+        ));
+
+        let variable = pb21::Variable {
+            offsets: Some(Box::new(ProtobufUtils21::range(32, 0, 3))),
+            values: None,
+        };
+        let decoder = BinaryMiniBlockDecompressor::from_variable(&variable).unwrap();
+        let error = decoder
+            .decompress(vec![LanceBuffer::empty(), LanceBuffer::empty()], 2)
+            .unwrap_err();
+        assert!(error.to_string().contains("2 buffers, expected 1"));
+        let error = decoder
+            .decompress(vec![LanceBuffer::from(vec![0_u8; 5])], 2)
+            .unwrap_err();
+        assert!(error.to_string().contains("final generic offset 6"));
+    }
+
+    #[rstest]
+    #[case::range([16_usize; 4], "range")]
+    #[case::delta([4_usize, 10, 5, 8], "delta")]
+    #[test_log::test(tokio::test)]
+    async fn generic_offsets_support_scan_range_take(
+        #[case] lengths: [usize; 4],
+        #[case] expected_encoding: &str,
+    ) {
+        let values = StringArray::from_iter_values((0..10_000).map(|index| {
+            let len = lengths[index % lengths.len()];
+            format!("{index:04x}{}", "x".repeat(len - 4))
+        }));
+        let metadata = HashMap::from([
+            (
+                STRUCTURAL_ENCODING_META_KEY.to_string(),
+                STRUCTURAL_ENCODING_MINIBLOCK.to_string(),
+            ),
+            (COMPRESSION_META_KEY.to_string(), "none".to_string()),
+            (DICT_DIVISOR_META_KEY.to_string(), "100000".to_string()),
+        ]);
+        let test_cases = TestCases::basic()
+            .with_encoding(TestEncoding::StructuralSparse)
+            .with_expected_encoding(expected_encoding);
+        check_round_trip_encoding_of_data(vec![Arc::new(values)], &test_cases, metadata).await;
+    }
 
     #[test_log::test(tokio::test)]
     async fn test_utf8_binary() {
@@ -1045,9 +1764,7 @@ mod tests {
 
         // Test case 1: u32 offsets
         {
-            let decompressor = BinaryMiniBlockDecompressor {
-                bits_per_offset: 32,
-            };
+            let decompressor = BinaryMiniBlockDecompressor::new(32).unwrap();
 
             // Create test data with u32 offsets
             // BinaryMiniBlock format: all offsets followed by all string data
@@ -1101,9 +1818,7 @@ mod tests {
 
         // Test case 2: u64 offsets
         {
-            let decompressor = BinaryMiniBlockDecompressor {
-                bits_per_offset: 64,
-            };
+            let decompressor = BinaryMiniBlockDecompressor::new(64).unwrap();
 
             // Create test data with u64 offsets
             let mut test_data = Vec::new();
@@ -1171,7 +1886,7 @@ mod tests {
             LanceBuffer::from(chunk)
         }
 
-        let decompressor = BinaryMiniBlockDecompressor::new(32);
+        let decompressor = BinaryMiniBlockDecompressor::new(32).unwrap();
 
         // The tail offset points past the end of the 32-byte chunk.
         let err = decompressor
@@ -1222,7 +1937,7 @@ mod tests {
             chunk.resize(chunk.len().next_multiple_of(8), 0);
             LanceBuffer::from(chunk)
         }
-        let decompressor = BinaryMiniBlockDecompressor::new(64);
+        let decompressor = BinaryMiniBlockDecompressor::new(64).unwrap();
         let err = decompressor
             .decompress(
                 vec![chunk_u64(&[32, 37, 41, 100_000], b"alphabetagamma")],
@@ -1238,7 +1953,7 @@ mod tests {
         assert!(err.to_string().contains("overlaps"), "{err}");
 
         // A valid chunk still decodes: offsets rebase to [0, 5, 9, 14].
-        let decompressor = BinaryMiniBlockDecompressor::new(32);
+        let decompressor = BinaryMiniBlockDecompressor::new(32).unwrap();
         let block = decompressor
             .decompress(vec![chunk_u32(&[16, 21, 25, 30], b"alphabetagamma")], 3)
             .unwrap();

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -32,6 +32,9 @@ use crate::format::{ProtobufUtils21, pb21};
 use lance_core::utils::bit::pad_bytes_to;
 use lance_core::{Error, Result};
 
+#[allow(dead_code)]
+mod offsets;
+
 #[derive(Debug)]
 pub struct BinaryMiniBlockEncoder {
     minichunk_size: i64,

--- a/rust/lance-encoding/src/encodings/physical/binary/offsets.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary/offsets.rs
@@ -1,0 +1,971 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Private codec selection for independently decoded offset chunks.
+
+use std::{ops::Range, str::FromStr, sync::Arc};
+
+use lance_core::{Error, Result};
+use prost::Message;
+
+use crate::{
+    buffer::LanceBuffer,
+    compression::BlockCompressor,
+    compression_config::CompressionFieldParams,
+    data::{BlockInfo, DataBlock, FixedWidthDataBlock},
+    encodings::physical::{
+        block::{
+            CompressedBufferEncoder, CompressionConfig, CompressionScheme, GeneralBufferCompressor,
+        },
+        checked_fixed_values,
+        constant::ConstantEncoder,
+        delta::DeltaEncoder,
+        dictionary::{BlockDictionaryEncoder, MAX_BLOCK_DICTIONARY_ITEMS},
+        general::GeneralBlockCompressor,
+        range::RangeEncoder,
+        rle::{BlockRleEncoder, GENERIC_BLOCK_RLE_HEADER_BYTES},
+        value::ValueEncoder,
+    },
+    format::{ProtobufUtils21, pb21::CompressiveEncoding},
+};
+
+#[cfg(feature = "bitpacking")]
+use crate::encodings::physical::bitpacking::{OutOfLineBitpacking, out_of_line_payload_bytes};
+
+mod statistics;
+
+use statistics::{FamilyStats, SequenceStats, analyze_family, combine};
+
+/// Container-specific serialized cost applied to every optional payload.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct BlockCost {
+    buffer_overhead_bytes: u64,
+    alignment: u64,
+}
+
+impl Default for BlockCost {
+    fn default() -> Self {
+        Self::new(0, 1)
+    }
+}
+
+impl BlockCost {
+    pub(super) fn new(buffer_overhead_bytes: u64, alignment: u64) -> Self {
+        Self {
+            buffer_overhead_bytes,
+            alignment: alignment.max(1),
+        }
+    }
+
+    fn payload_bytes(self, has_payload: bool, payload_bytes: u64) -> u64 {
+        let aligned = payload_bytes
+            .checked_add(self.alignment - 1)
+            .map(|padded| padded / self.alignment * self.alignment)
+            .unwrap_or(u64::MAX);
+        aligned.saturating_add(if has_payload {
+            self.buffer_overhead_bytes
+        } else {
+            0
+        })
+    }
+}
+
+/// One concrete codec reused across every offset chunk in a page.
+#[derive(Debug)]
+pub(super) struct OffsetBlockCodec {
+    compressor: Box<dyn BlockCompressor>,
+    expected_encoding: CompressiveEncoding,
+    has_payload: bool,
+}
+
+impl OffsetBlockCodec {
+    pub(super) fn expected_encoding(&self) -> &CompressiveEncoding {
+        &self.expected_encoding
+    }
+
+    pub(super) fn has_payload(&self) -> bool {
+        self.has_payload
+    }
+
+    pub(super) fn compress(
+        &self,
+        data: FixedWidthDataBlock,
+    ) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let (payload, encoding) = self.compressor.compress(DataBlock::FixedWidth(data))?;
+        if encoding != self.expected_encoding {
+            return Err(Error::internal(
+                "Offset block codec produced a different descriptor after selection".to_string(),
+            ));
+        }
+        if payload.is_some() != self.has_payload {
+            return Err(Error::internal(
+                "Offset block codec changed its payload arity after selection".to_string(),
+            ));
+        }
+        Ok((payload, encoding))
+    }
+}
+
+#[derive(Debug)]
+struct Candidate {
+    compressor: Box<dyn BlockCompressor>,
+    encoding: CompressiveEncoding,
+    has_payload: bool,
+    payload_bytes: Vec<u64>,
+    wire_bytes: u64,
+    transform_depth: u8,
+    decode_cpu_rank: u8,
+    stable_rank: u8,
+}
+
+impl Candidate {
+    fn is_better_than(&self, other: &Self) -> bool {
+        (
+            self.wire_bytes,
+            self.transform_depth,
+            self.decode_cpu_rank,
+            self.stable_rank,
+        ) < (
+            other.wire_bytes,
+            other.transform_depth,
+            other.decode_cpu_rank,
+            other.stable_rank,
+        )
+    }
+
+    fn finish(self) -> OffsetBlockCodec {
+        OffsetBlockCodec {
+            compressor: Box::new(NormalizedOffsetEncoder {
+                child: self.compressor,
+            }),
+            expected_encoding: self.encoding,
+            has_payload: self.has_payload,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NormalizedOffsetEncoder {
+    child: Box<dyn BlockCompressor>,
+}
+
+impl BlockCompressor for NormalizedOffsetEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Offset compression requires fixed-width data",
+            ));
+        };
+        self.child
+            .compress(DataBlock::FixedWidth(normalize_offsets(data)?))
+    }
+}
+
+/// Selects one bounded unsigned codec for all independently framed chunks.
+pub(super) fn select_offset_block_codec(
+    data: &FixedWidthDataBlock,
+    ranges: &[Range<usize>],
+    field_params: &CompressionFieldParams,
+    cost: BlockCost,
+) -> Result<OffsetBlockCodec> {
+    let collect_general_sample =
+        !matches!(field_params.compression.as_deref(), Some("none" | "fsst"));
+    let analysis = analyze_family(data, ranges, collect_general_sample)?;
+    let value_stats = analysis
+        .members
+        .iter()
+        .map(|member| &member.values)
+        .collect::<Vec<_>>();
+
+    if let Some(value) = common_constant(&value_stats) {
+        return Ok(metadata_candidate(
+            data.bits_per_value,
+            value,
+            MetadataCodec::Constant,
+            ranges.len(),
+            cost,
+            0,
+        )
+        .finish());
+    }
+    if let Some((start, step)) = common_range(&value_stats) {
+        return Ok(metadata_candidate(
+            data.bits_per_value,
+            start,
+            MetadataCodec::Range(step),
+            ranges.len(),
+            cost,
+            1,
+        )
+        .finish());
+    }
+
+    let mut candidates = direct_candidates(&value_stats, field_params, cost, true)?;
+    if let Some(delta) = delta_candidate(&analysis, field_params, cost)? {
+        candidates.push(delta);
+    }
+    if let Some(rle) = rle_candidate(&analysis, field_params, cost)? {
+        candidates.push(rle);
+    }
+    if let Some(dictionary) = dictionary_candidate(&analysis, field_params, cost)? {
+        candidates.push(dictionary);
+    }
+
+    candidates
+        .into_iter()
+        .reduce(|best, candidate| {
+            if candidate.is_better_than(&best) {
+                candidate
+            } else {
+                best
+            }
+        })
+        .map(Candidate::finish)
+        .ok_or_else(|| Error::internal("No offset block codec candidate".to_string()))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MetadataCodec {
+    Constant,
+    Range(u64),
+}
+
+fn metadata_candidate(
+    bits_per_value: u64,
+    value: u64,
+    codec: MetadataCodec,
+    num_members: usize,
+    cost: BlockCost,
+    stable_rank: u8,
+) -> Candidate {
+    let (compressor, encoding): (Box<dyn BlockCompressor>, _) = match codec {
+        MetadataCodec::Constant => (
+            Box::new(ConstantEncoder::new(bits_per_value, value)),
+            ProtobufUtils21::constant(Some(encode_scalar(bits_per_value, value))),
+        ),
+        MetadataCodec::Range(step) => (
+            Box::new(RangeEncoder::new(bits_per_value, value, step)),
+            ProtobufUtils21::range(bits_per_value, value, step),
+        ),
+    };
+    let payload_bytes = vec![0; num_members];
+    Candidate {
+        wire_bytes: wire_bytes(&encoding, false, &payload_bytes, cost),
+        compressor,
+        encoding,
+        has_payload: false,
+        payload_bytes,
+        transform_depth: 0,
+        decode_cpu_rank: 0,
+        stable_rank,
+    }
+}
+
+fn direct_candidates(
+    stats: &[&SequenceStats],
+    field_params: &CompressionFieldParams,
+    cost: BlockCost,
+    allow_general: bool,
+) -> Result<Vec<Candidate>> {
+    let combined = combine(stats)?;
+    let bits_per_value = combined.bits_per_value;
+    let flat_payloads = stats
+        .iter()
+        .map(|stats| stats.raw_bytes())
+        .collect::<Vec<_>>();
+    let flat_encoding = ProtobufUtils21::flat(bits_per_value, None);
+    let mut candidates = vec![Candidate {
+        wire_bytes: wire_bytes(&flat_encoding, true, &flat_payloads, cost),
+        compressor: Box::new(ValueEncoder::default()),
+        encoding: flat_encoding,
+        has_payload: true,
+        payload_bytes: flat_payloads,
+        transform_depth: 0,
+        decode_cpu_rank: 0,
+        stable_rank: 0,
+    }];
+
+    #[cfg(feature = "bitpacking")]
+    if combined.len > 0 && combined.required_bits() < bits_per_value {
+        let compressed_bits = combined.required_bits();
+        let compressor = Box::new(OutOfLineBitpacking::new(compressed_bits, bits_per_value));
+        let encoding = ProtobufUtils21::out_of_line_bitpacking(
+            bits_per_value,
+            ProtobufUtils21::flat(compressed_bits, None),
+        );
+        let payload_bytes = stats
+            .iter()
+            .map(|stats| out_of_line_payload_bytes(stats.len, bits_per_value, compressed_bits))
+            .collect::<Result<Vec<_>>>()?;
+        candidates.push(Candidate {
+            wire_bytes: wire_bytes(&encoding, true, &payload_bytes, cost),
+            compressor,
+            encoding,
+            has_payload: true,
+            payload_bytes,
+            transform_depth: 1,
+            decode_cpu_rank: 1,
+            stable_rank: 1,
+        });
+    }
+
+    if allow_general
+        && let Some(config) = general_config(&combined, field_params)?
+        && config.scheme != CompressionScheme::None
+    {
+        let payload_bytes = stats
+            .iter()
+            .map(|stats| estimate_general_bytes(stats, config))
+            .collect::<Result<Vec<_>>>()?;
+        let encoding =
+            ProtobufUtils21::wrapped(config, ProtobufUtils21::flat(bits_per_value, None))?;
+        candidates.push(Candidate {
+            wire_bytes: wire_bytes(&encoding, true, &payload_bytes, cost),
+            compressor: Box::new(GeneralBlockCompressor::new(
+                Box::new(ValueEncoder::default()),
+                config,
+            )),
+            encoding,
+            has_payload: true,
+            payload_bytes,
+            transform_depth: 1,
+            decode_cpu_rank: 4,
+            stable_rank: 2,
+        });
+    }
+    Ok(candidates)
+}
+
+fn leaf_candidate(
+    stats: &[&SequenceStats],
+    field_params: &CompressionFieldParams,
+) -> Result<Candidate> {
+    let bits_per_value = stats[0].bits_per_value;
+    if let Some(value) = common_constant(stats) {
+        return Ok(metadata_candidate(
+            bits_per_value,
+            value,
+            MetadataCodec::Constant,
+            stats.len(),
+            BlockCost::default(),
+            0,
+        ));
+    }
+    if let Some((start, step)) = common_range(stats) {
+        return Ok(metadata_candidate(
+            bits_per_value,
+            start,
+            MetadataCodec::Range(step),
+            stats.len(),
+            BlockCost::default(),
+            1,
+        ));
+    }
+    direct_candidates(stats, field_params, BlockCost::default(), false)?
+        .into_iter()
+        .reduce(|best, candidate| {
+            if candidate.is_better_than(&best) {
+                candidate
+            } else {
+                best
+            }
+        })
+        .ok_or_else(|| Error::internal("No block leaf candidate".to_string()))
+}
+
+fn delta_candidate(
+    analysis: &FamilyStats,
+    field_params: &CompressionFieldParams,
+    cost: BlockCost,
+) -> Result<Option<Candidate>> {
+    if analysis
+        .members
+        .iter()
+        .any(|member| member.deltas.is_none())
+    {
+        return Ok(None);
+    }
+    let stats = analysis
+        .members
+        .iter()
+        .map(|member| member.deltas.as_ref().expect("delta presence was checked"))
+        .collect::<Vec<_>>();
+    let child = leaf_candidate(&stats, field_params)?;
+    let bits_per_value = analysis.members[0].values.bits_per_value;
+    let encoding = ProtobufUtils21::delta(bits_per_value, 0, child.encoding);
+    Ok(Some(Candidate {
+        wire_bytes: wire_bytes(&encoding, child.has_payload, &child.payload_bytes, cost),
+        compressor: Box::new(DeltaEncoder::new(bits_per_value, 0, child.compressor)),
+        encoding,
+        has_payload: child.has_payload,
+        payload_bytes: child.payload_bytes,
+        transform_depth: child.transform_depth.saturating_add(1),
+        decode_cpu_rank: 2,
+        stable_rank: 5,
+    }))
+}
+
+fn rle_candidate(
+    analysis: &FamilyStats,
+    field_params: &CompressionFieldParams,
+    cost: BlockCost,
+) -> Result<Option<Candidate>> {
+    let total_values = analysis
+        .members
+        .iter()
+        .map(|member| member.values.len)
+        .sum::<u64>();
+    let total_runs = analysis
+        .members
+        .iter()
+        .map(|member| member.run_values.len)
+        .sum::<u64>();
+    if total_runs == 0 || total_runs >= total_values {
+        return Ok(None);
+    }
+    if let Some(threshold) = field_params.rle_threshold
+        && total_runs as f64 >= total_values as f64 * threshold
+    {
+        return Ok(None);
+    }
+    if analysis
+        .members
+        .iter()
+        .any(|member| member.run_lengths.max > u32::MAX as u64)
+    {
+        return Ok(None);
+    }
+
+    let value_stats = analysis
+        .members
+        .iter()
+        .map(|member| &member.run_values)
+        .collect::<Vec<_>>();
+    let length_stats = analysis
+        .members
+        .iter()
+        .map(|member| &member.run_lengths)
+        .collect::<Vec<_>>();
+    let values = leaf_candidate(&value_stats, field_params)?;
+    let mut lengths = leaf_candidate(&length_stats, field_params)?;
+    let lengths_are_metadata = matches!(
+        lengths.encoding.compression.as_ref(),
+        Some(crate::format::pb21::compressive_encoding::Compression::Constant(_))
+            | Some(crate::format::pb21::compressive_encoding::Compression::Range(_))
+    );
+    let values_are_flat = is_flat(&values.encoding);
+    if !lengths_are_metadata && !values_are_flat && !is_flat(&lengths.encoding) {
+        lengths = flat_candidate(&length_stats)?;
+    }
+
+    let has_payload = values.has_payload || lengths.has_payload;
+    let payload_bytes = values
+        .payload_bytes
+        .iter()
+        .zip(&lengths.payload_bytes)
+        .map(|(values, lengths)| {
+            if has_payload {
+                (GENERIC_BLOCK_RLE_HEADER_BYTES as u64)
+                    .saturating_add(*values)
+                    .saturating_add(*lengths)
+            } else {
+                0
+            }
+        })
+        .collect::<Vec<_>>();
+    let encoding = ProtobufUtils21::rle(values.encoding, lengths.encoding);
+    let bits_per_value = analysis.members[0].values.bits_per_value;
+    let compressor =
+        BlockRleEncoder::try_new(bits_per_value, values.compressor, lengths.compressor)?;
+    Ok(Some(Candidate {
+        wire_bytes: wire_bytes(&encoding, has_payload, &payload_bytes, cost),
+        compressor: Box::new(compressor),
+        encoding,
+        has_payload,
+        payload_bytes,
+        transform_depth: 1,
+        decode_cpu_rank: 3,
+        stable_rank: 3,
+    }))
+}
+
+fn dictionary_candidate(
+    analysis: &FamilyStats,
+    field_params: &CompressionFieldParams,
+    cost: BlockCost,
+) -> Result<Option<Candidate>> {
+    let Some(items) = analysis.dictionary_items.as_ref() else {
+        return Ok(None);
+    };
+    let total_values = analysis
+        .members
+        .iter()
+        .map(|member| member.values.len)
+        .sum::<u64>();
+    if items.len() < 2
+        || items.len() > MAX_BLOCK_DICTIONARY_ITEMS
+        || items.len() as u64 >= total_values.div_ceil(2)
+    {
+        return Ok(None);
+    }
+
+    let bits_per_value = analysis.members[0].values.bits_per_value;
+    let item_stats = sequence_stats_for_values(items, bits_per_value);
+    let repeated_items = (0..analysis.members.len())
+        .map(|_| &item_stats)
+        .collect::<Vec<_>>();
+    let index_stats = analysis
+        .members
+        .iter()
+        .map(|member| SequenceStats {
+            bits_per_value: 32,
+            len: member.values.len,
+            first: Some(0),
+            min: 0,
+            max: items.len().saturating_sub(1) as u64,
+            arithmetic_step: None,
+            run_count: member.values.len,
+            sample: Arc::from([]),
+        })
+        .collect::<Vec<_>>();
+    let index_refs = index_stats.iter().collect::<Vec<_>>();
+    let indices = leaf_candidate(&index_refs, field_params)?;
+    let dictionary_items = leaf_candidate(&repeated_items, field_params)?;
+    let has_payload = indices.has_payload || dictionary_items.has_payload;
+    let payload_bytes = indices
+        .payload_bytes
+        .iter()
+        .zip(&dictionary_items.payload_bytes)
+        .map(|(indices, items)| {
+            if has_payload {
+                16_u64.saturating_add(*indices).saturating_add(*items)
+            } else {
+                0
+            }
+        })
+        .collect::<Vec<_>>();
+    let encoding = ProtobufUtils21::dictionary(
+        indices.encoding,
+        dictionary_items.encoding,
+        items.len() as u32,
+    );
+    let compressor = BlockDictionaryEncoder::try_new(
+        bits_per_value,
+        items.clone(),
+        indices.compressor,
+        dictionary_items.compressor,
+    )?;
+    Ok(Some(Candidate {
+        wire_bytes: wire_bytes(&encoding, has_payload, &payload_bytes, cost),
+        compressor: Box::new(compressor),
+        encoding,
+        has_payload,
+        payload_bytes,
+        transform_depth: 1,
+        decode_cpu_rank: 3,
+        stable_rank: 4,
+    }))
+}
+
+fn flat_candidate(stats: &[&SequenceStats]) -> Result<Candidate> {
+    let bits_per_value = stats[0].bits_per_value;
+    if stats
+        .iter()
+        .any(|stats| stats.bits_per_value != bits_per_value)
+    {
+        return Err(Error::invalid_input(
+            "Flat child candidates must have one value width",
+        ));
+    }
+    let payload_bytes = stats
+        .iter()
+        .map(|stats| stats.raw_bytes())
+        .collect::<Vec<_>>();
+    let encoding = ProtobufUtils21::flat(bits_per_value, None);
+    Ok(Candidate {
+        wire_bytes: wire_bytes(&encoding, true, &payload_bytes, BlockCost::default()),
+        compressor: Box::new(ValueEncoder::default()),
+        encoding,
+        has_payload: true,
+        payload_bytes,
+        transform_depth: 0,
+        decode_cpu_rank: 0,
+        stable_rank: 0,
+    })
+}
+
+fn sequence_stats_for_values(values: &[u64], bits_per_value: u64) -> SequenceStats {
+    let arithmetic_step = values
+        .windows(2)
+        .map(|pair| pair[1].checked_sub(pair[0]))
+        .try_fold(None, |expected, step| match (expected, step) {
+            (None, Some(step)) => Some(Some(step)),
+            (Some(expected), Some(step)) if expected == step => Some(Some(expected)),
+            _ => None,
+        })
+        .flatten();
+    SequenceStats {
+        bits_per_value,
+        len: values.len() as u64,
+        first: values.first().copied(),
+        min: values.first().copied().unwrap_or(0),
+        max: values.last().copied().unwrap_or(0),
+        arithmetic_step: (values.len() >= 2).then_some(arithmetic_step).flatten(),
+        run_count: values.len() as u64,
+        sample: Arc::from([]),
+    }
+}
+
+fn common_constant(stats: &[&SequenceStats]) -> Option<u64> {
+    let value = stats.first()?.first?;
+    stats
+        .iter()
+        .all(|stats| stats.len > 0 && stats.min == value && stats.max == value)
+        .then_some(value)
+}
+
+fn common_range(stats: &[&SequenceStats]) -> Option<(u64, u64)> {
+    let first = stats.first()?;
+    let start = first.first?;
+    let step = first.arithmetic_step?;
+    if step == 0 {
+        return None;
+    }
+    stats
+        .iter()
+        .all(|stats| {
+            stats.len >= 2 && stats.first == Some(start) && stats.arithmetic_step == Some(step)
+        })
+        .then_some((start, step))
+}
+
+fn general_config(
+    stats: &SequenceStats,
+    field_params: &CompressionFieldParams,
+) -> Result<Option<CompressionConfig>> {
+    match field_params.compression.as_deref() {
+        Some("none" | "fsst") => Ok(None),
+        Some(name) => {
+            let scheme = CompressionScheme::from_str(name)?;
+            Ok(Some(CompressionConfig::new(
+                scheme,
+                field_params.compression_level,
+            )))
+        }
+        None if stats.raw_bytes() > 32 * 1024 => {
+            Ok(Some(CompressedBufferEncoder::default().compressor.config()))
+        }
+        None => Ok(None),
+    }
+}
+
+fn estimate_general_bytes(stats: &SequenceStats, config: CompressionConfig) -> Result<u64> {
+    if stats.raw_bytes() == 0 {
+        return Ok(0);
+    }
+    if stats.sample.is_empty() {
+        return Ok(u64::MAX);
+    }
+    let compressor = GeneralBufferCompressor::get_compressor(config)?;
+    let mut compressed = Vec::new();
+    compressor.compress(&stats.sample, &mut compressed)?;
+    Ok(if stats.sample.len() as u64 == stats.raw_bytes() {
+        compressed.len() as u64
+    } else {
+        (compressed.len() as u64)
+            .saturating_mul(stats.raw_bytes())
+            .div_ceil(stats.sample.len() as u64)
+    })
+}
+
+fn wire_bytes(
+    encoding: &CompressiveEncoding,
+    has_payload: bool,
+    payload_bytes: &[u64],
+    cost: BlockCost,
+) -> u64 {
+    (encoding.encoded_len() as u64).saturating_add(
+        payload_bytes
+            .iter()
+            .map(|payload_bytes| cost.payload_bytes(has_payload, *payload_bytes))
+            .sum::<u64>(),
+    )
+}
+
+fn encode_scalar(bits_per_value: u64, value: u64) -> bytes::Bytes {
+    match bits_per_value {
+        32 => bytes::Bytes::copy_from_slice(&(value as u32).to_le_bytes()),
+        64 => bytes::Bytes::copy_from_slice(&value.to_le_bytes()),
+        _ => unreachable!("offset width was validated during analysis"),
+    }
+}
+
+fn is_flat(encoding: &CompressiveEncoding) -> bool {
+    matches!(
+        encoding.compression.as_ref(),
+        Some(crate::format::pb21::compressive_encoding::Compression::Flat(_))
+    )
+}
+
+fn normalize_offsets(mut data: FixedWidthDataBlock) -> Result<FixedWidthDataBlock> {
+    if data.num_values == 0 {
+        return Err(Error::invalid_input("Offset chunks cannot be empty"));
+    }
+    data.data = match data.bits_per_value {
+        32 => {
+            let values = checked_fixed_values::<u32>(&data, "Offset chunk")?;
+            let base = values[0];
+            if base == 0 {
+                return Ok(data);
+            }
+            LanceBuffer::reinterpret_vec(
+                values
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        value.checked_sub(base).ok_or_else(|| {
+                            Error::invalid_input(format!(
+                                "Offset chunk decreases below its base at index {index}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            )
+        }
+        64 => {
+            let values = checked_fixed_values::<u64>(&data, "Offset chunk")?;
+            let base = values[0];
+            if base == 0 {
+                return Ok(data);
+            }
+            LanceBuffer::reinterpret_vec(
+                values
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        value.checked_sub(base).ok_or_else(|| {
+                            Error::invalid_input(format!(
+                                "Offset chunk decreases below its base at index {index}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            )
+        }
+        bits_per_value => {
+            return Err(Error::invalid_input(format!(
+                "Offset compression only supports 32 or 64-bit values, got {bits_per_value}"
+            )));
+        }
+    };
+    data.block_info = BlockInfo::default();
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        compression::create_fixed_width_block_decompressor,
+        format::pb21::compressive_encoding::Compression,
+    };
+
+    fn fixed_u32(values: &[u32]) -> FixedWidthDataBlock {
+        FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(values.to_vec()),
+            num_values: values.len() as u64,
+            block_info: BlockInfo::default(),
+        }
+    }
+
+    fn fixed_u64(values: &[u64]) -> FixedWidthDataBlock {
+        FixedWidthDataBlock {
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(values.to_vec()),
+            num_values: values.len() as u64,
+            block_info: BlockInfo::default(),
+        }
+    }
+
+    fn member(data: &FixedWidthDataBlock, range: Range<usize>) -> FixedWidthDataBlock {
+        let bytes_per_value = (data.bits_per_value / 8) as usize;
+        FixedWidthDataBlock {
+            bits_per_value: data.bits_per_value,
+            data: data
+                .data
+                .slice_with_length(range.start * bytes_per_value, range.len() * bytes_per_value),
+            num_values: range.len() as u64,
+            block_info: BlockInfo::default(),
+        }
+    }
+
+    fn round_trip(
+        codec: &OffsetBlockCodec,
+        data: &FixedWidthDataBlock,
+        range: Range<usize>,
+    ) -> Vec<u64> {
+        let num_values = range.len() as u64;
+        let (payload, encoding) = codec.compress(member(data, range)).unwrap();
+        let decoder =
+            create_fixed_width_block_decompressor(&encoding, data.bits_per_value).unwrap();
+        let decoded = decoder.decompress(payload, num_values).unwrap();
+        let decoded = decoded.as_fixed_width().unwrap();
+        match decoded.bits_per_value {
+            32 => decoded
+                .data
+                .borrow_to_typed_slice::<u32>()
+                .iter()
+                .map(|value| u64::from(*value))
+                .collect(),
+            64 => decoded.data.borrow_to_typed_slice::<u64>().to_vec(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn selects_shared_metadata_codecs() {
+        let constant = fixed_u32(&[5, 5, 5, 10, 10, 10]);
+        let codec = select_offset_block_codec(
+            &constant,
+            &[0..3, 3..6],
+            &CompressionFieldParams::default(),
+            BlockCost::new(0, 1),
+        )
+        .unwrap();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Constant(_))
+        ));
+        assert!(!codec.has_payload());
+        assert_eq!(round_trip(&codec, &constant, 3..6), vec![0, 0, 0]);
+
+        let range = fixed_u32(&[5, 7, 9, 11, 10, 12, 14, 16]);
+        let codec = select_offset_block_codec(
+            &range,
+            &[0..4, 4..8],
+            &CompressionFieldParams::default(),
+            BlockCost::new(0, 1),
+        )
+        .unwrap();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Range(_))
+        ));
+        assert_eq!(round_trip(&codec, &range, 4..8), vec![0, 2, 4, 6]);
+    }
+
+    #[test]
+    fn selects_delta_and_round_trips() {
+        let data = fixed_u32(&[0, 2, 5, 9, 14]);
+        let codec = select_offset_block_codec(
+            &data,
+            &[0..5],
+            &CompressionFieldParams {
+                compression: Some("none".to_string()),
+                ..Default::default()
+            },
+            BlockCost::new(0, 1),
+        )
+        .unwrap();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Delta(_))
+        ));
+        assert_eq!(round_trip(&codec, &data, 0..5), vec![0, 2, 5, 9, 14]);
+    }
+
+    #[test]
+    fn selects_rle_and_dictionary_candidates() {
+        let rle_member = (0..32_u64)
+            .flat_map(|value| std::iter::repeat_n(value, 8))
+            .collect::<Vec<_>>();
+        let mut rle_values = rle_member.clone();
+        rle_values.extend_from_slice(&rle_member);
+        let rle_data = fixed_u64(&rle_values);
+        let codec = select_offset_block_codec(
+            &rle_data,
+            &[0..rle_member.len(), rle_member.len()..rle_values.len()],
+            &CompressionFieldParams::default(),
+            BlockCost::new(0, 1),
+        )
+        .unwrap();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Rle(_))
+        ));
+        assert_eq!(
+            round_trip(&codec, &rle_data, 0..rle_member.len()),
+            rle_member
+        );
+
+        let dictionary_values = [0_u64, 1000, 5000, 9000]
+            .into_iter()
+            .flat_map(|value| std::iter::repeat_n(value, 128))
+            .collect::<Vec<_>>();
+        let dictionary_data = fixed_u64(&dictionary_values);
+        let analysis =
+            analyze_family(&dictionary_data, &[0..dictionary_values.len()], false).unwrap();
+        let codec = dictionary_candidate(
+            &analysis,
+            &CompressionFieldParams {
+                compression: Some("none".to_string()),
+                ..Default::default()
+            },
+            BlockCost::new(0, 1),
+        )
+        .unwrap()
+        .unwrap()
+        .finish();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Dictionary(_))
+        ));
+        assert_eq!(
+            round_trip(&codec, &dictionary_data, 0..512),
+            dictionary_values
+        );
+
+        let dictionary_values = dictionary_values
+            .into_iter()
+            .map(|value| value as u32)
+            .collect::<Vec<_>>();
+        let dictionary_data = fixed_u32(&dictionary_values);
+        let analysis =
+            analyze_family(&dictionary_data, &[0..dictionary_values.len()], false).unwrap();
+        let codec = dictionary_candidate(
+            &analysis,
+            &CompressionFieldParams {
+                compression: Some("none".to_string()),
+                ..Default::default()
+            },
+            BlockCost::new(0, 1),
+        )
+        .unwrap()
+        .unwrap()
+        .finish();
+        assert!(matches!(
+            codec.expected_encoding().compression,
+            Some(Compression::Dictionary(_))
+        ));
+        assert_eq!(
+            round_trip(&codec, &dictionary_data, 0..512),
+            dictionary_values
+                .into_iter()
+                .map(u64::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rejects_decreasing_member() {
+        let error = select_offset_block_codec(
+            &fixed_u32(&[0, 2, 1]),
+            &[0..3],
+            &CompressionFieldParams::default(),
+            BlockCost::new(0, 1),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("non-decreasing"));
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/binary/offsets/statistics.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary/offsets/statistics.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::BTreeSet, ops::Range, sync::Arc};
+
+use lance_core::{Error, Result};
+
+use crate::{
+    data::FixedWidthDataBlock,
+    encodings::physical::{checked_fixed_values, dictionary::MAX_BLOCK_DICTIONARY_ITEMS},
+};
+
+const GENERAL_SAMPLE_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub(super) struct SequenceStats {
+    pub(super) bits_per_value: u64,
+    pub(super) len: u64,
+    pub(super) first: Option<u64>,
+    pub(super) min: u64,
+    pub(super) max: u64,
+    pub(super) arithmetic_step: Option<u64>,
+    pub(super) run_count: u64,
+    pub(super) sample: Arc<[u8]>,
+}
+
+impl SequenceStats {
+    pub(super) fn raw_bytes(&self) -> u64 {
+        self.len.saturating_mul(self.bits_per_value / 8)
+    }
+
+    #[cfg(feature = "bitpacking")]
+    pub(super) fn required_bits(&self) -> u64 {
+        u64::from((u64::BITS - self.max.leading_zeros()).max(1))
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct MemberStats {
+    pub(super) values: SequenceStats,
+    pub(super) deltas: Option<SequenceStats>,
+    pub(super) run_values: SequenceStats,
+    pub(super) run_lengths: SequenceStats,
+}
+
+#[derive(Debug)]
+pub(super) struct FamilyStats {
+    pub(super) members: Vec<MemberStats>,
+    pub(super) dictionary_items: Option<Arc<[u64]>>,
+}
+
+#[derive(Debug)]
+struct SequenceStatsBuilder {
+    bits_per_value: u64,
+    len: u64,
+    first: Option<u64>,
+    previous: Option<u64>,
+    min: u64,
+    max: u64,
+    arithmetic_step: Option<u64>,
+    is_arithmetic: bool,
+    run_count: u64,
+    sample: Vec<u8>,
+    sample_limit: usize,
+}
+
+impl SequenceStatsBuilder {
+    fn new(bits_per_value: u64, sample_limit: usize) -> Self {
+        Self {
+            bits_per_value,
+            len: 0,
+            first: None,
+            previous: None,
+            min: u64::MAX,
+            max: 0,
+            arithmetic_step: None,
+            is_arithmetic: true,
+            run_count: 0,
+            sample: Vec::new(),
+            sample_limit,
+        }
+    }
+
+    fn push(&mut self, value: u64) {
+        if self.first.is_none() {
+            self.first = Some(value);
+            self.run_count = 1;
+        }
+        if let Some(previous) = self.previous {
+            if value != previous {
+                self.run_count += 1;
+            }
+            let step = value.checked_sub(previous);
+            match (self.arithmetic_step, step, self.len) {
+                (None, Some(step), 1) => self.arithmetic_step = Some(step),
+                (Some(expected), Some(actual), _) if expected == actual => {}
+                _ => self.is_arithmetic = false,
+            }
+        }
+        self.previous = Some(value);
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+        self.len += 1;
+
+        if self.sample.len() < self.sample_limit {
+            let bytes = value.to_le_bytes();
+            let value_bytes = (self.bits_per_value / 8) as usize;
+            let remaining = self.sample_limit - self.sample.len();
+            self.sample
+                .extend_from_slice(&bytes[..value_bytes.min(remaining)]);
+        }
+    }
+
+    fn finish(self) -> SequenceStats {
+        SequenceStats {
+            bits_per_value: self.bits_per_value,
+            len: self.len,
+            first: self.first,
+            min: if self.len == 0 { 0 } else { self.min },
+            max: self.max,
+            arithmetic_step: (self.len >= 2 && self.is_arithmetic)
+                .then_some(self.arithmetic_step)
+                .flatten(),
+            run_count: self.run_count,
+            sample: Arc::from(self.sample),
+        }
+    }
+}
+
+pub(super) fn analyze_family(
+    data: &FixedWidthDataBlock,
+    ranges: &[Range<usize>],
+    collect_general_sample: bool,
+) -> Result<FamilyStats> {
+    if ranges.is_empty() {
+        return Err(Error::invalid_input(
+            "Offset compression requires at least one chunk",
+        ));
+    }
+    let sample_limit = if collect_general_sample {
+        GENERAL_SAMPLE_BYTES / ranges.len()
+    } else {
+        0
+    };
+    match data.bits_per_value {
+        32 => {
+            let values = checked_fixed_values::<u32>(data, "Offset family")?;
+            analyze_typed_family(&values, ranges, 32, sample_limit, true, |value| {
+                u64::from(value)
+            })
+        }
+        64 => {
+            let values = checked_fixed_values::<u64>(data, "Offset family")?;
+            analyze_typed_family(&values, ranges, 64, sample_limit, true, |value| value)
+        }
+        bits_per_value => Err(Error::invalid_input(format!(
+            "Offset compression only supports 32 or 64-bit values, got {bits_per_value}"
+        ))),
+    }
+}
+
+fn analyze_typed_family<T: Copy + Eq>(
+    values: &[T],
+    ranges: &[Range<usize>],
+    bits_per_value: u64,
+    sample_limit: usize,
+    collect_dictionary: bool,
+    to_u64: impl Fn(T) -> u64 + Copy,
+) -> Result<FamilyStats> {
+    let mut dictionary = collect_dictionary.then(BoundedDistinct::default);
+    let members = ranges
+        .iter()
+        .enumerate()
+        .map(|(member_index, range)| {
+            let member = values.get(range.clone()).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Offset chunk {member_index} range {}..{} exceeds {} values",
+                    range.start,
+                    range.end,
+                    values.len()
+                ))
+            })?;
+            let base = member.first().copied().map(to_u64).ok_or_else(|| {
+                Error::invalid_input(format!("Offset chunk {member_index} is empty"))
+            })?;
+            let mut value_stats = SequenceStatsBuilder::new(bits_per_value, sample_limit);
+            let mut delta_stats = SequenceStatsBuilder::new(bits_per_value, 0);
+            let mut run_value_stats = SequenceStatsBuilder::new(bits_per_value, 0);
+            let mut run_length_stats = SequenceStatsBuilder::new(32, 0);
+            let mut previous = None;
+            let mut run_value = None;
+            let mut run_length = 0_u64;
+
+            for raw_value in member.iter().copied().map(to_u64) {
+                let value = raw_value.checked_sub(base).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Offset chunk {member_index} contains a value below its first offset"
+                    ))
+                })?;
+                if let Some(previous) = previous {
+                    let delta = value.checked_sub(previous).ok_or_else(|| {
+                        Error::invalid_input(format!(
+                            "Offset chunk {member_index} must be non-decreasing"
+                        ))
+                    })?;
+                    delta_stats.push(delta);
+                }
+                previous = Some(value);
+                value_stats.push(value);
+                if let Some(dictionary) = dictionary.as_mut() {
+                    dictionary.push(value);
+                }
+
+                match run_value {
+                    Some(current) if current == value => run_length += 1,
+                    Some(current) => {
+                        run_value_stats.push(current);
+                        run_length_stats.push(run_length);
+                        run_value = Some(value);
+                        run_length = 1;
+                    }
+                    None => {
+                        run_value = Some(value);
+                        run_length = 1;
+                    }
+                }
+            }
+            run_value_stats.push(run_value.expect("non-empty offset chunk has one run"));
+            run_length_stats.push(run_length);
+            let values = value_stats.finish();
+            Ok(MemberStats {
+                deltas: (values.len >= 2).then(|| delta_stats.finish()),
+                values,
+                run_values: run_value_stats.finish(),
+                run_lengths: run_length_stats.finish(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(FamilyStats {
+        members,
+        dictionary_items: dictionary.and_then(BoundedDistinct::finish),
+    })
+}
+
+#[derive(Debug)]
+struct BoundedDistinct {
+    values: Option<BTreeSet<u64>>,
+}
+
+impl Default for BoundedDistinct {
+    fn default() -> Self {
+        Self {
+            values: Some(BTreeSet::new()),
+        }
+    }
+}
+
+impl BoundedDistinct {
+    fn push(&mut self, value: u64) {
+        let Some(values) = self.values.as_mut() else {
+            return;
+        };
+        values.insert(value);
+        if values.len() > MAX_BLOCK_DICTIONARY_ITEMS {
+            self.values = None;
+        }
+    }
+
+    fn finish(self) -> Option<Arc<[u64]>> {
+        self.values
+            .map(|values| Arc::from(values.into_iter().collect::<Vec<_>>()))
+    }
+}
+
+pub(super) fn combine(stats: &[&SequenceStats]) -> Result<SequenceStats> {
+    let bits_per_value = stats
+        .first()
+        .ok_or_else(|| Error::invalid_input("Cannot combine an empty stats family"))?
+        .bits_per_value;
+    let mut len = 0_u64;
+    let mut run_count = 0_u64;
+    let mut min = u64::MAX;
+    let mut max = 0_u64;
+    let mut sample = Vec::new();
+    for member in stats {
+        if member.bits_per_value != bits_per_value {
+            return Err(Error::invalid_input(
+                "Cannot combine sequences with different value widths",
+            ));
+        }
+        len = len
+            .checked_add(member.len)
+            .ok_or_else(|| Error::invalid_input("Combined sequence length overflows u64"))?;
+        run_count = run_count
+            .checked_add(member.run_count)
+            .ok_or_else(|| Error::invalid_input("Combined run count overflows u64"))?;
+        if member.len > 0 {
+            min = min.min(member.min);
+            max = max.max(member.max);
+        }
+        let remaining = GENERAL_SAMPLE_BYTES.saturating_sub(sample.len());
+        sample.extend_from_slice(&member.sample[..member.sample.len().min(remaining)]);
+    }
+    Ok(SequenceStats {
+        bits_per_value,
+        len,
+        first: stats.first().and_then(|stats| stats.first),
+        min: if len == 0 { 0 } else { min },
+        max,
+        arithmetic_step: None,
+        run_count,
+        sample: Arc::from(sample),
+    })
+}

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -23,7 +23,9 @@ use lance_bitpacking::BitPacking;
 use lance_core::{Error, Result};
 
 use crate::buffer::LanceBuffer;
-use crate::compression::{BlockCompressor, BlockDecompressor, MiniBlockDecompressor};
+use crate::compression::{
+    BlockCompressor, BlockDecompressor, MiniBlockDecompressor, require_block_payload,
+};
 use crate::data::BlockInfo;
 use crate::data::{DataBlock, FixedWidthDataBlock};
 use crate::encodings::logical::primitive::miniblock::{
@@ -303,10 +305,27 @@ impl MiniBlockCompressor for InlineBitpacking {
 }
 
 impl BlockCompressor for InlineBitpacking {
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
-        let fixed_width = data.as_fixed_width().unwrap();
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(fixed_width) = data else {
+            return Err(Error::invalid_input(
+                "Inline bitpacking requires fixed-width data",
+            ));
+        };
+        if fixed_width.bits_per_value != self.uncompressed_bit_width {
+            return Err(Error::invalid_input(format!(
+                "Inline bitpacking expects {}-bit values, got {}",
+                self.uncompressed_bit_width, fixed_width.bits_per_value
+            )));
+        }
         let (chunked, _) = self.chunk_data(fixed_width);
-        Ok(chunked.data.into_iter().next().unwrap())
+        let payload =
+            chunked.data.into_iter().next().ok_or_else(|| {
+                Error::internal("Inline bitpacking produced no payload".to_string())
+            })?;
+        Ok((
+            Some(payload),
+            ProtobufUtils21::inline_bitpacking(self.uncompressed_bit_width, None),
+        ))
     }
 }
 
@@ -335,7 +354,8 @@ impl MiniBlockDecompressor for InlineBitpacking {
 }
 
 impl BlockDecompressor for InlineBitpacking {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "Inline bitpacking")?;
         if num_values == 0 {
             // Empty blocks carry no inline bit-width header to decode; avoid
             // spurious "too small for header" corrupt-file errors and mirror
@@ -553,21 +573,43 @@ impl OutOfLineBitpacking {
 }
 
 impl BlockCompressor for OutOfLineBitpacking {
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
-        let fixed_width = data.as_fixed_width().unwrap();
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(fixed_width) = data else {
+            return Err(Error::invalid_input(
+                "Out-of-line bitpacking requires fixed-width data",
+            ));
+        };
+        if fixed_width.bits_per_value != self.uncompressed_bit_width {
+            return Err(Error::invalid_input(format!(
+                "Out-of-line bitpacking expects {}-bit values, got {}",
+                self.uncompressed_bit_width, fixed_width.bits_per_value
+            )));
+        }
         let compressed = match fixed_width.bits_per_value {
             8 => bitpack_out_of_line::<u8>(fixed_width, self.compressed_bit_width as usize),
             16 => bitpack_out_of_line::<u16>(fixed_width, self.compressed_bit_width as usize),
             32 => bitpack_out_of_line::<u32>(fixed_width, self.compressed_bit_width as usize),
             64 => bitpack_out_of_line::<u64>(fixed_width, self.compressed_bit_width as usize),
-            _ => panic!("Bitpacking word size must be 8,16,32,64"),
+            _ => {
+                return Err(Error::invalid_input(format!(
+                    "Bitpacking word size must be 8, 16, 32, or 64, got {}",
+                    fixed_width.bits_per_value
+                )));
+            }
         };
-        Ok(compressed)
+        Ok((
+            Some(compressed),
+            ProtobufUtils21::out_of_line_bitpacking(
+                self.uncompressed_bit_width,
+                ProtobufUtils21::flat(self.compressed_bit_width, None),
+            ),
+        ))
     }
 }
 
 impl BlockDecompressor for OutOfLineBitpacking {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "Out-of-line bitpacking")?;
         let word_size = match self.uncompressed_bit_width {
             8 => std::mem::size_of::<u8>(),
             16 => std::mem::size_of::<u16>(),
@@ -660,7 +702,7 @@ mod test {
     fn test_inline_bitpacking_decompress_empty_block(#[case] bit_width: u64) {
         let decompressor = InlineBitpacking::new(bit_width);
         let decompressed =
-            BlockDecompressor::decompress(&decompressor, LanceBuffer::empty(), 0).unwrap();
+            BlockDecompressor::decompress(&decompressor, Some(LanceBuffer::empty()), 0).unwrap();
 
         let DataBlock::FixedWidth(block) = decompressed else {
             panic!("Expected FixedWidth block");

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -965,7 +965,7 @@ mod test {
                 block_info: BlockInfo::new(),
             }))
             .unwrap();
-        assert!(payload.as_ref().is_some_and(|payload| payload.len() == 0));
+        assert_eq!(payload.as_ref().map(LanceBuffer::len), Some(0));
 
         let decoded = compressor.decompress(payload, values.len() as u64).unwrap();
         let DataBlock::FixedWidth(decoded) = decoded else {

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -50,7 +50,7 @@ pub(crate) fn out_of_line_payload_bytes(
             "Out-of-line bitpacking requires an 8, 16, 32, or 64-bit word, got {uncompressed_bit_width}"
         )));
     }
-    if compressed_bit_width == 0 || compressed_bit_width >= uncompressed_bit_width {
+    if compressed_bit_width > uncompressed_bit_width {
         return Err(Error::invalid_input(format!(
             "Out-of-line bitpacking width {compressed_bit_width} is invalid for {uncompressed_bit_width}-bit values"
         )));
@@ -721,7 +721,7 @@ mod test {
     };
     use crate::{
         buffer::LanceBuffer,
-        compression::{BlockDecompressor, MiniBlockDecompressor},
+        compression::{BlockCompressor, BlockDecompressor, MiniBlockDecompressor},
         data::{BlockInfo, DataBlock, FixedWidthDataBlock},
         testing::{TestCases, check_round_trip_encoding_of_data},
     };
@@ -951,6 +951,27 @@ mod test {
         let decoded = unpack_out_of_line::<u32>(compressed_block, values.len(), bit_width);
         let decoded_values = decoded.data.borrow_to_typed_slice::<u32>();
         assert_eq!(decoded_values.as_ref(), values.as_slice());
+    }
+
+    #[test]
+    fn test_out_of_line_bitpack_zero_width_roundtrip() {
+        let values = vec![0_u16; 1025];
+        let compressor = OutOfLineBitpacking::new(0, 16);
+        let (payload, _) = compressor
+            .compress(DataBlock::FixedWidth(FixedWidthDataBlock {
+                data: LanceBuffer::reinterpret_vec(values.clone()),
+                bits_per_value: 16,
+                num_values: values.len() as u64,
+                block_info: BlockInfo::new(),
+            }))
+            .unwrap();
+        assert!(payload.as_ref().is_some_and(|payload| payload.len() == 0));
+
+        let decoded = compressor.decompress(payload, values.len() as u64).unwrap();
+        let DataBlock::FixedWidth(decoded) = decoded else {
+            panic!("expected fixed-width data");
+        };
+        assert_eq!(decoded.data.borrow_to_typed_slice::<u16>().as_ref(), values);
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -40,6 +40,50 @@ pub(crate) const LOG_ELEMS_PER_CHUNK: u8 = 10;
 /// Number of values encoded in each inline bitpacking chunk.
 pub const ELEMS_PER_CHUNK: u64 = 1 << LOG_ELEMS_PER_CHUNK;
 
+pub(crate) fn out_of_line_payload_bytes(
+    num_values: u64,
+    uncompressed_bit_width: u64,
+    compressed_bit_width: u64,
+) -> Result<u64> {
+    if !matches!(uncompressed_bit_width, 8 | 16 | 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Out-of-line bitpacking requires an 8, 16, 32, or 64-bit word, got {uncompressed_bit_width}"
+        )));
+    }
+    if compressed_bit_width == 0 || compressed_bit_width >= uncompressed_bit_width {
+        return Err(Error::invalid_input(format!(
+            "Out-of-line bitpacking width {compressed_bit_width} is invalid for {uncompressed_bit_width}-bit values"
+        )));
+    }
+    let words_per_chunk = ELEMS_PER_CHUNK
+        .checked_mul(compressed_bit_width)
+        .ok_or_else(|| Error::invalid_input("Bitpacking chunk width overflows u64"))?
+        .div_ceil(uncompressed_bit_width);
+    let full_chunks = num_values / ELEMS_PER_CHUNK;
+    let tail_values = num_values % ELEMS_PER_CHUNK;
+    let mut words = full_chunks
+        .checked_mul(words_per_chunk)
+        .ok_or_else(|| Error::invalid_input("Bitpacking word count overflows u64"))?;
+    if tail_values > 0 {
+        let padding_cost = compressed_bit_width
+            .checked_mul(ELEMS_PER_CHUNK - tail_values)
+            .ok_or_else(|| Error::invalid_input("Bitpacking tail padding overflows u64"))?;
+        let tail_savings = (uncompressed_bit_width - compressed_bit_width)
+            .checked_mul(tail_values)
+            .ok_or_else(|| Error::invalid_input("Bitpacking tail savings overflow u64"))?;
+        words = words
+            .checked_add(if padding_cost < tail_savings {
+                words_per_chunk
+            } else {
+                tail_values
+            })
+            .ok_or_else(|| Error::invalid_input("Bitpacking tail word count overflows u64"))?;
+    }
+    words
+        .checked_mul(uncompressed_bit_width / 8)
+        .ok_or_else(|| Error::invalid_input("Bitpacking payload byte length overflows u64"))
+}
+
 #[derive(Debug, Default)]
 pub struct InlineBitpacking {
     uncompressed_bit_width: u64,
@@ -615,9 +659,29 @@ impl BlockDecompressor for OutOfLineBitpacking {
             16 => std::mem::size_of::<u16>(),
             32 => std::mem::size_of::<u32>(),
             64 => std::mem::size_of::<u64>(),
-            _ => panic!("Bitpacking word size must be 8,16,32,64"),
+            bits => {
+                return Err(Error::invalid_input(format!(
+                    "Bitpacking word size must be 8, 16, 32, or 64, got {bits}"
+                )));
+            }
         };
-        debug_assert_eq!(data.len() % word_size, 0);
+        let expected_bytes = out_of_line_payload_bytes(
+            num_values,
+            self.uncompressed_bit_width,
+            self.compressed_bit_width,
+        )?;
+        let expected_bytes = usize::try_from(expected_bytes).map_err(|_| {
+            Error::invalid_input("Out-of-line bitpacking payload length does not fit usize")
+        })?;
+        if data.len() != expected_bytes {
+            return Err(Error::corrupt_file_named(
+                "out-of-line bitpacking",
+                format!(
+                    "payload has {} bytes, expected {expected_bytes} bytes for {num_values} values",
+                    data.len()
+                ),
+            ));
+        }
         let total_words = (data.len() / word_size) as u64;
         let block = FixedWidthDataBlock {
             data,
@@ -626,27 +690,14 @@ impl BlockDecompressor for OutOfLineBitpacking {
             block_info: BlockInfo::new(),
         };
 
+        let num_values = usize::try_from(num_values).map_err(|_| {
+            Error::invalid_input("Out-of-line bitpacking cardinality does not fit usize")
+        })?;
         let unpacked = match self.uncompressed_bit_width {
-            8 => unpack_out_of_line::<u8>(
-                block,
-                num_values as usize,
-                self.compressed_bit_width as usize,
-            ),
-            16 => unpack_out_of_line::<u16>(
-                block,
-                num_values as usize,
-                self.compressed_bit_width as usize,
-            ),
-            32 => unpack_out_of_line::<u32>(
-                block,
-                num_values as usize,
-                self.compressed_bit_width as usize,
-            ),
-            64 => unpack_out_of_line::<u64>(
-                block,
-                num_values as usize,
-                self.compressed_bit_width as usize,
-            ),
+            8 => unpack_out_of_line::<u8>(block, num_values, self.compressed_bit_width as usize),
+            16 => unpack_out_of_line::<u16>(block, num_values, self.compressed_bit_width as usize),
+            32 => unpack_out_of_line::<u32>(block, num_values, self.compressed_bit_width as usize),
+            64 => unpack_out_of_line::<u64>(block, num_values, self.compressed_bit_width as usize),
             _ => unreachable!(),
         };
         Ok(DataBlock::FixedWidth(unpacked))
@@ -664,7 +715,10 @@ mod test {
     use lance_bitpacking::BitPacking;
     use rstest::rstest;
 
-    use super::{ELEMS_PER_CHUNK, InlineBitpacking, bitpack_out_of_line, unpack_out_of_line};
+    use super::{
+        ELEMS_PER_CHUNK, InlineBitpacking, OutOfLineBitpacking, bitpack_out_of_line,
+        unpack_out_of_line,
+    };
     use crate::{
         buffer::LanceBuffer,
         compression::{BlockDecompressor, MiniBlockDecompressor},
@@ -897,5 +951,14 @@ mod test {
         let decoded = unpack_out_of_line::<u32>(compressed_block, values.len(), bit_width);
         let decoded_values = decoded.data.borrow_to_typed_slice::<u32>();
         assert_eq!(decoded_values.as_ref(), values.as_slice());
+    }
+
+    #[test]
+    fn test_out_of_line_bitpack_rejects_wrong_payload_length() {
+        let decompressor = OutOfLineBitpacking::new(8, 32);
+        let error = decompressor
+            .decompress(Some(LanceBuffer::from(vec![0_u8; 3])), 16)
+            .unwrap_err();
+        assert!(error.to_string().contains("expected 64 bytes"), "{error}");
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -141,6 +141,23 @@ impl FromStr for CompressionScheme {
 pub trait BufferCompressor: std::fmt::Debug + Send + Sync {
     fn compress(&self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()>;
     fn decompress(&self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()>;
+
+    fn decompress_exact(
+        &self,
+        input_buf: &[u8],
+        output_buf: &mut Vec<u8>,
+        expected_bytes: usize,
+    ) -> Result<()> {
+        self.decompress(input_buf, output_buf)?;
+        if output_buf.len() != expected_bytes {
+            return Err(Error::invalid_input(format!(
+                "General compression produced {} bytes, expected {expected_bytes}",
+                output_buf.len()
+            )));
+        }
+        Ok(())
+    }
+
     fn config(&self) -> CompressionConfig;
 }
 

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -307,6 +307,65 @@ mod zstd {
             Ok(())
         }
 
+        fn decompress_exact(
+            &self,
+            input_buf: &[u8],
+            output_buf: &mut Vec<u8>,
+            expected_bytes: usize,
+        ) -> Result<()> {
+            if input_buf.is_empty() {
+                if expected_bytes == 0 {
+                    return Ok(());
+                }
+                return Err(Error::invalid_input(format!(
+                    "Zstd payload is empty, expected {expected_bytes} output bytes"
+                )));
+            }
+            let compressed = if self.is_raw_stream_format(input_buf) {
+                input_buf
+            } else {
+                let declared = u64::from_le_bytes(input_buf[..8].try_into().map_err(|_| {
+                    Error::invalid_input("Zstd payload is shorter than its 8-byte length prefix")
+                })?);
+                let declared = usize::try_from(declared).map_err(|_| {
+                    Error::invalid_input("Zstd declared output length does not fit usize")
+                })?;
+                if declared != expected_bytes {
+                    return Err(Error::invalid_input(format!(
+                        "Zstd declares {declared} output bytes, expected {expected_bytes}"
+                    )));
+                }
+                &input_buf[8..]
+            };
+            let start = output_buf.len();
+            let end = start
+                .checked_add(expected_bytes)
+                .ok_or_else(|| Error::invalid_input("Zstd output buffer length overflows usize"))?;
+            output_buf
+                .try_reserve_exact(expected_bytes)
+                .map_err(|error| {
+                    Error::invalid_input(format!(
+                        "Zstd could not reserve {expected_bytes} output bytes: {error}"
+                    ))
+                })?;
+            output_buf.resize(end, 0);
+            let decoded = decompress_to_buffer(compressed, &mut output_buf[start..]);
+            let decoded = match decoded {
+                Ok(decoded) => decoded,
+                Err(error) => {
+                    output_buf.truncate(start);
+                    return Err(error.into());
+                }
+            };
+            if decoded != expected_bytes {
+                output_buf.truncate(start);
+                return Err(Error::invalid_input(format!(
+                    "Zstd produced {decoded} bytes, expected {expected_bytes}"
+                )));
+            }
+            Ok(())
+        }
+
         fn config(&self) -> CompressionConfig {
             CompressionConfig {
                 scheme: CompressionScheme::Zstd,
@@ -375,6 +434,56 @@ mod lz4 {
             Ok(())
         }
 
+        fn decompress_exact(
+            &self,
+            input_buf: &[u8],
+            output_buf: &mut Vec<u8>,
+            expected_bytes: usize,
+        ) -> Result<()> {
+            let declared = input_buf.get(..4).ok_or_else(|| {
+                Error::invalid_input("LZ4 payload is shorter than its 4-byte length prefix")
+            })?;
+            let declared =
+                u32::from_le_bytes(declared.try_into().map_err(|_| {
+                    Error::invalid_input("LZ4 payload has an invalid length prefix")
+                })?) as usize;
+            if declared != expected_bytes {
+                return Err(Error::invalid_input(format!(
+                    "LZ4 declares {declared} output bytes, expected {expected_bytes}"
+                )));
+            }
+            let start = output_buf.len();
+            let end = start
+                .checked_add(expected_bytes)
+                .ok_or_else(|| Error::invalid_input("LZ4 output buffer length overflows usize"))?;
+            output_buf
+                .try_reserve_exact(expected_bytes)
+                .map_err(|error| {
+                    Error::invalid_input(format!(
+                        "LZ4 could not reserve {expected_bytes} output bytes: {error}"
+                    ))
+                })?;
+            output_buf.resize(end, 0);
+            let decoded =
+                ::lz4::block::decompress_to_buffer(input_buf, None, &mut output_buf[start..]);
+            let decoded = match decoded {
+                Ok(decoded) => decoded,
+                Err(error) => {
+                    output_buf.truncate(start);
+                    return Err(Error::invalid_input(format!(
+                        "LZ4 decompression error: {error}"
+                    )));
+                }
+            };
+            if decoded != expected_bytes {
+                output_buf.truncate(start);
+                return Err(Error::invalid_input(format!(
+                    "LZ4 produced {decoded} bytes, expected {expected_bytes}"
+                )));
+            }
+            Ok(())
+        }
+
         fn config(&self) -> CompressionConfig {
             CompressionConfig {
                 scheme: CompressionScheme::Lz4,
@@ -394,6 +503,22 @@ impl BufferCompressor for NoopBufferCompressor {
     }
 
     fn decompress(&self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
+        output_buf.extend_from_slice(input_buf);
+        Ok(())
+    }
+
+    fn decompress_exact(
+        &self,
+        input_buf: &[u8],
+        output_buf: &mut Vec<u8>,
+        expected_bytes: usize,
+    ) -> Result<()> {
+        if input_buf.len() != expected_bytes {
+            return Err(Error::invalid_input(format!(
+                "Uncompressed payload has {} bytes, expected {expected_bytes}",
+                input_buf.len()
+            )));
+        }
         output_buf.extend_from_slice(input_buf);
         Ok(())
     }
@@ -728,6 +853,21 @@ mod tests {
         }
 
         #[test]
+        fn test_zstd_exact_output_rejects_declared_length() {
+            let compressor = ZstdBufferCompressor::new(0);
+            let mut compressed = Vec::new();
+            compressor.compress(b"bounded", &mut compressed).unwrap();
+            compressed[..8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+            let mut output = Vec::new();
+            let error = compressor
+                .decompress_exact(&compressed, &mut output, 7)
+                .unwrap_err();
+            assert!(error.to_string().contains("expected 7"));
+            assert!(output.is_empty());
+        }
+
+        #[test]
         fn test_zstd_compress_decompress_multiple_times() {
             let compressor = ZstdBufferCompressor::new(0);
             let (input_data_1, input_data_2) = (b"Hello ", b"World");
@@ -827,6 +967,21 @@ mod tests {
                 .decompress(&compressed_data, &mut decompressed_data)
                 .unwrap();
             assert_eq!(input_data, decompressed_data.as_slice());
+        }
+
+        #[test]
+        fn test_lz4_exact_output_rejects_declared_length() {
+            let compressor = Lz4BufferCompressor::default();
+            let mut compressed = Vec::new();
+            compressor.compress(b"bounded", &mut compressed).unwrap();
+            compressed[..4].copy_from_slice(&u32::MAX.to_le_bytes());
+
+            let mut output = Vec::new();
+            let error = compressor
+                .decompress_exact(&compressed, &mut output, 7)
+                .unwrap_err();
+            assert!(error.to_string().contains("declares"));
+            assert!(output.is_empty());
         }
 
         #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -26,7 +26,7 @@ use lance_core::{Error, Result};
 
 use std::str::FromStr;
 
-use crate::compression::{BlockCompressor, BlockDecompressor};
+use crate::compression::{BlockCompressor, BlockDecompressor, require_block_payload};
 use crate::encodings::physical::binary::{BinaryBlockDecompressor, VariableEncoder};
 use crate::format::{
     ProtobufUtils21,
@@ -450,11 +450,12 @@ impl GeneralBlockDecompressor {
 }
 
 impl BlockDecompressor for GeneralBlockDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "General block compression")?;
         let mut decompressed = Vec::new();
         self.compressor.decompress(&data, &mut decompressed)?;
         self.inner
-            .decompress(LanceBuffer::from(decompressed), num_values)
+            .decompress(Some(LanceBuffer::from(decompressed)), num_values)
     }
 }
 
@@ -614,13 +615,26 @@ impl VariablePerValueDecompressor for CompressedBufferEncoder {
 }
 
 impl BlockCompressor for CompressedBufferEncoder {
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
-        let encoded = match data {
-            DataBlock::FixedWidth(fixed_width) => fixed_width.data,
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let (encoded, inner_encoding) = match data {
+            DataBlock::FixedWidth(fixed_width) => (
+                fixed_width.data,
+                ProtobufUtils21::flat(fixed_width.bits_per_value, None),
+            ),
             DataBlock::VariableWidth(variable_width) => {
                 // Wrap VariableEncoder to handle the encoding
                 let encoder = VariableEncoder::default();
-                BlockCompressor::compress(&encoder, DataBlock::VariableWidth(variable_width))?
+                let (payload, encoding) =
+                    BlockCompressor::compress(&encoder, DataBlock::VariableWidth(variable_width))?;
+                (
+                    payload.ok_or_else(|| {
+                        Error::internal(
+                            "VariableEncoder returned no payload for general compression"
+                                .to_string(),
+                        )
+                    })?,
+                    encoding,
+                )
             }
             _ => {
                 return Err(Error::invalid_input_source(
@@ -631,18 +645,22 @@ impl BlockCompressor for CompressedBufferEncoder {
 
         let mut compressed = Vec::new();
         self.compressor.compress(&encoded, &mut compressed)?;
-        Ok(LanceBuffer::from(compressed))
+        Ok((
+            Some(LanceBuffer::from(compressed)),
+            ProtobufUtils21::wrapped(self.compressor.config(), inner_encoding)?,
+        ))
     }
 }
 
 impl BlockDecompressor for CompressedBufferEncoder {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "Compressed variable block")?;
         let mut decompressed = Vec::new();
         self.compressor.decompress(&data, &mut decompressed)?;
 
         // Delegate to BinaryBlockDecompressor which handles the inline metadata
         let inner_decoder = BinaryBlockDecompressor::default();
-        inner_decoder.decompress(LanceBuffer::from(decompressed), num_values)
+        inner_decoder.decompress(Some(LanceBuffer::from(decompressed)), num_values)
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/constant.rs
+++ b/rust/lance-encoding/src/encodings/physical/constant.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     buffer::LanceBuffer,
-    compression::{BlockDecompressor, FixedPerValueDecompressor},
+    compression::{BlockDecompressor, FixedPerValueDecompressor, require_no_block_payload},
     data::{AllNullDataBlock, ConstantDataBlock, DataBlock, FixedWidthDataBlock},
 };
 
@@ -24,7 +24,8 @@ impl ConstantDecompressor {
 }
 
 impl BlockDecompressor for ConstantDecompressor {
-    fn decompress(&self, _data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        require_no_block_payload(data, "Constant")?;
         if let Some(scalar) = self.scalar.clone() {
             Ok(DataBlock::Constant(ConstantDataBlock {
                 data: scalar,
@@ -33,6 +34,10 @@ impl BlockDecompressor for ConstantDecompressor {
         } else {
             Ok(DataBlock::AllNull(AllNullDataBlock { num_values }))
         }
+    }
+
+    fn requires_payload(&self) -> bool {
+        false
     }
 }
 
@@ -53,5 +58,24 @@ impl FixedPerValueDecompressor for ConstantDecompressor {
             .as_ref()
             .map(|s| s.len() as u64 * 8)
             .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_constant_requires_no_payload() {
+        let decompressor = ConstantDecompressor::new(None);
+
+        assert!(!decompressor.requires_payload());
+        assert!(matches!(
+            BlockDecompressor::decompress(&decompressor, None, 3).unwrap(),
+            DataBlock::AllNull(AllNullDataBlock { num_values: 3 })
+        ));
+        assert!(
+            BlockDecompressor::decompress(&decompressor, Some(LanceBuffer::empty()), 3).is_err()
+        );
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/constant.rs
+++ b/rust/lance-encoding/src/encodings/physical/constant.rs
@@ -5,11 +5,134 @@
 
 use crate::{
     buffer::LanceBuffer,
-    compression::{BlockDecompressor, FixedPerValueDecompressor, require_no_block_payload},
+    compression::{
+        BlockCompressor, BlockDecompressor, FixedPerValueDecompressor, require_no_block_payload,
+    },
     data::{AllNullDataBlock, ConstantDataBlock, DataBlock, FixedWidthDataBlock},
+    encodings::physical::{checked_fixed_values, try_vec_with_capacity},
+    format::{ProtobufUtils21, pb21::CompressiveEncoding},
 };
 
-use lance_core::Result;
+use lance_core::{Error, Result};
+
+/// Metadata-only compressor for a repeated unsigned `u32` or `u64` value.
+#[derive(Debug)]
+pub struct ConstantEncoder {
+    bits_per_value: u64,
+    value: u64,
+}
+
+impl ConstantEncoder {
+    pub fn new(bits_per_value: u64, value: u64) -> Self {
+        Self {
+            bits_per_value,
+            value,
+        }
+    }
+}
+
+impl BlockCompressor for ConstantEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Constant block compression requires fixed-width data",
+            ));
+        };
+        if data.bits_per_value != self.bits_per_value {
+            return Err(Error::invalid_input(format!(
+                "Constant codec expects {}-bit values, got {}",
+                self.bits_per_value, data.bits_per_value
+            )));
+        }
+        let scalar = match self.bits_per_value {
+            32 => {
+                let value = u32::try_from(self.value).map_err(|_| {
+                    Error::invalid_input(format!("Constant value {} exceeds u32::MAX", self.value))
+                })?;
+                if checked_fixed_values::<u32>(&data, "Constant input")?
+                    .iter()
+                    .any(|candidate| *candidate != value)
+                {
+                    return Err(Error::invalid_input(
+                        "Constant input contains a different value",
+                    ));
+                }
+                bytes::Bytes::copy_from_slice(&value.to_le_bytes())
+            }
+            64 => {
+                if checked_fixed_values::<u64>(&data, "Constant input")?
+                    .iter()
+                    .any(|candidate| *candidate != self.value)
+                {
+                    return Err(Error::invalid_input(
+                        "Constant input contains a different value",
+                    ));
+                }
+                bytes::Bytes::copy_from_slice(&self.value.to_le_bytes())
+            }
+            bits_per_value => {
+                return Err(Error::invalid_input(format!(
+                    "Constant block compression only supports 32 or 64-bit values, got {bits_per_value}"
+                )));
+            }
+        };
+        Ok((None, ProtobufUtils21::constant(Some(scalar))))
+    }
+}
+
+/// Materializes a metadata-only constant as a typed fixed-width block.
+#[derive(Debug)]
+pub(crate) struct ConstantBlockDecompressor {
+    bits_per_value: u64,
+    value: u64,
+}
+
+impl ConstantBlockDecompressor {
+    pub(crate) fn new(bits_per_value: u64, value: u64) -> Self {
+        Self {
+            bits_per_value,
+            value,
+        }
+    }
+}
+
+impl BlockDecompressor for ConstantBlockDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        require_no_block_payload(data, "Constant")?;
+        let output_len = usize::try_from(num_values)
+            .map_err(|_| Error::invalid_input("Constant output cardinality does not fit usize"))?;
+        let data = match self.bits_per_value {
+            32 => {
+                let value = u32::try_from(self.value).map_err(|_| {
+                    Error::invalid_input(format!("Constant value {} exceeds u32::MAX", self.value))
+                })?;
+                let mut values = try_vec_with_capacity::<u32>(num_values, "Constant output")?;
+                values.resize(output_len, value);
+                LanceBuffer::reinterpret_vec(values)
+            }
+            64 => {
+                let mut values = try_vec_with_capacity::<u64>(num_values, "Constant output")?;
+                values.resize(output_len, self.value);
+                LanceBuffer::reinterpret_vec(values)
+            }
+            bits_per_value => {
+                return Err(Error::invalid_input(format!(
+                    "Constant block decompression only supports 32 or 64-bit values, got {bits_per_value}"
+                )));
+            }
+        };
+        Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: self.bits_per_value,
+            data,
+            num_values,
+            block_info: Default::default(),
+        }))
+    }
+
+    fn requires_payload(&self) -> bool {
+        false
+    }
+}
 
 /// A decompressor for constant-encoded data
 #[derive(Debug)]

--- a/rust/lance-encoding/src/encodings/physical/delta.rs
+++ b/rust/lance-encoding/src/encodings/physical/delta.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Delta encoding for non-decreasing unsigned block sequences.
+
+use super::{checked_fixed_values, try_vec_with_capacity};
+use crate::{
+    buffer::LanceBuffer,
+    compression::{BlockCompressor, BlockDecompressor},
+    data::{BlockInfo, DataBlock, FixedWidthDataBlock},
+    format::{ProtobufUtils21, pb21::CompressiveEncoding},
+};
+use lance_core::{Error, Result};
+
+#[derive(Debug)]
+/// Encodes adjacent differences with a concrete child block codec.
+pub struct DeltaEncoder {
+    bits_per_value: u64,
+    base: u64,
+    child: Box<dyn BlockCompressor>,
+}
+
+impl DeltaEncoder {
+    /// Creates a delta codec with the first value and child difference codec.
+    pub fn new(bits_per_value: u64, base: u64, child: Box<dyn BlockCompressor>) -> Self {
+        Self {
+            bits_per_value,
+            base,
+            child,
+        }
+    }
+}
+
+impl BlockCompressor for DeltaEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Delta encoding requires a fixed-width data block",
+            ));
+        };
+        if data.bits_per_value != self.bits_per_value {
+            return Err(Error::invalid_input(format!(
+                "Delta codec expects {}-bit values, got {}",
+                self.bits_per_value, data.bits_per_value
+            )));
+        }
+        let deltas = encode_deltas(data, self.base)?;
+        let (payload, child_encoding) = self.child.compress(DataBlock::FixedWidth(deltas))?;
+        Ok((
+            payload,
+            ProtobufUtils21::delta(self.bits_per_value, self.base, child_encoding),
+        ))
+    }
+}
+
+fn encode_deltas(data: FixedWidthDataBlock, expected_base: u64) -> Result<FixedWidthDataBlock> {
+    if !matches!(data.bits_per_value, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Delta only supports 32 or 64-bit values, got {}",
+            data.bits_per_value
+        )));
+    }
+    if data.num_values < 2 {
+        return Err(Error::invalid_input(format!(
+            "Delta requires at least 2 values, got {}",
+            data.num_values
+        )));
+    }
+
+    let deltas = match data.bits_per_value {
+        32 => {
+            let values = checked_fixed_values::<u32>(&data, "Delta input")?;
+            if u64::from(values[0]) != expected_base {
+                return Err(Error::invalid_input(format!(
+                    "Delta base mismatch: codec expects {expected_base}, input starts with {}",
+                    values[0]
+                )));
+            }
+            let mut deltas = try_vec_with_capacity::<u32>(data.num_values - 1, "Delta output")?;
+            for (index, pair) in values.windows(2).enumerate() {
+                deltas.push(pair[1].checked_sub(pair[0]).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Delta input decreases at index {}: {} -> {}",
+                        index + 1,
+                        pair[0],
+                        pair[1]
+                    ))
+                })?);
+            }
+            LanceBuffer::reinterpret_vec(deltas)
+        }
+        64 => {
+            let values = checked_fixed_values::<u64>(&data, "Delta input")?;
+            if values[0] != expected_base {
+                return Err(Error::invalid_input(format!(
+                    "Delta base mismatch: codec expects {expected_base}, input starts with {}",
+                    values[0]
+                )));
+            }
+            let mut deltas = try_vec_with_capacity::<u64>(data.num_values - 1, "Delta output")?;
+            for (index, pair) in values.windows(2).enumerate() {
+                deltas.push(pair[1].checked_sub(pair[0]).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Delta input decreases at index {}: {} -> {}",
+                        index + 1,
+                        pair[0],
+                        pair[1]
+                    ))
+                })?);
+            }
+            LanceBuffer::reinterpret_vec(deltas)
+        }
+        _ => unreachable!("delta width was validated above"),
+    };
+    Ok(FixedWidthDataBlock {
+        bits_per_value: data.bits_per_value,
+        data: deltas,
+        num_values: data.num_values - 1,
+        block_info: BlockInfo::default(),
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct DeltaDecompressor {
+    bits_per_value: u64,
+    base: u64,
+    child: Box<dyn BlockDecompressor>,
+}
+
+impl DeltaDecompressor {
+    pub(crate) fn new(bits_per_value: u64, base: u64, child: Box<dyn BlockDecompressor>) -> Self {
+        Self {
+            bits_per_value,
+            base,
+            child,
+        }
+    }
+}
+
+impl BlockDecompressor for DeltaDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        validate_delta_header(self.bits_per_value, self.base, num_values)?;
+        let child = self.child.decompress(data, num_values - 1)?;
+        reconstruct_deltas(child, self.bits_per_value, self.base, num_values)
+    }
+
+    fn requires_payload(&self) -> bool {
+        self.child.requires_payload()
+    }
+}
+
+pub(crate) fn validate_delta_header(bits_per_value: u64, base: u64, num_values: u64) -> Result<()> {
+    if !matches!(bits_per_value, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Delta only supports 32 or 64-bit values, got {bits_per_value}"
+        )));
+    }
+    if bits_per_value == 32 && base > u32::MAX as u64 {
+        return Err(Error::invalid_input(format!(
+            "Delta base {base} exceeds u32::MAX"
+        )));
+    }
+    if num_values < 2 {
+        return Err(Error::invalid_input(format!(
+            "Delta requires at least 2 values, got {num_values}"
+        )));
+    }
+    Ok(())
+}
+
+fn reconstruct_deltas(
+    child: DataBlock,
+    bits_per_value: u64,
+    base: u64,
+    num_values: u64,
+) -> Result<DataBlock> {
+    let DataBlock::FixedWidth(child) = child else {
+        return Err(Error::invalid_input(
+            "Delta child decoded to a non fixed-width block",
+        ));
+    };
+    if child.bits_per_value != bits_per_value || child.num_values != num_values - 1 {
+        return Err(Error::invalid_input(format!(
+            "Delta child decoded {} {}-bit values, expected {} {}-bit values",
+            child.num_values,
+            child.bits_per_value,
+            num_values - 1,
+            bits_per_value
+        )));
+    }
+
+    let data = match bits_per_value {
+        32 => {
+            let deltas = checked_fixed_values::<u32>(&child, "Delta child")?;
+            let mut values = try_vec_with_capacity::<u32>(num_values, "Delta output")?;
+            let mut current = u32::try_from(base)
+                .map_err(|_| Error::invalid_input(format!("Delta base {base} exceeds u32::MAX")))?;
+            values.push(current);
+            for (index, delta) in deltas.iter().enumerate() {
+                current = current.checked_add(*delta).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Delta prefix sum overflows u32 at index {}",
+                        index + 1
+                    ))
+                })?;
+                values.push(current);
+            }
+            LanceBuffer::reinterpret_vec(values)
+        }
+        64 => {
+            let deltas = checked_fixed_values::<u64>(&child, "Delta child")?;
+            let mut values = try_vec_with_capacity::<u64>(num_values, "Delta output")?;
+            let mut current = base;
+            values.push(current);
+            for (index, delta) in deltas.iter().enumerate() {
+                current = current.checked_add(*delta).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Delta prefix sum overflows u64 at index {}",
+                        index + 1
+                    ))
+                })?;
+                values.push(current);
+            }
+            LanceBuffer::reinterpret_vec(values)
+        }
+        _ => unreachable!("delta header was validated before reconstruction"),
+    };
+
+    Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+        bits_per_value,
+        data,
+        num_values,
+        block_info: BlockInfo::default(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compression::DecompressionStrategy;
+    use crate::encodings::physical::{range::RangeEncoder, value::ValueEncoder};
+
+    use super::*;
+
+    #[test]
+    fn delta_round_trip_with_payload() {
+        let input = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(vec![5_u64, 5, 9, 12]),
+            num_values: 4,
+            block_info: BlockInfo::default(),
+        });
+        let encoder = DeltaEncoder::new(64, 5, Box::new(ValueEncoder::default()));
+        let (payload, encoding) = encoder.compress(input).unwrap();
+        let crate::format::pb21::compressive_encoding::Compression::Delta(delta) =
+            encoding.compression.as_ref().unwrap()
+        else {
+            panic!("expected Delta encoding");
+        };
+        let child = crate::compression::DefaultDecompressionStrategy::default()
+            .create_block_decompressor(delta.deltas.as_deref().unwrap())
+            .unwrap();
+        let decoded = DeltaDecompressor::new(64, 5, child)
+            .decompress(payload, 4)
+            .unwrap()
+            .as_fixed_width()
+            .unwrap();
+        assert_eq!(
+            decoded.data.borrow_to_typed_slice::<u64>().as_ref(),
+            &[5, 5, 9, 12]
+        );
+    }
+
+    #[test]
+    fn delta_propagates_metadata_only_child() {
+        let input = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(vec![0_u32, 1, 3, 6]),
+            num_values: 4,
+            block_info: BlockInfo::default(),
+        });
+        let encoder = DeltaEncoder::new(32, 0, Box::new(RangeEncoder::new(32, 1, 1)));
+        let (payload, encoding) = encoder.compress(input).unwrap();
+        assert!(payload.is_none());
+
+        let decoder = crate::compression::DefaultDecompressionStrategy::default()
+            .create_block_decompressor(&encoding)
+            .unwrap();
+        assert!(!decoder.requires_payload());
+        let decoded = decoder
+            .decompress(None, 4)
+            .unwrap()
+            .as_fixed_width()
+            .unwrap();
+        assert_eq!(
+            decoded.data.borrow_to_typed_slice::<u32>().as_ref(),
+            &[0, 1, 3, 6]
+        );
+    }
+
+    #[test]
+    fn delta_rejects_decreasing_input() {
+        let input = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(vec![2_u32, 1]),
+            num_values: 2,
+            block_info: BlockInfo::default(),
+        };
+        let error = encode_deltas(input, 2).unwrap_err();
+        assert!(error.to_string().contains("decreases"));
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/encodings/physical/dictionary.rs
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Dictionary encoding for bounded unsigned block sequences.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::{
+    buffer::LanceBuffer,
+    compression::{BlockCompressor, BlockDecompressor},
+    data::{BlockInfo, DataBlock, FixedWidthDataBlock},
+    encodings::physical::{checked_fixed_values, try_vec_with_capacity},
+    format::{ProtobufUtils21, pb21::CompressiveEncoding},
+};
+use lance_core::{Error, Result};
+
+pub(crate) const MAX_BLOCK_DICTIONARY_ITEMS: usize = 4096;
+const BLOCK_FRAME_BYTES: usize = 16;
+
+/// Encodes unsigned values through concrete index and dictionary-item codecs.
+#[derive(Debug)]
+pub struct BlockDictionaryEncoder {
+    bits_per_value: u64,
+    dictionary_items: Arc<[u64]>,
+    indices: Box<dyn BlockCompressor>,
+    items: Box<dyn BlockCompressor>,
+}
+
+impl BlockDictionaryEncoder {
+    /// Creates a bounded dictionary codec for `u32` or `u64` values.
+    pub fn try_new(
+        bits_per_value: u64,
+        dictionary_items: Arc<[u64]>,
+        indices: Box<dyn BlockCompressor>,
+        items: Box<dyn BlockCompressor>,
+    ) -> Result<Self> {
+        validate_dictionary_header(bits_per_value, dictionary_items.len())?;
+        if bits_per_value == 32
+            && dictionary_items
+                .iter()
+                .any(|value| *value > u32::MAX as u64)
+        {
+            return Err(Error::invalid_input(
+                "Dictionary contains an item that exceeds u32::MAX",
+            ));
+        }
+        Ok(Self {
+            bits_per_value,
+            dictionary_items,
+            indices,
+            items,
+        })
+    }
+}
+
+impl BlockCompressor for BlockDictionaryEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Dictionary block compression requires fixed-width data",
+            ));
+        };
+        if data.bits_per_value != self.bits_per_value {
+            return Err(Error::invalid_input(format!(
+                "Dictionary codec expects {}-bit values, got {}",
+                self.bits_per_value, data.bits_per_value
+            )));
+        }
+
+        let dictionary_index = self
+            .dictionary_items
+            .iter()
+            .enumerate()
+            .map(|(index, value)| (*value, index as u32))
+            .collect::<BTreeMap<_, _>>();
+        let values = read_unsigned_values(&data, "Dictionary input")?;
+        let mut encoded_indices =
+            try_vec_with_capacity::<u32>(data.num_values, "Dictionary indices")?;
+        for (position, value) in values.iter().enumerate() {
+            encoded_indices.push(*dictionary_index.get(value).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Dictionary does not contain input value {value} at position {position}"
+                ))
+            })?);
+        }
+
+        let indices_block = FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(encoded_indices),
+            num_values: data.num_values,
+            block_info: BlockInfo::default(),
+        };
+        let items_block = fixed_from_u64_values(
+            &self.dictionary_items,
+            self.bits_per_value,
+            "Dictionary items",
+        )?;
+        let (indices_payload, indices_encoding) = self
+            .indices
+            .compress(DataBlock::FixedWidth(indices_block))?;
+        let (items_payload, items_encoding) =
+            self.items.compress(DataBlock::FixedWidth(items_block))?;
+        let encoding = ProtobufUtils21::dictionary(
+            indices_encoding,
+            items_encoding,
+            self.dictionary_items.len() as u32,
+        );
+        if indices_payload.is_none() && items_payload.is_none() {
+            return Ok((None, encoding));
+        }
+
+        let indices_payload = indices_payload.unwrap_or_else(LanceBuffer::empty);
+        let items_payload = items_payload.unwrap_or_else(LanceBuffer::empty);
+        let mut output = try_frame(indices_payload.len(), items_payload.len())?;
+        output.extend_from_slice(&(indices_payload.len() as u64).to_le_bytes());
+        output.extend_from_slice(&(items_payload.len() as u64).to_le_bytes());
+        output.extend_from_slice(&indices_payload);
+        output.extend_from_slice(&items_payload);
+        Ok((Some(LanceBuffer::from(output)), encoding))
+    }
+}
+
+/// Decodes a framed block dictionary through concrete child codecs.
+#[derive(Debug)]
+pub struct BlockDictionaryDecompressor {
+    bits_per_value: u64,
+    num_dictionary_items: u32,
+    indices: Box<dyn BlockDecompressor>,
+    items: Box<dyn BlockDecompressor>,
+}
+
+impl BlockDictionaryDecompressor {
+    /// Creates a bounded dictionary decoder for `u32` or `u64` values.
+    pub fn try_new(
+        bits_per_value: u64,
+        num_dictionary_items: u32,
+        indices: Box<dyn BlockDecompressor>,
+        items: Box<dyn BlockDecompressor>,
+    ) -> Result<Self> {
+        validate_dictionary_header(bits_per_value, num_dictionary_items as usize)?;
+        Ok(Self {
+            bits_per_value,
+            num_dictionary_items,
+            indices,
+            items,
+        })
+    }
+}
+
+impl BlockDecompressor for BlockDictionaryDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let indices_have_payload = self.indices.requires_payload();
+        let items_have_payload = self.items.requires_payload();
+        let has_payload = indices_have_payload || items_have_payload;
+        let (indices_payload, items_payload) =
+            split_payload(data, indices_have_payload, items_have_payload, has_payload)?;
+
+        let indices = self.indices.decompress(indices_payload, num_values)?;
+        let items = self
+            .items
+            .decompress(items_payload, u64::from(self.num_dictionary_items))?;
+        let DataBlock::FixedWidth(indices) = indices else {
+            return Err(Error::invalid_input(
+                "Dictionary indices decoded to a non fixed-width block",
+            ));
+        };
+        let DataBlock::FixedWidth(items) = items else {
+            return Err(Error::invalid_input(
+                "Dictionary items decoded to a non fixed-width block",
+            ));
+        };
+        if indices.bits_per_value != 32 {
+            return Err(Error::invalid_input(format!(
+                "Dictionary indices decoded as {}-bit values, expected 32",
+                indices.bits_per_value
+            )));
+        }
+        if items.bits_per_value != self.bits_per_value {
+            return Err(Error::invalid_input(format!(
+                "Dictionary items decoded as {}-bit values, expected {}",
+                items.bits_per_value, self.bits_per_value
+            )));
+        }
+
+        let indices = checked_fixed_values::<u32>(&indices, "Dictionary indices")?;
+        let items = read_unsigned_values(&items, "Dictionary items")?;
+        let output = match self.bits_per_value {
+            32 => {
+                let mut output = try_vec_with_capacity::<u32>(num_values, "Dictionary output")?;
+                append_items(
+                    &mut output,
+                    &indices,
+                    &items,
+                    self.num_dictionary_items,
+                    |value| value as u32,
+                )?;
+                LanceBuffer::reinterpret_vec(output)
+            }
+            64 => {
+                let mut output = try_vec_with_capacity::<u64>(num_values, "Dictionary output")?;
+                append_items(
+                    &mut output,
+                    &indices,
+                    &items,
+                    self.num_dictionary_items,
+                    |value| value,
+                )?;
+                LanceBuffer::reinterpret_vec(output)
+            }
+            _ => unreachable!("dictionary width was validated at construction"),
+        };
+        Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: self.bits_per_value,
+            data: output,
+            num_values,
+            block_info: BlockInfo::default(),
+        }))
+    }
+
+    fn requires_payload(&self) -> bool {
+        self.indices.requires_payload() || self.items.requires_payload()
+    }
+}
+
+fn validate_dictionary_header(bits_per_value: u64, num_dictionary_items: usize) -> Result<()> {
+    if !matches!(bits_per_value, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Dictionary only supports 32 or 64-bit values, got {bits_per_value}"
+        )));
+    }
+    if !(1..=MAX_BLOCK_DICTIONARY_ITEMS).contains(&num_dictionary_items) {
+        return Err(Error::invalid_input(format!(
+            "Dictionary item count {num_dictionary_items} is outside 1..={MAX_BLOCK_DICTIONARY_ITEMS}"
+        )));
+    }
+    Ok(())
+}
+
+fn split_payload(
+    data: Option<LanceBuffer>,
+    indices_have_payload: bool,
+    items_have_payload: bool,
+    has_payload: bool,
+) -> Result<(Option<LanceBuffer>, Option<LanceBuffer>)> {
+    let Some(data) = data else {
+        if has_payload {
+            return Err(Error::invalid_input("Dictionary requires one payload"));
+        }
+        return Ok((None, None));
+    };
+    if !has_payload {
+        return Err(Error::invalid_input(
+            "Metadata-only Dictionary expects no payload",
+        ));
+    }
+    if data.len() < BLOCK_FRAME_BYTES {
+        return Err(Error::invalid_input(format!(
+            "Dictionary payload has {} bytes, shorter than its {BLOCK_FRAME_BYTES}-byte header",
+            data.len()
+        )));
+    }
+
+    let indices_size = u64::from_le_bytes(data[..8].try_into().unwrap());
+    let items_size = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    let indices_size = usize::try_from(indices_size).map_err(|_| {
+        Error::invalid_input("Dictionary indices payload length does not fit usize")
+    })?;
+    let items_size = usize::try_from(items_size)
+        .map_err(|_| Error::invalid_input("Dictionary items payload length does not fit usize"))?;
+    let items_start = BLOCK_FRAME_BYTES
+        .checked_add(indices_size)
+        .ok_or_else(|| Error::invalid_input("Dictionary indices payload end overflows"))?;
+    let end = items_start
+        .checked_add(items_size)
+        .ok_or_else(|| Error::invalid_input("Dictionary items payload end overflows"))?;
+    if end != data.len() {
+        return Err(Error::invalid_input(format!(
+            "Dictionary framing describes {end} bytes, payload has {}",
+            data.len()
+        )));
+    }
+    if !indices_have_payload && indices_size != 0 {
+        return Err(Error::invalid_input(format!(
+            "Metadata-only Dictionary indices child has {indices_size} framed payload bytes"
+        )));
+    }
+    if !items_have_payload && items_size != 0 {
+        return Err(Error::invalid_input(format!(
+            "Metadata-only Dictionary items child has {items_size} framed payload bytes"
+        )));
+    }
+    Ok((
+        indices_have_payload.then(|| data.slice_with_length(BLOCK_FRAME_BYTES, indices_size)),
+        items_have_payload.then(|| data.slice_with_length(items_start, items_size)),
+    ))
+}
+
+fn append_items<T>(
+    output: &mut Vec<T>,
+    indices: &[u32],
+    items: &[u64],
+    num_dictionary_items: u32,
+    convert: impl Fn(u64) -> T,
+) -> Result<()> {
+    for (position, index) in indices.iter().enumerate() {
+        let value = *items.get(*index as usize).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Dictionary index {index} at position {position} is out of bounds for {num_dictionary_items} items"
+            ))
+        })?;
+        output.push(convert(value));
+    }
+    Ok(())
+}
+
+fn read_unsigned_values(data: &FixedWidthDataBlock, label: &str) -> Result<Vec<u64>> {
+    match data.bits_per_value {
+        32 => Ok(checked_fixed_values::<u32>(data, label)?
+            .iter()
+            .map(|value| u64::from(*value))
+            .collect()),
+        64 => Ok(checked_fixed_values::<u64>(data, label)?.to_vec()),
+        bits_per_value => Err(Error::invalid_input(format!(
+            "{label} uses unsupported {bits_per_value}-bit values"
+        ))),
+    }
+}
+
+fn fixed_from_u64_values(
+    values: &[u64],
+    bits_per_value: u64,
+    label: &str,
+) -> Result<FixedWidthDataBlock> {
+    let data = match bits_per_value {
+        32 => LanceBuffer::reinterpret_vec(
+            values
+                .iter()
+                .map(|value| {
+                    u32::try_from(*value).map_err(|_| {
+                        Error::invalid_input(format!("{label} value {value} exceeds u32::MAX"))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        64 => LanceBuffer::reinterpret_vec(values.to_vec()),
+        _ => unreachable!("dictionary width was validated at construction"),
+    };
+    Ok(FixedWidthDataBlock {
+        bits_per_value,
+        data,
+        num_values: values.len() as u64,
+        block_info: BlockInfo::default(),
+    })
+}
+
+fn try_frame(indices_payload_bytes: usize, items_payload_bytes: usize) -> Result<Vec<u8>> {
+    let capacity = BLOCK_FRAME_BYTES
+        .checked_add(indices_payload_bytes)
+        .and_then(|capacity| capacity.checked_add(items_payload_bytes))
+        .ok_or_else(|| Error::invalid_input("Dictionary frame length overflows usize"))?;
+    let mut output = Vec::new();
+    output.try_reserve_exact(capacity).map_err(|error| {
+        Error::invalid_input(format!(
+            "Dictionary could not reserve {capacity} frame bytes: {error}"
+        ))
+    })?;
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::encodings::physical::{
+        range::{RangeDecompressor, RangeEncoder},
+        value::{ValueDecompressor, ValueEncoder},
+    };
+    use crate::format::pb21::Flat;
+
+    use super::*;
+
+    fn input_u64(values: Vec<u64>) -> DataBlock {
+        DataBlock::FixedWidth(FixedWidthDataBlock {
+            num_values: values.len() as u64,
+            bits_per_value: 64,
+            data: LanceBuffer::reinterpret_vec(values),
+            block_info: BlockInfo::default(),
+        })
+    }
+
+    fn flat_decoder(bits_per_value: u64) -> Box<dyn BlockDecompressor> {
+        Box::new(ValueDecompressor::from_flat(&Flat {
+            bits_per_value,
+            data: None,
+        }))
+    }
+
+    fn decoded_u64(block: DataBlock) -> Vec<u64> {
+        block
+            .as_fixed_width()
+            .unwrap()
+            .data
+            .borrow_to_typed_slice::<u64>()
+            .to_vec()
+    }
+
+    #[test]
+    fn dictionary_round_trip_with_payload_children() {
+        let items: Arc<[u64]> = Arc::from([10, 20]);
+        let encoder = BlockDictionaryEncoder::try_new(
+            64,
+            items,
+            Box::new(ValueEncoder::default()),
+            Box::new(ValueEncoder::default()),
+        )
+        .unwrap();
+        let (payload, encoding) = encoder
+            .compress(input_u64(vec![10, 20, 10, 20, 20]))
+            .unwrap();
+        let payload = payload.unwrap();
+        assert_eq!(u64::from_le_bytes(payload[..8].try_into().unwrap()), 20);
+        assert_eq!(u64::from_le_bytes(payload[8..16].try_into().unwrap()), 16);
+        assert!(matches!(
+            encoding.compression,
+            Some(crate::format::pb21::compressive_encoding::Compression::Dictionary(_))
+        ));
+
+        let decoder =
+            BlockDictionaryDecompressor::try_new(64, 2, flat_decoder(32), flat_decoder(64))
+                .unwrap();
+        assert_eq!(
+            decoded_u64(decoder.decompress(Some(payload), 5).unwrap()),
+            vec![10, 20, 10, 20, 20]
+        );
+    }
+
+    #[test]
+    fn dictionary_round_trip_without_payload() {
+        let encoder = BlockDictionaryEncoder::try_new(
+            64,
+            Arc::from([10, 20, 30]),
+            Box::new(RangeEncoder::new(32, 0, 1)),
+            Box::new(RangeEncoder::new(64, 10, 10)),
+        )
+        .unwrap();
+        let (payload, _) = encoder.compress(input_u64(vec![10, 20, 30])).unwrap();
+        assert!(payload.is_none());
+
+        let decoder = BlockDictionaryDecompressor::try_new(
+            64,
+            3,
+            Box::new(RangeDecompressor::new(32, 0, 1)),
+            Box::new(RangeDecompressor::new(64, 10, 10)),
+        )
+        .unwrap();
+        assert!(!decoder.requires_payload());
+        assert_eq!(
+            decoded_u64(decoder.decompress(None, 3).unwrap()),
+            vec![10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn dictionary_frames_a_mixed_payload() {
+        let encoder = BlockDictionaryEncoder::try_new(
+            64,
+            Arc::from([10, 20]),
+            Box::new(ValueEncoder::default()),
+            Box::new(RangeEncoder::new(64, 10, 10)),
+        )
+        .unwrap();
+        let (payload, _) = encoder.compress(input_u64(vec![10, 20, 10])).unwrap();
+        let payload = payload.unwrap();
+        assert_eq!(u64::from_le_bytes(payload[..8].try_into().unwrap()), 12);
+        assert_eq!(u64::from_le_bytes(payload[8..16].try_into().unwrap()), 0);
+
+        let decoder = BlockDictionaryDecompressor::try_new(
+            64,
+            2,
+            flat_decoder(32),
+            Box::new(RangeDecompressor::new(64, 10, 10)),
+        )
+        .unwrap();
+        assert_eq!(
+            decoded_u64(decoder.decompress(Some(payload), 3).unwrap()),
+            vec![10, 20, 10]
+        );
+    }
+
+    #[test]
+    fn dictionary_rejects_out_of_bounds_index() {
+        let indices = LanceBuffer::reinterpret_vec(vec![0_u32, 2]);
+        let items = LanceBuffer::reinterpret_vec(vec![9_u64]);
+        let mut frame = try_frame(indices.len(), items.len()).unwrap();
+        frame.extend_from_slice(&(indices.len() as u64).to_le_bytes());
+        frame.extend_from_slice(&(items.len() as u64).to_le_bytes());
+        frame.extend_from_slice(&indices);
+        frame.extend_from_slice(&items);
+
+        let decoder =
+            BlockDictionaryDecompressor::try_new(64, 1, flat_decoder(32), flat_decoder(64))
+                .unwrap();
+        let error = decoder
+            .decompress(Some(LanceBuffer::from(frame)), 2)
+            .unwrap_err();
+        assert!(error.to_string().contains("out of bounds"));
+    }
+
+    #[test]
+    fn dictionary_rejects_invalid_frame_lengths() {
+        let mut frame = Vec::from(16_u64.to_le_bytes());
+        frame.extend_from_slice(&0_u64.to_le_bytes());
+
+        let decoder =
+            BlockDictionaryDecompressor::try_new(64, 1, flat_decoder(32), flat_decoder(64))
+                .unwrap();
+        let error = decoder
+            .decompress(Some(LanceBuffer::from(frame)), 1)
+            .unwrap_err();
+        assert!(error.to_string().contains("framing describes"));
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/general.rs
+++ b/rust/lance-encoding/src/encodings/physical/general.rs
@@ -6,7 +6,9 @@ use log::trace;
 use crate::{
     Result,
     buffer::LanceBuffer,
-    compression::MiniBlockDecompressor,
+    compression::{
+        BlockCompressor, BlockDecompressor, MiniBlockDecompressor, require_block_payload,
+    },
     data::DataBlock,
     encodings::{
         logical::primitive::miniblock::{
@@ -16,6 +18,77 @@ use crate::{
     },
     format::{ProtobufUtils21, pb21::CompressiveEncoding},
 };
+use lance_core::Error;
+
+/// General-purpose compressor that wraps one payload-bearing block codec.
+#[derive(Debug)]
+pub struct GeneralBlockCompressor {
+    child: Box<dyn BlockCompressor>,
+    compression: CompressionConfig,
+}
+
+impl GeneralBlockCompressor {
+    pub fn new(child: Box<dyn BlockCompressor>, compression: CompressionConfig) -> Self {
+        Self { child, compression }
+    }
+}
+
+impl BlockCompressor for GeneralBlockCompressor {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let (payload, child_encoding) = self.child.compress(data)?;
+        let payload = payload.ok_or_else(|| {
+            Error::invalid_input("General block compression requires a payload-bearing child")
+        })?;
+        let compressor = GeneralBufferCompressor::get_compressor(self.compression)?;
+        let mut compressed = Vec::new();
+        compressor.compress(&payload, &mut compressed)?;
+        Ok((
+            Some(LanceBuffer::from(compressed)),
+            ProtobufUtils21::wrapped(self.compression, child_encoding)?,
+        ))
+    }
+}
+
+/// Bounded fixed-width decoder for a general-compressed block payload.
+#[derive(Debug)]
+pub(crate) struct FixedWidthGeneralBlockDecompressor {
+    child: Box<dyn BlockDecompressor>,
+    compression: CompressionConfig,
+    bits_per_value: u64,
+}
+
+impl FixedWidthGeneralBlockDecompressor {
+    pub(crate) fn new(
+        child: Box<dyn BlockDecompressor>,
+        compression: CompressionConfig,
+        bits_per_value: u64,
+    ) -> Self {
+        Self {
+            child,
+            compression,
+            bits_per_value,
+        }
+    }
+}
+
+impl BlockDecompressor for FixedWidthGeneralBlockDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "General fixed-width block")?;
+        let expected_bytes = usize::try_from(num_values)
+            .ok()
+            .and_then(|num_values| {
+                num_values.checked_mul(usize::try_from(self.bits_per_value / 8).ok()?)
+            })
+            .ok_or_else(|| {
+                Error::invalid_input("General fixed-width output length overflows usize")
+            })?;
+        let compressor = GeneralBufferCompressor::get_compressor(self.compression)?;
+        let mut decompressed = Vec::new();
+        compressor.decompress_exact(&data, &mut decompressed, expected_bytes)?;
+        self.child
+            .decompress(Some(LanceBuffer::from(decompressed)), num_values)
+    }
+}
 
 /// A miniblock compressor that wraps another miniblock compressor and applies
 /// general-purpose compression (LZ4, Zstd) to the resulting buffers.

--- a/rust/lance-encoding/src/encodings/physical/range.rs
+++ b/rust/lance-encoding/src/encodings/physical/range.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Metadata-only arithmetic range encoding for unsigned block sequences.
+
+use super::{checked_fixed_values, try_vec_with_capacity};
+use crate::{
+    buffer::LanceBuffer,
+    compression::{BlockCompressor, BlockDecompressor, require_no_block_payload},
+    data::{BlockInfo, DataBlock, FixedWidthDataBlock},
+    format::{ProtobufUtils21, pb21::CompressiveEncoding},
+};
+use lance_core::{Error, Result};
+
+pub(crate) fn checked_range_last(
+    bits_per_value: u64,
+    start: u64,
+    step: u64,
+    num_values: u64,
+) -> Result<u64> {
+    if !matches!(bits_per_value, 32 | 64) {
+        return Err(Error::invalid_input(format!(
+            "Range only supports 32 or 64-bit values, got {bits_per_value}"
+        )));
+    }
+    if step == 0 {
+        return Err(Error::invalid_input("Range step must be positive"));
+    }
+    if num_values < 2 {
+        return Err(Error::invalid_input(format!(
+            "Range requires at least 2 values, got {num_values}"
+        )));
+    }
+
+    let distance = step.checked_mul(num_values - 1).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "Range step multiplication overflows: step={step}, num_values={num_values}"
+        ))
+    })?;
+    let last = start.checked_add(distance).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "Range final value overflows: start={start}, step={step}, num_values={num_values}"
+        ))
+    })?;
+    if bits_per_value == 32 && last > u32::MAX as u64 {
+        return Err(Error::invalid_input(format!(
+            "Range final value {last} exceeds u32::MAX"
+        )));
+    }
+    Ok(last)
+}
+
+#[derive(Debug)]
+/// Encodes a validated arithmetic sequence without a payload buffer.
+pub struct RangeEncoder {
+    bits_per_value: u64,
+    start: u64,
+    step: u64,
+}
+
+impl RangeEncoder {
+    /// Creates a range codec for `u32` or `u64` values.
+    pub fn new(bits_per_value: u64, start: u64, step: u64) -> Self {
+        Self {
+            bits_per_value,
+            start,
+            step,
+        }
+    }
+}
+
+impl BlockCompressor for RangeEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Range encoding requires a fixed-width data block",
+            ));
+        };
+        if data.bits_per_value != self.bits_per_value {
+            return Err(Error::invalid_input(format!(
+                "Range codec expects {}-bit values, got {}",
+                self.bits_per_value, data.bits_per_value
+            )));
+        }
+        checked_range_last(self.bits_per_value, self.start, self.step, data.num_values)?;
+
+        match self.bits_per_value {
+            32 => validate_values(
+                checked_fixed_values::<u32>(&data, "Range input")?
+                    .iter()
+                    .map(|value| u64::from(*value)),
+                self.start,
+                self.step,
+            )?,
+            64 => validate_values(
+                checked_fixed_values::<u64>(&data, "Range input")?
+                    .iter()
+                    .copied(),
+                self.start,
+                self.step,
+            )?,
+            _ => unreachable!("range width was validated above"),
+        }
+        Ok((
+            None,
+            ProtobufUtils21::range(self.bits_per_value, self.start, self.step),
+        ))
+    }
+}
+
+fn validate_values(values: impl Iterator<Item = u64>, start: u64, step: u64) -> Result<()> {
+    for (index, value) in values.enumerate() {
+        let expected = step
+            .checked_mul(index as u64)
+            .and_then(|distance| start.checked_add(distance))
+            .ok_or_else(|| Error::invalid_input("Range value calculation overflows"))?;
+        if value != expected {
+            return Err(Error::invalid_input(format!(
+                "Range input mismatch at index {index}: expected {expected}, got {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct RangeDecompressor {
+    bits_per_value: u64,
+    start: u64,
+    step: u64,
+}
+
+impl RangeDecompressor {
+    pub(crate) fn new(bits_per_value: u64, start: u64, step: u64) -> Self {
+        Self {
+            bits_per_value,
+            start,
+            step,
+        }
+    }
+}
+
+impl BlockDecompressor for RangeDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        require_no_block_payload(data, "Range")?;
+        checked_range_last(self.bits_per_value, self.start, self.step, num_values)?;
+        materialize_range(self.bits_per_value, self.start, self.step, num_values)
+    }
+
+    fn requires_payload(&self) -> bool {
+        false
+    }
+}
+
+fn materialize_range(
+    bits_per_value: u64,
+    start: u64,
+    step: u64,
+    num_values: u64,
+) -> Result<DataBlock> {
+    let data = match bits_per_value {
+        32 => {
+            let mut current = u32::try_from(start).map_err(|_| {
+                Error::invalid_input(format!("Range value {start} exceeds u32::MAX"))
+            })?;
+            let step = u32::try_from(step)
+                .map_err(|_| Error::invalid_input(format!("Range step {step} exceeds u32::MAX")))?;
+            let mut values = try_vec_with_capacity::<u32>(num_values, "Range output")?;
+            for index in 0..num_values {
+                values.push(current);
+                if index + 1 < num_values {
+                    current += step;
+                }
+            }
+            LanceBuffer::reinterpret_vec(values)
+        }
+        64 => {
+            let mut current = start;
+            let mut values = try_vec_with_capacity::<u64>(num_values, "Range output")?;
+            for index in 0..num_values {
+                values.push(current);
+                if index + 1 < num_values {
+                    current += step;
+                }
+            }
+            LanceBuffer::reinterpret_vec(values)
+        }
+        _ => unreachable!("range width was validated before materialization"),
+    };
+    Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+        bits_per_value,
+        data,
+        num_values,
+        block_info: BlockInfo::default(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn range_round_trip_u32() {
+        let input = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(vec![3_u32, 8, 13, 18]),
+            num_values: 4,
+            block_info: BlockInfo::default(),
+        });
+        let (payload, encoding) = RangeEncoder::new(32, 3, 5).compress(input).unwrap();
+        assert!(payload.is_none());
+        assert_eq!(encoding, ProtobufUtils21::range(32, 3, 5));
+
+        let decoded = RangeDecompressor::new(32, 3, 5)
+            .decompress(payload, 4)
+            .unwrap()
+            .as_fixed_width()
+            .unwrap();
+        assert_eq!(
+            decoded.data.borrow_to_typed_slice::<u32>().as_ref(),
+            &[3, 8, 13, 18]
+        );
+    }
+
+    #[test]
+    fn range_rejects_overflow() {
+        let error = checked_range_last(32, u32::MAX as u64, 1, 2).unwrap_err();
+        assert!(error.to_string().contains("exceeds u32::MAX"));
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -1857,6 +1857,454 @@ impl RleDecompressor {
     }
 }
 
+// Generic block RLE uses the same outer frame as the stable block codec while
+// allowing each child to be any concrete block codec.
+pub(crate) const GENERIC_BLOCK_RLE_HEADER_BYTES: usize = 8;
+
+/// Block RLE compressor with concrete value and run-length children.
+#[derive(Debug)]
+pub struct BlockRleEncoder {
+    bits_per_value: u64,
+    values: Box<dyn BlockCompressor>,
+    run_lengths: Box<dyn BlockCompressor>,
+}
+
+impl BlockRleEncoder {
+    pub fn try_new(
+        bits_per_value: u64,
+        values: Box<dyn BlockCompressor>,
+        run_lengths: Box<dyn BlockCompressor>,
+    ) -> Result<Self> {
+        if !matches!(bits_per_value, 32 | 64) {
+            return Err(Error::invalid_input(format!(
+                "Generic block RLE only supports 32 or 64-bit values, got {bits_per_value}"
+            )));
+        }
+        Ok(Self {
+            bits_per_value,
+            values,
+            run_lengths,
+        })
+    }
+}
+
+impl BlockCompressor for BlockRleEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(data) = data else {
+            return Err(Error::invalid_input(
+                "Generic block RLE requires fixed-width data",
+            ));
+        };
+        let (run_values, run_lengths) = materialize_generic_runs(&data, self.bits_per_value)?;
+        let (values_payload, values_encoding) =
+            self.values.compress(DataBlock::FixedWidth(run_values))?;
+        let (lengths_payload, lengths_encoding) = self
+            .run_lengths
+            .compress(DataBlock::FixedWidth(run_lengths))?;
+        let encoding = ProtobufUtils21::rle(values_encoding, lengths_encoding);
+        if values_payload.is_none() && lengths_payload.is_none() {
+            return Ok((None, encoding));
+        }
+
+        let values_payload = values_payload.unwrap_or_else(LanceBuffer::empty);
+        let lengths_payload = lengths_payload.unwrap_or_else(LanceBuffer::empty);
+        let capacity = GENERIC_BLOCK_RLE_HEADER_BYTES
+            .checked_add(values_payload.len())
+            .and_then(|capacity| capacity.checked_add(lengths_payload.len()))
+            .ok_or_else(|| {
+                Error::invalid_input("Generic block RLE frame length overflows usize")
+            })?;
+        let mut output = Vec::new();
+        output.try_reserve_exact(capacity).map_err(|error| {
+            Error::invalid_input(format!(
+                "Generic block RLE could not reserve {capacity} frame bytes: {error}"
+            ))
+        })?;
+        output.extend_from_slice(&(values_payload.len() as u64).to_le_bytes());
+        output.extend_from_slice(&values_payload);
+        output.extend_from_slice(&lengths_payload);
+        Ok((Some(LanceBuffer::from(output)), encoding))
+    }
+}
+
+fn materialize_generic_runs(
+    data: &FixedWidthDataBlock,
+    bits_per_value: u64,
+) -> Result<(FixedWidthDataBlock, FixedWidthDataBlock)> {
+    if data.bits_per_value != bits_per_value {
+        return Err(Error::invalid_input(format!(
+            "Generic block RLE expects {bits_per_value}-bit values, got {}",
+            data.bits_per_value
+        )));
+    }
+    if data.num_values == 0 {
+        return Err(Error::invalid_input(
+            "Generic block RLE cannot encode an empty sequence",
+        ));
+    }
+
+    fn collect<T: ArrowNativeType + Copy + Eq>(values: &[T]) -> (Vec<T>, Vec<u32>) {
+        let mut run_values = Vec::new();
+        let mut run_lengths = Vec::new();
+        let mut current = values[0];
+        let mut length = 1_u32;
+        for value in values.iter().copied().skip(1) {
+            if value == current && length < u32::MAX {
+                length += 1;
+            } else {
+                run_values.push(current);
+                run_lengths.push(length);
+                current = value;
+                length = 1;
+            }
+        }
+        run_values.push(current);
+        run_lengths.push(length);
+        (run_values, run_lengths)
+    }
+
+    let (values, lengths, num_runs) = match bits_per_value {
+        32 => {
+            let input = crate::encodings::physical::checked_fixed_values::<u32>(
+                data,
+                "Generic block RLE input",
+            )?;
+            let (values, lengths) = collect(&input);
+            let num_runs = values.len() as u64;
+            (LanceBuffer::reinterpret_vec(values), lengths, num_runs)
+        }
+        64 => {
+            let input = crate::encodings::physical::checked_fixed_values::<u64>(
+                data,
+                "Generic block RLE input",
+            )?;
+            let (values, lengths) = collect(&input);
+            let num_runs = values.len() as u64;
+            (LanceBuffer::reinterpret_vec(values), lengths, num_runs)
+        }
+        _ => unreachable!("generic block RLE width was validated at construction"),
+    };
+    Ok((
+        FixedWidthDataBlock {
+            bits_per_value,
+            data: values,
+            num_values: num_runs,
+            block_info: BlockInfo::default(),
+        },
+        FixedWidthDataBlock {
+            bits_per_value: 32,
+            data: LanceBuffer::reinterpret_vec(lengths),
+            num_values: num_runs,
+            block_info: BlockInfo::default(),
+        },
+    ))
+}
+
+/// Descriptor-derived source used to recover the RLE child cardinality.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum BlockRleRunCount {
+    ConstantRunLength(u64),
+    RangeRunLengths { start: u64, step: u64 },
+    FlatValues,
+    FlatRunLengths,
+}
+
+/// Block RLE decompressor with concrete value and run-length children.
+#[derive(Debug)]
+pub(crate) struct BlockRleDecompressor {
+    bits_per_value: u64,
+    values: Box<dyn BlockDecompressor>,
+    run_lengths: Box<dyn BlockDecompressor>,
+    run_count: BlockRleRunCount,
+}
+
+impl BlockRleDecompressor {
+    pub(crate) fn try_new(
+        bits_per_value: u64,
+        values: Box<dyn BlockDecompressor>,
+        run_lengths: Box<dyn BlockDecompressor>,
+        run_count: BlockRleRunCount,
+    ) -> Result<Self> {
+        if !matches!(bits_per_value, 32 | 64) {
+            return Err(Error::invalid_input(format!(
+                "Generic block RLE only supports 32 or 64-bit values, got {bits_per_value}"
+            )));
+        }
+        Ok(Self {
+            bits_per_value,
+            values,
+            run_lengths,
+            run_count,
+        })
+    }
+}
+
+impl BlockDecompressor for BlockRleDecompressor {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        if num_values == 0 {
+            return Err(Error::invalid_input(
+                "Generic block RLE cannot decode an empty sequence",
+            ));
+        }
+        let values_have_payload = self.values.requires_payload();
+        let lengths_have_payload = self.run_lengths.requires_payload();
+        let (values_payload, lengths_payload) =
+            split_generic_rle_payload(data, values_have_payload, lengths_have_payload)?;
+        let run_count = infer_generic_run_count(
+            self.run_count,
+            values_payload.as_ref(),
+            lengths_payload.as_ref(),
+            self.bits_per_value,
+            num_values,
+        )?;
+        let values = self.values.decompress(values_payload, run_count)?;
+        let lengths = self.run_lengths.decompress(lengths_payload, run_count)?;
+        expand_generic_runs(values, lengths, self.bits_per_value, num_values, run_count)
+    }
+
+    fn requires_payload(&self) -> bool {
+        self.values.requires_payload() || self.run_lengths.requires_payload()
+    }
+}
+
+fn split_generic_rle_payload(
+    data: Option<LanceBuffer>,
+    values_have_payload: bool,
+    lengths_have_payload: bool,
+) -> Result<(Option<LanceBuffer>, Option<LanceBuffer>)> {
+    if !values_have_payload && !lengths_have_payload {
+        if data.is_some() {
+            return Err(Error::invalid_input(
+                "Metadata-only generic block RLE expects no payload",
+            ));
+        }
+        return Ok((None, None));
+    }
+    let data = require_block_payload(data, "Generic block RLE")?;
+    if data.len() < GENERIC_BLOCK_RLE_HEADER_BYTES {
+        return Err(Error::invalid_input(format!(
+            "Generic block RLE payload has {} bytes, shorter than its {GENERIC_BLOCK_RLE_HEADER_BYTES}-byte header",
+            data.len()
+        )));
+    }
+    let values_size = u64::from_le_bytes(
+        data[..GENERIC_BLOCK_RLE_HEADER_BYTES]
+            .try_into()
+            .expect("generic block RLE header length was checked"),
+    );
+    let values_size = usize::try_from(values_size).map_err(|_| {
+        Error::invalid_input("Generic block RLE values payload length does not fit usize")
+    })?;
+    let lengths_start = GENERIC_BLOCK_RLE_HEADER_BYTES
+        .checked_add(values_size)
+        .ok_or_else(|| Error::invalid_input("Generic block RLE values payload end overflows"))?;
+    if lengths_start > data.len() {
+        return Err(Error::invalid_input(format!(
+            "Generic block RLE values payload ends at {lengths_start}, beyond {} bytes",
+            data.len()
+        )));
+    }
+    if !values_have_payload && values_size != 0 {
+        return Err(Error::invalid_input(format!(
+            "Metadata-only RLE values child has {values_size} framed payload bytes"
+        )));
+    }
+    if !lengths_have_payload && lengths_start != data.len() {
+        return Err(Error::invalid_input(format!(
+            "Metadata-only RLE run-length child has {} framed payload bytes",
+            data.len() - lengths_start
+        )));
+    }
+    Ok((
+        values_have_payload
+            .then(|| data.slice_with_length(GENERIC_BLOCK_RLE_HEADER_BYTES, values_size)),
+        lengths_have_payload
+            .then(|| data.slice_with_length(lengths_start, data.len() - lengths_start)),
+    ))
+}
+
+fn infer_generic_run_count(
+    source: BlockRleRunCount,
+    values_payload: Option<&LanceBuffer>,
+    lengths_payload: Option<&LanceBuffer>,
+    bits_per_value: u64,
+    num_values: u64,
+) -> Result<u64> {
+    let run_count = match source {
+        BlockRleRunCount::ConstantRunLength(length) => {
+            if length == 0 || !num_values.is_multiple_of(length) {
+                return Err(Error::invalid_input(format!(
+                    "RLE constant run length {length} does not divide {num_values} values"
+                )));
+            }
+            num_values / length
+        }
+        BlockRleRunCount::RangeRunLengths { start, step } => {
+            if start == 0 || step == 0 {
+                return Err(Error::invalid_input(
+                    "RLE range run lengths must be positive",
+                ));
+            }
+            let target = u128::from(num_values);
+            let mut low = 1_u64;
+            let mut high = num_values;
+            let mut found = None;
+            while low <= high {
+                let count = low + (high - low) / 2;
+                let count128 = u128::from(count);
+                let sum = count128
+                    .checked_mul(
+                        u128::from(start)
+                            .checked_mul(2)
+                            .and_then(|start| {
+                                u128::from(count - 1)
+                                    .checked_mul(u128::from(step))
+                                    .and_then(|tail| start.checked_add(tail))
+                            })
+                            .unwrap_or(u128::MAX),
+                    )
+                    .map(|sum| sum / 2)
+                    .unwrap_or(u128::MAX);
+                match sum.cmp(&target) {
+                    std::cmp::Ordering::Less => low = count + 1,
+                    std::cmp::Ordering::Greater => high = count - 1,
+                    std::cmp::Ordering::Equal => {
+                        found = Some(count);
+                        break;
+                    }
+                }
+            }
+            found.ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RLE range run lengths start={start} step={step} do not sum to {num_values}"
+                ))
+            })?
+        }
+        BlockRleRunCount::FlatValues => flat_generic_run_count(
+            values_payload.ok_or_else(|| {
+                Error::invalid_input("RLE values payload is required to infer the run count")
+            })?,
+            bits_per_value,
+            num_values,
+            "values",
+        )?,
+        BlockRleRunCount::FlatRunLengths => flat_generic_run_count(
+            lengths_payload.ok_or_else(|| {
+                Error::invalid_input("RLE run-length payload is required to infer the run count")
+            })?,
+            32,
+            num_values,
+            "run lengths",
+        )?,
+    };
+    if run_count == 0 {
+        return Err(Error::invalid_input(
+            "Generic block RLE describes zero runs",
+        ));
+    }
+    Ok(run_count)
+}
+
+fn flat_generic_run_count(
+    payload: &LanceBuffer,
+    bits_per_value: u64,
+    max_runs: u64,
+    label: &str,
+) -> Result<u64> {
+    let bytes_per_value = usize::try_from(bits_per_value / 8)
+        .map_err(|_| Error::invalid_input("RLE child width does not fit usize"))?;
+    if bytes_per_value == 0 || !payload.len().is_multiple_of(bytes_per_value) {
+        return Err(Error::invalid_input(format!(
+            "RLE {label} payload has {} bytes, not divisible by {bytes_per_value}",
+            payload.len()
+        )));
+    }
+    let run_count = (payload.len() / bytes_per_value) as u64;
+    if run_count > max_runs {
+        return Err(Error::invalid_input(format!(
+            "RLE {label} payload contains {run_count} runs, exceeding {max_runs}"
+        )));
+    }
+    Ok(run_count)
+}
+
+fn expand_generic_runs(
+    values: DataBlock,
+    lengths: DataBlock,
+    bits_per_value: u64,
+    num_values: u64,
+    run_count: u64,
+) -> Result<DataBlock> {
+    let DataBlock::FixedWidth(values) = values else {
+        return Err(Error::invalid_input(
+            "RLE values decoded to a non fixed-width block",
+        ));
+    };
+    let DataBlock::FixedWidth(lengths) = lengths else {
+        return Err(Error::invalid_input(
+            "RLE run lengths decoded to a non fixed-width block",
+        ));
+    };
+    if values.bits_per_value != bits_per_value
+        || values.num_values != run_count
+        || lengths.bits_per_value != 32
+        || lengths.num_values != run_count
+    {
+        return Err(Error::invalid_input(
+            "RLE child cardinality or bit width does not match its descriptor",
+        ));
+    }
+    let lengths =
+        crate::encodings::physical::checked_fixed_values::<u32>(&lengths, "RLE run lengths")?;
+    let total = lengths
+        .iter()
+        .enumerate()
+        .try_fold(0_u64, |total, (index, length)| {
+            if *length == 0 {
+                return Err(Error::invalid_input(format!(
+                    "RLE run length at index {index} is zero"
+                )));
+            }
+            total.checked_add(u64::from(*length)).ok_or_else(|| {
+                Error::invalid_input(format!("RLE run length sum overflows at index {index}"))
+            })
+        })?;
+    if total != num_values {
+        return Err(Error::invalid_input(format!(
+            "RLE run lengths sum to {total}, expected {num_values}"
+        )));
+    }
+    let output = match bits_per_value {
+        32 => {
+            let values =
+                crate::encodings::physical::checked_fixed_values::<u32>(&values, "RLE values")?;
+            let mut output =
+                crate::encodings::physical::try_vec_with_capacity::<u32>(num_values, "RLE output")?;
+            for (value, length) in values.iter().zip(lengths.iter()) {
+                output.extend(std::iter::repeat_n(*value, *length as usize));
+            }
+            LanceBuffer::reinterpret_vec(output)
+        }
+        64 => {
+            let values =
+                crate::encodings::physical::checked_fixed_values::<u64>(&values, "RLE values")?;
+            let mut output =
+                crate::encodings::physical::try_vec_with_capacity::<u64>(num_values, "RLE output")?;
+            for (value, length) in values.iter().zip(lengths.iter()) {
+                output.extend(std::iter::repeat_n(*value, *length as usize));
+            }
+            LanceBuffer::reinterpret_vec(output)
+        }
+        _ => unreachable!("generic block RLE width was validated at construction"),
+    };
+    Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+        bits_per_value,
+        data: output,
+        num_values,
+        block_info: BlockInfo::default(),
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -58,7 +58,9 @@ use arrow_buffer::{ArrowNativeType, ScalarBuffer};
 use log::trace;
 
 use crate::buffer::LanceBuffer;
-use crate::compression::{BlockCompressor, BlockDecompressor, MiniBlockDecompressor};
+use crate::compression::{
+    BlockCompressor, BlockDecompressor, MiniBlockDecompressor, require_block_payload,
+};
 use crate::data::DataBlock;
 use crate::data::{BlockInfo, FixedWidthDataBlock};
 use crate::encodings::logical::primitive::miniblock::{
@@ -872,7 +874,10 @@ impl RleEncoder {
                 num_values: child_values,
                 block_info: BlockInfo::default(),
             });
-            let chunk_packed = BlockCompressor::compress(&compressor, block)?;
+            let (chunk_packed, _) = BlockCompressor::compress(&compressor, block)?;
+            let chunk_packed = chunk_packed.ok_or_else(|| {
+                Error::internal("RLE bitpacking child returned no payload".to_string())
+            })?;
             let packed_size = u32::try_from(chunk_packed.len()).map_err(|_| {
                 Error::invalid_input_source(
                     format!(
@@ -1107,7 +1112,7 @@ impl MiniBlockCompressor for RleEncoder {
 
 impl BlockCompressor for RleEncoder {
     // Block format: [8-byte header: values buffer size][values buffer][run_lengths buffer]
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
         match data {
             DataBlock::FixedWidth(fixed_width) => {
                 let num_values = fixed_width.num_values;
@@ -1122,7 +1127,13 @@ impl BlockCompressor for RleEncoder {
                 combined.extend_from_slice(&values_size.to_le_bytes());
                 combined.extend_from_slice(&all_buffers[0]);
                 combined.extend_from_slice(&all_buffers[1]);
-                Ok(LanceBuffer::from(combined))
+                Ok((
+                    Some(LanceBuffer::from(combined)),
+                    ProtobufUtils21::rle(
+                        ProtobufUtils21::flat(bits_per_value, None),
+                        ProtobufUtils21::flat(self.run_length_width.bits_per_value(), None),
+                    ),
+                ))
             }
             _ => Err(Error::invalid_input_source(
                 "RLE encoding only supports FixedWidth data blocks".into(),
@@ -1216,7 +1227,7 @@ impl RleChildDecompressor {
                 } else {
                     num_values.unwrap_or(0)
                 };
-                let decoded = decompressor.decompress(data, num_values)?;
+                let decoded = decompressor.decompress(Some(data), num_values)?;
                 self.extract_fixed_width(decoded, num_values, label)
             }
         }
@@ -1565,7 +1576,8 @@ impl MiniBlockDecompressor for RleDecompressor {
 }
 
 impl BlockDecompressor for RleDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "RLE")?;
         let (values_buffer, lengths_buffer) = parse_rle_block_frame(&data)?;
         self.decode_data(vec![values_buffer, lengths_buffer], num_values, false)
     }
@@ -1892,11 +1904,17 @@ mod tests {
             num_values,
             block_info: BlockInfo::new(),
         });
-        let frame = BlockCompressor::compress(&RleEncoder::new(), block).unwrap();
+        let frame = BlockCompressor::compress(&RleEncoder::new(), block)
+            .unwrap()
+            .0
+            .unwrap();
 
-        let eager =
-            BlockDecompressor::decompress(&RleDecompressor::new(16), frame.clone(), num_values)
-                .unwrap();
+        let eager = BlockDecompressor::decompress(
+            &RleDecompressor::new(16),
+            Some(frame.clone()),
+            num_values,
+        )
+        .unwrap();
         let DataBlock::FixedWidth(eager) = eager else {
             panic!("expected fixed-width block");
         };
@@ -1969,7 +1987,10 @@ mod tests {
             num_values,
             block_info: BlockInfo::new(),
         });
-        let frame = BlockCompressor::compress(&RleEncoder::new(), block).unwrap();
+        let frame = BlockCompressor::compress(&RleEncoder::new(), block)
+            .unwrap()
+            .0
+            .unwrap();
         let (values, lengths) = parse_rle_block_frame(&frame).unwrap();
 
         let compression = test_general_compression();
@@ -2011,7 +2032,10 @@ mod tests {
             num_values,
             block_info: BlockInfo::new(),
         });
-        let frame = BlockCompressor::compress(&RleEncoder::new(), block).unwrap();
+        let frame = BlockCompressor::compress(&RleEncoder::new(), block)
+            .unwrap()
+            .0
+            .unwrap();
         let runs = RleDecompressor::new(16)
             .decode_u16_runs(frame, num_values)
             .unwrap();
@@ -2032,7 +2056,10 @@ mod tests {
             num_values: n,
             block_info: BlockInfo::new(),
         });
-        let frame = BlockCompressor::compress(&RleEncoder::new(), block).unwrap();
+        let frame = BlockCompressor::compress(&RleEncoder::new(), block)
+            .unwrap()
+            .0
+            .unwrap();
         let runs = RleDecompressor::new(16).decode_u16_runs(frame, n).unwrap();
         assert_eq!(
             runs.coalesced_runs() as u64,
@@ -2211,7 +2238,10 @@ mod tests {
             block_info: BlockInfo::default(),
         });
         let bitpacked_run_lengths =
-            BlockCompressor::compress(&OutOfLineBitpacking::new(3, 8), run_lengths_block).unwrap();
+            BlockCompressor::compress(&OutOfLineBitpacking::new(3, 8), run_lengths_block)
+                .unwrap()
+                .0
+                .unwrap();
         let encoding = ProtobufUtils21::rle(
             ProtobufUtils21::flat(32, None),
             ProtobufUtils21::out_of_line_bitpacking(8, ProtobufUtils21::flat(3, None)),
@@ -2699,8 +2729,9 @@ mod tests {
         payload.extend_from_slice(&values);
         payload.extend_from_slice(&lengths);
 
-        let error = BlockDecompressor::decompress(&decompressor, LanceBuffer::from(payload), 5)
-            .unwrap_err();
+        let error =
+            BlockDecompressor::decompress(&decompressor, Some(LanceBuffer::from(payload)), 5)
+                .unwrap_err();
         assert!(matches!(&error, Error::InvalidInput { .. }));
         assert!(
             error
@@ -3151,7 +3182,7 @@ mod tests {
 
         let mut data = Vec::new();
         data.extend_from_slice(&u64::MAX.to_le_bytes());
-        let result = BlockDecompressor::decompress(&decompressor, LanceBuffer::from(data), 1);
+        let result = BlockDecompressor::decompress(&decompressor, Some(LanceBuffer::from(data)), 1);
         assert!(result.is_err());
         assert!(
             result
@@ -3164,8 +3195,11 @@ mod tests {
     #[test]
     fn test_block_decompressor_too_small() {
         let decompressor = RleDecompressor::new(32);
-        let result =
-            BlockDecompressor::decompress(&decompressor, LanceBuffer::from(vec![1, 2, 3]), 10);
+        let result = BlockDecompressor::decompress(
+            &decompressor,
+            Some(LanceBuffer::from(vec![1, 2, 3])),
+            10,
+        );
         assert!(result.is_err());
         assert!(
             result
@@ -3181,7 +3215,10 @@ mod tests {
 
         let data = vec![1i32, 1, 1];
         let array = Int32Array::from(data);
-        let compressed = BlockCompressor::compress(&encoder, DataBlock::from_array(array)).unwrap();
+        let compressed = BlockCompressor::compress(&encoder, DataBlock::from_array(array))
+            .unwrap()
+            .0
+            .unwrap();
 
         // Verify header format: first 8 bytes should be values_size as u64
         assert!(compressed.len() >= 8);
@@ -3205,7 +3242,7 @@ mod tests {
         let array = Int32Array::from(data.clone());
         let data_block = DataBlock::from_array(array);
 
-        let compressed = BlockCompressor::compress(&encoder, data_block).unwrap();
+        let compressed = BlockCompressor::compress(&encoder, data_block).unwrap().0;
         let decompressed =
             BlockDecompressor::decompress(&decompressor, compressed, data.len() as u64).unwrap();
 
@@ -3234,7 +3271,9 @@ mod tests {
         assert_eq!(total_values, 10000);
 
         let array = Int32Array::from(data.clone());
-        let compressed = BlockCompressor::compress(&encoder, DataBlock::from_array(array)).unwrap();
+        let compressed = BlockCompressor::compress(&encoder, DataBlock::from_array(array))
+            .unwrap()
+            .0;
         let decompressed =
             BlockDecompressor::decompress(&decompressor, compressed, total_values as u64).unwrap();
 

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -6,6 +6,7 @@ use arrow_buffer::{BooleanBufferBuilder, bit_util};
 use crate::buffer::LanceBuffer;
 use crate::compression::{
     BlockCompressor, BlockDecompressor, FixedPerValueDecompressor, MiniBlockDecompressor,
+    require_block_payload,
 };
 use crate::data::{
     BlockInfo, DataBlock, FixedSizeListBlock, FixedWidthDataBlock, NullableDataBlock,
@@ -458,15 +459,17 @@ impl ValueEncoder {
 }
 
 impl BlockCompressor for ValueEncoder {
-    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
-        let data = match data {
-            DataBlock::FixedWidth(fixed_width) => fixed_width.data,
-            _ => unimplemented!(
-                "Cannot compress block of type {} with ValueEncoder",
+    fn compress(&self, data: DataBlock) -> Result<(Option<LanceBuffer>, CompressiveEncoding)> {
+        let DataBlock::FixedWidth(fixed_width) = data else {
+            return Err(Error::invalid_input(format!(
+                "ValueEncoder cannot compress a {} block",
                 data.name()
-            ),
+            )));
         };
-        Ok(data)
+        Ok((
+            Some(fixed_width.data),
+            ProtobufUtils21::flat(fixed_width.bits_per_value, None),
+        ))
     }
 }
 
@@ -575,7 +578,8 @@ impl ValueDecompressor {
 }
 
 impl BlockDecompressor for ValueDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Option<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let data = require_block_payload(data, "Flat block")?;
         let block = self.buffer_to_block(data, num_values);
         assert_eq!(block.num_values(), num_values);
         Ok(block)

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -706,6 +706,24 @@ impl ProtobufUtils21 {
         }
     }
 
+    pub fn dictionary(
+        indices: crate::format::pb21::CompressiveEncoding,
+        items: crate::format::pb21::CompressiveEncoding,
+        num_dictionary_items: u32,
+    ) -> crate::format::pb21::CompressiveEncoding {
+        crate::format::pb21::CompressiveEncoding {
+            compression: Some(
+                crate::format::pb21::compressive_encoding::Compression::Dictionary(Box::new(
+                    crate::format::pb21::Dictionary {
+                        indices: Some(Box::new(indices)),
+                        items: Some(Box::new(items)),
+                        num_dictionary_items,
+                    },
+                )),
+            ),
+        }
+    }
+
     pub fn constant_layout(
         def_meaning: &[DefinitionInterpretation],
         inline_value: Option<Vec<u8>>,

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -670,6 +670,42 @@ macro_rules! impl_common_protobuf_utils {
 impl_common_protobuf_utils!(pb21, ProtobufUtils21);
 
 impl ProtobufUtils21 {
+    pub fn range(
+        uncompressed_bits_per_value: u64,
+        start: u64,
+        step: u64,
+    ) -> crate::format::pb21::CompressiveEncoding {
+        crate::format::pb21::CompressiveEncoding {
+            compression: Some(
+                crate::format::pb21::compressive_encoding::Compression::Range(
+                    crate::format::pb21::Range {
+                        uncompressed_bits_per_value,
+                        start,
+                        step,
+                    },
+                ),
+            ),
+        }
+    }
+
+    pub fn delta(
+        uncompressed_bits_per_value: u64,
+        base: u64,
+        deltas: crate::format::pb21::CompressiveEncoding,
+    ) -> crate::format::pb21::CompressiveEncoding {
+        crate::format::pb21::CompressiveEncoding {
+            compression: Some(
+                crate::format::pb21::compressive_encoding::Compression::Delta(Box::new(
+                    crate::format::pb21::Delta {
+                        uncompressed_bits_per_value,
+                        base,
+                        deltas: Some(Box::new(deltas)),
+                    },
+                )),
+            ),
+        }
+    }
+
     pub fn constant_layout(
         def_meaning: &[DefinitionInterpretation],
         inline_value: Option<Vec<u8>>,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -195,7 +195,7 @@ impl CompressionStrategy for TestCompressionStrategy {
         &self,
         field: &LanceField,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+    ) -> Result<Box<dyn BlockCompressor>> {
         let params = self.field_params(field);
         let rle = match self.encoding {
             TestEncoding::Array | TestEncoding::StructuralU16 => None,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -868,6 +868,8 @@ fn tag(e: &Compression) -> &'static str {
         FixedSizeList(_) => "fixed_size_list",
         PackedStruct(_) => "packed_struct",
         VariablePackedStruct(_) => "variable_packed_struct",
+        Range(_) => "range",
+        Delta(_) => "delta",
     }
 }
 

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -35,7 +35,7 @@ use crate::{
         try_general_block, try_raw_block, try_raw_fixed_size_list_miniblock,
         try_raw_fixed_width_miniblock, try_raw_per_value, try_uncompressed_fixed_width_miniblock,
         try_variable_packed_struct_per_value, try_variable_rle_block, try_variable_width_miniblock,
-        try_variable_width_per_value,
+        try_variable_width_miniblock_with_generic_offsets, try_variable_width_per_value,
     },
     compression_config::{CompressionFieldParams, CompressionParams},
     data::DataBlock,
@@ -141,7 +141,11 @@ impl CompressionStrategy for TestCompressionStrategy {
                 compressor
             } else if let Some(compressor) = try_raw_fixed_width_miniblock(data) {
                 compressor
-            } else if let Some(compressor) = try_variable_width_miniblock(field, data, &params)? {
+            } else if let Some(compressor) = if self.encoding == TestEncoding::StructuralSparse {
+                try_variable_width_miniblock_with_generic_offsets(field, data, &params)?
+            } else {
+                try_variable_width_miniblock(field, data, &params)?
+            } {
                 compressor
             } else if let Some(compressor) = try_fixed_packed_struct_miniblock(data)? {
                 compressor

--- a/rust/lance-file/src/versions/v2_1/compression.rs
+++ b/rust/lance-file/src/versions/v2_1/compression.rs
@@ -14,7 +14,6 @@ use lance_encoding::{
     compression_config::{CompressionFieldParams, CompressionParams},
     data::DataBlock,
     encodings::logical::primitive::{fullzip::PerValueCompressor, miniblock::MiniBlockCompressor},
-    format::pb21::CompressiveEncoding,
 };
 
 #[derive(Debug, Clone)]
@@ -111,7 +110,7 @@ impl CompressionStrategy for Strategy {
         &self,
         field: &Field,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+    ) -> Result<Box<dyn BlockCompressor>> {
         let _params = self.field_params(field);
         if let Some(compressor) = try_bitpacking_block(data) {
             return Ok(compressor);

--- a/rust/lance-file/src/versions/v2_1/reader.rs
+++ b/rust/lance-file/src/versions/v2_1/reader.rs
@@ -93,6 +93,9 @@ fn validate_compressive_encoding(encoding: &pb21::CompressiveEncoding) -> Result
         Some(Compression::VariablePackedStruct(_)) => Err(Error::invalid_input_source(
             "Variable packed struct compression is not part of the Lance v2.1 grammar".into(),
         )),
+        Some(Compression::Range(_) | Compression::Delta(_)) => Err(Error::invalid_input_source(
+            "Range and delta compression are not part of the Lance v2.1 grammar".into(),
+        )),
         None => Err(Error::invalid_input_source(
             "Lance v2.1 compressive encoding is missing its compression variant".into(),
         )),
@@ -300,5 +303,32 @@ mod grammar_tests {
                 .to_string()
                 .contains("Variable packed struct compression is not part")
         );
+    }
+
+    #[test]
+    fn rejects_range_and_delta() {
+        let range = CompressiveEncoding {
+            compression: Some(Compression::Range(pb21::Range {
+                uncompressed_bits_per_value: 32,
+                start: 0,
+                step: 1,
+            })),
+        };
+        let delta = CompressiveEncoding {
+            compression: Some(Compression::Delta(Box::new(pb21::Delta {
+                uncompressed_bits_per_value: 32,
+                base: 0,
+                deltas: Some(Box::new(range.clone())),
+            }))),
+        };
+
+        for encoding in [&range, &delta] {
+            let error = validate_compressive_encoding(encoding).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("not part of the Lance v2.1 grammar")
+            );
+        }
     }
 }

--- a/rust/lance-file/src/versions/v2_2/compression.rs
+++ b/rust/lance-file/src/versions/v2_2/compression.rs
@@ -17,7 +17,6 @@ use lance_encoding::{
     compression_config::{CompressionFieldParams, CompressionParams},
     data::DataBlock,
     encodings::logical::primitive::{fullzip::PerValueCompressor, miniblock::MiniBlockCompressor},
-    format::pb21::CompressiveEncoding,
 };
 
 #[derive(Debug, Clone)]
@@ -105,7 +104,7 @@ impl CompressionStrategy for Strategy {
         &self,
         field: &Field,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+    ) -> Result<Box<dyn BlockCompressor>> {
         let params = self.field_params(field);
         if let Some(compressor) = try_fixed_u8_rle_block(data, &params)? {
             return Ok(compressor);

--- a/rust/lance-file/src/versions/v2_2/reader.rs
+++ b/rust/lance-file/src/versions/v2_2/reader.rs
@@ -99,6 +99,9 @@ fn validate_compressive_encoding(encoding: &pb21::CompressiveEncoding) -> Result
             }
             Ok(())
         }
+        Some(Compression::Range(_) | Compression::Delta(_)) => Err(Error::invalid_input_source(
+            "Range and delta compression are not part of the Lance v2.2 grammar".into(),
+        )),
         None => Err(Error::invalid_input_source(
             "Lance v2.2 compressive encoding is missing its compression variant".into(),
         )),
@@ -304,5 +307,32 @@ mod grammar_tests {
                 .to_string()
                 .contains("flat values and flat u8 run lengths")
         );
+    }
+
+    #[test]
+    fn rejects_range_and_delta() {
+        let range = CompressiveEncoding {
+            compression: Some(Compression::Range(pb21::Range {
+                uncompressed_bits_per_value: 64,
+                start: 0,
+                step: 1,
+            })),
+        };
+        let delta = CompressiveEncoding {
+            compression: Some(Compression::Delta(Box::new(pb21::Delta {
+                uncompressed_bits_per_value: 64,
+                base: 0,
+                deltas: Some(Box::new(range.clone())),
+            }))),
+        };
+
+        for encoding in [&range, &delta] {
+            let error = validate_compressive_encoding(encoding).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("not part of the Lance v2.2 grammar")
+            );
+        }
     }
 }

--- a/rust/lance-file/src/versions/v2_3/compression.rs
+++ b/rust/lance-file/src/versions/v2_3/compression.rs
@@ -11,8 +11,8 @@ use lance_encoding::{
         try_child_rle_miniblock, try_fixed_packed_struct_miniblock, try_general_block,
         try_raw_block, try_raw_fixed_size_list_miniblock, try_raw_fixed_width_miniblock,
         try_raw_per_value, try_uncompressed_fixed_width_miniblock,
-        try_variable_packed_struct_per_value, try_variable_rle_block, try_variable_width_miniblock,
-        try_variable_width_per_value,
+        try_variable_packed_struct_per_value, try_variable_rle_block,
+        try_variable_width_miniblock_with_generic_offsets, try_variable_width_per_value,
     },
     compression_config::{CompressionFieldParams, CompressionParams},
     data::DataBlock,
@@ -56,7 +56,9 @@ impl CompressionStrategy for Strategy {
                 compressor
             } else if let Some(compressor) = try_raw_fixed_width_miniblock(data) {
                 compressor
-            } else if let Some(compressor) = try_variable_width_miniblock(field, data, &params)? {
+            } else if let Some(compressor) =
+                try_variable_width_miniblock_with_generic_offsets(field, data, &params)?
+            {
                 compressor
             } else if let Some(compressor) = try_fixed_packed_struct_miniblock(data)? {
                 compressor

--- a/rust/lance-file/src/versions/v2_3/compression.rs
+++ b/rust/lance-file/src/versions/v2_3/compression.rs
@@ -17,7 +17,6 @@ use lance_encoding::{
     compression_config::{CompressionFieldParams, CompressionParams},
     data::DataBlock,
     encodings::logical::primitive::{fullzip::PerValueCompressor, miniblock::MiniBlockCompressor},
-    format::pb21::CompressiveEncoding,
 };
 
 #[derive(Debug, Clone)]
@@ -105,7 +104,7 @@ impl CompressionStrategy for Strategy {
         &self,
         field: &Field,
         data: &DataBlock,
-    ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
+    ) -> Result<Box<dyn BlockCompressor>> {
         let params = self.field_params(field);
         if let Some(compressor) = try_variable_rle_block(data, &params)? {
             return Ok(compressor);

--- a/rust/lance-file/src/versions/v2_3/reader.rs
+++ b/rust/lance-file/src/versions/v2_3/reader.rs
@@ -82,6 +82,10 @@ fn validate_compressive_encoding(encoding: &pb21::CompressiveEncoding) -> Result
             }
             Ok(())
         }
+        Some(Compression::Range(_)) => Ok(()),
+        Some(Compression::Delta(delta)) => {
+            validate_compressive_encoding(required(delta.deltas.as_deref(), "delta values")?)
+        }
         None => Err(Error::invalid_input_source(
             "Lance v2.3 compressive encoding is missing its compression variant".into(),
         )),
@@ -337,5 +341,26 @@ mod grammar_tests {
         };
 
         validate_page_layout(&layout).unwrap();
+    }
+
+    #[test]
+    fn accepts_range_and_delta() {
+        let range = CompressiveEncoding {
+            compression: Some(Compression::Range(pb21::Range {
+                uncompressed_bits_per_value: 32,
+                start: 0,
+                step: 1,
+            })),
+        };
+        let delta = CompressiveEncoding {
+            compression: Some(Compression::Delta(Box::new(pb21::Delta {
+                uncompressed_bits_per_value: 32,
+                base: 0,
+                deltas: Some(Box::new(range.clone())),
+            }))),
+        };
+
+        validate_compressive_encoding(&range).unwrap();
+        validate_compressive_encoding(&delta).unwrap();
     }
 }


### PR DESCRIPTION
Stack 8 of 10 for Lance generic block sequence compression.

This makes Lance 2.3 variable-width mini-block offsets the first non-sparse adopter of generic block compression. The writer emits the generic representation only when its complete serialized form is strictly smaller; otherwise it keeps the legacy interleaved flat layout. Chunk-local scan, range, and take scheduling remain intact.

Lance 2.0–2.2 writers and readers keep their existing bytes and selection behavior. SparseLayout keeps its existing wire format and explicitly vetoes the generic path.

## Benchmark

Representative 262,144-row UTF-8 workloads compare equivalent v2.2 and v2.3 mini-block encoding at `ae0a49ba2` with the `release-with-debug` profile. The descendant measurement commit adds only documentation and the benchmark harness after this PR's runtime code.

| Workload | Encoded bytes | Encode median | Scan median | Cold take median |
| --- | ---: | ---: | ---: | ---: |
| Range, v2.2 → v2.3 | 5,283,840 → 4,218,880 (-20.2%) | 1.512 → 6.824 ms | 1.330 → 1.170 ms | 249.2 → 202.3 µs |
| Delta, v2.2 → v2.3 | 10,436,608 → 9,355,264 (-10.4%) | 2.650 → 10.014 ms | 2.136 → 2.259 ms | 232.4 → 246.3 µs |

<!-- generic-block-v5-stack-navigation -->
## Stack navigation
- Position: 8 of 10
- Root: #8324
- Previous: #8330
- Next: #8332
- Top: #8333
