### PR TITLE
test(index): add unit tests for FlatTransformer

### DIFF
--- a/rust/lance-index/src/vector/flat/transform.rs
+++ b/rust/lance-index/src/vector/flat/transform.rs
@@ -45,3 +45,91 @@ impl Transformer for FlatTransformer {
         Ok(batch)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use arrow_array::{Array, FixedSizeListArray, Float32Array, Int32Array};
+    use arrow_schema::{DataType, Schema};
+    use lance_arrow::FixedSizeListArrayExt;
+
+    const DIM: i32 = 4;
+    const ROWS: usize = 8;
+
+    fn batch() -> RecordBatch {
+        let values = Float32Array::from_iter((0..(DIM as usize * ROWS)).map(|v| v as f32));
+        let vectors = Arc::new(FixedSizeListArray::try_new_from_values(values, DIM).unwrap());
+        let schema = Schema::new(vec![
+            Field::new("vec", vectors.data_type().clone(), true),
+            Field::new("other", DataType::Int32, false),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                vectors,
+                Arc::new(Int32Array::from_iter_values(0..ROWS as i32)),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_flat_transform_renames_vector_column() {
+        let input = batch();
+        let output = FlatTransformer::new("vec").transform(&input).unwrap();
+
+        assert!(output.column_by_name("vec").is_none());
+        assert!(
+            output.column_by_name("other").is_some(),
+            "unrelated columns should survive"
+        );
+        assert_eq!(output.num_rows(), ROWS);
+
+        let flat = output.column_by_name(FLAT_COLUMN).unwrap();
+        assert_eq!(
+            flat.data_type(),
+            input.column_by_name("vec").unwrap().data_type()
+        );
+        assert_eq!(flat.as_ref(), input.column_by_name("vec").unwrap().as_ref());
+    }
+
+    #[test]
+    fn test_flat_transform_preserves_nullability() {
+        // The renamed field copies the source column's nullability rather than
+        // hardcoding it, so a non-nullable vector column stays non-nullable.
+        let values = Float32Array::from_iter((0..(DIM as usize * ROWS)).map(|v| v as f32));
+        let vectors = Arc::new(FixedSizeListArray::try_new_from_values(values, DIM).unwrap());
+        let schema = Schema::new(vec![
+            Field::new("vec", vectors.data_type().clone(), false),
+            Field::new("other", DataType::Int32, false),
+        ]);
+        let input = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                vectors,
+                Arc::new(Int32Array::from_iter_values(0..ROWS as i32)),
+            ],
+        )
+        .unwrap();
+
+        let output = FlatTransformer::new("vec").transform(&input).unwrap();
+        let field = output
+            .schema()
+            .field_with_name(FLAT_COLUMN)
+            .unwrap()
+            .clone();
+        assert!(!field.is_nullable());
+    }
+
+    #[test]
+    fn test_flat_transform_reports_missing_column() {
+        let message = FlatTransformer::new("absent")
+            .transform(&batch())
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("column absent"), "{message}");
+    }
+}


### PR DESCRIPTION
`flat/transform.rs` had no tests, unlike its siblings `pq/transform.rs`,
`bq/transform.rs` and `vector/transform.rs`. It runs on the IVF_FLAT build path
(`vector/ivf.rs:177`) and does three things: rename the vector column to
`FLAT_COLUMN`, copy the source column's nullability onto the new field, and
error when the column is absent.

Adds a test per behaviour, mirroring `test_pq_transform`'s shape.

Verified non-vacuous: hardcoding the new field to nullable fails
`test_flat_transform_preserves_nullability`, and dropping the `drop_column`
call fails `test_flat_transform_renames_vector_column`.
