### PR TITLE
fix(index): drop stale rows when merging vector index segments

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -54,20 +54,9 @@ pub struct IndexMergeResults<'a> {
     pub files: Vec<lance_table::format::IndexFile>,
 }
 
-/// Which rows of a still-covered fragment an old-data filter keeps.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum OldRowRetention {
-    /// Every row the fragment ever held. Coverage is the only criterion.
-    Covered,
-    /// Only rows the fragment's deletion vector still considers live, so an old
-    /// posting for a row rewritten under the same stable row id is dropped too.
-    Live,
-}
-
 async fn build_stable_row_id_filter(
     dataset: &Dataset,
     effective_old_frags: &RoaringBitmap,
-    retention: OldRowRetention,
 ) -> Result<RowAddrTreeMap> {
     // For stable row IDs we cannot derive fragment ownership from row_id bits.
     // Instead, we:
@@ -98,10 +87,7 @@ async fn build_stable_row_id_filter(
 
     let mut row_id_maps = Vec::with_capacity(row_id_sequences.len());
     for (frag_id, seq) in &row_id_sequences {
-        row_id_maps.push(match retention {
-            OldRowRetention::Live => live_row_ids(frag_by_id.get(frag_id), seq).await?,
-            OldRowRetention::Covered => RowAddrTreeMap::from(seq.as_ref()),
-        });
+        row_id_maps.push(live_row_ids(frag_by_id.get(frag_id), seq).await?);
     }
     let row_id_map_refs = row_id_maps.iter().collect::<Vec<_>>();
 
@@ -145,37 +131,13 @@ pub async fn build_old_data_filter(
     deleted_old_frags: &RoaringBitmap,
 ) -> Result<Option<OldIndexDataFilter>> {
     if dataset.manifest.uses_stable_row_ids() {
-        let valid_old_row_ids =
-            build_stable_row_id_filter(dataset, effective_old_frags, OldRowRetention::Live).await?;
+        let valid_old_row_ids = build_stable_row_id_filter(dataset, effective_old_frags).await?;
         Ok(Some(OldIndexDataFilter::RowIds(valid_old_row_ids)))
     } else {
         Ok(Some(OldIndexDataFilter::Fragments {
             to_keep: effective_old_frags.clone(),
             to_remove: deleted_old_frags.clone(),
         }))
-    }
-}
-
-/// Build the filter that keeps exactly the rows a segment still covers.
-///
-/// Unlike [`build_old_data_filter`] this ignores deletion vectors, matching what the
-/// address-domain filter already does: a covered fragment's deleted rows stay in the
-/// index and are masked at query time. It exists for merge paths that only need to
-/// drop rows whose fragment the segment lost, such as after an in-place column update.
-pub async fn build_coverage_filter(
-    dataset: &Dataset,
-    effective_old_frags: &RoaringBitmap,
-) -> Result<OldIndexDataFilter> {
-    if dataset.manifest.uses_stable_row_ids() {
-        let covered_row_ids =
-            build_stable_row_id_filter(dataset, effective_old_frags, OldRowRetention::Covered)
-                .await?;
-        Ok(OldIndexDataFilter::RowIds(covered_row_ids))
-    } else {
-        Ok(OldIndexDataFilter::Fragments {
-            to_keep: effective_old_frags.clone(),
-            to_remove: RoaringBitmap::new(),
-        })
     }
 }
 
@@ -1308,12 +1270,9 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     let old_data_filter = if selected_indices.is_empty() {
                         None
                     } else if dataset.manifest.uses_stable_row_ids() {
-                        let valid_old_row_ids = build_stable_row_id_filter(
-                            dataset.as_ref(),
-                            &effective_old_frags,
-                            OldRowRetention::Live,
-                        )
-                        .await?;
+                        let valid_old_row_ids =
+                            build_stable_row_id_filter(dataset.as_ref(), &effective_old_frags)
+                                .await?;
                         Some(OldIndexDataFilter::RowIds(valid_old_row_ids))
                     } else {
                         Some(OldIndexDataFilter::Fragments {
@@ -3705,6 +3664,178 @@ mod tests {
                 hits[0]
             );
         }
+    }
+
+    /// The ordinary update path (`UpdateBuilder`, `UpdateMode::RewriteRows`) commits
+    /// `fields_modified: vec![]`, so the old fragment keeps its place in the segment's
+    /// bitmap while its physical row is only deletion-marked. Under stable row ids the
+    /// rewritten copy reuses the same row id, so a merge that keeps every covered row
+    /// emits that id twice and the read-time filter admits both: the id is live again
+    /// at its new address. Coverage alone is therefore not a sufficient merge filter.
+    #[rstest]
+    // The two optimize modes read existing rows through different code, and both must
+    // filter: an explicit merge through `take_partition_batches`, and the default
+    // options over under-sized partitions through `partition_row_ids`, which feeds the
+    // join that rebuilds them.
+    #[case::merge(1, OptimizeOptions::merge(1))]
+    #[case::join(4, OptimizeOptions::new())]
+    #[tokio::test]
+    async fn test_optimize_vector_index_drops_rewritten_rows_on_merge(
+        #[case] num_partitions: usize,
+        #[case] optimize_options: OptimizeOptions,
+        // Only the stable-row-id scheme can duplicate: an address-domain rewrite lands
+        // at a new address, so the stale posting is masked at query time.
+        #[values(false, true)] enable_stable_row_ids: bool,
+    ) {
+        use crate::dataset::UpdateBuilder;
+        use arrow::datatypes::UInt64Type;
+        use arrow_array::Float32Array;
+        use lance_core::ROW_ID;
+        use lance_index::vector::DIST_COL;
+
+        const DIM: usize = 4;
+        const BULK_ROWS: usize = 1000;
+        const UPDATED_ID: u32 = 10_000;
+        const STALE_VALUE: f32 = 2.0;
+        const FRESH_VALUE: f32 = 10.8;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIM as i32,
+                ),
+                true,
+            ),
+        ]));
+        let constant_vector = |value: f32| {
+            FixedSizeListArray::try_new_from_values(
+                Float32Array::from_iter_values(std::iter::repeat_n(value, DIM)),
+                DIM as i32,
+            )
+            .unwrap()
+        };
+
+        // The updated row shares its fragment with the bulk rows, so the update leaves
+        // that fragment covered by the segment with one row deletion-marked instead of
+        // retiring it. The bulk vectors sit in [0, 1), far from the query, so a
+        // surviving stale copy of the updated row ranks well inside top-k.
+        let bulk = generate_random_array_with_seed::<Float32Type>(BULK_ROWS * DIM, [42; 32]);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from_iter_values(
+                    (0..BULK_ROWS as u32).chain(std::iter::once(UPDATED_ID)),
+                )),
+                Arc::new(
+                    FixedSizeListArray::try_new_from_values(
+                        Float32Array::from_iter_values(
+                            bulk.values()
+                                .iter()
+                                .copied()
+                                .chain(std::iter::repeat_n(STALE_VALUE, DIM)),
+                        ),
+                        DIM as i32,
+                    )
+                    .unwrap(),
+                ),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                enable_stable_row_ids,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                None,
+                &VectorIndexParams::ivf_flat(num_partitions, MetricType::L2),
+                true,
+            )
+            .await
+            .unwrap();
+
+        let fresh_literal = format!(
+            "array[{}]",
+            std::iter::repeat_n(FRESH_VALUE.to_string(), DIM)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let mut dataset = UpdateBuilder::new(Arc::new(dataset))
+            .update_where(&format!("id = {UPDATED_ID}"))
+            .unwrap()
+            .set("vector", &fresh_literal)
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap()
+            .new_dataset
+            .as_ref()
+            .clone();
+        dataset.optimize_indices(&optimize_options).await.unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let segments = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(segments.len(), 1, "merge must leave a single segment");
+        let partitions_after = dataset
+            .open_vector_index("vector", &segments[0].uuid, &NoOpMetricsCollector)
+            .await
+            .unwrap()
+            .ivf_model()
+            .num_partitions();
+        // A join is what routes existing rows through `partition_row_ids`; without it
+        // this case would silently degrade into a second copy of the merge case.
+        assert!(
+            num_partitions == 1 || partitions_after < num_partitions,
+            "expected a join, but the index still has {partitions_after} partitions"
+        );
+
+        let mut scanner = dataset.scan();
+        scanner
+            .nearest("vector", &constant_vector(FRESH_VALUE).value(0), 10)
+            .unwrap()
+            .with_row_id()
+            .project(&["id"])
+            .unwrap();
+        let results = scanner.try_into_batch().await.unwrap();
+        let hits = results["id"]
+            .as_primitive::<UInt32Type>()
+            .values()
+            .iter()
+            .zip(results[DIST_COL].as_primitive::<Float32Type>().values())
+            .filter(|(id, _)| **id == UPDATED_ID)
+            .map(|(_, distance)| *distance)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            hits.len(),
+            1,
+            "rewritten row returned {} times after optimize; row ids = {:?}",
+            hits.len(),
+            results[ROW_ID].as_primitive::<UInt64Type>().values()
+        );
+        // The pre-update vector would sit at (FRESH - STALE)^2 * DIM from the query, so
+        // anything but ~0 means the stale copy is the one that survived.
+        assert!(
+            hits[0] < 1.0,
+            "surviving copy is the pre-update one: distance {} to the updated vector",
+            hits[0]
+        );
     }
 
     /// Under stable row ids, updating an indexed column and then calling

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -54,9 +54,20 @@ pub struct IndexMergeResults<'a> {
     pub files: Vec<lance_table::format::IndexFile>,
 }
 
