### PR TITLE
test(compat): cover vector maintenance sequences

### DIFF
--- a/.github/workflows/compat-pair.yml
+++ b/.github/workflows/compat-pair.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: ""
       kinds:
-        description: "Comma-separated index kinds (INVERTED,BTREE,...) or 'all'."
+        description: "Comma-separated index kinds (INVERTED,BTREE,IVF_PQ,...) or 'all'."
         required: false
         default: "all"
       max_length:
@@ -63,7 +63,7 @@ jobs:
           KINDS_IN: ${{ inputs.kinds }}
         run: |
           if [ -z "$KINDS_IN" ] || [ "$KINDS_IN" = "all" ]; then
-            echo "value=INVERTED,BTREE,BITMAP,LABEL_LIST,NGRAM,ZONEMAP,BLOOMFILTER" >> "$GITHUB_OUTPUT"
+            echo "value=INVERTED,BTREE,BITMAP,LABEL_LIST,NGRAM,ZONEMAP,BLOOMFILTER,IVF_PQ" >> "$GITHUB_OUTPUT"
           else
             echo "value=$KINDS_IN" >> "$GITHUB_OUTPUT"
           fi

--- a/python/python/tests/compat/compat_sequence.py
+++ b/python/python/tests/compat/compat_sequence.py
@@ -11,8 +11,8 @@ full (unindexed) scan. This *discovers* cross-version regressions (e.g. ENT-1662
 without hand-coding the triggering sequence.
 
 The scenario is parameterized by index *kind* so every scalar index type gets the same
-aged-lifecycle, cross-version treatment. The oracle runs the same predicate twice --
-normally and with use_scalar_index=False (lance ignores the index) -- and requires
+aged-lifecycle, cross-version treatment. The scalar oracle runs the same predicate twice
+-- normally and with use_scalar_index=False (lance ignores the index) -- and requires
 the results to match. If the two query plans are identical the index wasn't used, so the
 comparison is skipped rather than failed (uninformative, not a regression). FTS has no
 "ignore the index" mode to diff against, so its oracle reconstructs ground truth from a
@@ -22,9 +22,15 @@ on-disk format versions (1 and 2), which take different merge paths. New Lance v
 pin this with the create-index `format_version` parameter; old Lance versions still use
 `LANCE_FTS_FORMAT_VERSION`.
 
-The op vocabulary and bounds are deliberately small so the search is runnable; this is
-exhaustive over the maintenance-lifecycle grammar up to the configured lengths, not over
-every op permutation.
+IVF_PQ uses a separate bounded grammar because exhaustively applying the scalar grammar
+to a trained vector index would be prohibitively expensive. It covers every ordered pair
+of vector/scalar maintenance operations plus a few deeper lifecycle sequences. Its
+oracle compares scalar-prefiltered ANN results with an exact, index-free KNN scan and
+requires at least 0.5 recall, as well as checking the scalar filter exactly.
+
+The op vocabulary and bounds are deliberately small so the search is runnable. Scalar
+and FTS cases are exhaustive over their maintenance grammar up to the configured length;
+vector cases cover every ordered pair plus the curated deeper lifecycles above.
 """
 
 import itertools
@@ -33,9 +39,26 @@ import shutil
 from pathlib import Path
 
 ROWS_PER_WRITE = 200
+VECTOR_ROWS_PER_WRITE = 512
+VECTOR_DIM = 8
+VECTOR_K = 10
+VECTOR_KIND = "IVF_PQ"
+VECTOR_INDEX_NAME = "vector_idx"
+VECTOR_SCALAR_INDEX_NAME = "scalar_idx"
 
 SETUP_TAIL_OPS = ["D", "C", "W"]
 EXERCISE_OPS = ["W", "D", "C", "Oa", "Om", "Od"]
+VECTOR_OPS = ("W", "D", "C", "Os", "Ov", "Om")
+
+# All ordered operation pairs are searched below. These longer cases preserve the
+# state combinations that motivated the old recurring test without growing as 6**N.
+VECTOR_CRITICAL_SEQUENCES = (
+    ("W", "Ov", "W", "Ov", "W"),  # two vector deltas, then unindexed rows
+    ("W", "Os", "W", "Ov", "Om"),
+    ("D", "C", "W", "Ov", "Om"),
+    ("W", "D", "Os", "C", "Ov"),
+    ("W", "Ov", "D", "C", "Om"),
+)
 
 OP_NAMES = {
     "W": "write rows",
@@ -45,6 +68,8 @@ OP_NAMES = {
     "Oa": "optimize (append)",
     "Om": "optimize (merge)",
     "Od": "optimize",
+    "Os": "optimize scalar index (append)",
+    "Ov": "optimize vector index (append)",
 }
 
 
@@ -58,7 +83,7 @@ def describe(kind, from_ref, to_ref, setup_ops, exercise_ops, fts_version=None):
 
 # Index kinds covered by the maintenance-sequence search.
 SCALAR_KINDS = ["BTREE", "BITMAP", "LABEL_LIST", "NGRAM", "ZONEMAP", "BLOOMFILTER"]
-ALL_KINDS = ["INVERTED", *SCALAR_KINDS]
+ALL_KINDS = ["INVERTED", *SCALAR_KINDS, VECTOR_KIND]
 
 
 class IndexScenario:
@@ -83,6 +108,19 @@ class IndexScenario:
         import pyarrow as pa
 
         idx = list(range(a, b))
+        if self.kind == VECTOR_KIND:
+            # Deterministic pseudo-random vectors keep every appended batch in the
+            # training distribution without depending on numpy or process RNG state.
+            flat = []
+            for i in idx:
+                state = ((i + 1) * 2654435761) & 0xFFFFFFFF
+                for _ in range(VECTOR_DIM):
+                    state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+                    flat.append(state / 4294967296.0)
+            vector = pa.FixedSizeListArray.from_arrays(
+                pa.array(flat, type=pa.float32()), VECTOR_DIM
+            )
+            return pa.table({"idx": idx, "vector": vector})
         if self.kind == "INVERTED":
             # Each row's text mixes tokens of different frequency: a unique term, a
             # mid-frequency bucket (~1/7 of rows), and one shared by every row. Sampling
@@ -115,7 +153,8 @@ class IndexScenario:
     def _op_W(self):
         import lance
 
-        a, b = self.next_idx, self.next_idx + ROWS_PER_WRITE
+        num_rows = VECTOR_ROWS_PER_WRITE if self.kind == VECTOR_KIND else ROWS_PER_WRITE
+        a, b = self.next_idx, self.next_idx + num_rows
         self.next_idx = b
         tbl = self._batch(a, b)
         if not os.path.exists(self.path):
@@ -124,6 +163,18 @@ class IndexScenario:
             self._open().insert(tbl)
 
     def _op_I(self):
+        if self.kind == VECTOR_KIND:
+            self._open().create_scalar_index(
+                "idx", "BTREE", name=VECTOR_SCALAR_INDEX_NAME
+            )
+            self._open().create_index(
+                "vector",
+                index_type="IVF_PQ",
+                name=VECTOR_INDEX_NAME,
+                num_partitions=2,
+                num_sub_vectors=2,
+            )
+            return
         kwargs = {"with_position": True} if self.kind == "INVERTED" else {}
         if self.kind == "INVERTED" and self.fts_version is not None:
             kwargs["format_version"] = int(self.fts_version)
@@ -145,10 +196,26 @@ class IndexScenario:
         self._open().optimize.optimize_indices(num_indices_to_merge=0)
 
     def _op_Om(self):
-        self._open().optimize.optimize_indices(num_indices_to_merge=10)
+        kwargs = {"num_indices_to_merge": 10}
+        if self.kind == VECTOR_KIND:
+            kwargs = {
+                "num_indices_to_merge": 1,
+                "index_names": [VECTOR_INDEX_NAME],
+            }
+        self._open().optimize.optimize_indices(**kwargs)
 
     def _op_Od(self):
         self._open().optimize.optimize_indices()
+
+    def _op_Os(self):
+        self._open().optimize.optimize_indices(
+            num_indices_to_merge=0, index_names=[VECTOR_SCALAR_INDEX_NAME]
+        )
+
+    def _op_Ov(self):
+        self._open().optimize.optimize_indices(
+            num_indices_to_merge=0, index_names=[VECTOR_INDEX_NAME]
+        )
 
     def _run(self, ops):
         for op in ops:
@@ -164,6 +231,9 @@ class IndexScenario:
     def exercise_and_check(self):
         self._run(self.exercise_ops)
         ds = self._open()
+        if self.kind == VECTOR_KIND:
+            self._check_vector_prefilter(ds)
+            return
         if self.kind == "INVERTED":
             # Differential oracle: rebuild the token -> rows map from a full (unindexed)
             # scan, then require an FTS search for a spread of sampled terms to return
@@ -208,6 +278,136 @@ class IndexScenario:
             f"{self.kind}: index gave {got} rows, full scan {expected}, for '{pred}'"
         )
 
+    def _check_vector_prefilter(self, ds):
+        """Check both BTREE filtering and IVF_PQ recall against index-free scans."""
+        # Both ranges avoid the deterministic delete window. The first is always in
+        # the original index while the newest range may be an unindexed append, so
+        # the same query covers the indexed + unindexed prefilter path.
+        filter_rows = VECTOR_ROWS_PER_WRITE // 8
+        lo = self.next_idx - filter_rows
+        pred = f"idx < {filter_rows} OR (idx >= {lo} AND idx < {self.next_idx})"
+
+        filtered_scan = ds.to_table(
+            columns=["idx", "vector"], filter=pred, use_scalar_index=False
+        )
+        filtered_rows = sorted(
+            zip(
+                filtered_scan.column("idx").to_pylist(),
+                filtered_scan.column("vector").to_pylist(),
+            )
+        )
+        filtered_ids = [idx for idx, _ in filtered_rows]
+        filtered_id_set = set(filtered_ids)
+        assert len(filtered_ids) == len(filtered_id_set), (
+            f"BTREE prefilter returned duplicate row ids for '{pred}'"
+        )
+        assert len(filtered_ids) >= VECTOR_K, (
+            f"not enough live rows ({len(filtered_ids)}) for vector oracle '{pred}'"
+        )
+
+        scalar_plan = ds.scanner(filter=pred).explain_plan(True)
+        scan_plan = ds.scanner(filter=pred, use_scalar_index=False).explain_plan(True)
+        scalar_markers = ("ScalarIndexQuery", "MaterializeIndex")
+        assert any(marker in scalar_plan for marker in scalar_markers), (
+            f"BTREE index was not used for '{pred}':\n{scalar_plan}"
+        )
+        assert not any(marker in scan_plan for marker in scalar_markers), (
+            f"BTREE index disabling was ignored for '{pred}':\n{scan_plan}"
+        )
+        scalar_ids = ds.to_table(columns=["idx"], filter=pred).column("idx").to_pylist()
+        assert len(scalar_ids) == len(set(scalar_ids)), (
+            f"BTREE returned duplicate row ids for '{pred}'"
+        )
+        assert set(scalar_ids) == filtered_id_set, (
+            f"BTREE returned {len(scalar_ids)} rows, full scan returned "
+            f"{len(filtered_ids)}, for '{pred}'"
+        )
+
+        query_positions = (0, len(filtered_ids) // 2, len(filtered_ids) - 1)
+        vectors = [vector for _, vector in filtered_rows]
+        for query_position in query_positions:
+            query = vectors[query_position]
+            indexed_nearest = {
+                "column": "vector",
+                "q": query,
+                "k": VECTOR_K,
+                "nprobes": 2,
+                "refine_factor": 10,
+            }
+            exact_nearest = {
+                "column": "vector",
+                "q": query,
+                "k": VECTOR_K,
+                "use_index": False,
+            }
+
+            ann_plan = ds.scanner(
+                nearest=indexed_nearest, filter=pred, prefilter=True
+            ).explain_plan(True)
+            exact_plan = ds.scanner(
+                nearest=exact_nearest,
+                filter=pred,
+                prefilter=True,
+                use_scalar_index=False,
+            ).explain_plan(True)
+            ann_markers = ("ANNSubIndex", "ANNIvfPartition")
+            assert any(marker in ann_plan for marker in ann_markers), (
+                f"IVF_PQ index was not used by vector search:\n{ann_plan}"
+            )
+            assert not any(marker in exact_plan for marker in ann_markers), (
+                f"IVF_PQ index disabling was ignored:\n{exact_plan}"
+            )
+            assert any(marker in ann_plan for marker in scalar_markers), (
+                f"BTREE index was not used by vector prefilter:\n{ann_plan}"
+            )
+            assert not any(marker in exact_plan for marker in scalar_markers), (
+                f"BTREE index disabling was ignored by exact prefilter:\n{exact_plan}"
+            )
+
+            got = (
+                ds.to_table(
+                    columns=["idx", "_distance"],
+                    nearest=indexed_nearest,
+                    filter=pred,
+                    prefilter=True,
+                )
+                .column("idx")
+                .to_pylist()
+            )
+            expected = (
+                ds.to_table(
+                    columns=["idx", "_distance"],
+                    nearest=exact_nearest,
+                    filter=pred,
+                    prefilter=True,
+                    use_scalar_index=False,
+                )
+                .column("idx")
+                .to_pylist()
+            )
+
+            assert len(got) == len(set(got)), "IVF_PQ search returned duplicate row ids"
+            assert len(expected) == len(set(expected)), (
+                "exact vector search returned duplicate row ids"
+            )
+            assert set(got) <= filtered_id_set, (
+                f"IVF_PQ prefilter returned ids outside '{pred}': "
+                f"{sorted(set(got) - filtered_id_set)[:5]}"
+            )
+            assert set(expected) <= filtered_id_set, (
+                f"exact prefilter returned ids outside '{pred}': "
+                f"{sorted(set(expected) - filtered_id_set)[:5]}"
+            )
+            assert len(got) == len(expected) == VECTOR_K, (
+                f"IVF_PQ returned {len(got)} rows, exact search returned "
+                f"{len(expected)}"
+            )
+            recall = len(set(got) & set(expected)) / VECTOR_K
+            assert recall >= 0.5, (
+                f"IVF_PQ prefilter recall@{VECTOR_K}={recall:.3f}; "
+                f"expected at least 0.5 (got={got}, exact={expected})"
+            )
+
 
 def generate(max_length):
     """Yield every (setup_ops, exercise_ops) whose combined length is 1..max_length,
@@ -221,6 +421,31 @@ def generate(max_length):
             for s in itertools.product(SETUP_TAIL_OPS, repeat=setup_len):
                 for e in itertools.product(EXERCISE_OPS, repeat=total - setup_len):
                     yield list(s), list(e)
+
+
+def generate_vector(max_length):
+    """Yield a bounded IVF_PQ + BTREE maintenance search space.
+
+    Every ordered pair of operations is covered on both sides of the version split.
+    A small set of deeper cases captures multi-delta, unindexed-row, delete, compact,
+    and merge interactions without expanding the full operation grammar to 6**N.
+    """
+    seen = set()
+    for total in range(1, min(max_length, 2) + 1):
+        for sequence in itertools.product(VECTOR_OPS, repeat=total):
+            for setup_len in range(total):
+                case = (sequence[:setup_len], sequence[setup_len:])
+                if case not in seen:
+                    seen.add(case)
+                    yield list(case[0]), list(case[1])
+    for sequence in VECTOR_CRITICAL_SEQUENCES:
+        if len(sequence) > max_length:
+            continue
+        for setup_len in range(len(sequence)):
+            case = (sequence[:setup_len], sequence[setup_len:])
+            if case not in seen:
+                seen.add(case)
+                yield list(case[0]), list(case[1])
 
 
 def search(
@@ -254,7 +479,10 @@ def search(
     # than rebuilding the index). Cached per shard, keyed by the setup ops.
     snapshots = {}  # tuple(setup) -> (snapshot_path, next_idx), or None if setup failed
     try:
-        for i, (setup_tail, exercise) in enumerate(generate(max_length)):
+        cases = (
+            generate_vector(max_length) if kind == VECTOR_KIND else generate(max_length)
+        )
+        for i, (setup_tail, exercise) in enumerate(cases):
             if i % num_shards != shard:
                 continue
             key = tuple(setup_tail)

--- a/python/python/tests/compat/test_index_sequence.py
+++ b/python/python/tests/compat/test_index_sequence.py
@@ -11,16 +11,51 @@ hand-coded sequence.
 
 Refs and max length are environment-driven so the suite can run between two refs
 (versions, commits, or branches): COMPAT_FROM_REF / COMPAT_TO_REF / COMPAT_MAX_LENGTH /
-COMPAT_KINDS (comma-separated subset of kinds) / COMPAT_SHARDS (split each kind's search
-into this many cases so pytest-xdist (`-n auto`) parallelizes them across cores).
+COMPAT_VECTOR_MAX_LENGTH / COMPAT_KINDS (comma-separated subset of kinds) /
+COMPAT_SHARDS (split each scalar/FTS kind's search into this many cases so pytest-xdist
+(`-n auto`) parallelizes them across cores) / COMPAT_VECTOR_SHARDS (the bounded IVF_PQ
+search uses fewer shards to avoid repeatedly training the same small index).
 """
 
 import os
+from itertools import product
 
 import pytest
 
 from .compat_decorator import pylance_stable_versions
-from .compat_sequence import ALL_KINDS, search
+from .compat_sequence import (
+    ALL_KINDS,
+    VECTOR_KIND,
+    VECTOR_OPS,
+    generate_vector,
+    search,
+)
+
+
+def test_vector_sequence_generation_is_bounded_and_covers_high_risk_orders():
+    cases = list(generate_vector(max_length=5))
+    combined = [tuple(setup + exercise) for setup, exercise in cases]
+
+    assert cases
+    assert len(cases) < 128
+    assert len(cases) == len(set((tuple(s), tuple(e)) for s, e in cases))
+    assert all(exercise for _, exercise in cases)
+    assert all(1 <= len(sequence) <= 5 for sequence in combined)
+
+    split_cases = {(tuple(setup), tuple(exercise)) for setup, exercise in cases}
+    for pair in product(VECTOR_OPS, repeat=2):
+        assert ((), pair) in split_cases
+        assert (pair[:1], pair[1:]) in split_cases
+
+    two_delta_then_unindexed = ("W", "Ov", "W", "Ov", "W")
+    assert {
+        (tuple(setup), tuple(exercise))
+        for setup, exercise in cases
+        if tuple(setup + exercise) == two_delta_then_unindexed
+    } == {
+        (two_delta_then_unindexed[:split], two_delta_then_unindexed[split:])
+        for split in range(len(two_delta_then_unindexed))
+    }
 
 
 def _default_refs():
@@ -35,10 +70,15 @@ _default_from, _default_to = _default_refs()
 FROM_REF = os.environ.get("COMPAT_FROM_REF") or _default_from
 TO_REF = os.environ.get("COMPAT_TO_REF") or _default_to
 MAX_LENGTH = int(os.environ.get("COMPAT_MAX_LENGTH", "4"))
+VECTOR_MAX_LENGTH = int(os.environ.get("COMPAT_VECTOR_MAX_LENGTH", str(MAX_LENGTH)))
 KINDS = os.environ.get("COMPAT_KINDS", ",".join(ALL_KINDS)).split(",")
 # Many small shards (default 4x cores) so xdist's dynamic scheduler keeps every worker
 # busy and an oversubscribed `-n` has work to overlap.
 NUM_SHARDS = int(os.environ.get("COMPAT_SHARDS", str((os.cpu_count() or 1) * 4)))
+# Training IVF_PQ once per generic shard would multiply total work without expanding
+# coverage. Four cases still parallelize the bounded vector search while retaining
+# snapshot reuse within each case.
+VECTOR_NUM_SHARDS = int(os.environ.get("COMPAT_VECTOR_SHARDS", str(min(NUM_SHARDS, 4))))
 
 
 def _cases():
@@ -53,25 +93,42 @@ def _cases():
     return cases
 
 
-CASES = _cases()
-CASE_IDS = [k if v is None else f"{k}-fmtv{v}" for k, v in CASES]
+def _search_cases():
+    cases = []
+    for kind, fts_version in _cases():
+        num_shards = VECTOR_NUM_SHARDS if kind == VECTOR_KIND else NUM_SHARDS
+        kind_id = kind if fts_version is None else f"{kind}-fmtv{fts_version}"
+        cases.extend(
+            pytest.param(
+                kind,
+                fts_version,
+                shard,
+                num_shards,
+                id=f"{kind_id}-shard{shard}",
+            )
+            for shard in range(num_shards)
+        )
+    return cases
+
+
+SEARCH_CASES = _search_cases()
 
 
 @pytest.mark.compat
-@pytest.mark.parametrize("kind,fts_version", CASES, ids=CASE_IDS)
-@pytest.mark.parametrize("shard", range(NUM_SHARDS))
+@pytest.mark.parametrize("kind,fts_version,shard,num_shards", SEARCH_CASES)
 def test_index_maintenance_sequence_search(
-    venv_factory, tmp_path, kind, fts_version, shard
+    venv_factory, tmp_path, kind, fts_version, shard, num_shards
 ):
+    max_length = VECTOR_MAX_LENGTH if kind == VECTOR_KIND else MAX_LENGTH
     failures = search(
         venv_factory,
         FROM_REF,
         TO_REF,
         tmp_path,
         kind,
-        max_length=MAX_LENGTH,
+        max_length=max_length,
         shard=shard,
-        num_shards=NUM_SHARDS,
+        num_shards=num_shards,
         fts_version=fts_version,
     )
     # First line is the failure itself so it shows in pytest's bottom summary; the rest


### PR DESCRIPTION
## What changed?

Extend the cross-version index maintenance-sequence search with a bounded `IVF_PQ` + `BTREE` prefilter scenario.

- cover every single maintenance operation and ordered operation pair across valid writer/reader splits
- add five curated deeper lifecycles, including the two-vector-delta plus scalar-unindexed-row state from #3769
- compare scalar-index results with a full scan
- compare indexed ANN prefilter results with exact index-free KNN and require recall@10 >= 0.5
- cap vector search at four shards and avoid exponential sequence growth
- include `IVF_PQ` in manual compat-pair `all`

## Why is this needed?

The existing sequence search covers scalar and FTS indexes but not vector/scalar prefilter interactions. That is the main remaining unique signal in the legacy recurring test. This adds deterministic, isolated cross-version coverage with correctness oracles before that recurring matrix is removed.

## Validation

- deterministic bounded-generator test
- current runtime: all 103 max-length-5 cases passed across four shards in 10.51s
- Pylance 9.0.1 writer to 10.0.0 reader:
  - all 103 cases passed in one shard
  - the default four-shard run passed in 9.07s after environment setup
- existing `BTREE` sequence smoke passed
- `uv run make lint`
- workflow YAML parse
- `git diff --check`