### PR TITLE
feat(mem-wal): derive index catch-up from the version a commit read

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -342,6 +342,16 @@ Important fields:
 - `snapshot_ts_millis`, `num_shards`, and `inline_snapshots`: optional shard snapshot fields for read optimization.
 
 If a shard is absent from `index_catchup` for an index, that index is assumed to be fully caught up for the shard.
+Because absence carries that meaning, a writer records an entry for every base-table index once any SSTable has been compacted, naming every shard with recorded compaction progress and using generation `0` for a shard whose coverage it cannot prove.
+
+Entries are derived when a commit is built, not asserted by the caller.
+An index whose fragments cover every fragment that was live at the committing transaction's read version holds every row compaction had copied into the base table by that version, so it is recorded as caught up to the `compacted_sstables` progress at that version.
+This is the only available proof: nothing maps a compaction generation to the fragments its rows landed in, so covering the whole table as the transaction read it is how an index shows it covered those rows.
+Fragments appended after that version are a later catch-up gap and are not required.
+
+A recorded position is capped by the `compacted_sstables` progress the commit itself records, so a read version that was later rolled back cannot retire SSTables no live commit copied in.
+An index that does not cover the read version keeps the position it last recorded only while it remains physically unchanged; a rebuilt, replaced, or remapped index is a different index, so its position drops to generation `0` until some later commit proves coverage again.
+A position is never lowered, so a commit that reads an older version does not withdraw coverage an index has already demonstrated.
 
 Shard snapshots, when present, use the following Lance file schema:
 
@@ -494,7 +504,7 @@ On commit conflict, a compactor reloads the conflicting base-table version:
 The garbage collector may remove obsolete SSTables after:
 
 1. The SSTable has been compacted into the base table.
-2. Every maintained index has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads.
+2. Every maintained index has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads. An index recorded at generation `0` for the shard has not caught up.
 3. No retained base-table version needs the SSTable for time travel or consistency.
 
 !!! warning

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -693,6 +693,11 @@ message IndexCatchupProgress {
   // Per-shard progress: the generation up to which this index covers.
   // If a shard is not present, the index is assumed to be fully caught up
   // (i.e., caught_up_generation >= compacted_generation for that shard).
+  //
+  // Because absence means "caught up", writers name every shard that has
+  // recorded compaction progress, using generation 0 for one this index cannot
+  // vouch for. Leaving a shard out would let its SSTables be retired against an
+  // index that never covered them.
   repeated CompactedSsTable caught_up_generations = 2;
 }
 
