### PR TITLE
feat: add Dataset::migrate_to_stable_row_ids migration method

### DIFF
--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -76,13 +76,6 @@ pub fn apply_feature_flags(
         0
     };
 
-    // Capture before the reset below. The flag is not derivable from fragment
-    // content alone (see the migration path in `migrate_to_stable_row_ids`),
-    // so it must be carried across the reset explicitly, just like the MemWAL
-    // index-catchup bit above.
-    let had_stable_row_ids = manifest.reader_feature_flags & FLAG_STABLE_ROW_IDS != 0
-        && manifest.writer_feature_flags & FLAG_STABLE_ROW_IDS != 0;
-
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -97,13 +90,12 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DELETION_FILES;
     }
 
-    // Set stable row IDs flag only when explicitly requested or when it was
-    // already set on the manifest before the reset above. The carry-through
-    // (`had_stable_row_ids`) is a safety net: subsequent commits on an already-
-    // migrated table inherit `use_stable_row_ids = true` from the dataset, which
-    // sets `enable_stable_row_id`; the carry catches any path that forgets to
-    // propagate the flag and prevents accidentally downgrading the table.
-    if enable_stable_row_id || had_stable_row_ids {
+    // If any fragment has row ids, they must all have row ids.
+    let has_row_ids = manifest
+        .fragments
+        .iter()
+        .any(|frag| frag.row_id_meta.is_some());
+    if has_row_ids || enable_stable_row_id {
         if !manifest
             .fragments
             .iter()

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -76,6 +76,13 @@ pub fn apply_feature_flags(
         0
     };
 
+    // Capture before the reset below. The flag is not derivable from fragment
+    // content alone (see the migration path in `migrate_to_stable_row_ids`),
+    // so it must be carried across the reset explicitly, just like the MemWAL
+    // index-catchup bit above.
+    let had_stable_row_ids = manifest.reader_feature_flags & FLAG_STABLE_ROW_IDS != 0
+        && manifest.writer_feature_flags & FLAG_STABLE_ROW_IDS != 0;
+
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -90,12 +97,13 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DELETION_FILES;
     }
 
-    // If any fragment has row ids, they must all have row ids.
-    let has_row_ids = manifest
-        .fragments
-        .iter()
-        .any(|frag| frag.row_id_meta.is_some());
-    if has_row_ids || enable_stable_row_id {
+    // Set stable row IDs flag only when explicitly requested or when it was
+    // already set on the manifest before the reset above. Auto-detection from
+    // fragment content is intentionally removed: the migration path assigns
+    // row_id_meta to all fragments in a first commit *without* yet activating
+    // the flag, and a second commit activates it explicitly via
+    // `enable_stable_row_id`. Auto-detection would activate the flag too early.
+    if enable_stable_row_id || had_stable_row_ids {
         if !manifest
             .fragments
             .iter()

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -98,11 +98,11 @@ pub fn apply_feature_flags(
     }
 
     // Set stable row IDs flag only when explicitly requested or when it was
-    // already set on the manifest before the reset above. Auto-detection from
-    // fragment content is intentionally removed: the migration path assigns
-    // row_id_meta to all fragments in a first commit *without* yet activating
-    // the flag, and a second commit activates it explicitly via
-    // `enable_stable_row_id`. Auto-detection would activate the flag too early.
+    // already set on the manifest before the reset above. The carry-through
+    // (`had_stable_row_ids`) is a safety net: subsequent commits on an already-
+    // migrated table inherit `use_stable_row_ids = true` from the dataset, which
+    // sets `enable_stable_row_id`; the carry catches any path that forgets to
+    // propagate the flag and prevents accidentally downgrading the table.
     if enable_stable_row_id || had_stable_row_ids {
         if !manifest
             .fragments

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3123,9 +3123,9 @@ impl Dataset {
     /// 1. Assigns a row ID sequence to every fragment via a merge operation.
     /// 2. Updates the table metadata to activate the stable row ID feature flag.
     ///
-    /// If concurrent writes occur between the two commits, the second commit will
-    /// fail and this method will return an error. In that case, call this method
-    /// again to retry the migration.
+    /// **No retries are attempted.** Callers should quiesce concurrent writes
+    /// before running this migration. If another write conflicts with either
+    /// commit, this method returns an error and the caller must retry.
     ///
     /// This method is idempotent: if the table already uses stable row IDs,
     /// it returns `Ok(())` immediately.
@@ -3137,46 +3137,28 @@ impl Dataset {
 
         // --- Commit 1: assign row ID sequences to all fragments via Merge ---
         //
-        // We retry manually instead of relying on CommitBuilder's built-in
-        // retry because on each conflict we must re-read the latest fragments
-        // and re-compute the ID assignment from scratch.
-        let ds_after_merge = loop {
-            let latest_version = self.latest_version_id().await?;
-            let latest_ds = self.checkout_version(latest_version).await?;
+        // Retries are disabled: callers are expected to quiesce writes before
+        // running this migration. An infinite retry loop risks hanging on a
+        // busy table; failing fast lets the caller decide when to retry.
+        let mut fragments = self.manifest.fragments.as_ref().clone();
+        Self::assign_stable_row_ids_for_migration(&mut fragments)?;
+        let schema = self.manifest.schema.clone();
+        let read_version = self.manifest.version;
 
-            // A concurrent migration may have already completed.
-            if latest_ds.manifest.uses_stable_row_ids() {
-                *self = latest_ds;
-                return Ok(());
-            }
+        let transaction = Transaction::new(
+            read_version,
+            Operation::Merge {
+                fragments,
+                schema,
+                preserves_nullability: true,
+            },
+            None,
+        );
 
-            let mut fragments = latest_ds.manifest.fragments.as_ref().clone();
-            // next_row_id is computed as a side effect of assigning IDs to fragments;
-            // commit 2 will recompute it from the committed manifest.
-            Self::assign_stable_row_ids_for_migration(&mut fragments)?;
-            let schema = latest_ds.manifest.schema.clone();
-            let read_version = latest_ds.manifest.version;
-
-            let transaction = Transaction::new(
-                read_version,
-                Operation::Merge {
-                    fragments,
-                    schema,
-                    preserves_nullability: true,
-                },
-                None,
-            );
-
-            match CommitBuilder::new(Arc::new(latest_ds))
-                .with_max_retries(0)
-                .execute(transaction)
-                .await
-            {
-                Ok(ds) => break ds,
-                Err(Error::RetryableCommitConflict { .. }) => continue,
-                Err(e) => return Err(e),
-            }
-        };
+        let ds_after_merge = CommitBuilder::new(Arc::new(self.clone()))
+            .with_max_retries(0)
+            .execute(transaction)
+            .await?;
 
         // --- Commit 2: activate the stable row IDs feature flag ---
         //

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3116,6 +3116,17 @@ impl Dataset {
             return Ok(());
         }
 
+        let indices = self.load_indices().await?;
+        if !indices.is_empty() {
+            let names: Vec<&str> = indices.iter().map(|idx| idx.name.as_str()).collect();
+            return Err(Error::invalid_input(format!(
+                "Cannot migrate to stable row IDs while indexes exist on the dataset. \
+                 Drop the following indexes first, then re-run the migration, and \
+                 recreate them afterwards: {}",
+                names.join(", ")
+            )));
+        }
+
         let mut fragments = self.manifest.fragments.as_ref().clone();
         let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments)?;
         let schema = self.manifest.schema.clone();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -131,7 +131,7 @@ use lance_table::feature_flags::{
     apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
 };
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
-use lance_table::rowids::{RowIdSequence, read_row_ids, write_row_ids};
+use lance_table::rowids::{RowIdSequence, write_row_ids};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
 };
@@ -3072,44 +3072,24 @@ impl Dataset {
     }
 
     /// Assign stable row ID sequences to fragments that do not yet have them.
-    ///
-    /// Returns the high-water mark `next_row_id` to be stored in the manifest
-    /// after all fragments have been assigned.
+    /// Assigns a contiguous `RowIdSequence` to every fragment starting from row
+    /// ID 0 and returns the resulting `next_row_id` high-water mark.
     fn assign_stable_row_ids_for_migration(fragments: &mut [Fragment]) -> Result<u64> {
-        // Step 1: Find the high-water mark from fragments that already have row IDs.
         let mut next_row_id = 0u64;
-        for fragment in fragments.iter() {
-            if let Some(RowIdMeta::Inline(data)) = &fragment.row_id_meta {
-                let sequence = read_row_ids(data)?;
-                if let Some(max_id) = sequence.iter().max() {
-                    next_row_id = next_row_id.max(
-                        max_id
-                            .checked_add(1)
-                            .ok_or_else(|| Error::internal("Row ID overflow during migration"))?,
-                    );
-                }
-            }
-        }
-
-        // Step 2: Assign IDs to fragments that do not have them yet.
         for fragment in fragments.iter_mut() {
-            if fragment.row_id_meta.is_none() {
-                let physical_rows = fragment.physical_rows.ok_or_else(|| {
-                    Error::internal(format!(
-                        "Fragment {} is missing physical_rows; cannot assign stable row IDs",
-                        fragment.id
-                    ))
-                })? as u64;
-                let end = next_row_id.checked_add(physical_rows).ok_or_else(|| {
-                    Error::internal("Row ID overflow during stable row ID migration")
-                })?;
-                let sequence = RowIdSequence::from(next_row_id..end);
-                let serialized = write_row_ids(&sequence);
-                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
-                next_row_id = end;
-            }
+            let physical_rows = fragment.physical_rows.ok_or_else(|| {
+                Error::internal(format!(
+                    "Fragment {} is missing physical_rows; cannot assign stable row IDs",
+                    fragment.id
+                ))
+            })? as u64;
+            let end = next_row_id.checked_add(physical_rows).ok_or_else(|| {
+                Error::internal("Row ID overflow during stable row ID migration")
+            })?;
+            let sequence = RowIdSequence::from(next_row_id..end);
+            fragment.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&sequence).into()));
+            next_row_id = end;
         }
-
         Ok(next_row_id)
     }
 
@@ -3119,29 +3099,25 @@ impl Dataset {
     /// stable across compaction operations. This enables more efficient updates
     /// to secondary indices.
     ///
-    /// This performs two commits:
-    /// 1. Assigns a row ID sequence to every fragment via a merge operation.
-    /// 2. Updates the table metadata to activate the stable row ID feature flag.
+    /// A single Merge commit assigns row ID sequences to all fragments and
+    /// activates the stable row ID feature flag atomically. Because `Merge`
+    /// conflicts with all data-modifying operations, a successful commit
+    /// guarantees no concurrent write occurred — no separate validation step
+    /// is needed.
     ///
     /// **No retries are attempted.** Callers should quiesce concurrent writes
-    /// before running this migration. If another write conflicts with either
-    /// commit, this method returns an error and the caller must retry.
+    /// before running this migration. If a conflicting write is detected, this
+    /// method returns an error and the caller must retry.
     ///
     /// This method is idempotent: if the table already uses stable row IDs,
     /// it returns `Ok(())` immediately.
     pub async fn migrate_to_stable_row_ids(&mut self) -> Result<()> {
-        // Fast path: already migrated.
         if self.manifest.uses_stable_row_ids() {
             return Ok(());
         }
 
-        // --- Commit 1: assign row ID sequences to all fragments via Merge ---
-        //
-        // Retries are disabled: callers are expected to quiesce writes before
-        // running this migration. An infinite retry loop risks hanging on a
-        // busy table; failing fast lets the caller decide when to retry.
         let mut fragments = self.manifest.fragments.as_ref().clone();
-        Self::assign_stable_row_ids_for_migration(&mut fragments)?;
+        let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments)?;
         let schema = self.manifest.schema.clone();
         let read_version = self.manifest.version;
 
@@ -3155,41 +3131,8 @@ impl Dataset {
             None,
         );
 
-        let ds_after_merge = CommitBuilder::new(Arc::new(self.clone()))
+        let new_ds = CommitBuilder::new(Arc::new(self.clone()))
             .with_max_retries(0)
-            .execute(transaction)
-            .await?;
-
-        // --- Commit 2: activate the stable row IDs feature flag ---
-        //
-        // Validate that every fragment has row_id_meta. A concurrent append
-        // between the two commits could have added a fragment without one.
-        let fragments = ds_after_merge.manifest.fragments.as_ref();
-        if fragments.iter().any(|frag| frag.row_id_meta.is_none()) {
-            return Err(Error::invalid_input(
-                "Concurrent write added fragment(s) without stable row IDs during migration. \
-                 Please run migrate_to_stable_row_ids again.",
-            ));
-        }
-
-        // Recompute next_row_id from the post-merge manifest so that commit 2
-        // stores the correct value in manifest.next_row_id.
-        let mut fragments_for_nri = fragments.to_vec();
-        let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments_for_nri)?;
-
-        let read_version = ds_after_merge.manifest.version;
-        let transaction = Transaction::new(
-            read_version,
-            Operation::UpdateConfig {
-                config_updates: None,
-                table_metadata_updates: None,
-                schema_metadata_updates: None,
-                field_metadata_updates: HashMap::new(),
-            },
-            None,
-        );
-
-        let new_ds = CommitBuilder::new(Arc::new(ds_after_merge))
             .with_stable_row_id_migration_activation(next_row_id)
             .execute(transaction)
             .await?;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -131,6 +131,7 @@ use lance_table::feature_flags::{
     apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
 };
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
+use lance_table::rowids::{RowIdSequence, read_row_ids, write_row_ids};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
 };
