### PR TITLE
test(scalar): cover multi-fragment addresses and empty-index queries in the btree flat page

### DIFF
--- a/rust/lance-index/src/scalar/btree/flat.rs
+++ b/rust/lance-index/src/scalar/btree/flat.rs
@@ -619,4 +619,80 @@ mod tests {
             &[0, 1, 2],
         );
     }
+
+    /// Row addresses pack `(fragment_id << 32) | offset`, so a page spanning
+    /// several fragments must report exactly those fragments, deduped and
+    /// sorted. Every other test in this module uses offsets inside fragment 0,
+    /// which never exercises the shift.
+    #[test]
+    fn test_calculate_included_frags_spans_fragments() {
+        let addr = |frag: u32, offset: u32| u64::from(RowAddress::new_from_parts(frag, offset));
+        let batch = record_batch!(
+            (
+                BTREE_VALUES_COLUMN,
+                Int32,
+                [Some(1), Some(2), Some(3), Some(4)]
+            ),
+            (
+                BTREE_IDS_COLUMN,
+                UInt64,
+                [addr(0, 0), addr(2, 7), addr(0, 1), addr(5, 3)]
+            )
+        )
+        .unwrap();
+        let index = FlatIndex::try_new(batch).unwrap();
+
+        assert_eq!(
+            index.calculate_included_frags().unwrap(),
+            RoaringBitmap::from_iter([0u32, 2, 5])
+        );
+
+        // A hit still carries the full 64-bit address, not a bare offset.
+        let hit = index
+            .search(
+                &SargableQuery::Equals(ScalarValue::from(2)),
+                true,
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(
+            hit,
+            NullableRowAddrSet::new(RowAddrTreeMap::from_iter(&[addr(2, 7)]), Default::default())
+        );
+    }
+
+    /// A zero-row page has to answer queries with empty sets rather than
+    /// panicking inside the Arrow predicate evaluation. The roundtrip test
+    /// builds an empty index but never queries one. Both `track_nulls` modes
+    /// take different shortcuts, and neither has any row to return here.
+    #[test]
+    fn test_empty_index_answers_queries_with_empty_sets() {
+        let empty = RecordBatch::new_empty(example_index().data.schema());
+        let index = FlatIndex::try_new(empty).unwrap();
+        let nothing = NullableRowAddrSet::new(RowAddrTreeMap::new(), RowAddrTreeMap::new());
+
+        for query in [
+            SargableQuery::Equals(ScalarValue::from(10)),
+            SargableQuery::Equals(ScalarValue::Int32(None)),
+            SargableQuery::IsNull(),
+            SargableQuery::IsIn(vec![ScalarValue::from(10), ScalarValue::from(20)]),
+            SargableQuery::Range(Bound::Unbounded, Bound::Unbounded),
+        ] {
+            for track_nulls in [true, false] {
+                assert_eq!(
+                    index
+                        .search(&query, track_nulls, &NoOpMetricsCollector)
+                        .unwrap(),
+                    nothing,
+                    "query: {query:?}, track_nulls: {track_nulls}"
+                );
+            }
+        }
+
+        assert!(index.all().true_rows().is_empty());
+        assert_eq!(
+            index.calculate_included_frags().unwrap(),
+            RoaringBitmap::new()
+        );
+    }
 }


### PR DESCRIPTION
Two gaps in the flat page's test module.

`calculate_included_frags` decodes `(fragment_id << 32) | offset`, but every row
address in this module — `vec![5, 0, 3, 100]` and `vec![5, 2000, 100]` — sits in
fragment 0, so the shift is never exercised. Nothing in the tree asserts on this
method, while zonemap asserts its own at four sites.

`test_cache_codec_roundtrip` builds an empty index but only round-trips it, so
`search` on a zero-row page is untested — including the `Unbounded/Unbounded`
and `IsNull` shortcuts.

Verified non-vacuous: replacing `fragment_id()` with a constant 0 fails the
first test, and returning a bogus row from the `IsNull` arm fails the second.
