### PR TITLE
test(dataset): pin FileType discriminants to the Arrow dictionary

### DIFF
--- a/rust/lance/src/dataset/files/file_types.rs
+++ b/rust/lance/src/dataset/files/file_types.rs
@@ -31,3 +31,47 @@ impl From<FileType> for i8 {
         file_type as Self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_array::{Array, StringArray, cast::AsArray};
+
+    use crate::dataset::files::arrow::FILE_TYPE_DICT_ARRAY;
+
+    const ALL: [FileType; 5] = [
+        FileType::Manifest,
+        FileType::DataFile,
+        FileType::DeletionFile,
+        FileType::TransactionFile,
+        FileType::IndexFile,
+    ];
+
+    /// The discriminants double as dictionary keys for the `tracked_files`
+    /// output, so reordering either list would silently mislabel every row.
+    #[test]
+    fn test_discriminants_index_into_the_dictionary() {
+        let dict: &StringArray = FILE_TYPE_DICT_ARRAY.as_string();
+        assert_eq!(
+            dict.len(),
+            ALL.len(),
+            "every variant needs a dictionary slot"
+        );
+
+        for file_type in ALL {
+            let key = i8::from(file_type);
+            assert_eq!(
+                dict.value(key as usize),
+                file_type.to_string(),
+                "{file_type:?} has key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_discriminants_are_contiguous_from_zero() {
+        let keys: Vec<i8> = ALL.iter().copied().map(i8::from).collect();
+        assert_eq!(keys, (0..ALL.len() as i8).collect::<Vec<_>>());
+    }
+}


### PR DESCRIPTION
`file_types.rs` carries a hand-maintained invariant in its header comment — the
`FileType` discriminants are the dictionary keys for the `tracked_files` output,
and must stay in sync with `FILE_TYPE_DICT_ARRAY` in `arrow.rs` — but nothing
asserted it. The existing tests in `files.rs` only check that the strings appear
in query output, never that a variant's discriminant indexes its own slot, so
reordering either list would silently mislabel every row.

Verified non-vacuous: swapping `DataFile` and `DeletionFile` in the dictionary
fails with `DataFile has key 1`.
