### PR TITLE
fix(mem-wal): carry fragments through UpdateMemWalState

### DIFF
--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3050,6 +3050,8 @@ impl Transaction {
             Operation::UpdateMemWalState {
                 compacted_sstables, ..
             } => {
+                // Updates the MemWAL index only; the fragments are unchanged.
+                final_fragments.extend(maybe_existing_fragments?.clone());
                 update_mem_wal_index_compacted_sstables(
                     &mut final_indices,
                     new_version,

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -208,6 +208,41 @@ mod tests {
             .unwrap()
     }
 
+    /// UpdateMemWalState touches indexes, not data, so it must carry the
+    /// fragment list forward. The operation builds its manifest from scratch,
+    /// and an unpopulated fragment list is published as an empty one.
+    #[tokio::test]
+    async fn test_update_mem_wal_state_preserves_fragments() {
+        let dataset = test_dataset_with_mem_wal().await;
+        let rows_before = dataset.count_rows(None).await.unwrap();
+        let fragments_before: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+        assert!(rows_before > 0, "precondition: the table holds rows");
+
+        let txn = Transaction::new(
+            dataset.manifest.version,
+            Operation::UpdateMemWalState {
+                compacted_sstables: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
+                require_index_catchup: false,
+            },
+            None,
+        );
+        let dataset = CommitBuilder::new(Arc::new(dataset))
+            .execute(txn)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            dataset.fragments().iter().map(|f| f.id).collect::<Vec<_>>(),
+            fragments_before,
+            "UpdateMemWalState dropped fragments"
+        );
+        assert_eq!(
+            dataset.count_rows(None).await.unwrap(),
+            rows_before,
+            "UpdateMemWalState dropped rows"
+        );
+    }
+
     /// Test that UpdateMemWalState with lower generation than committed fails without retry.
     /// Per spec: If committed_generation >= to_commit_generation, abort without retry.
     #[tokio::test]


### PR DESCRIPTION
## What

`Operation::UpdateMemWalState` builds its manifest from scratch and never populates `final_fragments`, so the commit publishes a manifest with **no fragments**. Every row in the table disappears.

Nothing errors. The operation touches indexes rather than data, so it is declared compatible with concurrent `Append` / `CreateIndex` and no conflict is raised — the commit succeeds and the data is gone.

Compare `UpdateBases`, the arm immediately below: also index/metadata-only, and it does carry the fragment list forward.

## Fix

```rust
final_fragments.extend(maybe_existing_fragments?.clone());
```

## Reachability

No caller in this repo commits a standalone `UpdateMemWalState` today. MemWAL compaction progress is recorded by `MergeInsertBuilder::mark_sstables_as_compacted`, which rides an `Operation::Update` — a data operation that populates fragments normally. So the bug is latent here, not active.

It becomes reachable the moment anything commits the operation on its own, which the MemWAL index catch-up work (#8263) does.

## Tests

`test_update_mem_wal_state_preserves_fragments`: commit `UpdateMemWalState` on a dataset with rows, assert the fragment list and row count are unchanged. Verified it fails without the fix (`left: []`, `right: [0]`).

The existing tests in `index/mem_wal.rs` already commit this operation against a dataset holding 10 rows — they pass because none of them read the rows afterwards, asserting only on conflict behavior and `compacted_sstables`.

`cargo test -p lance --lib -- mem_wal transaction` — 636 passed.