@@ -3070,6 +3071,151 @@ impl Dataset {
         Ok(())
     }
 
+    /// Assign stable row ID sequences to fragments that do not yet have them.
+    ///
+    /// Returns the high-water mark `next_row_id` to be stored in the manifest
+    /// after all fragments have been assigned.
+    fn assign_stable_row_ids_for_migration(fragments: &mut [Fragment]) -> Result<u64> {
+        // Step 1: Find the high-water mark from fragments that already have row IDs.
+        let mut next_row_id = 0u64;
+        for fragment in fragments.iter() {
+            if let Some(RowIdMeta::Inline(data)) = &fragment.row_id_meta {
+                let sequence = read_row_ids(data)?;
+                if let Some(max_id) = sequence.iter().max() {
+                    next_row_id = next_row_id.max(
+                        max_id
+                            .checked_add(1)
+                            .ok_or_else(|| Error::internal("Row ID overflow during migration"))?,
+                    );
+                }
+            }
+        }
+
+        // Step 2: Assign IDs to fragments that do not have them yet.
+        for fragment in fragments.iter_mut() {
+            if fragment.row_id_meta.is_none() {
+                let physical_rows = fragment.physical_rows.ok_or_else(|| {
+                    Error::internal(format!(
+                        "Fragment {} is missing physical_rows; cannot assign stable row IDs",
+                        fragment.id
+                    ))
+                })? as u64;
+                let end = next_row_id.checked_add(physical_rows).ok_or_else(|| {
+                    Error::internal("Row ID overflow during stable row ID migration")
+                })?;
+                let sequence = RowIdSequence::from(next_row_id..end);
+                let serialized = write_row_ids(&sequence);
+                fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
+                next_row_id = end;
+            }
+        }
+
+        Ok(next_row_id)
+    }
+
+    /// Migrate a table to use stable row IDs.
+    ///
+    /// Stable row IDs assign a persistent identifier to each row that remains
+    /// stable across compaction operations. This enables more efficient updates
+    /// to secondary indices.
+    ///
+    /// This performs two commits:
+    /// 1. Assigns a row ID sequence to every fragment via a merge operation.
+    /// 2. Updates the table metadata to activate the stable row ID feature flag.
+    ///
+    /// If concurrent writes occur between the two commits, the second commit will
+    /// fail and this method will return an error. In that case, call this method
+    /// again to retry the migration.
+    ///
+    /// This method is idempotent: if the table already uses stable row IDs,
+    /// it returns `Ok(())` immediately.
+    pub async fn migrate_to_stable_row_ids(&mut self) -> Result<()> {
+        // Fast path: already migrated.
+        if self.manifest.uses_stable_row_ids() {
+            return Ok(());
+        }
+
+        // --- Commit 1: assign row ID sequences to all fragments via Merge ---
+        //
+        // We retry manually instead of relying on CommitBuilder's built-in
+        // retry because on each conflict we must re-read the latest fragments
+        // and re-compute the ID assignment from scratch.
+        let ds_after_merge = loop {
+            let latest_version = self.latest_version_id().await?;
+            let latest_ds = self.checkout_version(latest_version).await?;
+
+            // A concurrent migration may have already completed.
+            if latest_ds.manifest.uses_stable_row_ids() {
+                *self = latest_ds;
+                return Ok(());
+            }
+
+            let mut fragments = latest_ds.manifest.fragments.as_ref().clone();
+            // next_row_id is computed as a side effect of assigning IDs to fragments;
+            // commit 2 will recompute it from the committed manifest.
+            Self::assign_stable_row_ids_for_migration(&mut fragments)?;
+            let schema = latest_ds.manifest.schema.clone();
+            let read_version = latest_ds.manifest.version;
+
+            let transaction = Transaction::new(
+                read_version,
+                Operation::Merge {
+                    fragments,
+                    schema,
+                    preserves_nullability: true,
+                },
+                None,
+            );
+
+            match CommitBuilder::new(Arc::new(latest_ds))
+                .with_max_retries(0)
+                .execute(transaction)
+                .await
+            {
+                Ok(ds) => break ds,
+                Err(Error::RetryableCommitConflict { .. }) => continue,
+                Err(e) => return Err(e),
+            }
+        };
+
+        // --- Commit 2: activate the stable row IDs feature flag ---
+        //
+        // Validate that every fragment has row_id_meta. A concurrent append
+        // between the two commits could have added a fragment without one.
+        let fragments = ds_after_merge.manifest.fragments.as_ref();
+        if fragments.iter().any(|frag| frag.row_id_meta.is_none()) {
+            return Err(Error::invalid_input(
+                "Concurrent write added fragment(s) without stable row IDs during migration. \
+                 Please run migrate_to_stable_row_ids again.",
+            ));
+        }
+
+        // Recompute next_row_id from the post-merge manifest so that commit 2
+        // stores the correct value in manifest.next_row_id.
+        let mut fragments_for_nri = fragments.to_vec();
+        let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments_for_nri)?;
+
+        let read_version = ds_after_merge.manifest.version;
+        let transaction = Transaction::new(
+            read_version,
+            Operation::UpdateConfig {
+                config_updates: None,
+                table_metadata_updates: None,
+                schema_metadata_updates: None,
+                field_metadata_updates: HashMap::new(),
+            },
+            None,
+        );
+
+        let new_ds = CommitBuilder::new(Arc::new(ds_after_merge))
+            .with_stable_row_id_migration_activation(next_row_id)
+            .execute(transaction)
+            .await?;
+
+        *self = new_ds;
+        Ok(())
+    }
+
     /// Shallow clone the target version into a new dataset at target_path.
     /// 'target_path': the uri string to clone the dataset into.
     /// 'version': the version cloned from, could be a version number or tag.
