### PR TITLE
feat(java): expose index segment sizes

### DIFF
--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -35,10 +35,15 @@ impl IntoJava for &Arc<dyn IndexDescription> {
         let metadata_list = export_vec(env, self.metadata())?;
         let details_json = self.details()?;
         let details = env.new_string(details_json)?;
+        let total_size_bytes = if let Some(size) = self.total_size_bytes() {
+            env.new_object("java/lang/Long", "(J)V", &[JValue::Long(size as i64)])?
+        } else {
+            JObject::null()
+        };
 
         let j_index_desc = env.new_object(
             "org/lance/index/IndexDescription",
-            "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;)V",
+            "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;Ljava/lang/Long;)V",
             &[
                 JValue::Object(&name),
                 JValue::Object(&field_ids_list),
@@ -47,6 +52,7 @@ impl IntoJava for &Arc<dyn IndexDescription> {
                 JValue::Long(rows_indexed),
                 JValue::Object(&metadata_list),
                 JValue::Object(&details),
+                JValue::Object(&total_size_bytes),
             ],
         )?;
         Ok(j_index_desc)
@@ -125,13 +131,19 @@ impl IntoJava for &IndexMetadata {
             JObject::null()
         };
 
+        let size_bytes = if let Some(size) = self.total_size_bytes() {
+            env.new_object("java/lang/Long", "(J)V", &[JValue::Long(size as i64)])?
+        } else {
+            JObject::null()
+        };
+
         // Determine index type from index_details type_url
         let index_type = determine_index_type(env, &self.index_details)?;
 
         // Create Index object
         Ok(env.new_object(
             "org/lance/index/Index",
-            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Lorg/lance/index/IndexType;)V",
+            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Ljava/lang/Long;Lorg/lance/index/IndexType;)V",
             &[
                 JValue::Object(&uuid),
                 JValue::Object(&fields),
@@ -142,6 +154,7 @@ impl IntoJava for &IndexMetadata {
                 JValue::Int(self.index_version),
                 JValue::Object(&created_at),
                 JValue::Object(&base_id),
+                JValue::Object(&size_bytes),
                 JValue::Object(&index_type),
             ],
         )?)

--- a/java/src/main/java/org/lance/index/Index.java
+++ b/java/src/main/java/org/lance/index/Index.java
@@ -36,6 +36,7 @@ public class Index {
   private final int indexVersion;
   private final Instant createdAt;
   private final Integer baseId;
+  private final Long sizeBytes;
   private final IndexType indexType;
 
   private Index(
@@ -48,6 +49,7 @@ public class Index {
       int indexVersion,
       Instant createdAt,
       Integer baseId,
+      Long sizeBytes,
       IndexType indexType) {
     this.uuid = uuid;
     this.fields = fields;
@@ -58,6 +60,7 @@ public class Index {
     this.indexVersion = indexVersion;
     this.createdAt = createdAt;
     this.baseId = baseId;
+    this.sizeBytes = sizeBytes;
     this.indexType = indexType;
   }
 
@@ -105,6 +108,17 @@ public class Index {
   }
 
   /**
+   * Get the total size of all files in this physical index segment.
+   *
+   * <p>The size is unavailable for indices created before index file sizes were tracked.
+   *
+   * @return the segment size in bytes, or empty if unavailable
+   */
+  public Optional<Long> getSizeBytes() {
+    return Optional.ofNullable(sizeBytes);
+  }
+
+  /**
    * Get the index version.
    *
    * @return the index version
@@ -145,6 +159,7 @@ public class Index {
         && Arrays.equals(indexDetails, index.indexDetails)
         && Objects.equals(createdAt, index.createdAt)
         && Objects.equals(baseId, index.baseId)
+        && Objects.equals(sizeBytes, index.sizeBytes)
         && indexType == index.indexType;
   }
 
@@ -159,6 +174,7 @@ public class Index {
             indexVersion,
             createdAt,
             baseId,
+            sizeBytes,
             fragments,
             indexType);
     result = 31 * result + Arrays.hashCode(indexDetails);
@@ -176,6 +192,7 @@ public class Index {
         .add("indexType", indexType)
         .add("createdAt", createdAt)
         .add("baseId", baseId)
+        .add("sizeBytes", sizeBytes)
         .toString();
   }
 
@@ -199,6 +216,7 @@ public class Index {
     private int indexVersion;
     private Instant createdAt;
     private Integer baseId;
+    private Long sizeBytes;
     private IndexType indexType;
 
     private Builder() {}
@@ -248,6 +266,11 @@ public class Index {
       return this;
     }
 
+    public Builder sizeBytes(Long sizeBytes) {
+      this.sizeBytes = sizeBytes;
+      return this;
+    }
+
     public Builder indexType(IndexType indexType) {
       this.indexType = indexType;
       return this;
@@ -264,6 +287,7 @@ public class Index {
           indexVersion,
           createdAt,
           baseId,
+          sizeBytes,
           indexType);
     }
   }

--- a/java/src/main/java/org/lance/index/IndexDescription.java
+++ b/java/src/main/java/org/lance/index/IndexDescription.java
@@ -15,6 +15,7 @@ package org.lance.index;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * High-level description of an index, aggregating metadata across all segments.
@@ -31,6 +32,7 @@ public final class IndexDescription {
   private final long rowsIndexed;
   private final List<Index> metadata;
   private final String detailsJson;
+  private final Long totalSizeBytes;
 
   public IndexDescription(
       String name,
@@ -40,6 +42,18 @@ public final class IndexDescription {
       long rowsIndexed,
       List<Index> metadata,
       String detailsJson) {
+    this(name, fieldIds, typeUrl, indexType, rowsIndexed, metadata, detailsJson, null);
+  }
+
+  public IndexDescription(
+      String name,
+      List<Integer> fieldIds,
+      String typeUrl,
+      String indexType,
+      long rowsIndexed,
+      List<Index> metadata,
+      String detailsJson,
+      Long totalSizeBytes) {
     this.name = Objects.requireNonNull(name, "name must not be null");
     this.fieldIds = Objects.requireNonNull(fieldIds, "fieldIds must not be null");
     this.typeUrl = Objects.requireNonNull(typeUrl, "typeUrl must not be null");
@@ -47,6 +61,7 @@ public final class IndexDescription {
     this.rowsIndexed = rowsIndexed;
     this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
     this.detailsJson = detailsJson;
+    this.totalSizeBytes = totalSizeBytes;
   }
 
   /** The logical name of the index. */
@@ -99,5 +114,16 @@ public final class IndexDescription {
    */
   public String getDetailsJson() {
     return detailsJson;
+  }
+
+  /**
+   * Total size of all files across all physical index segments.
+   *
+   * <p>The size is unavailable if any segment predates index file size tracking.
+   *
+   * @return the logical index size in bytes, or empty if unavailable
+   */
+  public Optional<Long> getTotalSizeBytes() {
+    return Optional.ofNullable(totalSizeBytes);
   }
 }

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -2153,6 +2153,13 @@ public class DatasetTest {
 
         assertEquals(1, desc.getSegments().size(), "Expected exactly one physical segment");
         assertEquals("index1", desc.getSegments().get(0).name());
+        assertTrue(
+            desc.getSegments().get(0).getSizeBytes().orElse(0L) > 0,
+            "segment size should be positive");
+        assertEquals(
+            desc.getSegments().get(0).getSizeBytes(),
+            desc.getTotalSizeBytes(),
+            "single-segment size should equal the logical index size");
 
         descriptions = dataset.describeIndices();
         assertEquals(2, descriptions.size(), "Expected exactly one matching index");
@@ -2165,6 +2172,8 @@ public class DatasetTest {
               indexDesc.getSegments(),
               "segments alias should match metadata");
           assertNotNull(indexDesc.getDetailsJson(), "Details JSON should not be null");
+          assertTrue(
+              indexDesc.getTotalSizeBytes().orElse(0L) > 0, "total index size should be positive");
         }
       }
     }


### PR DESCRIPTION
## Summary

- expose per-segment index file size through `Index#getSizeBytes()`
- expose aggregate logical-index size through `IndexDescription#getTotalSizeBytes()`
- preserve `Optional.empty()` for indices created before file-size tracking and retain the existing public constructor

## Why

Rust and Python already expose persisted index file-size metadata, while Java drops it at the JNI boundary. Java engines therefore cannot inspect physical segment sizes when planning index maintenance, including the size-tiered work tracked in [lance-spark#744](https://github.com/lance-format/lance-spark/issues/744).

## Validation

- `./mvnw -Dtest=DatasetTest#testDescribeIndicesByName test`
- `./mvnw spotless:check`
- `cargo clippy --target-dir target/rust-maven-plugin/lance-jni --tests --manifest-path ./lance-jni/Cargo.toml -- -D warnings`