### PR TITLE
fix(java): correct CompactionMode type across the JNI boundary

### DIFF
--- a/java/lance-jni/src/optimize.rs
+++ b/java/lance-jni/src/optimize.rs
@@ -312,6 +312,7 @@ const REWRITE_RESULT_CLASS: &str = "org/lance/compaction/RewriteResult";
 const REWRITE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/compaction/CompactionMetrics;Ljava/util/List;Ljava/util/List;J[B)V";
 const COMPACTION_OPTIONS_CLASS: &str = "org/lance/compaction/CompactionOptions";
+const COMPACTION_MODE_CLASS: &str = "org/lance/compaction/CompactionMode";
 const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V";
 
 impl IntoJava for &TaskData {
@@ -361,13 +362,22 @@ impl IntoJava for &CompactionOptions {
         let batch_size_opt = to_java_optional(env, batch_size)?;
         let defer_index_remap = to_java_boolean_obj(env, Some(self.defer_index_remap))?;
         let defer_index_remap_opt = to_java_optional(env, defer_index_remap)?;
-        let compaction_mode_str = self.compaction_mode.as_ref().map(|mode| match mode {
-            CompactionMode::Reencode => "reencode",
-            CompactionMode::TryBinaryCopy => "try_binary_copy",
-            CompactionMode::ForceBinaryCopy => "force_binary_copy",
-        });
-        let compaction_mode_obj = match compaction_mode_str {
-            Some(s) => env.new_string(s)?.into(),
+        // The Java field is Optional<CompactionMode>; type erasure would let a
+        // plain String slip through the constructor, so fetch the enum constant.
+        let compaction_mode_obj = match self.compaction_mode {
+            Some(mode) => {
+                let name = match mode {
+                    CompactionMode::Reencode => "REENCODE",
+                    CompactionMode::TryBinaryCopy => "TRY_BINARY_COPY",
+                    CompactionMode::ForceBinaryCopy => "FORCE_BINARY_COPY",
+                };
+                env.get_static_field(
+                    COMPACTION_MODE_CLASS,
+                    name,
+                    format!("L{};", COMPACTION_MODE_CLASS),
+                )?
+                .l()?
+            }
             None => JObject::null(),
         };
         let compaction_mode_opt = to_java_optional(env, compaction_mode_obj)?;

--- a/java/lance-jni/src/optimize.rs
+++ b/java/lance-jni/src/optimize.rs
@@ -362,8 +362,6 @@ impl IntoJava for &CompactionOptions {
         let batch_size_opt = to_java_optional(env, batch_size)?;
         let defer_index_remap = to_java_boolean_obj(env, Some(self.defer_index_remap))?;
         let defer_index_remap_opt = to_java_optional(env, defer_index_remap)?;
-        // The Java field is Optional<CompactionMode>; type erasure would let a
-        // plain String slip through the constructor, so fetch the enum constant.
         let compaction_mode_obj = match self.compaction_mode {
             Some(mode) => {
                 let name = match mode {

--- a/java/src/test/java/org/lance/CompactionTest.java
+++ b/java/src/test/java/org/lance/CompactionTest.java
@@ -15,6 +15,7 @@ package org.lance;
 
 import org.lance.compaction.Compaction;
 import org.lance.compaction.CompactionMetrics;
+import org.lance.compaction.CompactionMode;
 import org.lance.compaction.CompactionOptions;
 import org.lance.compaction.CompactionPlan;
 import org.lance.compaction.CompactionTask;
@@ -23,6 +24,8 @@ import org.lance.compaction.RewriteResult;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -31,6 +34,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -126,6 +130,40 @@ public class CompactionTest {
         dataset.checkoutLatest();
         assertEquals(1, dataset.getFragments().size());
         assertEquals(11, dataset.getFragments().get(0).countRows());
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(CompactionMode.class)
+  public void testCompactionModeRoundTrip(CompactionMode mode, @TempDir Path tempDir)
+      throws Exception {
+    String datasetPath = tempDir.resolve("test_dataset_for_compaction").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+
+      testDataset.write(1, 10).close();
+      try (Dataset dataset = testDataset.write(2, 10)) {
+        CompactionOptions compactionOptions =
+            CompactionOptions.builder()
+                .withTargetRowsPerFragment(100)
+                .withNumThreads(1)
+                .withCompactionMode(mode)
+                .build();
+        CompactionPlan compactionPlan = Compaction.planCompaction(dataset, compactionOptions);
+
+        // The plan's options are rebuilt by the native layer; the mode must come
+        // back as a CompactionMode enum, not a raw String.
+        assertEquals(
+            Optional.of(mode.getValue()),
+            compactionPlan.getCompactionOptions().getCompactionMode());
+
+        CompactionTask task = serializeAndDeserialize(compactionPlan.getCompactionTasks().get(0));
+        RewriteResult result = task.execute(dataset);
+        assertEquals(2, result.getMetrics().getFragmentsRemoved());
+        assertEquals(1, result.getMetrics().getFragmentsAdded());
       }
     }
   }


### PR DESCRIPTION
Without this PR, any code that sets a compaction mode crashes on the normal plan → execute path, because `CompactionTask.execute()` reads `compactionOptions.getCompactionMode()` from an options object that the native layer filled with a raw `String` instead of a `CompactionMode`.

```java
import org.lance.Dataset;
import org.lance.compaction.*;

try (Dataset dataset = Dataset.open("/path/to/dataset")) {  // 2 fragments
  CompactionOptions options =
      CompactionOptions.builder()
          .withTargetRowsPerFragment(100)
          .withCompactionMode(CompactionMode.FORCE_BINARY_COPY)
          .build();

  CompactionPlan plan = Compaction.planCompaction(dataset, options);  // returns fine

  CompactionTask task = plan.getCompactionTasks().get(0);
  RewriteResult result = task.execute(dataset);                       // throws here
}
```

```
java.lang.ClassCastException: class java.lang.String cannot be cast to
class org.lance.compaction.CompactionMode
(java.lang.String is in module java.base of loader 'bootstrap';
 org.lance.compaction.CompactionMode is in unnamed module of loader 'app')

    at java.base/java.util.Optional.map(Optional.java:265)
    at org.lance.compaction.CompactionOptions.getCompactionMode(CompactionOptions.java:75)
    at org.lance.compaction.CompactionTask.execute(CompactionTask.java:57)
```