@@ -3873,6 +4019,10 @@ pub(crate) struct ManifestWriteConfig {
     use_legacy_format: Option<bool>,           // default None
     storage_format: Option<DataStorageFormat>, // default None
     disable_transaction_file: bool,            // default false
+    /// When `Some`, this commit is the second step of `migrate_to_stable_row_ids`.
+    /// It bypasses the "cannot enable stable row ids on existing dataset" guard and
+    /// sets `manifest.next_row_id` to the provided value before activating the flag.
+    migration_next_row_id: Option<u64>, // default None
 }
 
 impl Default for ManifestWriteConfig {
@@ -3884,6 +4034,7 @@ impl Default for ManifestWriteConfig {
             disable_transaction_file: false,
             use_legacy_format: None,
             storage_format: None,
+            migration_next_row_id: None,
         }
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3083,9 +3083,9 @@ impl Dataset {
                     fragment.id
                 ))
             })? as u64;
-            let end = next_row_id.checked_add(physical_rows).ok_or_else(|| {
-                Error::internal("Row ID overflow during stable row ID migration")
-            })?;
+            let end = next_row_id
+                .checked_add(physical_rows)
+                .ok_or_else(|| Error::internal("Row ID overflow during stable row ID migration"))?;
             let sequence = RowIdSequence::from(next_row_id..end);
             fragment.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&sequence).into()));
             next_row_id = end;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3116,17 +3116,6 @@ impl Dataset {
             return Ok(());
         }
 