@@ -759,6 +764,14 @@ message MemWalIndexDetails {
   // scanning unindexed data in the base table.
   //
   // If an index is not present in this list, it is assumed to be fully caught up.
+  // A writer therefore lists every base table index once any SSTable has been
+  // compacted, recording generation 0 for one whose coverage it cannot prove.
+  //
+  // Entries are derived at commit time, not asserted by the caller: an index
+  // covering every fragment that was live at the committing transaction's read
+  // version holds every row compacted by then, so it is caught up to the
+  // progress recorded at that version. An index that changes without proving
+  // that again loses the position recorded for it.
   repeated IndexCatchupProgress index_catchup = 10;
 
   // Default ShardWriter configuration values for this MemWAL index.

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -395,6 +395,7 @@ async fn test_inline_transaction() {
             ds.load_indices().await.unwrap().as_ref().clone(),
             &tx_file,
             &ManifestWriteConfig::default(),
+            None,
         )
         .unwrap();
     let location = write_manifest_file(

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -264,20 +264,20 @@ pub struct Transaction {
     pub transaction_properties: Option<Arc<HashMap<String, String>>>,
 }
 
-/// The MemWAL state of the version a transaction read.
+/// The table as the version a transaction read, for the parts of building a
+/// manifest that depend on what the transaction *saw* rather than what it is
+/// committing onto.
 ///
-/// An index this transaction publishes was built against this fragment set, so
-/// covering it proves the index holds every row compacted as of
-/// `compacted_sstables`. Neither half can be recovered while building the
-/// manifest, which sees only the version being committed onto -- by then
-/// fragments may have been appended, and compaction may have advanced into
-/// them.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct MemWalReadSnapshot {
-    /// Fragments live in the table at that version.
-    pub fragments: RoaringBitmap,
-    /// Per-shard SSTable compaction progress recorded at that version.
-    pub compacted_sstables: Vec<CompactedSsTable>,
+/// The two differ whenever anything committed in between, which is exactly when
+/// the distinction matters: an index published here was built against this
+/// state, not the one it lands on.
+///
+/// Held as the materialized version rather than its number because building a
+/// manifest does no I/O, so it cannot resolve one into the other.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReadVersionState<'a> {
+    pub manifest: &'a Manifest,
+    pub indices: &'a [IndexMetadata],
 }
 
 /// Every non-system logical index, mapped to its sorted physical segment UUIDs.
@@ -1887,7 +1887,8 @@ impl Transaction {
     fn apply_mem_wal_index_coverage(
         final_indices: &mut [IndexMetadata],
         segments_before: &LogicalIndexSegments,
-        read_snapshot: &MemWalReadSnapshot,
+        read_fragments: &RoaringBitmap,
+        read_compacted_sstables: &[CompactedSsTable],
         new_version: u64,
     ) -> Result<()> {
         let Some(position) = final_indices
@@ -1923,8 +1924,7 @@ impl Transaction {
             .compacted_sstables
             .iter()
             .map(|committed| {
-                let inspected = read_snapshot
-                    .compacted_sstables
+                let inspected = read_compacted_sstables
                     .iter()
                     .find(|sstable| sstable.shard_id == committed.shard_id)
                     .map_or(0, |sstable| sstable.generation);
@@ -1958,7 +1958,7 @@ impl Transaction {
                 }
             }
 
-            let proven = covered.is_some_and(|covered| read_snapshot.fragments.is_subset(&covered));
+            let proven = covered.is_some_and(|covered| read_fragments.is_subset(&covered));
 
             // Only an index that is still physically the same may carry its old
             // position forward; otherwise that position was recorded against an
@@ -2005,17 +2005,17 @@ impl Transaction {
     ///
     /// `current_manifest` should only be None if the dataset does not yet exist.
     ///
-    /// `mem_wal_read_snapshot` describes the version this transaction read, and
-    /// is what lets an index published here record how far it has caught up. It
-    /// is `None` when the table has no MemWAL state to maintain, and on paths
-    /// with no version to read (dataset creation, detached commits).
+    /// `read_version_state` is the table as the version this transaction read,
+    /// which is what lets an index published here record how far it has caught
+    /// up. It is `None` on paths with no version to read: dataset creation and
+    /// detached commits.
     pub(crate) fn build_manifest(
         &self,
         current_manifest: Option<&Manifest>,
         current_indices: Vec<IndexMetadata>,
         transaction_file_path: &str,
         config: &ManifestWriteConfig,
-        mem_wal_read_snapshot: Option<&MemWalReadSnapshot>,
+        read_version_state: Option<ReadVersionState<'_>>,
     ) -> Result<(Manifest, Vec<IndexMetadata>)> {
         if config.use_stable_row_ids
             && current_manifest
@@ -2088,7 +2088,7 @@ impl Transaction {
         // Taken before the operation rewrites the list, so coverage can be
         // compared against what each logical index looked like going in. Only
         // tables carrying MemWAL state pay for it.
-        let mem_wal_segments_before = mem_wal_read_snapshot
+        let mem_wal_segments_before = read_version_state
             .is_some_and(|_| {
                 final_indices
                     .iter()
@@ -2726,14 +2726,28 @@ impl Transaction {
 
         // Applied once the final index list is known, so it sees exactly the
         // indices this commit publishes rather than what any one operation arm
-        // intended.
-        if let (Some(segments_before), Some(read_snapshot)) =
-            (&mem_wal_segments_before, mem_wal_read_snapshot)
+        // intended. The read version is parsed here rather than by the commit
+        // path, which has no business knowing what MemWAL keeps in its system
+        // index.
+        if let (Some(segments_before), Some(read_version_state)) =
+            (&mem_wal_segments_before, read_version_state)
+            && let Some(read_mem_wal_index) = read_version_state
+                .indices
+                .iter()
+                .find(|index| index.name == MEM_WAL_INDEX_NAME)
         {
+            let read_details = load_mem_wal_index_details(read_mem_wal_index.clone())?;
+            let read_fragments: RoaringBitmap = read_version_state
+                .manifest
+                .fragments
+                .iter()
+                .map(|fragment| fragment.id as u32)
+                .collect();
             Self::apply_mem_wal_index_coverage(
                 &mut final_indices,
                 segments_before,
-                read_snapshot,
+                &read_fragments,
+                &read_details.compacted_sstables,
                 new_version,
             )?;
         }
@@ -7358,14 +7372,19 @@ mod tests {
             new_mem_wal_index_meta(1, details).unwrap()
         }
 
-        fn snapshot(fragments: &[u32], compacted: &[(Uuid, u64)]) -> MemWalReadSnapshot {
-            MemWalReadSnapshot {
-                fragments: fragments.iter().copied().collect(),
-                compacted_sstables: compacted
+        /// What `build_manifest` derives from the read version before applying
+        /// coverage: the fragments live there, and its compaction progress.
+        fn snapshot(
+            fragments: &[u32],
+            compacted: &[(Uuid, u64)],
+        ) -> (RoaringBitmap, Vec<CompactedSsTable>) {
+            (
+                fragments.iter().copied().collect(),
+                compacted
                     .iter()
                     .map(|&(shard, generation)| CompactedSsTable::new(shard, generation))
                     .collect(),
-            }
+            )
         }
 
         /// Apply coverage to `indices`, treating `before` as the pre-operation
@@ -7373,14 +7392,15 @@ mod tests {
         fn recorded(
             indices: &mut [IndexMetadata],
             before: &[IndexMetadata],
-            read_snapshot: &MemWalReadSnapshot,
+            read_snapshot: &(RoaringBitmap, Vec<CompactedSsTable>),
             shard: Uuid,
         ) -> Vec<(String, u64)> {
             let segments_before = Transaction::logical_index_segments(before);
             Transaction::apply_mem_wal_index_coverage(
                 indices,
                 &segments_before,
-                read_snapshot,
+                &read_snapshot.0,
+                &read_snapshot.1,
                 VERSION,
             )
             .unwrap();
@@ -7617,13 +7637,14 @@ mod tests {
         fn a_table_that_has_never_compacted_records_nothing() {
             let before = vec![segment("idx", Some(&[0])), mem_wal_index(&[], &[])];
             let mut after = before.clone();
-            let read_snapshot = snapshot(&[0, 1], &[]);
+            let (read_fragments, read_compacted) = snapshot(&[0, 1], &[]);
 
             let segments_before = Transaction::logical_index_segments(&before);
             Transaction::apply_mem_wal_index_coverage(
                 &mut after,
                 &segments_before,
-                &read_snapshot,
+                &read_fragments,
+                &read_compacted,
                 VERSION,
             )
             .unwrap();

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -17,7 +17,9 @@ use super::write::merge_insert::inserted_rows::KeyExistenceFilter;
 use crate::dataset::overlay::collect_overlay_stale_frags;
 use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
 use crate::index::index_results_are_row_addrs;
-use crate::index::mem_wal::update_mem_wal_index_compacted_sstables;
+use crate::index::mem_wal::{
+    load_mem_wal_index_details, new_mem_wal_index_meta, update_mem_wal_index_compacted_sstables,
+};
 use crate::utils::temporal::timestamp_to_nanos;
 use lance_core::datatypes::{
     LANCE_UNENFORCED_CLUSTERING_KEY_POSITION, LANCE_UNENFORCED_PRIMARY_KEY,
@@ -29,7 +31,7 @@ use lance_file::{
     datatypes::Fields,
     version::{ConcreteFileVersion, LanceFileVersion},
 };
-use lance_index::mem_wal::CompactedSsTable;
+use lance_index::mem_wal::{CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX_NAME};
 use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
@@ -51,7 +53,7 @@ use object_store::path::Path;
 use roaring::RoaringBitmap;
 use std::cmp::Ordering;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 use uuid::Uuid;
@@ -261,6 +263,30 @@ pub struct Transaction {
     pub tag: Option<String>,
     pub transaction_properties: Option<Arc<HashMap<String, String>>>,
 }
+
+/// The MemWAL state of the version a transaction read.
+///
+/// An index this transaction publishes was built against this fragment set, so
+/// covering it proves the index holds every row compacted as of
+/// `compacted_sstables`. Neither half can be recovered while building the
+/// manifest, which sees only the version being committed onto -- by then
+/// fragments may have been appended, and compaction may have advanced into
+/// them.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MemWalReadSnapshot {
+    /// Fragments live in the table at that version.
+    pub fragments: RoaringBitmap,
+    /// Per-shard SSTable compaction progress recorded at that version.
+    pub compacted_sstables: Vec<CompactedSsTable>,
+}
+
+/// Every non-system logical index, mapped to its sorted physical segment UUIDs.
+///
+/// A logical index may be backed by several segments, and Lance mints a fresh
+/// UUID whenever one is written, so the sorted set is a faithful identity for
+/// "is this still the same physical index" -- unlike any one arbitrarily chosen
+/// segment.
+type LogicalIndexSegments = BTreeMap<String, Vec<Uuid>>;
 
 #[derive(Debug, Clone, DeepSizeOf, PartialEq)]
 pub struct DataReplacementGroup(pub u64, pub DataFile);
@@ -1825,15 +1851,171 @@ impl Transaction {
         Ok((manifest, indices))
     }
 
+    fn logical_index_segments(indices: &[IndexMetadata]) -> LogicalIndexSegments {
+        let mut by_name: LogicalIndexSegments = BTreeMap::new();
+        for index in indices.iter().filter(|index| !is_system_index(index)) {
+            by_name
+                .entry(index.name.clone())
+                .or_default()
+                .push(index.uuid);
+        }
+        for uuids in by_name.values_mut() {
+            uuids.sort_unstable();
+        }
+        by_name
+    }
+
+    /// Record how far each index has caught up with compacted MemWAL SSTables.
+    ///
+    /// An index covering every fragment that was live when this transaction read
+    /// the table demonstrably holds every row compaction had copied in by then,
+    /// so it is caught up to the progress recorded at that version. That is the
+    /// only claim available: nothing maps a compaction generation to the
+    /// fragments its rows landed in, so covering the whole inspected table is
+    /// how an index shows it covered those rows. Fragments appended since are a
+    /// later catch-up gap.
+    ///
+    /// An index that does not cover the snapshot proves nothing and keeps the
+    /// position it last recorded only while it is physically unchanged. A
+    /// rebuilt, replaced or remapped index is a different index, and the old
+    /// position no longer describes it.
+    ///
+    /// Every index gets an explicit entry, including generation 0 for a shard it
+    /// cannot vouch for. A *missing* entry reads as "fully caught up" (see
+    /// `MemWalIndex::is_index_caught_up`), which would let the WAL retire an
+    /// SSTable whose rows no index holds.
+    fn apply_mem_wal_index_coverage(
+        final_indices: &mut [IndexMetadata],
+        segments_before: &LogicalIndexSegments,
+        read_snapshot: &MemWalReadSnapshot,
+        new_version: u64,
+    ) -> Result<()> {
+        let Some(position) = final_indices
+            .iter()
+            .position(|index| index.name == MEM_WAL_INDEX_NAME)
+        else {
+            // The system index is gone (MemWAL disabled, or an overwrite), so
+            // there is no coverage left to gate anything.
+            return Ok(());
+        };
+
+        let mut details = load_mem_wal_index_details(final_indices[position].clone())?;
+        let mut catchup_before = std::mem::take(&mut details.index_catchup);
+        catchup_before.sort_by(|a, b| a.index_name.cmp(&b.index_name));
+
+        // Nothing has been compacted, so no index can be behind and there is no
+        // shard to name in an entry.
+        if details.compacted_sstables.is_empty() {
+            if catchup_before.is_empty() {
+                return Ok(());
+            }
+            final_indices[position] = new_mem_wal_index_meta(new_version, details)?;
+            return Ok(());
+        }
+
+        // Per shard: what this commit records as compacted, and the most this
+        // snapshot may credit. The snapshot cap is the point of the whole
+        // exercise -- generations compacted after the read landed in fragments
+        // the index never saw. The committed value caps it in turn, so a
+        // snapshot from a version that was since rolled back cannot retire
+        // SSTables no live commit copied in.
+        let shards: Vec<(Uuid, u64, u64)> = details
+            .compacted_sstables
+            .iter()
+            .map(|committed| {
+                let inspected = read_snapshot
+                    .compacted_sstables
+                    .iter()
+                    .find(|sstable| sstable.shard_id == committed.shard_id)
+                    .map_or(0, |sstable| sstable.generation);
+                (
+                    committed.shard_id,
+                    committed.generation,
+                    inspected.min(committed.generation),
+                )
+            })
+            .collect();
+
+        let mut segments_after: BTreeMap<&str, Vec<&IndexMetadata>> = BTreeMap::new();
+        for index in final_indices.iter().filter(|index| !is_system_index(index)) {
+            segments_after
+                .entry(index.name.as_str())
+                .or_default()
+                .push(index);
+        }
+
+        for (name, segments) in segments_after {
+            // A segment that does not record which fragments it covers cannot
+            // prove anything, so the whole index falls back to its old position.
+            let mut covered = Some(RoaringBitmap::new());
+            for segment in &segments {
+                match (covered.as_mut(), segment.fragment_bitmap.as_ref()) {
+                    (Some(accumulated), Some(bitmap)) => *accumulated |= bitmap,
+                    _ => {
+                        covered = None;
+                        break;
+                    }
+                }
+            }
+
+            let proven = covered.is_some_and(|covered| read_snapshot.fragments.is_subset(&covered));
+
+            // Only an index that is still physically the same may carry its old
+            // position forward; otherwise that position was recorded against an
+            // index that no longer exists.
+            let mut uuids: Vec<Uuid> = segments.iter().map(|segment| segment.uuid).collect();
+            uuids.sort_unstable();
+            let prior = segments_before
+                .get(name)
+                .is_some_and(|before| *before == uuids)
+                .then(|| catchup_before.iter().find(|entry| entry.index_name == name))
+                .flatten();
+
+            let caught_up_generations = shards
+                .iter()
+                .map(|&(shard_id, committed, creditable)| {
+                    let carried = prior
+                        .and_then(|prior| prior.caught_up_generation_for_shard(&shard_id))
+                        .unwrap_or(0);
+                    let credited = if proven { creditable } else { 0 };
+                    // Never lowers what an unchanged index already recorded: a
+                    // commit reading an older version still knows this index
+                    // covered more than its own snapshot can prove.
+                    CompactedSsTable::new(shard_id, carried.max(credited).min(committed))
+                })
+                .collect();
+
+            details.index_catchup.push(IndexCatchupProgress::new(
+                name.to_string(),
+                caught_up_generations,
+            ));
+        }
+
+        // Every commit on a compacted table reaches this point, so rewriting the
+        // entry unconditionally would mint a new UUID and drop the decoded-details
+        // cache on unrelated high-volume commits.
+        if details.index_catchup == catchup_before {
+            return Ok(());
+        }
+        final_indices[position] = new_mem_wal_index_meta(new_version, details)?;
+        Ok(())
+    }
+
     /// Create a new manifest from the current manifest and the transaction.
     ///
     /// `current_manifest` should only be None if the dataset does not yet exist.
+    ///
+    /// `mem_wal_read_snapshot` describes the version this transaction read, and
+    /// is what lets an index published here record how far it has caught up. It
+    /// is `None` when the table has no MemWAL state to maintain, and on paths
+    /// with no version to read (dataset creation, detached commits).
     pub(crate) fn build_manifest(
         &self,
         current_manifest: Option<&Manifest>,
         current_indices: Vec<IndexMetadata>,
         transaction_file_path: &str,
         config: &ManifestWriteConfig,
+        mem_wal_read_snapshot: Option<&MemWalReadSnapshot>,
     ) -> Result<(Manifest, Vec<IndexMetadata>)> {
         if config.use_stable_row_ids
             && current_manifest
@@ -1902,6 +2084,17 @@ impl Transaction {
             .unwrap_or(0);
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
+
+        // Taken before the operation rewrites the list, so coverage can be
+        // compared against what each logical index looked like going in. Only
+        // tables carrying MemWAL state pay for it.
+        let mem_wal_segments_before = mem_wal_read_snapshot
+            .is_some_and(|_| {
+                final_indices
+                    .iter()
+                    .any(|index| index.name == MEM_WAL_INDEX_NAME)
+            })
+            .then(|| Self::logical_index_segments(&final_indices));
 
         let mut next_row_id = {
             // Only use row ids if the feature flag is set already or
@@ -2529,6 +2722,20 @@ impl Transaction {
             if !fragment.overlays.is_empty() {
                 lance_table::format::overlay::verify_overlays_newest_last(&fragment.overlays)?;
             }
+        }
+
+        // Applied once the final index list is known, so it sees exactly the
+        // indices this commit publishes rather than what any one operation arm
+        // intended.
+        if let (Some(segments_before), Some(read_snapshot)) =
+            (&mem_wal_segments_before, mem_wal_read_snapshot)
+        {
+            Self::apply_mem_wal_index_coverage(
+                &mut final_indices,
+                segments_before,
+                read_snapshot,
+                new_version,
+            )?;
         }
 
         let user_requested_version = match (&config.storage_format, config.use_legacy_format) {
@@ -4453,6 +4660,7 @@ mod tests {
                 vec![first_index.clone(), second_index.clone()],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -4488,6 +4696,7 @@ mod tests {
                 vec![first_index.clone(), second_index.clone()],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -4540,6 +4749,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -4576,6 +4786,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -5402,6 +5613,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -5775,6 +5987,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -5861,6 +6074,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -5937,6 +6151,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6017,6 +6232,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6086,6 +6302,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6156,6 +6373,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6215,6 +6433,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6274,6 +6493,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6319,6 +6539,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6359,6 +6580,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6404,6 +6626,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6482,6 +6705,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6534,6 +6758,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6598,6 +6823,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6673,6 +6899,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6865,6 +7092,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6941,6 +7169,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -6981,6 +7210,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap();
 
@@ -7009,6 +7239,7 @@ mod tests {
                 vec![],
                 "txn",
                 &ManifestWriteConfig::default(),
+                None,
             )
             .unwrap_err();
         assert!(err.to_string().contains("does not exist"), "{err}");
@@ -7072,6 +7303,361 @@ mod tests {
             assert!(
                 matches!(txn.operation, Operation::Merge { preserves_nullability, .. } if preserves_nullability == encoded),
                 "encoded={encoded:?}"
+            );
+        }
+    }
+
+    /// Coverage is recorded from what the commit can see: the index list it
+    /// publishes, and the MemWAL state of the version the transaction read.
+    mod mem_wal_index_coverage {
+        use super::*;
+        use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails};
+
+        const VERSION: u64 = 7;
+
+        fn segment(name: &str, fragments: Option<&[u32]>) -> IndexMetadata {
+            IndexMetadata {
+                uuid: Uuid::new_v4(),
+                name: name.into(),
+                fields: vec![0],
+                dataset_version: 1,
+                fragment_bitmap: fragments.map(|ids| ids.iter().copied().collect()),
+                index_details: None,
+                index_version: 0,
+                created_at: None,
+                base_id: None,
+                files: None,
+            }
+        }
+
+        fn mem_wal_index(
+            compacted: &[(Uuid, u64)],
+            catchup: &[(&str, &[(Uuid, u64)])],
+        ) -> IndexMetadata {
+            let details = MemWalIndexDetails {
+                compacted_sstables: compacted
+                    .iter()
+                    .map(|&(shard, generation)| CompactedSsTable::new(shard, generation))
+                    .collect(),
+                index_catchup: catchup
+                    .iter()
+                    .map(|(name, generations)| {
+                        IndexCatchupProgress::new(
+                            (*name).to_string(),
+                            generations
+                                .iter()
+                                .map(|&(shard, generation)| {
+                                    CompactedSsTable::new(shard, generation)
+                                })
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+                ..Default::default()
+            };
+            new_mem_wal_index_meta(1, details).unwrap()
+        }
+
+        fn snapshot(fragments: &[u32], compacted: &[(Uuid, u64)]) -> MemWalReadSnapshot {
+            MemWalReadSnapshot {
+                fragments: fragments.iter().copied().collect(),
+                compacted_sstables: compacted
+                    .iter()
+                    .map(|&(shard, generation)| CompactedSsTable::new(shard, generation))
+                    .collect(),
+            }
+        }
+
+        /// Apply coverage to `indices`, treating `before` as the pre-operation
+        /// index list, and read back what each index recorded for `shard`.
+        fn recorded(
+            indices: &mut [IndexMetadata],
+            before: &[IndexMetadata],
+            read_snapshot: &MemWalReadSnapshot,
+            shard: Uuid,
+        ) -> Vec<(String, u64)> {
+            let segments_before = Transaction::logical_index_segments(before);
+            Transaction::apply_mem_wal_index_coverage(
+                indices,
+                &segments_before,
+                read_snapshot,
+                VERSION,
+            )
+            .unwrap();
+            let mem_wal = indices
+                .iter()
+                .find(|index| index.name == MEM_WAL_INDEX_NAME)
+                .unwrap();
+            load_mem_wal_index_details(mem_wal.clone())
+                .unwrap()
+                .index_catchup
+                .into_iter()
+                .map(|entry| {
+                    let generation = entry
+                        .caught_up_generation_for_shard(&shard)
+                        .expect("every entry names every compacted shard");
+                    (entry.index_name, generation)
+                })
+                .collect()
+        }
+
+        #[test]
+        fn an_index_covering_the_read_version_records_its_compaction_progress() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                mem_wal_index(&[(shard, 5)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 5)]);
+        }
+
+        /// The whole point of the read snapshot: an index built against an older
+        /// version cannot vouch for rows compacted into fragments it never saw.
+        #[test]
+        fn coverage_is_capped_by_what_the_read_version_had_compacted() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                mem_wal_index(&[(shard, 9)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 5)]);
+        }
+
+        /// A snapshot from a version that was since rolled back must not retire
+        /// SSTables no live commit copied in.
+        #[test]
+        fn coverage_is_capped_by_what_the_commit_records_as_compacted() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                mem_wal_index(&[(shard, 3)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 9)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 3)]);
+        }
+
+        /// A missing entry reads as "fully caught up", so an index that proves
+        /// nothing must still be named, at generation 0.
+        #[test]
+        fn an_index_that_proves_nothing_records_an_explicit_zero() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0])),
+                mem_wal_index(&[(shard, 5)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 0)]);
+        }
+
+        /// Fragments appended since the read are a later catch-up gap, not a
+        /// reason to withdraw a position an unchanged index already earned.
+        #[test]
+        fn an_unchanged_index_carries_its_position_forward() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0])),
+                mem_wal_index(&[(shard, 5)], &[("idx", &[(shard, 5)])]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 5)]);
+        }
+
+        /// A rebuilt or replaced index is a different index; the position was
+        /// recorded against one that no longer exists.
+        #[test]
+        fn a_changed_index_loses_the_position_it_did_not_re_prove() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0])),
+                mem_wal_index(&[(shard, 5)], &[("idx", &[(shard, 5)])]),
+            ];
+            let mut after = vec![segment("idx", Some(&[0])), before[1].clone()];
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 0)]);
+        }
+
+        /// A commit reading an older version still knows this index covered
+        /// more than its own snapshot can prove.
+        #[test]
+        fn an_older_snapshot_never_lowers_a_recorded_position() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                mem_wal_index(&[(shard, 9)], &[("idx", &[(shard, 7)])]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 3)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 7)]);
+        }
+
+        /// A delta index is caught up only if its segments cover the snapshot
+        /// between them.
+        #[test]
+        fn coverage_is_the_union_across_a_logical_index_segments() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0])),
+                segment("idx", Some(&[1])),
+                mem_wal_index(&[(shard, 5)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 5)]);
+        }
+
+        /// A segment that does not say which fragments it covers cannot prove
+        /// anything, so the whole logical index falls back.
+        #[test]
+        fn a_segment_without_a_fragment_bitmap_proves_nothing() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                segment("idx", None),
+                mem_wal_index(&[(shard, 5)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(progress, vec![("idx".to_string(), 0)]);
+        }
+
+        /// Every commit on a compacted table reaches this code, so an unchanged
+        /// result must not mint a new UUID and drop the decoded-details cache.
+        #[test]
+        fn an_unchanged_result_leaves_the_system_index_untouched() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("idx", Some(&[0, 1])),
+                mem_wal_index(&[(shard, 5)], &[("idx", &[(shard, 5)])]),
+            ];
+            let mut after = before.clone();
+
+            recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(after[1].uuid, before[1].uuid);
+        }
+
+        /// Nothing has been compacted, so no index can be behind and there is no
+        /// shard an entry could name.
+        #[test]
+        fn a_table_that_has_never_compacted_records_nothing() {
+            let before = vec![segment("idx", Some(&[0])), mem_wal_index(&[], &[])];
+            let mut after = before.clone();
+            let read_snapshot = snapshot(&[0, 1], &[]);
+
+            let segments_before = Transaction::logical_index_segments(&before);
+            Transaction::apply_mem_wal_index_coverage(
+                &mut after,
+                &segments_before,
+                &read_snapshot,
+                VERSION,
+            )
+            .unwrap();
+
+            assert!(
+                load_mem_wal_index_details(after[1].clone())
+                    .unwrap()
+                    .index_catchup
+                    .is_empty()
+            );
+            assert_eq!(after[1].uuid, before[1].uuid);
+        }
+
+        /// Each index is judged on its own coverage, and every one is named.
+        #[test]
+        fn indices_are_judged_independently() {
+            let shard = Uuid::new_v4();
+            let before = vec![
+                segment("covers", Some(&[0, 1])),
+                segment("lags", Some(&[0])),
+                mem_wal_index(&[(shard, 5)], &[]),
+            ];
+            let mut after = before.clone();
+
+            let progress = recorded(
+                &mut after,
+                &before,
+                &snapshot(&[0, 1], &[(shard, 5)]),
+                shard,
+            );
+
+            assert_eq!(
+                progress,
+                vec![("covers".to_string(), 5), ("lags".to_string(), 0)]
             );
         }
     }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -46,13 +46,14 @@ use super::ObjectStore;
 use crate::Dataset;
 use crate::dataset::cleanup::auto_cleanup_hook;
 use crate::dataset::fragment::FileFragment;
