### PR TITLE
feat(python): expose FTS query tokenization

### DIFF
--- a/docs/src/guide/tokenizer.md
+++ b/docs/src/guide/tokenizer.md
@@ -12,6 +12,39 @@ ${system data directory}/lance/language_models
 It also supports configuring user dictionaries,
 which makes it convenient for users to expand their own dictionaries without retraining the language models.
 
+## Inspect Query Tokenization
+
+Use `lance.tokenize` to inspect the tokens that a full-text query will produce
+without creating a dataset or index:
+
+```python
+import lance
+
+tokens = lance.tokenize("the Cats and Dogs")
+[(token.text, token.position) for token in tokens]
+# [("cat", 0), ("dog", 2)]
+```
+
+Positions start at the first retained query token and preserve gaps left by stop
+word removal and other filters. This is the same representation used for phrase
+matching. The function accepts the tokenizer-related options supported by
+`LanceDataset.create_scalar_index`, including custom stop words, n-grams, and the
+code analyzer:
+
+```python
+tokens = lance.tokenize(
+    "getUserName::value42",
+    analyzer="code",
+    split_identifiers=True,
+    index_operators=True,
+)
+```
+
+Options set to `None` use the selected analyzer profile's default. For example,
+the code analyzer disables stemming and stop-word removal unless explicitly
+overridden. The exception is `max_token_length`: omitting it keeps the default
+length limit of 40, while `max_token_length=None` disables the limit.
+
 ## ICU Tokenizer
 
 ICU uses Unicode word boundary rules and bundled dictionary data for complex scripts. It is useful for mixed-language text and does not require downloading a language model.

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -44,10 +44,12 @@ from .lance import (
     CleanupStats,
     DatasetBasePath,
     FFILanceTableProvider,
+    FtsToken,
     ScanStatistics,
     bytes_read_counter,
     iops_counter,
     simd_info,
+    tokenize,
 )
 from .mem_wal import (
     CompactedSsTable,
@@ -98,6 +100,7 @@ __all__ = [
     "DataStatistics",
     "FieldStatistics",
     "FragmentMetadata",
+    "FtsToken",
     "Index",
     "IndexFile",
     "LanceDataset",
@@ -117,6 +120,7 @@ __all__ = [
     "schema_to_json",
     "set_logger",
     "simd_info",
+    "tokenize",
     "write_dataset",
     "FFILanceTableProvider",
     "IndexProgress",

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -109,6 +109,37 @@ def register_lance_metrics_recorder() -> bool: ...
 def lance_metrics_catalog() -> List[MetricDescription]: ...
 def snapshot_lance_metrics() -> List[MetricPoint]: ...
 
+class FtsToken:
+    text: str
+    position: int
+    def __repr__(self) -> str: ...
+
+def tokenize(
+    query: str,
+    *,
+    analyzer: Optional[Literal["text", "code"]] = None,
+    base_tokenizer: Optional[str] = None,
+    language: Optional[str] = None,
+    max_token_length: Optional[int] = 40,
+    lower_case: Optional[bool] = None,
+    stem: Optional[bool] = None,
+    remove_stop_words: Optional[bool] = None,
+    custom_stop_words: Optional[List[str]] = None,
+    ascii_folding: Optional[bool] = None,
+    min_ngram_length: Optional[int] = None,
+    max_ngram_length: Optional[int] = None,
+    prefix_only: Optional[bool] = None,
+    split_identifiers: Optional[bool] = None,
+    split_on_numerics: Optional[bool] = None,
+    preserve_original: Optional[bool] = None,
+    index_operators: Optional[bool] = None,
+) -> List[FtsToken]:
+    """Tokenize an FTS query without an index.
+
+    ``max_token_length`` defaults to 40; pass ``None`` to disable the limit.
+    """
+    ...
+
 class CleanupStats:
     bytes_removed: int
     old_versions: int

--- a/python/python/tests/test_lance.py
+++ b/python/python/tests/test_lance.py
@@ -271,6 +271,52 @@ def test_simd_info():
 
 
 @pytest.mark.parametrize(
+    ("query", "options", "expected"),
+    [
+        ("the cats and dogs", {}, [("cat", 0), ("dog", 2)]),
+        (
+            "the skip alpha",
+            {"stem": False, "custom_stop_words": ["skip"]},
+            [("the", 0), ("alpha", 2)],
+        ),
+        (
+            "getUserName",
+            {"analyzer": "code", "split_identifiers": True},
+            [
+                ("getusername", 0),
+                ("get", 0),
+                ("user", 1),
+                ("name", 2),
+            ],
+        ),
+        (
+            "a::b",
+            {"analyzer": "code", "index_operators": True},
+            [("a", 0), ("::", 1), ("b", 2)],
+        ),
+    ],
+)
+def test_tokenize_fts_query(query, options, expected):
+    tokens = lance.tokenize(query, **options)
+    assert [(token.text, token.position) for token in tokens] == expected
+
+
+def test_tokenize_fts_query_validates_analyzer_options():
+    with pytest.raises(ValueError, match="code analyzer flags require analyzer='code'"):
+        lance.tokenize("getUserName", split_identifiers=True)
+
+    with pytest.raises(ValueError, match="unknown base tokenizer"):
+        lance.tokenize("hello", base_tokenizer="unknown")
+
+
+def test_tokenize_fts_query_can_disable_max_token_length():
+    long_token = "x" * 41
+    assert lance.tokenize(long_token, stem=False) == []
+    unlimited_tokens = lance.tokenize(long_token, max_token_length=None, stem=False)
+    assert [token.text for token in unlimited_tokens] == [long_token]
+
+
+@pytest.mark.parametrize(
     "row_param, column_name",
     [("with_row_id", "_rowid"), ("with_row_address", "_rowaddr")],
 )

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -98,6 +98,7 @@ use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
 use crate::fragment::FileFragment;
+use crate::fts::FtsTokenizerOptions;
 use crate::indices::{PyIndexConfig, PyIndexDescription, PyIndexSegment};
 use crate::namespace::extract_namespace_arc;
 use crate::rt;
@@ -2592,57 +2593,7 @@ impl Dataset {
                         }
                     }
 
-                    let analyzer: Option<String> = kwargs
-                        .get_item("analyzer")?
-                        .map(|value| value.extract())
-                        .transpose()?;
-                    let base_tokenizer: Option<String> = kwargs
-                        .get_item("base_tokenizer")?
-                        .map(|value| value.extract())
-                        .transpose()?;
-
-                    match (analyzer.as_deref(), base_tokenizer.as_deref()) {
-                        (Some("text"), Some("code")) => {
-                            return Err(PyValueError::new_err(
-                                "base_tokenizer='code' requires analyzer='code'",
-                            ));
-                        }
-                        (Some("code"), Some(base_tokenizer)) if base_tokenizer != "code" => {
-                            return Err(PyValueError::new_err(format!(
-                                "analyzer='code' requires base_tokenizer='code', got '{}'",
-                                base_tokenizer
-                            )));
-                        }
-                        _ => {}
-                    }
-
-                    let uses_code_analyzer = match analyzer.as_deref() {
-                        Some("code") => true,
-                        Some("text") | None => base_tokenizer.as_deref() == Some("code"),
-                        Some(_) => true,
-                    };
-                    if !uses_code_analyzer {
-                        for flag in [
-                            "split_identifiers",
-                            "split_on_numerics",
-                            "preserve_original",
-                            "index_operators",
-                        ] {
-                            if let Some(value) = kwargs.get_item(flag)?
-                                && value.extract::<bool>()?
-                            {
-                                return Err(PyValueError::new_err(
-                                    "code analyzer flags require analyzer='code'",
-                                ));
-                            }
-                        }
-                    }
-
-                    if let Some(analyzer) = analyzer {
-                        params = params
-                            .analyzer(&analyzer)
-                            .map_err(|err| PyValueError::new_err(err.to_string()))?;
-                    }
+                    params = FtsTokenizerOptions::from_kwargs(kwargs)?.apply(params)?;
                     if let Some(document_granularity) = kwargs.get_item("document_granularity")? {
                         let document_granularity: String = document_granularity.extract()?;
                         params = params.document_granularity(
@@ -2653,62 +2604,10 @@ impl Dataset {
                     if let Some(with_position) = kwargs.get_item("with_position")? {
                         params = params.with_position(with_position.extract()?);
                     }
-                    if let Some(base_tokenizer) = base_tokenizer {
-                        params = params.base_tokenizer(base_tokenizer);
-                    }
-                    if let Some(language) = kwargs.get_item("language")? {
-                        let language: PyBackedStr =
-                            language.cast::<PyString>()?.clone().try_into()?;
-                        params = params.language(&language).map_err(|err| {
-                            PyValueError::new_err(format!(
-                                "can't set tokenizer language to {}: {}",
-                                language, err
-                            ))
-                        })?;
-                    }
-                    if let Some(max_token_length) = kwargs.get_item("max_token_length")? {
-                        params = params.max_token_length(max_token_length.extract()?);
-                    }
-                    if let Some(lower_case) = kwargs.get_item("lower_case")? {
-                        params = params.lower_case(lower_case.extract()?);
-                    }
-                    if let Some(stem) = kwargs.get_item("stem")? {
-                        params = params.stem(stem.extract()?);
-                    }
-                    if let Some(remove_stop_words) = kwargs.get_item("remove_stop_words")? {
-                        params = params.remove_stop_words(remove_stop_words.extract()?);
-                    }
-                    if let Some(custom_stop_words) = kwargs.get_item("custom_stop_words")? {
-                        params = params.custom_stop_words(custom_stop_words.extract()?);
-                    }
-                    if let Some(ascii_folding) = kwargs.get_item("ascii_folding")? {
-                        params = params.ascii_folding(ascii_folding.extract()?);
-                    }
-                    if let Some(min_ngram_length) = kwargs.get_item("min_ngram_length")? {
-                        params = params.ngram_min_length(min_ngram_length.extract()?);
-                    }
-                    if let Some(max_ngram_length) = kwargs.get_item("max_ngram_length")? {
-                        params = params.ngram_max_length(max_ngram_length.extract()?);
-                    }
-                    if let Some(prefix_only) = kwargs.get_item("prefix_only")? {
-                        params = params.ngram_prefix_only(prefix_only.extract()?);
-                    }
                     if let Some(block_size) = kwargs.get_item("block_size")? {
                         params = params
                             .block_size(block_size.extract()?)
                             .map_err(|e| PyValueError::new_err(e.to_string()))?;
-                    }
-                    if let Some(split_identifiers) = kwargs.get_item("split_identifiers")? {
-                        params = params.split_identifiers(split_identifiers.extract()?);
-                    }
-                    if let Some(split_on_numerics) = kwargs.get_item("split_on_numerics")? {
-                        params = params.split_on_numerics(split_on_numerics.extract()?);
-                    }
-                    if let Some(preserve_original) = kwargs.get_item("preserve_original")? {
-                        params = params.preserve_original(preserve_original.extract()?);
-                    }
-                    if let Some(index_operators) = kwargs.get_item("index_operators")? {
-                        params = params.index_operators(index_operators.extract()?);
                     }
                     if let Some(memory_limit) = kwargs.get_item("memory_limit")? {
                         params = params.memory_limit_mb(memory_limit.extract()?);

--- a/python/src/fts.rs
+++ b/python/src/fts.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use lance_index::scalar::InvertedIndexParams;
+use lance_index::scalar::inverted::query::collect_query_tokens;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+fn extract_kwarg<'py, T>(kwargs: &Bound<'py, PyDict>, key: &str) -> PyResult<Option<T>>
+where
+    T: FromPyObjectOwned<'py>,
+{
+    kwargs
+        .get_item(key)?
+        .map(|value| value.extract::<T>().map_err(Into::into))
+        .transpose()
+}
+
+pub(crate) struct FtsTokenizerOptions {
+    analyzer: Option<String>,
+    base_tokenizer: Option<String>,
+    language: Option<String>,
+    // The outer option tracks omission; the inner None explicitly disables the limit.
+    max_token_length: Option<Option<usize>>,
+    lower_case: Option<bool>,
+    stem: Option<bool>,
+    remove_stop_words: Option<bool>,
+    // Preserve omitted versus explicit None to match create-index keyword semantics.
+    custom_stop_words: Option<Option<Vec<String>>>,
+    ascii_folding: Option<bool>,
+    min_ngram_length: Option<u32>,
+    max_ngram_length: Option<u32>,
+    prefix_only: Option<bool>,
+    split_identifiers: Option<bool>,
+    split_on_numerics: Option<bool>,
+    preserve_original: Option<bool>,
+    index_operators: Option<bool>,
+}
+
+impl FtsTokenizerOptions {
+    pub(crate) fn from_kwargs(kwargs: &Bound<'_, PyDict>) -> PyResult<Self> {
+        Ok(Self {
+            analyzer: extract_kwarg(kwargs, "analyzer")?,
+            base_tokenizer: extract_kwarg(kwargs, "base_tokenizer")?,
+            language: extract_kwarg(kwargs, "language")?,
+            max_token_length: extract_kwarg(kwargs, "max_token_length")?,
+            lower_case: extract_kwarg(kwargs, "lower_case")?,
+            stem: extract_kwarg(kwargs, "stem")?,
+            remove_stop_words: extract_kwarg(kwargs, "remove_stop_words")?,
+            custom_stop_words: extract_kwarg(kwargs, "custom_stop_words")?,
+            ascii_folding: extract_kwarg(kwargs, "ascii_folding")?,
+            min_ngram_length: extract_kwarg(kwargs, "min_ngram_length")?,
+            max_ngram_length: extract_kwarg(kwargs, "max_ngram_length")?,
+            prefix_only: extract_kwarg(kwargs, "prefix_only")?,
+            split_identifiers: extract_kwarg(kwargs, "split_identifiers")?,
+            split_on_numerics: extract_kwarg(kwargs, "split_on_numerics")?,
+            preserve_original: extract_kwarg(kwargs, "preserve_original")?,
+            index_operators: extract_kwarg(kwargs, "index_operators")?,
+        })
+    }
+
+    pub(crate) fn apply(self, mut params: InvertedIndexParams) -> PyResult<InvertedIndexParams> {
+        match (self.analyzer.as_deref(), self.base_tokenizer.as_deref()) {
+            (Some("text"), Some("code")) => {
+                return Err(PyValueError::new_err(
+                    "base_tokenizer='code' requires analyzer='code'",
+                ));
+            }
+            (Some("code"), Some(base_tokenizer)) if base_tokenizer != "code" => {
+                return Err(PyValueError::new_err(format!(
+                    "analyzer='code' requires base_tokenizer='code', got '{base_tokenizer}'"
+                )));
+            }
+            _ => {}
+        }
+
+        let uses_code_analyzer = match self.analyzer.as_deref() {
+            Some("code") => true,
+            Some("text") | None => self.base_tokenizer.as_deref() == Some("code"),
+            Some(_) => true,
+        };
+        if !uses_code_analyzer
+            && [
+                self.split_identifiers,
+                self.split_on_numerics,
+                self.preserve_original,
+                self.index_operators,
+            ]
+            .into_iter()
+            .flatten()
+            .any(|value| value)
+        {
+            return Err(PyValueError::new_err(
+                "code analyzer flags require analyzer='code'",
+            ));
+        }
+
+        if let Some(analyzer) = self.analyzer {
+            params = params
+                .analyzer(&analyzer)
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        }
+        if let Some(base_tokenizer) = self.base_tokenizer {
+            params = params.base_tokenizer(base_tokenizer);
+        }
+        if let Some(language) = self.language {
+            params = params.language(&language).map_err(|err| {
+                PyValueError::new_err(format!("can't set tokenizer language to {language}: {err}"))
+            })?;
+        }
+        if let Some(max_token_length) = self.max_token_length {
+            params = params.max_token_length(max_token_length);
+        }
+        if let Some(lower_case) = self.lower_case {
+            params = params.lower_case(lower_case);
+        }
+        if let Some(stem) = self.stem {
+            params = params.stem(stem);
+        }
+        if let Some(remove_stop_words) = self.remove_stop_words {
+            params = params.remove_stop_words(remove_stop_words);
+        }
+        if let Some(custom_stop_words) = self.custom_stop_words {
+            params = params.custom_stop_words(custom_stop_words);
+        }
+        if let Some(ascii_folding) = self.ascii_folding {
+            params = params.ascii_folding(ascii_folding);
+        }
+        if let Some(min_ngram_length) = self.min_ngram_length {
+            params = params.ngram_min_length(min_ngram_length);
+        }
+        if let Some(max_ngram_length) = self.max_ngram_length {
+            params = params.ngram_max_length(max_ngram_length);
+        }
+        if let Some(prefix_only) = self.prefix_only {
+            params = params.ngram_prefix_only(prefix_only);
+        }
+        if let Some(split_identifiers) = self.split_identifiers {
+            params = params.split_identifiers(split_identifiers);
+        }
+        if let Some(split_on_numerics) = self.split_on_numerics {
+            params = params.split_on_numerics(split_on_numerics);
+        }
+        if let Some(preserve_original) = self.preserve_original {
+            params = params.preserve_original(preserve_original);
+        }
+        if let Some(index_operators) = self.index_operators {
+            params = params.index_operators(index_operators);
+        }
+        Ok(params)
+    }
+}
+
+/// A token produced by the full-text search query tokenizer.
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct FtsToken {
+    /// The token text after all configured filters have been applied.
+    pub text: String,
+    /// The position used by full-text query matching.
+    pub position: u32,
+}
+
+#[pymethods]
+impl FtsToken {
+    fn __repr__(&self) -> String {
+        format!("FtsToken(text={:?}, position={})", self.text, self.position)
+    }
+}
+
+/// Tokenize a full-text search query without creating a dataset or index.
+///
+/// The tokenizer options are the same as the tokenizer-related options accepted by
+/// ``LanceDataset.create_scalar_index(..., index_type="INVERTED")``. ``None`` uses
+/// the selected analyzer profile's default, except ``max_token_length=None``, which
+/// disables the length limit; omitting it keeps the default limit of 40. Returned
+/// positions are normalized to the first retained token while preserving gaps left
+/// by token filters.
+///
+/// Examples
+/// --------
+/// >>> import lance
+/// >>> tokens = lance.tokenize("the Cats and Dogs")
+/// >>> [(token.text, token.position) for token in tokens]
+/// [('cat', 0), ('dog', 2)]
+#[pyfunction]
+#[pyo3(signature = (
+    query,
+    *,
+    analyzer = None,
+    base_tokenizer = None,
+    language = None,
+    max_token_length = Some(40),
+    lower_case = None,
+    stem = None,
+    remove_stop_words = None,
+    custom_stop_words = None,
+    ascii_folding = None,
+    min_ngram_length = None,
+    max_ngram_length = None,
+    prefix_only = None,
+    split_identifiers = None,
+    split_on_numerics = None,
+    preserve_original = None,
+    index_operators = None,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn tokenize(
+    query: &str,
+    analyzer: Option<String>,
+    base_tokenizer: Option<String>,
+    language: Option<String>,
+    max_token_length: Option<usize>,
+    lower_case: Option<bool>,
+    stem: Option<bool>,
+    remove_stop_words: Option<bool>,
+    custom_stop_words: Option<Vec<String>>,
+    ascii_folding: Option<bool>,
+    min_ngram_length: Option<u32>,
+    max_ngram_length: Option<u32>,
+    prefix_only: Option<bool>,
+    split_identifiers: Option<bool>,
+    split_on_numerics: Option<bool>,
+    preserve_original: Option<bool>,
+    index_operators: Option<bool>,
+) -> PyResult<Vec<FtsToken>> {
+    let params = FtsTokenizerOptions {
+        analyzer,
+        base_tokenizer,
+        language,
+        max_token_length: Some(max_token_length),
+        lower_case,
+        stem,
+        remove_stop_words,
+        custom_stop_words: custom_stop_words.map(Some),
+        ascii_folding,
+        min_ngram_length,
+        max_ngram_length,
+        prefix_only,
+        split_identifiers,
+        split_on_numerics,
+        preserve_original,
+        index_operators,
+    }
+    .apply(InvertedIndexParams::default())?;
+
+    let mut tokenizer = params
+        .build()
+        .map_err(|err| PyValueError::new_err(format!("Failed to build tokenizer: {err}")))?;
+    let tokens = collect_query_tokens(query, &mut tokenizer);
+    Ok((0..tokens.len())
+        .map(|index| FtsToken {
+            text: tokens.get_token(index).to_string(),
+            position: tokens.position(index),
+        })
+        .collect())
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -71,6 +71,7 @@ pub(crate) mod error;
 pub(crate) mod executor;
 pub(crate) mod file;
 pub(crate) mod fragment;
+pub(crate) mod fts;
 pub(crate) mod indices;
 pub(crate) mod mem_wal;
 pub(crate) mod namespace;
@@ -296,6 +297,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Session>()?;
     m.add_class::<PyTraceEvent>()?;
     m.add_class::<TraceGuard>()?;
+    m.add_class::<fts::FtsToken>()?;
     m.add_class::<schema::LanceSchema>()?;
     m.add_class::<PyFullTextQuery>()?;
     m.add_class::<PySearchFilter>()?;
@@ -324,6 +326,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(trace_to_chrome))?;
     m.add_wrapped(wrap_pyfunction!(capture_trace_events))?;
     m.add_wrapped(wrap_pyfunction!(shutdown_tracing))?;
+    m.add_wrapped(wrap_pyfunction!(fts::tokenize))?;
     // OpenTelemetry metrics bridge
     m.add_class::<otel::PyMetricPoint>()?;
     m.add_class::<otel::PyMetricDescription>()?;


### PR DESCRIPTION
## What is the new feature?

Add public `lance.tokenize(...)` and `FtsToken(text, position)` APIs for inspecting FTS query tokenization without creating a dataset or index.

## Why do we need this feature?

Applications need to preview and debug the exact query terms and positions produced by Lance tokenizer configuration before running a search or building an index.

## How does it work?

- Reuse the Rust FTS tokenizer and query-token collection logic.
- Share tokenizer option parsing with PyLance INVERTED index creation so the two APIs cannot drift.
- Support text/code analyzer profiles, language, custom stop words, n-grams, maximum token length, and code tokenizer flags.
- Add top-level exports, type stubs, API examples, focused tests, and user documentation.

## Validation

- `CARGO_BUILD_JOBS=2 make build` from `python/`: passed
- New and adjacent Python tests: 8 passed
- Runtime example: `the Cats and Dogs` -> `[("cat", 0), ("dog", 2)]`
- `uv run make lint` from `python/`: passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --all --tests --benches -- -D warnings`: passed
- `git diff main...HEAD --check`: passed

The only build warning was the existing macOS linker warning that `__eh_frame` is too large.

Linear: [OSS-2008](https://linear.app/lancedb/issue/OSS-2008/featpython-expose-fts-query-tokenization-in-pylance)