### PR TITLE
fix(docs): align integrations nav with website assembly script

### DIFF
--- a/docs/clean-full-website.sh
+++ b/docs/clean-full-website.sh
@@ -39,7 +39,7 @@ cat > "$docs_src/integrations/.pages" <<'EOF'
 nav:
   - Overview: index.md
   - Apache DataFusion: datafusion.md
-  - PostgreSQL: https://github.com/lancedb/pglance
+  - PostgreSQL: https://github.com/lance-format/pglance
   - PyTorch: pytorch.md
   - TensorFlow: tensorflow.md
 EOF

--- a/docs/src/integrations/.pages
+++ b/docs/src/integrations/.pages
@@ -1,9 +1,6 @@
 nav:
   - Overview: index.md
   - Apache DataFusion: datafusion.md
-  - PostgreSQL: https://github.com/lancedb/pglance
+  - PostgreSQL: https://github.com/lance-format/pglance
   - PyTorch: pytorch.md
   - TensorFlow: tensorflow.md
-  - Apache Spark: spark
-  - Ray: ray
-  - Trino: trino


### PR DESCRIPTION
The checked-in `.pages` lists `Apache Spark`, `Ray` and `Trino`, but those three
are appended by `make-full-website.sh` only when the external docs are present.
So the committed file does not represent the clean baseline that
`clean-full-website.sh` writes, and either script leaves a dirty `git diff`.

Dropping them makes the committed file match the clean baseline, so the two
scripts round-trip. Also updates the pglance link, which `index.md` already
points at the new org.

Verified by replaying the assembly order (clean, then collect, then append):
the nav is unchanged in content and the committed file is now stable.