+/// Which rows of a still-covered fragment an old-data filter keeps.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OldRowRetention {
+    /// Every row the fragment ever held. Coverage is the only criterion.
+    Covered,
+    /// Only rows the fragment's deletion vector still considers live, so an old
+    /// posting for a row rewritten under the same stable row id is dropped too.
+    Live,
+}
+
 async fn build_stable_row_id_filter(
     dataset: &Dataset,
     effective_old_frags: &RoaringBitmap,
+    retention: OldRowRetention,
 ) -> Result<RowAddrTreeMap> {
     // For stable row IDs we cannot derive fragment ownership from row_id bits.
     // Instead, we:
@@ -87,7 +98,10 @@ async fn build_stable_row_id_filter(
 
     let mut row_id_maps = Vec::with_capacity(row_id_sequences.len());
     for (frag_id, seq) in &row_id_sequences {
-        row_id_maps.push(live_row_ids(frag_by_id.get(frag_id), seq).await?);
+        row_id_maps.push(match retention {
+            OldRowRetention::Live => live_row_ids(frag_by_id.get(frag_id), seq).await?,
+            OldRowRetention::Covered => RowAddrTreeMap::from(seq.as_ref()),
+        });
     }
     let row_id_map_refs = row_id_maps.iter().collect::<Vec<_>>();
 
@@ -131,13 +145,37 @@ pub async fn build_old_data_filter(
     deleted_old_frags: &RoaringBitmap,
 ) -> Result<Option<OldIndexDataFilter>> {
     if dataset.manifest.uses_stable_row_ids() {
-        let valid_old_row_ids = build_stable_row_id_filter(dataset, effective_old_frags).await?;
+        let valid_old_row_ids =
+            build_stable_row_id_filter(dataset, effective_old_frags, OldRowRetention::Live).await?;
         Ok(Some(OldIndexDataFilter::RowIds(valid_old_row_ids)))
     } else {
         Ok(Some(OldIndexDataFilter::Fragments {
             to_keep: effective_old_frags.clone(),
             to_remove: deleted_old_frags.clone(),
         }))
+    }
+}
+
+/// Build the filter that keeps exactly the rows a segment still covers.
+///
+/// Unlike [`build_old_data_filter`] this ignores deletion vectors, matching what the
+/// address-domain filter already does: a covered fragment's deleted rows stay in the
+/// index and are masked at query time. It exists for merge paths that only need to
+/// drop rows whose fragment the segment lost, such as after an in-place column update.
+pub async fn build_coverage_filter(
+    dataset: &Dataset,
+    effective_old_frags: &RoaringBitmap,
+) -> Result<OldIndexDataFilter> {
+    if dataset.manifest.uses_stable_row_ids() {
+        let covered_row_ids =
+            build_stable_row_id_filter(dataset, effective_old_frags, OldRowRetention::Covered)
+                .await?;
+        Ok(OldIndexDataFilter::RowIds(covered_row_ids))
+    } else {
+        Ok(OldIndexDataFilter::Fragments {
+            to_keep: effective_old_frags.clone(),
+            to_remove: RoaringBitmap::new(),
+        })
     }
 }
 
@@ -1270,9 +1308,12 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     let old_data_filter = if selected_indices.is_empty() {
                         None
                     } else if dataset.manifest.uses_stable_row_ids() {
-                        let valid_old_row_ids =
-                            build_stable_row_id_filter(dataset.as_ref(), &effective_old_frags)
-                                .await?;
+                        let valid_old_row_ids = build_stable_row_id_filter(
+                            dataset.as_ref(),
+                            &effective_old_frags,
+                            OldRowRetention::Live,
+                        )
+                        .await?;
                         Some(OldIndexDataFilter::RowIds(valid_old_row_ids))
                     } else {
                         Some(OldIndexDataFilter::Fragments {
@@ -3466,6 +3507,204 @@ mod tests {
 
         let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
         assert_eq!(query_id_count(&dataset, "song-42").await, 1);
+    }
+
+    /// Updating an indexed vector column in place (`update_columns` +
+    /// `Operation::Update`) keeps the fragment id and the row address, so after the
+    /// fragment is pruned from the old segment's bitmap that segment still physically
+    /// holds the pre-update vector. Merging the segment must drop those rows: the merge
+    /// concatenates its physical rows with the freshly scanned ones and commits the
+    /// union of both coverages, so a surviving stale row is authorized by the same
+    /// bitmap as its fresh copy and no read-time filter can separate them.
+    #[rstest]
+    // IVF_FLAT keeps the vector verbatim, so the query distance tells which of the two
+    // copies survived. IVF_PQ re-uses the codebook trained before the update, which
+    // cannot represent the new value, so it only pins the row count and covers the
+    // transposed-code path in `take_partition_batches`.
+    #[case::ivf_flat(VectorIndexParams::ivf_flat(1, MetricType::L2), true)]
+    #[case::ivf_pq(VectorIndexParams::ivf_pq(1, 8, 16, MetricType::L2, 2), false)]
+    #[tokio::test]
+    async fn test_optimize_vector_index_drops_stale_rows_on_merge(
+        #[case] index_params: VectorIndexParams,
+        #[case] distance_is_exact: bool,
+        // The two row-id schemes take different filter branches: an address carries its
+        // fragment, a stable row id needs the fragments' persisted row-id sequences.
+        #[values(false, true)] enable_stable_row_ids: bool,
+    ) {
+        use crate::dataset::transaction::{Operation, UpdateMode, UpdatedFragmentOffsets};
+        use arrow::datatypes::UInt64Type;
+        use arrow_array::{Float32Array, RecordBatchReader, UInt64Array};
+        use lance_core::ROW_ID;
+        use lance_index::vector::DIST_COL;
+        use std::collections::HashMap;
+
+        // Must match the sub-vector count in the IVF_PQ case above.
+        const DIM: usize = 16;
+        const BULK_ROWS: usize = 1000;
+        const UPDATED_ID: u32 = 10_000;
+        const STALE_VALUE: f32 = 2.0;
+        const FRESH_VALUE: f32 = 10.8;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let vector_type = DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            DIM as i32,
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt32, false),
+            Field::new("vector", vector_type.clone(), true),
+        ]));
+        let constant_vector = |value: f32| {
+            FixedSizeListArray::try_new_from_values(
+                Float32Array::from_iter_values(std::iter::repeat_n(value, DIM)),
+                DIM as i32,
+            )
+            .unwrap()
+        };
+
+        // Fragment 0: bulk vectors in [0, 1). None of them is near the query, so a
+        // surviving stale copy of the updated row ranks well inside top-k.
+        let bulk = generate_random_array_with_seed::<Float32Type>(BULK_ROWS * DIM, [42; 32]);
+        let bulk_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from_iter_values(0..BULK_ROWS as u32)),
+                Arc::new(FixedSizeListArray::try_new_from_values(bulk, DIM as i32).unwrap()),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(bulk_batch)], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                enable_stable_row_ids,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Fragment 1: the single row that gets updated in place.
+        let stale_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from_iter_values([UPDATED_ID])),
+                Arc::new(constant_vector(STALE_VALUE)),
+            ],
+        )
+        .unwrap();
+        dataset
+            .append(
+                RecordBatchIterator::new(vec![Ok(stale_batch)], schema.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 2);
+
+        // One segment covering both fragments.
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &index_params, true)
+            .await
+            .unwrap();
+
+        let mut fragment = dataset.get_fragment(1).unwrap();
+        let mut fragment_scan = fragment.scan();
+        fragment_scan.with_row_id();
+        let updated_row_id = fragment_scan.try_into_batch().await.unwrap()[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .value(0);
+
+        let update_schema = Arc::new(Schema::new(vec![
+            Field::new(ROW_ID, DataType::UInt64, false),
+            Field::new("vector", vector_type, true),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            update_schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from_iter_values([updated_row_id])),
+                Arc::new(constant_vector(FRESH_VALUE)),
+            ],
+        )
+        .unwrap();
+        let right_stream: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+            vec![Ok(update_batch)],
+            update_schema,
+        ));
+        let updated = fragment
+            .update_columns_with_offsets(right_stream, ROW_ID, ROW_ID)
+            .await
+            .unwrap();
+        let updated_fragment_id = updated.fragment.id;
+        let dataset = Dataset::commit(
+            test_uri,
+            Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![updated.fragment],
+                new_fragments: vec![],
+                fields_modified: updated.fields_modified,
+                compacted_sstables: Vec::new(),
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_fragment_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                    updated_fragment_id,
+                    updated.matched_offsets,
+                )]))),
+            },
+            Some(dataset.version().version),
+            None,
+            None,
+            Default::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        let mut dataset = dataset;
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(1))
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let segments = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(segments.len(), 1, "merge must leave a single segment");
+
+        let mut scanner = dataset.scan();
+        scanner
+            .nearest("vector", &constant_vector(FRESH_VALUE).value(0), 10)
+            .unwrap()
+            .with_row_id()
+            .project(&["id"])
+            .unwrap();
+        let results = scanner.try_into_batch().await.unwrap();
+        let hits = results["id"]
+            .as_primitive::<UInt32Type>()
+            .values()
+            .iter()
+            .zip(results[DIST_COL].as_primitive::<Float32Type>().values())
+            .filter(|(id, _)| **id == UPDATED_ID)
+            .map(|(_, distance)| *distance)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            hits.len(),
+            1,
+            "updated row returned {} times after merge; row ids = {:?}",
+            hits.len(),
+            results[ROW_ID].as_primitive::<UInt64Type>().values()
+        );
+        if distance_is_exact {
+            // The pre-update vector would sit at (FRESH - STALE)^2 * DIM from the query,
+            // so anything but ~0 means the stale copy is the one that survived.
+            assert!(
+                hits[0] < 1.0,
+                "surviving copy is the pre-update one: distance {} to the updated vector",
+                hits[0]
+            );
+        }
     }
 
     /// Under stable row ids, updating an indexed column and then calling

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -65,7 +65,7 @@ use lance_index::{
 };
 use lance_index::{
     INDEX_METADATA_SCHEMA_KEY, IndexMetadata, IndexType, MAX_PARTITION_SIZE_FACTOR,
-    MIN_PARTITION_SIZE_PERCENT,
+    MIN_PARTITION_SIZE_PERCENT, scalar::OldIndexDataFilter,
 };
 use lance_io::local::to_local_path;
 use lance_io::stream::RecordBatchStream;
