### PR TITLE
ci: restore nightly jobs after repository rename

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-24.04
-    if: github.repository == 'lancedb/lance'
+    if: github.repository == 'lance-format/lance'
     permissions:
       actions: write
     steps:
@@ -25,7 +25,7 @@ jobs:
   jumbo-tests:
     # jumbo tests need more resources
     runs-on: ubuntu-24.04-8x
-    if: github.repository == 'lancedb/lance'
+    if: github.repository == 'lance-format/lance'
     timeout-minutes: 60
     permissions:
       contents: read
@@ -51,7 +51,7 @@ jobs:
   # slow and unbounded in depth, so it runs nightly with a generous timeout rather than blocking
   # merges; the manual escape hatch for arbitrary ref pairs lives in compat-pair.yml.
   compat-sequence:
-    if: github.repository == 'lancedb/lance'
+    if: github.repository == 'lance-format/lance'
     timeout-minutes: 360
     runs-on: ubuntu-24.04
     name: Index Sequence Compat


### PR DESCRIPTION
## What changed?

Update the origin-only guards in the nightly workflow from the former `lancedb/lance` repository name to `lance-format/lance`.

## Why is this needed?

The stale repository checks skip every nightly job on the current repository. This restores the file-verification dispatch, jumbo tests, and the index maintenance-sequence compatibility test.

Recent scheduled runs showing the workflow was skipped: https://github.com/lance-format/lance/actions/workflows/nightly_run.yml

## Validation

- Parsed `.github/workflows/nightly_run.yml` with Ruby YAML
- Confirmed all three origin guards use the current repository name
- `git diff --check`
- Pre-commit hooks passed
