### PR TITLE
feat(python): expose more scanner options on LanceFragment

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -566,6 +566,9 @@ class LanceFragment(pa.dataset.Fragment):
         use_scalar_index: Optional[bool] = None,
         io_buffer_size: Optional[int] = None,
         late_materialization: Optional[bool | List[str]] = None,
+        include_deleted_rows: Optional[bool] = None,
+        batch_size_bytes: Optional[int] = None,
+        strict_batch_size: Optional[bool] = None,
     ) -> "LanceScanner":
         """See Dataset::scanner for details"""
         filter_str = str(filter) if filter is not None else None
@@ -590,6 +593,9 @@ class LanceFragment(pa.dataset.Fragment):
             use_scalar_index=use_scalar_index,
             io_buffer_size=io_buffer_size,
             late_materialization=late_materialization,
+            include_deleted_rows=include_deleted_rows,
+            batch_size_bytes=batch_size_bytes,
+            strict_batch_size=strict_batch_size,
             **columns_arg,
         )
         from .dataset import LanceScanner
@@ -609,6 +615,7 @@ class LanceFragment(pa.dataset.Fragment):
             ),
             "_nearest": None,
             "_batch_size": batch_size,
+            "_batch_size_bytes": batch_size_bytes,
             "_io_buffer_size": io_buffer_size,
             "_batch_readahead": batch_readahead,
             "_fragment_readahead": None,
@@ -620,9 +627,11 @@ class LanceFragment(pa.dataset.Fragment):
             "_fast_search": False,
             "_full_text_query": None,
             "_use_scalar_index": use_scalar_index,
-            "_include_deleted_rows": None,
+            "_include_deleted_rows": include_deleted_rows,
             "_scan_stats_callback": None,
-            "_strict_batch_size": False,
+            "_strict_batch_size": (
+                strict_batch_size if strict_batch_size is not None else False
+            ),
             "_orderings": tuple(order_by) if order_by is not None else None,
             "_disable_scoring_autoprojection": False,
             "_substrait_aggregate": None,
@@ -676,6 +685,9 @@ class LanceFragment(pa.dataset.Fragment):
         use_scalar_index: Optional[bool] = None,
         io_buffer_size: Optional[int] = None,
         late_materialization: Optional[bool | List[str]] = None,
+        include_deleted_rows: Optional[bool] = None,
+        batch_size_bytes: Optional[int] = None,
+        strict_batch_size: Optional[bool] = None,
     ) -> Iterator[pa.RecordBatch]:
         return self.scanner(
             columns=columns,
@@ -691,6 +703,9 @@ class LanceFragment(pa.dataset.Fragment):
             use_scalar_index=use_scalar_index,
             io_buffer_size=io_buffer_size,
             late_materialization=late_materialization,
+            include_deleted_rows=include_deleted_rows,
+            batch_size_bytes=batch_size_bytes,
+            strict_batch_size=strict_batch_size,
         ).to_batches()
 
     def to_table(
@@ -708,6 +723,9 @@ class LanceFragment(pa.dataset.Fragment):
         use_scalar_index: Optional[bool] = None,
         io_buffer_size: Optional[int] = None,
         late_materialization: Optional[bool | List[str]] = None,
+        include_deleted_rows: Optional[bool] = None,
+        batch_size_bytes: Optional[int] = None,
+        strict_batch_size: Optional[bool] = None,
     ) -> pa.Table:
         return self.scanner(
             columns=columns,
@@ -721,6 +739,9 @@ class LanceFragment(pa.dataset.Fragment):
             use_scalar_index=use_scalar_index,
             io_buffer_size=io_buffer_size,
             late_materialization=late_materialization,
+            include_deleted_rows=include_deleted_rows,
+            batch_size_bytes=batch_size_bytes,
+            strict_batch_size=strict_batch_size,
         ).to_table()
 
     def to_pandas(

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -563,6 +563,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> "LanceScanner":
         """See Dataset::scanner for details"""
         filter_str = str(filter) if filter is not None else None
@@ -584,6 +587,9 @@ class LanceFragment(pa.dataset.Fragment):
             batch_readahead=batch_readahead,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
             **columns_arg,
         )
         from .dataset import LanceScanner
