### PR TITLE
test: surface pip output and retry transient failures in compat venv installs

### DIFF
--- a/python/python/tests/compat/test_venv_manager.py
+++ b/python/python/tests/compat/test_venv_manager.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import subprocess
+
 import pytest
 
-from .venv_manager import _lance_namespace_dependency
+from . import venv_manager
+from .venv_manager import _lance_namespace_dependency, _pip_install
 
 
 @pytest.mark.parametrize(
@@ -19,3 +22,57 @@ from .venv_manager import _lance_namespace_dependency
 )
 def test_lance_namespace_dependency(version: str, expected: str):
     assert _lance_namespace_dependency(version) == expected
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    sleeps: list[float] = []
+    monkeypatch.setattr(venv_manager.time, "sleep", sleeps.append)
+    return sleeps
+
+
+def test_pip_install_failure_includes_pip_output(monkeypatch, no_sleep):
+    calls: list[list[str]] = []
+
+    def failing_run(cmd, **kwargs):
+        calls.append(cmd)
+        raise subprocess.CalledProcessError(
+            2, cmd, output="resolving deps", stderr="No matching distribution found"
+        )
+
+    monkeypatch.setattr(venv_manager.subprocess, "run", failing_run)
+    with pytest.raises(RuntimeError) as exc_info:
+        _pip_install("python", ["pylance==0.38.0"])
+    # The error must surface pip's captured output, which CalledProcessError hides.
+    message = str(exc_info.value)
+    assert "No matching distribution found" in message
+    assert "resolving deps" in message
+    assert "pylance==0.38.0" in message
+    assert len(calls) == venv_manager._PIP_INSTALL_ATTEMPTS
+    assert len(no_sleep) == venv_manager._PIP_INSTALL_ATTEMPTS - 1
+
+
+def test_pip_install_retries_transient_failure(monkeypatch, no_sleep):
+    calls: list[list[str]] = []
+
+    def flaky_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            raise subprocess.CalledProcessError(
+                2, cmd, output="", stderr="ReadTimeoutError: pypi.fury.io"
+            )
+
+    monkeypatch.setattr(venv_manager.subprocess, "run", flaky_run)
+    _pip_install("python", ["pylance==0.38.0"])
+    assert len(calls) == 2
+    assert len(no_sleep) == 1
+
+
+def test_pip_install_succeeds_first_try_without_sleeping(monkeypatch, no_sleep):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        venv_manager.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd)
+    )
+    _pip_install("python", ["pytest"])
+    assert calls == [["python", "-m", "pip", "install", "--quiet", "pytest"]]
+    assert no_sleep == []

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -17,8 +17,9 @@ import shutil
 import struct
 import subprocess
 import sys
+import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import pytest
 from packaging.version import InvalidVersion, Version
@@ -41,6 +42,35 @@ def _venv_lock(lock_path: Path):
         finally:
             if fcntl is not None:
                 fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+_PIP_INSTALL_ATTEMPTS = 3
+_PIP_RETRY_BACKOFF_SECONDS = 2.0
+
+
+def _pip_install(python: Union[str, Path], args: list[str]) -> None:
+    """Run ``pip install`` with output captured, retrying transient failures.
+
+    pip installs hit the network (PyPI / fury.io) and a single flaky download
+    should not fail a whole test run, so retry a bounded number of times with a
+    short backoff. On final failure raise an error that includes pip's
+    stdout/stderr, which a bare CalledProcessError from ``capture_output=True``
+    would hide from the test log.
+    """
+    cmd = [str(python), "-m", "pip", "install", "--quiet", *args]
+    for attempt in range(1, _PIP_INSTALL_ATTEMPTS + 1):
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            return
+        except subprocess.CalledProcessError as exc:  # noqa: PERF203
+            if attempt == _PIP_INSTALL_ATTEMPTS:
+                raise RuntimeError(
+                    f"pip install failed after {attempt} attempts "
+                    f"(exit status {exc.returncode}): {cmd}\n"
+                    f"stdout:\n{exc.stdout}\n"
+                    f"stderr:\n{exc.stderr}"
+                ) from exc
+            time.sleep(_PIP_RETRY_BACKOFF_SECONDS * attempt)
 
 
 NAMESPACE_0_6_DEPENDENCY = "lance-namespace<0.7"
@@ -221,20 +251,12 @@ class VenvExecutor:
         self._created = True
 
     def _install_wheel(self, wheel: str):
-        subprocess.run(
-            [str(self.python_path), "-m", "pip", "install", "--quiet", wheel, "pytest"],
-            check=True,
-            capture_output=True,
-        )
+        _pip_install(self.python_path, [wheel, "pytest"])
 
     def _install_release_wheel(self):
-        subprocess.run(
+        _pip_install(
+            self.python_path,
             [
-                str(self.python_path),
-                "-m",
-                "pip",
-                "install",
-                "--quiet",
                 "--pre",
                 "--extra-index-url",
                 "https://pypi.fury.io/lance-format/",
@@ -248,8 +270,6 @@ class VenvExecutor:
                 _lance_namespace_dependency(self.version),
                 "pytest",
             ],
-            check=True,
-            capture_output=True,
         )
 
     def _build_from_source(self):
@@ -272,11 +292,7 @@ class VenvExecutor:
                 check=True,
                 capture_output=True,
             )
-        subprocess.run(
-            [py, "-m", "pip", "install", "--quiet", "maturin", "pytest", "pyarrow"],
-            check=True,
-            capture_output=True,
-        )
+        _pip_install(py, ["maturin", "pytest", "pyarrow"])
         wheels = src / "target" / "compat-wheels"
         subprocess.run(
             [
@@ -296,11 +312,7 @@ class VenvExecutor:
             capture_output=True,
         )
         wheel = next(wheels.glob("pylance-*.whl"))
-        subprocess.run(
-            [py, "-m", "pip", "install", "--quiet", str(wheel)],
-            check=True,
-            capture_output=True,
-        )
+        _pip_install(py, [str(wheel)])
 
     def _ensure_subprocess(self):
         """Ensure the persistent subprocess is running."""


### PR DESCRIPTION
## Why

In CI run [31083308713](https://github.com/lance-format/lance/actions/runs/31083308713/job/92558361992) on `main`, a transient network failure installing `pylance==0.38.0` from pypi.fury.io failed one compat test, while the identical install succeeded 18 seconds later in the next test — a single flaky pip install turned `main` red. Worse, the failure was undiagnosable from the log: `subprocess.run(..., check=True, capture_output=True)` swallows pip's stderr, so `CalledProcessError` only reported "returned non-zero exit status 2".

This wraps the pip install calls in `venv_manager.py` with a small helper that:

- retries up to 3 attempts with short incremental backoff, absorbing transient index/network hiccups;
- on final failure raises an error carrying pip's full stdout/stderr plus the command and exit status, so the next such failure is diagnosable directly from the CI log.

The retry is deliberately indiscriminate: pip exit codes can't reliably distinguish network errors from deterministic ones, so a deterministic failure (e.g. nonexistent version) now costs a few extra seconds of retries before surfacing.

Non-pip subprocess calls (venv creation, git worktree, maturin build) are unchanged.
