### PR TITLE
docs: trim redundant agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,22 +31,11 @@ Also see directory-specific guidelines: [rust/](rust/AGENTS.md) | [python/](pyth
 * Use `release-with-debug` for benchmarks and profiling so optimized builds keep debug symbols without a rebuild.
 * Use `release-no-lto` only for local debugging, IO-bound benchmarks, or compile-time-sensitive performance investigation where LTO would not affect the measured bottleneck.
 
-### Python / Java
-
-See [python/AGENTS.md](python/AGENTS.md) and [java/AGENTS.md](java/AGENTS.md).
-
 ## Language-Specific Environment Contract
 
 - For language-specific tasks, always follow the environment and command rules in the corresponding subdirectory guide before running build, test, lint, format, or tooling commands.
 - Do not substitute a different environment manager or toolchain just because a command appears missing, unavailable, or slow.
 - If a language-specific command fails outside the documented workflow, treat that as an environment usage mistake first. Fix the environment usage, rerun with the prescribed commands, and only then conclude that a dependency or tool is unavailable.
-
-### Integration Testing
-
-```bash
-cd test_data && docker compose up -d
-AWS_DEFAULT_REGION=us-east-1 pytest --run-integration python/tests/test_s3_ddb.py
-```
 
 ## Coding Standards
 
@@ -56,7 +45,6 @@ AWS_DEFAULT_REGION=us-east-1 pytest --run-integration python/tests/test_s3_ddb.p
 - Code is for readability, not just execution. Only add meaningful comments and tests.
 - Comments should explain non-obvious "why" reasoning, not restate what the code does.
 - Remove debug prints (`println!`, `dbg!`, `print()`) before merging — use `tracing` or logging frameworks.
-- Extract logic repeated in 2+ places into a shared helper; inline single-use logic at its call site.
 - Think carefully before adding a helper: only introduce one when it materially reduces cognitive load or eliminates substantial duplication, and do not add thin wrappers that only rename or forward existing calls.
 - Keep PRs focused — no drive-by refactors, reformatting, or cosmetic changes.
 - Be mindful of memory use: avoid collecting streams of `RecordBatch` into memory; use `RoaringBitmap` instead of `HashSet<u32>`.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -7,12 +7,10 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 * Environment: use `uv` for all local Python environment setup in this repository.
 * First step in every new worktree or fresh checkout: run `make install` from `python/` before any Python command. This runs `uv sync` (dev and test dependencies are included by default via `[tool.uv] default-groups`) and sets up pre-commit hooks. Add `--group benchmarks`, `--extra torch`, or `--extra geo` only when needed.
 * `uv sync` builds the local `pylance` Rust extension as part of environment setup. This can take a long time. Start it early, let it finish, and do not interrupt it or switch to a different setup path just because the build is slow.
-* After the initial `make install`, use `uv run make test` to run tests.
 * Only run `uv sync` again when dependencies change (e.g., after pulling new commits that update `pyproject.toml` or `uv.lock`).
 * Command execution: always use `uv run ...` for Python-related repository commands. Do not rely on a globally activated environment.
 * Never invoke bare `python`, `pytest`, `pip`, `maturin`, `make test`, `make doctest`, `make lint`, or `make format` for repository work.
 * If a Python command fails outside `uv run`, that does not count as a dependency or test failure. Fix the environment usage first and rerun correctly.
-* Build time expectations: `make install` and `make build` build the local `pylance` Rust extension as part of the environment workflow. This can be slow, especially on the first run or after Rust dependency changes; treat that as expected and do not switch to a different environment manager or shortcut around the build just because it takes time.
 * Build: `make build` (required after Rust changes)
 * Test: `uv run make test`
 * Run single test: `uv run pytest python/tests/<test_file>.py::<test_name>`
@@ -39,11 +37,4 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 
 ## Testing
 
-- Use `@pytest.mark.parametrize` for tests that differ only in inputs — extract shared setup into helpers.
 - Add tests to existing `test_{module}.py` files rather than creating new test files for the same module.
-- Replace `print()` in tests with `assert` statements.
-
-## Common Failure Mode
-
-- A missing module or missing command error from bare `python`, `pytest`, `pip`, `maturin`, or `make` is usually an environment usage mistake, not a repository issue.
-- Before reporting a Python dependency as unavailable, verify that `uv sync` has been run in the current worktree and that the failing command was executed with `uv run ...`.


### PR DESCRIPTION
The repository guidance has accumulated duplicated and stale instructions. In particular, the root integration example bypasses the current uv-based Python workflow, while several other rules restate authoritative guidance already present in the root or language-specific files.

This trims only those redundant project-local entries so the closest applicable rule remains the single source of truth.
