### PR TITLE
docs: use indices instead of indexes in guide and quickstart

### DIFF
--- a/docs/src/guide/data_types.md
+++ b/docs/src/guide/data_types.md
@@ -408,7 +408,7 @@ This maps to Lance's `FixedSizeList(Float32, 384)` type, which is optimized for:
 
 3. **Align dimensions for SIMD**: Vector dimensions divisible by 8 enable optimal SIMD acceleration. Common dimensions: 128, 256, 384, 512, 768, 1024, 1536.
 
-4. **Create indexes for large datasets**: For datasets with more than ~10,000 vectors, create an ANN index for fast search:
+4. **Create indices for large datasets**: For datasets with more than ~10,000 vectors, create an ANN index for fast search:
 
     ```python
     # IVF_PQ is recommended for most use cases

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -105,4 +105,4 @@ dataset.to_table().to_pandas()
 Now that you've mastered the basics of creating Lance datasets, here's what you can explore next:
 
 - **[Versioning Your Datasets with Lance](versioning.md)** - Learn how to track changes over time with native versioning
-- **[Vector Indexing and Vector Search With Lance](vector-search.md)** - Build high-performance vector search capabilities with ANN indexes
+- **[Vector Indexing and Vector Search With Lance](vector-search.md)** - Build high-performance vector search capabilities with ANN indices

--- a/docs/src/quickstart/vector-search.md
+++ b/docs/src/quickstart/vector-search.md
@@ -1,13 +1,13 @@
 ---
 title: Vector Search
-description: High-performance vector search with ANN indexes, including IVF_PQ, IVF_HNSW_PQ, and IVF_HNSW_SQ
+description: High-performance vector search with ANN indices, including IVF_PQ, IVF_HNSW_PQ, and IVF_HNSW_SQ
 ---
 
 # Vector Indexing and Vector Search With Lance
 
-Lance provides high-performance vector search capabilities with ANN (Approximate Nearest Neighbor) indexes.
+Lance provides high-performance vector search capabilities with ANN (Approximate Nearest Neighbor) indices.
 
-By the end of this tutorial, you'll be able to build and use ANN indexes to dramatically speed up vector search operations while maintaining high accuracy. You'll also learn how to tune search parameters for optimal performance and combine vector search with metadata queries in a single operation.
+By the end of this tutorial, you'll be able to build and use ANN indices to dramatically speed up vector search operations while maintaining high accuracy. You'll also learn how to tune search parameters for optimal performance and combine vector search with metadata queries in a single operation.
 
 ## Install the Python SDK
 


### PR DESCRIPTION
`AGENTS.md` asks for `indices` (not `indexes`) consistently in APIs and docs.
These five occurrences are all prose about index objects, so the rule applies
directly.

Left alone: `maintained_indexes` in `dataset.py`, which matches the field name
in `python/src/dataset.rs` and `mem_wal/api.rs` — renaming it on the Python
side only would break the stronger cross-language naming rule.
