### PR TITLE
docs: update crate READMEs to lance-format org

### DIFF
--- a/rust/lance-arrow/README.md
+++ b/rust/lance-arrow/README.md
@@ -1,7 +1,7 @@
 # lance-arrow
 
-`lance-arrow` is a internal sub-crate, containing [Apache-Arrow](https://github.com/apache/arrow-rs)
-extensions used by [Lance](https://github.com/lancedb/lance).
+`lance-arrow` is an internal sub-crate, containing [Apache-Arrow](https://github.com/apache/arrow-rs)
+extensions used by [Lance](https://github.com/lance-format/lance).
 
 **Important Note**: This crate is **not intended for external usage**. 
 

--- a/rust/lance-index/README.md
+++ b/rust/lance-index/README.md
@@ -1,7 +1,7 @@
 # lance-index
 
 `lance-index` is an internal sub-crate, containing various vector index implementations
-used in [Lance](https://github.com/lancedb/lance).
+used in [Lance](https://github.com/lance-format/lance).
 
 **Important Note**: This crate is **not intended for external usage**.
 

--- a/rust/lance-linalg/README.md
+++ b/rust/lance-linalg/README.md
@@ -1,6 +1,6 @@
 # Lance Linear Algebra Library
 
-`lance-linalg` is a internal sub-crate, containing [Apache-Arrow](https://github.com/apache/arrow-rs)
-native linear algebra algorithm used the [Lance](https://github.com/lancedb/lance).
+`lance-linalg` is an internal sub-crate, containing [Apache-Arrow](https://github.com/apache/arrow-rs)
+native linear algebra algorithms used by [Lance](https://github.com/lance-format/lance).
 
 


### PR DESCRIPTION
These three crates set `readme = "README.md"` and are published, so their
READMEs render on crates.io — where the Lance link still points at the old
`lancedb/lance` org.

Also fixes `is a internal` in two of them, and `algorithm used the [Lance]`
in lance-linalg.

Only the three crate READMEs that mention the old org; the other 15 under
`rust/` do not.