-use crate::dataset::transaction::{Operation, Transaction};
+use crate::dataset::transaction::{MemWalReadSnapshot, Operation, Transaction};
 use crate::dataset::{
     ManifestWriteConfig, NewTransactionResult, TRANSACTIONS_DIR, load_new_transactions,
     write_manifest_file,
 };
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::mem_wal::load_mem_wal_index_details;
 use crate::index::vector::details::infer_missing_vector_details;
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::session::Session;
@@ -62,6 +63,7 @@ use futures::future::Either;
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::{Error, Result};
 use lance_index::is_system_index;
+use lance_index::mem_wal::MEM_WAL_INDEX_NAME;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
 use object_store::ObjectStoreExt;
@@ -460,7 +462,7 @@ async fn do_commit_new_dataset(
         }
     } else {
         let (manifest, indices) =
-            transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
+            transaction.build_manifest(None, vec![], &transaction_file, write_config, None)?;
         (manifest, indices)
     };
 
@@ -1137,11 +1139,14 @@ pub(crate) async fn do_commit_detached_transaction(
                 )
                 .await?
             }
+            // Detached commits sit outside the version chain, so there is no
+            // read version whose coverage this could advance.
             _ => transaction.build_manifest(
                 Some(dataset.manifest.as_ref()),
                 dataset.load_indices().await?.as_ref().clone(),
                 &transaction_file,
                 write_config,
+                None,
             )?,
         };
 
