### PR TITLE
feat(python): expose scanner options on LanceFragment

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -563,6 +563,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> "LanceScanner":
         """See Dataset::scanner for details"""
         filter_str = str(filter) if filter is not None else None
@@ -584,6 +587,9 @@ class LanceFragment(pa.dataset.Fragment):
             batch_readahead=batch_readahead,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
             **columns_arg,
         )
         from .dataset import LanceScanner
@@ -594,7 +600,7 @@ class LanceFragment(pa.dataset.Fragment):
             "_search_filter": None,
             "_substrait_filter": None,
             "_prefilter": False,
-            "_late_materialization": None,
+            "_late_materialization": late_materialization,
             "_blob_handling": blob_handling,
             "_offset": offset,
             "_columns": tuple(columns) if isinstance(columns, list) else None,
@@ -603,7 +609,7 @@ class LanceFragment(pa.dataset.Fragment):
             ),
             "_nearest": None,
             "_batch_size": batch_size,
-            "_io_buffer_size": None,
+            "_io_buffer_size": io_buffer_size,
             "_batch_readahead": batch_readahead,
             "_fragment_readahead": None,
             "_scan_in_order": True,
@@ -613,7 +619,7 @@ class LanceFragment(pa.dataset.Fragment):
             "_use_stats": True,
             "_fast_search": False,
             "_full_text_query": None,
-            "_use_scalar_index": None,
+            "_use_scalar_index": use_scalar_index,
             "_include_deleted_rows": None,
             "_scan_stats_callback": None,
             "_strict_batch_size": False,