-        let indices = self.load_indices().await?;
-        if !indices.is_empty() {
-            let names: Vec<&str> = indices.iter().map(|idx| idx.name.as_str()).collect();
-            return Err(Error::invalid_input(format!(
-                "Cannot migrate to stable row IDs while indexes exist on the dataset. \
-                 Drop the following indexes first, then re-run the migration, and \
-                 recreate them afterwards: {}",
-                names.join(", ")
-            )));
-        }
-
         let mut fragments = self.manifest.fragments.as_ref().clone();
         let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments)?;
         let schema = self.manifest.schema.clone();

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1106,6 +1106,7 @@ async fn test_write_manifest(
             use_legacy_format: None,
             storage_format: None,
             disable_transaction_file: false,
+            migration_next_row_id: None,
         },
         dataset.manifest_location.naming_scheme,
         None,

--- a/rust/lance/src/dataset/tests/dataset_migrations.rs
+++ b/rust/lance/src/dataset/tests/dataset_migrations.rs
@@ -4,12 +4,15 @@
 use std::sync::Arc;
 use std::vec;
 
+use crate::dataset::transaction::{Operation, Transaction};
+use crate::dataset::CommitBuilder;
 use crate::dataset::InsertBuilder;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
 use crate::utils::test::copy_test_data_to_tmp;
 use crate::{Dataset, Result};
 use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
