### PR TITLE
fix(python): annotate LanceFragment.data_files and deletion_file

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -1051,12 +1051,12 @@ class LanceFragment(pa.dataset.Fragment):
 
         return self._fragment.schema()
 
-    def data_files(self):
+    def data_files(self) -> List[DataFile]:
         """Return the data files of this fragment."""
 
         return self._fragment.data_files()
 
-    def deletion_file(self):
+    def deletion_file(self) -> Optional[str]:
         """Return the deletion file, if any"""
         return self._fragment.deletion_file()
 


### PR DESCRIPTION
Both are thin wrappers over the Rust methods, whose return types are already pinned down there:

```
    fn data_files(...)   -> PyResult<Vec<PyLance<DataFile>>>
    fn deletion_file(&self) -> PyResult<Option<String>>
```

Being unannotated makes them ``Any`` for every caller, which silently defeats type checking downstream -- e.g. summing ``data_file.file_size_bytes`` over ``fragment.data_files()`` produces ``Any`` rather than ``int | None``, so the None case is not flagged. ``FragmentMetadata.data_files`` in the same module already declares ``List[DataFile]``.