### PR TITLE
perf(fts): add MAXSCORE for pure SHOULD queries

### DIFF
--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+mod should_maxscore;
+
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
@@ -24,10 +26,12 @@ use super::{
     tokenizer::document_tokenizer::TextTokenizer,
     wand::{
         FLAT_SEARCH_PERCENT_THRESHOLD, LegacyWandDocuments, ModernWandDocuments, PostingIterator,
-        WandCursor, WandDocuments,
+        WandCursor, WandDocuments, score_sum_upper_bound_factor,
     },
 };
 use crate::{metrics::MetricsCollector, prefilter::PreFilter};
+
+use self::should_maxscore::ShouldMaxScoreScorer;
 
 const DEFAULT_BLOCK_SIZE: usize = 128;
 const SCORE_FLOOR_RESOLUTION_BATCH_SIZE: usize = DEFAULT_BLOCK_SIZE;
@@ -196,6 +200,11 @@ pub(super) trait ComposableScorer: Send {
     fn score(&mut self) -> Result<f32>;
     fn advance_shallow(&mut self, target: u64) -> Result<u64>;
     fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds>;
+    /// Conservative list-wide score upper bound, independent of iterator
+    /// position. `None` keeps the scorer on exact eager composition paths.
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        None
+    }
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()>;
 
     fn matches(&mut self) -> Result<bool> {
@@ -214,6 +223,22 @@ pub(super) trait ComposableScorer: Send {
 }
 
 type BoxScorer<'a> = Box<dyn ComposableScorer + 'a>;
+
+fn sum_global_score_upper_bounds(children: &[BoxScorer<'_>]) -> Option<f32> {
+    children.iter().try_fold(0.0, |upper, child| {
+        let child_upper = child.global_score_upper_bound()?;
+        if !child_upper.is_finite() || child_upper < 0.0 {
+            return None;
+        }
+        let combined = ScoreBounds { lower: 0.0, upper }
+            .add(ScoreBounds {
+                lower: 0.0,
+                upper: child_upper,
+            })
+            .upper;
+        combined.is_finite().then_some(combined)
+    })
+}
 
 #[derive(Debug, Clone)]
 enum CompoundScorerPlan {
@@ -366,6 +391,10 @@ impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
             lower: 0.0,
             upper: self.score_upper_bound(up_to)?,
         })
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        WandCursor::global_score_upper_bound(self)
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -534,6 +563,14 @@ impl ComposableScorer for MaterializedScorer {
         let end = shallow.start
             + self.rows[shallow.start..shallow.end].partition_point(|row| row.row_id <= up_to);
         self.block_bounds(shallow.start, end)
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        self.rows
+            .iter()
+            .map(|row| row.score)
+            .max_by(f32::total_cmp)
+            .or(Some(0.0))
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -898,6 +935,10 @@ impl ComposableScorer for EmptyScorer {
         Ok(ScoreBounds::ZERO)
     }
 
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        Some(0.0)
+    }
+
     fn set_min_competitive_score(&mut self, _min_score: f32) -> Result<()> {
         Ok(())
     }
@@ -957,6 +998,17 @@ impl ComposableScorer for ScaleScorer<'_> {
             .child
             .score_bounds(up_to)?
             .scale_non_negative(self.factor))
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        self.child
+            .global_score_upper_bound()
+            .map(|upper| {
+                ScoreBounds { lower: 0.0, upper }
+                    .scale_non_negative(self.factor)
+                    .upper
+            })
+            .filter(|upper| upper.is_finite() && *upper >= 0.0)
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -1142,6 +1194,16 @@ impl ComposableScorer for DisjunctionScorer<'_> {
             Ok(ScoreBounds::ZERO)
         } else {
             Ok(bounds)
+        }
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        match self.mode {
+            DisjunctionScore::Sum => sum_global_score_upper_bounds(&self.children),
+            DisjunctionScore::Max => self.children.iter().try_fold(0.0_f32, |upper, child| {
+                let child_upper = child.global_score_upper_bound()?;
+                child_upper.is_finite().then_some(upper.max(child_upper))
+            }),
         }
     }
 