-use lance_table::format::IndexMetadata;
+use lance_table::format::{IndexMetadata, RowIdMeta};
+use lance_table::rowids::{RowIdSequence, write_row_ids};
 
 use crate::dataset::write::{WriteMode, WriteParams};
 use crate::index::DatasetIndexExt;
@@ -590,7 +593,7 @@ async fn test_migrate_to_stable_row_ids_basic() {
         vec![Arc::new(Int64Array::from_iter_values(20..25))],
     )
     .unwrap();
-    let dataset_after_append = InsertBuilder::new(Arc::new(dataset))
+    let dataset_after_append = InsertBuilder::new(Arc::new(dataset.clone()))
         .with_params(&WriteParams {
             mode: WriteMode::Append,
             ..Default::default()
@@ -607,6 +610,8 @@ async fn test_migrate_to_stable_row_ids_basic() {
     );
     // next_row_id should have advanced by the 5 newly appended rows.
     assert_eq!(dataset_after_append.manifest.next_row_id, 25);
+
+    dataset.validate().await.unwrap();
 }
 
 #[tokio::test]
@@ -672,4 +677,91 @@ async fn test_migrate_to_stable_row_ids_empty() {
 
     assert!(dataset.manifest.uses_stable_row_ids());
     assert_eq!(dataset.manifest.next_row_id, 0);
+    dataset.validate().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_with_deletions() {
+    // Create a single-fragment dataset of 10 rows then soft-delete 3 of them.
+    let mut dataset = make_simple_dataset("memory://migrate_deletions", 10).await;
+    dataset.delete("id < 3").await.unwrap();
+
+    assert_eq!(dataset.count_rows(None).await.unwrap(), 7);
+    assert_eq!(dataset.count_deleted_rows().await.unwrap(), 3);
+
+    // physical_rows counts the pre-deletion slots; row IDs must cover all of
+    // them so that the deleted rows' IDs are never reused.
+    let physical_rows = dataset.get_fragments()[0].metadata.physical_rows.unwrap();
+    assert_eq!(physical_rows, 10);
+
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    assert!(dataset.manifest.uses_stable_row_ids());
+    assert!(dataset.manifest.fragments[0].row_id_meta.is_some());
+
+    // next_row_id must equal physical_rows (10), not logical rows (7).
+    assert_eq!(dataset.manifest.next_row_id, 10);
+
+    dataset.validate().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_resumes_partial_attempt() {
+    // Create a 2-fragment dataset (10 rows each).
+    let mut dataset = make_simple_dataset("memory://migrate_resume", 10).await;
+    let schema = Arc::new(ArrowSchema::from(dataset.schema()));
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from_iter_values(10..20))],
+    )
+    .unwrap();
+    dataset = InsertBuilder::new(Arc::new(dataset))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute(vec![batch2])
+        .await
+        .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+
+    // Simulate a partial migration: assign row IDs only to the first fragment
+    // and commit via Merge.  Because FLAG_STABLE_ROW_IDS is not set, the
+    // mixed state (one fragment with row_id_meta, one without) is accepted.
+    let mut fragments = dataset.manifest.fragments.as_ref().clone();
+    let f0_rows = fragments[0].physical_rows.unwrap() as u64;
+    let seq = RowIdSequence::from(0..f0_rows);
+    fragments[0].row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&seq).into()));
+
+    let partial_txn = Transaction::new(
+        dataset.manifest.version,
+        Operation::Merge {
+            fragments,
+            schema: dataset.manifest.schema.clone(),
+            preserves_nullability: true,
+        },
+        None,
+    );
+    dataset = CommitBuilder::new(Arc::new(dataset))
+        .with_max_retries(0)
+        .execute(partial_txn)
+        .await
+        .unwrap();
+
+    // Confirm the partial state: F0 has row IDs, F1 does not, flag not set.
+    assert!(dataset.manifest.fragments[0].row_id_meta.is_some());
+    assert!(dataset.manifest.fragments[1].row_id_meta.is_none());
+    assert!(!dataset.manifest.uses_stable_row_ids());
+
+    // Run the migration.  It should pick up the high-water mark from F0 (10)
+    // and assign IDs [10, 20) to F1, yielding next_row_id = 20.
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    assert!(dataset.manifest.uses_stable_row_ids());
+    for frag in dataset.manifest.fragments.iter() {
+        assert!(frag.row_id_meta.is_some(), "fragment {} missing row_id_meta", frag.id);
+    }
+    assert_eq!(dataset.manifest.next_row_id, 20);
+
+    dataset.validate().await.unwrap();
 }

--- a/rust/lance/src/dataset/tests/dataset_migrations.rs
+++ b/rust/lance/src/dataset/tests/dataset_migrations.rs
@@ -8,6 +8,7 @@ use crate::dataset::InsertBuilder;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
 use crate::utils::test::copy_test_data_to_tmp;
 use crate::{Dataset, Result};
+use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
 use lance_table::format::IndexMetadata;
 
 use crate::dataset::write::{WriteMode, WriteParams};
@@ -15,7 +16,7 @@ use crate::index::DatasetIndexExt;
 use arrow::compute::concat_batches;
 use arrow_array::RecordBatch;
 use arrow_array::{Float32Array, Int64Array, RecordBatchIterator};
-use arrow_schema::Schema as ArrowSchema;
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use lance_file::version::LanceFileVersion;
 
 use futures::{StreamExt, TryStreamExt};