@@ -1354,6 +1359,28 @@ async fn record_successful_commit(
     }
 }
 
+/// The MemWAL state of `dataset`, for a transaction that read it.
+///
+/// `None` for a table with no MemWAL index, which is every ordinary table. The
+/// index list is loaded from the session cache the commit path already warms,
+/// so a table without MemWAL pays only the lookup.
+async fn read_mem_wal_snapshot(dataset: &Dataset) -> Result<Option<MemWalReadSnapshot>> {
+    let indices = dataset.load_indices().await?;
+    let Some(mem_wal_index) = indices.iter().find(|idx| idx.name == MEM_WAL_INDEX_NAME) else {
+        return Ok(None);
+    };
+    let details = load_mem_wal_index_details(mem_wal_index.clone())?;
+    Ok(Some(MemWalReadSnapshot {
+        fragments: dataset
+            .manifest
+            .fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .collect(),
+        compacted_sstables: details.compacted_sstables,
+    }))
+}
+
 /// Attempt to commit a transaction, with retries and conflict resolution.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn commit_transaction(
@@ -1387,6 +1414,11 @@ pub(crate) async fn commit_transaction(
             // If the dataset version is the same as the read version, we can use it directly.
             dataset.clone()
         };
+
+    // Captured here, while `dataset` is still the version this transaction read.
+    // The loop below advances it to the latest version, which is exactly the
+    // state that cannot answer what the transaction saw.
+    let mem_wal_read_snapshot = read_mem_wal_snapshot(&dataset).await?;
 
     let mut transaction = transaction.clone();
 
