### PR TITLE
feat(java): support cache backend register and switch

### DIFF
--- a/java/lance-jni/src/session.rs
+++ b/java/lance-jni/src/session.rs
@@ -4,14 +4,15 @@
 use std::sync::Arc;
 
 use jni::JNIEnv;
-use jni::objects::{JObject, JValue};
+use jni::objects::{JMap, JObject, JString, JValue};
 use jni::sys::jlong;
-use lance::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
-use lance::session::Session as LanceSession;
+use lance::session::{CacheSpec, Session as LanceSession};
+use lance_core::cache::{BackendConfig, build_from_config, build_from_uri};
 use lance_io::object_store::ObjectStoreRegistry;
 
 use crate::block_on;
 use crate::error::{Error, Result};
+use crate::utils::to_rust_map;
 
 /// Creates a new Session and returns a handle to it.
 ///
@@ -23,33 +24,64 @@ pub extern "system" fn Java_org_lance_Session_createNative(
     _obj: JObject,
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
+    index_cache_backend_uri: JString,
+    index_cache_backend_kind: JString,
+    index_cache_backend_options: JObject,
+    metadata_cache_backend_uri: JString,
+    metadata_cache_backend_kind: JString,
+    metadata_cache_backend_options: JObject,
 ) -> jlong {
     ok_or_throw_with_return!(
         env,
-        create_session(index_cache_size_bytes, metadata_cache_size_bytes),
+        create_session(
+            &mut env,
+            index_cache_size_bytes,
+            metadata_cache_size_bytes,
+            index_cache_backend_uri,
+            index_cache_backend_kind,
+            index_cache_backend_options,
+            metadata_cache_backend_uri,
+            metadata_cache_backend_kind,
+            metadata_cache_backend_options,
+        ),
         0
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_session(
+    env: &mut JNIEnv,
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
+    index_cache_backend_uri: JString,
+    index_cache_backend_kind: JString,
+    index_cache_backend_options: JObject,
+    metadata_cache_backend_uri: JString,
+    metadata_cache_backend_kind: JString,
+    metadata_cache_backend_options: JObject,
 ) -> Result<jlong> {
-    let index_cache_size = if index_cache_size_bytes >= 0 {
-        index_cache_size_bytes as usize
-    } else {
-        DEFAULT_INDEX_CACHE_SIZE
-    };
+    let index_cache = resolve_cache_spec(
+        env,
+        "indexCacheBackend",
+        "indexCacheSizeBytes",
+        index_cache_size_bytes,
+        index_cache_backend_uri,
+        index_cache_backend_kind,
+        index_cache_backend_options,
+    )?;
+    let metadata_cache = resolve_cache_spec(
+        env,
+        "metadataCacheBackend",
+        "metadataCacheSizeBytes",
+        metadata_cache_size_bytes,
+        metadata_cache_backend_uri,
+        metadata_cache_backend_kind,
+        metadata_cache_backend_options,
+    )?;
 
-    let metadata_cache_size = if metadata_cache_size_bytes >= 0 {
-        metadata_cache_size_bytes as usize
-    } else {
-        DEFAULT_METADATA_CACHE_SIZE
-    };
-
-    let session = LanceSession::new(
-        index_cache_size,
-        metadata_cache_size,
+    let session = LanceSession::with_cache_backends(
+        index_cache,
+        metadata_cache,
         Arc::new(ObjectStoreRegistry::default()),
     );
 
@@ -57,6 +89,63 @@ fn create_session(
     let boxed: Box<Arc<LanceSession>> = Box::new(Arc::new(session));
     let handle = Box::into_raw(boxed) as jlong;
     Ok(handle)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_cache_spec(
+    env: &mut JNIEnv,
+    backend_field: &str,
+    size_field: &str,
+    size_bytes: jlong,
+    backend_uri: JString,
+    backend_kind: JString,
+    backend_options: JObject,
+) -> Result<CacheSpec> {
+    let has_uri = !backend_uri.is_null();
+    let has_kind = !backend_kind.is_null();
+    if has_uri && has_kind {
+        return Err(Error::input_error(format!(
+            "{} must use either a URI or a structured config, not both",
+            backend_field
+        )));
+    }
+    if size_bytes >= 0 && (has_uri || has_kind) {
+        return Err(Error::input_error(format!(
+            "{} and {} are mutually exclusive; set one or the other",
+            size_field, backend_field
+        )));
+    }
+
+    if has_uri {
+        let uri: String = env.get_string(&backend_uri)?.into();
+        return build_from_uri(&uri)
+            .map(CacheSpec::Backend)
+            .map_err(Error::from);
+    }
+
+    if has_kind {
+        let kind: String = env.get_string(&backend_kind)?.into();
+        let mut config = BackendConfig::new(&kind)?;
+        if !backend_options.is_null() {
+            let options = JMap::from_env(env, &backend_options)?;
+            config.options = to_rust_map(env, &options)?;
+        }
+        return build_from_config(&config)
+            .map(CacheSpec::Backend)
+            .map_err(Error::from);
+    }
+
+    if size_bytes >= 0 {
+        let size = usize::try_from(size_bytes).map_err(|_| {
+            Error::input_error(format!(
+                "{} value {} does not fit in usize",
+                size_field, size_bytes
+            ))
+        })?;
+        Ok(CacheSpec::Size(size))
+    } else {
+        Ok(CacheSpec::Default)
+    }
 }
 
 /// Returns the current size of the session in bytes.

--- a/java/src/main/java/org/lance/CacheBackendConfig.java
+++ b/java/src/main/java/org/lance/CacheBackendConfig.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.apache.arrow.util.Preconditions;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Structured configuration for a cache backend registered with the native Lance runtime.
+ *
+ * <p>The {@code kind} selects a registered backend constructor, while {@code options} contains
+ * backend-specific string settings. For example:
+ *
+ * <pre>{@code
+ * CacheBackendConfig config = CacheBackendConfig.builder("moka")
+ *     .option("capacity", "1048576")
+ *     .build();
+ * }</pre>
+ *
+ * <p>Third-party native backend crates register their constructors with Lance at application
+ * startup. This class selects and configures one of those registered constructors; it does not
+ * register a Java implementation as a native cache backend.
+ */
+public final class CacheBackendConfig {
+  private final String kind;
+  private final Map<String, String> options;
+
+  private CacheBackendConfig(Builder builder) {
+    this.kind = builder.kind;
+    this.options = Collections.unmodifiableMap(new HashMap<>(builder.options));
+  }
+
+  /**
+   * Creates a builder for a registered backend kind.
+   *
+   * @param kind registered backend identifier, such as {@code moka}
+   * @return a new builder
+   */
+  public static Builder builder(String kind) {
+    return new Builder(kind);
+  }
+
+  /** Returns the registered backend identifier. */
+  public String getKind() {
+    return kind;
+  }
+
+  /** Returns an immutable map of backend-specific options. */
+  public Map<String, String> getOptions() {
+    return options;
+  }
+
+  /** Builder for {@link CacheBackendConfig}. */
+  public static final class Builder {
+    private final String kind;
+    private final Map<String, String> options = new HashMap<>();
+
+    private Builder(String kind) {
+      Preconditions.checkNotNull(kind, "kind must not be null");
+      Preconditions.checkArgument(!kind.isEmpty(), "kind must not be empty");
+      this.kind = kind;
+    }
+
+    /**
+     * Adds a backend-specific option.
+     *
+     * @param key option name
+     * @param value option value
+     * @return this builder
+     */
+    public Builder option(String key, String value) {
+      Preconditions.checkNotNull(key, "cache backend option key must not be null");
+      Preconditions.checkNotNull(value, "cache backend option value must not be null");
+      Preconditions.checkArgument(!key.isEmpty(), "cache backend option key must not be empty");
+      options.put(key, value);
+      return this;
+    }
+
+    /**
+     * Replaces the current backend options.
+     *
+     * @param options backend-specific options
+     * @return this builder
+     */
+    public Builder options(Map<String, String> options) {
+      Preconditions.checkNotNull(options, "options must not be null");
+      this.options.clear();
+      for (Map.Entry<String, String> option : options.entrySet()) {
+        option(option.getKey(), option.getValue());
+      }
+      return this;
+    }
+
+    /** Builds the immutable backend configuration. */
+    public CacheBackendConfig build() {
+      return new CacheBackendConfig(this);
+    }
+  }
+}

--- a/java/src/main/java/org/lance/Session.java
+++ b/java/src/main/java/org/lance/Session.java
@@ -16,6 +16,8 @@ package org.lance;
 import org.apache.arrow.util.Preconditions;
 
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A user session that holds runtime state for Lance datasets.
@@ -33,6 +35,14 @@ import java.io.Closeable;
  * Session customSession = Session.builder()
  *     .indexCacheSizeBytes(2L * 1024 * 1024 * 1024)  // 2 GiB
  *     .metadataCacheSizeBytes(512L * 1024 * 1024)    // 512 MiB
+ *     .build();
+ *
+ * // Select registered cache backends using URIs or structured configuration
+ * Session backendSession = Session.builder()
+ *     .indexCacheBackend("moka://?capacity=1073741824")
+ *     .metadataCacheBackend(CacheBackendConfig.builder("moka")
+ *         .option("capacity", "268435456")
+ *         .build())
  *     .build();
  *
  * // Open multiple datasets with shared session
@@ -110,8 +120,12 @@ public class Session implements Closeable {
 
   /** Builder for creating Session instances with custom configuration. */
   public static class Builder {
-    private long indexCacheSizeBytes = DEFAULT_INDEX_CACHE_SIZE_BYTES;
-    private long metadataCacheSizeBytes = DEFAULT_METADATA_CACHE_SIZE_BYTES;
+    private Long indexCacheSizeBytes;
+    private Long metadataCacheSizeBytes;
+    private String indexCacheBackendUri;
+    private CacheBackendConfig indexCacheBackendConfig;
+    private String metadataCacheBackendUri;
+    private CacheBackendConfig metadataCacheBackendConfig;
 
     private Builder() {}
 
@@ -124,6 +138,37 @@ public class Session implements Closeable {
     public Builder indexCacheSizeBytes(long indexCacheSizeBytes) {
       Preconditions.checkArgument(indexCacheSizeBytes >= 0, "indexCacheSizeBytes must be >= 0");
       this.indexCacheSizeBytes = indexCacheSizeBytes;
+      return this;
+    }
+
+    /**
+     * Selects a registered index cache backend using a backend URI.
+     *
+     * <p>For example, {@code moka://?capacity=1048576}. This option is mutually exclusive with
+     * {@link #indexCacheSizeBytes(long)}.
+     *
+     * @param backendUri backend URI whose scheme identifies the registered backend
+     * @return this builder instance
+     */
+    public Builder indexCacheBackend(String backendUri) {
+      Preconditions.checkNotNull(backendUri, "backendUri must not be null");
+      this.indexCacheBackendUri = backendUri;
+      this.indexCacheBackendConfig = null;
+      return this;
+    }
+
+    /**
+     * Selects a registered index cache backend using structured configuration.
+     *
+     * <p>This option is mutually exclusive with {@link #indexCacheSizeBytes(long)}.
+     *
+     * @param backendConfig backend kind and backend-specific options
+     * @return this builder instance
+     */
+    public Builder indexCacheBackend(CacheBackendConfig backendConfig) {
+      Preconditions.checkNotNull(backendConfig, "backendConfig must not be null");
+      this.indexCacheBackendConfig = backendConfig;
+      this.indexCacheBackendUri = null;
       return this;
     }
 
@@ -141,13 +186,74 @@ public class Session implements Closeable {
     }
 
     /**
+     * Selects a registered metadata cache backend using a backend URI.
+     *
+     * <p>For example, {@code moka://?capacity=1048576}. This option is mutually exclusive with
+     * {@link #metadataCacheSizeBytes(long)}.
+     *
+     * @param backendUri backend URI whose scheme identifies the registered backend
+     * @return this builder instance
+     */
+    public Builder metadataCacheBackend(String backendUri) {
+      Preconditions.checkNotNull(backendUri, "backendUri must not be null");
+      this.metadataCacheBackendUri = backendUri;
+      this.metadataCacheBackendConfig = null;
+      return this;
+    }
+
+    /**
+     * Selects a registered metadata cache backend using structured configuration.
+     *
+     * <p>This option is mutually exclusive with {@link #metadataCacheSizeBytes(long)}.
+     *
+     * @param backendConfig backend kind and backend-specific options
+     * @return this builder instance
+     */
+    public Builder metadataCacheBackend(CacheBackendConfig backendConfig) {
+      Preconditions.checkNotNull(backendConfig, "backendConfig must not be null");
+      this.metadataCacheBackendConfig = backendConfig;
+      this.metadataCacheBackendUri = null;
+      return this;
+    }
+
+    /**
      * Builds the Session with the configured settings.
      *
      * @return a new Session instance
      */
     public Session build() {
-      long handle = createNative(indexCacheSizeBytes, metadataCacheSizeBytes);
+      validateCacheConfiguration();
+      long handle =
+          createNative(
+              indexCacheSizeBytes == null ? -1 : indexCacheSizeBytes,
+              metadataCacheSizeBytes == null ? -1 : metadataCacheSizeBytes,
+              indexCacheBackendUri,
+              backendKind(indexCacheBackendConfig),
+              backendOptions(indexCacheBackendConfig),
+              metadataCacheBackendUri,
+              backendKind(metadataCacheBackendConfig),
+              backendOptions(metadataCacheBackendConfig));
       return new Session(handle);
+    }
+
+    private void validateCacheConfiguration() {
+      Preconditions.checkArgument(
+          indexCacheSizeBytes == null
+              || (indexCacheBackendUri == null && indexCacheBackendConfig == null),
+          "indexCacheSizeBytes and indexCacheBackend are mutually exclusive; set one or the other");
+      Preconditions.checkArgument(
+          metadataCacheSizeBytes == null
+              || (metadataCacheBackendUri == null && metadataCacheBackendConfig == null),
+          "metadataCacheSizeBytes and metadataCacheBackend are mutually exclusive; "
+              + "set one or the other");
+    }
+
+    private static String backendKind(CacheBackendConfig config) {
+      return config == null ? null : config.getKind();
+    }
+
+    private static Map<String, String> backendOptions(CacheBackendConfig config) {
+      return config == null ? Collections.emptyMap() : config.getOptions();
     }
   }
 
@@ -251,7 +357,15 @@ public class Session implements Closeable {
     return String.format("Session(sizeBytes=%d)", sizeBytes());
   }
 
-  private static native long createNative(long indexCacheSizeBytes, long metadataCacheSizeBytes);
+  private static native long createNative(
+      long indexCacheSizeBytes,
+      long metadataCacheSizeBytes,
+      String indexCacheBackendUri,
+      String indexCacheBackendKind,
+      Map<String, String> indexCacheBackendOptions,
+      String metadataCacheBackendUri,
+      String metadataCacheBackendKind,
+      Map<String, String> metadataCacheBackendOptions);
 
   private native long sizeBytesNative();
 

--- a/java/src/test/java/org/lance/SessionTest.java
+++ b/java/src/test/java/org/lance/SessionTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,6 +68,135 @@ public class SessionTest {
       assertNotNull(session);
       assertFalse(session.isClosed());
     }
+  }
+
+  @Test
+  void testCreateSessionWithCacheBackendUris() {
+    try (Session session =
+        Session.builder()
+            .indexCacheBackend("moka://?capacity=1048576")
+            .metadataCacheBackend("moka://?capacity=524288")
+            .build()) {
+      assertNotNull(session);
+      assertFalse(session.isClosed());
+      assertEquals(0, session.metadataCacheStats().getNumEntries());
+    }
+  }
+
+  @Test
+  void testCreateSessionWithStructuredCacheBackendConfigs() {
+    CacheBackendConfig indexBackend =
+        CacheBackendConfig.builder("moka").option("capacity", "1048576").build();
+    CacheBackendConfig metadataBackend =
+        CacheBackendConfig.builder("moka")
+            .options(Collections.singletonMap("capacity", "524288"))
+            .build();
+
+    assertEquals("moka", indexBackend.getKind());
+    assertEquals(Collections.singletonMap("capacity", "1048576"), indexBackend.getOptions());
+    assertThrows(
+        UnsupportedOperationException.class, () -> indexBackend.getOptions().put("capacity", "1"));
+
+    try (Session session =
+        Session.builder()
+            .indexCacheBackend(indexBackend)
+            .metadataCacheBackend(metadataBackend)
+            .build()) {
+      assertNotNull(session);
+      assertFalse(session.isClosed());
+    }
+  }
+
+  @Test
+  void testCacheBackendReplacesPreviousDescriptorForSameTier() {
+    CacheBackendConfig structuredBackend =
+        CacheBackendConfig.builder("moka").option("capacity", "1048576").build();
+
+    try (Session session =
+        Session.builder()
+            .indexCacheBackend("missing://")
+            .indexCacheBackend(structuredBackend)
+            .build()) {
+      assertNotNull(session);
+    }
+
+    try (Session session =
+        Session.builder()
+            .metadataCacheBackend(structuredBackend)
+            .metadataCacheBackend("moka://?capacity=1048576")
+            .build()) {
+      assertNotNull(session);
+    }
+  }
+
+  @Test
+  void testCacheBackendRejectsSizeAndBackend() {
+    IllegalArgumentException indexError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                Session.builder()
+                    .indexCacheSizeBytes(1024)
+                    .indexCacheBackend("moka://?capacity=1048576")
+                    .build());
+    assertTrue(
+        indexError
+            .getMessage()
+            .contains("indexCacheSizeBytes and indexCacheBackend are mutually exclusive"));
+
+    IllegalArgumentException metadataError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                Session.builder()
+                    .metadataCacheBackend(
+                        CacheBackendConfig.builder("moka").option("capacity", "1048576").build())
+                    .metadataCacheSizeBytes(1024)
+                    .build());
+    assertTrue(
+        metadataError
+            .getMessage()
+            .contains("metadataCacheSizeBytes and metadataCacheBackend are mutually exclusive"));
+  }
+
+  @Test
+  void testCacheBackendRejectsUnknownKind() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Session.builder().indexCacheBackend("missing://").build());
+    assertTrue(error.getMessage().contains("unknown cache backend kind"));
+  }
+
+  @Test
+  void testCacheBackendRejectsInvalidMokaConfig() {
+    IllegalArgumentException missingCapacity =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Session.builder().indexCacheBackend("moka://").build());
+    assertTrue(missingCapacity.getMessage().contains("capacity is required"));
+
+    IllegalArgumentException unknownOption =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                Session.builder()
+                    .metadataCacheBackend(
+                        CacheBackendConfig.builder("moka").option("unknown", "value").build())
+                    .build());
+    assertTrue(unknownOption.getMessage().contains("unknown option"));
+  }
+
+  @Test
+  void testCacheBackendConfigValidatesInputs() {
+    assertThrows(NullPointerException.class, () -> CacheBackendConfig.builder(null));
+    assertThrows(IllegalArgumentException.class, () -> CacheBackendConfig.builder(""));
+    assertThrows(
+        NullPointerException.class,
+        () -> CacheBackendConfig.builder("moka").options((Map<String, String>) null));
+    assertThrows(
+        NullPointerException.class,
+        () -> CacheBackendConfig.builder("moka").option("capacity", null));
   }
 
   @Test


### PR DESCRIPTION
Summary

  - Add Java APIs to select registered native cache backends using either
    backend URIs or structured CacheBackendConfig.

  - Allow index and metadata caches to switch backends independently while
    preserving existing size-based and default configurations.

  - Bridge backend configuration through JNI to Lance’s cache registry, with
    validation and tests for conflicting or invalid settings.