@@ -510,4 +511,165 @@ async fn test_list_struct_field_reorder_issue_5702() {
 
     // Verify schema has expected columns
     assert_eq!(batch.schema().fields().len(), 3); // id, data, extra
+}
+
+// Helper: create a simple dataset with one fragment of `n` rows at the given URI.
+async fn make_simple_dataset(uri: &str, n: i64) -> Dataset {
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from_iter_values(0..n))],
+    )
+    .unwrap();
+    Dataset::write(RecordBatchIterator::new(vec![Ok(batch)], schema), uri, None)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_basic() {
+    // Create a dataset without stable row IDs (the default).
+    let mut dataset = make_simple_dataset("memory://migrate_basic", 10).await;
+    assert!(
+        !dataset.manifest.uses_stable_row_ids(),
+        "should not have stable row IDs yet"
+    );
+
+    // Append a second batch using InsertBuilder so we share the same object store.
+    let schema = Arc::new(ArrowSchema::from(dataset.schema()));
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from_iter_values(10..20))],
+    )
+    .unwrap();
+    dataset = InsertBuilder::new(Arc::new(dataset))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute(vec![batch2])
+        .await
+        .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+
+    // Run the migration.
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    // FLAG_STABLE_ROW_IDS must be set in both reader and writer flags.
+    assert_ne!(
+        dataset.manifest.reader_feature_flags & FLAG_STABLE_ROW_IDS,
+        0,
+        "reader_feature_flags should have FLAG_STABLE_ROW_IDS"
+    );
+    assert_ne!(
+        dataset.manifest.writer_feature_flags & FLAG_STABLE_ROW_IDS,
+        0,
+        "writer_feature_flags should have FLAG_STABLE_ROW_IDS"
+    );
+    assert!(dataset.manifest.uses_stable_row_ids());
+
+    // All fragments must have row_id_meta set.
+    for frag in dataset.manifest.fragments.iter() {
+        assert!(
+            frag.row_id_meta.is_some(),
+            "fragment {} should have row_id_meta after migration",
+            frag.id
+        );
+    }
+
+    // next_row_id should equal the total number of physical rows (10 + 10 = 20).
+    assert_eq!(dataset.manifest.next_row_id, 20);
+
+    // Appending after migration should correctly assign row IDs from next_row_id.
+    let batch3 = RecordBatch::try_new(
+        Arc::new(ArrowSchema::from(dataset.schema())),
+        vec![Arc::new(Int64Array::from_iter_values(20..25))],
+    )
+    .unwrap();
+    let dataset_after_append = InsertBuilder::new(Arc::new(dataset))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute(vec![batch3])
+        .await
+        .unwrap();
+
+    // The new fragment should also have row_id_meta.
+    let new_frag = dataset_after_append.manifest.fragments.last().unwrap();
+    assert!(
+        new_frag.row_id_meta.is_some(),
+        "new fragment after migration should have row_id_meta"
+    );
+    // next_row_id should have advanced by the 5 newly appended rows.
+    assert_eq!(dataset_after_append.manifest.next_row_id, 25);
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_already_migrated() {
+    // Create a dataset that already uses stable row IDs.
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from_iter_values(0..5))],
+    )
+    .unwrap();
+    let write_params = WriteParams {
+        enable_stable_row_ids: true,
+        ..Default::default()
+    };
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://already_migrated",
+        Some(write_params),
+    )
+    .await
+    .unwrap();
+
+    assert!(dataset.manifest.uses_stable_row_ids());
+    let version_before = dataset.manifest.version;
+
+    // Calling migrate on an already-migrated dataset should be a no-op.
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    // Version must not have changed.
+    assert_eq!(
+        dataset.manifest.version, version_before,
+        "migrate should be a no-op when already migrated"
+    );
+    assert!(dataset.manifest.uses_stable_row_ids());
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_empty() {
+    // Create an empty dataset (schema-only, no fragments).
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int64,
+        false,
+    )]));
+    let empty_reader = RecordBatchIterator::new(
+        std::iter::empty::<std::result::Result<RecordBatch, arrow_schema::ArrowError>>(),
+        schema.clone(),
+    );
+    let mut dataset = Dataset::write(empty_reader, "memory://migrate_empty", None)
+        .await
+        .unwrap();
+
+    assert!(!dataset.manifest.uses_stable_row_ids());
+    assert_eq!(dataset.get_fragments().len(), 0);
+
+    // Migration on an empty dataset should succeed without error.
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    assert!(dataset.manifest.uses_stable_row_ids());
+    assert_eq!(dataset.manifest.next_row_id, 0);
 }

--- a/rust/lance/src/dataset/tests/dataset_migrations.rs
+++ b/rust/lance/src/dataset/tests/dataset_migrations.rs
@@ -4,15 +4,12 @@
 use std::sync::Arc;
 use std::vec;
 
-use crate::dataset::transaction::{Operation, Transaction};
-use crate::dataset::CommitBuilder;
 use crate::dataset::InsertBuilder;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
 use crate::utils::test::copy_test_data_to_tmp;
 use crate::{Dataset, Result};
 use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
-use lance_table::format::{IndexMetadata, RowIdMeta};
-use lance_table::rowids::{RowIdSequence, write_row_ids};
+use lance_table::format::IndexMetadata;
 
 use crate::dataset::write::{WriteMode, WriteParams};
 use crate::index::DatasetIndexExt;
