### PR TITLE
feat(io): expose native directory path capability

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -136,8 +136,27 @@ impl<O: OSObjectStore + ?Sized> ObjectStoreExt for O {
 
 type NativeDirectoryPathFn = dyn Fn(&Path) -> PathBuf + Send + Sync;
 
+/// Maps an object-store path to the exact native filesystem path represented by a store.
+///
+/// Constructing this resolver is an explicit capability assertion: native filesystem metadata
+/// for the returned path must be authoritative for the corresponding object-store path.
 #[derive(Clone)]
-struct NativeDirectoryPathResolver(Arc<NativeDirectoryPathFn>);
+pub struct NativeDirectoryPathResolver(Arc<NativeDirectoryPathFn>);
+
+impl NativeDirectoryPathResolver {
+    /// Create a native-directory path resolver.
+    pub fn new(resolver: impl Fn(&Path) -> PathBuf + Send + Sync + 'static) -> Self {
+        Self(Arc::new(resolver))
+    }
+
+    fn resolve(&self, path: &Path) -> PathBuf {
+        self.0(path)
+    }
+
+    fn allocation_ptr(&self) -> *const () {
+        Arc::as_ptr(&self.0) as *const ()
+    }
+}
 
 impl std::fmt::Debug for NativeDirectoryPathResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -241,6 +260,11 @@ pub struct ObjectStoreParams {
     pub block_size: Option<usize>,
     #[deprecated(note = "Implement an ObjectStoreProvider instead")]
     pub object_store: Option<(Arc<DynObjectStore>, Url)>,
+    /// Native-directory capability for the store supplied through [`Self::object_store`].
+    ///
+    /// Leave this unset for direct stores whose object-store paths cannot be authoritatively
+    /// mapped to native filesystem paths.
+    pub native_directory_path_resolver: Option<NativeDirectoryPathResolver>,
     /// Refresh offset for AWS credentials when using the legacy AWS credentials path.
     /// For StorageOptionsAccessor, use `refresh_offset_millis` storage option instead.
     pub s3_credentials_refresh_offset: Duration,
@@ -266,6 +290,7 @@ impl Default for ObjectStoreParams {
         #[allow(deprecated)]
         Self {
             object_store: None,
+            native_directory_path_resolver: None,
             block_size: None,
             s3_credentials_refresh_offset: Duration::from_secs(60),
             #[cfg(feature = "aws")]
@@ -331,6 +356,9 @@ impl std::hash::Hash for ObjectStoreParams {
             Arc::as_ptr(store).hash(state);
             url.hash(state);
         }
+        if let Some(resolver) = &self.native_directory_path_resolver {
+            resolver.allocation_ptr().hash(state);
+        }
         self.s3_credentials_refresh_offset.hash(state);
         #[cfg(feature = "aws")]
         if let Some(aws_credentials) = &self.aws_credentials {
@@ -368,6 +396,14 @@ impl PartialEq for ObjectStoreParams {
                     .object_store
                     .as_ref()
                     .map(|(store, url)| (Arc::as_ptr(store), url))
+            && self
+                .native_directory_path_resolver
+                .as_ref()
+                .map(NativeDirectoryPathResolver::allocation_ptr)
+                == other
+                    .native_directory_path_resolver
+                    .as_ref()
+                    .map(NativeDirectoryPathResolver::allocation_ptr)
             && self.s3_credentials_refresh_offset == other.s3_credentials_refresh_offset
             && self
                 .object_store_wrapper
@@ -545,7 +581,7 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
                 store_prefix,
-                native_directory_path_resolver: None,
+                native_directory_path_resolver: params.native_directory_path_resolver.clone(),
             };
             if let Some(wrapper) = params.object_store_wrapper.as_ref() {
                 store.apply_wrapper(wrapper.as_ref());
@@ -647,7 +683,7 @@ impl ObjectStore {
     pub fn native_directory_path(&self, path: &Path) -> Option<PathBuf> {
         self.native_directory_path_resolver
             .as_ref()
-            .map(|resolver| resolver.0(path))
+            .map(|resolver| resolver.resolve(path))
     }
 
     /// Apply an object-store wrapper and update capabilities for the effective store.
@@ -670,7 +706,7 @@ impl ObjectStore {
         mut self,
         resolver: impl Fn(&Path) -> PathBuf + Send + Sync + 'static,
     ) -> Self {
-        self.native_directory_path_resolver = Some(NativeDirectoryPathResolver(Arc::new(resolver)));
+        self.native_directory_path_resolver = Some(NativeDirectoryPathResolver::new(resolver));
         self
     }
 
@@ -1743,6 +1779,32 @@ mod tests {
             store
                 .native_directory_path(&Path::from("tmp/table.lance"))
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn test_direct_store_carries_explicit_native_directory_path() {
+        let url = Url::parse("file:///tmp/table.lance").unwrap();
+        let params = ObjectStoreParams {
+            object_store: Some((Arc::new(InMemory::new()), url.clone())),
+            native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
+                PathBuf::from("/native").join(path.as_ref())
+            })),
+            ..Default::default()
+        };
+
+        let (store, path) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            url.as_ref(),
+            &params,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            store.native_directory_path(&path),
+            Some(PathBuf::from("/native/tmp/table.lance"))
         );
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -164,6 +164,39 @@ impl std::fmt::Debug for NativeDirectoryPathResolver {
     }
 }
 
+#[derive(Clone)]
+struct NativeDirectoryPathCapability {
+    resolver: NativeDirectoryPathResolver,
+    inner: Weak<DynObjectStore>,
+}
+
+impl NativeDirectoryPathCapability {
+    fn new(resolver: NativeDirectoryPathResolver, inner: &Arc<DynObjectStore>) -> Self {
+        Self {
+            resolver,
+            inner: Arc::downgrade(inner),
+        }
+    }
+
+    fn is_valid_for(&self, inner: &Arc<DynObjectStore>) -> bool {
+        self.inner
+            .upgrade()
+            .is_some_and(|bound| Arc::ptr_eq(&bound, inner))
+    }
+
+    fn rebind(&mut self, inner: &Arc<DynObjectStore>) {
+        self.inner = Arc::downgrade(inner);
+    }
+}
+
+impl std::fmt::Debug for NativeDirectoryPathCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NativeDirectoryPathCapability")
+            .field("resolver", &self.resolver)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Wraps [ObjectStore](object_store::ObjectStore)
 #[derive(Debug, Clone)]
 pub struct ObjectStore {
@@ -189,7 +222,7 @@ pub struct ObjectStore {
     pub store_prefix: String,
     /// Maps object-store paths to exact native filesystem paths when this resolved store
     /// explicitly supports native directory metadata.
-    native_directory_path_resolver: Option<NativeDirectoryPathResolver>,
+    native_directory_path_capability: Option<NativeDirectoryPathCapability>,
 }
 
 impl DeepSizeOf for ObjectStore {
@@ -581,8 +614,11 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
                 store_prefix,
-                native_directory_path_resolver: params.native_directory_path_resolver.clone(),
+                native_directory_path_capability: None,
             };
+            if let Some(resolver) = &params.native_directory_path_resolver {
+                store = store.with_native_directory_path_resolver(resolver.clone());
+            }
             if let Some(wrapper) = params.object_store_wrapper.as_ref() {
                 store.apply_wrapper(wrapper.as_ref());
             }
@@ -681,9 +717,10 @@ impl ObjectStore {
     /// This returns `None` unless the resolved provider explicitly opted into native directory
     /// semantics and every configured wrapper declared that it preserves those semantics.
     pub fn native_directory_path(&self, path: &Path) -> Option<PathBuf> {
-        self.native_directory_path_resolver
-            .as_ref()
-            .map(|resolver| resolver.resolve(path))
+        let capability = self.native_directory_path_capability.as_ref()?;
+        capability
+            .is_valid_for(&self.inner)
+            .then(|| capability.resolver.resolve(path))
     }
 
     /// Apply an object-store wrapper and update capabilities for the effective store.
@@ -692,8 +729,16 @@ impl ObjectStore {
     /// that it preserves their exact semantics.
     pub fn apply_wrapper(&mut self, wrapper: &dyn WrappingObjectStore) {
         self.inner = wrapper.wrap(&self.store_prefix, self.inner.clone());
-        if !wrapper.preserves_native_directory_path() {
-            self.native_directory_path_resolver = None;
+        if wrapper.preserves_native_directory_path() {
+            self.rebind_native_directory_path();
+        } else {
+            self.native_directory_path_capability = None;
+        }
+    }
+
+    fn rebind_native_directory_path(&mut self) {
+        if let Some(capability) = &mut self.native_directory_path_capability {
+            capability.rebind(&self.inner);
         }
     }
 
@@ -706,7 +751,8 @@ impl ObjectStore {
         mut self,
         resolver: NativeDirectoryPathResolver,
     ) -> Self {
-        self.native_directory_path_resolver = Some(resolver);
+        self.native_directory_path_capability =
+            Some(NativeDirectoryPathCapability::new(resolver, &self.inner));
         self
     }
 
@@ -1317,7 +1363,7 @@ impl ObjectStore {
             download_retry_count,
             io_tracker,
             store_prefix,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         };
         if let Some(wrapper) = wrapper {
             object_store.apply_wrapper(wrapper.as_ref());
@@ -1780,6 +1826,17 @@ mod tests {
                 .native_directory_path(&Path::from("tmp/table.lance"))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_replacing_inner_invalidates_native_directory_path() {
+        let mut store = ObjectStore::local();
+        let path = Path::from("tmp/table.lance");
+        assert!(store.native_directory_path(&path).is_some());
+
+        store.inner = Arc::new(InMemory::new());
+
+        assert!(store.native_directory_path(&path).is_none());
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -533,15 +533,9 @@ impl ObjectStore {
             let mut io_tracker = IOTracker::default();
             meter_store(&mut inner, &mut io_tracker, &store_prefix);
 
-            if let Some(wrapper) = params.object_store_wrapper.as_ref() {
-                inner = wrapper.wrap(&store_prefix, inner);
-            }
-
-            // Always wrap with IO tracking
-            let tracked_store = io_tracker.wrap("", inner);
-
-            let store = Self {
-                inner: tracked_store,
+            let io_tracking_wrapper = io_tracker.clone();
+            let mut store = Self {
+                inner,
                 scheme: path.scheme().to_string(),
                 block_size: params.block_size.unwrap_or(64 * 1024),
                 max_iop_size: *DEFAULT_MAX_IOP_SIZE,
@@ -553,6 +547,10 @@ impl ObjectStore {
                 store_prefix,
                 native_directory_path_resolver: None,
             };
+            if let Some(wrapper) = params.object_store_wrapper.as_ref() {
+                store.apply_wrapper(wrapper.as_ref());
+            }
+            store.apply_wrapper(&io_tracking_wrapper);
             let path = Path::parse(path.path())?;
             return Ok((Arc::new(store), path));
         }
@@ -650,6 +648,17 @@ impl ObjectStore {
         self.native_directory_path_resolver
             .as_ref()
             .map(|resolver| resolver.0(path))
+    }
+
+    /// Apply an object-store wrapper and update capabilities for the effective store.
+    ///
+    /// Native directory paths remain available only when the wrapper explicitly declares
+    /// that it preserves their exact semantics.
+    pub fn apply_wrapper(&mut self, wrapper: &dyn WrappingObjectStore) {
+        self.inner = wrapper.wrap(&self.store_prefix, self.inner.clone());
+        if !wrapper.preserves_native_directory_path() {
+            self.native_directory_path_resolver = None;
+        }
     }
 
     /// Opt this resolved store into exact native filesystem directory inspection.
@@ -1260,16 +1269,9 @@ impl ObjectStore {
         let mut io_tracker = IOTracker::default();
         meter_store(&mut store, &mut io_tracker, &store_prefix);
 
-        let store = match wrapper {
-            Some(wrapper) => wrapper.wrap(&store_prefix, store),
-            None => store,
-        };
-
-        // Always wrap with IO tracking
-        let tracked_store = io_tracker.wrap("", store);
-
-        Self {
-            inner: tracked_store,
+        let io_tracking_wrapper = io_tracker.clone();
+        let mut object_store = Self {
+            inner: store,
             scheme: scheme.into(),
             block_size,
             max_iop_size: *DEFAULT_MAX_IOP_SIZE,
@@ -1280,7 +1282,12 @@ impl ObjectStore {
             io_tracker,
             store_prefix,
             native_directory_path_resolver: None,
+        };
+        if let Some(wrapper) = wrapper {
+            object_store.apply_wrapper(wrapper.as_ref());
         }
+        object_store.apply_wrapper(&io_tracking_wrapper);
+        object_store
     }
 }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1786,26 +1786,33 @@ mod tests {
     #[allow(deprecated)]
     async fn test_direct_store_carries_explicit_native_directory_path() {
         let url = Url::parse("file:///tmp/table.lance").unwrap();
-        let params = ObjectStoreParams {
-            object_store: Some((Arc::new(InMemory::new()), url.clone())),
-            native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
-                PathBuf::from("/native").join(path.as_ref())
-            })),
-            ..Default::default()
-        };
+        let cases: [(Option<Arc<dyn WrappingObjectStore>>, bool); 3] = [
+            (None, true),
+            (Some(Arc::new(PassthroughWrapper)), false),
+            (Some(Arc::new(NativeDirectoryPreservingWrapper)), true),
+        ];
 
-        let (store, path) = ObjectStore::from_uri_and_params(
-            Arc::new(ObjectStoreRegistry::default()),
-            url.as_ref(),
-            &params,
-        )
-        .await
-        .unwrap();
+        for (wrapper, should_preserve) in cases {
+            let params = ObjectStoreParams {
+                object_store: Some((Arc::new(InMemory::new()), url.clone())),
+                native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
+                    PathBuf::from("/native").join(path.as_ref())
+                })),
+                object_store_wrapper: wrapper,
+                ..Default::default()
+            };
 
-        assert_eq!(
-            store.native_directory_path(&path),
-            Some(PathBuf::from("/native/tmp/table.lance"))
-        );
+            let (store, path) = ObjectStore::from_uri_and_params(
+                Arc::new(ObjectStoreRegistry::default()),
+                url.as_ref(),
+                &params,
+            )
+            .await
+            .unwrap();
+
+            let expected = should_preserve.then(|| PathBuf::from("/native/tmp/table.lance"));
+            assert_eq!(store.native_directory_path(&path), expected);
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -6,6 +6,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -133,6 +134,17 @@ impl<O: OSObjectStore + ?Sized> ObjectStoreExt for O {
     }
 }
 
+type NativeDirectoryPathFn = dyn Fn(&Path) -> PathBuf + Send + Sync;
+
+#[derive(Clone)]
+struct NativeDirectoryPathResolver(Arc<NativeDirectoryPathFn>);
+
+impl std::fmt::Debug for NativeDirectoryPathResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NativeDirectoryPathResolver")
+    }
+}
+
 /// Wraps [ObjectStore](object_store::ObjectStore)
 #[derive(Debug, Clone)]
 pub struct ObjectStore {
@@ -156,6 +168,9 @@ pub struct ObjectStore {
     /// which usually cannot be found in the URL such as Azure account name. The prefix plus the
     /// path uniquely identifies any object inside the store.
     pub store_prefix: String,
+    /// Maps object-store paths to exact native filesystem paths when this resolved store
+    /// explicitly supports native directory metadata.
+    native_directory_path_resolver: Option<NativeDirectoryPathResolver>,
 }
 
 impl DeepSizeOf for ObjectStore {
@@ -180,6 +195,14 @@ pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
     /// The store_prefix is a string which uniquely identifies the object
     /// store being wrapped.
     fn wrap(&self, store_prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
+
+    /// Whether this wrapper preserves the exact native filesystem path semantics of the
+    /// wrapped store.
+    ///
+    /// The default is `false` because a wrapper may hide, rewrite, or synthesize paths.
+    fn preserves_native_directory_path(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -202,6 +225,12 @@ impl WrappingObjectStore for ChainedWrappingObjectStore {
         self.wrappers
             .iter()
             .fold(original, |acc, wrapper| wrapper.wrap(store_prefix, acc))
+    }
+
+    fn preserves_native_directory_path(&self) -> bool {
+        self.wrappers
+            .iter()
+            .all(|wrapper| wrapper.preserves_native_directory_path())
     }
 }
 
@@ -522,6 +551,7 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
                 store_prefix,
+                native_directory_path_resolver: None,
             };
             let path = Path::parse(path.path())?;
             return Ok((Arc::new(store), path));
@@ -610,6 +640,29 @@ impl ObjectStore {
 
     pub fn scheme(&self) -> &str {
         &self.scheme
+    }
+
+    /// Map an object-store path to the exact native filesystem path represented by this store.
+    ///
+    /// This returns `None` unless the resolved provider explicitly opted into native directory
+    /// semantics and every configured wrapper declared that it preserves those semantics.
+    pub fn native_directory_path(&self, path: &Path) -> Option<PathBuf> {
+        self.native_directory_path_resolver
+            .as_ref()
+            .map(|resolver| resolver.0(path))
+    }
+
+    /// Opt this resolved store into exact native filesystem directory inspection.
+    ///
+    /// The resolver must return a path whose native metadata is authoritative for the same
+    /// object-store path. Providers should only opt in when that equivalence holds for every
+    /// path served by the store.
+    pub fn with_native_directory_path_resolver(
+        mut self,
+        resolver: impl Fn(&Path) -> PathBuf + Send + Sync + 'static,
+    ) -> Self {
+        self.native_directory_path_resolver = Some(NativeDirectoryPathResolver(Arc::new(resolver)));
+        self
     }
 
     pub fn block_size(&self) -> usize {
@@ -1226,6 +1279,7 @@ impl ObjectStore {
             download_retry_count,
             io_tracker,
             store_prefix,
+            native_directory_path_resolver: None,
         }
     }
 }
@@ -1631,6 +1685,84 @@ mod tests {
     impl TestWrapper {
         fn called(&self) -> bool {
             self.called.load(Ordering::Relaxed)
+        }
+    }
+
+    #[derive(Debug)]
+    struct PassthroughWrapper;
+
+    impl WrappingObjectStore for PassthroughWrapper {
+        fn wrap(
+            &self,
+            _store_prefix: &str,
+            original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            original
+        }
+    }
+
+    #[derive(Debug)]
+    struct NativeDirectoryPreservingWrapper;
+
+    impl WrappingObjectStore for NativeDirectoryPreservingWrapper {
+        fn wrap(
+            &self,
+            _store_prefix: &str,
+            original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            original
+        }
+
+        fn preserves_native_directory_path(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test_direct_store_does_not_infer_native_directory_path_from_scheme() {
+        let store = ObjectStore::new(
+            Arc::new(InMemory::new()),
+            Url::parse("file:///").unwrap(),
+            None,
+            None,
+            false,
+            false,
+            DEFAULT_LOCAL_IO_PARALLELISM,
+            DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
+        );
+
+        assert!(
+            store
+                .native_directory_path(&Path::from("tmp/table.lance"))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wrapper_must_preserve_native_directory_path() {
+        let path = TempStdDir::default();
+        let uri = Url::from_directory_path(&path).unwrap();
+        let wrappers: [(Arc<dyn WrappingObjectStore>, bool); 2] = [
+            (Arc::new(PassthroughWrapper), false),
+            (Arc::new(NativeDirectoryPreservingWrapper), true),
+        ];
+
+        for (wrapper, should_preserve) in wrappers {
+            let params = ObjectStoreParams {
+                object_store_wrapper: Some(wrapper),
+                ..Default::default()
+            };
+            let (store, object_path) = ObjectStore::from_uri_and_params(
+                Arc::new(ObjectStoreRegistry::default()),
+                uri.as_ref(),
+                &params,
+            )
+            .await
+            .unwrap();
+
+            let expected = should_preserve.then(|| path.to_path_buf());
+            assert_eq!(store.native_directory_path(&object_path), expected);
         }
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -704,9 +704,9 @@ impl ObjectStore {
     /// path served by the store.
     pub fn with_native_directory_path_resolver(
         mut self,
-        resolver: impl Fn(&Path) -> PathBuf + Send + Sync + 'static,
+        resolver: NativeDirectoryPathResolver,
     ) -> Self {
-        self.native_directory_path_resolver = Some(NativeDirectoryPathResolver::new(resolver));
+        self.native_directory_path_resolver = Some(resolver);
         self
     }
 

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -12,7 +12,6 @@ use std::{
 use object_store::path::Path;
 use url::Url;
 
-use crate::object_store::WrappingObjectStore;
 use crate::object_store::uri_to_url;
 
 use super::{ObjectStore, ObjectStoreParams, tracing::ObjectStoreTracingExt};
@@ -270,14 +269,12 @@ impl ObjectStoreRegistry {
         crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, &cache_path);
 
         if let Some(wrapper) = &params.object_store_wrapper {
-            store.inner = wrapper.wrap(&cache_path, store.inner);
-            if !wrapper.preserves_native_directory_path() {
-                store.native_directory_path_resolver = None;
-            }
+            store.apply_wrapper(wrapper.as_ref());
         }
 
         // Always wrap with IO tracking
-        store.inner = store.io_tracker.wrap("", store.inner);
+        let io_tracking_wrapper = store.io_tracker.clone();
+        store.apply_wrapper(&io_tracking_wrapper);
 
         let store = Arc::new(store);
 

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -270,6 +270,7 @@ impl ObjectStoreRegistry {
         // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
         // `az$container@account`) so multiple stores on one cloud differ.
         crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, &cache_path);
+        store.rebind_native_directory_path();
 
         if let Some(wrapper) = &params.object_store_wrapper {
             store.apply_wrapper(wrapper.as_ref());

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -261,6 +261,9 @@ impl ObjectStoreRegistry {
         self.misses.fetch_add(1, Ordering::Relaxed);
 
         let mut store = provider.new_store(base_path, params).await?;
+        // The active provider's cache identity is authoritative for the resolved store and
+        // every wrapper applied to it.
+        store.store_prefix.clone_from(&cache_path);
 
         store.inner = store.inner.traced();
 
@@ -378,6 +381,7 @@ impl ObjectStoreRegistry {
 mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Mutex;
 
     use super::*;
     use object_store::memory::InMemory;
@@ -426,6 +430,52 @@ mod tests {
             } else {
                 Ok(store)
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct CustomPrefixProvider;
+
+    #[async_trait::async_trait]
+    impl ObjectStoreProvider for CustomPrefixProvider {
+        async fn new_store(
+            &self,
+            base_path: Url,
+            _params: &ObjectStoreParams,
+        ) -> Result<ObjectStore> {
+            Ok(ObjectStore::new(
+                Arc::new(InMemory::new()),
+                base_path,
+                None,
+                None,
+                false,
+                true,
+                1,
+                0,
+                None,
+            ))
+        }
+
+        fn calculate_object_store_prefix(
+            &self,
+            _url: &Url,
+            _storage_options: Option<&HashMap<String, String>>,
+        ) -> Result<String> {
+            Ok("authoritative-prefix".to_string())
+        }
+    }
+
+    #[derive(Debug)]
+    struct PrefixCapturingWrapper(Arc<Mutex<Option<String>>>);
+
+    impl crate::object_store::WrappingObjectStore for PrefixCapturingWrapper {
+        fn wrap(
+            &self,
+            store_prefix: &str,
+            original: Arc<dyn object_store::ObjectStore>,
+        ) -> Arc<dyn object_store::ObjectStore> {
+            *self.0.lock().unwrap() = Some(store_prefix.to_string());
+            original
         }
     }
 
@@ -506,6 +556,28 @@ mod tests {
             cached.native_directory_path(&path),
             Some(PathBuf::from("/native/table.lance"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_registry_wrapper_uses_provider_prefix() {
+        let registry = ObjectStoreRegistry::empty();
+        registry.insert("custom-prefix", Arc::new(CustomPrefixProvider));
+        let captured = Arc::new(Mutex::new(None));
+        let params = ObjectStoreParams {
+            object_store_wrapper: Some(Arc::new(PrefixCapturingWrapper(captured.clone()))),
+            ..Default::default()
+        };
+
+        let store = registry
+            .get_store(Url::parse("custom-prefix://bucket").unwrap(), &params)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            captured.lock().unwrap().as_deref(),
+            Some("authoritative-prefix")
+        );
+        assert_eq!(store.store_prefix, "authoritative-prefix");
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -424,9 +424,11 @@ mod tests {
                 None,
             );
             if self.has_capability {
-                Ok(store.with_native_directory_path_resolver(|path| {
-                    PathBuf::from("/native").join(path.as_ref())
-                }))
+                Ok(store.with_native_directory_path_resolver(
+                    crate::object_store::NativeDirectoryPathResolver::new(|path| {
+                        PathBuf::from("/native").join(path.as_ref())
+                    }),
+                ))
             } else {
                 Ok(store)
             }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -271,6 +271,9 @@ impl ObjectStoreRegistry {
 
         if let Some(wrapper) = &params.object_store_wrapper {
             store.inner = wrapper.wrap(&cache_path, store.inner);
+            if !wrapper.preserves_native_directory_path() {
+                store.native_directory_path_resolver = None;
+            }
         }
 
         // Always wrap with IO tracking
@@ -377,8 +380,10 @@ impl ObjectStoreRegistry {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::PathBuf;
 
     use super::*;
+    use object_store::memory::InMemory;
 
     #[derive(Debug)]
     struct DummyProvider;
@@ -391,6 +396,39 @@ mod tests {
             _params: &ObjectStoreParams,
         ) -> Result<ObjectStore> {
             unreachable!("This test doesn't create stores")
+        }
+    }
+
+    #[derive(Debug)]
+    struct NativeDirectoryCapabilityProvider {
+        has_capability: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreProvider for NativeDirectoryCapabilityProvider {
+        async fn new_store(
+            &self,
+            base_path: Url,
+            _params: &ObjectStoreParams,
+        ) -> Result<ObjectStore> {
+            let store = ObjectStore::new(
+                Arc::new(InMemory::new()),
+                base_path,
+                None,
+                None,
+                false,
+                true,
+                1,
+                0,
+                None,
+            );
+            if self.has_capability {
+                Ok(store.with_native_directory_path_resolver(|path| {
+                    PathBuf::from("/native").join(path.as_ref())
+                }))
+            } else {
+                Ok(store)
+            }
         }
     }
 
@@ -432,6 +470,45 @@ mod tests {
         let store_scoped = registry.get_store(url.clone(), &with_scoped).await.unwrap();
         let store_plain = registry.get_store(url, &without_scoped).await.unwrap();
         assert!(Arc::ptr_eq(&store_scoped, &store_plain));
+    }
+
+    #[tokio::test]
+    async fn test_cached_store_retains_native_directory_capability() {
+        let registry = ObjectStoreRegistry::empty();
+        registry.insert(
+            "capability",
+            Arc::new(NativeDirectoryCapabilityProvider {
+                has_capability: true,
+            }),
+        );
+        let url = Url::parse("capability://test").unwrap();
+        let path = Path::from("table.lance");
+
+        let first = registry
+            .get_store(url.clone(), &ObjectStoreParams::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            first.native_directory_path(&path),
+            Some(PathBuf::from("/native/table.lance"))
+        );
+
+        registry.insert(
+            "capability",
+            Arc::new(NativeDirectoryCapabilityProvider {
+                has_capability: false,
+            }),
+        );
+        let cached = registry
+            .get_store(url, &ObjectStoreParams::default())
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &cached));
+        assert_eq!(
+            cached.native_directory_path(&path),
+            Some(PathBuf::from("/native/table.lance"))
+        );
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -216,7 +216,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -216,6 +216,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -298,6 +298,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -298,7 +298,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -157,6 +157,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -157,7 +157,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -190,7 +190,7 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -190,6 +190,7 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -216,6 +216,7 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -216,7 +216,7 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -33,7 +33,11 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-        })
+            native_directory_path_resolver: None,
+        }
+        .with_native_directory_path_resolver(|path| {
+            std::path::PathBuf::from(crate::local::to_local_path(path))
+        }))
     }
 
     fn extract_path(&self, url: &Url) -> Result<Path> {
@@ -104,6 +108,33 @@ mod tests {
                 )
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_native_directory_path_capability() {
+        let provider = FileStoreProvider;
+        let path = Path::from("tmp/table.lance");
+        let schemes = [
+            "file",
+            "file-object-store",
+            #[cfg(target_os = "linux")]
+            "file+uring",
+        ];
+
+        for scheme in schemes {
+            let store = provider
+                .new_store(
+                    Url::parse(&format!("{scheme}:///")).unwrap(),
+                    &ObjectStoreParams::default(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                store.native_directory_path(&path),
+                Some(std::path::PathBuf::from(crate::local::to_local_path(&path))),
+                "scheme: {scheme}"
+            );
+        }
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -33,7 +33,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         }
         .with_native_directory_path_resolver(
             crate::object_store::NativeDirectoryPathResolver::new(|path| {

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -35,9 +35,11 @@ impl ObjectStoreProvider for FileStoreProvider {
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             native_directory_path_resolver: None,
         }
-        .with_native_directory_path_resolver(|path| {
-            std::path::PathBuf::from(crate::local::to_local_path(path))
-        }))
+        .with_native_directory_path_resolver(
+            crate::object_store::NativeDirectoryPathResolver::new(|path| {
+                std::path::PathBuf::from(crate::local::to_local_path(path))
+            }),
+        ))
     }
 
     fn extract_path(&self, url: &Url) -> Result<Path> {

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -33,6 +33,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -33,7 +33,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -144,7 +144,7 @@ impl ObjectStoreProvider for OssStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -144,6 +144,7 @@ impl ObjectStoreProvider for OssStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -100,7 +100,7 @@ impl ObjectStoreProvider for TencentStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -100,6 +100,7 @@ impl ObjectStoreProvider for TencentStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -150,6 +150,7 @@ impl ObjectStoreProvider for TosStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            native_directory_path_resolver: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -150,7 +150,7 @@ impl ObjectStoreProvider for TosStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
-            native_directory_path_resolver: None,
+            native_directory_path_capability: None,
         })
     }
 }

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -183,6 +183,10 @@ impl WrappingObjectStore for IOTracker {
     fn wrap(&self, _store_prefix: &str, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
         Arc::new(IoTrackingStore::new(target, self.stats.clone()))
     }
+
+    fn preserves_native_directory_path(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2035,8 +2035,7 @@ impl Dataset {
         let mut cloned = self.clone();
         let mut object_store = self.object_store.as_ref().clone();
         for wrapper in &wrappers {
-            object_store.inner =
-                wrapper.wrap(&object_store.store_prefix, object_store.inner.clone());
+            object_store.apply_wrapper(wrapper.as_ref());
         }
         cloned.object_store = Arc::new(object_store);
         cloned.refs = Refs::new(

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -567,7 +567,13 @@ impl DatasetBuilder {
                     download_retry_count,
                     None, // No storage_options available here
                 );
-                if let Some(resolver) = &self.options.native_directory_path_resolver {
+                if self
+                    .options
+                    .object_store_wrapper
+                    .as_ref()
+                    .is_none_or(|wrapper| wrapper.preserves_native_directory_path())
+                    && let Some(resolver) = &self.options.native_directory_path_resolver
+                {
                     object_store =
                         object_store.with_native_directory_path_resolver(resolver.clone());
                 }

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -553,8 +553,8 @@ impl DatasetBuilder {
 
         #[allow(deprecated)]
         let (object_store, base_path) = match &self.options.object_store {
-            Some(store) => (
-                Arc::new(ObjectStore::new(
+            Some(store) => {
+                let mut object_store = ObjectStore::new(
                     store.0.clone(),
                     store.1.clone(),
                     self.options.block_size,
@@ -566,9 +566,13 @@ impl DatasetBuilder {
                     DEFAULT_CLOUD_IO_PARALLELISM,
                     download_retry_count,
                     None, // No storage_options available here
-                )),
-                Path::from(store.1.path()),
-            ),
+                );
+                if let Some(resolver) = &self.options.native_directory_path_resolver {
+                    object_store =
+                        object_store.with_native_directory_path_resolver(resolver.clone());
+                }
+                (Arc::new(object_store), Path::from(store.1.path()))
+            }
             None => {
                 ObjectStore::from_uri_and_params(store_registry, &self.table_uri, &self.options)
                     .await?

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -203,27 +203,35 @@ async fn test_with_object_store_wrappers_wraps_primary_store() {
 #[allow(deprecated)]
 async fn test_builder_carries_direct_store_native_directory_path() {
     let uri = "file:///tmp/direct.lance";
-    let params = ObjectStoreParams {
-        object_store: Some((
-            Arc::new(object_store::memory::InMemory::new()),
-            url::Url::parse(uri).unwrap(),
-        )),
-        native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
-            std::path::PathBuf::from("/native").join(path.as_ref())
-        })),
-        ..Default::default()
-    };
+    let cases: [(Option<Arc<dyn WrappingObjectStore>>, bool); 3] = [
+        (None, true),
+        (Some(Arc::new(NonPreservingWrapper)), false),
+        (Some(Arc::new(NativeDirectoryPreservingWrapper)), true),
+    ];
 
-    let (store, path, _) = DatasetBuilder::from_uri(uri)
-        .with_store_params(params)
-        .build_object_store()
-        .await
-        .unwrap();
+    for (wrapper, should_preserve) in cases {
+        let params = ObjectStoreParams {
+            object_store: Some((
+                Arc::new(object_store::memory::InMemory::new()),
+                url::Url::parse(uri).unwrap(),
+            )),
+            native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
+                std::path::PathBuf::from("/native").join(path.as_ref())
+            })),
+            object_store_wrapper: wrapper,
+            ..Default::default()
+        };
 
-    assert_eq!(
-        store.native_directory_path(&path),
-        Some(std::path::PathBuf::from("/native/tmp/direct.lance"))
-    );
+        let (store, path, _) = DatasetBuilder::from_uri(uri)
+            .with_store_params(params)
+            .build_object_store()
+            .await
+            .unwrap();
+
+        let expected =
+            should_preserve.then(|| std::path::PathBuf::from("/native/tmp/direct.lance"));
+        assert_eq!(store.native_directory_path(&path), expected);
+    }
 }
 
 #[derive(Debug)]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -48,7 +48,8 @@ use futures::TryStreamExt;
 use lance_index::IndexType;
 use lance_index::scalar::ScalarIndexParams;
 use lance_io::object_store::{
-    ObjectStore, ObjectStoreParams, StorageOptionsAccessor, WrappingObjectStore,
+    NativeDirectoryPathResolver, ObjectStore, ObjectStoreParams, StorageOptionsAccessor,
+    WrappingObjectStore,
 };
 use lance_io::utils::tracking_store::IOTracker;
 use lance_table::io::manifest::read_manifest;
@@ -196,6 +197,33 @@ async fn test_with_object_store_wrappers_wraps_primary_store() {
     let _ = tracker.incremental_stats();
     drain_scan(&wrapped).await;
     assert!(tracker.incremental_stats().read_iops > 0);
+}
+
+#[tokio::test]
+#[allow(deprecated)]
+async fn test_builder_carries_direct_store_native_directory_path() {
+    let uri = "file:///tmp/direct.lance";
+    let params = ObjectStoreParams {
+        object_store: Some((
+            Arc::new(object_store::memory::InMemory::new()),
+            url::Url::parse(uri).unwrap(),
+        )),
+        native_directory_path_resolver: Some(NativeDirectoryPathResolver::new(|path| {
+            std::path::PathBuf::from("/native").join(path.as_ref())
+        })),
+        ..Default::default()
+    };
+
+    let (store, path, _) = DatasetBuilder::from_uri(uri)
+        .with_store_params(params)
+        .build_object_store()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.native_directory_path(&path),
+        Some(std::path::PathBuf::from("/native/tmp/direct.lance"))
+    );
 }
 
 #[derive(Debug)]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -198,6 +198,67 @@ async fn test_with_object_store_wrappers_wraps_primary_store() {
     assert!(tracker.incremental_stats().read_iops > 0);
 }
 
+#[derive(Debug)]
+struct NonPreservingWrapper;
+
+impl WrappingObjectStore for NonPreservingWrapper {
+    fn wrap(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        original
+    }
+}
+
+#[derive(Debug)]
+struct NativeDirectoryPreservingWrapper;
+
+impl WrappingObjectStore for NativeDirectoryPreservingWrapper {
+    fn wrap(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        original
+    }
+
+    fn preserves_native_directory_path(&self) -> bool {
+        true
+    }
+}
+
+#[tokio::test]
+async fn test_with_object_store_wrappers_updates_native_directory_path() {
+    let test_dir = TempStdDir::default();
+    create_file(&test_dir, WriteMode::Create, LanceFileVersion::Stable).await;
+    let dataset = Dataset::open(test_dir.to_str().unwrap()).await.unwrap();
+    let native_path = dataset
+        .object_store
+        .native_directory_path(&dataset.base)
+        .unwrap();
+
+    let non_preserving = dataset.with_object_store_wrappers([
+        Arc::new(NonPreservingWrapper) as Arc<dyn WrappingObjectStore>
+    ]);
+    assert!(
+        non_preserving
+            .object_store
+            .native_directory_path(&non_preserving.base)
+            .is_none()
+    );
+
+    let preserving = dataset.with_object_store_wrappers([
+        Arc::new(NativeDirectoryPreservingWrapper) as Arc<dyn WrappingObjectStore>,
+    ]);
+    assert_eq!(
+        preserving
+            .object_store
+            .native_directory_path(&preserving.base),
+        Some(native_path)
+    );
+}
+
 #[tokio::test]
 async fn test_with_object_store_wrappers_wraps_base_store_params() {
     let test_dir = TempStdDir::default();


### PR DESCRIPTION
## Summary
- carry an explicit native-path resolver on the resolved `ObjectStore`, with direct and custom stores opting out by default
- bind capability validity to the exact effective `inner` store identity, so direct replacement automatically invalidates stale authority
- advertise the capability for built-in `file`, `file-object-store`, and Linux `file+uring` stores
- allow deprecated direct object-store bindings to attach the same explicit capability; `DatasetBuilder` retains it only when configured wrappers preserve native authority
- centralize wrapper application so registry-time and post-open wrappers clear the capability unless they explicitly preserve and rebind exact native-path semantics
- keep the active provider's calculated registry prefix authoritative for resolved stores and wrapper identity
- unblock [LanceDB #3919](https://github.com/lancedb/lancedb/pull/3919) from distinguishing an empty native table directory without listing its parent or trusting provider-controlled error text

## Test plan
- [x] `cargo test -p lance-io` (204 passed; 2 doctests passed, 1 ignored)
- [x] `cargo test -p lance test_builder_carries_direct_store_native_directory_path --lib`
- [x] `cargo test -p lance test_with_object_store_wrappers_ --lib` (4 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p lance-io -p lance --all-features --tests --benches -- -D warnings -A clippy::single_range_in_vec_init -A clippy::implicit_clone -A clippy::collapsible_else_if`
- [ ] local `cargo clippy --all --tests --benches -- -D warnings` is blocked on unchanged `main` code by Rust 1.91 lints; repository CI runs the full lint matrix