### PR TITLE
ci: shard recurring tests and add failure alerts

### DIFF
--- a/.github/actions/create-failure-issue/action.yml
+++ b/.github/actions/create-failure-issue/action.yml
@@ -1,5 +1,5 @@
-name: Create Failure Issue
-description: Creates a GitHub issue if any jobs in the workflow failed
+name: Create Workflow Alert Issue
+description: Creates or updates a GitHub issue for reportable workflow job results
 
 inputs:
   job-results:
@@ -8,38 +8,25 @@ inputs:
   workflow-name:
     description: 'Name of the workflow'
     required: true
+  include-cancelled:
+    description: 'Create a notification when any job was cancelled'
+    required: false
+    default: 'false'
+  deduplicate:
+    description: 'Comment on an existing open issue for this workflow instead of creating a duplicate'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
   steps:
-    - name: Check for failures and create issue
+    - name: Check results and update issue
       shell: bash
       env:
         JOB_RESULTS: ${{ inputs.job-results }}
         WORKFLOW_NAME: ${{ inputs.workflow-name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GH_TOKEN: ${{ github.token }}
-      run: |
-        # Check if any job failed
-        if echo "$JOB_RESULTS" | jq -e 'to_entries | any(.value.result == "failure")' > /dev/null; then
-          echo "Detected job failures, creating issue..."
-
-          # Extract failed job names
-          FAILED_JOBS=$(echo "$JOB_RESULTS" | jq -r 'to_entries | map(select(.value.result == "failure")) | map(.key) | join(", ")')
-
-          # Create issue with workflow name, failed jobs, and run URL
-          gh issue create \
-            --title "$WORKFLOW_NAME Failed ($FAILED_JOBS)" \
-            --body "The workflow **$WORKFLOW_NAME** failed during execution.
-
-        **Failed jobs:** $FAILED_JOBS
-
-        **Run URL:** $RUN_URL
-
-        Please investigate the failed jobs and address any issues." \
-            --label "ci"
-
-          echo "Issue created successfully"
-        else
-          echo "No job failures detected, skipping issue creation"
-        fi
+        INCLUDE_CANCELLED: ${{ inputs.include-cancelled }}
+        DEDUPLICATE: ${{ inputs.deduplicate }}
+      run: bash "${{ github.action_path }}/create-failure-issue.sh"

--- a/.github/actions/create-failure-issue/create-failure-issue.sh
+++ b/.github/actions/create-failure-issue/create-failure-issue.sh
@@ -22,7 +22,7 @@ validate_boolean() {
 validate_boolean "INCLUDE_CANCELLED" "$INCLUDE_CANCELLED"
 validate_boolean "DEDUPLICATE" "$DEDUPLICATE"
 
-find_canonical_issue_number() {
+find_matching_issues() {
   local marker="$1"
 
   gh issue list \
@@ -30,11 +30,65 @@ find_canonical_issue_number() {
     --label ci \
     --limit 1000 \
     --json number,body |
-    jq -r --arg marker "$marker" '
+    jq -c --arg marker "$marker" '
       map(select((.body // "") | contains($marker)))
-      | min_by(.number)
-      | .number // empty
+      | sort_by(.number)
     '
+}
+
+load_issue_contents() {
+  local issue_number="$1"
+
+  gh issue view "$issue_number" --json body,comments |
+    jq -r '[.body // "", (.comments[]?.body // "")] | join("\n")'
+}
+
+reconcile_duplicate_issue() {
+  local canonical_issue_number="$1"
+  local duplicate_issue_number="$2"
+  local duplicate_issue_body="$3"
+  local canonical_contents
+  local duplicate_run_marker
+  local migration_body
+  local migration_marker="<!-- create-failure-issue-migrated:$duplicate_issue_number -->"
+
+  canonical_contents="$(load_issue_contents "$canonical_issue_number")"
+  duplicate_run_marker="$(
+    grep -Eo '<!-- create-failure-issue-run:[^>]+ -->' <<<"$duplicate_issue_body" |
+      head -n 1 || true
+  )"
+
+  if [[ "$canonical_contents" == *"$migration_marker"* ]] ||
+    [[ -n "$duplicate_run_marker" && "$canonical_contents" == *"$duplicate_run_marker"* ]]; then
+    echo "Issue #$duplicate_issue_number is already recorded on #$canonical_issue_number"
+  else
+    migration_body="$migration_marker
+
+$duplicate_issue_body"
+    echo "Recording issue #$duplicate_issue_number on canonical issue #$canonical_issue_number"
+    gh issue comment "$canonical_issue_number" --body "$migration_body"
+  fi
+
+  gh issue close "$duplicate_issue_number" \
+    --comment "Closing this concurrently-created alert as a duplicate of #$canonical_issue_number."
+  echo "Closed duplicate issue #$duplicate_issue_number"
+}
+
+record_notification_once() {
+  local issue_number="$1"
+  local run_marker="$2"
+  local comment_body="$3"
+  local issue_contents
+
+  issue_contents="$(load_issue_contents "$issue_number")"
+  if [[ "$issue_contents" == *"$run_marker"* ]]; then
+    echo "This workflow run is already recorded on issue #$issue_number"
+    return
+  fi
+
+  echo "Adding this workflow run to issue #$issue_number"
+  gh issue comment "$issue_number" --body "$comment_body"
+  echo "Issue comment created successfully"
 }
 
 failed_jobs="$(
@@ -96,18 +150,34 @@ issue_body="$notification_body"
 if [[ "$DEDUPLICATE" == "true" ]]; then
   marker_key="$(jq -nr --arg workflow "$WORKFLOW_NAME" '$workflow | @uri')"
   deduplication_marker="<!-- create-failure-issue:$marker_key -->"
-  existing_issue_number="$(find_canonical_issue_number "$deduplication_marker")"
+  run_marker_key="$(jq -nr --arg run_url "$RUN_URL" '$run_url | @uri')"
+  run_marker="<!-- create-failure-issue-run:$run_marker_key -->"
+  notification_comment="$run_marker
+
+$notification_body"
+  matching_issues="$(find_matching_issues "$deduplication_marker")"
+  existing_issue_number="$(jq -r '.[0].number // empty' <<<"$matching_issues")"
 
   if [[ -n "$existing_issue_number" ]]; then
-    echo "Found existing issue #$existing_issue_number; adding this run as a comment"
-    gh issue comment "$existing_issue_number" --body "$notification_body"
-    echo "Issue comment created successfully"
+    echo "Found canonical issue #$existing_issue_number; reconciling open duplicates"
+    while IFS= read -r duplicate_issue; do
+      duplicate_issue_number="$(jq -r '.number' <<<"$duplicate_issue")"
+      duplicate_issue_body="$(jq -r '.body // ""' <<<"$duplicate_issue")"
+      reconcile_duplicate_issue \
+        "$existing_issue_number" \
+        "$duplicate_issue_number" \
+        "$duplicate_issue_body"
+    done < <(
+      jq -c --argjson canonical "$existing_issue_number" \
+        '.[] | select(.number != $canonical)' <<<"$matching_issues"
+    )
+    record_notification_once "$existing_issue_number" "$run_marker" "$notification_comment"
     exit 0
   fi
 
   issue_body="$deduplication_marker
 
-$notification_body"
+$notification_comment"
 fi
 
 echo "Detected reportable job results; creating issue"
@@ -128,12 +198,19 @@ if [[ "$DEDUPLICATE" == "true" ]]; then
 
   # Different refs can pass the initial lookup concurrently. Keep the oldest
   # issue canonical and move this run there if this creation lost the race.
-  canonical_issue_number="$(find_canonical_issue_number "$deduplication_marker")"
+  matching_issues="$(find_matching_issues "$deduplication_marker")"
+  canonical_issue_number="$(jq -r '.[0].number // empty' <<<"$matching_issues")"
   if [[ -n "$canonical_issue_number" && "$canonical_issue_number" != "$created_issue_number" ]]; then
     echo "Issue #$created_issue_number duplicates #$canonical_issue_number; reconciling"
-    gh issue comment "$canonical_issue_number" --body "$notification_body"
-    gh issue close "$created_issue_number" \
-      --comment "Closing this concurrently-created alert as a duplicate of #$canonical_issue_number."
-    echo "Recorded this run on issue #$canonical_issue_number and closed duplicate #$created_issue_number"
+    created_issue_body="$(
+      jq -r --argjson created "$created_issue_number" \
+        '.[] | select(.number == $created) | .body // ""' <<<"$matching_issues"
+    )"
+    if [[ -n "$created_issue_body" ]]; then
+      reconcile_duplicate_issue \
+        "$canonical_issue_number" \
+        "$created_issue_number" \
+        "$created_issue_body"
+    fi
   fi
 fi

--- a/.github/actions/create-failure-issue/create-failure-issue.sh
+++ b/.github/actions/create-failure-issue/create-failure-issue.sh
@@ -22,6 +22,21 @@ validate_boolean() {
 validate_boolean "INCLUDE_CANCELLED" "$INCLUDE_CANCELLED"
 validate_boolean "DEDUPLICATE" "$DEDUPLICATE"
 
+find_canonical_issue_number() {
+  local marker="$1"
+
+  gh issue list \
+    --state open \
+    --label ci \
+    --limit 1000 \
+    --json number,body |
+    jq -r --arg marker "$marker" '
+      map(select((.body // "") | contains($marker)))
+      | min_by(.number)
+      | .number // empty
+    '
+}
+
 failed_jobs="$(
   jq -er '
     to_entries
@@ -76,19 +91,12 @@ else
 Please investigate the affected jobs and address any issues."
 fi
 
+issue_body="$notification_body"
+
 if [[ "$DEDUPLICATE" == "true" ]]; then
   marker_key="$(jq -nr --arg workflow "$WORKFLOW_NAME" '$workflow | @uri')"
   deduplication_marker="<!-- create-failure-issue:$marker_key -->"
-  existing_issue_number="$({
-    gh issue list \
-      --state open \
-      --label ci \
-      --limit 1000 \
-      --json number,body
-  } | jq -r --arg marker "$deduplication_marker" '
-    first(.[] | select((.body // "") | contains($marker)))
-    | .number // empty
-  ')"
+  existing_issue_number="$(find_canonical_issue_number "$deduplication_marker")"
 
   if [[ -n "$existing_issue_number" ]]; then
     echo "Found existing issue #$existing_issue_number; adding this run as a comment"
@@ -97,14 +105,35 @@ if [[ "$DEDUPLICATE" == "true" ]]; then
     exit 0
   fi
 
-  notification_body="$deduplication_marker
+  issue_body="$deduplication_marker
 
 $notification_body"
 fi
 
 echo "Detected reportable job results; creating issue"
-gh issue create \
-  --title "$issue_title" \
-  --body "$notification_body" \
-  --label ci
-echo "Issue created successfully"
+created_issue_url="$(
+  gh issue create \
+    --title "$issue_title" \
+    --body "$issue_body" \
+    --label ci
+)"
+echo "Issue created successfully: $created_issue_url"
+
+if [[ "$DEDUPLICATE" == "true" ]]; then
+  created_issue_number="${created_issue_url##*/}"
+  if [[ ! "$created_issue_number" =~ ^[0-9]+$ ]]; then
+    echo "Could not determine the created issue number from '$created_issue_url'" >&2
+    exit 1
+  fi
+
+  # Different refs can pass the initial lookup concurrently. Keep the oldest
+  # issue canonical and move this run there if this creation lost the race.
+  canonical_issue_number="$(find_canonical_issue_number "$deduplication_marker")"
+  if [[ -n "$canonical_issue_number" && "$canonical_issue_number" != "$created_issue_number" ]]; then
+    echo "Issue #$created_issue_number duplicates #$canonical_issue_number; reconciling"
+    gh issue comment "$canonical_issue_number" --body "$notification_body"
+    gh issue close "$created_issue_number" \
+      --comment "Closing this concurrently-created alert as a duplicate of #$canonical_issue_number."
+    echo "Recorded this run on issue #$canonical_issue_number and closed duplicate #$created_issue_number"
+  fi
+fi

--- a/.github/actions/create-failure-issue/create-failure-issue.sh
+++ b/.github/actions/create-failure-issue/create-failure-issue.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${JOB_RESULTS:?JOB_RESULTS must be set}"
+: "${WORKFLOW_NAME:?WORKFLOW_NAME must be set}"
+: "${RUN_URL:?RUN_URL must be set}"
+
+INCLUDE_CANCELLED="${INCLUDE_CANCELLED:-false}"
+DEDUPLICATE="${DEDUPLICATE:-false}"
+
+validate_boolean() {
+  local name="$1"
+  local value="$2"
+
+  if [[ "$value" != "true" && "$value" != "false" ]]; then
+    echo "$name must be 'true' or 'false', got '$value'" >&2
+    exit 2
+  fi
+}
+
+validate_boolean "INCLUDE_CANCELLED" "$INCLUDE_CANCELLED"
+validate_boolean "DEDUPLICATE" "$DEDUPLICATE"
+
+failed_jobs="$(
+  jq -er '
+    to_entries
+    | map(select(.value.result == "failure"))
+    | map(.key)
+    | join(", ")
+  ' <<<"$JOB_RESULTS"
+)"
+
+cancelled_jobs="$(
+  jq -er '
+    to_entries
+    | map(select(.value.result == "cancelled"))
+    | map(.key)
+    | join(", ")
+  ' <<<"$JOB_RESULTS"
+)"
+
+if [[ -z "$failed_jobs" && ( "$INCLUDE_CANCELLED" != "true" || -z "$cancelled_jobs" ) ]]; then
+  echo "No reportable job failures or cancellations detected, skipping issue creation"
+  exit 0
+fi
+
+if [[ -n "$failed_jobs" && ( "$INCLUDE_CANCELLED" != "true" || -z "$cancelled_jobs" ) ]]; then
+  issue_title="$WORKFLOW_NAME Failed ($failed_jobs)"
+  notification_body="The workflow **$WORKFLOW_NAME** failed during execution.
+
+**Failed jobs:** $failed_jobs
+
+**Run URL:** $RUN_URL
+
+Please investigate the failed jobs and address any issues."
+elif [[ -z "$failed_jobs" ]]; then
+  issue_title="$WORKFLOW_NAME Cancelled ($cancelled_jobs)"
+  notification_body="The workflow **$WORKFLOW_NAME** reported cancelled jobs.
+
+**Cancelled jobs:** $cancelled_jobs
+
+**Run URL:** $RUN_URL
+
+Please investigate the cancelled jobs and address any issues."
+else
+  issue_title="$WORKFLOW_NAME Failed or Cancelled ($failed_jobs, $cancelled_jobs)"
+  notification_body="The workflow **$WORKFLOW_NAME** reported failed or cancelled jobs.
+
+**Failed jobs:** $failed_jobs
+
+**Cancelled jobs:** $cancelled_jobs
+
+**Run URL:** $RUN_URL
+
+Please investigate the affected jobs and address any issues."
+fi
+
+if [[ "$DEDUPLICATE" == "true" ]]; then
+  marker_key="$(jq -nr --arg workflow "$WORKFLOW_NAME" '$workflow | @uri')"
+  deduplication_marker="<!-- create-failure-issue:$marker_key -->"
+  existing_issue_number="$({
+    gh issue list \
+      --state open \
+      --label ci \
+      --limit 1000 \
+      --json number,body
+  } | jq -r --arg marker "$deduplication_marker" '
+    first(.[] | select((.body // "") | contains($marker)))
+    | .number // empty
+  ')"
+
+  if [[ -n "$existing_issue_number" ]]; then
+    echo "Found existing issue #$existing_issue_number; adding this run as a comment"
+    gh issue comment "$existing_issue_number" --body "$notification_body"
+    echo "Issue comment created successfully"
+    exit 0
+  fi
+
+  notification_body="$deduplication_marker
+
+$notification_body"
+fi
+
+echo "Detected reportable job results; creating issue"
+gh issue create \
+  --title "$issue_title" \
+  --body "$notification_body" \
+  --label ci
+echo "Issue created successfully"

--- a/.github/actions/create-failure-issue/test.sh
+++ b/.github/actions/create-failure-issue/test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION_SCRIPT="$SCRIPT_DIR/create-failure-issue.sh"
+
+mock_gh() {
+  local call_number=1
+  local arg
+
+  if [[ -f "$MOCK_GH_CALLS/count" ]]; then
+    read -r call_number <"$MOCK_GH_CALLS/count"
+    call_number=$((call_number + 1))
+  fi
+  printf '%s\n' "$call_number" >"$MOCK_GH_CALLS/count"
+  for arg in "$@"; do
+    printf '%s\0' "$arg"
+  done >"$MOCK_GH_CALLS/$call_number"
+
+  if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+    printf '%s\n' "${MOCK_GH_LIST_RESPONSE:-[]}"
+  elif [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+    printf '%s\n' "https://github.com/lance-format/lance/issues/999"
+  fi
+}
+
+if [[ "$(basename "$0")" == "gh" ]]; then
+  mock_gh "$@"
+  exit 0
+fi
+
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+mkdir -p "$TEST_TMP/bin" "$TEST_TMP/calls"
+ln -s "$SCRIPT_DIR/test.sh" "$TEST_TMP/bin/gh"
+MOCK_GH_CALLS="$TEST_TMP/calls"
+export MOCK_GH_CALLS
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" == *"$needle"* ]] || fail "expected '$needle' in '$haystack'"
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+reset_mock() {
+  rm -f "$MOCK_GH_CALLS"/count "$MOCK_GH_CALLS"/[0-9]*
+  unset MOCK_GH_LIST_RESPONSE || true
+}
+
+run_action() {
+  PATH="$TEST_TMP/bin:$PATH" \
+    GH_TOKEN=test-token \
+    JOB_RESULTS="$1" \
+    WORKFLOW_NAME="Recurring Tests" \
+    RUN_URL="https://github.com/lance-format/lance/actions/runs/123" \
+    INCLUDE_CANCELLED="${2:-false}" \
+    DEDUPLICATE="${3:-false}" \
+    bash "$ACTION_SCRIPT"
+}
+
+load_call() {
+  local call_number="$1"
+  local arg
+  CALL_ARGS=()
+  while IFS= read -r -d '' arg; do
+    CALL_ARGS+=("$arg")
+  done <"$MOCK_GH_CALLS/$call_number"
+}
+
+test_failure_creates_issue() {
+  local output
+
+  reset_mock
+  output="$(run_action '{"build":{"result":"failure"},"docs":{"result":"success"}}')"
+  assert_contains "$output" "creating issue"
+  assert_equals "1" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 1
+  assert_equals "issue" "${CALL_ARGS[0]}"
+  assert_equals "create" "${CALL_ARGS[1]}"
+  assert_equals "Recurring Tests Failed (build)" "${CALL_ARGS[3]}"
+  assert_contains "${CALL_ARGS[5]}" "**Failed jobs:** build"
+  assert_contains "${CALL_ARGS[5]}" "actions/runs/123"
+  assert_equals "ci" "${CALL_ARGS[7]}"
+}
+
+test_cancelled_is_opt_in() {
+  local output
+
+  reset_mock
+  output="$(run_action '{"matrix":{"result":"cancelled"}}')"
+  assert_contains "$output" "skipping issue creation"
+  [[ ! -f "$MOCK_GH_CALLS/count" ]] || fail "cancelled job notified without opt-in"
+
+  output="$(run_action '{"matrix":{"result":"cancelled"}}' true)"
+  assert_equals "1" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 1
+  assert_equals "Recurring Tests Cancelled (matrix)" "${CALL_ARGS[3]}"
+  assert_contains "${CALL_ARGS[5]}" "**Cancelled jobs:** matrix"
+}
+
+test_deduplicate_seeds_new_issue() {
+  reset_mock
+  MOCK_GH_LIST_RESPONSE='[]'
+  export MOCK_GH_LIST_RESPONSE
+
+  run_action '{"build":{"result":"failure"}}' false true >/dev/null
+  assert_equals "2" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 1
+  assert_equals "list" "${CALL_ARGS[1]}"
+  load_call 2
+  assert_equals "create" "${CALL_ARGS[1]}"
+  assert_contains "${CALL_ARGS[5]}" "<!-- create-failure-issue:Recurring%20Tests -->"
+}
+
+test_deduplicate_comments_on_open_issue() {
+  reset_mock
+  MOCK_GH_LIST_RESPONSE='[{"number":42,"body":"<!-- create-failure-issue:Recurring%20Tests -->\nPrevious run"}]'
+  export MOCK_GH_LIST_RESPONSE
+
+  run_action '{"build":{"result":"failure"}}' false true >/dev/null
+  assert_equals "2" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 2
+  assert_equals "issue" "${CALL_ARGS[0]}"
+  assert_equals "comment" "${CALL_ARGS[1]}"
+  assert_equals "42" "${CALL_ARGS[2]}"
+  assert_equals "--body" "${CALL_ARGS[3]}"
+  assert_contains "${CALL_ARGS[4]}" "**Failed jobs:** build"
+  assert_contains "${CALL_ARGS[4]}" "actions/runs/123"
+}
+
+test_failure_creates_issue
+test_cancelled_is_opt_in
+test_deduplicate_seeds_new_issue
+test_deduplicate_comments_on_open_issue
+
+echo "All create-failure-issue tests passed"

--- a/.github/actions/create-failure-issue/test.sh
+++ b/.github/actions/create-failure-issue/test.sh
@@ -24,6 +24,7 @@ release_mock_state_lock() {
 mock_stateful_gh() {
   local args=("$@")
   local body=""
+  local close_failures_remaining
   local close_comment=""
   local initial_list_call="false"
   local initial_list_count
@@ -67,6 +68,22 @@ mock_stateful_gh() {
     return
   fi
 
+  if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+    issue_number="${3:?issue number is required}"
+    acquire_mock_state_lock
+    jq \
+      --argjson number "$issue_number" \
+      --slurpfile comments "$MOCK_GH_STATE_DIR/comments.json" \
+      '(.[] | select(.number == $number)) as $issue
+      | {
+          body: $issue.body,
+          comments: [$comments[0][] | select(.number == $number) | {body}]
+        }' \
+      "$MOCK_GH_STATE_DIR/issues.json"
+    release_mock_state_lock
+    return
+  fi
+
   for ((index = 0; index < ${#args[@]}; index++)); do
     if [[ "${args[index]}" == "--body" ]]; then
       body="${args[index + 1]}"
@@ -103,19 +120,29 @@ mock_stateful_gh() {
   elif [[ "${1:-}" == "issue" && "${2:-}" == "close" ]]; then
     issue_number="${3:?issue number is required}"
     acquire_mock_state_lock
+    read -r close_failures_remaining <"$MOCK_GH_STATE_DIR/close-failures-remaining"
+    tmp_file="$MOCK_GH_STATE_DIR/closes.json.$$"
+    jq \
+      --argjson number "$issue_number" \
+      --arg comment "$close_comment" \
+      --argjson succeeded "$((close_failures_remaining == 0))" \
+      '. + [{number: $number, comment: $comment, succeeded: $succeeded}]' \
+      "$MOCK_GH_STATE_DIR/closes.json" >"$tmp_file"
+    mv "$tmp_file" "$MOCK_GH_STATE_DIR/closes.json"
+
+    if (( close_failures_remaining > 0 )); then
+      printf '%s\n' "$((close_failures_remaining - 1))" \
+        >"$MOCK_GH_STATE_DIR/close-failures-remaining"
+      release_mock_state_lock
+      return 1
+    fi
+
     tmp_file="$MOCK_GH_STATE_DIR/issues.json.$$"
     jq \
       --argjson number "$issue_number" \
       'map(if .number == $number then .state = "closed" else . end)' \
       "$MOCK_GH_STATE_DIR/issues.json" >"$tmp_file"
     mv "$tmp_file" "$MOCK_GH_STATE_DIR/issues.json"
-    tmp_file="$MOCK_GH_STATE_DIR/closes.json.$$"
-    jq \
-      --argjson number "$issue_number" \
-      --arg comment "$close_comment" \
-      '. + [{number: $number, comment: $comment}]' \
-      "$MOCK_GH_STATE_DIR/closes.json" >"$tmp_file"
-    mv "$tmp_file" "$MOCK_GH_STATE_DIR/closes.json"
     release_mock_state_lock
   fi
 }
@@ -142,6 +169,12 @@ mock_gh() {
     printf '%s\n' "${MOCK_GH_LIST_RESPONSE:-[]}"
   elif [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
     printf '%s\n' "https://github.com/lance-format/lance/issues/999"
+  elif [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+    if [[ -n "${MOCK_GH_VIEW_RESPONSE:-}" ]]; then
+      printf '%s\n' "$MOCK_GH_VIEW_RESPONSE"
+    else
+      printf '%s\n' '{"body":"","comments":[]}'
+    fi
   fi
 }
 
@@ -177,6 +210,7 @@ assert_equals() {
 reset_mock() {
   rm -f "$MOCK_GH_CALLS"/count "$MOCK_GH_CALLS"/[0-9]*
   unset MOCK_GH_LIST_RESPONSE || true
+  unset MOCK_GH_VIEW_RESPONSE || true
   unset MOCK_GH_STATE_DIR || true
 }
 
@@ -198,6 +232,23 @@ load_call() {
   while IFS= read -r -d '' arg; do
     CALL_ARGS+=("$arg")
   done <"$MOCK_GH_CALLS/$call_number"
+}
+
+setup_stateful_mock() {
+  local state_dir="$1"
+  local close_failures="${2:-0}"
+
+  reset_mock
+  rm -rf "$state_dir"
+  mkdir -p "$state_dir"
+  printf '%s\n' '0' >"$state_dir/initial-list-count"
+  printf '%s\n' '1000' >"$state_dir/next-issue-number"
+  printf '%s\n' "$close_failures" >"$state_dir/close-failures-remaining"
+  printf '%s\n' '[]' >"$state_dir/issues.json"
+  printf '%s\n' '[]' >"$state_dir/comments.json"
+  printf '%s\n' '[]' >"$state_dir/closes.json"
+  MOCK_GH_STATE_DIR="$state_dir"
+  export MOCK_GH_STATE_DIR
 }
 
 test_failure_creates_issue() {
@@ -243,6 +294,7 @@ test_deduplicate_seeds_new_issue() {
   load_call 2
   assert_equals "create" "${CALL_ARGS[1]}"
   assert_contains "${CALL_ARGS[5]}" "<!-- create-failure-issue:Recurring%20Tests -->"
+  assert_contains "${CALL_ARGS[5]}" "<!-- create-failure-issue-run:https%3A%2F%2Fgithub.com"
   load_call 3
   assert_equals "list" "${CALL_ARGS[1]}"
 }
@@ -253,14 +305,30 @@ test_deduplicate_comments_on_open_issue() {
   export MOCK_GH_LIST_RESPONSE
 
   run_action '{"build":{"result":"failure"}}' false true >/dev/null
-  assert_equals "2" "$(<"$MOCK_GH_CALLS/count")"
-  load_call 2
+  assert_equals "3" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 3
   assert_equals "issue" "${CALL_ARGS[0]}"
   assert_equals "comment" "${CALL_ARGS[1]}"
   assert_equals "42" "${CALL_ARGS[2]}"
   assert_equals "--body" "${CALL_ARGS[3]}"
+  assert_contains "${CALL_ARGS[4]}" "<!-- create-failure-issue-run:https%3A%2F%2Fgithub.com"
   assert_contains "${CALL_ARGS[4]}" "**Failed jobs:** build"
   assert_contains "${CALL_ARGS[4]}" "actions/runs/123"
+}
+
+test_deduplicate_skips_recorded_run() {
+  local output
+
+  reset_mock
+  MOCK_GH_LIST_RESPONSE='[{"number":42,"body":"<!-- create-failure-issue:Recurring%20Tests -->\nPrevious run"}]'
+  MOCK_GH_VIEW_RESPONSE='{"body":"<!-- create-failure-issue:Recurring%20Tests -->","comments":[{"body":"<!-- create-failure-issue-run:https%3A%2F%2Fgithub.com%2Flance-format%2Flance%2Factions%2Fruns%2F123 -->"}]}'
+  export MOCK_GH_LIST_RESPONSE MOCK_GH_VIEW_RESPONSE
+
+  output="$(run_action '{"build":{"result":"failure"}}' false true)"
+  assert_contains "$output" "already recorded"
+  assert_equals "2" "$(<"$MOCK_GH_CALLS/count")"
+  load_call 2
+  assert_equals "view" "${CALL_ARGS[1]}"
 }
 
 test_deduplicate_reconciles_concurrent_creates() {
@@ -272,16 +340,7 @@ test_deduplicate_reconciles_concurrent_creates() {
   local second_pid
   local state_dir="$TEST_TMP/concurrent-state"
 
-  reset_mock
-  rm -rf "$state_dir"
-  mkdir -p "$state_dir"
-  printf '%s\n' '0' >"$state_dir/initial-list-count"
-  printf '%s\n' '1000' >"$state_dir/next-issue-number"
-  printf '%s\n' '[]' >"$state_dir/issues.json"
-  printf '%s\n' '[]' >"$state_dir/comments.json"
-  printf '%s\n' '[]' >"$state_dir/closes.json"
-  MOCK_GH_STATE_DIR="$state_dir"
-  export MOCK_GH_STATE_DIR
+  setup_stateful_mock "$state_dir"
 
   run_action \
     '{"build":{"result":"failure"}}' \
@@ -326,10 +385,82 @@ $(jq -r '.[0].body' "$state_dir/comments.json")"
   assert_contains "$combined_notifications" "actions/runs/200"
 }
 
+test_retry_reconciles_close_failure() {
+  local combined_notifications
+  local failed_run_url
+  local first_pid
+  local first_rc
+  local open_issue_body
+  local second_pid
+  local second_rc
+  local state_dir="$TEST_TMP/close-retry-state"
+
+  setup_stateful_mock "$state_dir" 1
+
+  run_action \
+    '{"build":{"result":"failure"}}' \
+    false \
+    true \
+    'https://github.com/lance-format/lance/actions/runs/100' \
+    >"$state_dir/first-output" 2>&1 &
+  first_pid=$!
+  run_action \
+    '{"build":{"result":"failure"}}' \
+    false \
+    true \
+    'https://github.com/lance-format/lance/actions/runs/200' \
+    >"$state_dir/second-output" 2>&1 &
+  second_pid=$!
+
+  if wait "$first_pid"; then
+    first_rc=0
+  else
+    first_rc=$?
+  fi
+  if wait "$second_pid"; then
+    second_rc=0
+  else
+    second_rc=$?
+  fi
+
+  if [[ "$first_rc" == "1" && "$second_rc" == "0" ]]; then
+    failed_run_url='https://github.com/lance-format/lance/actions/runs/100'
+  elif [[ "$first_rc" == "0" && "$second_rc" == "1" ]]; then
+    failed_run_url='https://github.com/lance-format/lance/actions/runs/200'
+  else
+    fail "expected one initial action to fail, got first_rc=$first_rc second_rc=$second_rc"
+  fi
+
+  run_action \
+    '{"build":{"result":"failure"}}' \
+    false \
+    true \
+    "$failed_run_url" \
+    >"$state_dir/retry-output"
+  unset MOCK_GH_STATE_DIR
+
+  assert_equals "1" "$(jq '[.[] | select(.state == "open")] | length' "$state_dir/issues.json")"
+  assert_equals "1" "$(jq '[.[] | select(.state == "closed")] | length' "$state_dir/issues.json")"
+  assert_equals "1" "$(jq 'length' "$state_dir/comments.json")"
+  assert_equals "2" "$(jq 'length' "$state_dir/closes.json")"
+  assert_equals "0" "$(jq -r '.[0].succeeded' "$state_dir/closes.json")"
+  assert_equals "1" "$(jq -r '.[1].succeeded' "$state_dir/closes.json")"
+
+  open_issue_body="$(
+    jq -r '.[] | select(.state == "open") | .body' "$state_dir/issues.json"
+  )"
+  combined_notifications="$open_issue_body
+$(jq -r '.[].body' "$state_dir/comments.json")"
+  assert_contains "$combined_notifications" "actions/runs/100"
+  assert_contains "$combined_notifications" "actions/runs/200"
+}
+
 test_failure_creates_issue
 test_cancelled_is_opt_in
 test_deduplicate_seeds_new_issue
 test_deduplicate_comments_on_open_issue
+test_deduplicate_skips_recorded_run
 test_deduplicate_reconciles_concurrent_creates
+test_retry_reconciles_close_failure
 
 echo "All create-failure-issue tests passed"

--- a/.github/actions/create-failure-issue/test.sh
+++ b/.github/actions/create-failure-issue/test.sh
@@ -5,9 +5,129 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ACTION_SCRIPT="$SCRIPT_DIR/create-failure-issue.sh"
 
+acquire_mock_state_lock() {
+  local attempt
+
+  for ((attempt = 0; attempt < 1000; attempt++)); do
+    mkdir "$MOCK_GH_STATE_DIR/lock" 2>/dev/null && return
+    sleep 0.01
+  done
+
+  echo "Timed out waiting for mock state lock" >&2
+  exit 1
+}
+
+release_mock_state_lock() {
+  rmdir "$MOCK_GH_STATE_DIR/lock"
+}
+
+mock_stateful_gh() {
+  local args=("$@")
+  local body=""
+  local close_comment=""
+  local initial_list_call="false"
+  local initial_list_count
+  local issue_number
+  local next_issue_number
+  local attempt
+  local index
+  local tmp_file
+
+  if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+    # Hold the first two lookups at a barrier so both actions observe no issue.
+    acquire_mock_state_lock
+    read -r initial_list_count <"$MOCK_GH_STATE_DIR/initial-list-count"
+    if (( initial_list_count < 2 )); then
+      initial_list_count=$((initial_list_count + 1))
+      printf '%s\n' "$initial_list_count" >"$MOCK_GH_STATE_DIR/initial-list-count"
+      initial_list_call="true"
+    fi
+    release_mock_state_lock
+
+    if [[ "$initial_list_call" == "true" ]]; then
+      for ((attempt = 0; attempt < 1000; attempt++)); do
+        acquire_mock_state_lock
+        read -r initial_list_count <"$MOCK_GH_STATE_DIR/initial-list-count"
+        release_mock_state_lock
+        (( initial_list_count >= 2 )) && break
+        sleep 0.01
+      done
+      if (( initial_list_count < 2 )); then
+        echo "Timed out waiting for both initial issue-list calls" >&2
+        exit 1
+      fi
+      printf '%s\n' '[]'
+      return
+    fi
+
+    acquire_mock_state_lock
+    jq '[.[] | select(.state == "open") | {number, body}]' \
+      "$MOCK_GH_STATE_DIR/issues.json"
+    release_mock_state_lock
+    return
+  fi
+
+  for ((index = 0; index < ${#args[@]}; index++)); do
+    if [[ "${args[index]}" == "--body" ]]; then
+      body="${args[index + 1]}"
+    elif [[ "${args[index]}" == "--comment" ]]; then
+      close_comment="${args[index + 1]}"
+    fi
+  done
+
+  if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+    acquire_mock_state_lock
+    read -r next_issue_number <"$MOCK_GH_STATE_DIR/next-issue-number"
+    issue_number="$next_issue_number"
+    printf '%s\n' "$((next_issue_number + 1))" >"$MOCK_GH_STATE_DIR/next-issue-number"
+    tmp_file="$MOCK_GH_STATE_DIR/issues.json.$$"
+    jq \
+      --argjson number "$issue_number" \
+      --arg body "$body" \
+      '. + [{number: $number, body: $body, state: "open"}]' \
+      "$MOCK_GH_STATE_DIR/issues.json" >"$tmp_file"
+    mv "$tmp_file" "$MOCK_GH_STATE_DIR/issues.json"
+    release_mock_state_lock
+    printf 'https://github.com/lance-format/lance/issues/%s\n' "$issue_number"
+  elif [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+    issue_number="${3:?issue number is required}"
+    acquire_mock_state_lock
+    tmp_file="$MOCK_GH_STATE_DIR/comments.json.$$"
+    jq \
+      --argjson number "$issue_number" \
+      --arg body "$body" \
+      '. + [{number: $number, body: $body}]' \
+      "$MOCK_GH_STATE_DIR/comments.json" >"$tmp_file"
+    mv "$tmp_file" "$MOCK_GH_STATE_DIR/comments.json"
+    release_mock_state_lock
+  elif [[ "${1:-}" == "issue" && "${2:-}" == "close" ]]; then
+    issue_number="${3:?issue number is required}"
+    acquire_mock_state_lock
+    tmp_file="$MOCK_GH_STATE_DIR/issues.json.$$"
+    jq \
+      --argjson number "$issue_number" \
+      'map(if .number == $number then .state = "closed" else . end)' \
+      "$MOCK_GH_STATE_DIR/issues.json" >"$tmp_file"
+    mv "$tmp_file" "$MOCK_GH_STATE_DIR/issues.json"
+    tmp_file="$MOCK_GH_STATE_DIR/closes.json.$$"
+    jq \
+      --argjson number "$issue_number" \
+      --arg comment "$close_comment" \
+      '. + [{number: $number, comment: $comment}]' \
+      "$MOCK_GH_STATE_DIR/closes.json" >"$tmp_file"
+    mv "$tmp_file" "$MOCK_GH_STATE_DIR/closes.json"
+    release_mock_state_lock
+  fi
+}
+
 mock_gh() {
   local call_number=1
   local arg
+
+  if [[ -n "${MOCK_GH_STATE_DIR:-}" ]]; then
+    mock_stateful_gh "$@"
+    return
+  fi
 
   if [[ -f "$MOCK_GH_CALLS/count" ]]; then
     read -r call_number <"$MOCK_GH_CALLS/count"
@@ -57,6 +177,7 @@ assert_equals() {
 reset_mock() {
   rm -f "$MOCK_GH_CALLS"/count "$MOCK_GH_CALLS"/[0-9]*
   unset MOCK_GH_LIST_RESPONSE || true
+  unset MOCK_GH_STATE_DIR || true
 }
 
 run_action() {
@@ -64,7 +185,7 @@ run_action() {
     GH_TOKEN=test-token \
     JOB_RESULTS="$1" \
     WORKFLOW_NAME="Recurring Tests" \
-    RUN_URL="https://github.com/lance-format/lance/actions/runs/123" \
+    RUN_URL="${4:-https://github.com/lance-format/lance/actions/runs/123}" \
     INCLUDE_CANCELLED="${2:-false}" \
     DEDUPLICATE="${3:-false}" \
     bash "$ACTION_SCRIPT"
@@ -116,12 +237,14 @@ test_deduplicate_seeds_new_issue() {
   export MOCK_GH_LIST_RESPONSE
 
   run_action '{"build":{"result":"failure"}}' false true >/dev/null
-  assert_equals "2" "$(<"$MOCK_GH_CALLS/count")"
+  assert_equals "3" "$(<"$MOCK_GH_CALLS/count")"
   load_call 1
   assert_equals "list" "${CALL_ARGS[1]}"
   load_call 2
   assert_equals "create" "${CALL_ARGS[1]}"
   assert_contains "${CALL_ARGS[5]}" "<!-- create-failure-issue:Recurring%20Tests -->"
+  load_call 3
+  assert_equals "list" "${CALL_ARGS[1]}"
 }
 
 test_deduplicate_comments_on_open_issue() {
@@ -140,9 +263,73 @@ test_deduplicate_comments_on_open_issue() {
   assert_contains "${CALL_ARGS[4]}" "actions/runs/123"
 }
 
+test_deduplicate_reconciles_concurrent_creates() {
+  local canonical_issue_number
+  local closed_issue_number
+  local combined_notifications
+  local first_pid
+  local open_issue_body
+  local second_pid
+  local state_dir="$TEST_TMP/concurrent-state"
+
+  reset_mock
+  rm -rf "$state_dir"
+  mkdir -p "$state_dir"
+  printf '%s\n' '0' >"$state_dir/initial-list-count"
+  printf '%s\n' '1000' >"$state_dir/next-issue-number"
+  printf '%s\n' '[]' >"$state_dir/issues.json"
+  printf '%s\n' '[]' >"$state_dir/comments.json"
+  printf '%s\n' '[]' >"$state_dir/closes.json"
+  MOCK_GH_STATE_DIR="$state_dir"
+  export MOCK_GH_STATE_DIR
+
+  run_action \
+    '{"build":{"result":"failure"}}' \
+    false \
+    true \
+    'https://github.com/lance-format/lance/actions/runs/100' \
+    >"$state_dir/first-output" &
+  first_pid=$!
+  run_action \
+    '{"build":{"result":"failure"}}' \
+    false \
+    true \
+    'https://github.com/lance-format/lance/actions/runs/200' \
+    >"$state_dir/second-output" &
+  second_pid=$!
+
+  wait "$first_pid" || fail "first concurrent action failed"
+  wait "$second_pid" || fail "second concurrent action failed"
+  unset MOCK_GH_STATE_DIR
+
+  assert_equals "1" "$(jq '[.[] | select(.state == "open")] | length' "$state_dir/issues.json")"
+  assert_equals "1" "$(jq '[.[] | select(.state == "closed")] | length' "$state_dir/issues.json")"
+  assert_equals "1" "$(jq 'length' "$state_dir/comments.json")"
+  assert_equals "1" "$(jq 'length' "$state_dir/closes.json")"
+
+  canonical_issue_number="$(
+    jq -r '.[] | select(.state == "open") | .number' "$state_dir/issues.json"
+  )"
+  closed_issue_number="$(
+    jq -r '.[] | select(.state == "closed") | .number' "$state_dir/issues.json"
+  )"
+  assert_equals "$canonical_issue_number" "$(jq -r '.[0].number' "$state_dir/comments.json")"
+  assert_equals "$closed_issue_number" "$(jq -r '.[0].number' "$state_dir/closes.json")"
+  assert_contains "$(jq -r '.[0].comment' "$state_dir/closes.json")" "#$canonical_issue_number"
+
+  open_issue_body="$(
+    jq -r '.[] | select(.state == "open") | .body' "$state_dir/issues.json"
+  )"
+  combined_notifications="$open_issue_body
+$(jq -r '.[0].body' "$state_dir/comments.json")"
+  assert_contains "$combined_notifications" "actions/runs/100"
+  assert_contains "$combined_notifications" "actions/runs/200"
+}
+
 test_failure_creates_issue
 test_cancelled_is_opt_in
 test_deduplicate_seeds_new_issue
 test_deduplicate_comments_on_open_issue
+test_deduplicate_reconciles_concurrent_creates
 
 echo "All create-failure-issue tests passed"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -3,22 +3,44 @@ name: Recurring Tests
 on:
   schedule:
     - cron: "0 0 * * 0" # Runs at 00:00 UTC every Sunday
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths:
+      - .github/actions/create-failure-issue/**
+      - .github/workflows/recurring-tests.yml
+      - python/python/tests/recurring/test_recurring.py
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # The slowest stable-version job completed about 5% of the unsharded test in
+  # six hours. 64 shards leave enough room to test both the stable and current
+  # versions in one hosted-runner job.
+  LANCE_RECURRING_SHARD_COUNT: "64"
+
 jobs:
   get-pylance-versions:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      shards: ${{ steps.set-matrix.outputs.shards }}
     steps:
       - name: Fetch latest 2 stable pylance versions
         id: set-matrix
         run: |
+          set -euo pipefail
+
           # Get all versions from PyPI
-          pypi_versions=$(curl -s https://pypi.org/pypi/pylance/json | jq -r '.releases | keys_unsorted | .[]')
+          pypi_versions=$(curl -fsSL https://pypi.org/pypi/pylance/json | jq -r '.releases | keys_unsorted | .[]')
 
           # Use only PyPI versions
           all_versions=$(echo -e "$pypi_versions" | sort -u -V)
@@ -44,19 +66,68 @@ jobs:
           done
           json_array="$json_array]"
 
-          matrix="{\"pylance-version\": $json_array}"
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          shards=$(jq -cn --argjson count "$LANCE_RECURRING_SHARD_COUNT" '[range(0; $count)]')
+          matrix=$(jq -cn \
+            --argjson versions "$json_array" \
+            --argjson shards "$shards" \
+            '{"pylance-version": $versions, "shard": $shards}')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+
+  # Pull requests only need to prove that the workflow and test still execute.
+  # The scheduled jobs below retain the full permutation coverage.
+  recurring-smoke:
+    if: github.event_name == 'pull_request'
+    name: "Recurring: PR smoke"
+    runs-on: ubuntu-24.04-4x
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Test failure issue action
+        working-directory: .
+        run: bash .github/actions/create-failure-issue/test.sh
+      - name: Install protobuf
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: python
+      - name: Install Lance
+        run: pip install -e ".[tests]"
+      - name: Run recurring smoke test
+        env:
+          LANCE_RECURRING_NUM_ROWS: "10000"
+          LANCE_RECURRING_SHARD_INDEX: "0"
+          LANCE_RECURRING_SHARD_COUNT: "1"
+          LANCE_RECURRING_MAX_PERMUTATIONS: "2"
+        run: pytest -vvv -s python/tests/recurring/test_recurring.py -m recurring
 
   # This job is used to test the recurring tests on the latest 2 stable versions of Lance,
   # and the back-compat of the recurring tests.
   recurring-linux:
     needs: get-pylance-versions
-    name: "Recurring: Linux (Pylance ${{ matrix.pylance-version }})"
+    if: github.event_name != 'pull_request'
+    name: "Recurring: Linux (Pylance ${{ matrix.pylance-version }}, shard ${{ matrix.shard }})"
     runs-on: ubuntu-24.04
-    timeout-minutes: 7200
+    timeout-minutes: 330
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix: ${{ fromJson(needs.get-pylance-versions.outputs.matrix) }}
+    env:
+      LANCE_RECURRING_SHARD_INDEX: ${{ matrix.shard }}
     defaults:
       run:
         shell: bash
@@ -74,14 +145,14 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: python
       - name: Install dependencies
         working-directory: python
         shell: bash
         run: |
           pip install -e ".[tests]"
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-        with:
-          workspaces: python
       - name: Install Pylance
         run: |
           pip install pylance==${{ matrix.pylance-version }}
@@ -95,9 +166,18 @@ jobs:
 
   # This job is used to test the recurring tests on the main branch.
   recurring-linux-fresh-main:
-    name: "Recurring: Linux (main)"
+    needs: get-pylance-versions
+    if: github.event_name != 'pull_request'
+    name: "Recurring: Linux (main, shard ${{ matrix.shard }})"
     runs-on: ubuntu-24.04
-    timeout-minutes: 7200
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        shard: ${{ fromJson(needs.get-pylance-versions.outputs.shards) }}
+    env:
+      LANCE_RECURRING_SHARD_INDEX: ${{ matrix.shard }}
     defaults:
       run:
         shell: bash
@@ -122,3 +202,20 @@ jobs:
         run: pip install -e ".[tests]"
       - name: Run recurring tests
         run: pytest -vvv -s python/tests/recurring/test_recurring.py
+
+  report-failure:
+    name: Report Workflow Failure
+    needs: [get-pylance-versions, recurring-linux, recurring-linux-fresh-main]
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/create-failure-issue
+        with:
+          job-results: ${{ toJSON(needs) }}
+          workflow-name: ${{ github.workflow }}
+          include-cancelled: "true"
+          deduplicate: "true"

--- a/python/python/tests/recurring/test_recurring.py
+++ b/python/python/tests/recurring/test_recurring.py
@@ -1,24 +1,120 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-# Recurring tests that runs all operations on a large dataset,
-# these operations are ran in random order repeated 10 times
+# Recurring tests that run all permutations of write operations on a large dataset.
 
 import abc
 import itertools
+import math
+import os
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
+from typing import Mapping, Optional
 
 import lance
 import numpy as np
 import pyarrow as pa
 import pytest
 
-# For testing, use smaller numbers to make tests run faster
-# In production, you might want to use: NUM_ROWS = 1_000_000
-NUM_ROWS = 1_000_000
+DEFAULT_NUM_ROWS = 1_000_000
 BATCH_SIZE = 1_000
 DIM = 32
+
+NUM_ROWS_ENV = "LANCE_RECURRING_NUM_ROWS"
+SHARD_INDEX_ENV = "LANCE_RECURRING_SHARD_INDEX"
+SHARD_COUNT_ENV = "LANCE_RECURRING_SHARD_COUNT"
+MAX_PERMUTATIONS_ENV = "LANCE_RECURRING_MAX_PERMUTATIONS"
+
+
+@dataclass(frozen=True)
+class RecurringTestConfig:
+    num_rows: int = DEFAULT_NUM_ROWS
+    shard_index: int = 0
+    shard_count: int = 1
+    max_permutations: Optional[int] = None
+
+    def __post_init__(self):
+        if self.num_rows <= 0:
+            raise ValueError(f"{NUM_ROWS_ENV} must be greater than 0")
+        if self.shard_count <= 0:
+            raise ValueError(f"{SHARD_COUNT_ENV} must be greater than 0")
+        if self.shard_index < 0:
+            raise ValueError(f"{SHARD_INDEX_ENV} must be greater than or equal to 0")
+        if self.shard_index >= self.shard_count:
+            raise ValueError(
+                f"{SHARD_INDEX_ENV} must be less than {SHARD_COUNT_ENV} "
+                f"({self.shard_count}), got {self.shard_index}"
+            )
+        if self.max_permutations is not None and self.max_permutations <= 0:
+            raise ValueError(f"{MAX_PERMUTATIONS_ENV} must be greater than 0")
+
+
+def _read_env_int(
+    environ: Mapping[str, str], name: str, default: Optional[int]
+) -> Optional[int]:
+    value = environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from None
+
+
+def _recurring_test_config(
+    environ: Optional[Mapping[str, str]] = None,
+) -> RecurringTestConfig:
+    if environ is None:
+        environ = os.environ
+
+    num_rows = _read_env_int(environ, NUM_ROWS_ENV, DEFAULT_NUM_ROWS)
+    shard_index = _read_env_int(environ, SHARD_INDEX_ENV, 0)
+    shard_count = _read_env_int(environ, SHARD_COUNT_ENV, 1)
+    max_permutations = _read_env_int(environ, MAX_PERMUTATIONS_ENV, None)
+    assert num_rows is not None
+    assert shard_index is not None
+    assert shard_count is not None
+    return RecurringTestConfig(
+        num_rows=num_rows,
+        shard_index=shard_index,
+        shard_count=shard_count,
+        max_permutations=max_permutations,
+    )
+
+
+def _permutation_bounds(
+    total_permutations: int, config: RecurringTestConfig
+) -> tuple[int, int]:
+    if total_permutations <= 0:
+        raise ValueError("total_permutations must be greater than 0")
+
+    selected_permutations = config.max_permutations or total_permutations
+    if selected_permutations > total_permutations:
+        raise ValueError(
+            f"{MAX_PERMUTATIONS_ENV} ({selected_permutations}) cannot exceed the "
+            f"{total_permutations} available permutations"
+        )
+
+    permutations_per_shard, remainder = divmod(
+        selected_permutations, config.shard_count
+    )
+    start = config.shard_index * permutations_per_shard + min(
+        config.shard_index, remainder
+    )
+    shard_size = permutations_per_shard
+    if config.shard_index < remainder:
+        shard_size += 1
+    return start, start + shard_size
+
+
+def _sharded_permutations(num_operations: int, config: RecurringTestConfig):
+    if num_operations <= 0:
+        raise ValueError("num_operations must be greater than 0")
+
+    start, stop = _permutation_bounds(math.factorial(num_operations), config)
+    permutations = itertools.permutations(range(num_operations))
+    return itertools.islice(permutations, start, stop)
+
 
 schema = pa.schema(
     [
@@ -47,7 +143,7 @@ def random_batch(start_id: int, batch_size: int) -> pa.Table:
     )
 
 
-def create_or_load_dataset(dataset_name: str, kwargs: dict):
+def create_or_load_dataset(dataset_name: str, kwargs: dict, num_rows: int):
     uri = f"tests/recurring/{dataset_name}"
 
     # Try to open existing dataset first
@@ -59,12 +155,13 @@ def create_or_load_dataset(dataset_name: str, kwargs: dict):
         pass
 
     # Create new dataset with initial data
-    initial_batch = random_batch(0, BATCH_SIZE)
+    initial_batch_size = min(BATCH_SIZE, num_rows)
+    initial_batch = random_batch(0, initial_batch_size)
     ds = lance.write_dataset(initial_batch, uri, schema=schema, mode="overwrite")
 
     # Add remaining data
-    for i in range(BATCH_SIZE, NUM_ROWS, BATCH_SIZE):
-        batch = random_batch(i, BATCH_SIZE)
+    for i in range(initial_batch_size, num_rows, BATCH_SIZE):
+        batch = random_batch(i, min(BATCH_SIZE, num_rows - i))
         ds.insert(batch)
 
     # Create indices
@@ -195,9 +292,17 @@ class FullTextSearch(ReadOnlyOperation):
 @pytest.mark.recurring
 @pytest.mark.parametrize("with_position", [True])
 def test_all_permutations(with_position):
-    """Test all operations on dataset without FTS position tracking"""
-    dataset_name = f"test_table_with_position_{with_position}"
-    ds = create_or_load_dataset(dataset_name, {"with_position": with_position})
+    """Test each write ordering assigned to this recurring-test shard."""
+    config = _recurring_test_config()
+    permutation_limit = config.max_permutations or "all"
+    dataset_name = (
+        f"test_table_with_position_{with_position}_{config.num_rows}_rows_"
+        f"{permutation_limit}_permutations_"
+        f"shard_{config.shard_index}_of_{config.shard_count}"
+    )
+    ds = create_or_load_dataset(
+        dataset_name, {"with_position": with_position}, config.num_rows
+    )
 
     write_operations = [
         Append(),
@@ -217,7 +322,18 @@ def test_all_permutations(with_position):
         FullTextSearch(has_position=False, filter="id >= 1000 and id < 8000"),
     ]
 
-    for permutation in itertools.permutations(range(len(write_operations))):
+    permutation_start, permutation_stop = _permutation_bounds(
+        math.factorial(len(write_operations)), config
+    )
+    print(
+        f"Running recurring-test shard {config.shard_index}/{config.shard_count}: "
+        f"permutations [{permutation_start}, {permutation_stop})"
+    )
+    for permutation_index, permutation in enumerate(
+        _sharded_permutations(len(write_operations), config),
+        start=permutation_start,
+    ):
+        print(f"Running permutation {permutation_index}: {permutation}")
         for idx in permutation:
             write_operation = write_operations[idx]
             print(f"Running {write_operation.__class__.__name__}")
@@ -229,3 +345,79 @@ def test_all_permutations(with_position):
             for read_only_operation in read_only_operations:
                 print(f"Running {read_only_operation.__class__.__name__}")
                 read_only_operation.run(ds)
+
+
+def test_recurring_config_defaults_to_full_workload():
+    config = _recurring_test_config({})
+
+    assert config == RecurringTestConfig()
+    assert list(_sharded_permutations(3, config)) == list(
+        itertools.permutations(range(3))
+    )
+
+
+def test_sharded_permutations_are_balanced_complete_and_disjoint():
+    expected = list(itertools.permutations(range(4)))
+    shards = [
+        list(
+            _sharded_permutations(
+                4, RecurringTestConfig(shard_index=index, shard_count=5)
+            )
+        )
+        for index in range(5)
+    ]
+    combined = list(itertools.chain.from_iterable(shards))
+
+    assert [len(shard) for shard in shards] == [5, 5, 5, 5, 4]
+    assert combined == expected
+    assert len(set(combined)) == len(expected)
+
+
+def test_max_permutations_is_applied_before_sharding():
+    expected = list(itertools.islice(itertools.permutations(range(3)), 3))
+    shards = [
+        list(
+            _sharded_permutations(
+                3,
+                RecurringTestConfig(
+                    shard_index=index, shard_count=5, max_permutations=3
+                ),
+            )
+        )
+        for index in range(5)
+    ]
+
+    assert [len(shard) for shard in shards] == [1, 1, 1, 0, 0]
+    assert list(itertools.chain.from_iterable(shards)) == expected
+
+
+@pytest.mark.parametrize(
+    ("environ", "error"),
+    [
+        ({NUM_ROWS_ENV: "not-an-integer"}, f"{NUM_ROWS_ENV} must be an integer"),
+        ({NUM_ROWS_ENV: "0"}, f"{NUM_ROWS_ENV} must be greater than 0"),
+        ({SHARD_COUNT_ENV: "0"}, f"{SHARD_COUNT_ENV} must be greater than 0"),
+        (
+            {SHARD_INDEX_ENV: "-1"},
+            f"{SHARD_INDEX_ENV} must be greater than or equal to 0",
+        ),
+        (
+            {SHARD_INDEX_ENV: "2", SHARD_COUNT_ENV: "2"},
+            f"{SHARD_INDEX_ENV} must be less than {SHARD_COUNT_ENV}",
+        ),
+        (
+            {MAX_PERMUTATIONS_ENV: "0"},
+            f"{MAX_PERMUTATIONS_ENV} must be greater than 0",
+        ),
+    ],
+)
+def test_recurring_config_rejects_invalid_values(environ, error):
+    with pytest.raises(ValueError, match=error):
+        _recurring_test_config(environ)
+
+
+def test_max_permutations_cannot_exceed_available_permutations():
+    config = RecurringTestConfig(max_permutations=7)
+
+    with pytest.raises(ValueError, match="cannot exceed the 6 available permutations"):
+        list(_sharded_permutations(3, config))


### PR DESCRIPTION
## What changed

- add a path-filtered pull request smoke job for recurring workflow, test, and alert-action changes
- split all 5,040 operation permutations into 64 deterministic shards for main and the latest two stable Pylance versions
- make recurring dataset size and permutation limits configurable while preserving the existing full-workload defaults
- report failures and cancellations through the shared CI issue action, deduplicating repeated alerts into one open issue
- reconcile concurrent alert creation by keeping the oldest issue canonical, preserving each run as a comment, and closing duplicate issues
- make reconciliation retry-safe with per-run and per-migration markers so retries heal close failures without duplicate comments
- add focused tests for shard coverage, configuration validation, concurrent alert creation, and reconciliation retries

## Why

The recurring workflow had never completed successfully. Its unsharded jobs exceeded the six-hour GitHub-hosted runner limit, changes were not exercised in pull requests, and failures or cancellations did not notify maintainers.

Fixes #4511.

## Validation

Current head `0dbf7bc50`, rebased onto current `main`:

- `uv run make lint`
- `uv run make build`
- `uv run pytest python/tests/recurring/test_recurring.py -m "not recurring"` — 10 passed
- recurring smoke with 10,000 rows and 2 permutations — 1 passed
- `bash .github/actions/create-failure-issue/test.sh`, including concurrent creation and close-failure retry reconciliation
- the concurrent/retry action suite passed 25 consecutive local runs
- shell syntax, YAML parsing, commit hooks, and `git diff --check`

The equivalent sharding patch was also exercised end to end before the latest-main rebase in [Recurring Tests run #52](https://github.com/lance-format/lance/actions/runs/31202432846):

- 192/192 matrix jobs passed: 64 main, 64 Pylance 9.0.0, and 64 Pylance 9.0.1
- the longest matrix job completed in 51m17s, below the 330-minute job timeout
- the reporting job passed and correctly skipped issue creation for the successful run

The pull request smoke workflow validates the rebased head on GitHub.