@@ -1464,6 +1496,7 @@ pub(crate) async fn commit_transaction(
                 dataset.load_indices().await?.as_ref().clone(),
                 transaction_file,
                 write_config,
+                mem_wal_read_snapshot.as_ref(),
             )?,
         };
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -46,14 +46,13 @@ use super::ObjectStore;
 use crate::Dataset;
 use crate::dataset::cleanup::auto_cleanup_hook;
 use crate::dataset::fragment::FileFragment;
-use crate::dataset::transaction::{MemWalReadSnapshot, Operation, Transaction};
+use crate::dataset::transaction::{Operation, ReadVersionState, Transaction};
 use crate::dataset::{
     ManifestWriteConfig, NewTransactionResult, TRANSACTIONS_DIR, load_new_transactions,
     write_manifest_file,
 };
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
-use crate::index::mem_wal::load_mem_wal_index_details;
 use crate::index::vector::details::infer_missing_vector_details;
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::session::Session;
@@ -63,7 +62,6 @@ use futures::future::Either;
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::{Error, Result};
 use lance_index::is_system_index;
-use lance_index::mem_wal::MEM_WAL_INDEX_NAME;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
 use object_store::ObjectStoreExt;
@@ -1359,28 +1357,6 @@ async fn record_successful_commit(
     }
 }
 
