### PR TITLE
fix(commit): serialize external manifest finalization

### DIFF
--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -24,7 +24,7 @@ use object_store::{
     StaticCredentialProvider,
     aws::{
         AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
-        AwsCredentialProvider,
+        AwsCredentialProvider, S3CopyIfNotExists,
     },
 };
 use tokio::sync::RwLock;
@@ -60,6 +60,7 @@ impl AwsStoreProvider {
 
         let mut s3_storage_options = storage_options.as_s3_options();
         let region = resolve_s3_region(base_path, &s3_storage_options).await?;
+        let uses_external_manifest = base_path.scheme() == "s3+ddb";
 
         // Get accessor from params
         let accessor = params.get_accessor();
@@ -93,6 +94,13 @@ impl AwsStoreProvider {
         // we can't use parse_url_opts here because we need to manually set the credentials provider
         let mut builder =
             AmazonS3Builder::new().with_client_options(storage_options.client_options()?);
+        if let Some(config) = default_native_s3_copy_if_not_exists(
+            &s3_storage_options,
+            is_s3_express,
+            uses_external_manifest,
+        ) {
+            builder = builder.with_copy_if_not_exists(config);
+        }
         for (key, value) in s3_storage_options {
             builder = builder.with_config(key, value);
         }
@@ -223,11 +231,56 @@ impl ObjectStoreProvider for AwsStoreProvider {
 /// Check if the storage is S3 Express
 fn check_s3_express(url: &Url, storage_options: &StorageOptions) -> bool {
     storage_options
-        .0
-        .get("s3_express")
+        .as_s3_options()
+        .get(&AmazonS3ConfigKey::S3Express)
         .map(|v| v == "true")
         .unwrap_or(false)
         || url.authority().ends_with("--x-s3")
+}
+
+/// Whether the external-manifest commit path can rely on an atomic,
+/// synchronous `copy_if_not_exists` implementation for this S3 configuration.
+pub fn supports_external_manifest_create_only_copy(
+    url: &Url,
+    storage_options: &StorageOptions,
+) -> bool {
+    if url.scheme() != "s3+ddb"
+        || storage_options
+            .0
+            .get("use_opendal")
+            .map(|value| value == "true")
+            .unwrap_or(false)
+        || check_s3_express(url, storage_options)
+    {
+        return false;
+    }
+
+    let s3_options = storage_options.as_s3_options();
+    !s3_options.contains_key(&AmazonS3ConfigKey::Endpoint)
+        && !s3_options.contains_key(&AmazonS3ConfigKey::S3Endpoint)
+        && !s3_options.contains_key(&AmazonS3ConfigKey::CopyIfNotExists)
+}
+
+fn default_native_s3_copy_if_not_exists(
+    storage_options: &HashMap<AmazonS3ConfigKey, String>,
+    is_s3_express: bool,
+    uses_external_manifest: bool,
+) -> Option<S3CopyIfNotExists> {
+    if !uses_external_manifest
+        || is_s3_express
+        || storage_options.contains_key(&AmazonS3ConfigKey::Endpoint)
+        || storage_options.contains_key(&AmazonS3ConfigKey::S3Endpoint)
+        || storage_options.contains_key(&AmazonS3ConfigKey::CopyIfNotExists)
+    {
+        return None;
+    }
+
+    // Native S3 supports a destination precondition on CopyObject. Compatible
+    // services may not, so only provide this default when using AWS endpoints.
+    Some(S3CopyIfNotExists::Header(
+        "If-None-Match".to_string(),
+        "*".to_string(),
+    ))
 }
 
 /// Figure out the S3 region of the bucket.
@@ -585,6 +638,7 @@ mod tests {
     use aws_credential_types::provider::error::CredentialsError;
     use mock_instant::thread_local::MockClock;
     use object_store::path::Path;
+    use rstest::rstest;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
@@ -749,6 +803,11 @@ mod tests {
                 true, // URL takes precedence
             ),
             ("s3://bucket--x-s3/path/to/file", HashMap::from([]), true),
+            (
+                "s3://bucket/path/to/file",
+                HashMap::from([("aws_s3_express".to_string(), "true".to_string())]),
+                true,
+            ),
         ];
 
         for (uri, storage_map, expected) in cases {
@@ -757,6 +816,78 @@ mod tests {
             let is_s3_express = check_s3_express(&url, &storage_options);
             assert_eq!(is_s3_express, expected);
         }
+    }
+
+    #[rstest]
+    #[case::native("s3+ddb://bucket/path", HashMap::new(), true)]
+    #[case::plain_s3("s3://bucket/path", HashMap::new(), false)]
+    #[case::opendal(
+        "s3+ddb://bucket/path",
+        HashMap::from([("use_opendal".to_string(), "true".to_string())]),
+        false
+    )]
+    #[case::custom_endpoint(
+        "s3+ddb://bucket/path",
+        HashMap::from([("aws_endpoint".to_string(), "https://example.com".to_string())]),
+        false
+    )]
+    #[case::express_option(
+        "s3+ddb://bucket/path",
+        HashMap::from([("aws_s3_express".to_string(), "true".to_string())]),
+        false
+    )]
+    #[case::explicit_copy_mode(
+        "s3+ddb://bucket/path",
+        HashMap::from([("aws_copy_if_not_exists".to_string(), "multipart".to_string())]),
+        false
+    )]
+    #[case::express_bucket("s3+ddb://bucket--x-s3/path", HashMap::new(), false)]
+    fn test_supports_external_manifest_create_only_copy(
+        #[case] uri: &str,
+        #[case] storage_map: HashMap<String, String>,
+        #[case] expected: bool,
+    ) {
+        let url = Url::parse(uri).unwrap();
+        let storage_options = StorageOptions(storage_map);
+        assert_eq!(
+            supports_external_manifest_create_only_copy(&url, &storage_options),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case::external_native_s3(None, false, false, true, true)]
+    #[case::plain_native_s3(None, false, false, false, false)]
+    #[case::custom_endpoint(Some(AmazonS3ConfigKey::Endpoint), false, false, true, false)]
+    #[case::custom_s3_endpoint(Some(AmazonS3ConfigKey::S3Endpoint), false, false, true, false)]
+    #[case::explicit_config(None, true, false, true, false)]
+    #[case::s3_express(None, false, true, true, false)]
+    fn test_default_native_s3_copy_if_not_exists(
+        #[case] endpoint_key: Option<AmazonS3ConfigKey>,
+        #[case] has_explicit_config: bool,
+        #[case] is_s3_express: bool,
+        #[case] uses_external_manifest: bool,
+        #[case] expects_default: bool,
+    ) {
+        let mut storage_options = HashMap::new();
+        if let Some(endpoint_key) = endpoint_key {
+            storage_options.insert(
+                endpoint_key,
+                "https://s3-compatible.example.com".to_string(),
+            );
+        }
+        if has_explicit_config {
+            storage_options.insert(AmazonS3ConfigKey::CopyIfNotExists, "multipart".to_string());
+        }
+
+        let actual = default_native_s3_copy_if_not_exists(
+            &storage_options,
+            is_s3_express,
+            uses_external_manifest,
+        );
+        let expected = expects_default
+            .then(|| S3CopyIfNotExists::Header("If-None-Match".to_string(), "*".to_string()));
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -250,15 +250,16 @@ pub fn supports_external_manifest_create_only_copy(
             .get("use_opendal")
             .map(|value| value == "true")
             .unwrap_or(false)
-        || check_s3_express(url, storage_options)
     {
         return false;
     }
 
-    let s3_options = storage_options.as_s3_options();
-    !s3_options.contains_key(&AmazonS3ConfigKey::Endpoint)
-        && !s3_options.contains_key(&AmazonS3ConfigKey::S3Endpoint)
-        && !s3_options.contains_key(&AmazonS3ConfigKey::CopyIfNotExists)
+    default_native_s3_copy_if_not_exists(
+        &storage_options.as_s3_options(),
+        check_s3_express(url, storage_options),
+        true,
+    )
+    .is_some()
 }
 
 fn default_native_s3_copy_if_not_exists(
@@ -638,7 +639,6 @@ mod tests {
     use aws_credential_types::provider::error::CredentialsError;
     use mock_instant::thread_local::MockClock;
     use object_store::path::Path;
-    use rstest::rstest;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
@@ -818,76 +818,59 @@ mod tests {
         }
     }
 
-    #[rstest]
-    #[case::native("s3+ddb://bucket/path", HashMap::new(), true)]
-    #[case::plain_s3("s3://bucket/path", HashMap::new(), false)]
-    #[case::opendal(
-        "s3+ddb://bucket/path",
-        HashMap::from([("use_opendal".to_string(), "true".to_string())]),
-        false
-    )]
-    #[case::custom_endpoint(
-        "s3+ddb://bucket/path",
-        HashMap::from([("aws_endpoint".to_string(), "https://example.com".to_string())]),
-        false
-    )]
-    #[case::express_option(
-        "s3+ddb://bucket/path",
-        HashMap::from([("aws_s3_express".to_string(), "true".to_string())]),
-        false
-    )]
-    #[case::explicit_copy_mode(
-        "s3+ddb://bucket/path",
-        HashMap::from([("aws_copy_if_not_exists".to_string(), "multipart".to_string())]),
-        false
-    )]
-    #[case::express_bucket("s3+ddb://bucket--x-s3/path", HashMap::new(), false)]
-    fn test_supports_external_manifest_create_only_copy(
-        #[case] uri: &str,
-        #[case] storage_map: HashMap<String, String>,
-        #[case] expected: bool,
-    ) {
-        let url = Url::parse(uri).unwrap();
-        let storage_options = StorageOptions(storage_map);
-        assert_eq!(
-            supports_external_manifest_create_only_copy(&url, &storage_options),
-            expected
-        );
-    }
-
-    #[rstest]
-    #[case::external_native_s3(None, false, false, true, true)]
-    #[case::plain_native_s3(None, false, false, false, false)]
-    #[case::custom_endpoint(Some(AmazonS3ConfigKey::Endpoint), false, false, true, false)]
-    #[case::custom_s3_endpoint(Some(AmazonS3ConfigKey::S3Endpoint), false, false, true, false)]
-    #[case::explicit_config(None, true, false, true, false)]
-    #[case::s3_express(None, false, true, true, false)]
-    fn test_default_native_s3_copy_if_not_exists(
-        #[case] endpoint_key: Option<AmazonS3ConfigKey>,
-        #[case] has_explicit_config: bool,
-        #[case] is_s3_express: bool,
-        #[case] uses_external_manifest: bool,
-        #[case] expects_default: bool,
-    ) {
-        let mut storage_options = HashMap::new();
-        if let Some(endpoint_key) = endpoint_key {
-            storage_options.insert(
-                endpoint_key,
-                "https://s3-compatible.example.com".to_string(),
+    #[test]
+    fn test_external_manifest_create_only_copy_support() {
+        let configured =
+            |key: &str, value: &str| HashMap::from([(key.to_string(), value.to_string())]);
+        for (uri, options, expected) in [
+            ("s3+ddb://bucket/path", HashMap::new(), true),
+            ("s3://bucket/path", HashMap::new(), false),
+            (
+                "s3+ddb://bucket/path",
+                configured("use_opendal", "true"),
+                false,
+            ),
+            (
+                "s3+ddb://bucket/path",
+                configured("aws_endpoint", "https://example.com"),
+                false,
+            ),
+            (
+                "s3+ddb://bucket/path",
+                configured("aws_endpoint_url_s3", "https://example.com"),
+                false,
+            ),
+            (
+                "s3+ddb://bucket/path",
+                configured("aws_s3_express", "true"),
+                false,
+            ),
+            (
+                "s3+ddb://bucket/path",
+                configured("aws_copy_if_not_exists", "multipart"),
+                false,
+            ),
+            ("s3+ddb://bucket--x-s3/path", HashMap::new(), false),
+        ] {
+            assert_eq!(
+                supports_external_manifest_create_only_copy(
+                    &Url::parse(uri).unwrap(),
+                    &StorageOptions(options)
+                ),
+                expected,
+                "unexpected capability for {uri}"
             );
         }
-        if has_explicit_config {
-            storage_options.insert(AmazonS3ConfigKey::CopyIfNotExists, "multipart".to_string());
-        }
 
-        let actual = default_native_s3_copy_if_not_exists(
-            &storage_options,
-            is_s3_express,
-            uses_external_manifest,
+        let expected = S3CopyIfNotExists::Header("If-None-Match".to_string(), "*".to_string());
+        assert_eq!(
+            default_native_s3_copy_if_not_exists(&HashMap::new(), false, true),
+            Some(expected)
         );
-        let expected = expects_default
-            .then(|| S3CopyIfNotExists::Header("If-None-Match".to_string(), "*".to_string()));
-        assert_eq!(actual, expected);
+        assert_eq!(
+            default_native_s3_copy_if_not_exists(&HashMap::new(), false, false),
+            None
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -60,7 +60,10 @@ use {
     self::external_manifest::{ExternalManifestCommitHandler, ExternalManifestStore},
     aws_credential_types::provider::ProvideCredentials,
     aws_credential_types::provider::error::CredentialsError,
-    lance_io::object_store::{StorageOptions, providers::aws::build_aws_credential},
+    lance_io::object_store::{
+        StorageOptions,
+        providers::aws::{build_aws_credential, supports_external_manifest_create_only_copy},
+    },
     object_store::aws::AmazonS3ConfigKey,
     object_store::aws::AwsCredentialProvider,
     std::borrow::Cow,
@@ -1063,6 +1066,7 @@ async fn build_dynamodb_external_store(
     region: &str,
     endpoint: Option<String>,
     app_name: &str,
+    use_create_only_manifest_copy: bool,
 ) -> Result<Arc<dyn ExternalManifestStore>> {
     use super::commit::dynamodb::DynamoDBExternalManifestStore;
     use aws_sdk_dynamodb::{
@@ -1085,7 +1089,13 @@ async fn build_dynamodb_external_store(
     }
     let client = Client::from_conf(dynamodb_config.build());
 
-    DynamoDBExternalManifestStore::new_external_store(client.into(), table_name, app_name).await
+    DynamoDBExternalManifestStore::new_external_store_with_create_only_copy(
+        client.into(),
+        table_name,
+        app_name,
+        use_create_only_manifest_copy,
+    )
+    .await
 }
 
 pub async fn commit_handler_from_url(
@@ -1145,10 +1155,15 @@ pub async fn commit_handler_from_url(
                 }
             };
             let options = options.clone().unwrap_or_default();
-            let storage_options_raw =
+            let mut storage_options_raw =
                 StorageOptions(options.storage_options().cloned().unwrap_or_default());
+            storage_options_raw.with_env_s3();
             let dynamo_endpoint = get_dynamodb_endpoint(&storage_options_raw);
             let storage_options = storage_options_raw.as_s3_options();
+            #[allow(deprecated)]
+            let uses_custom_object_store = options.object_store.is_some();
+            let use_create_only_manifest_copy = !uses_custom_object_store
+                && supports_external_manifest_create_only_copy(&url, &storage_options_raw);
 
             let region = storage_options.get(&AmazonS3ConfigKey::Region).cloned();
 
@@ -1174,6 +1189,7 @@ pub async fn commit_handler_from_url(
                     &region,
                     dynamo_endpoint,
                     "lancedb",
+                    use_create_only_manifest_copy,
                 )
                 .await?,
             }))

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -112,6 +112,7 @@ pub struct DynamoDBExternalManifestStore {
     client: Arc<Client>,
     table_name: String,
     committer_name: String,
+    use_create_only_manifest_copy: bool,
 }
 
 // these are in macro because I want to use them in a match statement
@@ -136,11 +137,44 @@ macro_rules! committer {
     };
 }
 
+fn matches_final_location(
+    location: &ManifestLocation,
+    final_path: &str,
+    size: u64,
+    e_tag: &Option<String>,
+) -> bool {
+    location.path.as_ref() == final_path && location.size == Some(size) && &location.e_tag == e_tag
+}
+
 impl DynamoDBExternalManifestStore {
     pub async fn new_external_store(
         client: Arc<Client>,
         table_name: &str,
         committer_name: &str,
+    ) -> Result<Arc<dyn ExternalManifestStore>> {
+        Self::new_external_store_impl(client, table_name, committer_name, false).await
+    }
+
+    pub(crate) async fn new_external_store_with_create_only_copy(
+        client: Arc<Client>,
+        table_name: &str,
+        committer_name: &str,
+        use_create_only_manifest_copy: bool,
+    ) -> Result<Arc<dyn ExternalManifestStore>> {
+        Self::new_external_store_impl(
+            client,
+            table_name,
+            committer_name,
+            use_create_only_manifest_copy,
+        )
+        .await
+    }
+
+    async fn new_external_store_impl(
+        client: Arc<Client>,
+        table_name: &str,
+        committer_name: &str,
+        use_create_only_manifest_copy: bool,
     ) -> Result<Arc<dyn ExternalManifestStore>> {
         static SANITY_CHECK_CACHE: LazyLock<RwLock<HashSet<String>>> =
             LazyLock::new(|| RwLock::new(HashSet::new()));
@@ -149,6 +183,7 @@ impl DynamoDBExternalManifestStore {
             client: client.clone(),
             table_name: table_name.to_string(),
             committer_name: committer_name.to_string(),
+            use_create_only_manifest_copy,
         });
 
         // already checked this table before, skip
@@ -243,6 +278,10 @@ impl DynamoDBExternalManifestStore {
 
 #[async_trait]
 impl ExternalManifestStore for DynamoDBExternalManifestStore {
+    fn use_create_only_manifest_copy(&self) -> bool {
+        self.use_create_only_manifest_copy
+    }
+
     /// Get the manifest path for a given base_uri and version
     async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
         let get_item_result = self
@@ -465,6 +504,59 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
         Ok(())
     }
 
+    async fn finalize_staging_manifest(
+        &self,
+        base_uri: &str,
+        version: u64,
+        staging_path: &str,
+        final_path: &str,
+        size: u64,
+        e_tag: Option<String>,
+    ) -> Result<()> {
+        let mut put_item = self
+            .ddb_put()
+            .item(base_uri!(), AttributeValue::S(base_uri.into()))
+            .item(version!(), AttributeValue::N(version.to_string()))
+            .item(path!(), AttributeValue::S(final_path.to_string()))
+            .item(committer!(), AttributeValue::S(self.committer_name.clone()))
+            .item("size", AttributeValue::N(size.to_string()));
+
+        if let Some(e_tag) = e_tag.as_ref() {
+            put_item = put_item.item("e_tag", AttributeValue::S(e_tag.clone()));
+        }
+
+        let write_result = put_item
+            .condition_expression(format!(
+                "attribute_exists({}) AND attribute_exists({}) AND #manifest_path = :staging_path",
+                base_uri!(),
+                version!(),
+            ))
+            .expression_attribute_names("#manifest_path", path!())
+            .expression_attribute_values(
+                ":staging_path",
+                AttributeValue::S(staging_path.to_string()),
+            )
+            .send()
+            .await;
+
+        let Err(write_error) = write_result else {
+            return Ok(());
+        };
+
+        // A conditional failure can mean another finalizer won, while a transport
+        // error can mean this write succeeded but its response was lost. Only the
+        // exact target tuple makes either outcome safely idempotent.
+        if self
+            .get_manifest_location(base_uri, version)
+            .await
+            .is_ok_and(|location| matches_final_location(&location, final_path, size, &e_tag))
+        {
+            return Ok(());
+        }
+
+        Err(write_error).wrap_err()
+    }
+
     /// Delete the manifest information for the given base_uri in dynamodb
     async fn delete(&self, base_uri: &str) -> Result<()> {
         let query_result = self
@@ -491,5 +583,62 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::commit::ManifestNamingScheme;
+
+    #[test]
+    fn final_location_match_requires_exact_metadata() {
+        let final_path = Path::from("dataset/_versions/1.manifest");
+        let mut location = ManifestLocation {
+            version: 1,
+            path: final_path.clone(),
+            size: Some(42),
+            naming_scheme: ManifestNamingScheme::V2,
+            e_tag: Some("final-etag".to_string()),
+        };
+
+        assert!(matches_final_location(
+            &location,
+            final_path.as_ref(),
+            42,
+            &Some("final-etag".to_string()),
+        ));
+        assert!(!matches_final_location(
+            &location,
+            "dataset/_versions/2.manifest",
+            42,
+            &Some("final-etag".to_string()),
+        ));
+        assert!(!matches_final_location(
+            &location,
+            final_path.as_ref(),
+            43,
+            &Some("final-etag".to_string()),
+        ));
+        assert!(!matches_final_location(
+            &location,
+            final_path.as_ref(),
+            42,
+            &Some("stale-etag".to_string()),
+        ));
+        assert!(!matches_final_location(
+            &location,
+            final_path.as_ref(),
+            42,
+            &None,
+        ));
+
+        location.size = None;
+        assert!(!matches_final_location(
+            &location,
+            final_path.as_ref(),
+            42,
+            &Some("final-etag".to_string()),
+        ));
     }
 }

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -137,15 +137,6 @@ macro_rules! committer {
     };
 }
 
-fn matches_final_location(
-    location: &ManifestLocation,
-    final_path: &str,
-    size: u64,
-    e_tag: &Option<String>,
-) -> bool {
-    location.path.as_ref() == final_path && location.size == Some(size) && &location.e_tag == e_tag
-}
-
 impl DynamoDBExternalManifestStore {
     pub async fn new_external_store(
         client: Arc<Client>,
@@ -549,7 +540,11 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
         if self
             .get_manifest_location(base_uri, version)
             .await
-            .is_ok_and(|location| matches_final_location(&location, final_path, size, &e_tag))
+            .is_ok_and(|location| {
+                location.path.as_ref() == final_path
+                    && location.size == Some(size)
+                    && location.e_tag == e_tag
+            })
         {
             return Ok(());
         }
@@ -583,62 +578,5 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
             }
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::io::commit::ManifestNamingScheme;
-
-    #[test]
-    fn final_location_match_requires_exact_metadata() {
-        let final_path = Path::from("dataset/_versions/1.manifest");
-        let mut location = ManifestLocation {
-            version: 1,
-            path: final_path.clone(),
-            size: Some(42),
-            naming_scheme: ManifestNamingScheme::V2,
-            e_tag: Some("final-etag".to_string()),
-        };
-
-        assert!(matches_final_location(
-            &location,
-            final_path.as_ref(),
-            42,
-            &Some("final-etag".to_string()),
-        ));
-        assert!(!matches_final_location(
-            &location,
-            "dataset/_versions/2.manifest",
-            42,
-            &Some("final-etag".to_string()),
-        ));
-        assert!(!matches_final_location(
-            &location,
-            final_path.as_ref(),
-            43,
-            &Some("final-etag".to_string()),
-        ));
-        assert!(!matches_final_location(
-            &location,
-            final_path.as_ref(),
-            42,
-            &Some("stale-etag".to_string()),
-        ));
-        assert!(!matches_final_location(
-            &location,
-            final_path.as_ref(),
-            42,
-            &None,
-        ));
-
-        location.size = None;
-        assert!(!matches_final_location(
-            &location,
-            final_path.as_ref(),
-            42,
-            &Some("final-etag".to_string()),
-        ));
     }
 }

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -42,13 +42,8 @@ use crate::io::commit::{CommitError, CommitHandler};
 /// <https://github.com/lance-format/lance/assets/12615154/b0822312-0826-432a-b554-3965f8d48d04>
 #[async_trait]
 pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
-    /// Whether this store is paired with an object store whose
-    /// `copy_if_not_exists` implementation is known to provide an atomic,
-    /// synchronous destination create.
-    ///
-    /// The conservative default preserves the existing copy behavior. Stores
-    /// that opt in use destination creation as the object-level linearization
-    /// point for supported manifest sizes.
+    /// Whether the paired object store provides an atomic, synchronous
+    /// `copy_if_not_exists` for supported manifest sizes.
     fn use_create_only_manifest_copy(&self) -> bool {
         false
     }
@@ -179,13 +174,8 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
         e_tag: Option<String>,
     ) -> Result<()>;
 
-    /// Publish a finalized manifest only while the external row still points at
-    /// the staging object being materialized.
-    ///
-    /// Stores with conditional-write support should override this method with
-    /// an atomic compare-and-swap. The default preserves compatibility for
-    /// stores where create-only object materialization is the only available
-    /// serialization primitive.
+    /// Publish `final_path` only while the row still points at `staging_path`.
+    /// Conditional stores should override this with an atomic compare-and-swap.
     #[allow(clippy::too_many_arguments)]
     async fn finalize_staging_manifest(
         &self,
@@ -348,35 +338,14 @@ async fn copy_via_read_rewrite(
 const MANIFEST_COMPARE_RANGE_BYTES: u64 = 8 * 1024 * 1024;
 
 enum MaterializeManifestResult {
-    Created(ObjectMeta),
-    Existing(ObjectMeta),
-    /// Compatibility path for stores or object sizes without an atomic
-    /// create-only copy primitive.
-    Overwritten(ObjectMeta),
-    SourceMissing,
+    Available(ObjectMeta),
+    SourceMissing(u64),
 }
 
 enum ManifestComparison {
     Match,
     Different,
     SourceMissing,
-}
-
-fn published_location_matches_object(
-    published: &ManifestLocation,
-    final_path: &Path,
-    final_meta: &ObjectMeta,
-) -> bool {
-    published.path == *final_path
-        && published
-            .size
-            .map(|size| size == final_meta.size)
-            .unwrap_or(true)
-        && published
-            .e_tag
-            .as_ref()
-            .map(|e_tag| Some(e_tag) == final_meta.e_tag.as_ref())
-            .unwrap_or(true)
 }
 
 fn validate_materialized_size(
@@ -436,7 +405,7 @@ async fn resolve_existing_manifest(
     )?;
 
     match manifests_match(store, staging_path, final_path, staging_size).await {
-        Ok(ManifestComparison::Match) => Ok(MaterializeManifestResult::Existing(final_meta)),
+        Ok(ManifestComparison::Match) => Ok(MaterializeManifestResult::Available(final_meta)),
         Ok(ManifestComparison::Different) => Err(Error::corrupt_file(
             final_path.clone(),
             format!(
@@ -444,7 +413,9 @@ async fn resolve_existing_manifest(
                 staging_path
             ),
         )),
-        Ok(ManifestComparison::SourceMissing) => Ok(MaterializeManifestResult::SourceMissing),
+        Ok(ManifestComparison::SourceMissing) => {
+            Ok(MaterializeManifestResult::SourceMissing(staging_size))
+        }
         Err(e) => Err(e.into()),
     }
 }
@@ -478,13 +449,14 @@ async fn materialize_manifest_create(
     if use_create_only_copy && size < MAX_SERVER_SIDE_COPY_BYTES {
         match store.copy_if_not_exists(staging_path, final_path).await {
             Ok(()) => {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
                 let final_meta = validate_materialized_size(
                     store.head(final_path).await?,
                     final_path,
                     staging_path,
                     size,
                 )?;
-                return Ok(MaterializeManifestResult::Created(final_meta));
+                return Ok(MaterializeManifestResult::Available(final_meta));
             }
             Err(ObjectStoreError::AlreadyExists { .. })
             | Err(ObjectStoreError::Precondition { .. }) => {
@@ -500,21 +472,18 @@ async fn materialize_manifest_create(
 
     match copy_size_aware(store, staging_path, final_path, size).await {
         Ok(()) => {
+            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
             let final_meta = validate_materialized_size(
                 store.head(final_path).await?,
                 final_path,
                 staging_path,
                 size,
             )?;
-            Ok(MaterializeManifestResult::Overwritten(final_meta))
+            Ok(MaterializeManifestResult::Available(final_meta))
         }
-        Err(error @ ObjectStoreError::NotFound { .. }) => match store.head(final_path).await {
-            Ok(meta) => {
-                validate_materialized_size(meta, final_path, staging_path, size)?;
-                Ok(MaterializeManifestResult::SourceMissing)
-            }
-            Err(_) => Err(error.into()),
-        },
+        Err(ObjectStoreError::NotFound { .. }) => {
+            Ok(MaterializeManifestResult::SourceMissing(size))
+        }
         Err(error) => Err(error.into()),
     }
 }
@@ -530,42 +499,22 @@ async fn complete_manifest_finalization<S: ExternalManifestStore + ?Sized>(
     object_store: &dyn OSObjectStore,
     materialized: MaterializeManifestResult,
 ) -> Result<ManifestLocation> {
-    let (final_meta, published_e_tag) = match materialized {
-        MaterializeManifestResult::Created(meta) => {
-            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
-            let e_tag = meta.e_tag.clone();
-            (meta, e_tag)
-        }
-        MaterializeManifestResult::Existing(meta) => {
-            let e_tag = meta.e_tag.clone();
-            (meta, e_tag)
-        }
-        MaterializeManifestResult::Overwritten(meta) => {
-            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
-            let e_tag = meta.e_tag.clone();
-            (meta, e_tag)
-        }
-        MaterializeManifestResult::SourceMissing => {
-            let current_meta = object_store.head(&final_path).await?;
-            let published = external_store
-                .get_manifest_location(base_path.as_ref(), version)
-                .await?;
-            if published_location_matches_object(&published, &final_path, &current_meta) {
-                return Ok(ManifestLocation {
-                    version,
-                    path: final_path,
-                    size: Some(current_meta.size),
-                    naming_scheme,
-                    e_tag: current_meta.e_tag,
-                });
-            }
-            return Err(Error::corrupt_file(
-                staging_path.clone(),
-                format!(
-                    "Staging manifest disappeared before final metadata for version {} was published",
-                    version
-                ),
-            ));
+    let final_meta = match materialized {
+        MaterializeManifestResult::Available(meta) => meta,
+        MaterializeManifestResult::SourceMissing(staging_size) => {
+            let current_meta = validate_materialized_size(
+                object_store.head(&final_path).await?,
+                &final_path,
+                staging_path,
+                staging_size,
+            )?;
+            return Ok(ManifestLocation {
+                version,
+                path: final_path,
+                size: Some(current_meta.size),
+                naming_scheme,
+                e_tag: current_meta.e_tag,
+            });
         }
     };
 
@@ -574,7 +523,7 @@ async fn complete_manifest_finalization<S: ExternalManifestStore + ?Sized>(
         path: final_path,
         size: Some(final_meta.size),
         naming_scheme,
-        e_tag: published_e_tag,
+        e_tag: final_meta.e_tag.clone(),
     };
 
     external_store
@@ -996,6 +945,10 @@ mod tests {
     struct LostPutResponseStore {
         manifests: Mutex<HashMap<(String, u64), StoredManifest>>,
         fail_next_put_response: AtomicBool,
+        block_first_final_publish: bool,
+        final_publish_calls: AtomicUsize,
+        first_final_publish_started: Notify,
+        release_first_final_publish: Notify,
     }
 
     impl Default for LostPutResponseStore {
@@ -1003,12 +956,30 @@ mod tests {
             Self {
                 manifests: Mutex::new(HashMap::new()),
                 fail_next_put_response: AtomicBool::new(true),
+                block_first_final_publish: false,
+                final_publish_calls: AtomicUsize::new(0),
+                first_final_publish_started: Notify::new(),
+                release_first_final_publish: Notify::new(),
+            }
+        }
+    }
+
+    impl LostPutResponseStore {
+        fn blocking_first_final_publish() -> Self {
+            Self {
+                fail_next_put_response: AtomicBool::new(false),
+                block_first_final_publish: true,
+                ..Default::default()
             }
         }
     }
 
     #[async_trait]
     impl ExternalManifestStore for LostPutResponseStore {
+        fn use_create_only_manifest_copy(&self) -> bool {
+            self.block_first_final_publish
+        }
+
         async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
             self.manifests
                 .lock()
@@ -1091,6 +1062,12 @@ mod tests {
             size: u64,
             e_tag: Option<String>,
         ) -> Result<()> {
+            if self.block_first_final_publish
+                && self.final_publish_calls.fetch_add(1, Ordering::SeqCst) == 0
+            {
+                self.first_final_publish_started.notify_one();
+                self.release_first_final_publish.notified().await;
+            }
             let key = (base_uri.to_string(), version);
             let mut manifests = self.manifests.lock().unwrap();
             let manifest = manifests
@@ -1102,81 +1079,6 @@ mod tests {
                 e_tag,
             };
             Ok(())
-        }
-    }
-
-    #[derive(Debug)]
-    struct FirstFinalPublishBlockedStore {
-        inner: LostPutResponseStore,
-        final_publish_calls: AtomicUsize,
-        first_final_publish_started: Notify,
-        release_first_final_publish: Notify,
-    }
-
-    impl Default for FirstFinalPublishBlockedStore {
-        fn default() -> Self {
-            Self {
-                inner: LostPutResponseStore {
-                    manifests: Mutex::new(HashMap::new()),
-                    fail_next_put_response: AtomicBool::new(false),
-                },
-                final_publish_calls: AtomicUsize::new(0),
-                first_final_publish_started: Notify::new(),
-                release_first_final_publish: Notify::new(),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl ExternalManifestStore for FirstFinalPublishBlockedStore {
-        fn use_create_only_manifest_copy(&self) -> bool {
-            true
-        }
-
-        async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
-            self.inner.get(base_uri, version).await
-        }
-
-        async fn get_manifest_location(
-            &self,
-            base_uri: &str,
-            version: u64,
-        ) -> Result<ManifestLocation> {
-            self.inner.get_manifest_location(base_uri, version).await
-        }
-
-        async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
-            self.inner.get_latest_version(base_uri).await
-        }
-
-        async fn put_if_not_exists(
-            &self,
-            base_uri: &str,
-            version: u64,
-            path: &str,
-            size: u64,
-            e_tag: Option<String>,
-        ) -> Result<()> {
-            self.inner
-                .put_if_not_exists(base_uri, version, path, size, e_tag)
-                .await
-        }
-
-        async fn put_if_exists(
-            &self,
-            base_uri: &str,
-            version: u64,
-            path: &str,
-            size: u64,
-            e_tag: Option<String>,
-        ) -> Result<()> {
-            if self.final_publish_calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                self.first_final_publish_started.notify_one();
-                self.release_first_final_publish.notified().await;
-            }
-            self.inner
-                .put_if_exists(base_uri, version, path, size, e_tag)
-                .await
         }
     }
 
@@ -1225,7 +1127,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_existing_final_manifest_must_match_staging_bytes() {
+    async fn test_existing_manifest_validation() {
         let object_store = ObjectStore::memory();
         let staging_path = Path::from("dataset/_versions/1.manifest-staging-test");
         let final_path = Path::from("dataset/_versions/1.manifest");
@@ -1237,6 +1139,14 @@ mod tests {
             )
             .await
             .unwrap();
+
+        let missing_final =
+            manifests_match(object_store.inner.as_ref(), &staging_path, &final_path, 7).await;
+        assert!(matches!(
+            missing_final,
+            Err(ObjectStoreError::NotFound { .. })
+        ));
+
         object_store
             .inner
             .put(
@@ -1265,61 +1175,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_missing_final_is_not_mistaken_for_missing_staging() {
-        let object_store = ObjectStore::memory();
-        let staging_path = Path::from("dataset/_versions/1.manifest-staging-test");
-        let final_path = Path::from("dataset/_versions/1.manifest");
-        object_store
-            .inner
-            .put(
-                &staging_path,
-                object_store::PutPayload::from_static(b"staging"),
-            )
-            .await
-            .unwrap();
-
-        let result =
-            manifests_match(object_store.inner.as_ref(), &staging_path, &final_path, 7).await;
-        assert!(matches!(result, Err(ObjectStoreError::NotFound { .. })));
-    }
-
-    #[tokio::test]
-    async fn test_source_missing_accepts_path_only_store_metadata() {
-        let object_store = ObjectStore::memory();
-        let final_path = Path::from("dataset/_versions/1.manifest");
-        object_store
-            .inner
-            .put(
-                &final_path,
-                object_store::PutPayload::from_static(b"manifest"),
-            )
-            .await
-            .unwrap();
-        let final_meta = object_store.inner.head(&final_path).await.unwrap();
-        let published = ManifestLocation {
-            version: 1,
-            path: final_path.clone(),
-            size: None,
-            naming_scheme: ManifestNamingScheme::V1,
-            e_tag: None,
-        };
-
-        assert!(published_location_matches_object(
-            &published,
-            &final_path,
-            &final_meta
-        ));
-
-        let mut stale = published;
-        stale.e_tag = Some("stale-etag".to_string());
-        assert!(!published_location_matches_object(
-            &stale,
-            &final_path,
-            &final_meta
-        ));
-    }
-
     #[rstest::rstest]
     #[case(ManifestNamingScheme::V1)]
     #[case(ManifestNamingScheme::V2)]
@@ -1327,7 +1182,7 @@ mod tests {
     async fn test_concurrent_direct_and_reader_finalization_preserves_winner_metadata(
         #[case] naming_scheme: ManifestNamingScheme,
     ) {
-        let external_store = Arc::new(FirstFinalPublishBlockedStore::default());
+        let external_store = Arc::new(LostPutResponseStore::blocking_first_final_publish());
         let handler = ExternalManifestCommitHandler {
             external_manifest_store: external_store.clone(),
         };
@@ -1343,12 +1198,8 @@ mod tests {
                 object_store::PutPayload::from_static(b"manifest body"),
             )
             .await
-            .expect("seed staging manifest");
-        let staging_meta = object_store
-            .inner
-            .head(&staging_path)
-            .await
-            .expect("read staging metadata");
+            .unwrap();
+        let staging_meta = object_store.inner.head(&staging_path).await.unwrap();
 
         let writer_store = object_store.inner.clone();
         let writer_external_store = external_store.clone();
@@ -1384,34 +1235,23 @@ mod tests {
             .await;
 
         external_store.release_first_final_publish.notify_one();
-        let reader_location = reader_result.expect("reader-assisted finalization should succeed");
-        let writer_location = writer
-            .await
-            .expect("direct finalizer task should not panic")
-            .expect("direct finalization should succeed");
+        let reader_location = reader_result.unwrap();
+        let writer_location = writer.await.unwrap().unwrap();
 
-        let final_meta = object_store
-            .inner
-            .head(&final_path)
-            .await
-            .expect("read finalized metadata");
+        let final_meta = object_store.inner.head(&final_path).await.unwrap();
         let stored_location = external_store
             .get_manifest_location(base_path.as_ref(), version)
             .await
-            .expect("read published manifest location");
+            .unwrap();
 
-        assert_eq!(stored_location.path, final_path);
-        assert_eq!(stored_location.size, Some(final_meta.size));
-        assert_eq!(
-            stored_location.e_tag, final_meta.e_tag,
-            "external metadata must describe the materialized winner"
-        );
-        assert_eq!(writer_location.path, final_path);
-        assert_eq!(writer_location.size, Some(final_meta.size));
-        assert_eq!(writer_location.e_tag, final_meta.e_tag);
-        assert_eq!(reader_location.path, final_path);
-        assert_eq!(reader_location.size, Some(final_meta.size));
-        assert_eq!(reader_location.e_tag, final_meta.e_tag);
+        for location in [&stored_location, &writer_location, &reader_location] {
+            assert_eq!(location.path, final_path);
+            assert_eq!(location.size, Some(final_meta.size));
+            assert_eq!(
+                location.e_tag, final_meta.e_tag,
+                "all finalizers must describe the materialized winner"
+            );
+        }
 
         handler
             .resolve_version_location(&base_path, version, object_store.inner.as_ref())

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -42,6 +42,17 @@ use crate::io::commit::{CommitError, CommitHandler};
 /// <https://github.com/lance-format/lance/assets/12615154/b0822312-0826-432a-b554-3965f8d48d04>
 #[async_trait]
 pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
+    /// Whether this store is paired with an object store whose
+    /// `copy_if_not_exists` implementation is known to provide an atomic,
+    /// synchronous destination create.
+    ///
+    /// The conservative default preserves the existing copy behavior. Stores
+    /// that opt in use destination creation as the object-level linearization
+    /// point for supported manifest sizes.
+    fn use_create_only_manifest_copy(&self) -> bool {
+        false
+    }
+
     /// Get the manifest path for a given base_uri and version
     async fn get(&self, base_uri: &str, version: u64) -> Result<String>;
 
@@ -123,54 +134,29 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
         )
         .await?;
 
-        // Step 2: Copy staging to final path
+        // Step 2: Materialize staging at the final path. Stores that opt in use
+        // create-only copy for supported manifest sizes.
         let final_path = naming_scheme.manifest_path(base_path, version);
-        let copied = match copy_size_aware(object_store, staging_path, &final_path, size).await {
-            Ok(_) => true,
-            Err(ObjectStoreError::NotFound { .. }) => false,
-            Err(e) => return Err(e.into()),
-        };
-        if copied {
-            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
-        }
-
-        // A copy creates a new object whose metadata may differ from the source.
-        // Read the destination metadata before publishing the final path.
-        let final_meta = object_store.head(&final_path).await?;
-        let final_size = final_meta.size;
-        let final_e_tag = final_meta.e_tag;
-
-        let location = ManifestLocation {
-            version,
-            path: final_path.clone(),
-            size: Some(final_size),
-            naming_scheme,
-            e_tag: final_e_tag.clone(),
-        };
-
-        if !copied {
-            return Ok(location);
-        }
-
-        // Step 3: Update external store to final path
-        self.put_if_exists(
-            base_path.as_ref(),
-            version,
-            final_path.as_ref(),
-            final_size,
-            final_e_tag,
+        let materialized = materialize_manifest_create(
+            object_store,
+            staging_path,
+            &final_path,
+            size,
+            self.use_create_only_manifest_copy(),
         )
         .await?;
 
-        // Step 4: Delete staging manifest
-        match object_store.delete(staging_path).await {
-            Ok(_) => {}
-            Err(ObjectStoreError::NotFound { .. }) => {}
-            Err(e) => return Err(e.into()),
-        }
-        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_MANIFEST, path = staging_path.as_ref());
-
-        Ok(location)
+        complete_manifest_finalization(
+            self,
+            base_path,
+            version,
+            staging_path,
+            final_path,
+            naming_scheme,
+            object_store,
+            materialized,
+        )
+        .await
     }
 
     /// Put the manifest path for a given base_uri and version, should fail if the version already exists
@@ -192,6 +178,27 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
         size: u64,
         e_tag: Option<String>,
     ) -> Result<()>;
+
+    /// Publish a finalized manifest only while the external row still points at
+    /// the staging object being materialized.
+    ///
+    /// Stores with conditional-write support should override this method with
+    /// an atomic compare-and-swap. The default preserves compatibility for
+    /// stores where create-only object materialization is the only available
+    /// serialization primitive.
+    #[allow(clippy::too_many_arguments)]
+    async fn finalize_staging_manifest(
+        &self,
+        base_uri: &str,
+        version: u64,
+        _staging_path: &str,
+        final_path: &str,
+        size: u64,
+        e_tag: Option<String>,
+    ) -> Result<()> {
+        self.put_if_exists(base_uri, version, final_path, size, e_tag)
+            .await
+    }
 
     /// Delete the manifest information for given base_uri from the store
     async fn delete(&self, _base_uri: &str) -> Result<()> {
@@ -336,6 +343,260 @@ async fn copy_via_read_rewrite(
     Ok(())
 }
 
+/// Range size used to validate a create-only winner without buffering a whole
+/// manifest. This is only paid by finalizers that lose a destination create.
+const MANIFEST_COMPARE_RANGE_BYTES: u64 = 8 * 1024 * 1024;
+
+enum MaterializeManifestResult {
+    Created(ObjectMeta),
+    Existing(ObjectMeta),
+    /// Compatibility path for stores or object sizes without an atomic
+    /// create-only copy primitive.
+    Overwritten(ObjectMeta),
+    SourceMissing,
+}
+
+enum ManifestComparison {
+    Match,
+    Different,
+    SourceMissing,
+}
+
+fn published_location_matches_object(
+    published: &ManifestLocation,
+    final_path: &Path,
+    final_meta: &ObjectMeta,
+) -> bool {
+    published.path == *final_path
+        && published
+            .size
+            .map(|size| size == final_meta.size)
+            .unwrap_or(true)
+        && published
+            .e_tag
+            .as_ref()
+            .map(|e_tag| Some(e_tag) == final_meta.e_tag.as_ref())
+            .unwrap_or(true)
+}
+
+fn validate_materialized_size(
+    final_meta: ObjectMeta,
+    final_path: &Path,
+    staging_path: &Path,
+    staging_size: u64,
+) -> Result<ObjectMeta> {
+    if final_meta.size != staging_size {
+        return Err(Error::corrupt_file(
+            final_path.clone(),
+            format!(
+                "Finalized manifest has size {}, expected {} from staging manifest '{}'",
+                final_meta.size, staging_size, staging_path
+            ),
+        ));
+    }
+    Ok(final_meta)
+}
+
+async fn manifests_match(
+    store: &dyn OSObjectStore,
+    staging_path: &Path,
+    final_path: &Path,
+    size: u64,
+) -> std::result::Result<ManifestComparison, ObjectStoreError> {
+    let mut start = 0;
+    while start < size {
+        let end = (start + MANIFEST_COMPARE_RANGE_BYTES).min(size);
+        let staging = match store.get_range(staging_path, start..end).await {
+            Ok(staging) => staging,
+            Err(ObjectStoreError::NotFound { .. }) => {
+                return Ok(ManifestComparison::SourceMissing);
+            }
+            Err(e) => return Err(e),
+        };
+        let final_bytes = store.get_range(final_path, start..end).await?;
+        if staging != final_bytes {
+            return Ok(ManifestComparison::Different);
+        }
+        start = end;
+    }
+    Ok(ManifestComparison::Match)
+}
+
+async fn resolve_existing_manifest(
+    store: &dyn OSObjectStore,
+    staging_path: &Path,
+    final_path: &Path,
+    staging_size: u64,
+) -> Result<MaterializeManifestResult> {
+    let final_meta = validate_materialized_size(
+        store.head(final_path).await?,
+        final_path,
+        staging_path,
+        staging_size,
+    )?;
+
+    match manifests_match(store, staging_path, final_path, staging_size).await {
+        Ok(ManifestComparison::Match) => Ok(MaterializeManifestResult::Existing(final_meta)),
+        Ok(ManifestComparison::Different) => Err(Error::corrupt_file(
+            final_path.clone(),
+            format!(
+                "Existing finalized manifest does not match staging manifest '{}'",
+                staging_path
+            ),
+        )),
+        Ok(ManifestComparison::SourceMissing) => Ok(MaterializeManifestResult::SourceMissing),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn resolve_create_error(
+    store: &dyn OSObjectStore,
+    staging_path: &Path,
+    final_path: &Path,
+    staging_size: u64,
+    create_error: ObjectStoreError,
+) -> Result<MaterializeManifestResult> {
+    match store.head(final_path).await {
+        Ok(_) => resolve_existing_manifest(store, staging_path, final_path, staging_size).await,
+        Err(_) => Err(create_error.into()),
+    }
+}
+
+/// Materialize `staging_path` at `final_path`.
+///
+/// Stores that are known to support atomic create-only copy use it for
+/// manifests within the server-side copy limit. Other stores, and larger
+/// manifests, retain the compatible overwrite/read-and-rewrite path and its
+/// strict destination ETag validation.
+async fn materialize_manifest_create(
+    store: &dyn OSObjectStore,
+    staging_path: &Path,
+    final_path: &Path,
+    size: u64,
+    use_create_only_copy: bool,
+) -> Result<MaterializeManifestResult> {
+    if use_create_only_copy && size < MAX_SERVER_SIDE_COPY_BYTES {
+        match store.copy_if_not_exists(staging_path, final_path).await {
+            Ok(()) => {
+                let final_meta = validate_materialized_size(
+                    store.head(final_path).await?,
+                    final_path,
+                    staging_path,
+                    size,
+                )?;
+                return Ok(MaterializeManifestResult::Created(final_meta));
+            }
+            Err(ObjectStoreError::AlreadyExists { .. })
+            | Err(ObjectStoreError::Precondition { .. }) => {
+                return resolve_existing_manifest(store, staging_path, final_path, size).await;
+            }
+            Err(ObjectStoreError::NotImplemented { .. })
+            | Err(ObjectStoreError::NotSupported { .. }) => {}
+            Err(error) => {
+                return resolve_create_error(store, staging_path, final_path, size, error).await;
+            }
+        }
+    }
+
+    match copy_size_aware(store, staging_path, final_path, size).await {
+        Ok(()) => {
+            let final_meta = validate_materialized_size(
+                store.head(final_path).await?,
+                final_path,
+                staging_path,
+                size,
+            )?;
+            Ok(MaterializeManifestResult::Overwritten(final_meta))
+        }
+        Err(error @ ObjectStoreError::NotFound { .. }) => match store.head(final_path).await {
+            Ok(meta) => {
+                validate_materialized_size(meta, final_path, staging_path, size)?;
+                Ok(MaterializeManifestResult::SourceMissing)
+            }
+            Err(_) => Err(error.into()),
+        },
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn complete_manifest_finalization<S: ExternalManifestStore + ?Sized>(
+    external_store: &S,
+    base_path: &Path,
+    version: u64,
+    staging_path: &Path,
+    final_path: Path,
+    naming_scheme: ManifestNamingScheme,
+    object_store: &dyn OSObjectStore,
+    materialized: MaterializeManifestResult,
+) -> Result<ManifestLocation> {
+    let (final_meta, published_e_tag) = match materialized {
+        MaterializeManifestResult::Created(meta) => {
+            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
+            let e_tag = meta.e_tag.clone();
+            (meta, e_tag)
+        }
+        MaterializeManifestResult::Existing(meta) => {
+            let e_tag = meta.e_tag.clone();
+            (meta, e_tag)
+        }
+        MaterializeManifestResult::Overwritten(meta) => {
+            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_path.as_ref());
+            let e_tag = meta.e_tag.clone();
+            (meta, e_tag)
+        }
+        MaterializeManifestResult::SourceMissing => {
+            let current_meta = object_store.head(&final_path).await?;
+            let published = external_store
+                .get_manifest_location(base_path.as_ref(), version)
+                .await?;
+            if published_location_matches_object(&published, &final_path, &current_meta) {
+                return Ok(ManifestLocation {
+                    version,
+                    path: final_path,
+                    size: Some(current_meta.size),
+                    naming_scheme,
+                    e_tag: current_meta.e_tag,
+                });
+            }
+            return Err(Error::corrupt_file(
+                staging_path.clone(),
+                format!(
+                    "Staging manifest disappeared before final metadata for version {} was published",
+                    version
+                ),
+            ));
+        }
+    };
+
+    let location = ManifestLocation {
+        version,
+        path: final_path,
+        size: Some(final_meta.size),
+        naming_scheme,
+        e_tag: published_e_tag,
+    };
+
+    external_store
+        .finalize_staging_manifest(
+            base_path.as_ref(),
+            version,
+            staging_path.as_ref(),
+            location.path.as_ref(),
+            final_meta.size,
+            location.e_tag.clone(),
+        )
+        .await?;
+
+    match object_store.delete(staging_path).await {
+        Ok(()) | Err(ObjectStoreError::NotFound { .. }) => {}
+        Err(e) => return Err(e.into()),
+    }
+    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_MANIFEST, path = staging_path.as_ref());
+
+    Ok(location)
+}
+
 /// External manifest commit handler
 /// This handler is used to commit a manifest to an external store
 /// for detailed design, see <https://github.com/lance-format/lance/issues/1183>
@@ -427,57 +688,27 @@ impl ExternalManifestCommitHandler {
         store: &dyn OSObjectStore,
         naming_scheme: ManifestNamingScheme,
     ) -> std::result::Result<ManifestLocation, Error> {
-        // step 1: copy the manifest to the final location
         let final_manifest_path = naming_scheme.manifest_path(base_path, version);
+        let materialized = materialize_manifest_create(
+            store,
+            staging_manifest_path,
+            &final_manifest_path,
+            size,
+            self.external_manifest_store.use_create_only_manifest_copy(),
+        )
+        .await?;
 
-        let copied =
-            match copy_size_aware(store, staging_manifest_path, &final_manifest_path, size).await {
-                Ok(_) => true,
-                Err(ObjectStoreError::NotFound { .. }) => false, // Another writer beat us to it.
-                Err(e) => return Err(e.into()),
-            };
-        if copied {
-            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_MANIFEST, path = final_manifest_path.as_ref());
-        }
-
-        // A copy creates a new object whose metadata may differ from the source.
-        // Read the destination metadata before publishing the final path.
-        let final_meta = store.head(&final_manifest_path).await?;
-        let final_size = final_meta.size;
-        let final_e_tag = final_meta.e_tag;
-
-        let location = ManifestLocation {
+        complete_manifest_finalization(
+            self.external_manifest_store.as_ref(),
+            base_path,
             version,
-            path: final_manifest_path,
-            size: Some(final_size),
+            staging_manifest_path,
+            final_manifest_path,
             naming_scheme,
-            e_tag: final_e_tag,
-        };
-
-        if !copied {
-            return Ok(location);
-        }
-
-        // step 2: flip the external store to point to the final location
-        self.external_manifest_store
-            .put_if_exists(
-                base_path.as_ref(),
-                version,
-                location.path.as_ref(),
-                final_size,
-                location.e_tag.clone(),
-            )
-            .await?;
-
-        // step 3: delete the staging manifest
-        match store.delete(staging_manifest_path).await {
-            Ok(_) => {}
-            Err(ObjectStoreError::NotFound { .. }) => {}
-            Err(e) => return Err(e.into()),
-        }
-        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_MANIFEST, path = staging_manifest_path.as_ref());
-
-        Ok(location)
+            store,
+            materialized,
+        )
+        .await
     }
 }
 
@@ -743,11 +974,12 @@ impl CommitHandler for ExternalManifestCommitHandler {
 mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_core::datatypes::Schema;
     use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
+    use tokio::sync::Notify;
 
     use super::*;
     use crate::format::DataStorageFormat;
@@ -873,6 +1105,81 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FirstFinalPublishBlockedStore {
+        inner: LostPutResponseStore,
+        final_publish_calls: AtomicUsize,
+        first_final_publish_started: Notify,
+        release_first_final_publish: Notify,
+    }
+
+    impl Default for FirstFinalPublishBlockedStore {
+        fn default() -> Self {
+            Self {
+                inner: LostPutResponseStore {
+                    manifests: Mutex::new(HashMap::new()),
+                    fail_next_put_response: AtomicBool::new(false),
+                },
+                final_publish_calls: AtomicUsize::new(0),
+                first_final_publish_started: Notify::new(),
+                release_first_final_publish: Notify::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ExternalManifestStore for FirstFinalPublishBlockedStore {
+        fn use_create_only_manifest_copy(&self) -> bool {
+            true
+        }
+
+        async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
+            self.inner.get(base_uri, version).await
+        }
+
+        async fn get_manifest_location(
+            &self,
+            base_uri: &str,
+            version: u64,
+        ) -> Result<ManifestLocation> {
+            self.inner.get_manifest_location(base_uri, version).await
+        }
+
+        async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
+            self.inner.get_latest_version(base_uri).await
+        }
+
+        async fn put_if_not_exists(
+            &self,
+            base_uri: &str,
+            version: u64,
+            path: &str,
+            size: u64,
+            e_tag: Option<String>,
+        ) -> Result<()> {
+            self.inner
+                .put_if_not_exists(base_uri, version, path, size, e_tag)
+                .await
+        }
+
+        async fn put_if_exists(
+            &self,
+            base_uri: &str,
+            version: u64,
+            path: &str,
+            size: u64,
+            e_tag: Option<String>,
+        ) -> Result<()> {
+            if self.final_publish_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.first_final_publish_started.notify_one();
+                self.release_first_final_publish.notified().await;
+            }
+            self.inner
+                .put_if_exists(base_uri, version, path, size, e_tag)
+                .await
+        }
+    }
+
     #[tokio::test]
     async fn test_lost_external_store_response_retains_staging_manifest() {
         let external_store = Arc::new(LostPutResponseStore::default());
@@ -915,5 +1222,200 @@ mod tests {
             ManifestNamingScheme::V2.manifest_path(&base_path, 1)
         );
         object_store.inner.head(&resolved.path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_existing_final_manifest_must_match_staging_bytes() {
+        let object_store = ObjectStore::memory();
+        let staging_path = Path::from("dataset/_versions/1.manifest-staging-test");
+        let final_path = Path::from("dataset/_versions/1.manifest");
+        object_store
+            .inner
+            .put(
+                &staging_path,
+                object_store::PutPayload::from_static(b"staging"),
+            )
+            .await
+            .unwrap();
+        object_store
+            .inner
+            .put(
+                &final_path,
+                object_store::PutPayload::from_static(b"foreign"),
+            )
+            .await
+            .unwrap();
+
+        let result = materialize_manifest_create(
+            object_store.inner.as_ref(),
+            &staging_path,
+            &final_path,
+            7,
+            true,
+        )
+        .await;
+        let Err(error) = result else {
+            panic!("a different existing destination must not be accepted");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("does not match staging manifest"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_final_is_not_mistaken_for_missing_staging() {
+        let object_store = ObjectStore::memory();
+        let staging_path = Path::from("dataset/_versions/1.manifest-staging-test");
+        let final_path = Path::from("dataset/_versions/1.manifest");
+        object_store
+            .inner
+            .put(
+                &staging_path,
+                object_store::PutPayload::from_static(b"staging"),
+            )
+            .await
+            .unwrap();
+
+        let result =
+            manifests_match(object_store.inner.as_ref(), &staging_path, &final_path, 7).await;
+        assert!(matches!(result, Err(ObjectStoreError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_source_missing_accepts_path_only_store_metadata() {
+        let object_store = ObjectStore::memory();
+        let final_path = Path::from("dataset/_versions/1.manifest");
+        object_store
+            .inner
+            .put(
+                &final_path,
+                object_store::PutPayload::from_static(b"manifest"),
+            )
+            .await
+            .unwrap();
+        let final_meta = object_store.inner.head(&final_path).await.unwrap();
+        let published = ManifestLocation {
+            version: 1,
+            path: final_path.clone(),
+            size: None,
+            naming_scheme: ManifestNamingScheme::V1,
+            e_tag: None,
+        };
+
+        assert!(published_location_matches_object(
+            &published,
+            &final_path,
+            &final_meta
+        ));
+
+        let mut stale = published;
+        stale.e_tag = Some("stale-etag".to_string());
+        assert!(!published_location_matches_object(
+            &stale,
+            &final_path,
+            &final_meta
+        ));
+    }
+
+    #[rstest::rstest]
+    #[case(ManifestNamingScheme::V1)]
+    #[case(ManifestNamingScheme::V2)]
+    #[tokio::test]
+    async fn test_concurrent_direct_and_reader_finalization_preserves_winner_metadata(
+        #[case] naming_scheme: ManifestNamingScheme,
+    ) {
+        let external_store = Arc::new(FirstFinalPublishBlockedStore::default());
+        let handler = ExternalManifestCommitHandler {
+            external_manifest_store: external_store.clone(),
+        };
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("dataset");
+        let version = 1;
+        let final_path = naming_scheme.manifest_path(&base_path, version);
+        let staging_path = make_staging_manifest_path(&final_path).unwrap();
+        object_store
+            .inner
+            .put(
+                &staging_path,
+                object_store::PutPayload::from_static(b"manifest body"),
+            )
+            .await
+            .expect("seed staging manifest");
+        let staging_meta = object_store
+            .inner
+            .head(&staging_path)
+            .await
+            .expect("read staging metadata");
+
+        let writer_store = object_store.inner.clone();
+        let writer_external_store = external_store.clone();
+        let writer_base_path = base_path.clone();
+        let writer_staging_path = staging_path.clone();
+        let writer_e_tag = staging_meta.e_tag.clone();
+        let writer = tokio::spawn(async move {
+            writer_external_store
+                .put(
+                    &writer_base_path,
+                    version,
+                    &writer_staging_path,
+                    staging_meta.size,
+                    writer_e_tag,
+                    writer_store.as_ref(),
+                    naming_scheme,
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            external_store.first_final_publish_started.notified(),
+        )
+        .await
+        .expect("direct finalizer should reach metadata publication");
+
+        // The direct writer has copied the destination and read its metadata,
+        // but has not published it yet. A reader now observes the staging row
+        // and helps finalize the same manifest.
+        let reader_result = handler
+            .resolve_version_location(&base_path, version, object_store.inner.as_ref())
+            .await;
+
+        external_store.release_first_final_publish.notify_one();
+        let reader_location = reader_result.expect("reader-assisted finalization should succeed");
+        let writer_location = writer
+            .await
+            .expect("direct finalizer task should not panic")
+            .expect("direct finalization should succeed");
+
+        let final_meta = object_store
+            .inner
+            .head(&final_path)
+            .await
+            .expect("read finalized metadata");
+        let stored_location = external_store
+            .get_manifest_location(base_path.as_ref(), version)
+            .await
+            .expect("read published manifest location");
+
+        assert_eq!(stored_location.path, final_path);
+        assert_eq!(stored_location.size, Some(final_meta.size));
+        assert_eq!(
+            stored_location.e_tag, final_meta.e_tag,
+            "external metadata must describe the materialized winner"
+        );
+        assert_eq!(writer_location.path, final_path);
+        assert_eq!(writer_location.size, Some(final_meta.size));
+        assert_eq!(writer_location.e_tag, final_meta.e_tag);
+        assert_eq!(reader_location.path, final_path);
+        assert_eq!(reader_location.size, Some(final_meta.size));
+        assert_eq!(reader_location.e_tag, final_meta.e_tag);
+
+        handler
+            .resolve_version_location(&base_path, version, object_store.inner.as_ref())
+            .await
+            .expect("a strict reader should accept the finalized manifest");
     }
 }

--- a/rust/lance/src/io/commit/dynamodb.rs
+++ b/rust/lance/src/io/commit/dynamodb.rs
@@ -40,7 +40,7 @@ mod test {
         Dataset,
         dataset::{ReadParams, WriteMode, WriteParams, builder::DatasetBuilder},
     };
-    use lance_core::{Error, utils::tempfile::TempStrDir};
+    use lance_core::utils::tempfile::TempStrDir;
     use lance_table::io::commit::{
         CommitHandler, ManifestNamingScheme,
         dynamodb::DynamoDBExternalManifestStore,
@@ -59,11 +59,6 @@ mod test {
             commit_handler: Some(handler),
             ..Default::default()
         }
-    }
-
-    fn assert_dynamodb_write_error(error: &Error) {
-        assert!(matches!(error, Error::IO { .. }));
-        assert!(error.to_string().contains("WrappedSdkError"));
     }
 
     async fn make_dynamodb_store() -> Arc<dyn ExternalManifestStore> {
@@ -237,14 +232,6 @@ mod test {
             .await
             .unwrap();
 
-        let location = store
-            .get_manifest_location(base_uri, version)
-            .await
-            .unwrap();
-        assert_eq!(location.path, final_path);
-        assert_eq!(location.size, Some(final_size));
-        assert_eq!(location.e_tag, final_e_tag);
-
         // A retry sees the final row instead of the expected staging row. The
         // exact final tuple makes the failed conditional write idempotent.
         store
@@ -260,44 +247,31 @@ mod test {
             .unwrap();
 
         let replacement_path = ManifestNamingScheme::V2.manifest_path(&base_path, version + 1);
-        let stale_path_error = store
-            .finalize_staging_manifest(
-                base_uri,
-                version,
+        for (expected_staging, target, size, e_tag) in [
+            (
                 "cas-dataset/stale-staging",
                 replacement_path.as_ref(),
                 99,
                 Some("replacement-etag".to_string()),
-            )
-            .await
-            .unwrap_err();
-        assert_dynamodb_write_error(&stale_path_error);
-
-        let wrong_size_error = store
-            .finalize_staging_manifest(
-                base_uri,
-                version,
+            ),
+            (
                 staging_path.as_ref(),
                 final_path.as_ref(),
                 final_size + 1,
                 final_e_tag.clone(),
-            )
-            .await
-            .unwrap_err();
-        assert_dynamodb_write_error(&wrong_size_error);
-
-        let wrong_e_tag_error = store
-            .finalize_staging_manifest(
-                base_uri,
-                version,
+            ),
+            (
                 staging_path.as_ref(),
                 final_path.as_ref(),
                 final_size,
                 Some("stale-etag".to_string()),
-            )
-            .await
-            .unwrap_err();
-        assert_dynamodb_write_error(&wrong_e_tag_error);
+            ),
+        ] {
+            let result = store
+                .finalize_staging_manifest(base_uri, version, expected_staging, target, size, e_tag)
+                .await;
+            assert!(result.is_err());
+        }
 
         let location = store
             .get_manifest_location(base_uri, version)

--- a/rust/lance/src/io/commit/dynamodb.rs
+++ b/rust/lance/src/io/commit/dynamodb.rs
@@ -40,7 +40,7 @@ mod test {
         Dataset,
         dataset::{ReadParams, WriteMode, WriteParams, builder::DatasetBuilder},
     };
-    use lance_core::utils::tempfile::TempStrDir;
+    use lance_core::{Error, utils::tempfile::TempStrDir};
     use lance_table::io::commit::{
         CommitHandler, ManifestNamingScheme,
         dynamodb::DynamoDBExternalManifestStore,
@@ -59,6 +59,11 @@ mod test {
             commit_handler: Some(handler),
             ..Default::default()
         }
+    }
+
+    fn assert_dynamodb_write_error(error: &Error) {
+        assert!(matches!(error, Error::IO { .. }));
+        assert!(error.to_string().contains("WrappedSdkError"));
     }
 
     async fn make_dynamodb_store() -> Arc<dyn ExternalManifestStore> {
@@ -197,6 +202,110 @@ mod test {
 
         store.delete("test").await.unwrap();
         assert_eq!(store.get_latest_version("test").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_finalize_staging_manifest_cas() {
+        let store = make_dynamodb_store().await;
+        let base_path = Path::from("cas-dataset");
+        let base_uri = base_path.as_ref();
+        let version = 1;
+        let final_path = ManifestNamingScheme::V2.manifest_path(&base_path, version);
+        let staging_path = Path::from(format!("{final_path}-staging"));
+        let final_size = 42;
+        let final_e_tag = Some("final-etag".to_string());
+
+        store
+            .put_if_not_exists(
+                base_uri,
+                version,
+                staging_path.as_ref(),
+                21,
+                Some("staging-etag".to_string()),
+            )
+            .await
+            .unwrap();
+        store
+            .finalize_staging_manifest(
+                base_uri,
+                version,
+                staging_path.as_ref(),
+                final_path.as_ref(),
+                final_size,
+                final_e_tag.clone(),
+            )
+            .await
+            .unwrap();
+
+        let location = store
+            .get_manifest_location(base_uri, version)
+            .await
+            .unwrap();
+        assert_eq!(location.path, final_path);
+        assert_eq!(location.size, Some(final_size));
+        assert_eq!(location.e_tag, final_e_tag);
+
+        // A retry sees the final row instead of the expected staging row. The
+        // exact final tuple makes the failed conditional write idempotent.
+        store
+            .finalize_staging_manifest(
+                base_uri,
+                version,
+                staging_path.as_ref(),
+                final_path.as_ref(),
+                final_size,
+                final_e_tag.clone(),
+            )
+            .await
+            .unwrap();
+
+        let replacement_path = ManifestNamingScheme::V2.manifest_path(&base_path, version + 1);
+        let stale_path_error = store
+            .finalize_staging_manifest(
+                base_uri,
+                version,
+                "cas-dataset/stale-staging",
+                replacement_path.as_ref(),
+                99,
+                Some("replacement-etag".to_string()),
+            )
+            .await
+            .unwrap_err();
+        assert_dynamodb_write_error(&stale_path_error);
+
+        let wrong_size_error = store
+            .finalize_staging_manifest(
+                base_uri,
+                version,
+                staging_path.as_ref(),
+                final_path.as_ref(),
+                final_size + 1,
+                final_e_tag.clone(),
+            )
+            .await
+            .unwrap_err();
+        assert_dynamodb_write_error(&wrong_size_error);
+
+        let wrong_e_tag_error = store
+            .finalize_staging_manifest(
+                base_uri,
+                version,
+                staging_path.as_ref(),
+                final_path.as_ref(),
+                final_size,
+                Some("stale-etag".to_string()),
+            )
+            .await
+            .unwrap_err();
+        assert_dynamodb_write_error(&wrong_e_tag_error);
+
+        let location = store
+            .get_manifest_location(base_uri, version)
+            .await
+            .unwrap();
+        assert_eq!(location.path, final_path);
+        assert_eq!(location.size, Some(final_size));
+        assert_eq!(location.e_tag, final_e_tag);
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -920,6 +920,12 @@ mod test {
         capped
             .override_size(&staging_path, 14_961_429_442) // matches the production failure
             .await;
+        capped
+            .override_size(
+                &ManifestNamingScheme::V2.manifest_path(&base_path, 1),
+                14_961_429_442,
+            )
+            .await;
 
         // Spin up an ExternalManifestStore and drive `put` (the same code
         // path the failing CTAS hits via ExternalManifestCommitHandler).
@@ -951,6 +957,10 @@ mod test {
             capped.put_multipart_calls() >= 1,
             "read+rewrite path must initiate a multipart upload"
         );
+
+        let final_meta = capped.head(&location.path).await.unwrap();
+        assert_eq!(location.size, Some(final_meta.size));
+        assert_eq!(location.e_tag, final_meta.e_tag);
 
         // End-state assertions: final manifest exists with the original
         // bytes, and the staging file was deleted.


### PR DESCRIPTION
## What is the bug?

External-manifest finalization copies a staging manifest to a deterministic final path and then publishes the destination ETag. A direct writer and a reader-assisted finalizer can race:

1. A overwrites and HEADs destination ETag A.
2. B overwrites the same destination, HEADs ETag B, and publishes B.
3. A publishes its stale cached ETag A.

The object remains at ETag B while external metadata records A. A related ordering exposes a transient mismatch before metadata later converges.

## How does this PR fix the problem?

For native, non-Express AWS S3 reached through the standard `s3+ddb` path, with manifests below the single-copy 5 GiB limit:

- configure `copy_if_not_exists` to send destination `If-None-Match: *` on `CopyObject`;
- share create-only materialization between direct and reader-assisted finalization;
- make losers HEAD and byte-validate the immutable winner;
- publish DDB metadata with a compare-and-swap from the exact staging path;
- accept an ambiguous DDB result only after an exact, strongly consistent final tuple reread;
- delete staging only after publication is confirmed.

The capability is disabled for OpenDAL, custom endpoints, S3 Express, explicit copy configurations, and deprecated custom object stores.

AWS references:

- https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html

## Validation

- Deterministic V1/V2 direct-writer versus reader-finalizer regression.
- Winner byte-identity, missing source/destination, backend capability, and exact DDB tuple coverage.
- `cargo test -p lance-table --lib` (179 passed)
- `cargo test -p lance-io test_external_manifest_create_only_copy_support -- --nocapture`
- `cargo test -p lance-io test_is_s3_express -- --nocapture`
- `cargo test -p lance manifest_commit_ --features dynamodb -- --nocapture` (2 passed)
- `cargo check -p lance --features dynamodb_tests --tests`
- `cargo clippy -p lance-io --tests -- -D warnings`
- `cargo clippy -p lance-table --features dynamodb --tests -- -D warnings`
- `cargo clippy -p lance --features dynamodb_tests --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The LocalStack CAS integration test compiles under `dynamodb_tests`, but was not executed locally because Docker/LocalStack was unavailable. A real AWS conditional-copy request was not run locally.

## Scope and rollout notes

- This fixes the observed race for native standard S3 manifests below 5 GiB. Larger manifests retain the existing multipart overwrite path because `object_store 0.13.2` cannot express conditional ranged multipart copy through `dyn ObjectStore`.
- Custom endpoints, OpenDAL, S3 Express, explicit copy modes, and manually constructed public DDB stores retain the prior behavior.
- Only losing concurrent finalizers perform chunked byte comparison.
- Old overwrite-capable finalizers must be fully drained before enabling this path.
- LanceDB mirroring wrappers need the companion fix in https://github.com/lancedb/lancedb/pull/3918.

Internal tracking: ENT-2188 (parent incident ENT-2166).