@@ -120,6 +120,32 @@ fn apply_centroid_splits(
     )?)
 }
 
+/// An index segment an optimize pass reads existing rows from, paired with the rows
+/// that segment is still allowed to contribute.
+///
+/// A segment's index file keeps every row it was built with, but the fragments it
+/// covers can shrink afterwards: an in-place column update rewrites the data and
+/// prunes the fragment from the segment's bitmap while the row keeps its address.
+/// Copying such a row into a merged segment would duplicate it, because the merged
+/// coverage also spans the fresh copy's fragment and nothing downstream can tell the
+/// two apart. `old_data_filter` is `None` when the segment's coverage is unchanged,
+/// in which case all of its rows are kept.
+#[derive(Clone)]
+pub struct ExistingIndex {
+    pub index: Arc<dyn VectorIndex>,
+    pub old_data_filter: Option<Arc<OldIndexDataFilter>>,
+}
+
+impl ExistingIndex {
+    /// An existing index whose rows are all still valid.
+    pub fn unfiltered(index: Arc<dyn VectorIndex>) -> Self {
+        Self {
+            index,
+            old_data_filter: None,
+        }
+    }
+}
+
 // Builder for IVF index
 // The builder will train the IVF model and quantizer, shuffle the dataset, and build the sub index
 // for each partition.
