### PR TITLE
docs(format): add FM-Index to scalar index navigation

### DIFF
--- a/docs/src/format/index/scalar/.pages
+++ b/docs/src/format/index/scalar/.pages
@@ -7,4 +7,5 @@ nav:
   - Bloom Filter: bloom_filter.md
   - Full Text Search: fts.md
   - N-gram: ngram.md
+  - FM-Index: fmindex.md
   - RTree: rtree.md


### PR DESCRIPTION
`fmindex.md` has been in the tree since #7123 but was never added to the
scalar index nav, so the page is published yet unreachable from the sidebar:
`lance.org/format/index/scalar/fmindex/` returns 200, while the BTree page
lists only its seven other siblings.

Placed between N-gram and RTree, matching the file's position in the
directory listing.

Documentation only; no format change.
