### PR TITLE
fix: validate substrait filters that need no field pruning

### DIFF
--- a/rust/lance-datafusion/src/substrait.rs
+++ b/rust/lance-datafusion/src/substrait.rs
@@ -199,7 +199,7 @@ fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>)
             Ok(())
         }
         RexType::IfThen(ifthen) => {
-            for clause in ifthen.ifs.iter_mut() {
+            for (i, clause) in ifthen.ifs.iter_mut().enumerate() {
                 remap_expr_references(
                     clause
                         .r#if
@@ -207,10 +207,12 @@ fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>)
                         .ok_or_else(|| missing_field("if clause condition"))?,
                     mapping,
                 )?;
-                // The leading clause may omit `then`, in which case its condition is the case
-                // expression being matched against.
-                if let Some(then) = clause.then.as_mut() {
-                    remap_expr_references(then, mapping)?;
+                match clause.then.as_mut() {
+                    Some(then) => remap_expr_references(then, mapping)?,
+                    // Only the leading clause may omit `then`, in which case its condition is
+                    // the case expression being matched against.
+                    None if i == 0 => {}
+                    None => return Err(missing_field("if clause result")),
                 }
             }
             if let Some(otherwise) = ifthen.r#else.as_mut() {
@@ -819,6 +821,40 @@ mod tests {
                 when_then_expr: vec![],
                 else_expr: None,
             })
+        );
+    }
+
+    /// DataFusion only tolerates an omitted `then` on the leading clause, so a later clause
+    /// missing one has to be rejected here rather than reaching the consumer.
+    #[tokio::test]
+    async fn test_unpruned_if_then_missing_nonleading_then() {
+        let condition = || Expression {
+            rex_type: Some(RexType::Literal(Literal {
+                nullable: false,
+                type_variation_reference: 0,
+                literal_type: Some(LiteralType::Boolean(true)),
+            })),
+        };
+
+        let err = parse_unpruned_expr(RexType::IfThen(Box::new(IfThen {
+            ifs: vec![
+                IfClause {
+                    r#if: Some(condition()),
+                    then: Some(condition()),
+                },
+                IfClause {
+                    r#if: Some(condition()),
+                    then: None,
+                },
+            ],
+            r#else: None,
+        })))
+        .await
+        .expect_err("a non-leading clause without `then` is not valid");
+
+        assert!(
+            err.to_string().contains("if clause result"),
+            "unexpected error: {err}"
         );
     }
 

--- a/rust/lance-datafusion/src/substrait.rs
+++ b/rust/lance-datafusion/src/substrait.rs
@@ -301,19 +301,9 @@ pub async fn parse_substrait(
         let (substrait_schema, _, index_mapping) =
             remove_extension_types(envelope.base_schema.as_ref().unwrap(), input_schema.clone())?;
 
-        if substrait_schema.r#struct.as_ref().unwrap().types.len()
-            != envelope
-                .base_schema
-                .as_ref()
-                .unwrap()
-                .r#struct
-                .as_ref()
-                .unwrap()
-                .types
-                .len()
-        {
-            remap_expr_references(&mut expr, &index_mapping)?;
-        }
+        // Always walk the expression: this also rejects operators we cannot push down. When no
+        // fields were removed the mapping is the identity, so the remap itself is a no-op.
+        remap_expr_references(&mut expr, &index_mapping)?;
 
         substrait_schema
     } else {
@@ -662,6 +652,67 @@ mod tests {
             right: Box::new(Expr::Literal(ScalarValue::Int32(Some(0)), None)),
         });
         assert_eq!(df_expr, expected);
