### PR TITLE
docs: fix broken observability and tokenizer links

### DIFF
--- a/docs/src/guide/observability.md
+++ b/docs/src/guide/observability.md
@@ -2,8 +2,8 @@
 
 Lance can publish operational metrics to your monitoring stack. The table below
 is the authoritative catalogue of the metrics Lance emits, shared verbatim with
-the Rust [`lance::metrics`](https://docs.rs/lance/latest/lance/metrics/) module
-documentation.
+the Rust [`lance::metrics`](https://github.com/lance-format/lance/blob/main/rust/lance/src/metrics.md)
+module documentation.
 
 --8<-- "rust/lance/src/metrics.md"
 

--- a/docs/src/guide/tokenizer.md
+++ b/docs/src/guide/tokenizer.md
@@ -54,7 +54,7 @@ Create a file named config.json in the root directory of the current model.
 ```
 
 - The "main" field is optional. If not filled, the default is "dict.txt".
-- "users" is the path of the user dictionary. For the format of the user dictionary, please refer to https://github.com/messense/jieba-rs/blob/main/src/data/dict.txt.
+- "users" is the path of the user dictionary. For the format of the user dictionary, please refer to https://github.com/messense/jieba-rs/blob/main/jieba/src/data/dict.txt.
 
 ## Language Models of Lindera
 

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -12,7 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [package.metadata.docs.rs]
-features = []
+# Publish the feature-gated metrics catalogue; keep cloud backends off.
+features = ["metrics"]
 no-default-features = true
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the two documentation 404s reported in #8364.

- `docs/src/guide/tokenizer.md`: jieba-rs moved its dictionary into the `jieba/` crate path (`jieba/src/data/dict.txt`).
- `docs/src/guide/observability.md`: `lance::metrics` is feature-gated and docs.rs currently builds with no features, so `docs.rs/.../lance/metrics/` 404s. Point the guide at the in-repo `metrics.md` source that the page already includes, and enable the `metrics` feature in `[package.metadata.docs.rs]` so the module is published after the next crate release.

## Test plan

- [x] Confirmed both replacement URLs return HTTP 200
- [ ] Scheduled docs link checker should clear the Errors entries for these two files once this lands on `main`

Fixes #8364

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdc5b-66b4-7906-b358-eea702562058?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdc5b-66b4-7906-b358-eea702562058&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

