### PR TITLE
feat(fts): expose pure SHOULD MAXSCORE metrics

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -13,6 +13,13 @@ pub const COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC: &str =
     "compound_peak_address_resolution_batch_size";
 pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_overflows";
 pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
+pub const COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC: &str = "compound_should_skipped_windows";
+pub const COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC: &str =
+    "compound_should_bound_recomputations";
+pub const COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC: &str =
+    "compound_should_essential_evaluations";
+pub const COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC: &str =
+    "compound_should_non_essential_evaluations";
 
 /// A trait used by the index to report metrics
 ///
@@ -105,6 +112,18 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record a candidate-buffer high-water mark for compound FTS.
     fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}
+
+    /// Record pure-SHOULD compound FTS windows skipped using score bounds.
+    fn record_compound_should_skipped_windows(&self, _num_windows: usize) {}
+
+    /// Record score-bound recomputations for pure-SHOULD compound FTS windows.
+    fn record_compound_should_bound_recomputations(&self, _num_recomputations: usize) {}
+
+    /// Record essential-clause evaluations for pure-SHOULD compound FTS.
+    fn record_compound_should_essential_evaluations(&self, _num_evaluations: usize) {}
+
+    /// Record non-essential-clause evaluations for pure-SHOULD compound FTS.
+    fn record_compound_should_non_essential_evaluations(&self, _num_evaluations: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -307,7 +307,11 @@ impl CompoundScorerPlan {
         }
     }
 