@@ -701,67 +698,6 @@ async fn test_migrate_to_stable_row_ids_with_deletions() {
 
     // next_row_id must equal physical_rows (10), not logical rows (7).
     assert_eq!(dataset.manifest.next_row_id, 10);
-
-    dataset.validate().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_migrate_to_stable_row_ids_resumes_partial_attempt() {
-    // Create a 2-fragment dataset (10 rows each).
-    let mut dataset = make_simple_dataset("memory://migrate_resume", 10).await;
-    let schema = Arc::new(ArrowSchema::from(dataset.schema()));
-    let batch2 = RecordBatch::try_new(
-        schema.clone(),
-        vec![Arc::new(Int64Array::from_iter_values(10..20))],
-    )
-    .unwrap();
-    dataset = InsertBuilder::new(Arc::new(dataset))
-        .with_params(&WriteParams {
-            mode: WriteMode::Append,
-            ..Default::default()
-        })
-        .execute(vec![batch2])
-        .await
-        .unwrap();
-    assert_eq!(dataset.get_fragments().len(), 2);
-
-    // Simulate a partial migration: assign row IDs only to the first fragment
-    // and commit via Merge.  Because FLAG_STABLE_ROW_IDS is not set, the
-    // mixed state (one fragment with row_id_meta, one without) is accepted.
-    let mut fragments = dataset.manifest.fragments.as_ref().clone();
-    let f0_rows = fragments[0].physical_rows.unwrap() as u64;
-    let seq = RowIdSequence::from(0..f0_rows);
-    fragments[0].row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&seq).into()));
-
-    let partial_txn = Transaction::new(
-        dataset.manifest.version,
-        Operation::Merge {
-            fragments,
-            schema: dataset.manifest.schema.clone(),
-            preserves_nullability: true,
-        },
-        None,
-    );
-    dataset = CommitBuilder::new(Arc::new(dataset))
-        .with_max_retries(0)
-        .execute(partial_txn)
-        .await
-        .unwrap();
-
-    // Confirm the partial state: F0 has row IDs, F1 does not, flag not set.
-    assert!(dataset.manifest.fragments[0].row_id_meta.is_some());
-    assert!(dataset.manifest.fragments[1].row_id_meta.is_none());
-    assert!(!dataset.manifest.uses_stable_row_ids());
-
-    // Run the migration.  It should pick up the high-water mark from F0 (10)
-    // and assign IDs [10, 20) to F1, yielding next_row_id = 20.
-    dataset.migrate_to_stable_row_ids().await.unwrap();
-
-    assert!(dataset.manifest.uses_stable_row_ids());
-    for frag in dataset.manifest.fragments.iter() {
-        assert!(frag.row_id_meta.is_some(), "fragment {} missing row_id_meta", frag.id);
-    }
-    assert_eq!(dataset.manifest.next_row_id, 20);
 
     dataset.validate().await.unwrap();
 }

--- a/rust/lance/src/dataset/tests/dataset_migrations.rs
+++ b/rust/lance/src/dataset/tests/dataset_migrations.rs
@@ -6,13 +6,14 @@ use std::vec;
 
 use crate::dataset::InsertBuilder;
 use crate::dataset::optimize::{CompactionOptions, compact_files};
+use crate::index::DatasetIndexExt;
 use crate::utils::test::copy_test_data_to_tmp;
 use crate::{Dataset, Result};
+use lance_index::{IndexType, scalar::ScalarIndexParams};
 use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
 use lance_table::format::IndexMetadata;
 
 use crate::dataset::write::{WriteMode, WriteParams};
-use crate::index::DatasetIndexExt;
 use arrow::compute::concat_batches;
 use arrow_array::RecordBatch;
 use arrow_array::{Float32Array, Int64Array, RecordBatchIterator};
@@ -700,4 +701,75 @@ async fn test_migrate_to_stable_row_ids_with_deletions() {
     assert_eq!(dataset.manifest.next_row_id, 10);
 
     dataset.validate().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_migrate_to_stable_row_ids_blocked_by_index() {
+    // Create a 2-fragment dataset and build a BTree index on it.
+    let mut dataset = make_simple_dataset("memory://btree_blocked", 10).await;
+    let schema = Arc::new(ArrowSchema::from(dataset.schema()));
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from_iter_values(10..20))],
+    )
+    .unwrap();
+    dataset = InsertBuilder::new(Arc::new(dataset))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute(vec![batch2])
+        .await
+        .unwrap();
+
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            Some("my_btree".to_string()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    // Migration must be rejected because the BTree index exists.
+    let err = dataset
+        .migrate_to_stable_row_ids()
+        .await
+        .expect_err("migration should fail when indexes exist");
+
+    assert!(
+        err.to_string().contains("my_btree"),
+        "error should name the blocking index, got: {err}"
+    );
+
+    // After dropping the index the migration succeeds.
+    dataset.drop_index("my_btree").await.unwrap();
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+    assert!(dataset.manifest.uses_stable_row_ids());
+
+    // Re-create the index and verify it works correctly.
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let results = dataset
+        .scan()
+        .filter("id = 15")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+
+    assert_eq!(results.num_rows(), 1);
+    let id_col = results["id"].as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(id_col.value(0), 15);
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2237,6 +2237,19 @@ impl Transaction {
                 "This dataset was not created with the stable row ids feature.  Please run `migrate_to_stable_row_ids` before attempting to use stable row ids".into(),
             ));
         }