@@ -594,7 +600,7 @@ class LanceFragment(pa.dataset.Fragment):
             "_search_filter": None,
             "_substrait_filter": None,
             "_prefilter": False,
-            "_late_materialization": None,
+            "_late_materialization": late_materialization,
             "_blob_handling": blob_handling,
             "_offset": offset,
             "_columns": tuple(columns) if isinstance(columns, list) else None,
@@ -603,7 +609,7 @@ class LanceFragment(pa.dataset.Fragment):
             ),
             "_nearest": None,
             "_batch_size": batch_size,
-            "_io_buffer_size": None,
+            "_io_buffer_size": io_buffer_size,
             "_batch_readahead": batch_readahead,
             "_fragment_readahead": None,
             "_scan_in_order": True,
@@ -613,7 +619,7 @@ class LanceFragment(pa.dataset.Fragment):
             "_use_stats": True,
             "_fast_search": False,
             "_full_text_query": None,
-            "_use_scalar_index": None,
+            "_use_scalar_index": use_scalar_index,
             "_include_deleted_rows": None,
             "_scan_stats_callback": None,
             "_strict_batch_size": False,
@@ -667,6 +673,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> Iterator[pa.RecordBatch]:
         return self.scanner(
             columns=columns,
@@ -679,6 +688,9 @@ class LanceFragment(pa.dataset.Fragment):
             batch_readahead=batch_readahead,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
         ).to_batches()
 
     def to_table(
@@ -693,6 +705,9 @@ class LanceFragment(pa.dataset.Fragment):
             Literal["all_binary", "blobs_descriptions", "all_descriptions"]
         ] = None,
         order_by: Optional[List[ColumnOrdering]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> pa.Table:
         return self.scanner(
             columns=columns,
@@ -703,6 +718,9 @@ class LanceFragment(pa.dataset.Fragment):
             with_row_address=with_row_address,
             blob_handling=blob_handling,
             order_by=order_by,
+            use_scalar_index=use_scalar_index,
+            io_buffer_size=io_buffer_size,
+            late_materialization=late_materialization,
         ).to_table()
 
     def to_pandas(

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -727,6 +727,9 @@ class _Fragment:
         use_scalar_index: Optional[bool] = None,
         io_buffer_size: Optional[int] = None,
         late_materialization: Optional[bool | List[str]] = None,
+        include_deleted_rows: Optional[bool] = None,
+        batch_size_bytes: Optional[int] = None,
+        strict_batch_size: Optional[bool] = None,
     ) -> _Scanner: ...
     def add_columns_from_reader(
         self,

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -724,6 +724,9 @@ class _Fragment:
         batch_readahead: Optional[int] = None,
         blob_handling: Optional[str] = None,
         order_by: Optional[List[Any]] = None,
+        use_scalar_index: Optional[bool] = None,
+        io_buffer_size: Optional[int] = None,
+        late_materialization: Optional[bool | List[str]] = None,
     ) -> _Scanner: ...
     def add_columns_from_reader(
         self,

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1232,6 +1232,49 @@ def test_fragment_scanner_matches_dataset_scanner(tmp_path: Path, use_scalar_ind
     assert frag_plan == dataset_plan
 
 
+def _fragment_with_deletions(tmp_path: Path) -> LanceFragment:
+    dataset = write_dataset(pa.table({"a": range(20)}), tmp_path, max_rows_per_file=10)
+    dataset.delete("a < 3")
+    return dataset.get_fragments()[0]
+
+
+def test_fragment_scanner_include_deleted_rows(tmp_path: Path):
+    fragment = _fragment_with_deletions(tmp_path)
+    assert fragment.physical_rows == 10
+    assert fragment.num_deletions == 3
+
+    # By default the deleted rows are omitted.
+    default = fragment.to_table(with_row_id=True)
+    assert default.num_rows == 7
+    assert default["a"].to_pylist() == list(range(3, 10))
+
+    # With include_deleted_rows the deleted rows are surfaced with a null _rowid.
+    included = fragment.scanner(with_row_id=True, include_deleted_rows=True).to_table()
+    assert included.num_rows == fragment.physical_rows
+    assert included["a"].to_pylist() == list(range(10))
+    assert included["_rowid"].null_count == fragment.num_deletions
+
+
+def test_fragment_scanner_include_deleted_rows_requires_row_id(tmp_path: Path):
+    fragment = _fragment_with_deletions(tmp_path)
+    with pytest.raises(ValueError, match="with_row_id"):
+        fragment.scanner(include_deleted_rows=True).to_table()
+
+
+def test_fragment_scanner_include_deleted_rows_matches_dataset_scanner(tmp_path: Path):
+    dataset = write_dataset(pa.table({"a": range(20)}), tmp_path, max_rows_per_file=10)
+    dataset.delete("a < 3")
+    fragment = dataset.get_fragments()[0]
+
+    frag_plan = fragment.scanner(
+        with_row_id=True, include_deleted_rows=True
+    ).explain_plan(True)
+    dataset_plan = dataset.scanner(
+        fragments=[fragment], with_row_id=True, include_deleted_rows=True
+    ).explain_plan(True)
+    assert frag_plan == dataset_plan
+
+
 @pytest.mark.parametrize(
     ("late_materialization", "is_late"),
     [
@@ -1288,3 +1331,35 @@ def test_fragment_scanner_io_buffer_size_forwarded(tmp_path: Path):
         list(fragment.to_batches(filter=filt, io_buffer_size=4 * 1024 * 1024))
     )
     assert batched == expected
+
+
+def test_fragment_scanner_strict_batch_size(tmp_path: Path):
+    dataset = write_dataset(pa.table({"a": range(1000)}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "a % 3 == 0"
+
+    # A filtered scan emits uneven, sub-batch_size batches by default.
+    loose = [b.num_rows for b in fragment.to_batches(batch_size=100, filter=filt)]
+    assert any(n < 100 for n in loose[:-1])
+
+    # strict_batch_size coalesces to exactly batch_size (except the last batch).
+    strict = [
+        b.num_rows
+        for b in fragment.to_batches(
+            batch_size=100, filter=filt, strict_batch_size=True
+        )
+    ]
+    assert all(n == 100 for n in strict[:-1])
+    assert sum(strict) == sum(loose)
+
+
+def test_fragment_scanner_batch_size_bytes(tmp_path: Path):
+    # A small byte budget over wide rows forces many more batches than the
+    # default, without changing the results.
+    dataset = write_dataset(pa.table({"s": ["x" * 1024] * 2000}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+
+    default_batches = list(fragment.to_batches())
+    small_budget = list(fragment.to_batches(batch_size_bytes=64 * 1024))
+    assert len(small_budget) > len(default_batches)
+    assert pa.Table.from_batches(small_budget) == fragment.to_table()

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1184,3 +1184,107 @@ def test_fragment_validate_after_delete(tmp_path: Path):
     # A fragment carrying a deletion vector still validates.
     for fragment in dataset.get_fragments():
         fragment.validate()
+
+
+def _dataset_with_scalar_index(tmp_path: Path) -> LanceDataset:
+    dataset = write_dataset(
+        pa.table({"val": range(10000), "other": range(10000)}),
+        tmp_path,
+        max_rows_per_file=5000,
+    )
+    dataset.create_scalar_index("val", index_type="BTREE")
+    return dataset
+
+
+def test_fragment_scanner_use_scalar_index_disables_index_query(tmp_path: Path):
+    # A filtered fragment scan on an indexed column plans a dataset-wide
+    # ScalarIndexQuery (and caches its index pages) unless the scan opts out.
+    dataset = _dataset_with_scalar_index(tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val >= 10 AND val <= 20"
+
+    default_plan = fragment.scanner(filter=filt, with_row_id=True).explain_plan(True)
+    assert "ScalarIndexQuery" in default_plan
+
+    opted_out_plan = fragment.scanner(
+        filter=filt, with_row_id=True, use_scalar_index=False
+    ).explain_plan(True)
+    assert "ScalarIndexQuery" not in opted_out_plan
+
+
+@pytest.mark.parametrize("use_scalar_index", [None, True, False])
+def test_fragment_scanner_matches_dataset_scanner(tmp_path: Path, use_scalar_index):
+    # The fragment scanner must build the same plan as the dataset scanner
+    # restricted to that single fragment.
+    dataset = _dataset_with_scalar_index(tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val >= 10 AND val <= 20"
+
+    frag_plan = fragment.scanner(
+        filter=filt, with_row_id=True, use_scalar_index=use_scalar_index
+    ).explain_plan(True)
+    dataset_plan = dataset.scanner(
+        fragments=[fragment],
+        filter=filt,
+        with_row_id=True,
+        use_scalar_index=use_scalar_index,
+    ).explain_plan(True)
+    assert frag_plan == dataset_plan
+
+
+@pytest.mark.parametrize(
+    ("late_materialization", "is_late"),
+    [
+        pytest.param(None, False, id="default"),
+        pytest.param(True, True, id="all_late"),
+        pytest.param(False, False, id="all_early"),
+        pytest.param(["values"], True, id="late_column"),
+        pytest.param(["filter"], False, id="early_column"),
+    ],
+)
+def test_fragment_scanner_late_materialization(
+    tmp_path: Path, late_materialization, is_late
+):
+    # With no index, the plan shows whether `values` is fetched late (a take over
+    # the row stream) or early (materialized in the scan projection).
+    dataset = write_dataset(
+        pa.table({"filter": range(2000), "values": range(2000)}),
+        tmp_path,
+        data_storage_version="stable",
+    )
+    fragment = dataset.get_fragments()[0]
+
+    plan = fragment.scanner(
+        filter="filter % 2 == 0", late_materialization=late_materialization
+    ).explain_plan(True)
+
+    if is_late:
+        assert "projection=[values], source=stream" in plan
+    else:
+        assert "projection=[filter, values]" in plan
+
+
+def test_fragment_scanner_rejects_invalid_late_materialization(tmp_path: Path):
+    dataset = write_dataset(pa.table({"a": range(10)}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+
+    with pytest.raises(
+        ValueError, match="late_materialization must be a bool or a list of strings"
+    ):
+        fragment.scanner(late_materialization=123)
+
+
+def test_fragment_scanner_io_buffer_size_forwarded(tmp_path: Path):
+    # io_buffer_size has no plan-visible marker, so assert it is accepted through
+    # both scan entry points and leaves results unchanged.
+    dataset = write_dataset(pa.table({"val": range(1000)}), tmp_path)
+    fragment = dataset.get_fragments()[0]
+    filt = "val < 100"
+    expected = fragment.to_table(filter=filt)
+
+    assert fragment.to_table(filter=filt, io_buffer_size=4 * 1024 * 1024) == expected
+
+    batched = pa.Table.from_batches(
+        list(fragment.to_batches(filter=filt, io_buffer_size=4 * 1024 * 1024))
+    )
+    assert batched == expected

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -211,7 +211,7 @@ impl FileFragment {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None, include_deleted_rows=None, batch_size_bytes=None, strict_batch_size=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -228,6 +228,9 @@ impl FileFragment {
         use_scalar_index: Option<bool>,
         io_buffer_size: Option<u64>,
         late_materialization: Option<Bound<PyAny>>,
+        include_deleted_rows: Option<bool>,
+        batch_size_bytes: Option<u64>,
+        strict_batch_size: Option<bool>,
     ) -> PyResult<Scanner> {
         let mut scanner = self_.fragment.scan();
 
@@ -319,6 +322,15 @@ impl FileFragment {
                     "late_materialization must be a bool or a list of strings",
                 ));
             }
+        }
+        if let Some(batch_size_bytes) = batch_size_bytes {
+            scanner.batch_size_bytes(batch_size_bytes);
+        }
+        if let Some(true) = include_deleted_rows {
+            scanner.include_deleted_rows();
+        }
+        if let Some(strict_batch_size) = strict_batch_size {
+            scanner.strict_batch_size(strict_batch_size);
         }
         let scn = Arc::new(scanner);
         Ok(Scanner::new(scn))

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -21,7 +21,7 @@ use arrow_array::RecordBatchReader;
 use futures::TryFutureExt;
 use lance::Error;
 use lance::dataset::fragment::FileFragment as LanceFragment;
-use lance::dataset::scanner::ColumnOrdering;
+use lance::dataset::scanner::{ColumnOrdering, MaterializationStyle};
 use lance::dataset::transaction::{Operation, Transaction};
 use lance::dataset::{InsertBuilder, NewColumnTransform, WriteParams};
 use lance_core::datatypes::BlobHandling;
@@ -211,7 +211,7 @@ impl FileFragment {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -225,6 +225,9 @@ impl FileFragment {
         batch_readahead: Option<usize>,
         blob_handling: Option<Bound<PyAny>>,
         order_by: Option<Vec<PyLance<ColumnOrdering>>>,
+        use_scalar_index: Option<bool>,
+        io_buffer_size: Option<u64>,
+        late_materialization: Option<Bound<PyAny>>,
     ) -> PyResult<Scanner> {
         let mut scanner = self_.fragment.scan();
 
@@ -292,6 +295,30 @@ impl FileFragment {
             scanner
                 .order_by(col_orderings)
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        }
+        if let Some(io_buffer_size) = io_buffer_size {
+            scanner.io_buffer_size(io_buffer_size);
+        }
+        if let Some(use_scalar_index) = use_scalar_index {
+            scanner.use_scalar_index(use_scalar_index);
+        }
+        if let Some(late_materialization) = late_materialization {
+            if let Ok(style_as_bool) = late_materialization.extract::<bool>() {
+                if style_as_bool {
+                    scanner.materialization_style(MaterializationStyle::AllLate);
+                } else {
+                    scanner.materialization_style(MaterializationStyle::AllEarly);
+                }
+            } else if let Ok(columns) = late_materialization.extract::<Vec<String>>() {
+                scanner.materialization_style(
+                    MaterializationStyle::all_early_except(&columns, self_.fragment.schema())
+                        .infer_error()?,
+                );
+            } else {
+                return Err(PyValueError::new_err(
+                    "late_materialization must be a bool or a list of strings",
+                ));
+            }
         }
         let scn = Arc::new(scanner);
         Ok(Scanner::new(scn))


### PR DESCRIPTION
Follow-up to #8426, which exposed `use_scalar_index` / `io_buffer_size` / `late_materialization` on `LanceFragment.scanner`. This exposes the remaining dataset-scanner options that are meaningful for a single-fragment scan, so per-fragment consumers no longer have to fall back to `dataset.scanner(fragments=[frag], ...)`.

Each is pure parameter threading onto the same core `Scanner` that `FileFragment::scan()` already returns.

## Options added

- **`include_deleted_rows`** — the main one. The core builder's own docstring names "generating aligned fragments" as the use case: when writing a new column that must line up with a fragment's physical row layout, you need to read all physical rows (deleted rows come back with a null `_rowid`). This is exactly the per-fragment column-alignment step in distributed writes. As on the dataset path, the core requires `with_row_id=True` and rejects scalar-index / late-materialization when it is set — the thin binding preserves that behavior unchanged.
- **`batch_size_bytes`** — bound output-batch memory by bytes rather than a fixed row count; useful for per-fragment loaders over variable-width data (blobs, large lists, embeddings).
- **`strict_batch_size`** — require every batch except the last to have exactly `batch_size` rows, the common contract for per-fragment ML training loaders.

## Changes

- **pyo3 binding** (`python/src/fragment.rs`): three new optional params forwarded to `Scanner::include_deleted_rows` / `batch_size_bytes` / `strict_batch_size`, mirroring the dataset binding's conversions.
- **Python wrapper** (`python/python/lance/fragment.py`): the three kwargs added to `LanceFragment.scanner` (names/semantics identical to `LanceDataset.scanner`), threaded through `to_batches` / `to_table`, and reflected in the scanner snapshot.
- **Type stub** (`python/python/lance/lance/__init__.pyi`): the three params on `_Fragment.scanner`.
- **Tests** (`python/python/tests/test_fragment.py`): `include_deleted_rows` surfaces soft-deleted rows (with null `_rowid`) that a default scan omits; `strict_batch_size` yields exact-size batches; `batch_size_bytes` is accepted and leaves results unchanged; plan parity with `dataset.scanner(fragments=[frag], ...)`.

Additive and non-breaking. Independent of #8426; may need a trivial rebase depending on merge order (both touch the fragment scanner signature).

## Verification

- `python/tests/test_fragment.py` passes (new tests included).
- `uv run make format` idempotent; `uv run make lint` (ruff + pyright + rustfmt + clippy `-D warnings`) clean.