-/// The MemWAL state of `dataset`, for a transaction that read it.
-///
-/// `None` for a table with no MemWAL index, which is every ordinary table. The
-/// index list is loaded from the session cache the commit path already warms,
-/// so a table without MemWAL pays only the lookup.
-async fn read_mem_wal_snapshot(dataset: &Dataset) -> Result<Option<MemWalReadSnapshot>> {
-    let indices = dataset.load_indices().await?;
-    let Some(mem_wal_index) = indices.iter().find(|idx| idx.name == MEM_WAL_INDEX_NAME) else {
-        return Ok(None);
-    };
-    let details = load_mem_wal_index_details(mem_wal_index.clone())?;
-    Ok(Some(MemWalReadSnapshot {
-        fragments: dataset
-            .manifest
-            .fragments
-            .iter()
-            .map(|fragment| fragment.id as u32)
-            .collect(),
-        compacted_sstables: details.compacted_sstables,
-    }))
-}
-
 /// Attempt to commit a transaction, with retries and conflict resolution.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn commit_transaction(
@@ -1418,7 +1394,8 @@ pub(crate) async fn commit_transaction(
     // Captured here, while `dataset` is still the version this transaction read.
     // The loop below advances it to the latest version, which is exactly the
     // state that cannot answer what the transaction saw.
-    let mem_wal_read_snapshot = read_mem_wal_snapshot(&dataset).await?;
+    let read_manifest = dataset.manifest.clone();
+    let read_indices = dataset.load_indices().await?;
 
     let mut transaction = transaction.clone();
 
@@ -1496,7 +1473,10 @@ pub(crate) async fn commit_transaction(
                 dataset.load_indices().await?.as_ref().clone(),
                 transaction_file,
                 write_config,
-                mem_wal_read_snapshot.as_ref(),
+                Some(ReadVersionState {
+                    manifest: read_manifest.as_ref(),
+                    indices: read_indices.as_ref(),
+                }),
             )?,
         };
 


