### PR TITLE
refactor: extract the shared manifest walk behind tracked_files

### DIFF
--- a/rust/lance/src/dataset/files.rs
+++ b/rust/lance/src/dataset/files.rs
@@ -6,7 +6,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow_array::RecordBatch;
 use arrow_array::builder::{
@@ -16,8 +15,7 @@ use arrow_array::types::Int32Type;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use either::Either;
-use futures::stream::FuturesUnordered;
-use futures::{Future, StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt};
 use lance_table::format::IndexMetadata;
 use lance_table::utils::LanceIteratorExtension;
 use object_store::path::Path;
@@ -26,21 +24,16 @@ use uuid::Uuid;
 use crate::Dataset;
 use crate::dataset::files::arrow::{TRACKED_FILES_SCHEMA, TrackedFileBatch};
 use crate::dataset::files::file_types::FileType;
+use crate::dataset::files::scan::{ManifestScan, scan_manifests};
 use crate::dataset::{DATA_DIR, INDICES_DIR, TRANSACTIONS_DIR};
 use lance_core::Result;
 use lance_table::io::deletion::relative_deletion_file_path;
-use lance_table::io::manifest::{read_manifest, read_manifest_indexes};
 
 mod arrow;
 mod file_types;
+pub(crate) mod scan;
 
 const BATCH_SIZE: usize = 4096;
-/// Memory budget for in-flight manifests (estimated in-memory size).
-const MANIFEST_MEMORY_BUDGET: usize = 1024 * 1024 * 1024; // 1 GB
-/// Estimated ratio of in-memory size to on-disk size for manifests. Found
-/// empirically; manifests are protobuf with significant decompression and
-/// allocator overhead once parsed.
-const MANIFEST_DECOMPRESSION_RATIO: usize = 4;
 
 fn remove_prefix(path: &Path, prefix: &Path) -> Path {
     match path.prefix_match(prefix) {
@@ -276,12 +269,6 @@ pub struct TrackedFilesOptions {
     pub progress: Option<Box<dyn Fn(TrackedFilesProgress) + Send + Sync>>,
 }
 
-// A `ManifestLocation` is ~100 bytes, so a 50k-slot mpsc channel costs ~5 MB
-// in the worst case. That's enough headroom for the lister to run well ahead
-// of the reader on datasets with hundreds of thousands of manifests, while
-// still bounding memory.
-const MAX_BUFFERED_LOCATIONS: usize = 50_000;
-
 impl Dataset {
     /// Returns one row per (version, file) for every file referenced in any manifest.
     ///
@@ -309,201 +296,71 @@ impl Dataset {
         &self,
         options: TrackedFilesOptions,
     ) -> SendableRecordBatchStream {
-        use lance_table::io::commit::ManifestLocation;
-
-        let base = self.base.clone();
         let uri = self.uri().to_string();
         let object_store = self.object_store.clone();
-        let commit_handler = self.commit_handler.clone();
+        let base = self.base.clone();
 
         // Pipeline architecture:
         //
-        // Lister ──► tx_locations ──► Reader ──┬──► tx_manifest ──► Emitter ──► tx (output)
-        //                                      └──► tx_indexes  ──► IndexLister ──► tx (output)
+        // scan_manifests ──► Emitter ──┬──► tx (output)
+        //                              └──► tx_indexes ──► IndexLister ──► tx (output)
+        //
+        // The Lister and Reader stages live in `scan::scan_manifests`, shared
+        // with the keep-set walk.
+        let ManifestScan { stream, total, .. } = scan_manifests(self, options.min_version);
 
         // Output channel: Emitter and IndexLister both send batches here.
         let (tx, rx) = tokio::sync::mpsc::channel::<datafusion::error::Result<RecordBatch>>(4);
-        // Location channel: Lister -> Reader. Large buffer since locations are
-        // small (~100 bytes each) and we want the lister to run ahead.
-        let (tx_locations, mut rx_locations) =
-            tokio::sync::mpsc::channel::<ManifestLocation>(MAX_BUFFERED_LOCATIONS);
-        // Manifest channel: Reader -> Emitter (small buffer for backpressure
-        // since manifests can be large).
-        let (tx_manifest, mut rx_manifest) =
-            tokio::sync::mpsc::channel::<(Arc<lance_table::format::Manifest>, String, usize)>(2);
-        // Index channel: Reader -> IndexLister.
+        // Index channel: Emitter -> IndexLister.
         let (tx_indexes, mut rx_indexes) =
             tokio::sync::mpsc::channel::<(u64, Vec<IndexMetadata>)>(8);
 
-        // Tracks estimated in-memory size of in-flight manifests. Reader adds
-        // before sending; Emitter subtracts after processing.
-        let inflight_mem = Arc::new(AtomicUsize::new(0));
-        let mem_notify = Arc::new(tokio::sync::Notify::new());
-
-        // Progress: total is set by Lister once listing finishes, read by Emitter.
-        let total_manifests: Arc<std::sync::OnceLock<usize>> = Arc::new(std::sync::OnceLock::new());
-
-        // --- Lister task ---
-        // Lists manifest locations, applies min_version filter, and counts the
-        // total. Locations are lightweight so we buffer up to MAX_BUFFERED_LOCATIONS.
-        let tx_err_lister = tx.clone();
-        let os_lister = object_store.clone();
-        let base_lister = base.clone();
-        let total_manifests_lister = total_manifests.clone();
-        let min_version = options.min_version;
-        tokio::spawn(async move {
-            let result: lance_core::Result<()> = async {
-                let mut locations =
-                    commit_handler.list_manifest_locations(&base_lister, &os_lister, false);
-                let mut count = 0usize;
-                while let Some(loc) = locations.next().await {
-                    let loc = loc?;
-                    if let Some(min_v) = min_version
-                        && loc.version < min_v
-                    {
-                        continue;
-                    }
-                    count += 1;
-                    if tx_locations.send(loc).await.is_err() {
-                        return Ok(());
-                    }
-                }
-                let _ = total_manifests_lister.set(count);
-                Ok(())
-            }
-            .await;
-            if let Err(e) = result {
-                let _ = tx_err_lister
-                    .send(Err(datafusion::error::DataFusionError::from(e)))
-                    .await;
-            }
-        });
-
-        // --- Reader task ---
-        // Reads manifests with memory-aware parallelism and fans out to
-        // Emitter (file batches) and IndexLister (index metadata).
-        let tx_err_reader = tx.clone();
-        let os_reader = object_store.clone();
-        let base_reader = base.clone();
-        let inflight_mem_reader = inflight_mem.clone();
-        let mem_notify_reader = mem_notify.clone();
-        tokio::spawn(async move {
-            let result: lance_core::Result<()> = async {
-                let max_parallelism = os_reader.io_parallelism();
-
-                type ManifestResult = lance_core::Result<(
-                    Arc<lance_table::format::Manifest>,
-                    String,
-                    Vec<IndexMetadata>,
-                    usize,
-                )>;
-                let mut in_flight: FuturesUnordered<
-                    std::pin::Pin<Box<dyn Future<Output = ManifestResult> + Send>>,
-                > = FuturesUnordered::new();
-                let mut locations_exhausted = false;
-
-                loop {
-                    let can_launch = !locations_exhausted
-                        && in_flight.len() < max_parallelism
-                        && (in_flight.is_empty()
-                            || inflight_mem_reader.load(Ordering::Acquire)
-                                < MANIFEST_MEMORY_BUDGET);
-
-                    if in_flight.is_empty() && !can_launch {
-                        break;
-                    }
-
-                    tokio::select! {
-                        biased;
-                        // Always drain completed reads first.
-                        Some(item) = in_flight.next(), if !in_flight.is_empty() => {
-                            let (manifest, manifest_path, indexes, estimated) = item?;
-                            let version = manifest.version;
-                            if tx_manifest
-                                .send((manifest, manifest_path, estimated))
-                                .await
-                                .is_err()
-                            {
-                                return Ok(());
-                            }
-                            if !indexes.is_empty()
-                                && tx_indexes.send((version, indexes)).await.is_err()
-                            {
-                                return Ok(());
-                            }
-                        }
-                        // Receive next location and start a read.
-                        loc = rx_locations.recv(), if can_launch => {
-                            match loc {
-                                Some(loc) => {
-                                    let estimated =
-                                        loc.size.unwrap_or(0) as usize
-                                            * MANIFEST_DECOMPRESSION_RATIO;
-                                    inflight_mem_reader.fetch_add(estimated, Ordering::AcqRel);
-
-                                    let os = os_reader.clone();
-                                    let base = base_reader.clone();
-                                    in_flight.push(Box::pin(async move {
-                                        let manifest =
-                                            read_manifest(&os, &loc.path, loc.size).await?;
-                                        let indexes =
-                                            read_manifest_indexes(&os, &loc, &manifest).await?;
-                                        let manifest_path =
-                                            remove_prefix(&loc.path, &base).to_string();
-                                        lance_core::Result::Ok((
-                                            Arc::new(manifest),
-                                            manifest_path,
-                                            indexes,
-                                            estimated,
-                                        ))
-                                    }));
-                                }
-                                None => {
-                                    locations_exhausted = true;
-                                }
-                            }
-                        }
-                        // Wake up when Emitter frees memory.
-                        _ = mem_notify_reader.notified(),
-                            if !can_launch && !in_flight.is_empty() => {}
-                    }
-                }
-                Ok(())
-            }
-            .await;
-
-            if let Err(e) = result {
-                let _ = tx_err_reader
-                    .send(Err(datafusion::error::DataFusionError::from(e)))
-                    .await;
-            }
-        });
-
         // --- Emitter task ---
-        // Converts manifests into file-row batches, releases memory budget,
-        // and reports progress.
+        // Converts scanned manifests into file-row batches, forwards index
+        // metadata to the IndexLister, and reports progress. Dropping each
+        // `ScannedManifest` releases its share of the scan's memory budget.
         let tx_emitter = tx.clone();
         let uri_emitter = uri.clone();
         let progress_cb = options.progress;
         tokio::spawn(async move {
+            let mut stream = stream;
             let mut processed = 0usize;
-            while let Some((manifest, manifest_path, estimated)) = rx_manifest.recv().await {
-                let batches = manifest_file_batches(&manifest, &uri_emitter, &manifest_path);
+            while let Some(scanned) = stream.next().await {
+                let scanned = match scanned {
+                    Ok(scanned) => scanned,
+                    Err(e) => {
+                        let _ = tx_emitter
+                            .send(Err(datafusion::error::DataFusionError::from(e)))
+                            .await;
+                        return;
+                    }
+                };
+
+                let version = scanned.manifest.version;
+                if !scanned.indexes.is_empty()
+                    && tx_indexes
+                        .send((version, scanned.indexes.clone()))
+                        .await
+                        .is_err()
+                {
+                    return;
+                }
+
+                let batches =
+                    manifest_file_batches(&scanned.manifest, &uri_emitter, &scanned.manifest_path);
                 for batch_result in batches {
                     let df_result = batch_result.map_err(datafusion::error::DataFusionError::from);
                     if tx_emitter.send(df_result).await.is_err() {
                         return;
                     }
                 }
-                drop(manifest);
-                inflight_mem.fetch_sub(estimated, Ordering::AcqRel);
-                mem_notify.notify_one();
+                drop(scanned);
 
                 processed += 1;
                 if let Some(ref cb) = progress_cb {
                     cb(TrackedFilesProgress {
                         manifests_processed: processed,
-                        manifests_total: total_manifests.get().copied(),
+                        manifests_total: total.get().copied(),
                     });
                 }
             }

--- a/rust/lance/src/dataset/files.rs
+++ b/rust/lance/src/dataset/files.rs
@@ -326,7 +326,7 @@ impl Dataset {
             let mut stream = stream;
             let mut processed = 0usize;
             while let Some(scanned) = stream.next().await {
-                let scanned = match scanned {
+                let mut scanned = match scanned {
                     Ok(scanned) => scanned,
                     Err(e) => {
                         let _ = tx_emitter
@@ -336,16 +336,6 @@ impl Dataset {
                     }
                 };
 
-                let version = scanned.manifest.version;
-                if !scanned.indexes.is_empty()
-                    && tx_indexes
-                        .send((version, scanned.indexes.clone()))
-                        .await
-                        .is_err()
-                {
-                    return;
-                }
-
                 let batches =
                     manifest_file_batches(&scanned.manifest, &uri_emitter, &scanned.manifest_path);
                 for batch_result in batches {
@@ -354,7 +344,18 @@ impl Dataset {
                         return;
                     }
                 }
+
+                // Fan out to the index lister only after this manifest's rows
+                // are out and its memory is released. Doing it earlier would
+                // block file-row output on a full index channel while still
+                // holding the manifest's share of the scan's memory budget.
+                let version = scanned.manifest.version;
+                let indexes = std::mem::take(&mut scanned.indexes);
                 drop(scanned);
+
+                if !indexes.is_empty() && tx_indexes.send((version, indexes)).await.is_err() {
+                    return;
+                }
 
                 processed += 1;
                 if let Some(ref cb) = progress_cb {

--- a/rust/lance/src/dataset/files/scan.rs
+++ b/rust/lance/src/dataset/files/scan.rs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The shared manifest walk behind [`Dataset::tracked_files`] and
+//! [`Dataset::referenced_files`].
+//!
+//! Both need the same thing: every present manifest, read with bounded memory
+//! and bounded parallelism, together with the index metadata stored alongside
+//! it. They differ only in what they build from it, so the walk lives here and
+//! each caller materializes its own result.
+//!
+//! ```text
+//! Lister ──► tx_locations ──► Reader ──► tx_manifest ──► caller's stream
+//! ```
+//!
+//! The reader keeps several manifests in flight but stops launching reads once
+//! the estimated in-flight size reaches [`MANIFEST_MEMORY_BUDGET`]. A caller
+//! that holds every [`ScannedManifest`] it receives therefore stalls the walk
+//! rather than growing without bound; dropping each one after use is what keeps
+//! the pipeline moving.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::stream::{BoxStream, FuturesUnordered};
+use futures::{Future, StreamExt};
+use lance_core::Result;
+use lance_table::format::{IndexMetadata, Manifest};
+use lance_table::io::commit::ManifestLocation;
+use lance_table::io::manifest::{read_manifest, read_manifest_indexes};
+use object_store::path::Path;
+
+use super::remove_prefix;
+use crate::Dataset;
+
+/// Memory budget for in-flight manifests (estimated in-memory size).
+const MANIFEST_MEMORY_BUDGET: usize = 1024 * 1024 * 1024; // 1 GB
+/// Estimated ratio of in-memory size to on-disk size for manifests. Found
+/// empirically; manifests are protobuf with significant decompression and
+/// allocator overhead once parsed.
+const MANIFEST_DECOMPRESSION_RATIO: usize = 4;
+
+// A `ManifestLocation` is ~100 bytes, so a 50k-slot mpsc channel costs ~5 MB
+// in the worst case. That's enough headroom for the lister to run well ahead
+// of the reader on datasets with hundreds of thousands of manifests, while
+// still bounding memory.
+const MAX_BUFFERED_LOCATIONS: usize = 50_000;
+
+/// Releases a manifest's share of the memory budget and wakes the reader.
+///
+/// Held by [`ScannedManifest`] so the budget is returned when the caller drops
+/// it, whether or not the caller remembers to.
+struct MemoryPermit {
+    bytes: usize,
+    inflight: Arc<AtomicUsize>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl Drop for MemoryPermit {
+    fn drop(&mut self) {
+        self.inflight.fetch_sub(self.bytes, Ordering::AcqRel);
+        self.notify.notify_one();
+    }
+}
+
+/// One manifest produced by [`scan_manifests`], with what was read alongside it.
+pub struct ScannedManifest {
+    pub manifest: Arc<Manifest>,
+    /// The manifest's own path, relative to the dataset root.
+    pub manifest_path: String,
+    /// Index metadata from this manifest's index section. Empty when it has none.
+    pub indexes: Vec<IndexMetadata>,
+    // Order matters: dropping the permit last means the budget is returned only
+    // after `manifest` is freed.
+    _permit: MemoryPermit,
+}
+
+/// A running manifest walk.
+pub struct ManifestScan {
+    /// Manifests in completion order, which is not version order.
+    pub stream: BoxStream<'static, Result<ScannedManifest>>,
+    /// Number of manifests the walk will yield. Set once listing finishes, so a
+    /// consumer reading it mid-walk may still see `None`.
+    pub total: Arc<std::sync::OnceLock<usize>>,
+    /// Estimated in-memory bytes of the manifests the reader and the consumer
+    /// hold right now. Returns to zero once every [`ScannedManifest`] is
+    /// dropped, which is what lets the reader keep launching reads.
+    ///
+    /// Only the tests read this; production consumers rely on the budget
+    /// implicitly, by dropping each manifest after use.
+    #[cfg(test)]
+    pub inflight_bytes: Arc<AtomicUsize>,
+}
+
+/// Walk every present manifest of `dataset`.
+///
+/// `min_version`, when set, skips manifests older than that version. Note that
+/// this makes the result an incomplete view of what the dataset references, so
+/// a caller building a deletion predicate must leave it unset.
+pub fn scan_manifests(dataset: &Dataset, min_version: Option<u64>) -> ManifestScan {
+    let base = dataset.base.clone();
+    let object_store = dataset.object_store.clone();
+    let commit_handler = dataset.commit_handler.clone();
+
+    let (tx_manifest, rx_manifest) = tokio::sync::mpsc::channel::<Result<ScannedManifest>>(2);
+    let (tx_locations, rx_locations) =
+        tokio::sync::mpsc::channel::<ManifestLocation>(MAX_BUFFERED_LOCATIONS);
+
+    let inflight_mem = Arc::new(AtomicUsize::new(0));
+    let mem_notify = Arc::new(tokio::sync::Notify::new());
+    let total: Arc<std::sync::OnceLock<usize>> = Arc::new(std::sync::OnceLock::new());
+
+    spawn_lister(
+        commit_handler,
+        object_store.clone(),
+        base.clone(),
+        min_version,
+        tx_locations,
+        total.clone(),
+        tx_manifest.clone(),
+    );
+    spawn_reader(
+        object_store,
+        base,
+        rx_locations,
+        tx_manifest,
+        &inflight_mem,
+        mem_notify,
+    );
+
+    ManifestScan {
+        stream: tokio_stream::wrappers::ReceiverStream::new(rx_manifest).boxed(),
+        total,
+        #[cfg(test)]
+        inflight_bytes: inflight_mem,
+    }
+}
+
+/// Lists manifest locations, applies `min_version`, and records the total.
+///
+/// Locations are small, so they are buffered generously to let the lister run
+/// ahead of the reader.
+fn spawn_lister(
+    commit_handler: Arc<dyn lance_table::io::commit::CommitHandler>,
+    object_store: Arc<lance_io::object_store::ObjectStore>,
+    base: Path,
+    min_version: Option<u64>,
+    tx_locations: tokio::sync::mpsc::Sender<ManifestLocation>,
+    total: Arc<std::sync::OnceLock<usize>>,
+    tx_err: tokio::sync::mpsc::Sender<Result<ScannedManifest>>,
+) {
+    tokio::spawn(async move {
+        let result: Result<()> = async {
+            let mut locations = commit_handler.list_manifest_locations(&base, &object_store, false);
+            let mut count = 0usize;
+            while let Some(location) = locations.next().await {
+                let location = location?;
+                if let Some(min_version) = min_version
+                    && location.version < min_version
+                {
+                    continue;
+                }
+                count += 1;
+                if tx_locations.send(location).await.is_err() {
+                    // The consumer went away; stop listing.
+                    return Ok(());
+                }
+            }
+            let _ = total.set(count);
+            Ok(())
+        }
+        .await;
+        if let Err(error) = result {
+            let _ = tx_err.send(Err(error)).await;
+        }
+    });
+}
+
+/// Reads manifests with memory-aware parallelism.
+fn spawn_reader(
+    object_store: Arc<lance_io::object_store::ObjectStore>,
+    base: Path,
+    mut rx_locations: tokio::sync::mpsc::Receiver<ManifestLocation>,
+    tx_manifest: tokio::sync::mpsc::Sender<Result<ScannedManifest>>,
+    inflight_mem: &Arc<AtomicUsize>,
+    mem_notify: Arc<tokio::sync::Notify>,
+) {
+    let inflight_mem = inflight_mem.clone();
+    tokio::spawn(async move {
+        let result: Result<()> = async {
+            let max_parallelism = object_store.io_parallelism();
+            type ScanResult = Result<ScannedManifest>;
+            let mut in_flight: FuturesUnordered<
+                std::pin::Pin<Box<dyn Future<Output = ScanResult> + Send>>,
+            > = FuturesUnordered::new();
+            let mut locations_exhausted = false;
+
+            loop {
+                // Always allow one read even when over budget, or a single
+                // manifest larger than the budget would deadlock the walk.
+                let can_launch = !locations_exhausted
+                    && in_flight.len() < max_parallelism
+                    && (in_flight.is_empty()
+                        || inflight_mem.load(Ordering::Acquire) < MANIFEST_MEMORY_BUDGET);
+
+                if in_flight.is_empty() && !can_launch {
+                    break;
+                }
+
+                tokio::select! {
+                    biased;
+                    // Always drain completed reads first.
+                    Some(scanned) = in_flight.next(), if !in_flight.is_empty() => {
+                        if tx_manifest.send(scanned).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    location = rx_locations.recv(), if can_launch => {
+                        match location {
+                            Some(location) => {
+                                let estimated = location.size.unwrap_or(0) as usize
+                                    * MANIFEST_DECOMPRESSION_RATIO;
+                                inflight_mem.fetch_add(estimated, Ordering::AcqRel);
+                                let permit = MemoryPermit {
+                                    bytes: estimated,
+                                    inflight: inflight_mem.clone(),
+                                    notify: mem_notify.clone(),
+                                };
+
+                                let object_store = object_store.clone();
+                                let base = base.clone();
+                                in_flight.push(Box::pin(async move {
+                                    let manifest = read_manifest(
+                                        &object_store,
+                                        &location.path,
+                                        location.size,
+                                    )
+                                    .await?;
+                                    let indexes = read_manifest_indexes(
+                                        &object_store,
+                                        &location,
+                                        &manifest,
+                                    )
+                                    .await?;
+                                    Ok(ScannedManifest {
+                                        manifest: Arc::new(manifest),
+                                        manifest_path: remove_prefix(&location.path, &base)
+                                            .to_string(),
+                                        indexes,
+                                        _permit: permit,
+                                    })
+                                }));
+                            }
+                            None => locations_exhausted = true,
+                        }
+                    }
+                    // Wake up when a consumer frees budget by dropping a manifest.
+                    _ = mem_notify.notified(), if !can_launch && !in_flight.is_empty() => {}
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            let _ = tx_manifest.send(Err(error)).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+    fn simple_batch() -> impl arrow_array::RecordBatchReader {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        RecordBatchIterator::new(vec![Ok(batch)], schema)
+    }
+
+    async fn dataset_with_three_versions(uri: &str) -> Dataset {
+        let mut dataset = Dataset::write(simple_batch(), uri, None).await.unwrap();
+        dataset.append(simple_batch(), None).await.unwrap();
+        dataset.append(simple_batch(), None).await.unwrap();
+        dataset
+    }
+
+    /// The budget must return to zero once the consumer drops every manifest.
+    /// A leaked permit would leave it charged and eventually stall the reader.
+    #[tokio::test]
+    async fn budget_returns_to_zero_after_consuming() {
+        let dataset = dataset_with_three_versions("memory://scan_budget_zero").await;
+        let ManifestScan {
+            mut stream,
+            inflight_bytes,
+            ..
+        } = scan_manifests(&dataset, None);
+
+        let mut seen = 0usize;
+        while let Some(scanned) = stream.next().await {
+            scanned.unwrap();
+            seen += 1;
+        }
+
+        assert_eq!(seen, 3, "expected every present manifest");
+        assert_eq!(
+            inflight_bytes.load(Ordering::Acquire),
+            0,
+            "dropping every ScannedManifest must return the whole budget"
+        );
+    }
+
+    /// Holding manifests keeps the budget charged. That is the backpressure
+    /// signal the reader waits on, so a consumer that hoards stalls the walk
+    /// instead of growing without bound.
+    #[tokio::test]
+    async fn holding_manifests_keeps_budget_charged() {
+        let dataset = dataset_with_three_versions("memory://scan_budget_held").await;
+        let ManifestScan {
+            mut stream,
+            inflight_bytes,
+            ..
+        } = scan_manifests(&dataset, None);
+
+        let mut held = Vec::new();
+        while let Some(scanned) = stream.next().await {
+            held.push(scanned.unwrap());
+        }
+        assert!(
+            inflight_bytes.load(Ordering::Acquire) > 0,
+            "held manifests must still be charged against the budget"
+        );
+
+        drop(held);
+        assert_eq!(
+            inflight_bytes.load(Ordering::Acquire),
+            0,
+            "the budget must come back when the consumer lets go"
+        );
+    }
+
+    /// `min_version` really does skip manifests, which is why a keep-set must
+    /// leave it unset.
+    #[tokio::test]
+    async fn min_version_skips_older_manifests() {
+        let dataset = dataset_with_three_versions("memory://scan_min_version").await;
+
+        let mut versions = Vec::new();
+        let ManifestScan { mut stream, .. } = scan_manifests(&dataset, Some(3));
+        while let Some(scanned) = stream.next().await {
+            versions.push(scanned.unwrap().manifest.version);
+        }
+
+        assert_eq!(versions, vec![3], "min_version must drop versions 1 and 2");
+    }
+
+    /// The total is the number of manifests the walk will yield, available once
+    /// listing finishes.
+    #[tokio::test]
+    async fn total_counts_every_yielded_manifest() {
+        let dataset = dataset_with_three_versions("memory://scan_total").await;
+        let ManifestScan {
+            mut stream, total, ..
+        } = scan_manifests(&dataset, None);
+
+        let mut seen = 0usize;
+        while let Some(scanned) = stream.next().await {
+            scanned.unwrap();
+            seen += 1;
+        }
+
+        assert_eq!(total.get().copied(), Some(seen));
+    }
+}

--- a/rust/lance/src/dataset/files/scan.rs
+++ b/rust/lance/src/dataset/files/scan.rs
@@ -14,10 +14,15 @@
 //! ```
 //!
 //! The reader keeps several manifests in flight but stops launching reads once
-//! the estimated in-flight size reaches [`MANIFEST_MEMORY_BUDGET`]. A caller
-//! that holds every [`ScannedManifest`] it receives therefore stalls the walk
-//! rather than growing without bound; dropping each one after use is what keeps
-//! the pipeline moving.
+//! the estimated in-flight size reaches [`MANIFEST_MEMORY_BUDGET`]. The budget
+//! is charged for as long as the consumer holds a [`ScannedManifest`], so
+//! dropping each one after use is what keeps the pipeline moving.
+//!
+//! The bound is on the reader's prefetch, not on what a consumer chooses to
+//! retain: one read is always allowed when nothing is in flight, so a consumer
+//! that holds every manifest degrades the walk to serial reads rather than
+//! stopping it. That escape hatch is what keeps a manifest larger than the whole
+//! budget from deadlocking the walk.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -82,14 +87,25 @@ pub struct ManifestScan {
     /// Number of manifests the walk will yield. Set once listing finishes, so a
     /// consumer reading it mid-walk may still see `None`.
     pub total: Arc<std::sync::OnceLock<usize>>,
-    /// Estimated in-memory bytes of the manifests the reader and the consumer
-    /// hold right now. Returns to zero once every [`ScannedManifest`] is
-    /// dropped, which is what lets the reader keep launching reads.
-    ///
-    /// Only the tests read this; production consumers rely on the budget
-    /// implicitly, by dropping each manifest after use.
+    /// Estimated in-memory bytes the reader has read and the consumer has not
+    /// yet dropped. Test-only: production consumers rely on the budget
+    /// implicitly, by dropping each manifest after use, so keeping this in
+    /// release builds would be a field nothing reads.
     #[cfg(test)]
-    pub inflight_bytes: Arc<AtomicUsize>,
+    inflight_bytes: Arc<AtomicUsize>,
+}
+
+#[cfg(test)]
+impl ManifestScan {
+    /// Estimated in-memory bytes currently charged against the budget.
+    fn inflight_bytes(&self) -> usize {
+        self.inflight_bytes.load(Ordering::Acquire)
+    }
+
+    /// The budget counter itself, for assertions that outlive `stream`.
+    fn inflight_handle(&self) -> Arc<AtomicUsize> {
+        self.inflight_bytes.clone()
+    }
 }
 
 /// Walk every present manifest of `dataset`.
@@ -177,6 +193,9 @@ fn spawn_lister(
 }
 
 /// Reads manifests with memory-aware parallelism.
+///
+/// Read failures travel as `Err` items in the stream rather than ending the
+/// walk, so this task itself is infallible.
 fn spawn_reader(
     object_store: Arc<lance_io::object_store::ObjectStore>,
     base: Path,
@@ -187,83 +206,76 @@ fn spawn_reader(
 ) {
     let inflight_mem = inflight_mem.clone();
     tokio::spawn(async move {
-        let result: Result<()> = async {
-            let max_parallelism = object_store.io_parallelism();
-            type ScanResult = Result<ScannedManifest>;
-            let mut in_flight: FuturesUnordered<
-                std::pin::Pin<Box<dyn Future<Output = ScanResult> + Send>>,
-            > = FuturesUnordered::new();
-            let mut locations_exhausted = false;
+        let max_parallelism = object_store.io_parallelism();
+        type ScanResult = Result<ScannedManifest>;
+        let mut in_flight: FuturesUnordered<
+            std::pin::Pin<Box<dyn Future<Output = ScanResult> + Send>>,
+        > = FuturesUnordered::new();
+        let mut locations_exhausted = false;
 
-            loop {
-                // Always allow one read even when over budget, or a single
-                // manifest larger than the budget would deadlock the walk.
-                let can_launch = !locations_exhausted
-                    && in_flight.len() < max_parallelism
-                    && (in_flight.is_empty()
-                        || inflight_mem.load(Ordering::Acquire) < MANIFEST_MEMORY_BUDGET);
+        loop {
+            // Always allow one read even when over budget, or a single
+            // manifest larger than the budget would deadlock the walk.
+            let can_launch = !locations_exhausted
+                && in_flight.len() < max_parallelism
+                && (in_flight.is_empty()
+                    || inflight_mem.load(Ordering::Acquire) < MANIFEST_MEMORY_BUDGET);
 
-                if in_flight.is_empty() && !can_launch {
-                    break;
-                }
-
-                tokio::select! {
-                    biased;
-                    // Always drain completed reads first.
-                    Some(scanned) = in_flight.next(), if !in_flight.is_empty() => {
-                        if tx_manifest.send(scanned).await.is_err() {
-                            return Ok(());
-                        }
-                    }
-                    location = rx_locations.recv(), if can_launch => {
-                        match location {
-                            Some(location) => {
-                                let estimated = location.size.unwrap_or(0) as usize
-                                    * MANIFEST_DECOMPRESSION_RATIO;
-                                inflight_mem.fetch_add(estimated, Ordering::AcqRel);
-                                let permit = MemoryPermit {
-                                    bytes: estimated,
-                                    inflight: inflight_mem.clone(),
-                                    notify: mem_notify.clone(),
-                                };
-
-                                let object_store = object_store.clone();
-                                let base = base.clone();
-                                in_flight.push(Box::pin(async move {
-                                    let manifest = read_manifest(
-                                        &object_store,
-                                        &location.path,
-                                        location.size,
-                                    )
-                                    .await?;
-                                    let indexes = read_manifest_indexes(
-                                        &object_store,
-                                        &location,
-                                        &manifest,
-                                    )
-                                    .await?;
-                                    Ok(ScannedManifest {
-                                        manifest: Arc::new(manifest),
-                                        manifest_path: remove_prefix(&location.path, &base)
-                                            .to_string(),
-                                        indexes,
-                                        _permit: permit,
-                                    })
-                                }));
-                            }
-                            None => locations_exhausted = true,
-                        }
-                    }
-                    // Wake up when a consumer frees budget by dropping a manifest.
-                    _ = mem_notify.notified(), if !can_launch && !in_flight.is_empty() => {}
-                }
+            if in_flight.is_empty() && !can_launch {
+                break;
             }
-            Ok(())
-        }
-        .await;
 
-        if let Err(error) = result {
-            let _ = tx_manifest.send(Err(error)).await;
+            tokio::select! {
+                biased;
+                // Always drain completed reads first.
+                Some(scanned) = in_flight.next(), if !in_flight.is_empty() => {
+                    // The consumer went away; stop reading.
+                    if tx_manifest.send(scanned).await.is_err() {
+                        return;
+                    }
+                }
+                location = rx_locations.recv(), if can_launch => {
+                    match location {
+                        Some(location) => {
+                            let estimated = location.size.unwrap_or(0) as usize
+                                * MANIFEST_DECOMPRESSION_RATIO;
+                            inflight_mem.fetch_add(estimated, Ordering::AcqRel);
+                            let permit = MemoryPermit {
+                                bytes: estimated,
+                                inflight: inflight_mem.clone(),
+                                notify: mem_notify.clone(),
+                            };
+
+                            let object_store = object_store.clone();
+                            let base = base.clone();
+                            in_flight.push(Box::pin(async move {
+                                let manifest = read_manifest(
+                                    &object_store,
+                                    &location.path,
+                                    location.size,
+                                )
+                                .await?;
+                                let indexes = read_manifest_indexes(
+                                    &object_store,
+                                    &location,
+                                    &manifest,
+                                )
+                                .await?;
+                                Ok(ScannedManifest {
+                                    manifest: Arc::new(manifest),
+                                    manifest_path: remove_prefix(&location.path, &base)
+                                        .to_string(),
+                                    indexes,
+                                    _permit: permit,
+                                })
+                            }));
+                        }
+                        None => locations_exhausted = true,
+                    }
+                }
+                // Wake up when a consumer frees budget by dropping a manifest.
+                _ = mem_notify.notified(), if !can_launch && !in_flight.is_empty() => {}
+            }
         }
     });
 }
@@ -300,50 +312,43 @@ mod tests {
     #[tokio::test]
     async fn budget_returns_to_zero_after_consuming() {
         let dataset = dataset_with_three_versions("memory://scan_budget_zero").await;
-        let ManifestScan {
-            mut stream,
-            inflight_bytes,
-            ..
-        } = scan_manifests(&dataset, None);
+        let mut scan = scan_manifests(&dataset, None);
 
         let mut seen = 0usize;
-        while let Some(scanned) = stream.next().await {
+        while let Some(scanned) = scan.stream.next().await {
             scanned.unwrap();
             seen += 1;
         }
 
         assert_eq!(seen, 3, "expected every present manifest");
         assert_eq!(
-            inflight_bytes.load(Ordering::Acquire),
+            scan.inflight_bytes(),
             0,
             "dropping every ScannedManifest must return the whole budget"
         );
     }
 
-    /// Holding manifests keeps the budget charged. That is the backpressure
-    /// signal the reader waits on, so a consumer that hoards stalls the walk
-    /// instead of growing without bound.
+    /// Holding manifests keeps the budget charged, which is the signal the
+    /// reader throttles on. It does not stop the walk: one read is always
+    /// allowed when nothing is in flight, so a hoarding consumer gets serial
+    /// reads rather than a stall.
     #[tokio::test]
     async fn holding_manifests_keeps_budget_charged() {
         let dataset = dataset_with_three_versions("memory://scan_budget_held").await;
-        let ManifestScan {
-            mut stream,
-            inflight_bytes,
-            ..
-        } = scan_manifests(&dataset, None);
+        let mut scan = scan_manifests(&dataset, None);
 
         let mut held = Vec::new();
-        while let Some(scanned) = stream.next().await {
+        while let Some(scanned) = scan.stream.next().await {
             held.push(scanned.unwrap());
         }
         assert!(
-            inflight_bytes.load(Ordering::Acquire) > 0,
+            scan.inflight_bytes() > 0,
             "held manifests must still be charged against the budget"
         );
 
         drop(held);
         assert_eq!(
-            inflight_bytes.load(Ordering::Acquire),
+            scan.inflight_bytes(),
             0,
             "the budget must come back when the consumer lets go"
         );
@@ -362,6 +367,115 @@ mod tests {
         }
 
         assert_eq!(versions, vec![3], "min_version must drop versions 1 and 2");
+    }
+
+    /// Dropping the stream early must not leave the reader running: the closed
+    /// channel is what tells it to stop. Observed through the budget returning
+    /// to zero, which happens only once every in-flight permit is released.
+    #[tokio::test]
+    async fn dropping_the_stream_releases_every_permit() {
+        let dataset = dataset_with_three_versions("memory://scan_drop_early").await;
+        let scan = scan_manifests(&dataset, None);
+        // Keep the budget handle after the stream goes away.
+        let inflight = scan.inflight_handle();
+        let mut stream = scan.stream;
+
+        // Hold the first manifest so the budget is provably charged. Without
+        // this the assertion below could pass on a walk that never charged
+        // anything.
+        let first = stream.next().await.expect("at least one manifest").unwrap();
+        assert!(
+            inflight.load(Ordering::Acquire) > 0,
+            "holding a manifest must charge the budget"
+        );
+
+        // Drop the stream while the walk may still have reads in flight, then
+        // release our own manifest.
+        drop(stream);
+        drop(first);
+
+        // The reader unwinds asynchronously, so poll rather than assume it has
+        // already observed the closed channel. Ten seconds is far longer than
+        // this needs locally and is only here so a loaded machine reports a
+        // real failure instead of a flake.
+        let mut released = false;
+        for _ in 0..1000 {
+            if inflight.load(Ordering::Acquire) == 0 {
+                released = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            released,
+            "dropping the stream must release every in-flight permit; \
+             timed out waiting for the reader to unwind"
+        );
+    }
+
+    /// A manifest that cannot be read surfaces as an `Err` item in the stream
+    /// rather than being skipped. A skipped manifest would make the walk
+    /// silently incomplete, which for a deletion predicate means authorizing the
+    /// deletion of files only that manifest still references. The reader keeps
+    /// going after a failure; it is the consumer that decides whether to stop.
+    #[tokio::test]
+    async fn read_failure_surfaces_as_an_error_item() {
+        use crate::dataset::builder::DatasetBuilder;
+        use crate::dataset::{ObjectStoreParams, ReadParams};
+        use crate::utils::test::FailingProxyStore;
+
+        // A real store, not `memory://`: the failing proxy wraps the store, and
+        // re-opening with a wrapper changes the registry cache key, so an
+        // in-memory reopen would land on a fresh empty store and lose the three
+        // versions this test needs.
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        drop(dataset_with_three_versions(uri).await);
+
+        // Install the proxy at open time but arm it only afterwards: opening
+        // reads the latest manifest itself, so failing that read would break the
+        // open rather than the walk under test.
+        let failing = Arc::new(FailingProxyStore::new());
+        let dataset = DatasetBuilder::from_uri(uri)
+            .with_read_params(ReadParams {
+                store_options: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(failing.clone()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .load()
+            .await
+            .unwrap();
+        failing.fail_when("get_opts", "_versions", "injected manifest read failure");
+
+        let mut scan = scan_manifests(&dataset, None);
+        let mut errors = 0usize;
+        let mut successes = 0usize;
+        while let Some(scanned) = scan.stream.next().await {
+            match scanned {
+                Ok(_) => successes += 1,
+                Err(_) => errors += 1,
+            }
+        }
+
+        // One Err per manifest, not one for the whole walk: that is what pins
+        // the reader continuing after a failure. A listing failure would give a
+        // single Err instead, so this also proves the failure came from the
+        // reads rather than from listing.
+        assert_eq!(
+            successes, 0,
+            "no manifest read can succeed while every `_versions` read fails"
+        );
+        assert_eq!(
+            errors, 3,
+            "each of the three manifests must surface its own read error"
+        );
+        assert_eq!(
+            scan.inflight_bytes(),
+            0,
+            "a failed read must return its share of the budget"
+        );
     }
 
     /// The total is the number of manifests the walk will yield, available once


### PR DESCRIPTION
`tracked_files` walks every present manifest with a four-stage pipeline: a lister that enumerates manifest locations and applies `min_version`, a reader that fetches them with bounded parallelism under a memory budget, an emitter that turns each manifest into file rows, and an index lister that materializes index directories. Only the last two are about the rows it emits. The first two are about walking manifests, and a second consumer needs exactly them.

That consumer is `Dataset::referenced_files` in #8097, the keep-set an external orphan-cleanup driver uses to decide what it may delete. In the discussion there the suggestion was to factor out the reusable part before rebasing that PR onto it, which is what this does. Nothing in this PR depends on #8097; `tracked_files` is the only caller here and its behavior is unchanged.

## What moved

The lister and reader now live in `dataset::files::scan`, which yields a `ScannedManifest` per present manifest: the manifest, its own path, and the index metadata read alongside it. `tracked_files` keeps its emitter and index lister and consumes that stream. Channel capacities, the `can_launch` predicate, the `biased` select ordering, and the `min_version` filter are carried over unchanged.

## Why the budget accounting changed shape

Previously the reader charged bytes before sending and the emitter released them after processing. That worked because the emitter was the only consumer and sat in the same file, so the charge was bounded by the reader's in-flight reads plus two channel slots.

A shared walk cannot rely on that: a second consumer that forgets to release would silently stall the reader. The charge now lives in a `MemoryPermit` held by `ScannedManifest` and released on drop, so backpressure follows the manifest's lifetime rather than a convention. Field order is load-bearing and commented: the permit drops after the manifest it accounts for.

The bound is on the reader's prefetch, not on what a consumer retains. One read is always allowed when nothing is in flight, which is what keeps a manifest larger than the whole budget from deadlocking the walk, so a consumer that holds every manifest gets serial reads rather than a stall. That escape hatch is unchanged from before, and the module doc now states this rather than promising a bound it does not provide.

## Tests

Six cases in `scan::tests`, covering what the previous arrangement had no way to observe:

- the budget returns to zero once every manifest is dropped, and stays charged while a consumer holds them;
- `min_version` really does skip manifests, which is why a keep-set must leave it unset;
- `total` counts every manifest the walk yields;
- a failed manifest read surfaces one `Err` per manifest rather than being skipped, asserted as `errors == 3` because `errors > 0` would also pass on a reader that stopped at the first failure or on a listing failure;
- dropping the stream early releases every in-flight permit.

Each fails against the corresponding mistake: a leaked permit, a bypassed filter, a reader that aborts on first error.

`cargo clippy -p lance --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p lance --no-deps`, and `cargo fmt --all --check` are clean; `dataset::files` (18) and `dataset::cleanup` (41) pass. The full suite is left to CI.

## Reviewing this

The second commit is the result of reviewing the first, so the two are worth reading separately. It removes an unreachable error branch the extraction left behind, moves the index fan-out after the row batches so a full index channel cannot block row output while holding budget, makes the test-only budget accessor private, and corrects the module doc described above.
