### PR TITLE
fix(python): annotate BatchUDF and the batch_udf decorator

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -115,6 +115,7 @@ include = [
     "python/lance/util.py",
     "python/lance/arrow.py",
     "python/tests/test_arrow.py",
+    "python/tests/test_udf.py",
 ]
 # Dependencies like pyarrow make this difficult to enforce strictly.
 reportMissingTypeStubs = "warning"

--- a/python/python/lance/udf.py
+++ b/python/python/lance/udf.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import sqlite3
 from contextlib import closing
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Union
 
 import pyarrow as pa
 
@@ -18,6 +18,8 @@ from .dependencies import pandas as pd
 from .types import _coerce_reader
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from .dataset import LanceDataset, LanceFragment
     from .types import ReaderLike
 
@@ -28,20 +30,26 @@ class BatchUDF:
     Use :func:`lance.add_columns_udf` decorator to wrap a function with this class.
     """
 
-    def __init__(self, func, output_schema=None, checkpoint_file=None):
+    def __init__(
+        self,
+        func: Callable[[pa.RecordBatch], Any],
+        output_schema: Optional[pa.Schema] = None,
+        checkpoint_file: Optional[Union[str, Path]] = None,
+    ) -> None:
         self.func = func
         self.output_schema = output_schema
+        self.cache: Optional[BatchUDFCheckpoint]
         if checkpoint_file is not None:
             self.cache = BatchUDFCheckpoint(checkpoint_file)
         else:
             self.cache = None
 
-    def __call__(self, batch: pa.RecordBatch):
+    def __call__(self, batch: pa.RecordBatch) -> Any:
         # Directly call inner function. This is to allow the user to test the
         # function and have it behave exactly as it was written.
         return self.func(batch)
 
-    def _call(self, batch: pa.RecordBatch):
+    def _call(self, batch: pa.RecordBatch) -> pa.RecordBatch:
         if self.output_schema is None:
             raise ValueError(
                 "output_schema must be provided when using a function that "
@@ -59,7 +67,10 @@ class BatchUDF:
         return result
 
 
-def batch_udf(output_schema=None, checkpoint_file=None):
+def batch_udf(
+    output_schema: Optional[pa.Schema] = None,
+    checkpoint_file: Optional[Union[str, Path]] = None,
+) -> Callable[[Callable[[pa.RecordBatch], Any]], BatchUDF]:
     """
     Create a user defined function (UDF) that adds columns to a dataset.
 
@@ -88,7 +99,7 @@ def batch_udf(output_schema=None, checkpoint_file=None):
     AddColumnsUDF
     """
 
-    def inner(func):
+    def inner(func: Callable[[pa.RecordBatch], Any]) -> BatchUDF:
         return BatchUDF(func, output_schema, checkpoint_file)
 
     return inner

--- a/python/python/tests/test_udf.py
+++ b/python/python/tests/test_udf.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Tests for the ``BatchUDF`` public contract.
+
+This module is in the pyright target configured in ``pyproject.toml``, so it
+doubles as a strict client for the signatures: the annotated locals below fail
+the repository type check if a parameter or return type is narrowed or widened
+incorrectly -- narrowing ``checkpoint_file`` back to ``str``, for example,
+reports
+
+    error: Argument of type "Path" cannot be assigned to parameter
+           "checkpoint_file" of type "str | None"
+
+It cannot catch the annotations being *deleted*, because pyright infers the
+same types from the function bodies. That failure mode is mypy-specific
+(``no-untyped-call``); policing it would take
+``reportMissingParameterType`` on ``lance/udf.py``, which needs one more
+parameter annotated and a pre-existing narrowing diagnostic resolved.
+"""
+
+from pathlib import Path
+
+import pyarrow as pa
+from lance.udf import BatchUDF, batch_udf
+
+
+def _add_doubled(batch: pa.RecordBatch) -> pa.RecordBatch:
+    doubled = [value * 2 for value in batch.column("a").to_pylist()]
+    return pa.RecordBatch.from_pydict({"doubled": doubled})
+
+
+def test_batch_udf_constructor(tmp_path: Path) -> None:
+    output_schema = pa.schema([pa.field("doubled", pa.int64())])
+
+    udf: BatchUDF = BatchUDF(_add_doubled, output_schema=output_schema)
+    assert udf.output_schema == output_schema
+    assert udf.cache is None
+
+    # checkpoint_file accepts a Path as well as a str.
+    checkpointed: BatchUDF = BatchUDF(
+        _add_doubled,
+        output_schema=output_schema,
+        checkpoint_file=tmp_path / "checkpoint.sqlite",
+    )
+    assert checkpointed.cache is not None
+
+
+def test_batch_udf_decorator() -> None:
+    output_schema = pa.schema([pa.field("doubled", pa.int64())])
+
+    @batch_udf(output_schema=output_schema)
+    def doubled(batch: pa.RecordBatch) -> pa.RecordBatch:
+        return _add_doubled(batch)
+
+    # The decorator returns a BatchUDF, not the original function.
+    udf: BatchUDF = doubled
+    assert udf.output_schema == output_schema
+
+    # Calling it delegates straight to the wrapped function, so a UDF stays
+    # testable on its own.
+    result = udf(pa.RecordBatch.from_pydict({"a": [1, 2, 3]}))
+    assert result.column("doubled").to_pylist() == [2, 4, 6]


### PR DESCRIPTION
``BatchUDF`` is the public wrapper behind ``LanceDataset.add_columns`` and ``lance.batch_udf``, but neither its constructor nor the decorator carries annotations, so constructing one from type-checked code fails under strict mode:

```
    error: Call to untyped function "BatchUDF" in typed context
```

The parameter types are already spelled out in the ``batch_udf`` docstring (``output_schema : Schema, optional``, ``checkpoint_file : str or Path, optional``), and the wrapped function is documented as taking a RecordBatch. The user function's return value stays ``Any`` because ``_call`` deliberately accepts a RecordBatch or a pandas DataFrame and converts.

``self.cache`` gains a declaration so the None branch does not narrow the attribute to ``None``.