### PR TITLE
feat(java): expose manifest location metadata

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -128,10 +128,10 @@ impl BlockingDataset {
         })
     }
 
-    pub fn inspect_latest_manifest(
+    pub fn list_manifest_locations(
         uri: &str,
         storage_options: HashMap<String, String>,
-    ) -> Result<ManifestLocation> {
+    ) -> Result<Vec<ManifestLocation>> {
         let accessor = (!storage_options.is_empty()).then(|| {
             Arc::new(lance::io::StorageOptionsAccessor::with_static_options(
                 storage_options,
@@ -147,9 +147,10 @@ impl BlockingDataset {
         Ok(block_on(
             DatasetBuilder::from_uri(uri)
                 .with_read_params(params)
-                .latest_manifest_location(),
+                .list_manifest_locations(),
         )?)
     }
+
     pub fn write(
         reader: impl RecordBatchReader + Send + 'static,
         uri: &str,
@@ -811,6 +812,9 @@ impl IntoJava for Version {
 
 impl IntoJava for ManifestLocation {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let size = self.size.ok_or_else(|| {
+            Error::runtime_error(format!("Manifest size is unavailable for {}", self.path))
+        })?;
         let path = env.new_string(self.path.to_string())?;
         let naming_scheme = env.new_string(match self.naming_scheme {
             ManifestNamingScheme::V1 => "V1",
@@ -821,12 +825,12 @@ impl IntoJava for ManifestLocation {
             None => JObject::null(),
         };
         Ok(env.new_object(
-            "org/lance/ManifestLocationInfo",
+            "org/lance/ManifestLocation",
             "(JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V",
             &[
                 JValue::Long(self.version as i64),
                 JValue::Object(&path),
-                JValue::Long(self.size.unwrap_or(0) as i64),
+                JValue::Long(size as i64),
                 JValue::Object(&naming_scheme),
                 JValue::Object(&e_tag),
             ],
@@ -1428,7 +1432,7 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_org_lance_Dataset_inspectLatestManifestNative<'local>(
+pub extern "system" fn Java_org_lance_Dataset_listManifestLocationsNative<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject,
     path: JString,
@@ -1436,11 +1440,11 @@ pub extern "system" fn Java_org_lance_Dataset_inspectLatestManifestNative<'local
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
-        inner_inspect_latest_manifest(&mut env, path, storage_options_obj)
+        inner_list_manifest_locations(&mut env, path, storage_options_obj)
     )
 }
 
-fn inner_inspect_latest_manifest<'local>(
+fn inner_list_manifest_locations<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,
     storage_options_obj: JObject,
@@ -1448,7 +1452,21 @@ fn inner_inspect_latest_manifest<'local>(
     let path: String = path.extract(env)?;
     let storage_options = JMap::from_env(env, &storage_options_obj)?;
     let storage_options = to_rust_map(env, &storage_options)?;
-    BlockingDataset::inspect_latest_manifest(&path, storage_options)?.into_java(env)
+    let locations = BlockingDataset::list_manifest_locations(&path, storage_options)?;
+    let list = env.new_object("java/util/ArrayList", "()V", &[])?;
+    for location in locations {
+        env.with_local_frame(8, |env| {
+            let java_location = location.into_java(env)?;
+            env.call_method(
+                &list,
+                "add",
+                "(Ljava/lang/Object;)Z",
+                &[JValue::Object(&java_location)],
+            )?;
+            Ok::<(), Error>(())
+        })?;
+    }
+    Ok(list)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -58,6 +58,7 @@ use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOption
 use lance_namespace::LanceNamespace;
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
+use lance_table::io::commit::{ManifestLocation, ManifestNamingScheme};
 use std::collections::HashMap;
 use std::future::IntoFuture;
 use std::iter::empty;
@@ -125,6 +126,29 @@ impl BlockingDataset {
                 .await
                 .map_err(|e| Error::io_error(e.to_string()))
         })
+    }
+
+    pub fn inspect_latest_manifest(
+        uri: &str,
+        storage_options: HashMap<String, String>,
+    ) -> Result<ManifestLocation> {
+        let accessor = (!storage_options.is_empty()).then(|| {
+            Arc::new(lance::io::StorageOptionsAccessor::with_static_options(
+                storage_options,
+            ))
+        });
+        let params = ReadParams {
+            store_options: Some(ObjectStoreParams {
+                storage_options_accessor: accessor,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        Ok(block_on(
+            DatasetBuilder::from_uri(uri)
+                .with_read_params(params)
+                .latest_manifest_location(),
+        )?)
     }
     pub fn write(
         reader: impl RecordBatchReader + Send + 'static,
@@ -785,6 +809,31 @@ impl IntoJava for Version {
     }
 }
 
+impl IntoJava for ManifestLocation {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let path = env.new_string(self.path.to_string())?;
+        let naming_scheme = env.new_string(match self.naming_scheme {
+            ManifestNamingScheme::V1 => "V1",
+            ManifestNamingScheme::V2 => "V2",
+        })?;
+        let e_tag = match self.e_tag {
+            Some(value) => JObject::from(env.new_string(value)?),
+            None => JObject::null(),
+        };
+        Ok(env.new_object(
+            "org/lance/ManifestLocationInfo",
+            "(JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V",
+            &[
+                JValue::Long(self.version as i64),
+                JValue::Object(&path),
+                JValue::Long(self.size.unwrap_or(0) as i64),
+                JValue::Object(&naming_scheme),
+                JValue::Object(&e_tag),
+            ],
+        )?)
+    }
+}
+
 fn attach_native_dataset<'local>(
     env: &mut JNIEnv<'local>,
     dataset: BlockingDataset,
@@ -1376,6 +1425,30 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
             namespace_client_managed_versioning != 0,
         )
     )
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_inspectLatestManifestNative<'local>(
+    mut env: JNIEnv<'local>,
+    _obj: JObject,
+    path: JString,
+    storage_options_obj: JObject,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_inspect_latest_manifest(&mut env, path, storage_options_obj)
+    )
+}
+
+fn inner_inspect_latest_manifest<'local>(
+    env: &mut JNIEnv<'local>,
+    path: JString,
+    storage_options_obj: JObject,
+) -> Result<JObject<'local>> {
+    let path: String = path.extract(env)?;
+    let storage_options = JMap::from_env(env, &storage_options_obj)?;
+    let storage_options = to_rust_map(env, &storage_options)?;
+    BlockingDataset::inspect_latest_manifest(&path, storage_options)?.into_java(env)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -484,39 +484,42 @@ public class Dataset implements Closeable {
       boolean namespaceClientManagedVersioning);
 
   /**
-   * Resolve metadata for the latest manifest without reading or deserializing its contents.
+   * List manifest locations without reading or deserializing the manifest contents.
+   *
+   * <p>The returned locations are not guaranteed to be ordered. This operation may list and
+   * materialize the full manifest history.
    *
    * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
    * Namespace-managed tables and tables using a custom commit handler are not supported.
    *
    * @param uri dataset URI
-   * @return metadata for the latest manifest
+   * @return manifest locations
    */
-  public static ManifestLocationInfo inspectLatestManifest(String uri) {
-    return inspectLatestManifest(uri, new HashMap<>());
+  public static List<ManifestLocation> listManifestLocations(String uri) {
+    return listManifestLocations(uri, new HashMap<>());
   }
 
   /**
-   * Resolve metadata for the latest manifest without reading or deserializing its contents.
+   * List manifest locations without reading or deserializing the manifest contents.
+   *
+   * <p>The returned locations are not guaranteed to be ordered. This operation may list and
+   * materialize the full manifest history.
    *
    * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
    * Namespace-managed tables and tables using a custom commit handler are not supported.
    *
-   * <p>The supplied storage options are used to construct the object store. A metadata request is
-   * made only when the commit handler did not already provide the manifest size.
-   *
    * @param uri dataset URI
    * @param storageOptions object-store credentials and connection options
-   * @return metadata for the latest manifest
+   * @return manifest locations
    */
-  public static ManifestLocationInfo inspectLatestManifest(
+  public static List<ManifestLocation> listManifestLocations(
       String uri, Map<String, String> storageOptions) {
     Preconditions.checkNotNull(uri, "uri must not be null");
     Preconditions.checkNotNull(storageOptions, "storageOptions must not be null");
-    return inspectLatestManifestNative(uri, storageOptions);
+    return listManifestLocationsNative(uri, storageOptions);
   }
 
-  private static native ManifestLocationInfo inspectLatestManifestNative(
+  private static native List<ManifestLocation> listManifestLocationsNative(
       String uri, Map<String, String> storageOptions);
 
   /**

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -486,6 +486,9 @@ public class Dataset implements Closeable {
   /**
    * Resolve metadata for the latest manifest without reading or deserializing its contents.
    *
+   * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
+   * Namespace-managed tables and tables using a custom commit handler are not supported.
+   *
    * @param uri dataset URI
    * @return metadata for the latest manifest
    */
@@ -495,6 +498,9 @@ public class Dataset implements Closeable {
 
   /**
    * Resolve metadata for the latest manifest without reading or deserializing its contents.
+   *
+   * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
+   * Namespace-managed tables and tables using a custom commit handler are not supported.
    *
    * <p>The supplied storage options are used to construct the object store. A metadata request is
    * made only when the commit handler did not already provide the manifest size.

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -489,8 +489,9 @@ public class Dataset implements Closeable {
    * <p>The returned locations are not guaranteed to be ordered. This operation may list and
    * materialize the full manifest history.
    *
-   * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
-   * Namespace-managed tables and tables using a custom commit handler are not supported.
+   * <p>This method is for datasets whose committed manifests can be listed authoritatively from the
+   * object store. Namespace-managed tables, external version stores such as {@code s3+ddb}, and
+   * tables using a custom commit handler are not supported.
    *
    * @param uri dataset URI
    * @return manifest locations
@@ -505,8 +506,9 @@ public class Dataset implements Closeable {
    * <p>The returned locations are not guaranteed to be ordered. This operation may list and
    * materialize the full manifest history.
    *
-   * <p>This method is for datasets whose commit handler can be resolved directly from the URI.
-   * Namespace-managed tables and tables using a custom commit handler are not supported.
+   * <p>This method is for datasets whose committed manifests can be listed authoritatively from the
+   * object store. Namespace-managed tables, external version stores such as {@code s3+ddb}, and
+   * tables using a custom commit handler are not supported.
    *
    * @param uri dataset URI
    * @param storageOptions object-store credentials and connection options

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -484,6 +484,36 @@ public class Dataset implements Closeable {
       boolean namespaceClientManagedVersioning);
 
   /**
+   * Resolve metadata for the latest manifest without reading or deserializing its contents.
+   *
+   * @param uri dataset URI
+   * @return metadata for the latest manifest
+   */
+  public static ManifestLocationInfo inspectLatestManifest(String uri) {
+    return inspectLatestManifest(uri, new HashMap<>());
+  }
+
+  /**
+   * Resolve metadata for the latest manifest without reading or deserializing its contents.
+   *
+   * <p>The supplied storage options are used to construct the object store. A metadata request is
+   * made only when the commit handler did not already provide the manifest size.
+   *
+   * @param uri dataset URI
+   * @param storageOptions object-store credentials and connection options
+   * @return metadata for the latest manifest
+   */
+  public static ManifestLocationInfo inspectLatestManifest(
+      String uri, Map<String, String> storageOptions) {
+    Preconditions.checkNotNull(uri, "uri must not be null");
+    Preconditions.checkNotNull(storageOptions, "storageOptions must not be null");
+    return inspectLatestManifestNative(uri, storageOptions);
+  }
+
+  private static native ManifestLocationInfo inspectLatestManifestNative(
+      String uri, Map<String, String> storageOptions);
+
+  /**
    * Creates a builder for opening a dataset.
    *
    * <p>This builder supports opening datasets either directly from a URI or from a LanceNamespace.

--- a/java/src/main/java/org/lance/ManifestLocation.java
+++ b/java/src/main/java/org/lance/ManifestLocation.java
@@ -16,15 +16,14 @@ package org.lance;
 import java.util.Optional;
 
 /** Metadata describing the location of a dataset manifest. */
-public final class ManifestLocationInfo {
+public final class ManifestLocation {
   private final long version;
   private final String path;
   private final long sizeBytes;
   private final ManifestNamingScheme namingScheme;
   private final String eTag;
 
-  ManifestLocationInfo(
-      long version, String path, long sizeBytes, String namingScheme, String eTag) {
+  ManifestLocation(long version, String path, long sizeBytes, String namingScheme, String eTag) {
     this.version = version;
     this.path = path;
     this.sizeBytes = sizeBytes;

--- a/java/src/main/java/org/lance/ManifestLocationInfo.java
+++ b/java/src/main/java/org/lance/ManifestLocationInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import java.util.Optional;
+
+/** Metadata describing the location of a dataset manifest. */
+public final class ManifestLocationInfo {
+  private final long version;
+  private final String path;
+  private final long sizeBytes;
+  private final ManifestNamingScheme namingScheme;
+  private final String eTag;
+
+  ManifestLocationInfo(
+      long version, String path, long sizeBytes, String namingScheme, String eTag) {
+    this.version = version;
+    this.path = path;
+    this.sizeBytes = sizeBytes;
+    this.namingScheme = ManifestNamingScheme.valueOf(namingScheme);
+    this.eTag = eTag;
+  }
+
+  /** Dataset version represented by the manifest. */
+  public long getVersion() {
+    return version;
+  }
+
+  /** Manifest path relative to the dataset root. */
+  public String getPath() {
+    return path;
+  }
+
+  /** Manifest object size in bytes. */
+  public long getSizeBytes() {
+    return sizeBytes;
+  }
+
+  /** Naming scheme used by the manifest path. */
+  public ManifestNamingScheme getNamingScheme() {
+    return namingScheme;
+  }
+
+  /** Object-store entity tag, when available. */
+  public Optional<String> getETag() {
+    return Optional.ofNullable(eTag);
+  }
+}

--- a/java/src/main/java/org/lance/ManifestLocationInfo.java
+++ b/java/src/main/java/org/lance/ManifestLocationInfo.java
@@ -37,7 +37,7 @@ public final class ManifestLocationInfo {
     return version;
   }
 
-  /** Manifest path relative to the dataset root. */
+  /** Manifest path relative to the object-store namespace or root. */
   public String getPath() {
     return path;
   }

--- a/java/src/main/java/org/lance/ManifestNamingScheme.java
+++ b/java/src/main/java/org/lance/ManifestNamingScheme.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+/** Naming scheme used by a Lance manifest path. */
+public enum ManifestNamingScheme {
+  /** Manifest names based directly on the dataset version. */
+  V1,
+  /** Zero-padded, inverted version names optimized for latest-version lookup. */
+  V2
+}

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -131,6 +131,8 @@ public class DatasetTest {
         assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_1, dataset.getLanceFileFormatVersion());
         ManifestLocationInfo manifest = Dataset.inspectLatestManifest(defaultPath);
         assertEquals(dataset.version(), manifest.getVersion());
+        assertTrue(manifest.getPath().contains("default_version/_versions/"));
+        assertFalse(manifest.getPath().startsWith("_versions/"));
         assertTrue(manifest.getPath().endsWith(".manifest"));
         assertTrue(manifest.getSizeBytes() > 0);
         assertNotNull(manifest.getNamingScheme());

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -129,13 +129,6 @@ public class DatasetTest {
           new TestUtils.SimpleTestDataset(allocator, defaultPath);
       try (Dataset dataset = testDataset.createEmptyDataset()) {
         assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_1, dataset.getLanceFileFormatVersion());
-        ManifestLocationInfo manifest = Dataset.inspectLatestManifest(defaultPath);
-        assertEquals(dataset.version(), manifest.getVersion());
-        assertTrue(manifest.getPath().contains("default_version/_versions/"));
-        assertFalse(manifest.getPath().startsWith("_versions/"));
-        assertTrue(manifest.getPath().endsWith(".manifest"));
-        assertTrue(manifest.getSizeBytes() > 0);
-        assertNotNull(manifest.getNamingScheme());
       }
 
       // Test LEGACY version
@@ -150,6 +143,30 @@ public class DatasetTest {
               .execute()) {
         assertEquals(
             LanceConstants.FILE_FORMAT_VERSION_0_1, legacyDataset.getLanceFileFormatVersion());
+      }
+    }
+  }
+
+  @Test
+  void testListManifestLocations(@TempDir Path tempDir) {
+    String datasetPath = tempDir.resolve("manifest_locations").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      testDataset.write(1, 1).close();
+
+      List<ManifestLocation> manifests = Dataset.listManifestLocations(datasetPath);
+      assertEquals(2, manifests.size());
+      assertEquals(
+          Set.of(1L, 2L),
+          manifests.stream().map(ManifestLocation::getVersion).collect(Collectors.toSet()));
+      for (ManifestLocation manifest : manifests) {
+        assertTrue(manifest.getPath().contains("manifest_locations/_versions/"));
+        assertFalse(manifest.getPath().startsWith("_versions/"));
+        assertTrue(manifest.getPath().endsWith(".manifest"));
+        assertTrue(manifest.getSizeBytes() > 0);
+        assertNotNull(manifest.getNamingScheme());
       }
     }
   }

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -129,6 +129,11 @@ public class DatasetTest {
           new TestUtils.SimpleTestDataset(allocator, defaultPath);
       try (Dataset dataset = testDataset.createEmptyDataset()) {
         assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_1, dataset.getLanceFileFormatVersion());
+        ManifestLocationInfo manifest = Dataset.inspectLatestManifest(defaultPath);
+        assertEquals(dataset.version(), manifest.getVersion());
+        assertTrue(manifest.getPath().endsWith(".manifest"));
+        assertTrue(manifest.getSizeBytes() > 0);
+        assertNotNull(manifest.getNamingScheme());
       }
 
       // Test LEGACY version

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -603,11 +603,22 @@ impl DatasetBuilder {
     ///
     /// The returned locations are not guaranteed to be ordered. This operation may list and
     /// materialize the full manifest history. Explicit version, branch, and tag targets are not
-    /// supported.
+    /// supported. Custom commit handlers and externally managed version stores are also not
+    /// supported because listing physical manifest objects may omit committed versions whose
+    /// authoritative locations are held outside the object store.
     pub async fn list_manifest_locations(mut self) -> Result<Vec<ManifestLocation>> {
         if self.version.is_some() {
             return Err(Error::invalid_input(
                 "list_manifest_locations does not support an explicit version, branch, or tag",
+            ));
+        }
+        let uses_external_or_custom_commit_handler = self.commit_handler.is_some()
+            || self.namespace_managed.is_some()
+            || Url::parse(&self.table_uri).is_ok_and(|url| url.scheme() == "s3+ddb");
+        if uses_external_or_custom_commit_handler {
+            return Err(Error::not_supported(
+                "list_manifest_locations does not support external or custom commit handlers; \
+                 object-store listing may omit committed manifest locations",
             ));
         }
         self.apply_storage_options_override();
@@ -927,11 +938,22 @@ impl DatasetBuilder {
 mod tests {
     use async_trait::async_trait;
     use lance_io::object_store::StorageOptionsProvider;
+    use lance_table::io::commit::UnsafeCommitHandler;
 
     use super::*;
 
     #[derive(Debug)]
     struct TestStorageOptionsProvider;
+
+    #[derive(Debug)]
+    struct TestNamespace;
+
+    #[async_trait]
+    impl LanceNamespace for TestNamespace {
+        fn namespace_id(&self) -> String {
+            "test-namespace".to_string()
+        }
+    }
 
     #[async_trait]
     impl StorageOptionsProvider for TestStorageOptionsProvider {
@@ -980,5 +1002,28 @@ mod tests {
             "test-storage-options-provider"
         );
         assert!(builder.storage_options_override.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_manifest_locations_rejects_external_and_custom_commit_handlers() {
+        let mut namespace_builder = DatasetBuilder::from_uri("memory://namespace-table");
+        namespace_builder.namespace_managed =
+            Some((Arc::new(TestNamespace), vec!["namespace-table".to_string()]));
+
+        let builders = [
+            DatasetBuilder::from_uri("memory://custom-handler-table")
+                .with_commit_handler(Arc::new(UnsafeCommitHandler)),
+            DatasetBuilder::from_uri("s3+ddb://bucket/table.lance?ddbTableName=manifest-table"),
+            namespace_builder,
+        ];
+
+        for builder in builders {
+            let err = builder.list_manifest_locations().await.unwrap_err();
+            assert!(matches!(err, Error::NotSupported { .. }));
+            assert!(
+                err.to_string()
+                    .contains("does not support external or custom commit handlers")
+            );
+        }
     }
 }

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -9,7 +9,7 @@ use super::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE, ReadParams, W
 use crate::dataset::branch_location::BranchLocation;
 use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use crate::{Dataset, Error, Result, session::Session};
-use futures::FutureExt;
+use futures::{FutureExt, TryStreamExt};
 use lance_core::utils::tracing::{DATASET_LOADING_EVENT, TRACE_DATASET_EVENTS};
 use lance_file::reader::FileReaderOptions;
 use lance_io::object_store::{
@@ -25,7 +25,7 @@ use lance_table::{
 };
 #[cfg(feature = "aws")]
 use object_store::aws::AwsCredentialProvider;
-use object_store::{DynObjectStore, ObjectStoreExt, path::Path};
+use object_store::{DynObjectStore, path::Path};
 use prost::Message;
 use tracing::{info, instrument};
 use url::Url;
@@ -599,28 +599,23 @@ impl DatasetBuilder {
         Ok((object_store, base_path, commit_handler))
     }
 
-    /// Resolve metadata for the latest manifest without reading its contents.
+    /// List manifest locations without reading the manifest contents.
     ///
-    /// This locates the latest manifest and performs a metadata request only when the commit
-    /// handler did not already provide the object size. Explicit version, branch, and tag targets
-    /// are not supported by this lightweight operation.
-    pub async fn latest_manifest_location(mut self) -> Result<ManifestLocation> {
+    /// The returned locations are not guaranteed to be ordered. This operation may list and
+    /// materialize the full manifest history. Explicit version, branch, and tag targets are not
+    /// supported.
+    pub async fn list_manifest_locations(mut self) -> Result<Vec<ManifestLocation>> {
         if self.version.is_some() {
             return Err(Error::invalid_input(
-                "latest_manifest_location does not support an explicit version, branch, or tag",
+                "list_manifest_locations does not support an explicit version, branch, or tag",
             ));
         }
         self.apply_storage_options_override();
         let (object_store, base_path, commit_handler) = self.build_object_store().await?;
-        let mut location = commit_handler
-            .resolve_latest_location(&base_path, object_store.as_ref())
-            .await?;
-        if location.size.is_none() {
-            let metadata = object_store.inner.head(&location.path).await?;
-            location.size = Some(metadata.size);
-            location.e_tag = metadata.e_tag;
-        }
-        Ok(location)
+        commit_handler
+            .list_manifest_locations(&base_path, object_store.as_ref(), false)
+            .try_collect()
+            .await
     }
 
     #[instrument(skip_all)]

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -181,6 +181,66 @@ impl DatasetBuilder {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use lance_io::object_store::StorageOptionsProvider;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestStorageOptionsProvider;
+
+    #[async_trait]
+    impl StorageOptionsProvider for TestStorageOptionsProvider {
+        async fn fetch_storage_options(&self) -> Result<Option<HashMap<String, String>>> {
+            Ok(None)
+        }
+
+        fn provider_id(&self) -> String {
+            "test-storage-options-provider".to_string()
+        }
+    }
+
+    #[test]
+    fn test_storage_options_override_wins_and_preserves_provider() {
+        let caller_options = HashMap::from([
+            ("endpoint".to_string(), "caller".to_string()),
+            ("caller-only".to_string(), "caller-value".to_string()),
+        ]);
+        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(TestStorageOptionsProvider);
+        let options = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(
+                StorageOptionsAccessor::with_initial_and_provider(caller_options, provider),
+            )),
+            ..Default::default()
+        };
+        let mut builder = DatasetBuilder::from_uri("memory://table").with_store_params(options);
+        builder.storage_options_override = Some(HashMap::from([
+            ("endpoint".to_string(), "namespace".to_string()),
+            ("namespace-only".to_string(), "namespace-value".to_string()),
+        ]));
+
+        builder.apply_storage_options_override();
+
+        let merged = builder.options.storage_options().unwrap();
+        assert_eq!(merged.get("endpoint").unwrap(), "namespace");
+        assert_eq!(merged.get("caller-only").unwrap(), "caller-value");
+        assert_eq!(merged.get("namespace-only").unwrap(), "namespace-value");
+        assert_eq!(
+            builder
+                .options
+                .get_accessor()
+                .unwrap()
+                .provider()
+                .unwrap()
+                .provider_id(),
+            "test-storage-options-provider"
+        );
+        assert!(builder.storage_options_override.is_none());
+    }
+}
+
 // Much of this builder is directly inspired from the to delta-rs table builder implementation
 // https://github.com/delta-io/delta-rs/main/crates/deltalake-core/src/table/builder.rs
 impl DatasetBuilder {
@@ -602,8 +662,15 @@ impl DatasetBuilder {
     /// Resolve metadata for the latest manifest without reading its contents.
     ///
     /// This locates the latest manifest and performs a metadata request only when the commit
-    /// handler did not already provide the object size.
-    pub async fn latest_manifest_location(self) -> Result<ManifestLocation> {
+    /// handler did not already provide the object size. Explicit version, branch, and tag targets
+    /// are not supported by this lightweight operation.
+    pub async fn latest_manifest_location(mut self) -> Result<ManifestLocation> {
+        if self.version.is_some() {
+            return Err(Error::invalid_input(
+                "latest_manifest_location does not support an explicit version, branch, or tag",
+            ));
+        }
+        self.apply_storage_options_override();
         let (object_store, base_path, commit_handler) = self.build_object_store().await?;
         let mut location = commit_handler
             .resolve_latest_location(&base_path, object_store.as_ref())
@@ -662,12 +729,16 @@ impl DatasetBuilder {
         merged_params
     }
 
+    fn apply_storage_options_override(&mut self) {
+        if let Some(override_options) = self.storage_options_override.take() {
+            self.options =
+                Self::merge_store_params_with_storage_options(&self.options, &override_options);
+        }
+    }
+
     async fn load_impl(mut self) -> Result<Dataset> {
         // Apply storage_options_override to merge namespace client options with any existing accessor
-        if let Some(override_opts) = self.storage_options_override.take() {
-            self.options =
-                Self::merge_store_params_with_storage_options(&self.options, &override_opts);
-        }
+        self.apply_storage_options_override();
 
         let index_cache_backend = self.index_cache_backend.take();
         let session = match self.session.as_ref() {

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -21,11 +21,11 @@ use lance_namespace::models::DescribeTableRequest;
 use lance_table::{
     format::{Manifest, populate_manifest_schema_dictionaries},
     io::commit::external_manifest::ExternalManifestCommitHandler,
-    io::commit::{CommitHandler, commit_handler_from_url},
+    io::commit::{CommitHandler, ManifestLocation, commit_handler_from_url},
 };
 #[cfg(feature = "aws")]
 use object_store::aws::AwsCredentialProvider;
-use object_store::{DynObjectStore, path::Path};
+use object_store::{DynObjectStore, ObjectStoreExt, path::Path};
 use prost::Message;
 use tracing::{info, instrument};
 use url::Url;
@@ -597,6 +597,23 @@ impl DatasetBuilder {
             };
 
         Ok((object_store, base_path, commit_handler))
+    }
+
+    /// Resolve metadata for the latest manifest without reading its contents.
+    ///
+    /// This locates the latest manifest and performs a metadata request only when the commit
+    /// handler did not already provide the object size.
+    pub async fn latest_manifest_location(self) -> Result<ManifestLocation> {
+        let (object_store, base_path, commit_handler) = self.build_object_store().await?;
+        let mut location = commit_handler
+            .resolve_latest_location(&base_path, object_store.as_ref())
+            .await?;
+        if location.size.is_none() {
+            let metadata = object_store.inner.head(&location.path).await?;
+            location.size = Some(metadata.size);
+            location.e_tag = metadata.e_tag;
+        }
+        Ok(location)
     }
 
     #[instrument(skip_all)]

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -181,66 +181,6 @@ impl DatasetBuilder {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use async_trait::async_trait;
-    use lance_io::object_store::StorageOptionsProvider;
-
-    use super::*;
-
-    #[derive(Debug)]
-    struct TestStorageOptionsProvider;
-
-    #[async_trait]
-    impl StorageOptionsProvider for TestStorageOptionsProvider {
-        async fn fetch_storage_options(&self) -> Result<Option<HashMap<String, String>>> {
-            Ok(None)
-        }
-
-        fn provider_id(&self) -> String {
-            "test-storage-options-provider".to_string()
-        }
-    }
-
-    #[test]
-    fn test_storage_options_override_wins_and_preserves_provider() {
-        let caller_options = HashMap::from([
-            ("endpoint".to_string(), "caller".to_string()),
-            ("caller-only".to_string(), "caller-value".to_string()),
-        ]);
-        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(TestStorageOptionsProvider);
-        let options = ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(
-                StorageOptionsAccessor::with_initial_and_provider(caller_options, provider),
-            )),
-            ..Default::default()
-        };
-        let mut builder = DatasetBuilder::from_uri("memory://table").with_store_params(options);
-        builder.storage_options_override = Some(HashMap::from([
-            ("endpoint".to_string(), "namespace".to_string()),
-            ("namespace-only".to_string(), "namespace-value".to_string()),
-        ]));
-
-        builder.apply_storage_options_override();
-
-        let merged = builder.options.storage_options().unwrap();
-        assert_eq!(merged.get("endpoint").unwrap(), "namespace");
-        assert_eq!(merged.get("caller-only").unwrap(), "caller-value");
-        assert_eq!(merged.get("namespace-only").unwrap(), "namespace-value");
-        assert_eq!(
-            builder
-                .options
-                .get_accessor()
-                .unwrap()
-                .provider()
-                .unwrap()
-                .provider_id(),
-            "test-storage-options-provider"
-        );
-        assert!(builder.storage_options_override.is_none());
-    }
-}
-
 // Much of this builder is directly inspired from the to delta-rs table builder implementation
 // https://github.com/delta-io/delta-rs/main/crates/deltalake-core/src/table/builder.rs
 impl DatasetBuilder {
@@ -985,5 +925,65 @@ impl DatasetBuilder {
             store_params,
             base_store_params,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use lance_io::object_store::StorageOptionsProvider;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestStorageOptionsProvider;
+
+    #[async_trait]
+    impl StorageOptionsProvider for TestStorageOptionsProvider {
+        async fn fetch_storage_options(&self) -> Result<Option<HashMap<String, String>>> {
+            Ok(None)
+        }
+
+        fn provider_id(&self) -> String {
+            "test-storage-options-provider".to_string()
+        }
+    }
+
+    #[test]
+    fn test_storage_options_override_wins_and_preserves_provider() {
+        let caller_options = HashMap::from([
+            ("endpoint".to_string(), "caller".to_string()),
+            ("caller-only".to_string(), "caller-value".to_string()),
+        ]);
+        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(TestStorageOptionsProvider);
+        let options = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(
+                StorageOptionsAccessor::with_initial_and_provider(caller_options, provider),
+            )),
+            ..Default::default()
+        };
+        let mut builder = DatasetBuilder::from_uri("memory://table").with_store_params(options);
+        builder.storage_options_override = Some(HashMap::from([
+            ("endpoint".to_string(), "namespace".to_string()),
+            ("namespace-only".to_string(), "namespace-value".to_string()),
+        ]));
+
+        builder.apply_storage_options_override();
+
+        let merged = builder.options.storage_options().unwrap();
+        assert_eq!(merged.get("endpoint").unwrap(), "namespace");
+        assert_eq!(merged.get("caller-only").unwrap(), "caller-value");
+        assert_eq!(merged.get("namespace-only").unwrap(), "namespace-value");
+        assert_eq!(
+            builder
+                .options
+                .get_accessor()
+                .unwrap()
+                .provider()
+                .unwrap()
+                .provider_id(),
+            "test-storage-options-provider"
+        );
+        assert!(builder.storage_options_override.is_none());
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -49,6 +49,23 @@ fn assert_all_manifests_use_scheme(test_dir: &TempStdDir, scheme: ManifestNaming
 }
 
 #[tokio::test]
+async fn test_latest_manifest_location_rejects_explicit_refs() {
+    let test_dir = TempStdDir::default();
+    let test_uri = test_dir.to_str().unwrap();
+    let builders = [
+        DatasetBuilder::from_uri(test_uri).with_version(1),
+        DatasetBuilder::from_uri(test_uri).with_branch("dev", None),
+        DatasetBuilder::from_uri(test_uri).with_tag("release"),
+    ];
+
+    for builder in builders {
+        let err = builder.latest_manifest_location().await.unwrap_err();
+        assert!(matches!(err, Error::InvalidInput { .. }));
+        assert!(err.to_string().contains("does not support an explicit"));
+    }
+}
+
+#[tokio::test]
 async fn test_v2_manifest_path_create() {
     // Can create a dataset, using V2 paths
     let data = lance_datagen::gen_batch()

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -49,7 +49,7 @@ fn assert_all_manifests_use_scheme(test_dir: &TempStdDir, scheme: ManifestNaming
 }
 
 #[tokio::test]
-async fn test_latest_manifest_location_rejects_explicit_refs() {
+async fn test_list_manifest_locations_rejects_explicit_refs() {
     let test_dir = TempStdDir::default();
     let test_uri = test_dir.to_str().unwrap();
     let builders = [
@@ -59,7 +59,7 @@ async fn test_latest_manifest_location_rejects_explicit_refs() {
     ];
 
     for builder in builders {
-        let err = builder.latest_manifest_location().await.unwrap_err();
+        let err = builder.list_manifest_locations().await.unwrap_err();
         assert!(matches!(err, Error::InvalidInput { .. }));
         assert!(err.to_string().contains("does not support an explicit"));
     }


### PR DESCRIPTION
## Motivation

Java callers currently need to open a Lance dataset before they can inspect manifest metadata. Opening a dataset reads and deserializes the selected manifest, which can be expensive when the manifest itself is large.

The Rust commit layer already exposes manifest locations independently of manifest contents. Exposing this metadata to Java allows callers to make lightweight decisions before opening the dataset, for example:

- inspect manifest sizes before running profiling or analysis
- choose between synchronous and asynchronous processing
- locate the manifest for a specific version
- select the latest manifest by choosing the maximum version

The API returns the manifest-location list instead of embedding a "latest-version" policy. This keeps the primitive reusable and lets callers choose the version appropriate for their workflow.

## Changes

- add `DatasetBuilder::list_manifest_locations` in Rust
- expose `Dataset.listManifestLocations(...)` in Java
- introduce the typed Java `ManifestLocation` model
- expose:
  - dataset version
  - manifest path
  - manifest size in bytes
  - manifest naming scheme
  - optional ETag
- accept Java storage options for TOS, S3-compatible, and other object stores
- add Rust, JNI, and Java coverage

## API

```java
List<ManifestLocation> locations =
    Dataset.listManifestLocations(uri, storageOptions);

ManifestLocation latest =
    locations.stream()
        .max(Comparator.comparingLong(ManifestLocation::getVersion))
        .orElseThrow();
```

This API does not read or deserialize manifest contents.

## Semantics and limitations

- returned locations are not guaranteed to be ordered
- the complete manifest-location history is listed and materialized
- runtime cost therefore still grows with the number of dataset versions
- `sizeBytes` is the size of the manifest object, not the total dataset size
- explicit version, branch, and tag targets are not currently supported
- externally managed or custom commit handlers are rejected

External commit handlers may store an authoritative committed manifest at a staging location that cannot be discovered through physical object-store listing. The API fails explicitly for these handlers rather than returning an incomplete history.

Pagination may be added separately if required for datasets with very large version histories.

## Testing

- `cargo test -p lance test_list_manifest_locations_rejects -- --nocapture`
- `cargo clippy -p lance --tests --benches -- -D warnings`
- `cargo fmt --all -- --check`
- `cd java && ./mvnw -Dtest=DatasetTest#testListManifestLocations test`
- `cd java && ./mvnw spotless:check`