### PR TITLE
feat(java): add efficient dataset version count

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -253,6 +253,10 @@ impl BlockingDataset {
         Ok(versions)
     }
 
+    pub fn version_count(&self) -> Result<u64> {
+        Ok(block_on(self.inner.version_count())?)
+    }
+
     pub fn version(&self) -> Result<Version> {
         Ok(self.inner.version())
     }
@@ -1667,6 +1671,20 @@ pub extern "system" fn Java_org_lance_Dataset_nativeListVersions<'local>(
     java_dataset: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(env, inner_list_versions(&mut env, java_dataset))
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeGetVersionCount(
+    mut env: JNIEnv,
+    java_dataset: JObject,
+) -> jlong {
+    ok_or_throw_with_return!(env, inner_get_version_count(&mut env, java_dataset), -1) as jlong
+}
+
+fn inner_get_version_count(env: &mut JNIEnv, java_dataset: JObject) -> Result<u64> {
+    let dataset_guard =
+        unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+    dataset_guard.version_count()
 }
 
 fn inner_list_versions<'local>(

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -253,8 +253,8 @@ impl BlockingDataset {
         Ok(versions)
     }
 
-    pub fn version_count(&self) -> Result<u64> {
-        Ok(block_on(self.inner.version_count())?)
+    pub fn count_versions(&self) -> Result<u64> {
+        Ok(block_on(self.inner.count_versions())?)
     }
 
     pub fn version(&self) -> Result<Version> {
@@ -1684,7 +1684,7 @@ pub extern "system" fn Java_org_lance_Dataset_nativeGetVersionCount(
 fn inner_get_version_count(env: &mut JNIEnv, java_dataset: JObject) -> Result<u64> {
     let dataset_guard =
         unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
-    dataset_guard.version_count()
+    dataset_guard.count_versions()
 }
 
 fn inner_list_versions<'local>(

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -979,6 +979,23 @@ public class Dataset implements Closeable {
   private native List<Version> nativeListVersions();
 
   /**
+   * Get the number of versions in the current version history.
+   *
+   * <p>Unlike {@link #listVersions()}, this method does not read or deserialize every manifest.
+   * Detached versions are not included.
+   *
+   * @return the number of versions
+   */
+  public long getVersionCount() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeGetVersionCount();
+    }
+  }
+
+  private native long nativeGetVersionCount();
+
+  /**
    * @return the latest version of the dataset.
    */
   public long latestVersion() {

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -241,6 +241,9 @@ public class DatasetTest {
 
             List<Version> versions = dataset.listVersions();
             assertEquals(3, versions.size());
+            assertEquals(3, dataset.getVersionCount());
+            assertEquals(3, dataset2.getVersionCount());
+            assertEquals(3, dataset3.getVersionCount());
             assertEquals(1, versions.get(0).getId());
             assertEquals(2, versions.get(1).getId());
             assertEquals(3, versions.get(2).getId());

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2633,7 +2633,7 @@ impl Dataset {
     ///
     /// Unlike [`Self::versions`], this only enumerates manifest locations and does not read or
     /// deserialize every manifest.
-    pub async fn version_count(&self) -> Result<u64> {
+    pub async fn count_versions(&self) -> Result<u64> {
         self.commit_handler
             .list_manifest_locations(&self.base, &self.object_store, false)
             .try_fold(0_u64, |count, _| async move { Ok(count + 1) })

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2629,6 +2629,17 @@ impl Dataset {
         Ok(versions)
     }
 
+    /// Get the number of versions in the current version history.
+    ///
+    /// Unlike [`Self::versions`], this only enumerates manifest locations and does not read or
+    /// deserialize every manifest.
+    pub async fn version_count(&self) -> Result<u64> {
+        self.commit_handler
+            .list_manifest_locations(&self.base, &self.object_store, false)
+            .try_fold(0_u64, |count, _| async move { Ok(count + 1) })
+            .await
+    }
+
     /// List all detached manifest locations.
     ///
     /// Detached manifests are versions that are not part of the main version history.


### PR DESCRIPTION
## Summary

- add a streaming Rust version-count API that enumerates retained manifest locations
- avoid reading and deserializing every historical manifest, unlike `versions()`
- expose the count through Java as `Dataset.getVersionCount()`
- keep detached versions excluded, matching the normal version history

## Testing

- `cd java && ./mvnw test -Dtest=DatasetTest`
- `cargo clippy -p lance --tests --benches -- -D warnings`
- `cd java && cargo clippy --tests --manifest-path lance-jni/Cargo.toml -- -D warnings`
- `cd java && ./mvnw spotless:check`