### PR TITLE
feat(python): add RowIdSequence for constructing row id metadata

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -35,6 +35,9 @@ from .lance import (
 from .lance import (
     RowIdMeta as RowIdMeta,
 )
+from .lance import (
+    RowIdSequence as RowIdSequence,
+)
 from .lance import _Fragment, _write_fragments, _write_fragments_transaction
 from .progress import FragmentWriteProgress, NoopFragmentWriteProgress
 from .types import _coerce_reader

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -63,6 +63,9 @@ from .fragment import (
 from .fragment import (
     RowIdMeta as RowIdMeta,
 )
+from .fragment import (
+    RowIdSequence as RowIdSequence,
+)
 from .indices import IndexDescription as IndexDescription
 from .indices import IndexSegment as IndexSegment
 from .lance import PySearchFilter

--- a/python/python/lance/lance/fragment.pyi
+++ b/python/python/lance/lance/fragment.pyi
@@ -127,12 +127,21 @@ class RowIdSequence:
     """
     The stable row ids of the rows in a single fragment, in fragment order.
 
-    Row ids must be unique within a dataset; duplicates are rejected. Use this
-    to attach pre-existing row ids to a fragment when assembling a transaction
-    manually, so that rewritten rows keep their identity::
+    Use this to attach pre-existing row ids to a fragment when assembling a
+    transaction manually, so that rewritten rows keep their identity::
 
         sequence = RowIdSequence([7, 12])
         fragment = FragmentMetadata(..., row_id_meta=sequence.to_inline_metadata())
+
+    Warning
+    -------
+    Only duplicates within this sequence are rejected. Row ids must also be
+    unique across the dataset, and Lance does not re-check that when
+    committing, so the caller owns it. Supply only row ids that already exist
+    and are being relocated by the same transaction, which must also remove
+    every earlier occurrence of them. Do not supply unused row ids: a sequence
+    covering all of a fragment's rows leaves the dataset's row id allocator
+    untouched, so a later append will hand the same id out again.
 
     Parameters
     ----------

--- a/python/python/lance/lance/fragment.pyi
+++ b/python/python/lance/lance/fragment.pyi
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-from typing import Literal, Optional
+from typing import Iterable, Iterator, Literal, Optional, Union
+
+import pyarrow as pa
 
 class DeletionFile:
     """
@@ -119,4 +121,69 @@ class RowIdMeta:
         """
         ...
 
+    def __reduce__(self) -> tuple: ...
+
+class RowIdSequence:
+    """
+    The stable row ids of the rows in a single fragment, in fragment order.
+
+    Row ids must be unique within a dataset; duplicates are rejected. Use this
+    to attach pre-existing row ids to a fragment when assembling a transaction
+    manually, so that rewritten rows keep their identity::
+
+        sequence = RowIdSequence([7, 12])
+        fragment = FragmentMetadata(..., row_id_meta=sequence.to_inline_metadata())
+
+    Parameters
+    ----------
+    row_ids : range | pa.Array | pa.ChunkedArray | Iterable[int]
+        The row ids, in the order the corresponding rows appear in the
+        fragment. A ``range`` with a step of one is stored compactly without
+        materializing its values.
+    """
+
+    def __init__(
+        self, row_ids: Union[range, pa.Array, pa.ChunkedArray, Iterable[int]]
+    ) -> None: ...
+    @staticmethod
+    def from_inline_metadata(metadata: RowIdMeta) -> RowIdSequence:
+        """
+        Read back a sequence stored inline in fragment row id metadata.
+
+        Parameters
+        ----------
+        metadata : RowIdMeta
+            Row id metadata holding an inline sequence. Metadata pointing at an
+            external file is not supported.
+
+        Returns
+        -------
+        RowIdSequence
+        """
+        ...
+
+    def to_inline_metadata(self) -> RowIdMeta:
+        """
+        Encode the sequence as row id metadata to store inline in the manifest.
+
+        Returns
+        -------
+        RowIdMeta
+            Suitable for the ``row_id_meta`` argument of
+            :class:`lance.fragment.FragmentMetadata`.
+        """
+        ...
+
+    def to_pyarrow(self) -> pa.UInt64Array:
+        """
+        Get the row ids as a ``uint64`` array, in sequence order.
+
+        Returns
+        -------
+        pa.UInt64Array
+        """
+        ...
+
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator[int]: ...
     def __reduce__(self) -> tuple: ...

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -22,7 +22,7 @@ from lance import (
 )
 from lance.debug import format_fragment
 from lance.file import LanceFileWriter
-from lance.fragment import write_fragments
+from lance.fragment import RowIdMeta, RowIdSequence, write_fragments
 from lance.progress import FileSystemFragmentWriteProgress
 
 
@@ -962,3 +962,169 @@ def test_fragment_update_columns_with_json_column(tmp_path):
             assert "x" in meta_val or "x" in str(meta), (
                 f"id={id_val} should have original value, got {meta_val}"
             )
+
+
+def test_row_id_sequence_from_range():
+    # A step-of-one range is the compact case and must not materialize its ids.
+    sequence = RowIdSequence(range(10))
+
+    assert len(sequence) == 10
+    assert sequence.to_pyarrow() == pa.array(range(10), type=pa.uint64())
+    assert sequence.to_pyarrow().type == pa.uint64()
+    assert list(sequence) == list(range(10))
+
+
+@pytest.mark.parametrize(
+    "row_ids",
+    [
+        pytest.param(pa.array([1, 2, 3]), id="pyarrow_array"),
+        pytest.param(pa.array([1, 2, 3], type=pa.uint64()), id="pyarrow_uint64_array"),
+        pytest.param(pa.array([1, 2, 3], type=pa.int8()), id="pyarrow_int8_array"),
+        pytest.param(pa.array([1, 2, 3], type=pa.uint16()), id="pyarrow_uint16_array"),
+        # A slice carries an offset into a larger buffer; only the slice counts.
+        pytest.param(pa.array([9, 1, 2, 3, 9]).slice(1, 3), id="pyarrow_sliced_array"),
+        pytest.param(pa.chunked_array([[1], [2, 3]]), id="pyarrow_chunked_array"),
+        pytest.param((x for x in [1, 2, 3]), id="generator"),
+        pytest.param([1, 2, 3], id="list"),
+        pytest.param(range(1, 4), id="range"),
+        pytest.param(range(3, 0, -1), id="descending_range"),
+    ],
+)
+def test_row_id_sequence_accepts_input_types(row_ids):
+    sequence = RowIdSequence(row_ids)
+
+    assert sorted(sequence) == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "row_ids",
+    [
+        pytest.param([], id="empty_list"),
+        pytest.param(range(0), id="empty_range"),
+        pytest.param(pa.array([], type=pa.uint64()), id="empty_array"),
+    ],
+)
+def test_row_id_sequence_empty(row_ids):
+    sequence = RowIdSequence(row_ids)
+
+    assert len(sequence) == 0
+    assert list(sequence) == []
+    assert sequence.to_pyarrow() == pa.array([], type=pa.uint64())
+
+
+def test_row_id_sequence_unsorted_round_trips():
+    sequence = RowIdSequence([12, 11, 10])
+
+    assert list(sequence) == [12, 11, 10]
+    assert sequence.to_pyarrow() == pa.array([12, 11, 10], type=pa.uint64())
+
+
+@pytest.mark.parametrize(
+    "row_ids",
+    [
+        pytest.param([1, 1, 2], id="adjacent"),
+        pytest.param([1, 2, 3, 1], id="separated"),
+        pytest.param(pa.array([5, 3, 5]), id="unsorted_array"),
+    ],
+)
+def test_row_id_sequence_rejects_duplicates(row_ids):
+    with pytest.raises(ValueError, match="Row ids must be unique"):
+        RowIdSequence(row_ids)
+
+
+@pytest.mark.parametrize(
+    ("row_ids", "message"),
+    [
+        pytest.param(pa.array([1, None, 3]), "must not be null", id="null_in_array"),
+        pytest.param(pa.array([1.5, 2.5]), "array of integers", id="float_array"),
+        pytest.param(pa.array([-1, 2]), "uint64", id="negative_in_array"),
+        pytest.param(range(-5, 5), "non-negative", id="negative_range"),
+        pytest.param(5, "iterable of integers", id="not_iterable"),
+    ],
+)
+def test_row_id_sequence_rejects_invalid_input(row_ids, message):
+    with pytest.raises((ValueError, TypeError), match=message):
+        RowIdSequence(row_ids)
+
+
+def test_row_id_sequence_metadata_round_trip():
+    sequence = RowIdSequence([7, 12, 3])
+
+    metadata = sequence.to_inline_metadata()
+    assert isinstance(metadata, RowIdMeta)
+    assert RowIdSequence.from_inline_metadata(metadata) == sequence
+
+
+def test_row_id_sequence_equality_and_repr():
+    assert RowIdSequence(range(3)) == RowIdSequence([0, 1, 2])
+    assert RowIdSequence(range(3)) != RowIdSequence([0, 1])
+    # Comparing against an unrelated type is False rather than an error.
+    assert RowIdSequence(range(3)) != "not a sequence"
+
+    assert repr(RowIdSequence([1, 2])) == "RowIdSequence([1, 2])"
+    assert repr(RowIdSequence(range(12))) == (
+        "RowIdSequence([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...], len=12)"
+    )
+
+
+def test_row_id_sequence_pickle():
+    sequence = RowIdSequence([7, 12, 3])
+
+    assert pickle.loads(pickle.dumps(sequence)) == sequence
+
+
+def _row_ids_by_id(dataset: LanceDataset) -> dict:
+    table = dataset.to_table(columns=["id"], with_row_id=True)
+    return dict(zip(table["id"].to_pylist(), table["_rowid"].to_pylist()))
+
+
+def test_row_id_sequence_preserves_ids_in_manual_update(tmp_path: Path):
+    # An update assembled externally (delete the old row, append a replacement)
+    # keeps the row's identity only if the new fragment carries its row id.
+    dataset = write_dataset(
+        pa.table({"id": [1, 2, 3, 4], "v": [10, 20, 30, 40]}),
+        tmp_path,
+        max_rows_per_file=2,
+        enable_stable_row_ids=True,
+    )
+    row_ids_before = _row_ids_by_id(dataset)
+
+    updated_fragment = dataset.get_fragments()[0].delete("id = 2")
+    (new_fragment,) = write_fragments(pa.table({"id": [2], "v": [99]}), tmp_path)
+    new_fragment.row_id_meta = RowIdSequence([row_ids_before[2]]).to_inline_metadata()
+
+    dataset = LanceDataset.commit(
+        tmp_path,
+        LanceOperation.Update(
+            removed_fragment_ids=[],
+            updated_fragments=[updated_fragment],
+            new_fragments=[new_fragment],
+            fields_modified=[],
+        ),
+        read_version=dataset.version,
+    )
+
+    assert _row_ids_by_id(dataset) == row_ids_before
+    assert dataset.to_table().sort_by("id").to_pydict() == {
+        "id": [1, 2, 3, 4],
+        "v": [10, 99, 30, 40],
+    }
+
+
+def test_row_id_sequence_reads_back_fragment_metadata(tmp_path: Path):
+    dataset = write_dataset(
+        pa.table({"a": range(10)}),
+        tmp_path,
+        max_rows_per_file=5,
+        enable_stable_row_ids=True,
+    )
+
+    sequences = [
+        RowIdSequence.from_inline_metadata(fragment.metadata.row_id_meta)
+        for fragment in dataset.get_fragments()
+    ]
+
+    assert [list(sequence) for sequence in sequences] == [
+        [0, 1, 2, 3, 4],
+        [5, 6, 7, 8, 9],
+    ]

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1012,6 +1012,27 @@ def test_row_id_sequence_empty(row_ids):
     assert sequence.to_pyarrow() == pa.array([], type=pa.uint64())
 
 
+@pytest.mark.parametrize("num_rows", [1023, 1024, 1025, 4100])
+def test_row_id_sequence_iterates_across_buffer_refills(num_rows):
+    # Iteration refills a fixed-size buffer rather than materializing the whole
+    # sequence, so lengths either side of that boundary must all round-trip.
+    row_ids = list(range(0, num_rows * 2, 2))
+    sequence = RowIdSequence(row_ids)
+
+    assert list(sequence) == row_ids
+    # A second pass must start over rather than resume a spent buffer.
+    assert list(sequence) == row_ids
+
+
+def test_row_id_sequence_from_range_above_isize():
+    # Range bounds are read as isize; beyond that the values are read one at a
+    # time instead, which must still cover the whole uint64 row id domain.
+    start = 2**63
+    sequence = RowIdSequence(range(start, start + 3))
+
+    assert list(sequence) == [start, start + 1, start + 2]
+
+
 def test_row_id_sequence_unsorted_round_trips():
     sequence = RowIdSequence([12, 11, 10])
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1012,15 +1012,21 @@ def test_row_id_sequence_empty(row_ids):
     assert sequence.to_pyarrow() == pa.array([], type=pa.uint64())
 
 
-@pytest.mark.parametrize("num_rows", [1023, 1024, 1025, 4100])
-def test_row_id_sequence_iterates_across_buffer_refills(num_rows):
-    # Iteration refills a fixed-size buffer rather than materializing the whole
-    # sequence, so lengths either side of that boundary must all round-trip.
-    row_ids = list(range(0, num_rows * 2, 2))
+@pytest.mark.parametrize(
+    "row_ids",
+    [
+        pytest.param(list(range(4100)), id="contiguous"),
+        pytest.param(list(range(0, 8200, 2)), id="gapped"),
+        pytest.param(list(range(4100))[::-1], id="unsorted"),
+    ],
+)
+def test_row_id_sequence_iterates_large_sequences(row_ids):
+    # Each shape picks a different segment encoding, so all of them have to
+    # round-trip through iteration.
     sequence = RowIdSequence(row_ids)
 
     assert list(sequence) == row_ids
-    # A second pass must start over rather than resume a spent buffer.
+    # Each call must hand back a fresh iterator rather than a spent one.
     assert list(sequence) == row_ids
 
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -76,6 +76,7 @@ pub(crate) mod mem_wal;
 pub(crate) mod namespace;
 pub(crate) mod otel;
 pub(crate) mod reader;
+pub(crate) mod rowids;
 pub(crate) mod scanner;
 pub(crate) mod schema;
 pub(crate) mod session;
@@ -96,6 +97,7 @@ pub use dataset::write_dataset;
 use fragment::{FileFragment, PyDeletionFile, PyRowDatasetVersionMeta, PyRowIdMeta};
 pub use indices::register_indices;
 pub use reader::LanceReader;
+use rowids::{PyRowIdSequence, PyRowIdSequenceIterator};
 pub use scanner::Scanner;
 
 use crate::blob::{
@@ -259,6 +261,8 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FileFragment>()?;
     m.add_class::<PyDeletionFile>()?;
     m.add_class::<PyRowIdMeta>()?;
+    m.add_class::<PyRowIdSequence>()?;
+    m.add_class::<PyRowIdSequenceIterator>()?;
     m.add_class::<PyRowDatasetVersionMeta>()?;
     m.add_class::<MergeInsertBuilder>()?;
     m.add_class::<LanceBlobFile>()?;

--- a/python/src/rowids.rs
+++ b/python/src/rowids.rs
@@ -16,7 +16,7 @@ use lance_table::rowids::{RowIdSequence, read_row_ids, write_row_ids};
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyNotImplementedError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
+use pyo3::types::{PyRange, PyRangeMethods, PyTuple};
 use pyo3::{IntoPyObjectExt, intern};
 
 use crate::error::PythonErrorExt;
@@ -68,9 +68,17 @@ impl PyRowIdSequence {
         self.0.len() as usize
     }
 
-    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyRowIdSequenceIterator>> {
-        let row_ids: Vec<u64> = self.0.iter().collect();
-        Py::new(py, PyRowIdSequenceIterator(row_ids.into_iter()))
+    fn __iter__(slf: &Bound<'_, Self>) -> PyResult<Py<PyRowIdSequenceIterator>> {
+        let len = slf.borrow().0.len() as usize;
+        Py::new(
+            slf.py(),
+            PyRowIdSequenceIterator {
+                sequence: slf.clone().unbind(),
+                offset: 0,
+                len,
+                buffer: Vec::new().into_iter(),
+            },
+        )
     }
 
     fn __repr__(&self) -> String {
@@ -117,8 +125,23 @@ impl PyRowIdSequence {
     }
 }
 
+/// Row ids buffered per refill while iterating.
+///
+/// A borrowing iterator cannot be held by a `#[pyclass]`, and stepping through
+/// `RowIdSequence::get` is quadratic because segment lengths are recomputed on
+/// each call. Buffering slices keeps the memory held during iteration constant
+/// while amortizing the segment walk over a whole chunk.
+const ITER_CHUNK_LEN: usize = 1024;
+
 #[pyclass(name = "RowIdSequenceIterator", module = "lance.fragment")]
-pub struct PyRowIdSequenceIterator(std::vec::IntoIter<u64>);
+pub struct PyRowIdSequenceIterator {
+    sequence: Py<PyRowIdSequence>,
+    /// Offset of the next row id to buffer.
+    offset: usize,
+    /// Length of the sequence, which is immutable once constructed.
+    len: usize,
+    buffer: std::vec::IntoIter<u64>,
+}
 
 #[pymethods]
 impl PyRowIdSequenceIterator {
@@ -126,8 +149,25 @@ impl PyRowIdSequenceIterator {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<u64> {
-        slf.0.next()
+    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> Option<u64> {
+        if let Some(row_id) = slf.buffer.next() {
+            return Some(row_id);
+        }
+        if slf.offset >= slf.len {
+            return None;
+        }
+
+        let chunk_len = ITER_CHUNK_LEN.min(slf.len - slf.offset);
+        let sequence = slf.sequence.clone_ref(py);
+        let buffer: Vec<u64> = sequence
+            .borrow(py)
+            .0
+            .slice(slf.offset, chunk_len)
+            .iter()
+            .collect();
+        slf.offset += chunk_len;
+        slf.buffer = buffer.into_iter();
+        slf.buffer.next()
     }
 }
 
@@ -136,29 +176,22 @@ impl PyRowIdSequenceIterator {
 /// Returns `None` for anything else, including strided and descending ranges,
 /// which are handled by the general iterable path.
 fn contiguous_range(ob: &Bound<'_, PyAny>) -> PyResult<Option<Range<u64>>> {
-    let py = ob.py();
-    let range_type = PyModule::import(py, "builtins")?.getattr("range")?;
-    if !ob.is_instance(&range_type)? {
+    let Ok(range) = ob.cast::<PyRange>() else {
+        return Ok(None);
+    };
+    // Bounds are read as `isize`. A range reaching past that is well beyond any
+    // dataset's row count, so it falls through to the element-wise path, which
+    // reads each value as a u64, rather than failing.
+    let (Ok(start), Ok(stop), Ok(step)) = (range.start(), range.stop(), range.step()) else {
+        return Ok(None);
+    };
+    if step != 1 {
         return Ok(None);
     }
-    if ob.getattr("step")?.extract::<i64>()? != 1 {
-        return Ok(None);
-    }
-
-    // Row ids span the whole u64 domain, so the bounds are read as i128 to
-    // distinguish "negative" from "too large" rather than overflowing.
-    let start = ob.getattr("start")?.extract::<i128>()?;
-    let stop = ob.getattr("stop")?.extract::<i128>()?;
     if start < 0 {
         return Err(PyValueError::new_err(format!(
             "Row ids must be non-negative, but the range starts at {}",
             start
-        )));
-    }
-    if stop > u64::MAX as i128 + 1 {
-        return Err(PyValueError::new_err(format!(
-            "Row ids must fit in a uint64, but the range ends at {}",
-            stop
         )));
     }
     if stop <= start {

--- a/python/src/rowids.rs
+++ b/python/src/rowids.rs
@@ -68,17 +68,9 @@ impl PyRowIdSequence {
         self.0.len() as usize
     }
 
-    fn __iter__(slf: &Bound<'_, Self>) -> PyResult<Py<PyRowIdSequenceIterator>> {
-        let len = slf.borrow().0.len() as usize;
-        Py::new(
-            slf.py(),
-            PyRowIdSequenceIterator {
-                sequence: slf.clone().unbind(),
-                offset: 0,
-                len,
-                buffer: Vec::new().into_iter(),
-            },
-        )
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyRowIdSequenceIterator>> {
+        let row_ids: Vec<u64> = self.0.iter().collect();
+        Py::new(py, PyRowIdSequenceIterator(row_ids.into_iter()))
     }
 
     fn __repr__(&self) -> String {
@@ -125,23 +117,17 @@ impl PyRowIdSequence {
     }
 }
 
-/// Row ids buffered per refill while iterating.
+/// The row ids are materialized up front because `RowIdSequence::iter` borrows
+/// the sequence and a `#[pyclass]` cannot hold a borrowing iterator.
 ///
-/// A borrowing iterator cannot be held by a `#[pyclass]`, and stepping through
-/// `RowIdSequence::get` is quadratic because segment lengths are recomputed on
-/// each call. Buffering slices keeps the memory held during iteration constant
-/// while amortizing the segment walk over a whole chunk.
-const ITER_CHUNK_LEN: usize = 1024;
-
+/// Refilling a bounded buffer from `RowIdSequence::slice` looks like the way to
+/// avoid that, but it is quadratic: slicing takes an absolute offset, and for
+/// the gapped `RangeWithHoles` and `RangeWithBitmap` encodings the slice skips
+/// its prefix one element at a time. Making iteration both lazy and linear
+/// needs a forward cursor over the private segments, which belongs in
+/// `lance-table` rather than here. Bulk callers should use `to_pyarrow`.
 #[pyclass(name = "RowIdSequenceIterator", module = "lance.fragment")]
-pub struct PyRowIdSequenceIterator {
-    sequence: Py<PyRowIdSequence>,
-    /// Offset of the next row id to buffer.
-    offset: usize,
-    /// Length of the sequence, which is immutable once constructed.
-    len: usize,
-    buffer: std::vec::IntoIter<u64>,
-}
+pub struct PyRowIdSequenceIterator(std::vec::IntoIter<u64>);
 
 #[pymethods]
 impl PyRowIdSequenceIterator {
@@ -149,25 +135,8 @@ impl PyRowIdSequenceIterator {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> Option<u64> {
-        if let Some(row_id) = slf.buffer.next() {
-            return Some(row_id);
-        }
-        if slf.offset >= slf.len {
-            return None;
-        }
-
-        let chunk_len = ITER_CHUNK_LEN.min(slf.len - slf.offset);
-        let sequence = slf.sequence.clone_ref(py);
-        let buffer: Vec<u64> = sequence
-            .borrow(py)
-            .0
-            .slice(slf.offset, chunk_len)
-            .iter()
-            .collect();
-        slf.offset += chunk_len;
-        slf.buffer = buffer.into_iter();
-        slf.buffer.next()
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<u64> {
+        slf.0.next()
     }
 }
 

--- a/python/src/rowids.rs
+++ b/python/src/rowids.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::ops::Range;
+
+use arrow::array::{Array, UInt64Array, make_array};
+use arrow::compute::CastOptions;
+use arrow::compute::kernels::cast::cast_with_options;
+use arrow::datatypes::DataType;
+use arrow::pyarrow::{FromPyArrow, ToPyArrow};
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt64Type;
+use arrow_data::ArrayData;
+use lance_table::format::RowIdMeta;
+use lance_table::rowids::{RowIdSequence, read_row_ids, write_row_ids};
+use pyo3::basic::CompareOp;
+use pyo3::exceptions::{PyNotImplementedError, PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
+use pyo3::{IntoPyObjectExt, intern};
+
+use crate::error::PythonErrorExt;
+use crate::fragment::PyRowIdMeta;
+
+/// The number of row ids shown in `RowIdSequence.__repr__` before eliding.
+const REPR_PREVIEW_LEN: usize = 10;
+
+/// A sequence of stable row ids belonging to a single fragment.
+#[pyclass(name = "RowIdSequence", module = "lance.fragment")]
+pub struct PyRowIdSequence(pub RowIdSequence);
+
+#[pymethods]
+impl PyRowIdSequence {
+    #[new]
+    fn new(row_ids: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let sequence = match contiguous_range(row_ids)? {
+            // A `Range` segment is the most compact encoding, and taking it
+            // directly avoids materializing the ids of a large range.
+            Some(range) if range.is_empty() => RowIdSequence::new(),
+            Some(range) => RowIdSequence::from(range),
+            None => RowIdSequence::try_from_iter(extract_row_ids(row_ids)?).infer_error()?,
+        };
+        Ok(Self(sequence))
+    }
+
+    /// Read back the sequence stored inline in fragment row id metadata.
+    #[staticmethod]
+    fn from_inline_metadata(metadata: PyRef<'_, PyRowIdMeta>) -> PyResult<Self> {
+        match &metadata.0 {
+            RowIdMeta::Inline(data) => read_row_ids(data).infer_error().map(Self),
+            RowIdMeta::External(_) => Err(PyNotImplementedError::new_err(
+                "Row ids stored in an external file cannot be read into a RowIdSequence",
+            )),
+        }
+    }
+
+    /// Encode the sequence as row id metadata stored inline in the manifest.
+    fn to_inline_metadata(&self) -> PyRowIdMeta {
+        PyRowIdMeta(RowIdMeta::Inline(write_row_ids(&self.0).into()))
+    }
+
+    fn to_pyarrow<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let array = UInt64Array::from(self.0.iter().collect::<Vec<u64>>());
+        array.into_data().to_pyarrow(py)
+    }
+
+    fn __len__(&self) -> usize {
+        self.0.len() as usize
+    }
+
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyRowIdSequenceIterator>> {
+        let row_ids: Vec<u64> = self.0.iter().collect();
+        Py::new(py, PyRowIdSequenceIterator(row_ids.into_iter()))
+    }
+
+    fn __repr__(&self) -> String {
+        let len = self.0.len();
+        let preview = self
+            .0
+            .iter()
+            .take(REPR_PREVIEW_LEN)
+            .map(|row_id| row_id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if len > REPR_PREVIEW_LEN as u64 {
+            format!("RowIdSequence([{}, ...], len={})", preview, len)
+        } else {
+            format!("RowIdSequence([{}])", preview)
+        }
+    }
+
+    fn __richcmp__(
+        &self,
+        other: &Bound<'_, PyAny>,
+        op: CompareOp,
+        py: Python<'_>,
+    ) -> PyResult<Py<PyAny>> {
+        let Ok(other) = other.cast::<Self>() else {
+            return Ok(py.NotImplemented());
+        };
+        let equal = self.0 == other.borrow().0;
+        match op {
+            CompareOp::Eq => equal.into_py_any(py),
+            CompareOp::Ne => (!equal).into_py_any(py),
+            _ => Ok(py.NotImplemented()),
+        }
+    }
+
+    fn __reduce__(&self, py: Python<'_>) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+        let from_inline_metadata = PyModule::import(py, "lance.fragment")?
+            .getattr("RowIdSequence")?
+            .getattr("from_inline_metadata")?
+            .extract()?;
+        let metadata = Py::new(py, self.to_inline_metadata())?;
+        let state = PyTuple::new(py, [metadata])?.extract()?;
+        Ok((from_inline_metadata, state))
+    }
+}
+
+#[pyclass(name = "RowIdSequenceIterator", module = "lance.fragment")]
+pub struct PyRowIdSequenceIterator(std::vec::IntoIter<u64>);
+
+#[pymethods]
+impl PyRowIdSequenceIterator {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<u64> {
+        slf.0.next()
+    }
+}
+
+/// Recognize a `range` with a step of one, whose row ids need no materialization.
+///
+/// Returns `None` for anything else, including strided and descending ranges,
+/// which are handled by the general iterable path.
+fn contiguous_range(ob: &Bound<'_, PyAny>) -> PyResult<Option<Range<u64>>> {
+    let py = ob.py();
+    let range_type = PyModule::import(py, "builtins")?.getattr("range")?;
+    if !ob.is_instance(&range_type)? {
+        return Ok(None);
+    }
+    if ob.getattr("step")?.extract::<i64>()? != 1 {
+        return Ok(None);
+    }
+
+    // Row ids span the whole u64 domain, so the bounds are read as i128 to
+    // distinguish "negative" from "too large" rather than overflowing.
+    let start = ob.getattr("start")?.extract::<i128>()?;
+    let stop = ob.getattr("stop")?.extract::<i128>()?;
+    if start < 0 {
+        return Err(PyValueError::new_err(format!(
+            "Row ids must be non-negative, but the range starts at {}",
+            start
+        )));
+    }
+    if stop > u64::MAX as i128 + 1 {
+        return Err(PyValueError::new_err(format!(
+            "Row ids must fit in a uint64, but the range ends at {}",
+            stop
+        )));
+    }
+    if stop <= start {
+        return Ok(Some(0..0));
+    }
+    Ok(Some(start as u64..stop as u64))
+}
+
+fn extract_row_ids(ob: &Bound<'_, PyAny>) -> PyResult<Vec<u64>> {
+    let py = ob.py();
+    if ob.hasattr(intern!(py, "__arrow_c_array__"))? {
+        return row_ids_from_arrow(ob);
+    }
+    // A `pyarrow.ChunkedArray`, such as a `_rowid` column taken from a table.
+    let chunks = intern!(py, "chunks");
+    if ob.hasattr(chunks)? {
+        let mut row_ids = Vec::new();
+        for chunk in ob.getattr(chunks)?.try_iter()? {
+            row_ids.extend(row_ids_from_arrow(&chunk?)?);
+        }
+        return Ok(row_ids);
+    }
+
+    let iter = ob.try_iter().map_err(|_| {
+        PyTypeError::new_err(format!(
+            "Row ids must be an iterable of integers or an Arrow array, but got {}",
+            ob.get_type().name().map_or_else(
+                |_| "an object of unknown type".to_string(),
+                |name| name.to_string()
+            )
+        ))
+    })?;
+    iter.map(|row_id| row_id?.extract::<u64>()).collect()
+}
+
+fn row_ids_from_arrow(array: &Bound<'_, PyAny>) -> PyResult<Vec<u64>> {
+    let array = make_array(ArrayData::from_pyarrow_bound(array)?);
+    if !array.data_type().is_integer() {
+        return Err(PyTypeError::new_err(format!(
+            "Row ids must be an array of integers, but got an array of type {}",
+            array.data_type()
+        )));
+    }
+    if array.null_count() > 0 {
+        return Err(PyValueError::new_err(format!(
+            "Row ids must not be null, but the array has {} null values",
+            array.null_count()
+        )));
+    }
+
+    // `safe: false` so that negative values raise instead of wrapping around
+    // into the top of the row id space.
+    let cast_options = CastOptions {
+        safe: false,
+        ..Default::default()
+    };
+    let array = cast_with_options(&array, &DataType::UInt64, &cast_options)
+        .map_err(|err| PyValueError::new_err(format!("Row ids must fit in a uint64: {}", err)))?;
+    Ok(array.as_primitive::<UInt64Type>().values().to_vec())
+}

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -119,13 +119,16 @@ impl RowIdSequence {
         Self::default()
     }
 
-    /// Build a sequence from row ids, rejecting duplicates.
+    /// Build a sequence from row ids, rejecting duplicates within the sequence.
     ///
-    /// Row ids must be unique. The segment encodings represent a sorted run as
-    /// a range plus its holes, so a repeated value would be silently encoded as
-    /// a shorter sequence with a spurious hole. Callers assembling a sequence
-    /// from untrusted input should use this instead of the infallible `From`
-    /// conversions, which assume uniqueness.
+    /// The segment encodings represent a sorted run as a range plus its holes,
+    /// so a repeated value would be silently encoded as a shorter sequence with
+    /// a spurious hole. Callers assembling a sequence from untrusted input
+    /// should use this instead of the infallible `From` conversions, which
+    /// assume uniqueness.
+    ///
+    /// Row ids must also be unique across the dataset. That is not checked
+    /// here, and commit does not re-check it either.
     pub fn try_from_iter(row_ids: impl IntoIterator<Item = u64>) -> Result<Self> {
         let row_ids: Vec<u64> = row_ids.into_iter().collect();
         if row_ids.is_empty() {

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -98,9 +98,47 @@ impl From<&[u64]> for RowIdSequence {
     }
 }
 
+/// Return some value that appears more than once in `row_ids`, if any.
+///
+/// The already-sorted case is the common one for row id sequences, and is
+/// checked in a single pass without allocating.
+fn find_duplicate(row_ids: &[u64]) -> Option<u64> {
+    if row_ids.windows(2).all(|pair| pair[0] < pair[1]) {
+        return None;
+    }
+    let mut sorted = row_ids.to_vec();
+    sorted.sort_unstable();
+    sorted
+        .windows(2)
+        .find(|pair| pair[0] == pair[1])
+        .map(|pair| pair[0])
+}
+
 impl RowIdSequence {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Build a sequence from row ids, rejecting duplicates.
+    ///
+    /// Row ids must be unique. The segment encodings represent a sorted run as
+    /// a range plus its holes, so a repeated value would be silently encoded as
+    /// a shorter sequence with a spurious hole. Callers assembling a sequence
+    /// from untrusted input should use this instead of the infallible `From`
+    /// conversions, which assume uniqueness.
+    pub fn try_from_iter(row_ids: impl IntoIterator<Item = u64>) -> Result<Self> {
+        let row_ids: Vec<u64> = row_ids.into_iter().collect();
+        if row_ids.is_empty() {
+            return Ok(Self::new());
+        }
+        if let Some(duplicate) = find_duplicate(&row_ids) {
+            return Err(Error::invalid_input(format!(
+                "Row ids must be unique, but row id {} appears more than once in the sequence of {} row ids",
+                duplicate,
+                row_ids.len()
+            )));
+        }
+        Ok(Self(vec![U64Segment::from_iter(row_ids)]))
     }
 
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = u64> + '_ {
@@ -782,6 +820,50 @@ mod test {
 
         let iter = sequence.iter();
         assert_eq!(iter.collect::<Vec<_>>(), (0..10).collect::<Vec<_>>());
+    }
+
+    #[rstest::rstest]
+    #[case::sorted_contiguous(vec![0, 1, 2, 3])]
+    #[case::sorted_with_gaps(vec![0, 2, 4])]
+    #[case::sparse(vec![0, 1_000_000])]
+    #[case::unsorted(vec![12, 11, 10])]
+    fn test_row_id_sequence_try_from_iter(#[case] row_ids: Vec<u64>) {
+        let sequence = RowIdSequence::try_from_iter(row_ids.clone()).unwrap();
+        assert_eq!(sequence.len(), row_ids.len() as u64);
+        assert_eq!(sequence.iter().collect::<Vec<_>>(), row_ids);
+    }
+
+    #[test]
+    fn test_row_id_sequence_try_from_iter_contiguous_is_a_range() {
+        let sequence = RowIdSequence::try_from_iter(0..10).unwrap();
+        assert_eq!(sequence.0, vec![U64Segment::Range(0..10)]);
+    }
+
+    #[test]
+    fn test_row_id_sequence_try_from_iter_empty() {
+        let sequence = RowIdSequence::try_from_iter(std::iter::empty()).unwrap();
+        assert_eq!(sequence.len(), 0);
+        assert!(sequence.is_empty());
+    }
+
+    #[rstest::rstest]
+    #[case::adjacent(vec![1, 1, 2])]
+    #[case::separated(vec![1, 2, 3, 1])]
+    #[case::unsorted(vec![5, 3, 5])]
+    fn test_row_id_sequence_try_from_iter_rejects_duplicates(#[case] row_ids: Vec<u64>) {
+        // Without validation these encode to a shorter sequence with a spurious
+        // hole rather than failing, so assert the error rather than the output.
+        let error = RowIdSequence::try_from_iter(row_ids).unwrap_err();
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {:?}",
+            error
+        );
+        assert!(
+            error.to_string().contains("must be unique"),
+            "unexpected message: {}",
+            error
+        );
     }
 
     #[test]


### PR DESCRIPTION
There was no public way to build a stable row id sequence from Python. `RowIdMeta` could only be constructed via `from_json`/`from_dict`, so a caller assembling a transaction externally — a distributed engine computing updates on workers and committing from a driver — had to hand-encode the internal `RowIdSequence` protobuf to tell Lance that rows in a new fragment already have row ids. Without that, the commit path allocates fresh ids and the rewritten rows silently lose their identity.

This PR adds `lance.fragment.RowIdSequence`. It builds a sequence from a `range`, an Arrow integer array, a `ChunkedArray`, or any iterable of ints, and converts to and from the inline metadata carried on `FragmentMetadata.row_id_meta`. The commit path already honors a sequence supplied this way, so no changes were needed there.

Duplicate row ids are now rejected rather than silently mis-encoded. `U64Segment` assumes uniqueness: a repeated value makes `SegmentStats::n_holes` compute `total_slots - count`, which underflows. That panics in debug builds, and in release it wraps, steers encoding selection toward `RangeWithBitmap`, and yields a shorter sequence with a spurious hole — `[1, 1, 2]` encodes to `[1]`. The new `RowIdSequence::try_from_iter` validates before encoding; the existing infallible `From` conversions are unchanged, so internal callers on hot paths do not pay for the check.

Closes #8353. Addresses the narrowed request in #8317.

## Example

Preserving a row's identity in an update assembled outside of Lance — delete the old row, write a replacement fragment, and attach the original row id to it:

```python
from lance.fragment import RowIdSequence, write_fragments

updated_fragment = dataset.get_fragments()[0].delete("id = 2")
(new_fragment,) = write_fragments(pa.table({"id": [2], "v": [99]}), uri)
new_fragment.row_id_meta = RowIdSequence([original_row_id]).to_inline_metadata()

dataset = LanceDataset.commit(
    uri,
    LanceOperation.Update(
        updated_fragments=[updated_fragment],
        new_fragments=[new_fragment],
    ),
    read_version=dataset.version,
)
```

Reading a fragment's existing sequence back:

```python
sequence = RowIdSequence.from_inline_metadata(fragment.metadata.row_id_meta)
list(sequence)          # [0, 1, 2, 3, 4]
sequence.to_pyarrow()   # uint64 array
```

Accepted inputs are any of the eight Arrow integer types, a `ChunkedArray`, a `range` (a step-of-one range is stored compactly without materializing its values), or any iterable of ints. Nulls, non-integer arrays, negative values, and duplicates each raise a specific error.

## Not included

Validation is within-sequence only. Checking that supplied ids are unique across fragments and currently live in the dataset — also requested in #8317 — can only happen at commit time and is left out of this PR.

Documentation for the distributed-write guide will follow in a stacked PR based on this branch.
