### PR TITLE
docs(python): fix docstring parameter names that do not exist

### DIFF
--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -193,7 +193,7 @@ def maybe_sample(
         This is employed to minimize the number of random reads necessary for sampling.
         A sufficiently large value can provide an effective random sample without
         the need for excessive random reads.
-    filter : str, optional
+    filt : str, optional
         The filter to apply to the dataset, by default None.  If a filter is provided,
         then we will first load all row ids in memory and then batch through the ids
         in random order until enough matches have been found.

--- a/python/python/lance/schema.py
+++ b/python/python/lance/schema.py
@@ -12,17 +12,19 @@ from .lance import _json_to_schema, _schema_to_json
 
 def schema_to_json(schema: pa.Schema) -> Dict[str, Any]:
     """
-    Converts a pyarrow schema to a JSON string.
+    Converts a pyarrow schema to a JSON-compatible dict.
 
     Parameters
     ----------
+    schema: pa.Schema
+        The PyArrow schema to convert.
     """
     return json.loads(_schema_to_json(schema))
 
 
 def json_to_schema(schema_json: Dict[str, Any]) -> pa.Schema:
     """
-    Converts a JSON string to a PyArrow schema.
+    Converts a JSON-compatible dict to a PyArrow schema.
 
     Parameters
     ----------

--- a/python/python/lance/torch/bench_utils.py
+++ b/python/python/lance/torch/bench_utils.py
@@ -128,7 +128,7 @@ def recall(expected: np.ndarray, actual: np.ndarray) -> np.ndarray:
     ----------
     expected: ndarray
         The ground truth
-    results: ndarray
+    actual: ndarray
         The ANN results
     """
     assert expected.shape == actual.shape

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -289,12 +289,12 @@ def compute_pq_codes(
         Dataset to compute pq codes for.
     kmeans_list: List[lance.torch.kmeans.KMeans]
         KMeans models to use to compute pq (one per subspace)
-    batch_size: int, default 10240
+    batch_size: int, default 40960
         The batch size used to read the dataset.
     dst_dataset_uri: Union[str, Path], optional
         The path to store the partitions.  If not specified a random
         directory is used instead
-    allow_tf32: bool, default True
+    allow_cuda_tf32: bool, default True
         Whether to allow tf32 for matmul on CUDA.
 
     Returns
@@ -418,12 +418,12 @@ def compute_partitions(
         Column name of the vector column.
     kmeans: lance.torch.kmeans.KMeans
         KMeans model to use to compute partitions.
-    batch_size: int, default 10240
+    batch_size: int, default 40960
         The batch size used to read the dataset.
     dst_dataset_uri: Union[str, Path], optional
         The path to store the partitions.  If not specified a random
         directory is used instead
-    allow_tf32: bool, default True
+    allow_cuda_tf32: bool, default True
         Whether to allow tf32 for matmul on CUDA.
 
     Returns


### PR DESCRIPTION
Four docstrings named parameters that do not exist, so following them raises
`TypeError`:

- `vector.py`: `allow_tf32` is the torch attribute assigned inside the body;
  the parameter is `allow_cuda_tf32`. `batch_size` defaults to `1024 * 10 * 4`,
  which is 40960 rather than the documented 10240.
- `sampler.py`: `maybe_sample`'s parameter is `filt`, which is what
  `torch/data.py` passes.
- `bench_utils.py`: `recall`'s second parameter is `actual`, not `results`.
- `schema.py`: empty `Parameters` section, and both summaries had the direction
  backwards — these convert to and from a dict, not a JSON string.

Docstrings only; the public signatures are unchanged.
