### PR TITLE
feat(python): expose updated_fragment_offsets in the Update operation binding

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6012,6 +6012,11 @@ class LanceOperation:
         fields_for_preserving_frag_bitmap: list[int]
             The fields that used to judge whether to preserve the new frag's id into
             the frag bitmap of the specified indices.
+        updated_fragment_offsets: dict[int, bytes], optional
+            Physical row offsets that matched the update, keyed by fragment id,
+            each serialized in the portable RoaringBitmap format. Set on
+            ``rewrite_columns`` updates over stable row ids so the commit
+            refreshes row-level version metadata for the matched rows only.
         """
 
         removed_fragment_ids: List[int] = dataclasses.field(default_factory=list)
@@ -6024,6 +6029,7 @@ class LanceOperation:
             default_factory=list
         )
         update_mode: str = ""
+        updated_fragment_offsets: Optional[Dict[int, bytes]] = None
 
         def __post_init__(self):
             LanceOperation._validate_fragments(self.updated_fragments)

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2083,6 +2083,52 @@ def test_merge_insert_with_commit():
     )
 
 
+def test_update_with_commit_updated_fragment_offsets():
+    table = pa.table({"id": range(10), "updated": [False] * 10})
+    dataset = lance.write_dataset(table, "memory://test")
+
+    updates = pa.Table.from_pylist([{"id": 1, "updated": True}])
+    transaction, _ = (
+        dataset.merge_insert(on="id")
+        .when_matched_update_all()
+        .execute_uncommitted(updates)
+    )
+    assert transaction.operation.updated_fragment_offsets is None
+
+    # Portable RoaringBitmap serializations of {1, 3, 5, 7} and {0, 2, 100000}.
+    offsets = {
+        0: (
+            b"\x3a\x30\x00\x00\x01\x00\x00\x00\x00\x00\x03\x00"
+            b"\x10\x00\x00\x00\x01\x00\x03\x00\x05\x00\x07\x00"
+        ),
+        2: (
+            b"\x3a\x30\x00\x00\x02\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00"
+            b"\x00\x18\x00\x00\x00\x1c\x00\x00\x00\x00\x00\x02\x00\xa0\x86"
+        ),
+    }
+    transaction.operation.updated_fragment_offsets = offsets
+
+    dataset = lance.LanceDataset.commit(dataset, transaction)
+    read_back = dataset.read_transaction(dataset.version)
+    assert read_back.operation.updated_fragment_offsets == offsets
+
+
+def test_update_with_commit_rejects_invalid_offset_bytes():
+    table = pa.table({"id": range(10), "updated": [False] * 10})
+    dataset = lance.write_dataset(table, "memory://test")
+
+    updates = pa.Table.from_pylist([{"id": 1, "updated": True}])
+    transaction, _ = (
+        dataset.merge_insert(on="id")
+        .when_matched_update_all()
+        .execute_uncommitted(updates)
+    )
+    transaction.operation.updated_fragment_offsets = {0: b"not a bitmap"}
+
+    with pytest.raises(ValueError, match="RoaringBitmap"):
+        lance.LanceDataset.commit(dataset, transaction)
+
+
 def test_merge_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -8,7 +8,7 @@ use arrow::pyarrow::PyArrowType;
 use arrow_schema::Schema as ArrowSchema;
 use lance::dataset::transaction::{
     DataOverlayGroup, DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, Transaction,
-    UpdateMap, UpdateMapEntry, UpdateMode,
+    UpdateMap, UpdateMapEntry, UpdateMode, UpdatedFragmentOffsets,
 };
 use lance::datatypes::Schema;
 use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
@@ -413,6 +413,31 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                     .ok()
                     .map(|py_mode| py_mode.0);
 
+                // Absent on objects predating the field.
+                let updated_fragment_offsets = ob
+                    .getattr("updated_fragment_offsets")
+                    .ok()
+                    .map(|v| v.extract::<Option<HashMap<u64, Vec<u8>>>>())
+                    .transpose()?
+                    .flatten()
+                    .map(|offsets| {
+                        offsets
+                            .into_iter()
+                            .map(|(frag_id, bytes)| {
+                                RoaringBitmap::deserialize_from(&bytes[..])
+                                    .map(|bitmap| (frag_id, bitmap))
+                                    .map_err(|e| {
+                                        PyValueError::new_err(format!(
+                                            "updated_fragment_offsets[{frag_id}]: invalid \
+                                             portable RoaringBitmap bytes: {e}"
+                                        ))
+                                    })
+                            })
+                            .collect::<PyResult<HashMap<_, _>>>()
+                    })
+                    .transpose()?
+                    .map(UpdatedFragmentOffsets);
+
                 let op = Operation::Update {
                     removed_fragment_ids,
                     updated_fragments,
@@ -422,7 +447,7 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                     fields_for_preserving_frag_bitmap,
                     update_mode,
                     inserted_rows_filter: None,
-                    updated_fragment_offsets: None,
+                    updated_fragment_offsets,
                 };
                 Ok(Self(op))
             }
@@ -601,6 +626,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                 fields_modified,
                 fields_for_preserving_frag_bitmap,
                 update_mode,
+                updated_fragment_offsets,
                 ..
             } => {
                 let removed_fragment_ids = removed_fragment_ids.into_pyobject(py)?;
@@ -618,6 +644,21 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     },
                     None => "rewrite_rows",
                 };
+                let updated_fragment_offsets =
+                    updated_fragment_offsets
+                        .as_ref()
+                        .map(|UpdatedFragmentOffsets(offsets)| {
+                            offsets
+                                .iter()
+                                .map(|(frag_id, bitmap)| {
+                                    let mut buf = Vec::with_capacity(bitmap.serialized_size());
+                                    bitmap
+                                        .serialize_into(&mut buf)
+                                        .expect("RoaringBitmap serialization cannot fail");
+                                    (*frag_id, buf)
+                                })
+                                .collect::<HashMap<u64, Vec<u8>>>()
+                        });
                 let cls = namespace
                     .getattr("Update")
                     .expect("Failed to get Update class");
@@ -628,6 +669,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     fields_modified,
                     fields_for_preserving_frag_bitmap,
                     update_mode,
+                    updated_fragment_offsets,
                 ))
             }
             Operation::DataReplacement { replacements } => {


### PR DESCRIPTION
## Summary

`Operation::Update.updated_fragment_offsets` (#6650, #7432) is not reachable from Python: the Rust-to-Python export drops the field, and the Python-to-Rust conversion hardcodes `None`. This PR wires the field through the Python bindings as `dict[int, bytes]`.

The bytes are the portable RoaringBitmap serialization, the same encoding as proto field 10 (#7432). This keeps dense offset sets compact and avoids materializing one Python int per matched row. A Python RoaringBitmap wrapper type (#7695) can replace the raw bytes later.

## Changes

### python/python/lance/dataset.py

- Add `updated_fragment_offsets: Optional[Dict[int, bytes]] = None` to `LanceOperation.Update`, with attribute documentation.

### python/src/transaction.rs

- Python to Rust: extract the dict and deserialize each value with `RoaringBitmap::deserialize_from`. Invalid bytes raise `ValueError`. A missing attribute (objects predating the field) extracts as `None`.
- Rust to Python: serialize each bitmap with `RoaringBitmap::serialize_into` and pass the resulting `dict[int, bytes]` to the dataclass.

## Test plan

- `test_update_with_commit_updated_fragment_offsets`: commit an `Update` carrying offsets for two fragments, read it back with `read_transaction`, and verify a byte-identical round trip through proto field 10.
- `test_update_with_commit_rejects_invalid_offset_bytes`: a commit with invalid bitmap bytes fails with `ValueError`.
