### PR TITLE
fix(linalg): drop casts that make clippy::use_self fail off the CI baseline

### DIFF
--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -602,12 +602,12 @@ impl Cosine for f32 {
             // a plain AVX2 load) and only adds dispatch + eager-collect overhead.
             // Only the larger-dim path routes to AVX-512 on capable hosts — that's
             // where the wider lanes actually pay off.
-            return match dimension {
+            match dimension {
                 8 => Box::new(
                     batch
                         .chunks_exact(8)
                         .map(move |y| f32_baseline::cosine_once_8(x, x_norm, y)),
-                ) as Box<dyn Iterator<Item = f32> + 'a>,
+                ),
                 16 => Box::new(
                     batch
                         .chunks_exact(16)
@@ -619,7 +619,7 @@ impl Cosine for f32 {
                         unsafe {
                             f32::cosine_batch_avx512(x, x_norm, batch, dimension, &mut distances);
                         }
-                        Box::new(distances.into_iter()) as Box<dyn Iterator<Item = f32> + 'a>
+                        Box::new(distances.into_iter())
                     } else {
                         Box::new(
                             batch
@@ -628,7 +628,7 @@ impl Cosine for f32 {
                         )
                     }
                 }
-            };
+            }
         }
 
         // Sub-AVX2 build: select once. Dimension 8 uses an inlined SSE
@@ -673,7 +673,7 @@ impl Cosine for f32 {
                     batch
                         .chunks_exact(dimension)
                         .map(move |y| f32::cosine_once_8(x, x_norm, y)),
-                ) as Box<dyn Iterator<Item = f32> + 'a>,
+                ),
                 16 => Box::new(
                     batch
                         .chunks_exact(dimension)


### PR DESCRIPTION
## What

Removes three `as Box<dyn Iterator<Item = f32> + 'a>` casts in `<f32 as Cosine>::cosine_batch`, and the `return` that becomes needless once they are gone.

## Why

Inside `impl Cosine for f32`, `f32` is `Self`, so each cast trips `clippy::use_self`, which the workspace denies (`Cargo.toml`, `[workspace.lints.clippy]`). The casts are also unnecessary: the function's return type already names the trait object, so the first match arm coerces and the rest follow.

CI does not see this. `.cargo/config.toml` pins `target-cpu=x86-64-v2` for `x86_64-unknown-linux-gnu`, and AVX2 is v3, so the clippy job compiles the `not(target_feature = "avx2")` block and skips both blocks that hold the offending lines. Measured per target on `b147e505a`, before this change:

| target / features | `cargo clippy -p lance-linalg --lib -- -D warnings` |
|---|---|
| `aarch64-apple-darwin` | 1 error, in the `not(target_arch = "x86_64")` arm |
| `x86_64` + `avx2,fma` | 3 errors, in the `avx2` arm (2 casts + the needless return) |
| `x86_64` at the v2 baseline | clean, and this is what CI runs |

So `cargo clippy -p lance-linalg -- -D warnings` fails for anyone developing on Apple silicon, and it would start failing in CI if the x86 baseline ever moved to v3.

Dropping the two casts in the AVX2 arm leaves its `return match` as the last expression of that `cfg` block, which then trips `clippy::needless_return`, so the `return` goes too.

## Tests

No behavior change: the casts were coercions the return type already performed, and removing a tail `return` does not change control flow. After the change, at all three target/feature combinations above:

- `cargo clippy -p lance-linalg --lib --tests --benches -- -D warnings` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo test -p lance-linalg --lib`: 141 passed, including the scalar/SIMD parity tests that cover these kernels