@@ -667,6 +673,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> Iterator[pa.RecordBatch]:
         return self.scanner(
             columns=columns,
@@ -679,6 +688,9 @@ class LanceFragment(pa.dataset.Fragment):
             batch_readahead=batch_readahead,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
         ).to_batches()
 
     def to_table(
@@ -693,6 +705,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> pa.Table:
         return self.scanner(
             columns=columns,
@@ -703,6 +718,9 @@ class LanceFragment(pa.dataset.Fragment):
             with_row_address=with_row_address,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
         ).to_table()
 
     def to_pandas(

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -724,6 +724,9 @@ class _Fragment:
         batch_readahead: Optional[int] = None,
         blob_handling: Optional[str] = None,
         order_by: Optional[List[Any]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> _Scanner: ...
     def add_columns_from_reader(
         self,

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1184,3 +1184,107 @@ def test_fragment_validate_after_delete(tmp_path: Path):
     # A fragment carrying a deletion vector still validates.
     for fragment in dataset.get_fragments():
         fragment.validate()
+
+
+def _dataset_with_scalar_index(tmp_path: Path) -> LanceDataset:
+    dataset = write_dataset(
+        pa.table({"val": range(10000), "other": range(10000)}),
+        tmp_path,
+        max_rows_per_file=5000,
+    )
+    dataset.create_scalar_index("val", index_type="BTREE")
+    return dataset
+
+
+def test_fragment_scanner_use_scalar_index_disables_index_query(tmp_path: Path):
+    # A filtered fragment scan on an indexed column plans a dataset-wide
+    # ScalarIndexQuery (and caches its index pages) unless the scan opts out.
+    dataset = _dataset_with_scalar_index(tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val >= 10 AND val <= 20"
+
+    default_plan = fragment.scanner(filter=filt, with_row_id=True).explain_plan(True)
+    assert "ScalarIndexQuery" in default_plan
+
+    opted_out_plan = fragment.scanner(
+        filter=filt, with_row_id=True, use_scalar_index=False
+    ).explain_plan(True)
+    assert "ScalarIndexQuery" not in opted_out_plan
+
+
+@pytest.mark.parametrize("use_scalar_index", [None, True, False])
+def test_fragment_scanner_matches_dataset_scanner(tmp_path: Path, use_scalar_index):
+    # The fragment scanner must build the same plan as the dataset scanner
+    # restricted to that single fragment.
+    dataset = _dataset_with_scalar_index(tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val >= 10 AND val <= 20"
+
+    frag_plan = fragment.scanner(
+        filter=filt, with_row_id=True, use_scalar_index=use_scalar_index
+    ).explain_plan(True)
+    dataset_plan = dataset.scanner(
+        fragments=[fragment],
+        filter=filt,
+        with_row_id=True,
+        use_scalar_index=use_scalar_index,
+    ).explain_plan(True)
+    assert frag_plan == dataset_plan
+
+
+@pytest.mark.parametrize(
+    ("late_materialization", "is_late"),
+    [
+        pytest.param(None, False, id="default"),
+        pytest.param(True, True, id="all_late"),
+        pytest.param(False, False, id="all_early"),
+        pytest.param(["values"], True, id="late_column"),
+        pytest.param(["filter"], False, id="early_column"),
+    ],
+)
+def test_fragment_scanner_late_materialization(
+    tmp_path: Path, late_materialization, is_late
+):
+    # With no index, the plan shows whether `values` is fetched late (a take over
+    # the row stream) or early (materialized in the scan projection).
+    dataset = write_dataset(
+        pa.table({"filter": range(2000), "values": range(2000)}),
+        tmp_path,
+        data_storage_version="stable",
+    )
+    fragment = dataset.get_fragments()[0]
+
+    plan = fragment.scanner(
+        filter="filter % 2 == 0", late_materialization=late_materialization
+    ).explain_plan(True)
+
+    if is_late:
+        assert "projection=[values], source=stream" in plan
+    else:
+        assert "projection=[filter, values]" in plan
+
+
+def test_fragment_scanner_rejects_invalid_late_materialization(tmp_path: Path):
+    dataset = write_dataset(pa.table({"a": range(10)}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+
+    with pytest.raises(
+        ValueError, match="late_materialization must be a bool or a list of strings"
+    ):
+        fragment.scanner(late_materialization=123)
+
+
+def test_fragment_scanner_io_buffer_size_forwarded(tmp_path: Path):
+    # io_buffer_size has no plan-visible marker, so assert it is accepted through
+    # both scan entry points and leaves results unchanged.
+    dataset = write_dataset(pa.table({"val": range(1000)}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val < 100"
+    expected = fragment.to_table(filter=filt)
+
+    assert fragment.to_table(filter=filt, io_buffer_size=4 * 1024 * 1024) == expected
+
+    batched = pa.Table.from_batches(
+        list(fragment.to_batches(filter=filt, io_buffer_size=4 * 1024 * 1024))
+    )
+    assert batched == expected

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -21,7 +21,7 @@ use arrow_array::RecordBatchReader;
 use futures::TryFutureExt;
 use lance::Error;
 use lance::dataset::fragment::FileFragment as LanceFragment;
-use lance::dataset::scanner::ColumnOrdering;
+use lance::dataset::scanner::{ColumnOrdering, MaterializationStyle};
 use lance::dataset::transaction::{Operation, Transaction};
 use lance::dataset::{InsertBuilder, NewColumnTransform, WriteParams};
 use lance_core::datatypes::BlobHandling;
@@ -211,7 +211,7 @@ impl FileFragment {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -225,6 +225,9 @@ impl FileFragment {
         batch_readahead: Option<usize>,
         blob_handling: Option<Bound<PyAny>>,
         order_by: Option<Vec<PyLance<ColumnOrdering>>>,
+        use_scalar_index: Option<bool>,
+        io_buffer_size: Option<u64>,
+        late_materialization: Option<Bound<PyAny>>,
     ) -> PyResult<Scanner> {
         let mut scanner = self_.fragment.scan();
 
@@ -292,6 +295,30 @@ impl FileFragment {
             scanner
                 .order_by(col_orderings)
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        }
+        if let Some(io_buffer_size) = io_buffer_size {
+            scanner.io_buffer_size(io_buffer_size);
+        }
+        if let Some(use_scalar_index) = use_scalar_index {
+            scanner.use_scalar_index(use_scalar_index);
+        }
+        if let Some(late_materialization) = late_materialization {
+            if let Ok(style_as_bool) = late_materialization.extract::<bool>() {
+                if style_as_bool {
+                    scanner.materialization_style(MaterializationStyle::AllLate);
+                } else {
+                    scanner.materialization_style(MaterializationStyle::AllEarly);
+                }
+            } else if let Ok(columns) = late_materialization.extract::<Vec<String>>() {
+                scanner.materialization_style(
+                    MaterializationStyle::all_early_except(&columns, self_.fragment.schema())
+                        .infer_error()?,
+                );
+            } else {
+                return Err(PyValueError::new_err(
+                    "late_materialization must be a bool or a list of strings",
+                ));
+            }
         }
         let scn = Arc::new(scanner);
         Ok(Scanner::new(scn))


### PR DESCRIPTION
`LanceFragment.scanner` exposes only a subset of the dataset scanner's options, so per-fragment consumers cannot control the memory a filtered scan uses. The most consequential gap is `use_scalar_index`: a filtered fragment scan on an indexed column plans a whole-dataset `ScalarIndexQuery` and retains the resulting index pages in the per-worker session cache. In a data loader that scans one fragment per worker, that can reach multiple GB per node at 8+ workers, and there is no way to turn it off from the fragment API — callers are forced onto `dataset.scanner(fragments=[frag], ...)` or private-attribute workarounds.

This exposes the three dataset-scanner memory knobs on the fragment surface. It is pure parameter threading: `FileFragment::scan()` returns the same core `Scanner` the dataset uses, which already has the corresponding builder methods.

## Changes

- **pyo3 binding** (`python/src/fragment.rs`): `scanner` accepts `use_scalar_index: Option<bool>`, `io_buffer_size: Option<u64>`, and `late_materialization: Option<Bound<PyAny>>`, forwarding to `Scanner::use_scalar_index` / `io_buffer_size` / `materialization_style`. The `late_materialization` bool-or-column-list conversion mirrors the dataset binding, using the fragment's own schema for `all_early_except`.
- **Python wrapper** (`python/python/lance/fragment.py`): `LanceFragment.scanner` gains the three keyword args (names and semantics identical to `LanceDataset.scanner`), threaded through `to_batches` and `to_table`, and reflected in the scanner snapshot. The docstring stays the terse `See Dataset::scanner for details` pointer — the added args are documented on `LanceDataset.scanner`.
- **Type stub** (`python/python/lance/lance/__init__.pyi`): added the three params to `_Fragment.scanner`, matching the `_Dataset.scanner` stub.
- **Tests** (`python/python/tests/test_fragment.py`): the dominant-mechanism kill (`ScalarIndexQuery` present by default, absent with `use_scalar_index=False`); plan parity with `dataset.scanner(fragments=[frag], ...)` across `use_scalar_index` values; `late_materialization` early/late plan shapes (bool and column-list forms) plus the invalid-type `ValueError`; and `io_buffer_size` accepted through `to_table`/`to_batches` without changing results.

`fragment_readahead` is intentionally not exposed (meaningless for a single fragment). Additive and non-breaking.

## Verification

- `python/tests/test_fragment.py` passes (73 tests; 11 new).
- `uv run make format` idempotent; `uv run make lint` (ruff + pyright + rustfmt + clippy `-D warnings`) clean.
