### PR TITLE
docs: avoid mint wording in stable row id docs

### DIFF
--- a/docs/src/guide/distributed_write.md
+++ b/docs/src/guide/distributed_write.md
@@ -290,9 +290,9 @@ appeared in.
 A single fragment may hold both rewritten rows and brand new ones. Order it so
 that **the rewritten rows come first and the new rows last**, then pass only the
 row ids of the rewritten rows. The row ids bind to the leading rows in fragment
-order, and the commit mints ids for the remaining rows.
+order, and the commit generates new ids for the remaining rows.
 
-Do not mint ids for the new rows yourself. Row ids are handed out from a counter
+Do not generate ids for the new rows yourself. Row ids are handed out from a counter
 in the manifest, and a commit that loses a race is retried against the version
 that won, which may have consumed the very ids you picked. Only the commit knows
 which values are free, so it assigns them after conflict resolution has settled.

--- a/python/python/lance/lance/fragment.pyi
+++ b/python/python/lance/lance/fragment.pyi
@@ -134,10 +134,10 @@ class RowIdSequence:
         fragment = FragmentMetadata(..., row_id_meta=sequence.to_inline_metadata())
 
     The sequence may be shorter than the fragment's ``physical_rows``. The ids
-    bind to the leading rows and the commit mints ids for the remaining ones,
-    which is how a fragment holding both rewritten and newly inserted rows is
-    expressed: write the rewritten rows first and supply only their ids. Passing
-    more ids than the fragment has rows is rejected.
+    bind to the leading rows and the commit generates new ids for the remaining
+    ones, which is how a fragment holding both rewritten and newly inserted rows
+    is expressed: write the rewritten rows first and supply only their ids.
+    Passing more ids than the fragment has rows is rejected.
 
     Warning
     -------
@@ -145,8 +145,8 @@ class RowIdSequence:
     unique across the dataset, and Lance does not re-check that when
     committing, so the caller owns it. Supply only row ids that already exist
     and are being relocated by the same transaction, which must also remove
-    every earlier occurrence of them. Do not mint ids for new rows yourself --
-    they come from a counter in the manifest that a concurrent commit can
+    every earlier occurrence of them. Do not generate ids for new rows yourself
+    -- they come from a counter in the manifest that a concurrent commit can
     advance, so only the commit knows which values are free. Do not supply
     unused row ids either: a sequence covering all of a fragment's rows leaves
     the dataset's row id allocator untouched, so a later append will hand the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #8357 after it was merged before Weston's review comments landed.

## Changes

Apply the wording suggestions from [@westonpace](https://github.com/westonpace) on #8357:

- Prefer "generate" over "mint" when describing how commits assign row ids
- Updated `docs/src/guide/distributed_write.md` and `RowIdSequence` docs in `fragment.pyi`


