### PR TITLE
fix(fts): include must-not clauses in query planning

### DIFF
--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -865,6 +865,25 @@ pub fn has_query_token(
     false
 }
 
+fn fill_match_query_columns(
+    query: &MatchQuery,
+    columns: &[String],
+    replace: bool,
+) -> Result<Vec<MatchQuery>> {
+    if query.column.is_some() && !replace {
+        return Ok(vec![query.clone()]);
+    }
+    if columns.is_empty() {
+        return Err(Error::invalid_input(
+            "Cannot perform full text search unless an INVERTED index has been created on at least one column".to_string(),
+        ));
+    }
+    Ok(columns
+        .iter()
+        .map(|column| query.clone().with_column(Some(column.clone())))
+        .collect())
+}
+
 pub fn fill_fts_query_column(
     query: &FtsQuery,
     columns: &[String],
@@ -875,21 +894,11 @@ pub fn fill_fts_query_column(
     }
     match query {
         FtsQuery::Match(match_query) => {
-            match columns.len() {
-                0 => {
-                    Err(Error::invalid_input("Cannot perform full text search unless an INVERTED index has been created on at least one column".to_string()))
-                }
-                1 => {
-                    let column = columns[0].clone();
-                    let query = match_query.clone().with_column(Some(column));
-                    Ok(FtsQuery::Match(query))
-                }
-                _ => {
-                    // if there are multiple columns, we need to create a MultiMatch query
-                    let multi_match_query =
-                        MultiMatchQuery::try_new(match_query.terms.clone(), columns.to_vec())?;
-                    Ok(FtsQuery::MultiMatch(multi_match_query))
-                }
+            let match_queries = fill_match_query_columns(match_query, columns, replace)?;
+            if let [match_query] = match_queries.as_slice() {
+                Ok(FtsQuery::Match(match_query.clone()))
+            } else {
+                Ok(FtsQuery::MultiMatch(MultiMatchQuery { match_queries }))
             }
         }
         FtsQuery::Phrase(phrase_query) => {
@@ -920,17 +929,11 @@ pub fn fill_fts_query_column(
             let match_queries = multi_match_query
                 .match_queries
                 .iter()
-                .map(|query| fill_fts_query_column(&FtsQuery::Match(query.clone()), columns, replace))
-                .map(|result| {
-                    result.map(|query| {
-                        if let FtsQuery::Match(match_query) = query {
-                            match_query
-                        } else {
-                            unreachable!("Expected MatchQuery")
-                        }
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
+                .map(|query| fill_match_query_columns(query, columns, replace))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .flatten()
+                .collect();
             Ok(FtsQuery::MultiMatch(MultiMatchQuery { match_queries }))
        }
         FtsQuery::Boolean(bool_query) => {
@@ -960,6 +963,13 @@ mod tests {
     fn test_boolean_query_introspection_includes_must_not() {
         use super::*;
 
+        let implicit = MatchQuery::new("exclude".to_string())
+            .with_boost(3.0)
+            .with_fuzziness(Some(1))
+            .with_max_expansions(10)
+            .with_operator(Operator::And)
+            .with_prefix_length(2)
+            .with_document_granularity(DocumentGranularity::Row);
         let query = FtsQuery::Boolean(BooleanQuery::new([
             (
                 Occur::Must,
@@ -967,10 +977,7 @@ mod tests {
                     .with_column(Some("positive_text".to_string()))
                     .into(),
             ),
-            (
-                Occur::MustNot,
-                MatchQuery::new("exclude".to_string()).into(),
-            ),
+            (Occur::MustNot, implicit.clone().into()),
         ]));
 
         assert_eq!(
@@ -979,10 +986,59 @@ mod tests {
         );
         assert!(query.is_missing_column());
 
-        let filled = fill_fts_query_column(&query, &["negative_text".to_string()], false).unwrap();
+        let filled = fill_fts_query_column(
+            &query,
+            &["positive_text".to_string(), "negative_text".to_string()],
+            false,
+        )
+        .unwrap();
         assert_eq!(
             filled.columns(),
             HashSet::from(["positive_text".to_string(), "negative_text".to_string()])
+        );
+        let FtsQuery::Boolean(filled) = filled else {
+            unreachable!()
+        };
+        let FtsQuery::MultiMatch(expanded) = &filled.must_not[0] else {
+            unreachable!()
+        };
+        assert_eq!(
+            expanded.match_queries,
+            ["positive_text", "negative_text"]
+                .into_iter()
+                .map(|column| implicit.clone().with_column(Some(column.to_string())))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_fill_partial_multi_match_columns() {
+        use super::*;
+
+        let implicit = MatchQuery::new("include".to_string()).with_boost(2.0);
+        let query = FtsQuery::MultiMatch(MultiMatchQuery {
+            match_queries: vec![
+                MatchQuery::new("include".to_string())
+                    .with_column(Some("a".to_string()))
+                    .with_boost(3.0),
+                implicit.clone(),
+            ],
+        });
+
+        let filled =
+            fill_fts_query_column(&query, &["a".to_string(), "b".to_string()], false).unwrap();
+        let FtsQuery::MultiMatch(filled) = filled else {
+            unreachable!()
+        };
+        assert_eq!(
+            filled.match_queries,
+            vec![
+                MatchQuery::new("include".to_string())
+                    .with_column(Some("a".to_string()))
+                    .with_boost(3.0),
+                implicit.clone().with_column(Some("a".to_string())),
+                implicit.with_column(Some("b".to_string())),
+            ]
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -161,16 +161,7 @@ impl FtsQueryNode for FtsQuery {
                 }
                 columns
             }
-            Self::Boolean(query) => {
-                let mut columns = HashSet::new();
-                for query in &query.must {
-                    columns.extend(query.columns());
-                }
-                for query in &query.should {
-                    columns.extend(query.columns());
-                }
-                columns
-            }
+            Self::Boolean(query) => query.columns(),
         }
     }
 }
@@ -200,6 +191,7 @@ impl FtsQuery {
             Self::Boolean(query) => {
                 query.must.iter().any(|q| q.is_missing_column())
                     || query.should.iter().any(|q| q.is_missing_column())
+                    || query.must_not.iter().any(|q| q.is_missing_column())
             }
         }
     }
@@ -964,6 +956,36 @@ pub fn fill_fts_query_column(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_boolean_query_introspection_includes_must_not() {
+        use super::*;
+
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                MatchQuery::new("include".to_string())
+                    .with_column(Some("positive_text".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::MustNot,
+                MatchQuery::new("exclude".to_string()).into(),
+            ),
+        ]));
+
+        assert_eq!(
+            query.columns(),
+            HashSet::from(["positive_text".to_string()])
+        );
+        assert!(query.is_missing_column());
+
+        let filled = fill_fts_query_column(&query, &["negative_text".to_string()], false).unwrap();
+        assert_eq!(
+            filled.columns(),
+            HashSet::from(["positive_text".to_string(), "negative_text".to_string()])
+        );
+    }
+
     #[test]
     fn test_match_query_serde() {
         use super::*;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -494,7 +494,7 @@ impl FilterPlan {
         if self.refine_query_filter {
             match &self.query_filter {
                 Some(QueryFilter::Fts(fts_query)) => {
-                    let cols = if fts_query.columns().is_empty() {
+                    let cols = if fts_query.query.is_missing_column() {
                         let indexed_columns = fts_indexed_columns(dataset.clone()).await?;
                         let q = fill_fts_query_column(&fts_query.query, &indexed_columns, false)?;
                         q.columns()
@@ -3566,15 +3566,12 @@ impl Scanner {
                 .await
             }
             FtsQuery::Boolean(bool_query) => {
-                for query in bool_query.must.iter() {
-                    if !self
-                        .fragments_covered_by_fts_query_helper(query, accum)
-                        .await?
-                    {
-                        return Ok(false);
-                    }
-                }
-                for query in &bool_query.should {
+                for query in bool_query
+                    .must
+                    .iter()
+                    .chain(&bool_query.should)
+                    .chain(&bool_query.must_not)
+                {
                     if !self
                         .fragments_covered_by_fts_query_helper(query, accum)
                         .await?
@@ -3865,7 +3862,7 @@ impl Scanner {
         query: &FullTextSearchQuery,
     ) -> Result<FullTextSearchQuery> {
         let mut resolved = query.clone();
-        if resolved.columns().is_empty() {
+        if resolved.query.is_missing_column() {
             if Self::query_requests_list_element(&resolved.query) {
                 return Err(Error::invalid_input(
                     "ListElement FTS queries must explicitly specify a field path".to_string(),

--- a/rust/lance/tests/query/inverted.rs
+++ b/rust/lance/tests/query/inverted.rs
@@ -27,7 +27,7 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::{DocumentGranularity, Language};
 use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
-use lance_table::format::IndexMetadata;
+use lance_table::format::{Fragment, IndexMetadata};
 
 use super::{strip_score_column, test_fts, test_scan, test_take};
 use crate::utils::DatasetTestCases;
@@ -106,6 +106,23 @@ async fn run_fts(ds: &Dataset, query: FullTextSearchQuery, filter: Option<&str>)
         )]))
         .unwrap();
     scanner.try_into_batch().await.unwrap()
+}
+
+async fn boolean_fts_ids_on_fragment(
+    dataset: &Dataset,
+    fragment: Fragment,
+    query: BooleanQuery,
+) -> Vec<i32> {
+    let mut scanner = dataset.scan();
+    scanner.with_fragments(vec![fragment]);
+    scanner.project(&["id"]).unwrap();
+    scanner
+        .full_text_search(FullTextSearchQuery::new_query(FtsQuery::Boolean(query)))
+        .unwrap();
+    scanner.try_into_batch().await.unwrap()["id"]
+        .as_primitive::<arrow_array::types::Int32Type>()
+        .values()
+        .to_vec()
 }
 
 // Run an FTS query and assert results match a deterministic expected batch.
@@ -227,6 +244,86 @@ fn expected_bm25_score(
     let avg_doc_length = total_tokens as f32 / num_docs;
     let doc_norm = 1.2 * (1.0 - 0.75 + 0.75 * doc_tokens as f32 / avg_doc_length);
     idf * 2.2 / (1.0 + doc_norm)
+}
+
+#[tokio::test]
+async fn test_boolean_must_not_uses_all_index_fragment_coverage() {
+    let initial = arrow_array::record_batch!(
+        ("id", Int32, [0]),
+        ("positive_text", Utf8, ["placeholder"]),
+        ("negative_text", Utf8, ["placeholder"])
+    )
+    .unwrap();
+    let test_dir = tempfile::tempdir().unwrap();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(initial.clone())], initial.schema()),
+        test_dir.path().to_str().unwrap(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    dataset
+        .create_index(
+            &["positive_text"],
+            IndexType::Inverted,
+            None,
+            &base_inverted_params(false),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let appended = arrow_array::record_batch!(
+        ("id", Int32, [1, 2]),
+        ("positive_text", Utf8, ["include", "include"]),
+        ("negative_text", Utf8, ["exclude", "keep"])
+    )
+    .unwrap();
+    let appended_reader = RecordBatchIterator::new([Ok(appended.clone())], appended.schema());
+    dataset.append(appended_reader, None).await.unwrap();
+    let appended_fragment = dataset.fragments().last().unwrap().clone();
+
+    dataset
+        .create_index(
+            &["negative_text"],
+            IndexType::Inverted,
+            None,
+            &base_inverted_params(false),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let query = BooleanQuery::new([
+        (
+            Occur::Must,
+            FtsQuery::Match(row_match_node("positive_text", "include")),
+        ),
+        (
+            Occur::MustNot,
+            FtsQuery::Match(row_match_node("negative_text", "exclude")),
+        ),
+    ]);
+    assert_eq!(
+        boolean_fts_ids_on_fragment(&dataset, appended_fragment.clone(), query).await,
+        vec![2]
+    );
+
+    let partially_qualified_query = BooleanQuery::new([
+        (
+            Occur::Must,
+            FtsQuery::Match(MatchQuery::new("include".to_string())),
+        ),
+        (
+            Occur::MustNot,
+            FtsQuery::Match(row_match_node("negative_text", "exclude")),
+        ),
+    ]);
+    assert_eq!(
+        boolean_fts_ids_on_fragment(&dataset, appended_fragment, partially_qualified_query).await,
+        vec![2]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- include Boolean must-not clauses in FTS column introspection and implicit column filling
- include must-not index fragment coverage when building the shared FTS prefilter
- add regression coverage for cross-column Boolean queries with different index coverage and partially specified columns

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p lance-index scalar::inverted::query::tests --lib`
- `cargo test -p lance --features slow_tests --test integration_tests test_boolean_must_not_uses_all_index_fragment_coverage`
- `cargo clippy --all --tests --benches -- -D warnings` *(blocked by pre-existing `main` test compilation errors in `rust/lance/src/dataset/transaction.rs`: test constructors still use `merged_generations`, while `Operation::Update` and the protobuf now expose `compacted_sstables`)*