### PR TITLE
fix(namespace): reload rotated mTLS certificates in the REST client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4997,6 +4997,7 @@ dependencies = [
 name = "lance-namespace-impls"
 version = "11.0.0-beta.3"
 dependencies = [
+ "arc-swap",
  "arrow",
  "arrow-array",
  "arrow-ipc",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4180,6 +4180,7 @@ dependencies = [
 name = "lance-namespace-impls"
 version = "11.0.0-beta.3"
 dependencies = [
+ "arc-swap",
  "arrow",
  "arrow-ipc",
  "arrow-schema",

--- a/java/src/main/java/org/lance/namespace/RestNamespace.java
+++ b/java/src/main/java/org/lance/namespace/RestNamespace.java
@@ -124,6 +124,8 @@ import java.util.Optional;
  *   <li>tls.key_file (optional): Path to client key file
  *   <li>tls.ssl_ca_cert (optional): Path to CA certificate file
  *   <li>tls.assert_hostname (optional): "true" or "false" (default: true)
+ *   <li>tls.reload_interval_seconds (optional): How often the TLS files above are checked for
+ *       rotation (default: 300, "0" disables reloading)
  * </ul>
  *
  * <p>Example usage:

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4470,6 +4470,7 @@ dependencies = [
 name = "lance-namespace-impls"
 version = "11.0.0-beta.3"
 dependencies = [
+ "arc-swap",
  "arrow",
  "arrow-ipc",
  "arrow-schema",

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [features]
 default = ["dir-aws", "dir-azure", "dir-gcp", "dir-oss", "dir-huggingface"]
-rest = ["dep:reqwest", "dep:serde"]
+rest = ["dep:arc-swap", "dep:reqwest", "dep:serde"]
 rest-adapter = ["dep:axum", "dep:tower", "dep:tower-http", "dep:serde"]
 # Cloud storage features for directory implementation - align with lance-io
 dir-gcp = ["lance-io/gcp", "lance/gcp"]
@@ -32,6 +32,7 @@ lance-namespace.workspace = true
 lance-core.workspace = true
 
 # REST implementation dependencies (optional, enabled by "rest" feature)
+arc-swap = { workspace = true, optional = true }
 reqwest = { version = "0.12", optional = true, default-features = false, features = [
     "json",
     "charset",

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -3,11 +3,15 @@
 
 //! REST implementation of Lance Namespace
 
+mod tls;
+
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::OpsMetrics;
+use tls::{ReloadableClient, TlsConfig};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -57,15 +61,18 @@ use lance_namespace::error::NamespaceError;
 
 /// HTTP client wrapper that supports per-request header injection.
 ///
-/// This client wraps a single `reqwest::Client` and applies dynamic headers
-/// to each request without recreating the client. This is more efficient than
-/// creating a new client per request when using a `DynamicContextProvider`.
+/// This client applies dynamic headers to each request without recreating the
+/// client. This is more efficient than creating a new client per request when
+/// using a `DynamicContextProvider`.
 ///
 /// The design follows lancedb's `RestfulLanceDbClient` pattern where headers
 /// are applied to the built request using `headers_mut()` before execution.
+///
+/// The underlying `reqwest::Client` is only recreated when the TLS material it
+/// presents is rotated on disk, see [`ReloadableClient`].
 #[derive(Clone)]
 struct RestClient {
-    client: reqwest::Client,
+    client: Arc<ReloadableClient>,
     base_path: String,
     base_headers: HashMap<String, String>,
     context_provider: Option<Arc<dyn DynamicContextProvider>>,
@@ -131,7 +138,7 @@ impl RestClient {
     ) -> std::result::Result<reqwest::Response, reqwest::Error> {
         let mut request = req_builder.build()?;
         self.apply_headers(&mut request, operation, object_id);
-        self.client.execute(request).await
+        self.client().execute(request).await
     }
 
     /// Get the base path URL
@@ -139,9 +146,12 @@ impl RestClient {
         &self.base_path
     }
 
-    /// Get a reference to the underlying reqwest client
-    fn client(&self) -> &reqwest::Client {
-        &self.client
+    /// Get the reqwest client to use for the next request.
+    ///
+    /// Returned by value because the client is replaced when the TLS material it presents
+    /// is rotated on disk. Cloning it is cheap: `reqwest::Client` is a handle around an `Arc`.
+    fn client(&self) -> reqwest::Client {
+        self.client.current()
     }
 }
 
@@ -172,6 +182,8 @@ pub struct RestNamespaceBuilder {
     key_file: Option<String>,
     ssl_ca_cert: Option<String>,
     assert_hostname: bool,
+    /// How often the TLS files are checked for rotation, in seconds. 0 disables reloading.
+    reload_interval_seconds: u64,
     context_provider: Option<Arc<dyn DynamicContextProvider>>,
     /// When true, tracks operation metrics. Default: false.
     ops_metrics_enabled: bool,
@@ -187,6 +199,7 @@ impl std::fmt::Debug for RestNamespaceBuilder {
             .field("key_file", &self.key_file)
             .field("ssl_ca_cert", &self.ssl_ca_cert)
             .field("assert_hostname", &self.assert_hostname)
+            .field("reload_interval_seconds", &self.reload_interval_seconds)
             .field(
                 "context_provider",
                 &self.context_provider.as_ref().map(|_| "Some(...)"),
@@ -199,6 +212,12 @@ impl std::fmt::Debug for RestNamespaceBuilder {
 impl RestNamespaceBuilder {
     /// Default delimiter for object identifiers
     const DEFAULT_DELIMITER: &'static str = "$";
+
+    /// Default interval between two checks for rotated TLS material, in seconds.
+    ///
+    /// Certificate agents typically re-mint short-lived certificates hours before they expire,
+    /// so a few minutes of staleness is harmless while keeping the cost of the check negligible.
+    const DEFAULT_RELOAD_INTERVAL_SECONDS: u64 = 300;
 
     /// Create a new RestNamespaceBuilder with the specified URI.
     ///
@@ -214,6 +233,7 @@ impl RestNamespaceBuilder {
             key_file: None,
             ssl_ca_cert: None,
             assert_hostname: true,
+            reload_interval_seconds: Self::DEFAULT_RELOAD_INTERVAL_SECONDS,
             context_provider: None,
             ops_metrics_enabled: false,
         }
@@ -230,6 +250,8 @@ impl RestNamespaceBuilder {
     /// - `tls.key_file`: Path to client private key file (optional)
     /// - `tls.ssl_ca_cert`: Path to CA certificate file (optional)
     /// - `tls.assert_hostname`: Whether to verify hostname (optional, defaults to true)
+    /// - `tls.reload_interval_seconds`: How often the TLS files above are checked for rotation
+    ///   (optional, defaults to 300, `0` disables reloading)
     ///
     /// # Arguments
     ///
@@ -292,6 +314,17 @@ impl RestNamespaceBuilder {
             .get("tls.assert_hostname")
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(true);
+        let reload_interval_seconds = match properties.get("tls.reload_interval_seconds") {
+            Some(value) => value.parse::<u64>().map_err(|e| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Invalid value '{value}' for property 'tls.reload_interval_seconds', \
+                         expected a number of seconds: {e}"
+                    ),
+                })
+            })?,
+            None => Self::DEFAULT_RELOAD_INTERVAL_SECONDS,
+        };
 
         // Extract ops_metrics_enabled (default: false)
         let ops_metrics_enabled = properties
@@ -307,6 +340,7 @@ impl RestNamespaceBuilder {
             key_file,
             ssl_ca_cert,
             assert_hostname,
+            reload_interval_seconds,
             context_provider: None,
             ops_metrics_enabled,
         })
@@ -380,6 +414,23 @@ impl RestNamespaceBuilder {
     /// * `assert_hostname` - Whether to verify hostname
     pub fn assert_hostname(mut self, assert_hostname: bool) -> Self {
         self.assert_hostname = assert_hostname;
+        self
+    }
+
+    /// Set how often the TLS files are checked for rotation.
+    ///
+    /// Client certificates are commonly short-lived and re-minted onto the same paths while the
+    /// process runs. Once the interval has elapsed, the next request re-reads the configured
+    /// certificate, key and CA files, and rebuilds the HTTP client if their content changed.
+    /// Unchanged content leaves the client, and therefore its connection pool, untouched.
+    ///
+    /// Defaults to 300 seconds.
+    ///
+    /// # Arguments
+    ///
+    /// * `reload_interval_seconds` - Interval between checks in seconds, `0` to never reload
+    pub fn reload_interval_seconds(mut self, reload_interval_seconds: u64) -> Self {
+        self.reload_interval_seconds = reload_interval_seconds;
         self
     }
 
@@ -492,35 +543,18 @@ impl std::fmt::Display for RestNamespace {
 impl RestNamespace {
     /// Create a new REST namespace from builder
     pub(crate) fn from_builder(builder: RestNamespaceBuilder) -> Self {
-        // Build reqwest client WITHOUT default headers - we'll apply headers per-request
-        let mut client_builder = reqwest::Client::builder();
-
-        // Configure mTLS if certificate and key files are provided
-        if let (Some(cert_file), Some(key_file)) = (&builder.cert_file, &builder.key_file)
-            && let (Ok(cert), Ok(key)) = (std::fs::read(cert_file), std::fs::read(key_file))
-            && let Ok(identity) = reqwest::Identity::from_pem(&[&cert[..], &key[..]].concat())
-        {
-            client_builder = client_builder.identity(identity);
-        }
-
-        // Load CA certificate for server verification
-        if let Some(ca_cert_file) = &builder.ssl_ca_cert
-            && let Ok(ca_cert) = std::fs::read(ca_cert_file)
-            && let Ok(ca_cert) = reqwest::Certificate::from_pem(&ca_cert)
-        {
-            client_builder = client_builder.add_root_certificate(ca_cert);
-        }
-
-        // Configure hostname verification
-        client_builder = client_builder.danger_accept_invalid_hostnames(!builder.assert_hostname);
-
-        let client = client_builder
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+        let tls = TlsConfig {
+            cert_file: builder.cert_file,
+            key_file: builder.key_file,
+            ssl_ca_cert: builder.ssl_ca_cert,
+            assert_hostname: builder.assert_hostname,
+        };
+        let reload_interval = (builder.reload_interval_seconds > 0)
+            .then(|| Duration::from_secs(builder.reload_interval_seconds));
 
         // Create the RestClient that handles per-request header injection
         let rest_client = RestClient {
-            client,
+            client: Arc::new(ReloadableClient::new(tls, reload_interval)),
             base_path: builder.uri,
             base_headers: builder.headers,
             context_provider: builder.context_provider,
@@ -1747,6 +1781,75 @@ mod tests {
         assert_eq!(builder.key_file, Some("/path/to/key.pem".to_string()));
         assert_eq!(builder.ssl_ca_cert, Some("/path/to/ca.pem".to_string()));
         assert!(builder.assert_hostname);
+        assert_eq!(
+            builder.reload_interval_seconds,
+            RestNamespaceBuilder::DEFAULT_RELOAD_INTERVAL_SECONDS
+        );
+    }
+
+    #[test]
+    fn test_tls_reload_interval_parsing() {
+        let mut properties = HashMap::new();
+        properties.insert("uri".to_string(), "https://api.example.com".to_string());
+        properties.insert("tls.reload_interval_seconds".to_string(), "60".to_string());
+
+        let builder = RestNamespaceBuilder::from_properties(properties)
+            .expect("Failed to create namespace builder");
+        assert_eq!(builder.reload_interval_seconds, 60);
+    }
+
+    #[test]
+    fn test_tls_reload_disabled_by_zero_interval() {
+        let mut properties = HashMap::new();
+        properties.insert("uri".to_string(), "https://api.example.com".to_string());
+        properties.insert("tls.reload_interval_seconds".to_string(), "0".to_string());
+
+        let builder = RestNamespaceBuilder::from_properties(properties)
+            .expect("Failed to create namespace builder");
+        assert_eq!(builder.reload_interval_seconds, 0);
+    }
+
+    #[test]
+    fn test_tls_reload_interval_reaches_the_client() {
+        let namespace = RestNamespaceBuilder::new("https://api.example.com")
+            .cert_file("/path/to/cert.pem")
+            .key_file("/path/to/key.pem")
+            .build();
+        assert_eq!(
+            namespace.rest_client.client.reload_interval(),
+            Some(Duration::from_secs(
+                RestNamespaceBuilder::DEFAULT_RELOAD_INTERVAL_SECONDS
+            ))
+        );
+
+        let namespace = RestNamespaceBuilder::new("https://api.example.com")
+            .cert_file("/path/to/cert.pem")
+            .key_file("/path/to/key.pem")
+            .reload_interval_seconds(0)
+            .build();
+        assert_eq!(
+            namespace.rest_client.client.reload_interval(),
+            None,
+            "an interval of 0 should disable reloading"
+        );
+    }
+
+    #[test]
+    fn test_tls_reload_interval_rejects_invalid_value() {
+        let mut properties = HashMap::new();
+        properties.insert("uri".to_string(), "https://api.example.com".to_string());
+        properties.insert(
+            "tls.reload_interval_seconds".to_string(),
+            "5 minutes".to_string(),
+        );
+
+        let error = RestNamespaceBuilder::from_properties(properties)
+            .expect_err("an unparseable interval should be rejected")
+            .to_string();
+        assert!(
+            error.contains("tls.reload_interval_seconds") && error.contains("5 minutes"),
+            "the error should name the property and its value: {error}"
+        );
     }
 
     #[test]

--- a/rust/lance-namespace-impls/src/rest/tls.rs
+++ b/rust/lance-namespace-impls/src/rest/tls.rs
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! TLS configuration for the REST namespace client.
+//!
+//! Client certificates are usually short-lived: SPIFFE/Istio, Vault PKI and cert-manager all
+//! re-mint them onto disk long before the process using them restarts. A `reqwest::Identity`
+//! cannot be swapped inside a live `reqwest::Client`, so a client built once at startup keeps
+//! presenting the certificate it read then, and every request fails with a received
+//! `CertificateExpired` alert once that certificate passes its `notAfter`.
+//!
+//! [`ReloadableClient`] therefore re-reads the configured PEM files on the request path and
+//! publishes a rebuilt client through an [`ArcSwap`] when their content changes.
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
+use lance_core::{Error, Result};
+use lance_namespace::error::NamespaceError;
+
+/// TLS options of the REST client, including the paths its material is loaded from.
+#[derive(Clone, Debug)]
+pub(super) struct TlsConfig {
+    /// Path to the PEM client certificate. mTLS requires both this and `key_file`.
+    pub(super) cert_file: Option<String>,
+    /// Path to the PEM private key matching `cert_file`.
+    pub(super) key_file: Option<String>,
+    /// Path to a PEM CA certificate to trust in addition to the platform roots.
+    pub(super) ssl_ca_cert: Option<String>,
+    /// When false, the hostname in the server certificate is not verified.
+    pub(super) assert_hostname: bool,
+}
+
+impl TlsConfig {
+    /// Whether any PEM file is configured, i.e. whether there is anything to reload.
+    fn watches_files(&self) -> bool {
+        (self.cert_file.is_some() && self.key_file.is_some()) || self.ssl_ca_cert.is_some()
+    }
+
+    /// Read the configured PEM files from disk.
+    fn read_material(&self) -> Result<TlsMaterial> {
+        // mTLS needs both halves of the identity; a certificate without a key is ignored.
+        let identity_pem = match (&self.cert_file, &self.key_file) {
+            (Some(cert_file), Some(key_file)) => {
+                let cert = read_pem_file("certificate", cert_file)?;
+                let key = read_pem_file("private key", key_file)?;
+                Some([cert, key].concat())
+            }
+            _ => None,
+        };
+
+        let root_cert_pem = match &self.ssl_ca_cert {
+            Some(ca_cert_file) => Some(read_pem_file("CA certificate", ca_cert_file)?),
+            None => None,
+        };
+
+        Ok(TlsMaterial {
+            identity_pem,
+            root_cert_pem,
+        })
+    }
+
+    /// Build a client that presents `material`.
+    fn build_client(&self, material: &TlsMaterial) -> Result<reqwest::Client> {
+        // Build the client WITHOUT default headers - they are applied per-request.
+        let mut client_builder =
+            reqwest::Client::builder().danger_accept_invalid_hostnames(!self.assert_hostname);
+
+        if let Some(identity_pem) = &material.identity_pem {
+            let identity = reqwest::Identity::from_pem(identity_pem).map_err(|e| {
+                tls_config_error(format!(
+                    "Failed to load the client identity from certificate '{}' and key '{}': {e}",
+                    self.cert_file.as_deref().unwrap_or_default(),
+                    self.key_file.as_deref().unwrap_or_default(),
+                ))
+            })?;
+            client_builder = client_builder.identity(identity);
+        }
+
+        if let Some(root_cert_pem) = &material.root_cert_pem {
+            let root_cert = reqwest::Certificate::from_pem(root_cert_pem).map_err(|e| {
+                tls_config_error(format!(
+                    "Failed to load the CA certificate '{}': {e}",
+                    self.ssl_ca_cert.as_deref().unwrap_or_default(),
+                ))
+            })?;
+            client_builder = client_builder.add_root_certificate(root_cert);
+        }
+
+        client_builder
+            .build()
+            .map_err(|e| tls_config_error(format!("Failed to build the HTTP client: {e}")))
+    }
+}
+
+/// PEM bytes read from disk for one generation of TLS material.
+#[derive(Default)]
+struct TlsMaterial {
+    /// Client certificate concatenated with its private key, the form `reqwest::Identity` takes.
+    identity_pem: Option<Vec<u8>>,
+    /// CA certificate to add to the client's root store.
+    root_cert_pem: Option<Vec<u8>>,
+}
+
+impl TlsMaterial {
+    /// Digest of the PEM bytes, used to detect rotation.
+    ///
+    /// Rotation is commonly an atomic rename or a symlink swap, so modification times are not a
+    /// reliable signal but the content is. Digesting it keeps the comparison cheap without
+    /// retaining the private key bytes for the lifetime of the client.
+    fn digest(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.identity_pem.hash(&mut hasher);
+        self.root_cert_pem.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// Digest of the material the current client was built from, and when disk was last read.
+struct ReloadState {
+    /// `None` when the material could not be loaded, so that the next check retries the build
+    /// even if the files did not change again in the meantime.
+    digest: Option<u64>,
+    last_checked: Instant,
+}
+
+/// A `reqwest::Client` that is rebuilt when the TLS material it presents changes on disk.
+pub(super) struct ReloadableClient {
+    client: ArcSwap<reqwest::Client>,
+    tls: TlsConfig,
+    /// Minimum delay between two disk checks. `None` disables reloading entirely;
+    /// `Some(Duration::ZERO)` checks on every request.
+    reload_interval: Option<Duration>,
+    state: Mutex<ReloadState>,
+}
+
+impl ReloadableClient {
+    /// Build the initial client from the material currently on disk.
+    ///
+    /// A TLS configuration that fails to load is logged and downgraded to a client without
+    /// client identity or extra roots, which keeps `RestNamespaceBuilder::build` infallible as
+    /// it has always been.
+    pub(super) fn new(tls: TlsConfig, reload_interval: Option<Duration>) -> Self {
+        let loaded = tls
+            .read_material()
+            .and_then(|material| Ok((tls.build_client(&material)?, material.digest())));
+
+        let (client, digest) = match loaded {
+            Ok((client, digest)) => (client, Some(digest)),
+            Err(e) => {
+                log::warn!(
+                    "Failed to load the TLS configuration of the REST namespace client, \
+                     continuing without client identity or custom root certificate: {e}"
+                );
+                let client = tls
+                    .build_client(&TlsMaterial::default())
+                    .unwrap_or_else(|_| reqwest::Client::new());
+                (client, None)
+            }
+        };
+
+        // Without any PEM file configured there is nothing on disk to watch.
+        let reload_interval = reload_interval.filter(|_| tls.watches_files());
+
+        Self {
+            client: ArcSwap::from_pointee(client),
+            tls,
+            reload_interval,
+            state: Mutex::new(ReloadState {
+                digest,
+                last_checked: Instant::now(),
+            }),
+        }
+    }
+
+    /// The client to use for the next request.
+    ///
+    /// Returns a clone rather than a reference because a reload can replace the client at any
+    /// point. Cloning is cheap: `reqwest::Client` is a handle around an `Arc`.
+    pub(super) fn current(&self) -> reqwest::Client {
+        self.reload_if_due();
+        let client = self.client.load();
+        reqwest::Client::clone(&client)
+    }
+
+    /// The interval reloading actually runs at, `None` when the client never reloads.
+    #[cfg(test)]
+    pub(super) fn reload_interval(&self) -> Option<Duration> {
+        self.reload_interval
+    }
+
+    /// Re-read the PEM files if the check interval has elapsed, and replace the client if their
+    /// content changed.
+    ///
+    /// Replacing the client drops its connection pool, which is correct - pooled connections
+    /// were authenticated with the previous certificate - and is why the client is only replaced
+    /// on an actual content change.
+    fn reload_if_due(&self) {
+        let Some(interval) = self.reload_interval else {
+            return;
+        };
+
+        // Another request is already checking. Both callers would read the same files, and
+        // whoever loses the race is at most one interval behind.
+        let Ok(mut state) = self.state.try_lock() else {
+            return;
+        };
+        if state.last_checked.elapsed() < interval {
+            return;
+        }
+        state.last_checked = Instant::now();
+
+        let material = match self.tls.read_material() {
+            Ok(material) => material,
+            Err(e) => {
+                log::warn!(
+                    "Failed to re-read the TLS material of the REST namespace client, \
+                     keeping the current client: {e}"
+                );
+                return;
+            }
+        };
+
+        let digest = material.digest();
+        if state.digest == Some(digest) {
+            return;
+        }
+
+        match self.tls.build_client(&material) {
+            Ok(client) => {
+                self.client.store(Arc::new(client));
+                state.digest = Some(digest);
+                log::info!("Reloaded the TLS material of the REST namespace client from disk");
+            }
+            Err(e) => log::warn!(
+                "Rotated TLS material of the REST namespace client is unusable, \
+                 keeping the current client: {e}"
+            ),
+        }
+    }
+}
+
+/// Read a PEM file, reporting failures with the path and the role the file plays.
+fn read_pem_file(role: &str, path: &str) -> Result<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|e| tls_config_error(format!("Failed to read the TLS {role} '{path}': {e}")))
+}
+
+fn tls_config_error(message: String) -> Error {
+    NamespaceError::InvalidInput { message }.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    /// Self-signed certificate and matching key, only ever used to exercise PEM loading.
+    const CERT_A: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIUFnETCuqfjMXeoqoLZMxXObQElu8wCgYIKoZIzj0EAwIw
+FzEVMBMGA1UEAwwMbGFuY2UtdGVzdC1hMCAXDTI2MDgxMDE5NTU1N1oYDzIxMjYw
+NzE3MTk1NTU3WjAXMRUwEwYDVQQDDAxsYW5jZS10ZXN0LWEwWTATBgcqhkjOPQIB
+BggqhkjOPQMBBwNCAATBBAzMgIrkusG3gOZuyboh+RKancco6xC03O2mMyykqq52
+JRQnzlZm37BomXPtFlHW9mU7su1KcIBEKgRZfLnPo1MwUTAdBgNVHQ4EFgQUwKTV
+fIJnAXSuL2imQuMvyQfsK2MwHwYDVR0jBBgwFoAUwKTVfIJnAXSuL2imQuMvyQfs
+K2MwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiB6yQpGVALMCLxm
+8ekf9DmNDuSv36JRsG7l6yS/d4yqPgIhAPv4bKcpKGqE8PsQVXhnWweltcUrnJ+D
+H027pEBl+pKJ
+-----END CERTIFICATE-----
+"#;
+
+    const KEY_A: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQge8mgs5FZcchWUNkr
+JrJWhDOe7eOmgB03AFrpsQo1I5uhRANCAATBBAzMgIrkusG3gOZuyboh+RKancco
+6xC03O2mMyykqq52JRQnzlZm37BomXPtFlHW9mU7su1KcIBEKgRZfLnP
+-----END PRIVATE KEY-----
+"#;
+
+    /// A second self-signed pair, standing in for a re-minted certificate.
+    const CERT_B: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBhDCCASugAwIBAgIUfo81kW2IN2pBuO3jhwazB12Pd04wCgYIKoZIzj0EAwIw
+FzEVMBMGA1UEAwwMbGFuY2UtdGVzdC1iMCAXDTI2MDgxMDE5NTU1N1oYDzIxMjYw
+NzE3MTk1NTU3WjAXMRUwEwYDVQQDDAxsYW5jZS10ZXN0LWIwWTATBgcqhkjOPQIB
+BggqhkjOPQMBBwNCAARdbZsJo7FrzCRTFQQkGUNw3mllD0D2vlUSTstZkV9DqFsq
+GgtQZsdPpD/ndAKCeILH618omGtfieRWbNEfmLnDo1MwUTAdBgNVHQ4EFgQUFERt
+Mj+ePIr2LK2oV37TgpnKDvowHwYDVR0jBBgwFoAUFERtMj+ePIr2LK2oV37TgpnK
+DvowDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBEAiAPBW3FOuyZbNnL
+Jccb7r4yzAOWl25IX8mwiqL+IeMt4wIgSain0EVWElOQcBSaGcQTCmeB+v1yqg1a
+AW7D1q0IGho=
+-----END CERTIFICATE-----
+"#;
+
+    const KEY_B: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQguOhONlmNsse91H8r
+XYris7tqFIImbS16joxzji/SDT2hRANCAARdbZsJo7FrzCRTFQQkGUNw3mllD0D2
+vlUSTstZkV9DqFsqGgtQZsdPpD/ndAKCeILH618omGtfieRWbNEfmLnD
+-----END PRIVATE KEY-----
+"#;
+
+    /// Write `cert` and `key` to the fixed paths a client is configured with, the way a
+    /// certificate agent re-mints them in place.
+    fn write_identity(dir: &Path, cert: &str, key: &str) -> TlsConfig {
+        let cert_file = dir.join("cert.pem");
+        let key_file = dir.join("key.pem");
+        std::fs::write(&cert_file, cert).unwrap();
+        std::fs::write(&key_file, key).unwrap();
+
+        TlsConfig {
+            cert_file: Some(cert_file.to_str().unwrap().to_string()),
+            key_file: Some(key_file.to_str().unwrap().to_string()),
+            ssl_ca_cert: None,
+            assert_hostname: true,
+        }
+    }
+
+    #[test]
+    fn test_rotated_certificate_rebuilds_client() {
+        let dir = tempdir().unwrap();
+        let tls = write_identity(dir.path(), CERT_A, KEY_A);
+
+        let reloadable = ReloadableClient::new(tls, Some(Duration::ZERO));
+        let initial = reloadable.client.load_full();
+        assert!(
+            reloadable.state.lock().unwrap().digest.is_some(),
+            "the initial certificate should have loaded"
+        );
+
+        write_identity(dir.path(), CERT_B, KEY_B);
+        reloadable.current();
+
+        assert!(
+            !Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "a rotated certificate should be picked up"
+        );
+    }
+
+    #[test]
+    fn test_unchanged_certificate_keeps_client() {
+        let dir = tempdir().unwrap();
+        let tls = write_identity(dir.path(), CERT_A, KEY_A);
+
+        let reloadable = ReloadableClient::new(tls, Some(Duration::ZERO));
+        let initial = reloadable.client.load_full();
+
+        // Rewriting the same bytes changes modification times but not the identity, so the
+        // client - and its connection pool - must survive.
+        write_identity(dir.path(), CERT_A, KEY_A);
+        reloadable.current();
+        reloadable.current();
+
+        assert!(
+            Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "unchanged material should not rebuild the client"
+        );
+    }
+
+    #[test]
+    fn test_certificate_not_read_before_interval_elapses() {
+        let dir = tempdir().unwrap();
+        let tls = write_identity(dir.path(), CERT_A, KEY_A);
+
+        let reloadable = ReloadableClient::new(tls, Some(Duration::from_secs(300)));
+        let initial = reloadable.client.load_full();
+        let last_checked = reloadable.state.lock().unwrap().last_checked;
+
+        write_identity(dir.path(), CERT_B, KEY_B);
+        reloadable.current();
+
+        assert!(
+            Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "rotation should not be picked up before the interval elapses"
+        );
+        assert_eq!(
+            last_checked,
+            reloadable.state.lock().unwrap().last_checked,
+            "the files should not have been read"
+        );
+    }
+
+    #[test]
+    fn test_reload_disabled_ignores_rotation() {
+        let dir = tempdir().unwrap();
+        let tls = write_identity(dir.path(), CERT_A, KEY_A);
+
+        let reloadable = ReloadableClient::new(tls, None);
+        let initial = reloadable.client.load_full();
+
+        write_identity(dir.path(), CERT_B, KEY_B);
+        reloadable.current();
+
+        assert!(
+            Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "reloading is disabled, the client should never be replaced"
+        );
+    }
+
+    #[test]
+    fn test_reload_disabled_without_files_to_watch() {
+        let tls = TlsConfig {
+            cert_file: None,
+            key_file: None,
+            ssl_ca_cert: None,
+            assert_hostname: true,
+        };
+
+        let reloadable = ReloadableClient::new(tls, Some(Duration::ZERO));
+        assert!(reloadable.reload_interval.is_none());
+    }
+
+    #[test]
+    fn test_unusable_rotated_material_keeps_client() {
+        let dir = tempdir().unwrap();
+        let tls = write_identity(dir.path(), CERT_A, KEY_A);
+
+        let reloadable = ReloadableClient::new(tls, Some(Duration::ZERO));
+        let initial = reloadable.client.load_full();
+
+        // A truncated read, as can happen when a certificate is written in place, must not
+        // replace a working identity with one the server would reject.
+        write_identity(dir.path(), &CERT_B[..CERT_B.len() / 2], KEY_B);
+        reloadable.current();
+        assert!(
+            Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "unusable material should not replace the client"
+        );
+
+        // Once the complete material lands, the next check picks it up.
+        write_identity(dir.path(), CERT_B, KEY_B);
+        reloadable.current();
+        assert!(
+            !Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "the retry should pick up the complete material"
+        );
+    }
+
+    #[test]
+    fn test_missing_certificate_falls_back_to_plain_client() {
+        let dir = tempdir().unwrap();
+        let mut tls = write_identity(dir.path(), CERT_A, KEY_A);
+        tls.cert_file = Some(dir.path().join("missing.pem").to_str().unwrap().to_string());
+
+        // Loading is best effort at construction: the namespace still builds, and the missing
+        // digest makes the next check retry the load.
+        let reloadable = ReloadableClient::new(tls, Some(Duration::ZERO));
+        assert!(reloadable.state.lock().unwrap().digest.is_none());
+
+        let initial = reloadable.client.load_full();
+        write_identity(dir.path(), CERT_A, KEY_A);
+        reloadable.current();
+        assert!(
+            Arc::ptr_eq(&initial, &reloadable.client.load_full()),
+            "the certificate path is still missing, there is nothing to load"
+        );
+    }
+
+    #[test]
+    fn test_read_material_reports_missing_file() {
+        let tls = TlsConfig {
+            cert_file: Some("/nonexistent/cert.pem".to_string()),
+            key_file: Some("/nonexistent/key.pem".to_string()),
+            ssl_ca_cert: None,
+            assert_hostname: true,
+        };
+
+        let Err(error) = tls.read_material() else {
+            panic!("reading a missing certificate should fail");
+        };
+        let error = error.to_string();
+        assert!(
+            error.contains("/nonexistent/cert.pem"),
+            "the error should name the file that could not be read: {error}"
+        );
+    }
+
+    #[test]
+    fn test_digest_tracks_content() {
+        let identity = |cert: &str, key: &str| TlsMaterial {
+            identity_pem: Some([cert.as_bytes(), key.as_bytes()].concat()),
+            root_cert_pem: None,
+        };
+
+        assert_eq!(
+            identity(CERT_A, KEY_A).digest(),
+            identity(CERT_A, KEY_A).digest()
+        );
+        assert_ne!(
+            identity(CERT_A, KEY_A).digest(),
+            identity(CERT_B, KEY_B).digest()
+        );
+        // The identity and the CA certificate must not be interchangeable.
+        assert_ne!(
+            identity(CERT_A, "").digest(),
+            TlsMaterial {
+                identity_pem: None,
+                root_cert_pem: Some(CERT_A.as_bytes().to_vec()),
+            }
+            .digest()
+        );
+    }
+}


### PR DESCRIPTION
## Problem
Trino x Lance plugin started throwing `CertificateExpired` exception when trying to talk to iceberg rest catalog and the certs in trino co-ordinator instance got rotated.

`RestNamespace::from_builder` reads the mTLS certificate, key and CA once at construction
and bakes them into a single long-lived `reqwest::Client`. A `reqwest::Identity` cannot be
hot-swapped inside a live client, so the process keeps presenting the certificate it read at
startup forever.

Any environment that rotates short-lived certificates on disk therefore breaks once the
loaded certificate passes its `notAfter`. The server rejects the handshake and the client
sees a *received* TLS alert:

    reqwest::Error { kind: Request, url: "https://<catalog-host>:7004/api/lance/<ns>/v1/namespace/%24/list?delimiter=%24",
      source: hyper::Error(Io, Custom { kind: InvalidData, error: "received fatal alert: CertificateExpired" }) }

(`received` matters: the peer is rejecting *our* client cert. A stale CA bundle or bad server
cert would surface locally as `InvalidCertificate(Expired)` / `UnknownIssuer`.)

## Fix

`RestClient` now holds the client in an `ArcSwap<reqwest::Client>` and hands it out by value
(cheap — `reqwest::Client` is a handle around an `Arc`). Alongside it, the cert/key/CA paths,
the digest of the last-loaded content and the last-checked `Instant` are kept so the client
can be rebuilt.

The check is lazy, on the request path, gated by an interval:

- If the interval has elapsed, the PEM files are re-read and the client is rebuilt **only if
  the content changed**. Content, not mtime: rotation is often a symlink swap or an atomic
  rename. A digest keeps the comparison cheap without retaining private key bytes.
- Rebuilding drops the connection pool, which is correct (pooled connections were
  authenticated with the old certificate) and exactly why it is gated on a real change.
- Material that fails to read or build keeps the current client and retries on the next
  check, so a truncated read mid-rotation can't replace a working identity with one the
  server would reject.
- No background thread or task. A few-KB `std::fs::read` at most once per interval.
- `arc-swap` was already a workspace dependency; no new dependencies.

New property `tls.reload_interval_seconds`, parsed alongside the other `tls.*` keys, with a
matching builder setter. `0` disables reloading. Properties pass through the Python and Java
bindings opaquely, so both pick this up without binding changes; the `tls.*` list in
`RestNamespace`'s javadoc is updated.

## Verification

    cargo build -p lance-namespace -p lance-namespace-impls --features rest -p lance
    cargo test -p lance-namespace-impls --features rest
    cargo fmt --all
    cargo clippy --all --tests --benches -- -D warnings
