### PR TITLE
fix: report JSON index statistics

### DIFF
--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -92,7 +92,7 @@ impl Index for JsonIndex {
     }
 
     fn statistics(&self) -> Result<serde_json::Value> {
-        todo!()
+        self.target_index.statistics()
     }
 
     async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -4157,6 +4157,26 @@ async fn json_btree_dataset(initial_values: Vec<&str>) -> Dataset {
     dataset
 }
 
+#[tokio::test]
+async fn test_json_btree_index_statistics() {
+    let dataset = json_btree_dataset(vec![
+        r#"{"val": 1000}"#,
+        r#"{"val": 2000}"#,
+        r#"{"val": 3000}"#,
+    ])
+    .await;
+
+    let stats: serde_json::Value =
+        serde_json::from_str(&dataset.index_statistics("json_idx").await.unwrap()).unwrap();
+
+    assert_eq!(stats["name"], "json_idx");
+    assert_eq!(stats["num_indices"], 1);
+    assert_eq!(stats["num_indexed_rows"], 3);
+    assert_eq!(stats["num_unindexed_rows"], 0);
+    assert_eq!(stats["indices"][0]["min"], "1000");
+    assert_eq!(stats["indices"][0]["max"], "3000");
+}
+
 #[rstest]
 #[case::merge(false)]
 #[case::append_rebuild(true)]


### PR DESCRIPTION
Calling `Dataset::index_statistics` for a JSON index reaches `JsonIndex::statistics`, which still panics because it is unimplemented. JSON indices wrap a target scalar index, so their per-segment statistics should come from that target just like prewarming and fragment coverage.

Delegate statistics to the target index and add an end-to-end regression covering row counts and the indexed JSON path's BTree bounds.

Fixes #4627.
