### PR TITLE
fix(ci): resolve stable file versions in slow tests

### DIFF
--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -6149,7 +6149,7 @@ mod tests {
             "data.lance",
             vec![0],
             vec![0],
-            ConcreteFileVersion::from(LanceFileVersion::Stable),
+            LanceFileVersion::Stable.resolve(),
             None,
             None,
         );
@@ -6211,7 +6211,7 @@ mod tests {
             "data.lance",
             vec![0],
             vec![0],
-            ConcreteFileVersion::from(LanceFileVersion::Stable),
+            LanceFileVersion::Stable.resolve(),
             None,
             None,
         );
@@ -6273,7 +6273,7 @@ mod tests {
             "data.lance",
             vec![0],
             vec![0],
-            ConcreteFileVersion::from(LanceFileVersion::Stable),
+            LanceFileVersion::Stable.resolve(),
             None,
             None,
         );
@@ -6335,7 +6335,7 @@ mod tests {
                     format!("{id}.lance"),
                     vec![0],
                     vec![0],
-                    ConcreteFileVersion::from(LanceFileVersion::Stable),
+                    LanceFileVersion::Stable.resolve(),
                     None,
                     None,
                 )],


### PR DESCRIPTION
Enabling `slow_tests` in the main Rust workflow exposed four transaction fixtures that still tried to convert the `Stable` policy selector through the removed implicit `From` implementation. Resolve the selector explicitly before constructing `DataFile`, matching the exact persisted-version contract and restoring compilation across the Rust jobs.