### PR DESCRIPTION
## What

An index absent from `index_catchup` reads as fully caught up, so the WAL may retire an SSTable whose rows no index holds. Nothing ever wrote the field, so every table reads that way today.

This records it at commit time, derived from state the commit already has.

> Alternative design for the problem #8263 addresses, opened as a draft for discussion rather than to compete with it. Same goal and the same safety property; the difference is that nothing is transmitted, so `transaction.proto`, the feature flags, and the cross-language bindings are untouched.

## How

An index covering every fragment that was live at the transaction's **read version** holds every row compaction had copied into the base table by then, so it is caught up to the `compacted_sstables` progress at that version.

That is the only proof available: nothing maps a compaction generation to the fragments its rows landed in, so covering the whole table as the transaction read it is how an index shows it covered those rows. Fragments appended since are a later catch-up gap.

Both halves come from state the commit already holds:

| Needed | Source |
|---|---|
| fragments the index was built against | read version's manifest |
| generations it may claim | read version's `__lance_mem_wal` details |
| which indices, and what they cover | the final index list being published |

`read_version` is already on every transaction and `commit_transaction` already materializes that version, so no claim is passed and no message changes.

`build_manifest` gains one parameter, `Option<ReadVersionState>` — the read version's manifest and index list, symmetric with the existing `current_manifest` / `current_indices`. It is `None` only where there is no version to read: dataset creation and detached commits. Deriving MemWAL's view from it happens inside `build_manifest`, so the commit path stays generic — `commit.rs` needs no knowledge of the system index's name or layout, and anything else that later needs the read version has it.

