### PR TITLE
fix(compaction): skip binary copy when files miss schema columns

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -500,6 +500,7 @@ impl CompactionOptions {
 /// - No fragment has a deletion file
 ///   TODO: Need to support schema evolution case like add column and drop column
 /// - All data files share identical schema mappings (`fields`, `column_indices`)
+/// - That shared mapping matches the dataset schema's physical column layout
 /// - Input data files must not contain extra global buffers (beyond schema / file descriptor)
 async fn can_use_binary_copy(
     dataset: &Dataset,
@@ -551,6 +552,28 @@ pub(super) async fn can_use_binary_copy_current(
     }
     let ref_fields = &fragments[0].files[0].fields;
     let ref_cols = &fragments[0].files[0].column_indices;
+
+    // Binary copy only moves the physical columns that exist in the input files,
+    // but it describes the output file with the dataset schema: both the footer
+    // schema and the new `fields` / `column_indices` mapping are derived from it.
+    // A metadata-only schema change (an all-null `add_columns`, a `drop_columns`)
+    // leaves the inputs covering a different set of physical columns than the
+    // dataset schema describes, so that mapping would name columns the output file
+    // does not have. Re-encoding materializes those columns, so fall back to it.
+    let version = dataset.manifest.data_storage_format.lance_file_format();
+    let (schema_fields, schema_cols) =
+        lance_file::versions::data_file_columns(version, dataset.schema());
+    if ref_fields.as_ref() != schema_fields || ref_cols.as_ref() != schema_cols {
+        log::debug!(
+            "Binary copy disabled: data files map fields {:?} to columns {:?} but the dataset schema maps fields {:?} to columns {:?}",
+            ref_fields,
+            ref_cols,
+            schema_fields,
+            schema_cols
+        );
+        return Ok(false);
+    }
+
     for fragment in fragments {
         if fragment.deletion_file.is_some() {
             log::debug!(

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use super::*;
+use crate::dataset::NewColumnTransform;
 
 const NON_LEGACY_VERSIONS: [LanceFileVersion; 4] = [
     LanceFileVersion::V2_0,
@@ -111,6 +112,91 @@ async fn do_test_binary_copy_packed_struct_column_mapping(version: LanceFileVers
     let data_file = &dataset.manifest.fragments[0].files[0];
     assert_eq!(data_file.fields.len(), 2);
     assert_eq!(data_file.column_indices.as_ref(), &[0, 1]);
+}
+
+/// A metadata-only `add_columns` widens the dataset schema without touching the
+/// data files, so the files no longer cover every physical column the schema
+/// describes. Binary copy would still describe the compacted file with the full
+/// schema, registering a column index the file does not have and breaking the
+/// next scan. See https://github.com/lancedb/lance/issues/8281.
+#[tokio::test]
+async fn test_binary_copy_skipped_after_metadata_only_add_column() {
+    for version in NON_LEGACY_VERSIONS {
+        do_test_binary_copy_skipped_after_metadata_only_add_column(version).await;
+    }
+}
+
+async fn do_test_binary_copy_skipped_after_metadata_only_add_column(version: LanceFileVersion) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, true),
+        Field::new("b", DataType::Int32, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])) as ArrayRef,
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+
+    let test_dir = TempStrDir::default();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        &test_dir,
+        Some(WriteParams {
+            data_storage_version: Some(version),
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+
+    dataset
+        .add_columns(
+            NewColumnTransform::AllNulls(Arc::new(Schema::new(vec![Field::new(
+                "c",
+                DataType::Int32,
+                true,
+            )]))),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100_000,
+        compaction_mode: Some(CompactionMode::ForceBinaryCopy),
+        ..Default::default()
+    };
+    let err = compact_files(&mut dataset, options.clone(), None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::NotSupported { .. }) && err.to_string().contains("binary copy"),
+        "Error: {}",
+        err
+    );
+
+    compact_files(
+        &mut dataset,
+        CompactionOptions {
+            compaction_mode: Some(CompactionMode::TryBinaryCopy),
+            ..options
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 1);
+
+    let after = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(after.num_rows(), 4);
+    assert_eq!(after["a"].as_ref(), &Int32Array::from(vec![1, 2, 3, 4]));
+    assert_eq!(after["c"].null_count(), 4);
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -196,6 +196,9 @@ async fn do_test_binary_copy_skipped_after_metadata_only_add_column(version: Lan
     let after = dataset.scan().try_into_batch().await.unwrap();
     assert_eq!(after.num_rows(), 4);
     assert_eq!(after["a"].as_ref(), &Int32Array::from(vec![1, 2, 3, 4]));
+    // The columns that were already in the data files must survive the
+    // re-encode fallback untouched, not just the one the scan used to trip on.
+    assert_eq!(after["b"].as_ref(), &Int32Array::from(vec![10, 20, 30, 40]));
     assert_eq!(after["c"].null_count(), 4);
 }
 


### PR DESCRIPTION
# Issue #8281 — full scan fails with an out-of-range projection after `add_columns` + `compact_files`

## 1. Root cause

Binary-copy compaction registers the compacted file with a field/column mapping
derived from the **dataset schema**, but it only physically copies the columns
that exist in the **input files**. When those two disagree, the manifest names a
column index the output file does not have.

* `rewrite_files_binary_copy` (`rust/lance/src/dataset/optimize/binary_copy.rs`)
  copies pages column-by-column out of `src_column_infos` (whatever the input
  files contain), then at `binary_copy.rs:90` builds the output `DataFile` via
  `file_versions::data_file_columns(version, dataset.schema())` and writes the
  footer from that same full dataset schema.
* `can_use_binary_copy_current` (`rust/lance/src/dataset/optimize.rs`) only
  checked that every input data file agrees **with the other input files**
  (`data_file.fields != *ref_fields || data_file.column_indices != *ref_cols`).
  It never checked them against the dataset schema.

`add_columns` with `NewColumnTransform::AllNulls` is metadata-only: it widens the
manifest schema and leaves the fragments untouched (`schema_evolution.rs:353`,
"missing columns are synthesized as nulls at read time"). So after adding an
all-null column, all data files are still identical to each other — the existing
check passes — while the dataset schema now describes one more physical column
than any file holds.

The compacted file is therefore committed with `fields=[0,1,2] cols=[0,1,2]`
while containing only 2 columns. The next scan builds its projection from that
mapping (`FileFragment::open_current_file_reader` →
`reader_projection_from_field_ids`) and `FileReader::validate_projection` rejects
it:

```
The projection specified the column index 2 but there are only 2 columns in the file
```

which is the reporter's error (their dataset had 11 physical columns, so index 11).

The same mismatch exists in the opposite direction: `drop_columns` is also
metadata-only (`Operation::Project`), leaving files with *more* physical columns
than the schema describes.

This explains the issue's odd repro shape. On the default `Reencode` path the
scan reads the compacted file correctly, so only datasets whose compaction ran in
binary-copy mode (`compaction_mode = try_binary_copy`/`force_binary_copy`, or the
deprecated `enable_binary_copy`, settable per dataset via the
`lance.compaction.*` manifest config) are affected — and the reporter's
compaction succeeded while only the later scan failed, which is exactly the
binary-copy signature.

## 2. The fix and why

In `can_use_binary_copy_current`, compare the input files' shared
`(fields, column_indices)` mapping against
`lance_file::versions::data_file_columns(version, dataset.schema())` and return
`false` when they differ. Compaction then falls back to re-encoding, which reads
through the scanner (missing columns are materialized as nulls by `NullReader`)
and records the mapping from the writer's own `field_id_to_column_indices`, so
the compacted file is self-consistent.

Why a guard instead of fixing the mapping in `binary_copy.rs`: the output file's
footer schema is written from the same dataset schema
(`flush_footer` → `initialize_with_external_columns`). Emitting a narrower
`fields`/`column_indices` list would still leave a file whose declared schema has
more fields than it has column metadatas — i.e. a file that is wrong for any
reader that opens it by its own schema. Making binary copy genuinely support
schema evolution means writing a restricted schema and is what the existing
`TODO: Need to support schema evolution case like add column and drop column`
tracks. Binary copy is an optimization; declining it is correct and cheap.

`ForceBinaryCopy` now returns the existing `Error::NotSupported`
("binary copy is not supported") instead of silently producing a broken file.

## 3. Files changed

* `rust/lance/src/dataset/optimize.rs` — the guard in
  `can_use_binary_copy_current`, plus the matching precondition line in the
  `can_use_binary_copy` doc comment.
* `rust/lance/src/dataset/optimize/tests/binary_copy.rs` — regression test
  `test_binary_copy_skipped_after_metadata_only_add_column`, run over all four
  non-legacy file versions (V2_0/V2_1/V2_2/V2_3). It asserts `ForceBinaryCopy`
  errors, `TryBinaryCopy` falls back and succeeds, and the post-compaction scan
  returns all rows with the added column reading back as null.

## 4. Risk / uncertainty

* **Behaviour change:** datasets that have had a metadata-only `add_columns` or
  `drop_columns` no longer take the binary-copy fast path. That is a performance
  regression relative to today's behaviour, but today's behaviour writes a file
  that cannot be scanned, so it is not a regression in practice.
* **Strictness of the comparison:** the check is exact list equality. It holds
  because the writer's `ColumnIndexSequence` visits fields in the same order as
  `data_file_columns` for every supported layout (leaves for v2.1+; field-then-
  children for v2.0; one column for blob and packed-struct fields). The existing
  `test_binary_copy_compaction_with_complex_schema` (structs, nested structs,
  lists of structs, fixed-size lists, var-binary, under `ForceBinaryCopy`) and
  `test_binary_copy_packed_struct_column_mapping` both still pass, so normal
  layouts are not over-rejected. Blob datasets are already excluded from binary
  copy earlier in the same function.
* **Not fixed here — a separate, pre-existing defect.** Re-encoding an all-null
  `Dictionary<Int32, Utf8>` column fails during compaction:

  ```
  Invalid argument error: Value at position 0 out of bounds: 0 (should be in [0, -1])
    at rust/lance-encoding/src/encodings/logical/primitive.rs:6631
  ```

  `PrimitiveStructuralEncoder::extract_validity_buf` strips the null buffer off
  the synthesized all-null dictionary array, leaving keys of `0` against an empty
  dictionary, which Arrow's `ArrayData::build` rejects. I verified this
  reproduces on the **default `Reencode` path with no binary copy involved and
  without my change**, and that the same column scans fine before compaction — so
  it is an independent bug in `lance-encoding`, not the projection bug this issue
  reports. Fixing it means reworking dictionary null normalisation for empty
  dictionaries (a data-correctness change in the write path), which does not
  belong in this fix. It does mean the reporter's exact column type will now fail
  loudly at compaction time rather than silently corrupting the manifest; it
  deserves its own issue.

## 5. How I verified it

Toolchain: pinned `rustc 1.97.0`; `protoc` 28.3 on `PATH` (with its bundled
includes) is required for the build.

1. **Reproduced first.** A scratch integration test (2 fragments × 2 rows,
   storage v2.3, stable row ids off → metadata-only `add_columns` →
   `compact_files` → full scan) failed on the unmodified tree with the exact
   reported error and printed the bad manifest entry:

   ```
   frag 2 file ....lance fields=[0, 1, 2] cols=[0, 1, 2]
   InvalidInput { source: "The projection specified the column index 2 but there
   are only 2 columns in the file", location: rust/lance-file/src/reader.rs:1136 }
   ```

   The same scenario on `CompactionMode::Reencode` passed, isolating the failure
   to the binary-copy path.
2. **Confirmed the fix.** After the change the same scenario passes for
   `TryBinaryCopy` and for the default mode, and the `drop_columns` +
   binary-copy variant passes as well. The scratch file was deleted; its content
   is preserved as the committed regression test.
3. `cargo test -p lance --lib dataset::optimize::tests::binary_copy` — 15 passed,
   0 failed (includes the new test across all four file versions).
4. `cargo test -p lance --lib dataset::optimize` — 118 passed, 0 failed.
5. `cargo fmt --all`.
6. `cargo clippy --all --tests --benches -- -D warnings` — clean.

I did not run the full `cargo test --workspace` or the Python test suite; the
change is confined to one compaction precondition in the Rust core and touches no
binding surface.