+    }
+
+    /// A base schema with no extension types needs no field pruning, which is the case that
+    /// used to skip validation entirely.
+    async fn parse_unpruned_expr(rex_type: RexType) -> lance_core::Result<Expr> {
+        let expr = ExtendedExpression {
+            version: Some(Version {
+                major_number: 0,
+                minor_number: 63,
+                patch_number: 1,
+                git_hash: "".to_string(),
+                producer: "unit-test".to_string(),
+            }),
+            extension_urns: vec![],
+            extensions: vec![],
+            referred_expr: vec![ExpressionReference {
+                output_names: vec!["filter_mask".to_string()],
+                expr_type: Some(ExprType::Expression(Expression {
+                    rex_type: Some(rex_type),
+                })),
+            }],
+            base_schema: Some(NamedStruct {
+                names: vec!["x".to_string()],
+                r#struct: Some(Struct {
+                    types: vec![Type {
+                        kind: Some(Kind::I32(I32 {
+                            type_variation_reference: 0,
+                            nullability: Nullability::Nullable as i32,
+                        })),
+                    }],
+                    type_variation_reference: 0,
+                    nullability: Nullability::Required as i32,
+                }),
+            }),
+            advanced_extensions: None,
+            expected_type_urls: vec![],
+        };
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, true)]));
+        parse_substrait(expr.encode_to_vec().as_slice(), schema, &session_state()).await
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_operator_rejected_without_pruning() {
+        let err = parse_unpruned_expr(RexType::Subquery(Box::default()))
+            .await
+            .expect_err("subqueries should be rejected in filter expressions");
+        assert!(
+            err.to_string()
+                .contains("Window functions or subqueries not allowed in filter expression"),
+            "unexpected error: {err}"
+        );
+
+        let err = parse_unpruned_expr(RexType::Lambda(Box::default()))
+            .await
+            .expect_err("lambdas should be rejected in filter expressions");
+        assert!(
+            err.to_string()
+                .contains("Lambda expressions not allowed in filter expression"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-datafusion/src/substrait.rs
+++ b/rust/lance-datafusion/src/substrait.rs
@@ -153,8 +153,21 @@ fn remove_extension_types(
     Ok((new_substrait_schema, new_arrow_schema, index_mapping))
 }
 
+/// Substrait's optional message fields are `None` when a producer omits them, so unwrapping one
+/// turns a malformed (or merely terse) filter into a panic. This walker runs on every filter, so
+/// report the missing field instead.
+fn missing_field(what: &str) -> Error {
+    Error::invalid_input(format!(
+        "filter expression was missing a required {what} field"
+    ))
+}
+
 fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>) -> Result<()> {
-    match expr.rex_type.as_mut().unwrap() {
+    match expr
+        .rex_type
+        .as_mut()
+        .ok_or_else(|| missing_field("expression"))?
+    {
         // Simple, no field references possible
         RexType::Literal(_) | RexType::Nested(_) | RexType::DynamicParameter(_) => Ok(()),
         // Enum literals are deprecated in Substrait and should only appear in older plans.
@@ -174,7 +187,11 @@ fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>)
                 remap_expr_references(arg, mapping)?;
             }
             for arg in &mut func.arguments {
-                match arg.arg_type.as_mut().unwrap() {
+                match arg
+                    .arg_type
+                    .as_mut()
+                    .ok_or_else(|| missing_field("function argument"))?
+                {
                     ArgType::Value(expr) => remap_expr_references(expr, mapping)?,
                     ArgType::Enum(_) | ArgType::Type(_) => {}
                 }
@@ -183,24 +200,46 @@ fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>)
         }
         RexType::IfThen(ifthen) => {
             for clause in ifthen.ifs.iter_mut() {
-                remap_expr_references(clause.r#if.as_mut().unwrap(), mapping)?;
-                remap_expr_references(clause.then.as_mut().unwrap(), mapping)?;
+                remap_expr_references(
+                    clause
+                        .r#if
+                        .as_mut()
+                        .ok_or_else(|| missing_field("if clause condition"))?,
+                    mapping,
+                )?;
+                // The leading clause may omit `then`, in which case its condition is the case
+                // expression being matched against.
+                if let Some(then) = clause.then.as_mut() {
+                    remap_expr_references(then, mapping)?;
+                }
             }
-            remap_expr_references(ifthen.r#else.as_mut().unwrap(), mapping)?;
+            if let Some(otherwise) = ifthen.r#else.as_mut() {
+                remap_expr_references(otherwise, mapping)?;
+            }
             Ok(())
         }
         RexType::SwitchExpression(switch) => {
             for clause in switch.ifs.iter_mut() {
-                remap_expr_references(clause.then.as_mut().unwrap(), mapping)?;
+                if let Some(then) = clause.then.as_mut() {
+                    remap_expr_references(then, mapping)?;
+                }
             }
-            remap_expr_references(switch.r#else.as_mut().unwrap(), mapping)?;
+            if let Some(otherwise) = switch.r#else.as_mut() {
+                remap_expr_references(otherwise, mapping)?;
+            }
             Ok(())
         }
         RexType::SingularOrList(orlist) => {
             for opt in orlist.options.iter_mut() {
                 remap_expr_references(opt, mapping)?;
             }
-            remap_expr_references(orlist.value.as_mut().unwrap(), mapping)?;
+            remap_expr_references(
+                orlist
+                    .value
+                    .as_mut()
+                    .ok_or_else(|| missing_field("IN list value"))?,
+                mapping,
+            )?;
             Ok(())
         }
         RexType::MultiOrList(orlist) => {
@@ -215,22 +254,35 @@ fn remap_expr_references(expr: &mut Expression, mapping: &HashMap<usize, usize>)
             Ok(())
         }
         RexType::Cast(cast) => {
-            remap_expr_references(cast.input.as_mut().unwrap(), mapping)?;
+            remap_expr_references(
+                cast.input
+                    .as_mut()
+                    .ok_or_else(|| missing_field("cast input"))?,
+                mapping,
+            )?;
             Ok(())
         }
         RexType::Selection(sel) => {
-            // Finally, the selection, which might actually have field references
-            let root_type = sel.root_type.as_mut().unwrap();
-            // These types of references do not reference input fields so no remap needed
+            // Finally, the selection, which might actually have field references.
+            // An omitted root is a reference into the input, same as RootReference.
             if matches!(
-                root_type,
-                RootType::Expression(_) | RootType::OuterReference(_)
+                sel.root_type.as_mut(),
+                Some(RootType::Expression(_) | RootType::OuterReference(_))
             ) {
+                // These types of references do not reference input fields so no remap needed
                 return Ok(());
             }
-            match sel.reference_type.as_mut().unwrap() {
+            match sel
+                .reference_type
+                .as_mut()
+                .ok_or_else(|| missing_field("field reference"))?
+            {
                 ReferenceType::DirectReference(direct) => {
-                    match direct.reference_type.as_mut().unwrap() {
+                    match direct
+                        .reference_type
+                        .as_mut()
+                        .ok_or_else(|| missing_field("reference segment"))?
+                    {
                         reference_segment::ReferenceType::ListElement(_)
                         | reference_segment::ReferenceType::MapKey(_) => Err(Error::invalid_input(
                             "map/list nested references not supported in pushdown filters",
@@ -529,7 +581,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::{
         execution::SessionState,
-        logical_expr::{BinaryExpr, Operator},
+        logical_expr::{BinaryExpr, Case, Operator},
         prelude::{Expr, SessionContext},
     };
     use datafusion_common::{Column, ScalarValue};
@@ -537,8 +589,9 @@ mod tests {
         Expression, ExpressionReference, ExtendedExpression, FunctionArgument, NamedStruct, Type,
         Version,
         expression::{
-            FieldReference, Literal, ReferenceSegment, RexType, ScalarFunction,
+            FieldReference, IfThen, Literal, ReferenceSegment, RexType, ScalarFunction,
             field_reference::{ReferenceType, RootReference, RootType},
+            if_then::IfClause,
             literal::LiteralType,
             reference_segment::{self, StructField},
         },
@@ -712,6 +765,60 @@ mod tests {
             err.to_string()
                 .contains("Lambda expressions not allowed in filter expression"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unpruned_selection_without_explicit_root() {
+        let expr = parse_unpruned_expr(RexType::Selection(Box::new(FieldReference {
+            reference_type: Some(ReferenceType::DirectReference(ReferenceSegment {
+                reference_type: Some(reference_segment::ReferenceType::StructField(Box::new(
+                    StructField {
+                        field: 0,
+                        child: None,
+                    },
+                ))),
+            })),
+            root_type: None,
+        })))
+        .await
+        .unwrap();
+
+        assert_eq!(expr, Expr::Column(Column::new_unqualified("x")));
+    }
+
+    /// Optional message fields that a producer may legitimately omit must not panic the walker.
+    #[tokio::test]
+    async fn test_unpruned_if_then_with_omitted_optional_fields() {
+        let condition = Expression {
+            rex_type: Some(RexType::Literal(Literal {
+                nullable: false,
+                type_variation_reference: 0,
+                literal_type: Some(LiteralType::Boolean(true)),
+            })),
+        };
+
+        // A leading clause without `then` supplies the case expression, and `else` is optional.
+        let expr = parse_unpruned_expr(RexType::IfThen(Box::new(IfThen {
+            ifs: vec![IfClause {
+                r#if: Some(condition),
+                then: None,
+            }],
+            r#else: None,
+        })))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            expr,
+            Expr::Case(Case {
+                expr: Some(Box::new(Expr::Literal(
+                    ScalarValue::Boolean(Some(true)),
+                    None
+                ))),
+                when_then_expr: vec![],
+                else_expr: None,
+            })
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7805.

# Rationale for this change

`remap_expr_references` doubles as the validation pass that rejects operators we cannot push down (window functions, subqueries, lambdas), but `parse_substrait` only calls it when `remove_extension_types` actually drops a field. A filter whose base schema has no extension types skips the checks entirely, and the unsupported expression reaches the DataFusion consumer instead.

The user sees a consumer-level error rather than ours. A subquery over an unpruned schema reports:

```
Substrait error: Subquery expression without SubqueryType is not allowed
```

instead of `Window functions or subqueries not allowed in filter expression`.

# What changes are included in this PR?

`remap_expr_references` now runs unconditionally.

The guard it replaces is not load-bearing for the remapping itself: `remove_extension_types` builds the index mapping by walking every field and only advancing the destination counter for fields it keeps, so when nothing is dropped the mapping is the identity and the remap is a no-op. Dropping the guard adds the validation without changing any index.

This keeps validation and remapping as one traversal rather than two that have to be kept in step.

# Are these changes tested?

Yes. `test_unsupported_operator_rejected_without_pruning` parses a subquery and a lambda against a single-`Int32` base schema, which needs no pruning, and asserts each is rejected with its own message.

On the current code the subquery case reaches the consumer instead:

```
cargo test -p lance-datafusion --features substrait --lib substrait::tests::test_unsupported_operator
```

<details><summary>Before</summary>

```
running 1 test
test substrait::tests::test_unsupported_operator_rejected_without_pruning ... FAILED

---- substrait::tests::test_unsupported_operator_rejected_without_pruning stdout ----
thread '...' panicked at rust/lance-datafusion/src/substrait.rs:712:9:
unexpected error: LanceError(IO): Substrait error: Subquery expression without SubqueryType is not allowed, rust/lance-datafusion/src/substrait.rs:333:9

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 84 filtered out
```

</details>

<details><summary>After</summary>

```
running 14 tests
test substrait::tests::test_parse_substrait_aggregate_multiple_aggregates ... ok
test substrait::tests::test_parse_substrait_aggregate_sum ... ok
test substrait::tests::test_parse_substrait_aggregate_count_star ... ok
test substrait::tests::test_parse_substrait_aggregate_sum_with_group_by ... ok
test substrait::tests::test_substrait_conversion ... ok
test substrait::tests::test_expr_substrait_roundtrip ... ok
test substrait::tests::test_substrait_roundtrip_with_list_struct_struct ... ok
test substrait::tests::test_substrait_roundtrip_with_fixed_size_list_column ... ok
test substrait::tests::test_substrait_roundtrip_like ... ok
test substrait::tests::test_substrait_roundtrip_with_list_of_struct ... ok
test substrait::tests::test_substrait_roundtrip_with_many_nested_columns ... ok
test substrait::tests::test_substrait_roundtrip_starts_with ... ok
test substrait::tests::test_unsupported_operator_rejected_without_pruning ... ok
test substrait::tests::test_substrait_roundtrip_with_null_and_float16_columns ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 71 filtered out
```

</details>

The roundtrip tests above cover the pruning and nested-schema paths, including `List<Struct>` and extension-type removal, so they would catch a remap regression. The whole `lance-datafusion` suite passes (85 tests).

# Are there any user-facing changes?

Unsupported filter operators are now rejected with the descriptive error in the case that previously slipped through. No API change.