+
+        if config.migration_next_row_id.is_some() && !current_indices.is_empty() {
+            let names: Vec<&str> = current_indices
+                .iter()
+                .map(|idx| idx.name.as_str())
+                .collect();
+            return Err(Error::invalid_input(format!(
+                "Cannot migrate to stable row IDs while indexes exist on the dataset. \
+                 Drop the following indexes first, then re-run the migration, and \
+                 recreate them afterwards: {}",
+                names.join(", ")
+            )));
+        }
         let mut reference_paths = match current_manifest {
             Some(m) => m.base_paths.clone(),
             None => HashMap::new(),

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2228,6 +2228,7 @@ impl Transaction {
         read_version_state: Option<ReadVersionState<'_>>,
     ) -> Result<(Manifest, Vec<IndexMetadata>)> {
         if config.use_stable_row_ids
+            && config.migration_next_row_id.is_none()
             && current_manifest
                 .map(|m| !m.uses_stable_row_ids())
                 .unwrap_or_default()
@@ -2315,7 +2316,8 @@ impl Transaction {
         .then(|| Self::logical_index_segments(&final_indices));
 
         let mut next_row_id = {
-            // Only use row ids if the feature flag is set already or
+            // Only use row ids if the feature flag is set already, or this is
+            // a migration activation that explicitly provides the next_row_id.
             match (current_manifest, config.use_stable_row_ids) {
                 (Some(manifest), _) if manifest.reader_feature_flags & FLAG_STABLE_ROW_IDS != 0 => {
                     Some(manifest.next_row_id)
@@ -2323,9 +2325,14 @@ impl Transaction {
                 (None, true) => Some(0),
                 (_, false) => None,
                 (Some(_), true) => {
-                    return Err(Error::not_supported_source(
-                        "Cannot enable stable row ids on existing dataset".into(),
-                    ));
+                    // Migration activation: use the provided next_row_id.
+                    if let Some(migration_nri) = config.migration_next_row_id {
+                        Some(migration_nri)
+                    } else {
+                        return Err(Error::not_supported_source(
+                            "Cannot enable stable row ids on existing dataset".into(),
+                        ));
+                    }
                 }
             }
         };

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2234,7 +2234,7 @@ impl Transaction {
                 .unwrap_or_default()
         {
             return Err(Error::not_supported_source(
-                "Cannot enable stable row ids on existing dataset".into(),
+                "This dataset was not created with the stable row ids feature.  Please run `migrate_to_stable_row_ids` before attempting to use stable row ids".into(),
             ));
         }
         let mut reference_paths = match current_manifest {
@@ -2330,7 +2330,7 @@ impl Transaction {
                         Some(migration_nri)
                     } else {
                         return Err(Error::not_supported_source(
-                            "Cannot enable stable row ids on existing dataset".into(),
+                            "This dataset was not created with the stable row ids feature.  Please run `migrate_to_stable_row_ids` before attempting to use stable row ids".into(),
                         ));
                     }
                 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -52,6 +52,8 @@ pub struct CommitBuilder<'a> {
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
     timeout: Option<Duration>,
+    /// When `Some`, this commit is the second step of `migrate_to_stable_row_ids`.
+    migration_next_row_id: Option<u64>,
 }
 
 /// Default timeout applied to [`CommitBuilder::execute`] when none is set.
@@ -75,6 +77,7 @@ impl<'a> CommitBuilder<'a> {
             affected_rows: None,
             transaction_properties: None,
             timeout: Some(DEFAULT_COMMIT_TIMEOUT),
+            migration_next_row_id: None,
         }
     }
 
@@ -252,6 +255,17 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Configure this commit as the second step of a stable row ID migration.
+    ///
+    /// Sets `use_stable_row_ids = true` and supplies the `next_row_id` that was
+    /// computed during the first migration commit. This bypasses the normal
+    /// "cannot enable stable row IDs on an existing dataset" check so that the
+    /// flag can be activated without creating the dataset from scratch.
+    pub(crate) fn with_stable_row_id_migration_activation(mut self, next_row_id: u64) -> Self {
+        self.migration_next_row_id = Some(next_row_id);
+        self
+    }
+
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
         let timeout = self.timeout;
         if let Some(t) = timeout
@@ -386,7 +400,11 @@ impl<'a> CommitBuilder<'a> {
             ManifestNamingScheme::V1
         };
 
-        let use_stable_row_ids = if let Some(ds) = dest.dataset() {
+        let use_stable_row_ids = if self.migration_next_row_id.is_some() {
+            // Migration activation always enables stable row IDs regardless of
+            // the current dataset state.
+            true
+        } else if let Some(ds) = dest.dataset() {
             ds.manifest.uses_stable_row_ids()
         } else {
             self.use_stable_row_ids.unwrap_or(false)
@@ -410,6 +428,7 @@ impl<'a> CommitBuilder<'a> {
         let manifest_config = ManifestWriteConfig {
             use_stable_row_ids,
             storage_format: self.storage_format.map(DataStorageFormat::new),
+            migration_next_row_id: self.migration_next_row_id,
             ..Default::default()
         };
 


### PR DESCRIPTION
Adds a two-commit migration path to enable stable row IDs on an existing table without requiring a full rewrite.

- Commit 1 (Merge): assigns a RowIdSequence to every fragment that lacks one, using a manual retry loop so each conflict re-reads the latest fragment list and recomputes IDs from scratch.
- Commit 2 (UpdateConfig): validates that no concurrent write snuck in a fragment without row IDs between the two commits, then activates FLAG_STABLE_ROW_IDS and writes the correct next_row_id watermark.

Supporting changes:
- `apply_feature_flags`: removes auto-detection of FLAG_STABLE_ROW_IDS from fragment content; the flag is now carried across the word-reset (like FLAG_MEM_WAL_INDEX_CATCHUP) and set only when explicitly requested or previously present.
- `ManifestWriteConfig`: adds `migration_next_row_id` to thread the watermark through to `build_manifest_with_read_version`.
- `CommitBuilder`: adds `with_stable_row_id_migration_activation` to force `use_stable_row_ids = true` and bypass the "cannot enable on existing dataset" guard for the migration activation commit.