@@ -1388,6 +1450,12 @@ impl ComposableScorer for RequiredConjunctionScorer<'_> {
             bounds = bounds.add(child.score_bounds(up_to)?);
         }
         Ok(bounds)
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        self.scores_non_negative()
+            .then(|| sum_global_score_upper_bounds(&self.children))
+            .flatten()
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -1832,6 +1900,21 @@ impl ComposableScorer for ReqOptScorer<'_> {
         Ok(self.bounds(up_to)?.combined)
     }
 
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        let required = self.required.global_score_upper_bound()?;
+        let optional = self.optional.global_score_upper_bound()?;
+        let combined = ScoreBounds {
+            lower: 0.0,
+            upper: required,
+        }
+        .add(ScoreBounds {
+            lower: 0.0,
+            upper: optional,
+        })
+        .upper;
+        combined.is_finite().then_some(combined)
+    }
+
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
         if min_score.is_nan() {
             return Err(Error::invalid_input(
@@ -1876,21 +1959,30 @@ impl<'a> BooleanScorer<'a> {
         must: Vec<BoxScorer<'a>>,
         must_not: Vec<BoxScorer<'a>>,
     ) -> Result<Self> {
-        let mut optional = if should.is_empty() {
-            None
-        } else {
-            Some(
+        let (driver, optional) = if must.is_empty() {
+            if should.is_empty() {
+                return Err(Error::invalid_input(
+                    "boolean query must have at least one should/must query",
+                ));
+            }
+            let driver = if let Some(global_bounds) = ShouldMaxScoreScorer::global_bounds(&should) {
+                Box::new(ShouldMaxScoreScorer::new(should, global_bounds)) as BoxScorer<'a>
+            } else {
                 Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
-                    as BoxScorer<'a>,
-            )
-        };
-        let driver = if must.is_empty() {
-            optional.take().ok_or_else(|| {
-                Error::invalid_input("boolean query must have at least one should/must query")
-            })?
+                    as BoxScorer<'a>
+            };
+            (driver, None)
         } else {
+            let mut optional = if should.is_empty() {
+                None
+            } else {
+                Some(
+                    Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
+                        as BoxScorer<'a>,
+                )
+            };
             let required = Box::new(RequiredConjunctionScorer::try_new(must)?) as BoxScorer<'a>;
-            if required.scores_non_negative()
+            let driver = if required.scores_non_negative()
                 && optional
                     .as_ref()
                     .is_some_and(|optional| optional.scores_non_negative())
@@ -1903,7 +1995,8 @@ impl<'a> BooleanScorer<'a> {
                 )) as BoxScorer<'a>
             } else {
                 required
-            }
+            };
+            (driver, optional)
         };
         let prohibited = if must_not.is_empty() {
             None
@@ -2018,6 +2111,28 @@ impl ComposableScorer for BooleanScorer<'_> {
             bounds = bounds.add(optional.score_bounds(up_to)?.include_zero());
         }
         Ok(bounds)
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        if !self.scores_non_negative() {
+            return None;
+        }
+        let driver = self.driver.global_score_upper_bound()?;
+        let combined = if let Some(optional) = &self.optional {
+            let optional = optional.global_score_upper_bound()?;
+            ScoreBounds {
+                lower: 0.0,
+                upper: driver,
+            }
+            .add(ScoreBounds {
+                lower: 0.0,
+                upper: optional,
+            })
+            .upper
+        } else {
+            driver
+        };
+        (combined.is_finite() && combined >= 0.0).then_some(combined)
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -2700,7 +2815,10 @@ async fn compound_search_impl(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::atomic::AtomicUsize;
+
+    use rand::{Rng, SeedableRng, rngs::SmallRng};
 
     use super::*;
 
@@ -2713,6 +2831,11 @@ mod tests {
 
     fn materialized(values: &[(u64, f32)]) -> Box<dyn ComposableScorer> {
         Box::new(MaterializedScorer::try_new(rows(values)).unwrap())
+    }
+
+    fn should_maxscore(children: Vec<BoxScorer<'_>>) -> ShouldMaxScoreScorer<'_> {
+        let global_bounds = ShouldMaxScoreScorer::global_bounds(&children).unwrap();
+        ShouldMaxScoreScorer::new(children, global_bounds)
     }
 
     #[test]
@@ -2865,6 +2988,10 @@ mod tests {
             self.inner.score_bounds(up_to)
         }
 
+        fn global_score_upper_bound(&self) -> Option<f32> {
+            self.inner.global_score_upper_bound()
+        }
+
         fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
             self.inner.set_min_competitive_score(min_score)
         }
@@ -2962,6 +3089,10 @@ mod tests {
         fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
             self.work.bounds.fetch_add(1, AtomicOrdering::Relaxed);
             self.inner.score_bounds(up_to)
+        }
+
+        fn global_score_upper_bound(&self) -> Option<f32> {
+            self.inner.global_score_upper_bound()
         }
 
         fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -3071,6 +3202,10 @@ mod tests {
 
         fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
             self.inner.score_bounds(up_to)
+        }
+
+        fn global_score_upper_bound(&self) -> Option<f32> {
+            self.inner.global_score_upper_bound()
         }
 
         fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -3407,5 +3542,301 @@ mod tests {
             .unwrap();
 
         assert_eq!(results, rows(&[(2, 11.0)]));
+    }
+
+    fn pure_should_canary_children() -> (Vec<BoxScorer<'static>>, Vec<Arc<ScorerWork>>) {
+        let mut children = Vec::new();
+        let mut work = Vec::new();
+        let mut push = |child: BoxScorer<'static>| {
+            let (child, child_work) = instrumented(child);
+            children.push(child);
+            work.push(child_work);
+        };
+
+        push(materialized(&[(0, 2.0)]));
+        let dense = (1..=1024).map(|doc| (doc, 0.125)).collect::<Vec<_>>();
+        for _ in 0..8 {
+            push(materialized(&dense));
+        }
+        let sparse = (127..=1023)
+            .step_by(128)
+            .map(|doc| (doc, 1.5))
+            .collect::<Vec<_>>();
+        push(materialized(&sparse));
+        (children, work)
+    }
+
+    fn scorer_advances(work: &[Arc<ScorerWork>]) -> usize {
+        work.iter()
+            .map(|work| work.advances.load(AtomicOrdering::Relaxed))
+            .sum()
+    }
+
+    fn exhaustive_should_top_k(children: &[Vec<(u64, f32)>], limit: usize) -> Vec<ScoredRow> {
+        let mut scores = HashMap::<u64, f32>::new();
+        for child in children {
+            for (doc, score) in child {
+                *scores.entry(*doc).or_default() += *score;
+            }
+        }
+        let mut rows = scores
+            .into_iter()
+            .map(|(doc, score)| ScoredRow::new(doc, score).unwrap())
+            .collect::<Vec<_>>();
+        rows.sort_unstable_by(compare_scored_rows);
+        rows.truncate(limit);
+        rows
+    }
+
+    #[test]
+    fn pure_should_maxscore_reduces_posting_comparisons() {
+        let (children, eager_work) = pure_should_canary_children();
+        let mut eager = DisjunctionScorer::try_new(children, DisjunctionScore::Sum).unwrap();
+        let eager_results = TopKCollector::new(1).collect(&mut eager).unwrap();
+        let eager_comparisons = scorer_advances(&eager_work);
+
+        let (children, optimized_work) = pure_should_canary_children();
+        let optimized_results = {
+            let mut optimized = should_maxscore(children);
+            TopKCollector::new(1).collect(&mut optimized).unwrap()
+        };
+        let optimized_comparisons = scorer_advances(&optimized_work);
+
+        assert_eq!(eager_results, rows(&[(127, 2.5)]));
+        assert_eq!(optimized_results, eager_results);
+        assert!(eager_comparisons > 0);
+        assert!(
+            optimized_comparisons * 5 <= eager_comparisons * 4,
+            "pure-SHOULD MAXSCORE should reduce posting candidate probes by at least 20%: \
+             optimized={optimized_comparisons} eager={eager_comparisons}"
+        );
+    }
+
+    #[test]
+    fn pure_should_maxscore_matches_randomized_exhaustive_top_k() {
+        for seed in 0..8 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let children = (0..6)
+                .map(|_| {
+                    (0..256)
+                        .filter_map(|doc| {
+                            if rng.random_bool(0.35) {
+                                let score = rng.random_range(1..=16) as f32 * 0.25;
+                                Some((doc, score))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            for limit in [1, 7, 31, 512] {
+                let expected = exhaustive_should_top_k(&children, limit);
+
+                let mut optimized =
+                    should_maxscore(children.iter().map(|values| materialized(values)).collect());
+                let actual = TopKCollector::new(limit).collect(&mut optimized).unwrap();
+                assert_eq!(actual, expected, "seed={seed} limit={limit}");
+            }
+        }
+    }
+
+    #[test]
+    fn pure_should_maxscore_confirms_two_phase_children_before_scoring() {
+        let (phrase, _, confirmations) = two_phase(&[(1, 100.0)], Vec::new(), Some(10.0));
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(10.0);
+        let results = {
+            let mut scorer = should_maxscore(vec![
+                materialized(&[(0, 10.0)]),
+                phrase,
+                materialized(&[(1, 6.0)]),
+                materialized(&[(1, 5.0)]),
+            ]);
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut scorer)
+                .unwrap()
+        };
+
+        assert_eq!(results, rows(&[(1, 11.0)]));
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn pure_should_maxscore_preserves_query_score_order_and_terminal_doc() {
+        let mut scorer = should_maxscore(vec![
+            materialized(&[(u64::MAX, 16_777_216.0)]),
+            materialized(&[(u64::MAX, 1.0)]),
+            materialized(&[(u64::MAX, 1.0)]),
+            materialized(&[]),
+        ]);
+
+        assert_eq!(
+            TopKCollector::new(1).collect(&mut scorer).unwrap(),
+            rows(&[(u64::MAX, 16_777_216.0)])
+        );
+    }
+
+    #[test]
+    fn pure_should_maxscore_keeps_equal_floor_across_bound_ordering() {
+        let scores = [
+            f32::from_bits(0x4783_798b),
+            f32::from_bits(0x4dd3_8b75),
+            f32::from_bits(0x48e7_7236),
+            f32::from_bits(0x418e_5b26),
+            f32::from_bits(0x4241_b1eb),
+        ];
+        let exact_score = scores
+            .into_iter()
+            .fold(0.0_f32, |total, score| total + score);
+        assert_eq!(exact_score.to_bits(), 0x4dd3_cd8d);
+
+        let mut scorer = should_maxscore(
+            scores
+                .into_iter()
+                .map(|score| materialized(&[(7, score)]))
+                .collect(),
+        );
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(exact_score);
+
+        assert_eq!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut scorer)
+                .unwrap(),
+            rows(&[(7, exact_score)])
+        );
+    }
+
+    #[test]
+    fn pure_should_maxscore_supports_nested_non_negative_children() {
+        let nested_dismax = Box::new(
+            DisjunctionScorer::try_new(
+                vec![
+                    materialized(&[(0, 1.0), (1, 5.0)]),
+                    materialized(&[(0, 3.0), (2, 4.0)]),
+                ],
+                DisjunctionScore::Max,
+            )
+            .unwrap(),
+        );
+        let nested_boolean = Box::new(
+            BooleanScorer::try_new(
+                Vec::new(),
+                vec![materialized(&[(0, 2.0), (1, 2.0), (2, 2.0)])],
+                vec![materialized(&[(1, 0.0)])],
+            )
+            .unwrap(),
+        );
+        let results = {
+            let mut scorer = BooleanScorer::try_new(
+                vec![
+                    nested_dismax,
+                    nested_boolean,
+                    materialized(&[(0, 0.5), (1, 0.5), (2, 0.5)]),
+                ],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+            TopKCollector::new(1).collect(&mut scorer).unwrap()
+        };
+
+        assert_eq!(results, rows(&[(2, 6.5)]));
+    }
+
+    #[test]
+    fn pure_should_maxscore_applies_must_not_before_raising_the_floor() {
+        let results = {
+            let mut scorer = BooleanScorer::try_new(
+                vec![
+                    materialized(&[(0, 10.0), (1, 5.0)]),
+                    materialized(&[(0, 1.0), (1, 1.0)]),
+                    materialized(&[(2, 8.0)]),
+                ],
+                Vec::new(),
+                vec![materialized(&[(0, 1.0)])],
+            )
+            .unwrap();
+            TopKCollector::new(1).collect(&mut scorer).unwrap()
+        };
+
+        assert_eq!(results, rows(&[(2, 8.0)]));
+    }
+
+    #[test]
+    fn pure_should_uses_exact_fallback_for_unsupported_shapes() {
+        let signed_results = {
+            let signed = Box::new(
+                BoostScorer::try_new(
+                    materialized(&[(0, 5.0), (1, 1.0)]),
+                    materialized(&[(0, 2.0), (1, 4.0)]),
+                    1.0,
+                )
+                .unwrap(),
+            );
+            let mut scorer = BooleanScorer::try_new(
+                vec![
+                    signed,
+                    materialized(&[(0, 1.0), (1, 1.0)]),
+                    materialized(&[(1, 5.0)]),
+                ],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+            TopKCollector::new(2).collect(&mut scorer).unwrap()
+        };
+        assert_eq!(signed_results, rows(&[(0, 4.0), (1, 3.0)]));
+
+        let unbounded_results = {
+            let unbounded = Box::new(UnboundedScorer {
+                inner: MaterializedScorer::try_new(rows(&[(0, 1.0), (2, 3.0)])).unwrap(),
+            });
+            let mut scorer = BooleanScorer::try_new(
+                vec![
+                    unbounded,
+                    materialized(&[(0, 2.0), (1, 2.0)]),
+                    materialized(&[(1, 4.0)]),
+                ],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+            TopKCollector::new(3).collect(&mut scorer).unwrap()
+        };
+        assert_eq!(unbounded_results, rows(&[(1, 6.0), (0, 3.0), (2, 3.0)]));
+
+        {
+            let mut scorer = BooleanScorer::try_new(
+                vec![materialized(&[(0, 1.0)]), materialized(&[(1, 2.0)])],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+            assert_eq!(
+                TopKCollector::new(2).collect(&mut scorer).unwrap(),
+                rows(&[(1, 2.0), (0, 1.0)])
+            );
+        }
+
+        let large_score = f32::MAX / 2.0;
+        {
+            let mut scorer = BooleanScorer::try_new(
+                vec![
+                    materialized(&[(0, large_score)]),
+                    materialized(&[(1, large_score)]),
+                    materialized(&[(2, large_score)]),
+                ],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+            assert_eq!(
+                TopKCollector::new(3).collect(&mut scorer).unwrap(),
+                rows(&[(0, large_score), (1, large_score), (2, large_score)])
+            );
+        }
     }
 }

--- a/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
@@ -1,0 +1,534 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use super::*;
+
+/// Below three clauses, maintaining MAXSCORE windows costs more than the
+/// generic document-at-a-time union is likely to save.
+const MIN_SHOULD_MAXSCORE_CLAUSES: usize = 3;
+
+#[derive(Clone, Copy)]
+struct WindowBounds {
+    start: u64,
+    up_to: u64,
+    floor: f32,
+    combined_upper: f32,
+}
+
+#[derive(Clone, Copy)]
+struct ReportedBounds {
+    target: u64,
+    up_to: u64,
+    bounds: ScoreBounds,
+}
+
+/// Exact windowed MAXSCORE scorer for same-column Boolean SHOULD sums.
+///
+/// List-wide maxima split clauses into a non-essential prefix whose total
+/// score cannot reach the current floor and an essential suffix that drives
+/// candidate iteration and shallow-window boundaries. Non-essential clauses
+/// are only probed when they can still make an essential candidate competitive.
+pub(super) struct ShouldMaxScoreScorer<'a> {
+    children: Vec<BoxScorer<'a>>,
+    initialized: bool,
+    exhausted: bool,
+    current: Option<u64>,
+    confirmed_doc: Option<u64>,
+    confirmed: bool,
+    current_score: Option<f32>,
+    min_competitive_score: f32,
+    window: Option<WindowBounds>,
+    reported_bounds: Option<ReportedBounds>,
+    global_upper_bounds: Vec<f32>,
+    global_score_upper_bound: f32,
+    child_upper_bounds: Vec<f32>,
+    essential: Vec<bool>,
+    bound_order: Vec<usize>,
+    child_scores: Vec<Option<f32>>,
+}
+
+impl<'a> ShouldMaxScoreScorer<'a> {
+    pub(super) fn global_bounds(children: &[BoxScorer<'a>]) -> Option<Vec<f32>> {
+        if children.len() < MIN_SHOULD_MAXSCORE_CLAUSES {
+            return None;
+        }
+        if !children.iter().all(|child| child.scores_non_negative()) {
+            return None;
+        }
+        let bounds = children
+            .iter()
+            .map(|child| {
+                child
+                    .global_score_upper_bound()
+                    .filter(|upper| upper.is_finite() && *upper >= 0.0)
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Self::sum_uppers(bounds.iter())
+            .is_finite()
+            .then_some(bounds)
+    }
+
+    pub(super) fn new(children: Vec<BoxScorer<'a>>, global_upper_bounds: Vec<f32>) -> Self {
+        debug_assert_eq!(children.len(), global_upper_bounds.len());
+        let num_children = children.len();
+        let global_score_upper_bound = Self::sum_uppers(global_upper_bounds.iter());
+        let mut bound_order = (0..num_children).collect::<Vec<_>>();
+        bound_order.sort_by(|left, right| {
+            global_upper_bounds[*left]
+                .total_cmp(&global_upper_bounds[*right])
+                .then_with(|| left.cmp(right))
+        });
+        Self {
+            children,
+            initialized: false,
+            exhausted: false,
+            current: None,
+            confirmed_doc: None,
+            confirmed: false,
+            current_score: None,
+            min_competitive_score: f32::NEG_INFINITY,
+            window: None,
+            reported_bounds: None,
+            global_upper_bounds,
+            global_score_upper_bound,
+            child_upper_bounds: vec![0.0; num_children],
+            essential: vec![true; num_children],
+            bound_order,
+            child_scores: vec![None; num_children],
+        }
+    }
+
+    fn reset_current(&mut self) {
+        self.current = None;
+        self.confirmed_doc = None;
+        self.confirmed = false;
+        self.current_score = None;
+        self.child_scores.fill(None);
+        self.reported_bounds = None;
+    }
+
+    fn set_current(&mut self, current: u64) {
+        self.reset_current();
+        self.current = Some(current);
+    }
+
+    fn exhaust(&mut self) -> Option<u64> {
+        self.exhausted = true;
+        self.reset_current();
+        self.window = None;
+        None
+    }
+
+    fn initialize_next(&mut self) -> Result<()> {
+        if self.initialized {
+            return Ok(());
+        }
+        for child in &mut self.children {
+            child.next()?;
+        }
+        self.initialized = true;
+        Ok(())
+    }
+
+    fn initialize_advance(&mut self, target: u64) -> Result<()> {
+        if self.initialized {
+            return Ok(());
+        }
+        for child in &mut self.children {
+            child.advance(target)?;
+        }
+        self.initialized = true;
+        Ok(())
+    }
+
+    fn align_all_children(&mut self, target: u64) -> Result<()> {
+        for child in &mut self.children {
+            if child.doc().is_some_and(|doc| doc < target) {
+                child.advance(target)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn select_essential_children(&mut self) {
+        self.essential.fill(false);
+        let floor = self.min_competitive_score;
+        if floor <= 0.0 || floor.is_nan() {
+            for (is_essential, child) in self.essential.iter_mut().zip(&self.children) {
+                *is_essential = child.doc().is_some();
+            }
+            return;
+        }
+
+        let mut non_essential = 0.0_f64;
+        let mut num_non_essential = 0;
+        let mut found_essential = false;
+        for index in &self.bound_order {
+            if self.children[*index].doc().is_none() {
+                continue;
+            }
+            if found_essential {
+                self.essential[*index] = true;
+                continue;
+            }
+            let next = non_essential + f64::from(self.global_upper_bounds[*index]);
+            let widened_exact = next * score_sum_upper_bound_factor(num_non_essential + 1);
+            let rounded = widened_exact as f32;
+            let widened = if f64::from(rounded) < widened_exact {
+                next_up(rounded)
+            } else {
+                rounded
+            };
+            if widened < floor {
+                non_essential = next;
+                num_non_essential += 1;
+            } else {
+                self.essential[*index] = true;
+                found_essential = true;
+            }
+        }
+    }
+
+    fn usable_bounds(bounds: ScoreBounds) -> bool {
+        bounds.lower.is_finite()
+            && bounds.upper.is_finite()
+            && bounds.lower <= bounds.upper
+            && bounds.upper >= 0.0
+    }
+
+    fn add_upper(bounds: ScoreBounds, upper: f32) -> ScoreBounds {
+        bounds.add(ScoreBounds { lower: 0.0, upper })
+    }
+
+    fn sum_uppers<'b>(uppers: impl Iterator<Item = &'b f32>) -> f32 {
+        uppers
+            .fold(ScoreBounds::ZERO, |sum, upper| Self::add_upper(sum, *upper))
+            .upper
+    }
+
+    fn prepare_window(&mut self, target: u64) -> Result<()> {
+        self.child_upper_bounds.fill(0.0);
+        self.reported_bounds = None;
+
+        self.select_essential_children();
+        if !self.essential.iter().any(|is_essential| *is_essential) {
+            self.exhaust();
+            return Ok(());
+        }
+
+        let mut up_to = u64::MAX;
+        let mut has_active_child = false;
+        for (child, is_essential) in self.children.iter_mut().zip(&mut self.essential) {
+            if !*is_essential {
+                continue;
+            }
+            if child.doc().is_some_and(|doc| doc < target) {
+                child.advance(target)?;
+            }
+            if let Some(doc) = child.doc() {
+                has_active_child = true;
+                let child_target = target.max(doc);
+                let child_up_to = child.advance_shallow(child_target)?;
+                if child_up_to < child_target {
+                    return Err(Error::internal(format!(
+                        "FTS SHOULD child returned shallow range ending at {child_up_to} before target {child_target}"
+                    )));
+                }
+                up_to = up_to.min(child_up_to);
+            } else {
+                *is_essential = false;
+            }
+        }
+        if !has_active_child {
+            self.exhaust();
+            return Ok(());
+        }
+
+        for (index, child) in self.children.iter().enumerate() {
+            if !self.essential[index] && child.doc().is_some() {
+                self.child_upper_bounds[index] = self.global_upper_bounds[index];
+            }
+        }
+        for (index, child) in self.children.iter_mut().enumerate() {
+            if self.essential[index] && child.doc().is_some_and(|doc| doc <= up_to) {
+                let bounds = child.score_bounds(up_to)?;
+                if Self::usable_bounds(bounds) {
+                    self.child_upper_bounds[index] =
+                        bounds.upper.max(0.0).min(self.global_upper_bounds[index]);
+                } else {
+                    self.child_upper_bounds[index] = self.global_upper_bounds[index];
+                }
+            }
+        }
+
+        let combined_upper = Self::sum_uppers(self.child_upper_bounds.iter());
+        let floor = self.min_competitive_score;
+        self.window = Some(WindowBounds {
+            start: target,
+            up_to,
+            floor,
+            combined_upper,
+        });
+        Ok(())
+    }
+
+    fn position(&mut self, mut target: u64) -> Result<Option<u64>> {
+        if self.exhausted {
+            return Ok(None);
+        }
+
+        loop {
+            let needs_window = self.window.is_none_or(|window| {
+                target < window.start
+                    || target > window.up_to
+                    || self.min_competitive_score > window.floor
+            });
+            if needs_window {
+                self.window = None;
+                self.prepare_window(target)?;
+                if self.exhausted {
+                    return Ok(None);
+                }
+            }
+            let window = self
+                .window
+                .ok_or_else(|| Error::internal("FTS SHOULD scorer did not prepare a window"))?;
+
+            if window.combined_upper < self.min_competitive_score {
+                if window.up_to == u64::MAX {
+                    return Ok(self.exhaust());
+                }
+                target = window.up_to + 1;
+                self.window = None;
+                continue;
+            }
+
+            let next = self
+                .children
+                .iter()
+                .zip(&self.essential)
+                .filter_map(|(child, is_essential)| {
+                    (*is_essential)
+                        .then(|| child.doc())
+                        .flatten()
+                        .filter(|doc| *doc >= target && *doc <= window.up_to)
+                })
+                .min();
+            if let Some(next) = next {
+                self.set_current(next);
+                return Ok(self.current);
+            }
+
+            if window.up_to == u64::MAX {
+                return Ok(self.exhaust());
+            }
+            target = window.up_to + 1;
+            self.window = None;
+        }
+    }
+
+    fn partial_score_upper(&self) -> f32 {
+        let mut bounds = ScoreBounds::ZERO;
+        for (index, score) in self.child_scores.iter().enumerate() {
+            if let Some(score) = score {
+                bounds = bounds.add(ScoreBounds {
+                    lower: *score,
+                    upper: *score,
+                });
+            } else if !self.essential[index] {
+                bounds = Self::add_upper(bounds, self.child_upper_bounds[index]);
+            }
+        }
+        bounds.upper
+    }
+
+    fn ensure_confirmed(&mut self) -> Result<bool> {
+        let Some(current) = self.current else {
+            return Ok(false);
+        };
+        if self.confirmed_doc == Some(current) {
+            return Ok(self.confirmed);
+        }
+
+        self.child_scores.fill(None);
+        for index in 0..self.children.len() {
+            if !self.essential[index] || self.children[index].doc() != Some(current) {
+                continue;
+            }
+            if self.children[index].matches()? {
+                self.child_scores[index] = Some(self.children[index].score()?);
+            }
+        }
+
+        if self.partial_score_upper() >= self.min_competitive_score {
+            for index in 0..self.children.len() {
+                if self.essential[index] || self.child_upper_bounds[index] == 0.0 {
+                    continue;
+                }
+                if self.children[index].doc().is_some_and(|doc| doc < current) {
+                    self.children[index].advance(current)?;
+                }
+                if self.children[index].doc() == Some(current) && self.children[index].matches()? {
+                    self.child_scores[index] = Some(self.children[index].score()?);
+                }
+            }
+        }
+
+        let mut has_match = false;
+        let mut score = 0.0_f32;
+        for child_score in self.child_scores.iter().flatten() {
+            has_match = true;
+            score += *child_score;
+        }
+        score = checked_score(score, "FTS SHOULD MAXSCORE")?;
+        self.confirmed = has_match && score >= self.min_competitive_score;
+        self.current_score = self.confirmed.then_some(score);
+        self.confirmed_doc = Some(current);
+        Ok(self.confirmed)
+    }
+
+    fn combined_shallow_bounds(&self, target: u64) -> ReportedBounds {
+        ReportedBounds {
+            target,
+            up_to: u64::MAX,
+            bounds: ScoreBounds {
+                lower: 0.0,
+                upper: self.global_score_upper_bound,
+            },
+        }
+    }
+}
+
+impl ComposableScorer for ShouldMaxScoreScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        let current = self.current?;
+        self.children
+            .iter()
+            .find(|child| child.doc() == Some(current))
+            .and_then(|child| child.document_key())
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        if self.exhausted {
+            return Ok(None);
+        }
+        if !self.initialized {
+            self.initialize_next()?;
+            return self.position(0);
+        }
+        let Some(current) = self.current else {
+            return Ok(self.exhaust());
+        };
+        if current == u64::MAX {
+            return Ok(self.exhaust());
+        }
+        for child in &mut self.children {
+            if child.doc() == Some(current) {
+                child.next()?;
+            }
+        }
+        self.reset_current();
+        self.position(current + 1)
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.current.is_some_and(|current| current >= target) {
+            return Ok(self.current);
+        }
+        if self.exhausted {
+            return Ok(None);
+        }
+        self.initialize_advance(target)?;
+        self.align_all_children(target)?;
+        self.reset_current();
+        self.window = None;
+        self.position(target)
+    }
+
+    fn cost(&self) -> usize {
+        self.children
+            .iter()
+            .map(|child| child.cost())
+            .fold(0, usize::saturating_add)
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        if !self.ensure_confirmed()? {
+            return Err(Error::internal(
+                "score requested from an unconfirmed FTS SHOULD MAXSCORE document",
+            ));
+        }
+        self.current_score.ok_or_else(|| {
+            Error::internal("confirmed FTS SHOULD MAXSCORE document has no exact score")
+        })
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let target = self.current.map_or(target, |current| target.max(current));
+        let reported = if let Some(window) = self.window
+            && target >= window.start
+            && target <= window.up_to
+        {
+            ReportedBounds {
+                target,
+                up_to: window.up_to,
+                bounds: ScoreBounds {
+                    lower: 0.0,
+                    upper: window.combined_upper,
+                },
+            }
+        } else {
+            self.combined_shallow_bounds(target)
+        };
+        self.reported_bounds = Some(reported);
+        Ok(reported.up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let reported = self.reported_bounds.ok_or_else(|| {
+            Error::internal("score_bounds requires advance_shallow on the FTS SHOULD scorer")
+        })?;
+        if up_to < reported.target || up_to > reported.up_to {
+            return Err(Error::internal(format!(
+                "FTS SHOULD score bound up_to={up_to} is outside shallow range [{}, {}]",
+                reported.target, reported.up_to
+            )));
+        }
+        Ok(reported.bounds)
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        Some(self.global_score_upper_bound)
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        if min_score > self.min_competitive_score {
+            self.min_competitive_score = min_score;
+        }
+        Ok(())
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.ensure_confirmed()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.children
+            .iter()
+            .filter_map(|child| child.match_cost())
+            .reduce(|left, right| left + right)
+    }
+
+    fn scores_non_negative(&self) -> bool {
+        true
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -4,7 +4,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::{
-    cell::{RefCell, UnsafeCell},
+    cell::{OnceCell, RefCell, UnsafeCell},
     collections::{BinaryHeap, VecDeque},
 };
 use std::{cmp::Reverse, fmt::Debug};
@@ -1473,7 +1473,7 @@ const MAXSCORE_INNER_WINDOW: usize = 1 << 12;
 /// accumulation. Prefix bounds are summed in `f64`, then widened enough to
 /// cover any recursive `f32` summation order of the same non-negative values.
 #[inline]
-fn score_sum_upper_bound_factor(num_values: usize) -> f64 {
+pub(super) fn score_sum_upper_bound_factor(num_values: usize) -> f64 {
     if num_values <= 2 {
         1.0
     } else {
@@ -4371,6 +4371,7 @@ pub(super) struct WandCursor<'a, D: WandDocuments> {
     phrase_slop: Option<u32>,
     wand_factor: f32,
     cost: usize,
+    global_score_upper_bound: OnceCell<Option<f32>>,
     current_doc: Option<DocInfo>,
     current_document_key: Option<u64>,
     current_score: f32,
@@ -4405,6 +4406,7 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             phrase_slop: params.phrase_slop,
             wand_factor: params.wand_factor,
             cost,
+            global_score_upper_bound: OnceCell::new(),
             current_doc: None,
             current_document_key: None,
             current_score: 0.0,
@@ -4494,6 +4496,12 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         self.cost
     }
 
+    pub(super) fn global_score_upper_bound(&self) -> Option<f32> {
+        *self
+            .global_score_upper_bound
+            .get_or_init(|| self.wand.compound_global_score_upper_bound())
+    }
+
     pub(super) fn current_score(&self) -> Result<f32> {
         self.current_doc
             .map(|_| self.current_score)
@@ -4558,6 +4566,43 @@ impl<D: WandDocuments> Drop for WandCursor<'_, D> {
 }
 
 impl<S: Scorer, D: WandDocuments> Wand<'_, S, D> {
+    fn compound_global_score_upper_bound(&self) -> Option<f32> {
+        if self.lead.len() + self.head.len() + self.tail.len() != self.num_terms {
+            return None;
+        }
+        // Grouped expansions score their terms separately, while their union
+        // posting stores one aggregate bound whose f32 rounding is not proven
+        // conservative for that exact sum.
+        if self.lead.iter().any(|posting| posting.has_grouped_terms())
+            || self
+                .head
+                .iter()
+                .any(|posting| posting.posting.has_grouped_terms())
+            || self
+                .tail
+                .iter()
+                .any(|posting| posting.posting.has_grouped_terms())
+        {
+            return None;
+        }
+        let upper = conservative_score_sum(
+            self.lead
+                .iter()
+                .map(|posting| posting.global_upper_bound(&self.scorer))
+                .chain(
+                    self.head
+                        .iter()
+                        .map(|posting| posting.posting.global_upper_bound(&self.scorer)),
+                )
+                .chain(
+                    self.tail
+                        .iter()
+                        .map(|posting| posting.posting.global_upper_bound(&self.scorer)),
+                ),
+        );
+        (upper.is_finite() && upper >= 0.0).then_some(upper)
+    }
+
     fn seek(&mut self, target: u64) {
         self.up_to = None;
         self.and_max_score = f32::INFINITY;
@@ -4719,6 +4764,39 @@ mod tests {
             .fold(0.0_f32, |score, value| score + value);
         assert_eq!(reordered_score.to_bits(), 0x3da7_6086);
         assert!(bound >= reordered_score);
+    }
+
+    #[test]
+    fn compound_global_bound_rejects_grouped_term_scoring() {
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        let list = generate_posting_list(vec![0], 1.0, None, false);
+        let grouped_terms = Arc::<[GroupedTermScorer]>::from([GroupedTermScorer::new(1.0, &list)]);
+        let posting =
+            PostingIterator::with_query_weight(String::from("term"), 0, 0, 1.0, list, docs.len())
+                .with_grouped_terms(grouped_terms);
+        let wand = Wand::new(Operator::Or, std::iter::once(posting), &docs, UnitScorer);
+
+        assert_eq!(wand.compound_global_score_upper_bound(), None);
+    }
+
+    #[test]
+    fn compound_global_bound_rejects_late_partial_posting_state() {
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        let posting = PostingIterator::with_query_weight(
+            String::from("term"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0], 1.0, None, false),
+            docs.len(),
+        );
+        let mut wand = Wand::new(Operator::Or, std::iter::once(posting), &docs, UnitScorer);
+
+        assert!(wand.next().unwrap().is_some());
+        wand.push_back_leads(1);
+        assert_eq!(wand.compound_global_score_upper_bound(), None);
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1322,6 +1322,87 @@ async fn test_same_column_compound_scorer_is_exact_and_bounded() {
 }
 
 #[tokio::test]
+async fn test_pure_should_maxscore_is_exact_across_fragments() {
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        [
+            "alpha beta rare blocked",
+            "alpha beta rare",
+            "alpha beta",
+            "alpha gamma",
+            "beta gamma",
+            "alpha beta rare",
+            "alpha beta",
+            "gamma",
+            "alpha beta rare",
+            "alpha beta",
+            "beta",
+            "alpha"
+        ]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 3,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 4);
+    create_fragmented_fts_index_with_order(&mut dataset, "text", true, true).await;
+
+    let match_query = |term: &str, boost: f32| {
+        MatchQuery::new(term.to_owned())
+            .with_column(Some("text".to_owned()))
+            .with_boost(boost)
+            .into()
+    };
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Should, match_query("alpha", 0.25)),
+        (Occur::Should, match_query("beta", 0.25)),
+        (Occur::Should, match_query("rare", 4.0)),
+        (
+            Occur::Should,
+            PhraseQuery::new("alpha beta".to_owned())
+                .with_column(Some("text".to_owned()))
+                .into(),
+        ),
+        (Occur::MustNot, match_query("blocked", 1.0)),
+    ])
+    .into();
+
+    let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+    assert!(!exhaustive.iter().any(|(row_id, _)| *row_id == 0));
+    assert!(exhaustive.len() >= 3);
+    assert!(
+        exhaustive[..3]
+            .iter()
+            .all(|(_, score)| *score == exhaustive[0].1)
+            && exhaustive[..3].windows(2).all(|rows| rows[0].0 < rows[1].0),
+        "the top three identical rows should tie in ascending row-id order"
+    );
+    let limited = compound_fts_results(&dataset, query.clone(), Some(2)).await;
+    assert_eq!(limited, exhaustive[..2]);
+
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("CompoundFtsScorer"),
+        "same-column pure SHOULD should use the compound scorer:\n{plan}"
+    );
+}
+
+#[tokio::test]
 async fn test_compound_phrase_confirmation_short_circuit_is_exact() {
     let texts = (0..100)
         .map(|row| {


### PR DESCRIPTION
## What is the performance issue?

Pure Boolean SHOULD queries currently use an eager sum disjunction. A dense low-scoring clause can keep shallow windows small even when it cannot make a document competitive, so the scorer repeatedly probes candidates that a clause-level MAXSCORE split could defer.

## How does this PR improve performance?

- Add conservative list-wide upper bounds for composable scorers.
- Split eligible non-negative pure-SHOULD clauses into essential and non-essential sets.
- Let only essential clauses drive candidates and shallow-window boundaries.
- Probe non-essential clauses only when they can still make the current candidate competitive.
- Preserve exact query-order f32 summation, inclusive score ties, Phrase two-phase confirmation, MUST_NOT ordering, and eager fallback for signed, grouped, unbounded, low-clause-count, or overflowed shapes.

## Stack

This is 2/3 for OSS-1706:

1. #8473 - conservative score-sum bounds
2. #8474 - pure-SHOULD clause MAXSCORE
3. #8475 - metrics and end-to-end observability

Review this PR relative to branch yang/oss-1706-score-bounds.

## Benchmark

Measured on this exact PR head with the deterministic sparse-high-score plus dense-low-score unit canary: 1,025 documents, 10 SHOULD clauses, and k=1. Lower is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Candidate probes | 8,201 probes | 153 probes | 53.60x fewer probes |

Candidate probes count successful next/advance operations on instrumented clause scorers. It is an operational posting-candidate proxy, not a count of low-level doc-id comparisons inside PostingIterator. The 10M MMLB ABBA benchmark is reported on the exact full-stack head in #8475.

## Validation

- cargo fmt --all -- --check
- cargo test -p lance-index scalar::inverted::compound::tests --lib -- --nocapture
- cargo test -p lance-index compound_global_bound --lib
- cargo test -p lance dataset::tests::dataset_index::test_pure_should_maxscore_is_exact_across_fragments --lib -- --exact --nocapture
- cargo clippy --all --tests --benches -- -D warnings