Per logical index:

- covers the read version → credit `compacted_sstables@V`, capped by what the commit itself records as compacted (so a read version since rolled back cannot retire SSTables no live commit copied in)
- otherwise physically unchanged → carry the prior position forward
- otherwise → generation `0`

Every index is named explicitly, including at `0`, because a *missing* entry reads as "caught up". A position is never lowered, so a commit reading an older version does not withdraw coverage an index already demonstrated.

## Why not derive it purely at commit time

Two simpler variants were tried and are unsound or ineffective:

- **Compare the index against the fragments live at commit time.** The index was built at V but is judged at W. Any commit landing in between — a compaction flushing SSTables in, an ordinary append — makes the check fail, so on a table taking writes it never fires.
- **Store a scalar `max_fragment_id` watermark per generation.** Live fragments are not a prefix of the id space. Background compaction rewrites F1, F2 → F3, so `{live : id ≤ watermark}` shrinks or empties, and an empty required set is a subset of *every* index — including one holding none of those rows. It fails in the unsafe direction, and with the frag-reuse index deferring remapping (`conflict_resolver.rs`), it fails on the ordinary path rather than in a rare race.

Anchoring to the read version avoids both: the index and the fragment set are captured in the same id-space, and a rewrite moves rows between fragments without destroying them, so the conclusion stays true afterward.

## Scope

| | |
|---|---|
| `protos/transaction.proto` | untouched |
| `protos/table.proto` | comments only |
| `feature_flags.rs` | untouched |
| `OptimizeOptions` | untouched |
| Python / Java bindings | untouched |

Consumers need no new API — read `index_catchup` at trim time.

## Tests

12 unit tests in `dataset::transaction::tests::mem_wal_index_coverage`: coverage recorded; capped by the read version; capped by the commit; explicit `0` when unproven; carry-forward for an unchanged index; dropped for a changed one; never lowering a recorded position; union across delta segments; segment without a fragment bitmap; no-op leaves the system index UUID untouched; never-compacted table records nothing; indices judged independently.

- `cargo test -p lance --lib` — 2854 passed, 0 failed
- `cargo clippy -p lance --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Those three were run against the first commit. The follow-up refactor moves types and parameters without touching the coverage rule; it is `cargo check --tests` and `cargo fmt` clean, and relies on CI for the rest.

## Notes for review

- **No mixed-version writers.** An older writer can change an index without withdrawing its recorded position. This assumes the compactor and trim logic move in tandem with this change.
- **Expect SSTable retention to increase initially.** `is_index_caught_up` returns `true` unconditionally today because nothing writes the field. Indices that genuinely lag will now report `0`. That is the point of the change, but it will look like a storage regression the first time it happens.
- **No partial credit.** An index covering 90% of the read version records nothing. Addressing that needs a generation → fragment mapping recorded at compaction time.
- **Stable row ids would collapse this area.** Every rejected variant above failed on fragment ids being an unstable coordinate system; stable row ids do not move under rewrite. See the existing `// TODO: this will change with stable row ids.` on the `Rewrite` arm of the index conflict rules.
- Related: #8438 (`UpdateMemWalState` publishes no fragments). This design commits no standalone `UpdateMemWalState`, so it does not make that latent bug reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