-    fn build<'a>(&self, leaves: &mut [Option<BoxScorer<'a>>]) -> Result<BoxScorer<'a>> {
+    fn build<'a>(
+        &self,
+        leaves: &mut [Option<BoxScorer<'a>>],
+        metrics: &'a dyn MetricsCollector,
+    ) -> Result<BoxScorer<'a>> {
         match self {
             Self::Leaf { index, boost } => {
                 let leaf = leaves
@@ -325,14 +329,14 @@ impl CompoundScorerPlan {
                 negative,
                 negative_boost,
             } => Ok(Box::new(BoostScorer::try_new(
-                positive.build(leaves)?,
-                negative.build(leaves)?,
+                positive.build(leaves, metrics)?,
+                negative.build(leaves, metrics)?,
                 *negative_boost,
             )?)),
             Self::MultiMatch(children) => Ok(Box::new(DisjunctionScorer::try_new(
                 children
                     .iter()
-                    .map(|child| child.build(leaves))
+                    .map(|child| child.build(leaves, metrics))
                     .collect::<Result<Vec<_>>>()?,
                 DisjunctionScore::Max,
             )?)),
@@ -340,18 +344,19 @@ impl CompoundScorerPlan {
                 should,
                 must,
                 must_not,
-            } => Ok(Box::new(BooleanScorer::try_new(
+            } => Ok(Box::new(BooleanScorer::try_new_with_metrics(
                 should
                     .iter()
-                    .map(|child| child.build(leaves))
+                    .map(|child| child.build(leaves, metrics))
                     .collect::<Result<Vec<_>>>()?,
                 must.iter()
-                    .map(|child| child.build(leaves))
+                    .map(|child| child.build(leaves, metrics))
                     .collect::<Result<Vec<_>>>()?,
                 must_not
                     .iter()
-                    .map(|child| child.build(leaves))
+                    .map(|child| child.build(leaves, metrics))
                     .collect::<Result<Vec<_>>>()?,
+                Some(metrics),
             )?)),
         }
     }
@@ -1954,10 +1959,20 @@ pub(super) struct BooleanScorer<'a> {
 }
 
 impl<'a> BooleanScorer<'a> {
+    #[cfg(test)]
     pub(super) fn try_new(
         should: Vec<BoxScorer<'a>>,
         must: Vec<BoxScorer<'a>>,
         must_not: Vec<BoxScorer<'a>>,
+    ) -> Result<Self> {
+        Self::try_new_with_metrics(should, must, must_not, None)
+    }
+
+    fn try_new_with_metrics(
+        should: Vec<BoxScorer<'a>>,
+        must: Vec<BoxScorer<'a>>,
+        must_not: Vec<BoxScorer<'a>>,
+        metrics: Option<&'a dyn MetricsCollector>,
     ) -> Result<Self> {
         let (driver, optional) = if must.is_empty() {
             if should.is_empty() {
@@ -1966,7 +1981,7 @@ impl<'a> BooleanScorer<'a> {
                 ));
             }
             let driver = if let Some(global_bounds) = ShouldMaxScoreScorer::global_bounds(&should) {
-                Box::new(ShouldMaxScoreScorer::new(should, global_bounds)) as BoxScorer<'a>
+                Box::new(ShouldMaxScoreScorer::new(should, global_bounds, metrics)) as BoxScorer<'a>
             } else {
                 Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
                     as BoxScorer<'a>
@@ -2493,7 +2508,7 @@ where
             Some(scorer)
         })
         .collect::<Vec<_>>();
-    let mut scorer = plan.build(&mut leaf_scorers)?;
+    let mut scorer = plan.build(&mut leaf_scorers, metrics)?;
     if leaf_scorers.iter().any(Option::is_some) {
         return Err(Error::internal(
             "compound FTS scorer did not consume every prepared leaf",
@@ -2833,9 +2848,53 @@ mod tests {
         Box::new(MaterializedScorer::try_new(rows(values)).unwrap())
     }
 
-    fn should_maxscore(children: Vec<BoxScorer<'_>>) -> ShouldMaxScoreScorer<'_> {
+    fn should_maxscore<'a>(
+        children: Vec<BoxScorer<'a>>,
+        metrics: Option<&'a dyn MetricsCollector>,
+    ) -> ShouldMaxScoreScorer<'a> {
         let global_bounds = ShouldMaxScoreScorer::global_bounds(&children).unwrap();
-        ShouldMaxScoreScorer::new(children, global_bounds)
+        ShouldMaxScoreScorer::new(children, global_bounds, metrics)
+    }
+
+    #[derive(Default)]
+    struct ShouldMetrics {
+        reports: AtomicUsize,
+        skipped_windows: AtomicUsize,
+        bound_recomputations: AtomicUsize,
+        essential_evaluations: AtomicUsize,
+        non_essential_evaluations: AtomicUsize,
+    }
+
+    impl MetricsCollector for ShouldMetrics {
+        fn record_parts_loaded(&self, _num_parts: usize) {}
+
+        fn record_index_loads(&self, _num_loads: usize) {}
+
+        fn record_comparisons(&self, _num_comparisons: usize) {}
+
+        fn record_compound_should_skipped_windows(&self, num_windows: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
+            self.skipped_windows
+                .fetch_add(num_windows, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_should_bound_recomputations(&self, num_recomputations: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
+            self.bound_recomputations
+                .fetch_add(num_recomputations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_should_essential_evaluations(&self, num_evaluations: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
+            self.essential_evaluations
+                .fetch_add(num_evaluations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
+            self.non_essential_evaluations
+                .fetch_add(num_evaluations, AtomicOrdering::Relaxed);
+        }
     }
 
     #[test]
@@ -3595,9 +3654,10 @@ mod tests {
         let eager_results = TopKCollector::new(1).collect(&mut eager).unwrap();
         let eager_comparisons = scorer_advances(&eager_work);
 
+        let metrics = ShouldMetrics::default();
         let (children, optimized_work) = pure_should_canary_children();
         let optimized_results = {
-            let mut optimized = should_maxscore(children);
+            let mut optimized = should_maxscore(children, Some(&metrics));
             TopKCollector::new(1).collect(&mut optimized).unwrap()
         };
         let optimized_comparisons = scorer_advances(&optimized_work);
@@ -3609,6 +3669,16 @@ mod tests {
             optimized_comparisons * 5 <= eager_comparisons * 4,
             "pure-SHOULD MAXSCORE should reduce posting candidate probes by at least 20%: \
              optimized={optimized_comparisons} eager={eager_comparisons}"
+        );
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
+        assert!(metrics.skipped_windows.load(AtomicOrdering::Relaxed) > 0);
+        assert!(metrics.bound_recomputations.load(AtomicOrdering::Relaxed) > 0);
+        assert!(metrics.essential_evaluations.load(AtomicOrdering::Relaxed) > 0);
+        assert!(
+            metrics
+                .non_essential_evaluations
+                .load(AtomicOrdering::Relaxed)
+                > 0
         );
     }
 
@@ -3634,8 +3704,10 @@ mod tests {
             for limit in [1, 7, 31, 512] {
                 let expected = exhaustive_should_top_k(&children, limit);
 
-                let mut optimized =
-                    should_maxscore(children.iter().map(|values| materialized(values)).collect());
+                let mut optimized = should_maxscore(
+                    children.iter().map(|values| materialized(values)).collect(),
+                    None,
+                );
                 let actual = TopKCollector::new(limit).collect(&mut optimized).unwrap();
                 assert_eq!(actual, expected, "seed={seed} limit={limit}");
             }
@@ -3645,15 +3717,19 @@ mod tests {
     #[test]
     fn pure_should_maxscore_confirms_two_phase_children_before_scoring() {
         let (phrase, _, confirmations) = two_phase(&[(1, 100.0)], Vec::new(), Some(10.0));
+        let metrics = ShouldMetrics::default();
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(10.0);
         let results = {
-            let mut scorer = should_maxscore(vec![
-                materialized(&[(0, 10.0)]),
-                phrase,
-                materialized(&[(1, 6.0)]),
-                materialized(&[(1, 5.0)]),
-            ]);
+            let mut scorer = should_maxscore(
+                vec![
+                    materialized(&[(0, 10.0)]),
+                    phrase,
+                    materialized(&[(1, 6.0)]),
+                    materialized(&[(1, 5.0)]),
+                ],
+                Some(&metrics),
+            );
             TopKCollector::with_competitive_score(1, competitive_score)
                 .collect(&mut scorer)
                 .unwrap()
@@ -3661,16 +3737,25 @@ mod tests {
 
         assert_eq!(results, rows(&[(1, 11.0)]));
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert!(
+            metrics
+                .non_essential_evaluations
+                .load(AtomicOrdering::Relaxed)
+                > 0
+        );
     }
 
     #[test]
     fn pure_should_maxscore_preserves_query_score_order_and_terminal_doc() {
-        let mut scorer = should_maxscore(vec![
-            materialized(&[(u64::MAX, 16_777_216.0)]),
-            materialized(&[(u64::MAX, 1.0)]),
-            materialized(&[(u64::MAX, 1.0)]),
-            materialized(&[]),
-        ]);
+        let mut scorer = should_maxscore(
+            vec![
+                materialized(&[(u64::MAX, 16_777_216.0)]),
+                materialized(&[(u64::MAX, 1.0)]),
+                materialized(&[(u64::MAX, 1.0)]),
+                materialized(&[]),
+            ],
+            None,
+        );
 
         assert_eq!(
             TopKCollector::new(1).collect(&mut scorer).unwrap(),
@@ -3697,6 +3782,7 @@ mod tests {
                 .into_iter()
                 .map(|score| materialized(&[(7, score)]))
                 .collect(),
+            None,
         );
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(exact_score);
@@ -3729,8 +3815,9 @@ mod tests {
             )
             .unwrap(),
         );
+        let metrics = ShouldMetrics::default();
         let results = {
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![
                     nested_dismax,
                     nested_boolean,
@@ -3738,18 +3825,21 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
+                Some(&metrics),
             )
             .unwrap();
             TopKCollector::new(1).collect(&mut scorer).unwrap()
         };
 
         assert_eq!(results, rows(&[(2, 6.5)]));
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
     }
 
     #[test]
     fn pure_should_maxscore_applies_must_not_before_raising_the_floor() {
+        let metrics = ShouldMetrics::default();
         let results = {
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![
                     materialized(&[(0, 10.0), (1, 5.0)]),
                     materialized(&[(0, 1.0), (1, 1.0)]),
@@ -3757,16 +3847,19 @@ mod tests {
                 ],
                 Vec::new(),
                 vec![materialized(&[(0, 1.0)])],
+                Some(&metrics),
             )
             .unwrap();
             TopKCollector::new(1).collect(&mut scorer).unwrap()
         };
 
         assert_eq!(results, rows(&[(2, 8.0)]));
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
     }
 
     #[test]
     fn pure_should_uses_exact_fallback_for_unsupported_shapes() {
+        let signed_metrics = ShouldMetrics::default();
         let signed_results = {
             let signed = Box::new(
                 BoostScorer::try_new(
@@ -3776,7 +3869,7 @@ mod tests {
                 )
                 .unwrap(),
             );
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![
                     signed,
                     materialized(&[(0, 1.0), (1, 1.0)]),
@@ -3784,17 +3877,20 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
+                Some(&signed_metrics),
             )
             .unwrap();
             TopKCollector::new(2).collect(&mut scorer).unwrap()
         };
         assert_eq!(signed_results, rows(&[(0, 4.0), (1, 3.0)]));
+        assert_eq!(signed_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
+        let unbounded_metrics = ShouldMetrics::default();
         let unbounded_results = {
             let unbounded = Box::new(UnboundedScorer {
                 inner: MaterializedScorer::try_new(rows(&[(0, 1.0), (2, 3.0)])).unwrap(),
             });
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![
                     unbounded,
                     materialized(&[(0, 2.0), (1, 2.0)]),
@@ -3802,17 +3898,21 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
+                Some(&unbounded_metrics),
             )
             .unwrap();
             TopKCollector::new(3).collect(&mut scorer).unwrap()
         };
         assert_eq!(unbounded_results, rows(&[(1, 6.0), (0, 3.0), (2, 3.0)]));
+        assert_eq!(unbounded_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
+        let low_count_metrics = ShouldMetrics::default();
         {
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![materialized(&[(0, 1.0)]), materialized(&[(1, 2.0)])],
                 Vec::new(),
                 Vec::new(),
+                Some(&low_count_metrics),
             )
             .unwrap();
             assert_eq!(
@@ -3820,10 +3920,12 @@ mod tests {
                 rows(&[(1, 2.0), (0, 1.0)])
             );
         }
+        assert_eq!(low_count_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
+        let overflow_metrics = ShouldMetrics::default();
         let large_score = f32::MAX / 2.0;
         {
-            let mut scorer = BooleanScorer::try_new(
+            let mut scorer = BooleanScorer::try_new_with_metrics(
                 vec![
                     materialized(&[(0, large_score)]),
                     materialized(&[(1, large_score)]),
@@ -3831,6 +3933,7 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
+                Some(&overflow_metrics),
             )
             .unwrap();
             assert_eq!(
@@ -3838,5 +3941,6 @@ mod tests {
                 rows(&[(0, large_score), (1, large_score), (2, large_score)])
             );
         }
+        assert_eq!(overflow_metrics.reports.load(AtomicOrdering::Relaxed), 0);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
@@ -22,6 +22,14 @@ struct ReportedBounds {
     bounds: ScoreBounds,
 }
 
+#[derive(Default)]
+struct MaxScoreWork {
+    skipped_windows: usize,
+    bound_recomputations: usize,
+    essential_evaluations: usize,
+    non_essential_evaluations: usize,
+}
+
 /// Exact windowed MAXSCORE scorer for same-column Boolean SHOULD sums.
 ///
 /// List-wide maxima split clauses into a non-essential prefix whose total
@@ -45,6 +53,8 @@ pub(super) struct ShouldMaxScoreScorer<'a> {
     essential: Vec<bool>,
     bound_order: Vec<usize>,
     child_scores: Vec<Option<f32>>,
+    metrics: Option<&'a dyn MetricsCollector>,
+    work: MaxScoreWork,
 }
 
 impl<'a> ShouldMaxScoreScorer<'a> {
@@ -68,7 +78,11 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             .then_some(bounds)
     }
 
-    pub(super) fn new(children: Vec<BoxScorer<'a>>, global_upper_bounds: Vec<f32>) -> Self {
+    pub(super) fn new(
+        children: Vec<BoxScorer<'a>>,
+        global_upper_bounds: Vec<f32>,
+        metrics: Option<&'a dyn MetricsCollector>,
+    ) -> Self {
         debug_assert_eq!(children.len(), global_upper_bounds.len());
         let num_children = children.len();
         let global_score_upper_bound = Self::sum_uppers(global_upper_bounds.iter());
@@ -95,6 +109,8 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             essential: vec![true; num_children],
             bound_order,
             child_scores: vec![None; num_children],
+            metrics,
+            work: MaxScoreWork::default(),
         }
     }
 
@@ -212,6 +228,9 @@ impl<'a> ShouldMaxScoreScorer<'a> {
 
         self.select_essential_children();
         if !self.essential.iter().any(|is_essential| *is_essential) {
+            if self.children.iter().any(|child| child.doc().is_some()) {
+                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
+            }
             self.exhaust();
             return Ok(());
         }
@@ -240,6 +259,9 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             }
         }
         if !has_active_child {
+            if self.children.iter().any(|child| child.doc().is_some()) {
+                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
+            }
             self.exhaust();
             return Ok(());
         }
@@ -252,6 +274,7 @@ impl<'a> ShouldMaxScoreScorer<'a> {
         for (index, child) in self.children.iter_mut().enumerate() {
             if self.essential[index] && child.doc().is_some_and(|doc| doc <= up_to) {
                 let bounds = child.score_bounds(up_to)?;
+                self.work.bound_recomputations = self.work.bound_recomputations.saturating_add(1);
                 if Self::usable_bounds(bounds) {
                     self.child_upper_bounds[index] =
                         bounds.upper.max(0.0).min(self.global_upper_bounds[index]);
@@ -295,6 +318,7 @@ impl<'a> ShouldMaxScoreScorer<'a> {
                 .ok_or_else(|| Error::internal("FTS SHOULD scorer did not prepare a window"))?;
 
             if window.combined_upper < self.min_competitive_score {
+                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
                 if window.up_to == u64::MAX {
                     return Ok(self.exhaust());
                 }
@@ -320,6 +344,14 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             }
 
             if window.up_to == u64::MAX {
+                if self
+                    .children
+                    .iter()
+                    .zip(&self.essential)
+                    .any(|(child, is_essential)| !*is_essential && child.doc().is_some())
+                {
+                    self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
+                }
                 return Ok(self.exhaust());
             }
             target = window.up_to + 1;
@@ -355,6 +387,7 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             if !self.essential[index] || self.children[index].doc() != Some(current) {
                 continue;
             }
+            self.work.essential_evaluations = self.work.essential_evaluations.saturating_add(1);
             if self.children[index].matches()? {
                 self.child_scores[index] = Some(self.children[index].score()?);
             }
@@ -365,6 +398,8 @@ impl<'a> ShouldMaxScoreScorer<'a> {
                 if self.essential[index] || self.child_upper_bounds[index] == 0.0 {
                     continue;
                 }
+                self.work.non_essential_evaluations =
+                    self.work.non_essential_evaluations.saturating_add(1);
                 if self.children[index].doc().is_some_and(|doc| doc < current) {
                     self.children[index].advance(current)?;
                 }
@@ -530,5 +565,18 @@ impl ComposableScorer for ShouldMaxScoreScorer<'_> {
 
     fn scores_non_negative(&self) -> bool {
         true
+    }
+}
+
+impl Drop for ShouldMaxScoreScorer<'_> {
+    fn drop(&mut self) {
+        let Some(metrics) = self.metrics else {
+            return;
+        };
+        metrics.record_compound_should_skipped_windows(self.work.skipped_windows);
+        metrics.record_compound_should_bound_recomputations(self.work.bound_recomputations);
+        metrics.record_compound_should_essential_evaluations(self.work.essential_evaluations);
+        metrics
+            .record_compound_should_non_essential_evaluations(self.work.non_essential_evaluations);
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -37,13 +37,16 @@ use lance_core::cache::{
 };
 use lance_core::utils::tempfile::TempStrDir;
 use lance_datafusion::exec::ExecutionSummaryCounts;
+use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
 use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
 use lance_index::metrics::{
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
+    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
+    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
+    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
@@ -1388,6 +1391,44 @@ async fn test_pure_should_maxscore_is_exact_across_fragments() {
     );
     let limited = compound_fts_results(&dataset, query.clone(), Some(2)).await;
     assert_eq!(limited, exhaustive[..2]);
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    scanner.try_into_batch().await.unwrap();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    for metric in [
+        COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
+        COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
+        COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
+        COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
+    ] {
+        assert!(
+            stats.all_counts.contains_key(metric),
+            "pure-SHOULD execution stats should expose {metric}"
+        );
+    }
+    assert!(
+        stats.all_counts[COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC] > 0,
+        "pure-SHOULD execution should recompute clause bounds"
+    );
+    assert!(
+        stats.all_counts[COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC] > 0,
+        "pure-SHOULD execution should evaluate essential clauses"
+    );
+    assert_eq!(
+        stats.all_counts.get(PARTITIONS_SEARCHED_METRIC),
+        Some(&(4 * 5)),
+        "four index partitions should be searched once for each of five query leaves"
+    );
 
     let mut scanner = dataset.scan();
     scanner

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -46,7 +46,9 @@ use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
+    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
+    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
+    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -1058,6 +1060,10 @@ pub struct FtsIndexMetrics {
     compound_peak_address_resolution_batch_size: Gauge,
     compound_score_floor_overflows: Count,
     compound_peak_buffered_candidates: Gauge,
+    compound_should_skipped_windows: Count,
+    compound_should_bound_recomputations: Count,
+    compound_should_essential_evaluations: Count,
+    compound_should_non_essential_evaluations: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1087,6 +1093,14 @@ impl FtsIndexMetrics {
                 .new_count(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
             compound_peak_buffered_candidates: metrics
                 .new_gauge(COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
+            compound_should_skipped_windows: metrics
+                .new_count(COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, partition),
+            compound_should_bound_recomputations: metrics
+                .new_count(COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, partition),
+            compound_should_essential_evaluations: metrics
+                .new_count(COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, partition),
+            compound_should_non_essential_evaluations: metrics
+                .new_count(COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1159,6 +1173,25 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_compound_peak_buffered_candidates(&self, num_candidates: usize) {
         self.compound_peak_buffered_candidates
             .set_max(num_candidates);
+    }
+
+    fn record_compound_should_skipped_windows(&self, num_windows: usize) {
+        self.compound_should_skipped_windows.add(num_windows);
+    }
+
+    fn record_compound_should_bound_recomputations(&self, num_recomputations: usize) {
+        self.compound_should_bound_recomputations
+            .add(num_recomputations);
+    }
+
+    fn record_compound_should_essential_evaluations(&self, num_evaluations: usize) {
+        self.compound_should_essential_evaluations
+            .add(num_evaluations);
+    }
+
+    fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
+        self.compound_should_non_essential_evaluations
+            .add(num_evaluations);
     }
 }
 
@@ -3461,7 +3494,7 @@ mod tests {
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
     use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
     use lance_datagen::{BatchCount, ByteCount, RowCount};
-    use lance_index::metrics::NoOpMetricsCollector;
+    use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
     use lance_index::scalar::inverted::query::{
         BooleanQuery, BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, Occur, Operator,
         PhraseQuery, collect_query_tokens, has_query_token,
@@ -3511,6 +3544,22 @@ mod tests {
         fn consume(self) -> ExecutionSummaryCounts {
             self.collected_stats.lock().unwrap().take().unwrap()
         }
+    }
+
+    #[test]
+    fn test_compound_should_metrics_are_counted_independently() {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
+
+        metrics.record_compound_should_skipped_windows(2);
+        metrics.record_compound_should_bound_recomputations(3);
+        metrics.record_compound_should_essential_evaluations(5);
+        metrics.record_compound_should_non_essential_evaluations(7);
+
+        assert_eq!(metrics.compound_should_skipped_windows.value(), 2);
+        assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
+        assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);
+        assert_eq!(metrics.compound_should_non_essential_evaluations.value(), 7);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {


### PR DESCRIPTION
## What changed?

This final stack layer exposes the pure-SHOULD MAXSCORE work in FTS execution metrics:

- compound_should_skipped_windows
- compound_should_bound_recomputations
- compound_should_essential_evaluations
- compound_should_non_essential_evaluations

The collector is threaded recursively so nested eligible Boolean scorers report work. Counters are accumulated on the scorer hot path and flushed independently when the scorer is dropped. The end-to-end test verifies that production routing activates the optimization across four fragments and reports non-zero bound recomputations and essential evaluations.

## Stack

This is 3/3 for OSS-1706 and is stacked on #8474, which is stacked on #8473. Review this PR relative to branch yang/oss-1706-pure-should-maxscore.

This PR head has the exact source tree used for the 10M MMLB benchmark below.

## Benchmark

Environment and protocol: GCP c4-standard-16 VM; 10,000,000 MMLB rows in 10 fragments; one reused 37,785,665,554-byte FTS index; 8 query workers; 64 GiB cache; position streams prewarmed. Results use a two-block ABBA run, four isolated process samples per build, 1,000 queries per case, and geometric means. QPS is higher-is-better; p50 latency is lower-is-better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| SHOULD x3, k=10, QPS | 159.77 queries/s | 465.76 queries/s | 2.92x throughput |
| SHOULD x3, k=10, p50 | 31.02 ms | 9.21 ms | 3.37x speedup |
| SHOULD x3, k=100, QPS | 144.69 queries/s | 337.98 queries/s | 2.34x throughput |
| SHOULD x3, k=100, p50 | 31.64 ms | 14.95 ms | 2.12x speedup |
| SHOULD + Phrase, k=10, QPS | 320.42 queries/s | 885.60 queries/s | 2.76x throughput |
| SHOULD + Phrase, k=10, p50 | 13.29 ms | 4.88 ms | 2.72x speedup |
| SHOULD + Phrase, k=100, QPS | 221.36 queries/s | 462.28 queries/s | 2.09x throughput |
| SHOULD + Phrase, k=100, p50 | 14.73 ms | 8.43 ms | 1.75x speedup |

MUST controls remained within 0.99x-1.01x. The reused index hash was unchanged before and after the run. Exact-oracle checks passed 24/24 for each build, all 56,000 timed result signatures matched across builds, and there were no timed digest mismatches.

The existing index_comparisons metric is a WandCursor leaf-candidate proxy rather than a low-level PostingIterator doc-id comparison count; no stronger claim is made for that metric.

## Validation

- cargo fmt --all -- --check
- cargo test -p lance-index pure_should_maxscore --lib -- --nocapture
- cargo test -p lance io::exec::fts::tests::test_compound_should_metrics_are_counted_independently --lib -- --exact --nocapture
- cargo test -p lance dataset::tests::dataset_index::test_pure_should_maxscore_is_exact_across_fragments --lib -- --exact --nocapture
- cargo clippy --all --tests --benches -- -D warnings

Completes OSS-1706.