@@ -150,7 +176,7 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     shuffle_data_input: Mutex<Option<UnindexedStream>>,
 
     // fields for merging indices / remapping
-    existing_indices: Vec<Arc<dyn VectorIndex>>,
+    existing_indices: Vec<ExistingIndex>,
 
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
 
@@ -280,7 +306,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             quantizer: Some(ivf_index.quantizer().try_into()?),
             shuffle_reader: None,
             shuffle_data_input: Mutex::new(None),
-            existing_indices: vec![index],
+            existing_indices: vec![ExistingIndex::unfiltered(index)],
             frag_reuse_index: None,
             fragment_filter: None,
             optimize_options: None,
@@ -346,7 +372,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         };
 
         log::info!("remap {} partitions", ivf.num_partitions());
-        let existing_index = self.existing_indices[0].clone();
+        let existing_index = self.existing_indices[0].index.clone();
         let mapping = Arc::new(mapping.clone());
         let build_iter =
             (0..ivf.num_partitions()).map(move |part_id| {
@@ -390,8 +416,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         self
     }
 
+    /// Read existing rows from `indices`, keeping every row they hold.
     pub fn with_existing_indices(&mut self, indices: Vec<Arc<dyn VectorIndex>>) -> &mut Self {
-        self.existing_indices = indices;
+        self.existing_indices = indices.into_iter().map(ExistingIndex::unfiltered).collect();
+        self
+    }
+
+    /// Read existing rows from `sources`, keeping only the rows each segment is still
+    /// allowed to contribute. See [`ExistingIndex`].
+    pub fn with_existing_index_sources(&mut self, sources: Vec<ExistingIndex>) -> &mut Self {
+        self.existing_indices = sources;
         self
     }
 
@@ -1026,12 +1060,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     #[instrument(name = "take_partition_batches", level = "debug", skip_all)]
     async fn take_partition_batches(
         part_id: usize,
-        existing_indices: &[Arc<dyn VectorIndex>],
+        existing_indices: &[ExistingIndex],
         reader: Option<&dyn ShuffleReader>,
     ) -> Result<(Vec<RecordBatch>, f64)> {
         let mut batches = Vec::new();
-        for existing_index in existing_indices.iter() {
-            let existing_index = existing_index
+        for source in existing_indices.iter() {
+            let existing_index = source
+                .index
                 .as_any()
                 .downcast_ref::<IVFIndex<S, Q>>()
                 .ok_or(Error::invalid_input("existing index is not IVF index"))?;
@@ -1081,6 +1116,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     }
                 }
                 _ => {}
+            }
+
+            // Drop rows this segment no longer covers. They are physically still in
+            // its index file, and the merged segment's coverage spans their fragments
+            // again, so keeping them would emit the same row twice.
+            if let Some(filter) = source.old_data_filter.as_ref() {
+                for batch in part_batches.iter_mut() {
+                    let keep = filter.filter_row_ids(batch[ROW_ID].as_primitive::<UInt64Type>());
+                    if keep.true_count() < batch.num_rows() {
+                        *batch = arrow::compute::filter_record_batch(batch, &keep)?;
+                    }
+                }
             }
 
             batches.extend(part_batches);
@@ -1451,7 +1498,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     fn check_partition_adjustment(
         ivf: &IvfModel,
         reader: &dyn ShuffleReader,
-        existing_indices: &[Arc<dyn VectorIndex>],
+        existing_indices: &[ExistingIndex],
     ) -> Result<(Vec<usize>, Option<usize>)> {
         let index_type = IndexType::try_from(
             index_type_string(S::name().try_into()?, Q::quantization_type()).as_str(),
@@ -1462,8 +1509,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let mut min_partition_size = usize::MAX;
         for partition in 0..ivf.num_partitions() {
             let mut num_rows = reader.partition_size(partition)?;
-            for index in existing_indices.iter() {
-                num_rows += index.partition_size(partition);
+            for source in existing_indices.iter() {
+                num_rows += source.index.partition_size(partition);
             }
             if num_rows > MAX_PARTITION_SIZE_FACTOR * index_type.target_partition_size() {
                 split_partitions.push(partition);
@@ -2030,7 +2077,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     async fn partition_row_ids(&self, part_idx: usize) -> Result<Vec<u64>> {
         // existing part: read from the existing indices
         let mut row_ids = Vec::new();
-        for index in self.existing_indices.iter() {
+        for source in self.existing_indices.iter() {
+            let index = &source.index;
             if part_idx >= index.ivf_model().num_partitions() {
                 // there was a bug that may cause delta indices have different number of partitions,
                 // it's safe to skip loading the extra partition, and split/join the existing partitions,
@@ -2047,7 +2095,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .partition_reader(part_idx, false, &NoOpMetricsCollector)
                 .await?;
             while let Some(batch) = reader.try_next().await? {
-                row_ids.extend(batch[ROW_ID].as_primitive::<UInt64Type>().values());
+                let batch_row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+                match source.old_data_filter.as_ref() {
+                    // Rows the segment no longer covers must not be reassigned to a
+                    // partition; their live copy is contributed by another source.
+                    Some(filter) => row_ids.extend(
+                        batch_row_ids
+                            .values()
+                            .iter()
+                            .zip(filter.filter_row_ids(batch_row_ids).values().iter())
+                            .filter_map(|(row_id, keep)| keep.then_some(row_id)),
+                    ),
+                    None => row_ids.extend(batch_row_ids.values()),
+                }
             }
         }
 

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -76,11 +76,14 @@ use lance_table::format::IndexFile;
 use log::info;
 use object_store::path::Path;
 use prost::Message;
+use roaring::RoaringBitmap;
+use tokio::sync::OnceCell;
 use tracing::{Level, instrument, span};
 
 use crate::Dataset;
 use crate::dataset::ProjectionRequest;
 use crate::dataset::index::dataset_format_version;
+use crate::index::append::build_old_data_filter;
 use crate::index::vector::ivf::v2::PartitionEntry;
 use crate::index::vector::utils::infer_vector_dim;
 
@@ -123,17 +126,28 @@ fn apply_centroid_splits(
 /// An index segment an optimize pass reads existing rows from, paired with the rows
 /// that segment is still allowed to contribute.
 ///
-/// A segment's index file keeps every row it was built with, but the fragments it
-/// covers can shrink afterwards: an in-place column update rewrites the data and
-/// prunes the fragment from the segment's bitmap while the row keeps its address.
-/// Copying such a row into a merged segment would duplicate it, because the merged
-/// coverage also spans the fresh copy's fragment and nothing downstream can tell the
-/// two apart. `old_data_filter` is `None` when the segment's coverage is unchanged,
-/// in which case all of its rows are kept.
+/// A segment's index file keeps every row it was built with, but the rows it may still
+/// contribute shrink afterwards: an update rewrites a row and either prunes its
+/// fragment from the segment's bitmap (in-place column rewrite) or deletion-marks the
+/// old physical row while the rewritten copy reuses its stable row id. Copying such a
+/// row into a merged segment would duplicate it, because the merged coverage also spans
+/// the fresh copy and nothing downstream can tell the two apart.
+///
+/// The filter is resolved on first use rather than up front: under stable row ids
+/// building it loads every covered fragment's row-id sequence, and the common optimize
+/// pass appends a delta without reading a single existing row.
 #[derive(Clone)]
 pub struct ExistingIndex {
     pub index: Arc<dyn VectorIndex>,
-    pub old_data_filter: Option<Arc<OldIndexDataFilter>>,
+    coverage: Option<Arc<SegmentCoverage>>,
+}
+
+/// The inputs [`ExistingIndex::old_data_filter`] needs, plus the filter once built.
+struct SegmentCoverage {
+    dataset: Dataset,
+    effective_frags: RoaringBitmap,
+    deleted_frags: RoaringBitmap,
+    filter: OnceCell<Option<OldIndexDataFilter>>,
 }
 
 impl ExistingIndex {
@@ -141,8 +155,54 @@ impl ExistingIndex {
     pub fn unfiltered(index: Arc<dyn VectorIndex>) -> Self {
         Self {
             index,
-            old_data_filter: None,
+            coverage: None,
         }
+    }
+
+    /// An existing index that may only contribute rows still live in `effective_frags`.
+    pub fn with_coverage(
+        index: Arc<dyn VectorIndex>,
+        dataset: Dataset,
+        effective_frags: RoaringBitmap,
+        deleted_frags: RoaringBitmap,
+    ) -> Self {
+        Self {
+            index,
+            coverage: Some(Arc::new(SegmentCoverage {
+                dataset,
+                effective_frags,
+                deleted_frags,
+                filter: OnceCell::new(),
+            })),
+        }
+    }
+
+    /// Whether the filter has already been built. A pass that reads no existing rows
+    /// must never pay for one.
+    #[cfg(test)]
+    pub(crate) fn filter_is_built(&self) -> bool {
+        self.coverage
+            .as_deref()
+            .is_some_and(|coverage| coverage.filter.initialized())
+    }
+
+    /// The filter to apply to this segment's stored rows, or `None` when every row it
+    /// holds is still valid. Built once and shared by all partitions.
+    pub(crate) async fn old_data_filter(&self) -> Result<Option<&OldIndexDataFilter>> {
+        let Some(coverage) = self.coverage.as_deref() else {
+            return Ok(None);
+        };
+        let filter = coverage
+            .filter
+            .get_or_try_init(|| {
+                build_old_data_filter(
+                    &coverage.dataset,
+                    &coverage.effective_frags,
+                    &coverage.deleted_frags,
+                )
+            })
+            .await?;
+        Ok(filter.as_ref())
     }
 }
 
@@ -1077,6 +1137,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 continue;
             }
 
+            // Resolved before the partition is decoded: partitions are built
+            // concurrently, so whichever one builds the filter would otherwise hold a
+            // decoded partition per in-flight task while the rest wait on it.
+            let old_data_filter = source.old_data_filter().await?;
+
             let part_storage = existing_index.load_partition_storage(part_id, None).await?;
             let mut part_batches = part_storage.to_batches()?.collect::<Vec<_>>();
             // for PQ, the PQ codes are transposed, so we need to transpose them back
@@ -1118,10 +1183,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 _ => {}
             }
 
-            // Drop rows this segment no longer covers. They are physically still in
-            // its index file, and the merged segment's coverage spans their fragments
+            // Drop rows this segment may no longer contribute. They are physically
+            // still in its index file, and the merged segment covers their live copies
             // again, so keeping them would emit the same row twice.
-            if let Some(filter) = source.old_data_filter.as_ref() {
+            if let Some(filter) = old_data_filter {
                 for batch in part_batches.iter_mut() {
                     let keep = filter.filter_row_ids(batch[ROW_ID].as_primitive::<UInt64Type>());
                     if keep.true_count() < batch.num_rows() {
@@ -2094,11 +2159,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             let mut reader = index
                 .partition_reader(part_idx, false, &NoOpMetricsCollector)
                 .await?;
+            let old_data_filter = source.old_data_filter().await?;
             while let Some(batch) = reader.try_next().await? {
                 let batch_row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
-                match source.old_data_filter.as_ref() {
-                    // Rows the segment no longer covers must not be reassigned to a
-                    // partition; their live copy is contributed by another source.
+                match old_data_filter {
+                    // Rows the segment may no longer contribute must not be reassigned
+                    // to a partition; their live copy comes from another source.
                     Some(filter) => row_ids.extend(
                         batch_row_ids
                             .values()

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -15,7 +15,6 @@ use super::{
 use crate::dataset::index::dataset_format_version;
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
-use crate::index::append::build_coverage_filter;
 use crate::index::vector::open_index_file;
 use crate::index::vector::utils::{get_vector_dim, get_vector_type};
 use crate::{
@@ -568,40 +567,29 @@ fn shared_quantizer_model(left: &Quantizer, right: &Quantizer) -> bool {
     }
 }
 
-/// Pair every segment with the rows it may still contribute when this optimize pass
-/// copies its data into the new index.
+/// Pair every segment with the coverage that decides which of its rows this optimize
+/// pass may still copy into the new index.
 ///
-/// Building a filter costs a row-id sequence load under stable row ids, so it is
-/// skipped when the pass only appends a delta and never reads existing rows, and
-/// when any segment predates fragment bitmaps and its coverage is therefore unknown.
-async fn existing_index_sources(
+/// A segment that predates fragment bitmaps has unknown coverage, so it keeps every
+/// row it holds. Turning coverage into a filter is deferred to the first partition
+/// that actually reads the segment, because under stable row ids it costs a row-id
+/// sequence load per covered fragment and most passes only append a delta.
+fn existing_index_sources(
     dataset: &Dataset,
     logical_index: &LogicalIvfView<'_>,
-    options: &OptimizeOptions,
-) -> Result<Vec<ExistingIndex>> {
-    let segments = logical_index.segments().collect::<Vec<_>>();
-    let reads_existing_rows = options.num_indices_to_merge != Some(0) || options.retrain;
-    let all_have_bitmaps = segments
-        .iter()
-        .all(|(metadata, _)| metadata.fragment_bitmap.is_some());
-    if !reads_existing_rows || !all_have_bitmaps {
-        return Ok(segments
-            .into_iter()
-            .map(|(_, index)| ExistingIndex::unfiltered(index.clone()))
-            .collect());
-    }
-
-    let mut sources = Vec::with_capacity(segments.len());
-    for (metadata, index) in segments {
-        let effective = metadata
-            .effective_fragment_bitmap(&dataset.fragment_bitmap)
-            .unwrap_or_default();
-        sources.push(ExistingIndex {
-            index: index.clone(),
-            old_data_filter: Some(Arc::new(build_coverage_filter(dataset, &effective).await?)),
-        });
-    }
-    Ok(sources)
+) -> Vec<ExistingIndex> {
+    logical_index
+        .segments()
+        .map(|(metadata, index)| {
+            let (Some(effective), Some(deleted)) = (
+                metadata.effective_fragment_bitmap(&dataset.fragment_bitmap),
+                metadata.deleted_fragment_bitmap(&dataset.fragment_bitmap),
+            ) else {
+                return ExistingIndex::unfiltered(index.clone());
+            };
+            ExistingIndex::with_coverage(index.clone(), dataset.clone(), effective, deleted)
+        })
+        .collect()
 }
 
 // TODO: move to `lance-index` crate.
@@ -626,7 +614,7 @@ pub(crate) async fn optimize_vector_indices(
     // try cast to v1 IVFIndex,
     // fallback to v2 IVFIndex if it's not v1 IVFIndex
     if !existing_indices[0].as_any().is::<IVFIndex>() {
-        let sources = existing_index_sources(&dataset, logical_index, options).await?;
+        let sources = existing_index_sources(&dataset, logical_index);
         return optimize_vector_indices_v2(&dataset, unindexed, vector_column, &sources, options)
             .await;
     }
@@ -4771,6 +4759,7 @@ mod tests {
     use lance_datagen::{ArrayGeneratorExt, BatchCount, Dimension, RowCount, array, gen_batch};
     use lance_index::VECTOR_INDEX_VERSION;
     use lance_index::metrics::NoOpMetricsCollector;
+    use lance_index::scalar::OldIndexDataFilter;
     use lance_index::vector::sq::builder::SQBuildParams;
     use lance_linalg::distance::l2_distance_batch;
     use lance_testing::datagen::{
@@ -4788,6 +4777,117 @@ mod tests {
     use crate::utils::test::copy_test_data_to_tmp;
 
     const DIM: usize = 32;
+
+    /// Building a merge filter loads a row-id sequence per covered fragment under
+    /// stable row ids, and an optimize pass that only appends a delta reads no existing
+    /// row at all. Such a pass must therefore build no filter, and a pass that does
+    /// merge must build one and reuse it across partitions.
+    #[tokio::test]
+    async fn test_optimize_builds_merge_filters_only_when_merging() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let make_batch = || {
+            gen_batch()
+                .col(
+                    "vector",
+                    array::rand_vec::<Float32Type>(Dimension::from(DIM as u32)),
+                )
+                .into_batch_rows(RowCount::from(256))
+                .unwrap()
+        };
+        let batch = make_batch();
+        let schema = batch.schema();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        // A single partition keeps `check_partition_adjustment` from selecting a split
+        // or a join, which would legitimately merge every segment.
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                None,
+                &VectorIndexParams::ivf_flat(1, MetricType::L2),
+                true,
+            )
+            .await
+            .unwrap();
+        dataset
+            .append(
+                RecordBatchIterator::new(vec![Ok(make_batch())], schema),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let logical_index = dataset
+            .open_logical_vector_index("vector", "vector_idx")
+            .await
+            .unwrap();
+        let ivf_view = logical_index.as_ivf().unwrap();
+        let new_data = |fragments| async {
+            let mut scanner = dataset.scan();
+            scanner
+                .with_fragments(fragments)
+                .with_row_id()
+                .project(&["vector"])
+                .unwrap();
+            scanner.try_into_stream().await.unwrap()
+        };
+        let unindexed = dataset.unindexed_fragments("vector_idx").await.unwrap();
+        assert_eq!(
+            unindexed.len(),
+            1,
+            "the appended fragment must be unindexed"
+        );
+
+        // `ExistingIndex` shares its coverage behind an `Arc`, so the sources handed to
+        // the builder report what the builder actually did with them.
+        let sources = existing_index_sources(&dataset, &ivf_view);
+        optimize_vector_indices_v2(
+            &dataset,
+            Some(new_data(unindexed.clone()).await),
+            "vector",
+            &sources,
+            &OptimizeOptions::new(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            sources.iter().all(|source| !source.filter_is_built()),
+            "a delta append reads no existing row, so it must build no filter"
+        );
+
+        let sources = existing_index_sources(&dataset, &ivf_view);
+        optimize_vector_indices_v2(
+            &dataset,
+            Some(new_data(unindexed).await),
+            "vector",
+            &sources,
+            &OptimizeOptions::merge(1),
+        )
+        .await
+        .unwrap();
+        assert!(
+            sources.iter().all(|source| source.filter_is_built()),
+            "a merge reads existing rows, so it must build a filter per merged segment"
+        );
+        assert!(
+            matches!(
+                sources[0].old_data_filter().await.unwrap(),
+                Some(OldIndexDataFilter::RowIds(_))
+            ),
+            "a stable-row-id segment must filter on exact row-id membership"
+        );
+    }
 
     #[test]
     fn test_shared_quantizer_model_compares_skipped_payloads() {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -9,12 +9,13 @@ use super::{
     utils::{filter_finite_training_data, maybe_sample_training_data},
 };
 use super::{
-    builder::{IvfIndexBuilder, index_type_string},
+    builder::{ExistingIndex, IvfIndexBuilder, index_type_string},
     utils::PartitionLoadLock,
 };
 use crate::dataset::index::dataset_format_version;
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::append::build_coverage_filter;
 use crate::index::vector::open_index_file;
 use crate::index::vector::utils::{get_vector_dim, get_vector_type};
 use crate::{
@@ -567,6 +568,42 @@ fn shared_quantizer_model(left: &Quantizer, right: &Quantizer) -> bool {
     }
 }
 
+/// Pair every segment with the rows it may still contribute when this optimize pass
+/// copies its data into the new index.
+///
+/// Building a filter costs a row-id sequence load under stable row ids, so it is
+/// skipped when the pass only appends a delta and never reads existing rows, and
+/// when any segment predates fragment bitmaps and its coverage is therefore unknown.
+async fn existing_index_sources(
+    dataset: &Dataset,
+    logical_index: &LogicalIvfView<'_>,
+    options: &OptimizeOptions,
+) -> Result<Vec<ExistingIndex>> {
+    let segments = logical_index.segments().collect::<Vec<_>>();
+    let reads_existing_rows = options.num_indices_to_merge != Some(0) || options.retrain;
+    let all_have_bitmaps = segments
+        .iter()
+        .all(|(metadata, _)| metadata.fragment_bitmap.is_some());
+    if !reads_existing_rows || !all_have_bitmaps {
+        return Ok(segments
+            .into_iter()
+            .map(|(_, index)| ExistingIndex::unfiltered(index.clone()))
+            .collect());
+    }
+
+    let mut sources = Vec::with_capacity(segments.len());
+    for (metadata, index) in segments {
+        let effective = metadata
+            .effective_fragment_bitmap(&dataset.fragment_bitmap)
+            .unwrap_or_default();
+        sources.push(ExistingIndex {
+            index: index.clone(),
+            old_data_filter: Some(Arc::new(build_coverage_filter(dataset, &effective).await?)),
+        });
+    }
+    Ok(sources)
+}
+
 // TODO: move to `lance-index` crate.
 ///
 /// Returns (new_uuid, num_indices_merged, files)
@@ -589,14 +626,9 @@ pub(crate) async fn optimize_vector_indices(
     // try cast to v1 IVFIndex,
     // fallback to v2 IVFIndex if it's not v1 IVFIndex
     if !existing_indices[0].as_any().is::<IVFIndex>() {
-        return optimize_vector_indices_v2(
-            &dataset,
-            unindexed,
-            vector_column,
-            &existing_indices,
-            options,
-        )
-        .await;
+        let sources = existing_index_sources(&dataset, logical_index, options).await?;
+        return optimize_vector_indices_v2(&dataset, unindexed, vector_column, &sources, options)
+            .await;
     }
 
     let new_uuid = Uuid::new_v4();
@@ -665,7 +697,7 @@ pub(crate) async fn optimize_vector_indices_v2(
     dataset: &Dataset,
     unindexed: Option<impl RecordBatchStream + Unpin + 'static>,
     vector_column: &str,
-    existing_indices: &[Arc<dyn VectorIndex>],
+    existing_indices: &[ExistingIndex],
     options: &OptimizeOptions,
 ) -> Result<(Uuid, usize, Vec<IndexFile>)> {
     // Sanity check the indices
@@ -678,11 +710,12 @@ pub(crate) async fn optimize_vector_indices_v2(
 
     let new_uuid = Uuid::new_v4();
     let index_dir = dataset.indices_dir().join(new_uuid.to_string());
-    let ivf_model = existing_indices[0].ivf_model();
-    let quantizer = existing_indices[0].quantizer();
-    let distance_type = existing_indices[0].metric_type();
+    let reference_index = &existing_indices[0].index;
+    let ivf_model = reference_index.ivf_model();
+    let quantizer = reference_index.quantizer();
+    let distance_type = reference_index.metric_type();
     let num_partitions = ivf_model.num_partitions();
-    let index_type = existing_indices[0].sub_index_type();
+    let index_type = reference_index.sub_index_type();
     let frag_reuse_index = dataset.open_frag_reuse_index(&NoOpMetricsCollector).await?;
 
     let format_version = dataset_format_version(dataset);
@@ -708,7 +741,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
-                .with_existing_indices(existing_indices.clone())
+                .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
                 .build()
@@ -726,7 +759,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
-                .with_existing_indices(existing_indices.clone())
+                .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
                 .build()
@@ -747,7 +780,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()
@@ -767,7 +800,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()
@@ -787,7 +820,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()
@@ -806,7 +839,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()
@@ -821,13 +854,13 @@ pub(crate) async fn optimize_vector_indices_v2(
                     index_dir,
                     distance_type,
                     shuffler,
-                    derive_hnsw_params(existing_indices[0].as_ref()),
+                    derive_hnsw_params(reference_index.as_ref()),
                     frag_reuse_index,
                     options.clone(),
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
-                .with_existing_indices(existing_indices.clone())
+                .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
                 .build()
@@ -839,13 +872,13 @@ pub(crate) async fn optimize_vector_indices_v2(
                     index_dir,
                     distance_type,
                     shuffler,
-                    derive_hnsw_params(existing_indices[0].as_ref()),
+                    derive_hnsw_params(reference_index.as_ref()),
                     frag_reuse_index,
                     options.clone(),
                 )?
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
-                .with_existing_indices(existing_indices.clone())
+                .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
                 .shuffle_data_input(unindexed)
                 .build()
@@ -860,13 +893,13 @@ pub(crate) async fn optimize_vector_indices_v2(
                 index_dir,
                 distance_type,
                 shuffler,
-                derive_hnsw_params(existing_indices[0].as_ref()),
+                derive_hnsw_params(reference_index.as_ref()),
                 frag_reuse_index,
                 options.clone(),
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()
@@ -880,13 +913,13 @@ pub(crate) async fn optimize_vector_indices_v2(
                 index_dir,
                 distance_type,
                 shuffler,
-                derive_hnsw_params(existing_indices[0].as_ref()),
+                derive_hnsw_params(reference_index.as_ref()),
                 frag_reuse_index,
                 options.clone(),
             )?
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
-            .with_existing_indices(existing_indices.clone())
+            .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
             .shuffle_data_input(unindexed)
             .build()

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -6404,7 +6404,6 @@ mod tests {
 
     struct OptimizeAfterDelete {
         deleted_row_ids: HashSet<u64>,
-        partition_row_ids_before: Vec<Vec<u64>>,
         index_row_ids: HashSet<u64>,
         num_partitions_after: usize,
         stats_json: String,
@@ -6449,17 +6448,6 @@ mod tests {
             .await
             .unwrap();
 
-        let index_ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
-        let flat = index_ctx
-            .index
-            .as_any()
-            .downcast_ref::<IvfFlatIndex>()
-            .expect("expected IvfFlat index");
-        let mut partition_row_ids_before = Vec::with_capacity(nlist);
-        for part in 0..flat.ivf.num_partitions() {
-            partition_row_ids_before.push(load_flat_partition_row_ids(flat, part).await);
-        }
-
         let deleted_row_ids = row_ids_matching(&dataset, delete_predicate).await;
         let live_row_ids = row_ids_matching(&dataset, keep_predicate).await;
         dataset.delete(delete_predicate).await.unwrap();
@@ -6499,7 +6487,6 @@ mod tests {
 
         OptimizeAfterDelete {
             deleted_row_ids,
-            partition_row_ids_before,
             index_row_ids,
             num_partitions_after,
             stats_json,
@@ -6519,29 +6506,15 @@ mod tests {
             run.stats_json
         );
 
-        // Only the joined partition is rebuilt from live rows; untouched
-        // partitions keep their deleted ids (filtered at query time).
-        let missing = run
-            .deleted_row_ids
-            .difference(&run.index_row_ids)
-            .copied()
-            .collect::<HashSet<_>>();
-        assert!(
-            !missing.is_empty(),
-            "joined partition should have contained deleted row ids"
-        );
-        let matches_one_partition = run.partition_row_ids_before.iter().any(|part_ids| {
-            let part_deleted = part_ids
-                .iter()
-                .copied()
-                .filter(|id| run.deleted_row_ids.contains(id))
-                .collect::<HashSet<_>>();
-            part_deleted == missing
-        });
-        assert!(
-            matches_one_partition,
-            "row ids dropped from the index should be exactly the joined partition's deleted ids"
-        );
+        // The join reads every partition's stored rows through the merge filter, so
+        // deleted ids are dropped index-wide and not just from the joined partition.
+        for row_id in &run.deleted_row_ids {
+            assert!(
+                !run.index_row_ids.contains(row_id),
+                "deleted row id {} still in index after join",
+                row_id
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Related: #7370, #7371 (the delta-append manifestation of the same invariant, fixed on the query side).

## Problem

`optimize_indices(num_indices_to_merge >= 1)` can leave two copies of the same row in a vector index, and a KNN query then returns that row twice, one ranked by its pre-update vector. This reproduces on `main` through either update path.

An in-place column update (`update_columns` + `LanceOperation.Update` in `RewriteColumns` mode) keeps the fragment id and the row address, and committing the `Update` prunes that fragment from the segment's `fragment_bitmap`. The ordinary update path (`UpdateBuilder`, `RewriteRows`) instead deletion-marks the old physical row and commits `fields_modified: vec![]`, so the fragment stays covered; under stable row ids the replacement reuses the row id, so no read-time filter can tell the copies apart. Either way the segment's index file still physically holds the pre-update vector.

## Root cause

`take_partition_batches` concatenates every physical batch of the old segment with the freshly scanned rows and applies no row filter, and `merge_indices_with_unindexed_frags` commits the union of both coverages. Both copies then sit in one segment whose bitmap legitimately spans their fragment.

This is the half of the invariant a read-time fix cannot reach. While the copies live in separate segments their bitmaps differ and a per-segment mask can separate them; once a merge folds them into one segment that information is gone from the manifest. Scalar indices solved the same class of bug on the write side in #7359; the vector path had no equivalent.

## Fix

Pair every existing segment with a filter for the rows it may still contribute, and apply it wherever old data is read: in `take_partition_batches` before fresh rows are concatenated, and in `partition_row_ids` so a stale row is not reassigned during a split or a join. `ExistingIndex` in `builder.rs` keeps a segment and its coverage together so the two cannot drift apart positionally, and `existing_index_sources` in `ivf.rs` builds them from `LogicalIvfView::segments()`, the last point where the per-segment `IndexMetadata` is available.

The filter is #7359's `OldIndexDataFilter`, built by the same `build_old_data_filter` the scalar merge path already calls, so both paths now agree on what a segment may contribute: exact live row-id membership under stable row ids, which drops a deletion-marked posting whose id a rewrite reused; fragment coverage under address-style row ids, which suffices because a rewrite there lands at a new address and the stale posting is masked at query time. `append.rs` needs no production change at all.

Filtering is free in the address domain and costs one row-id sequence load per merged segment under stable row ids, the same cost the scalar merge already pays. It is deferred until a partition actually reads a segment, so the default optimize pass, which merges nothing unless a split or join fires, never builds one. A segment predating fragment bitmaps has unknown coverage and keeps every row it holds.

## Tests

`test_optimize_vector_index_drops_stale_rows_on_merge` covers the in-place column rewrite across IVF_FLAT and IVF_PQ and both row-id schemes. All four fail without the fix with `updated row returned 2 times after merge`, both copies at the same address. IVF_FLAT stores the vector verbatim, so it also asserts the query distance and pins that the surviving copy is the post-update one; IVF_PQ covers the transposed-code path.

`test_optimize_vector_index_drops_rewritten_rows_on_merge` covers the `UpdateBuilder` path across both row-id schemes and both filter sites: an explicit `merge(1)` reading through `take_partition_batches`, and the default options over under-sized partitions reading through `partition_row_ids` to feed a join. It asserts the join actually happened so the case cannot degrade into a duplicate of the merge case. The stable-row-id cases fail with coverage-only filtering (`rewritten row returned 2 times after optimize; row ids = [1000, 1000, ...]`).

`test_optimize_builds_merge_filters_only_when_merging` drives a real optimize pass and asserts a delta append builds no filter while a merge builds one per merged segment. It was mutation-tested against `num_indices_to_merge.unwrap_or(0)` and fails when that default is widened.

`test_optimize_join_after_delete_with_stable_row_ids` asserted that partitions untouched by a join keep their deleted row ids. Live membership drops them index-wide, matching what its split sibling already asserted. The #7701 invariants the shared scenario pins, no live row lost and no fabricated id, are unchanged.

## Not covered

The legacy v1 `IVFIndex` merge path (`optimize_ivf_pq_indices` / `optimize_ivf_hnsw_indices` into `write_pq_partitions`) has the same unfiltered merge. Current writers do not emit that format, so it is left untouched per the legacy-boundary rule in `AGENTS.md`.
