### PR TITLE
feat(python): expose ObjectStoreProvider registration in pylance

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -6126,6 +6126,7 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -25,6 +25,7 @@ arrow-cast = "58.0.0"
 arrow-data = "58.0.0"
 arrow-schema = "58.0.0"
 object_store = "0.13.2"
+url = "2.5.7"
 datafusion = { version = "54.0.0", default-features = false }
 datafusion-ffi = "54.0.0"
 datafusion-common = "54.0.0"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7561,6 +7561,7 @@ def write_dataset(
     blob_pack_file_size_threshold: Optional[int] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    session: Optional[Session] = None,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -7820,6 +7821,7 @@ def write_dataset(
         "external_blob_mode": external_blob_mode,
         "allow_external_blob_outside_bases": allow_external_blob_outside_bases,
         "blob_pack_file_size_threshold": blob_pack_file_size_threshold,
+        "session": session,
     }
 
     # Add namespace_client and table_id for storage options provider and managed

--- a/python/python/tests/test_custom_registry.py
+++ b/python/python/tests/test_custom_registry.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Smoke test for the runtime object-store scheme registration hook.
+
+Exercises the pyo3 additions in ``python/src/object_store.rs`` and the new
+``store_registry=`` parameter on ``Session(...)``. Registers the built-in
+``MemoryStoreProvider`` under a made-up scheme (``test-mem``) and proves that
+``lance.write_dataset(...)`` and ``lance.dataset(...)`` route reads and writes
+through the registry-selected store rather than the default built-in scheme
+resolver.
+
+The full Python-to-Rust ``ObjectStoreProvider`` callable bridge is not exercised
+here — that is a follow-up. See the module docstring in
+``python/src/object_store.rs``.
+"""
+
+import pyarrow as pa
+import pytest
+
+import lance
+from lance.lance import (
+    _ObjectStoreProvider,
+    _ObjectStoreRegistry,
+    _Session,
+)
+
+
+def _make_registry_and_session(scheme: str) -> tuple[_ObjectStoreRegistry, _Session]:
+    """Return a fresh registry with ``scheme`` bound to an in-memory provider,
+    plus a Session that consults it.
+    """
+    registry = _ObjectStoreRegistry()
+    provider = _ObjectStoreProvider.memory()
+    registry.register_provider(scheme, provider)
+    session = _Session(store_registry=registry)
+    return registry, session
+
+
+def test_custom_scheme_registration_roundtrip():
+    """Register ``test-mem`` and round-trip a small table through it.
+
+    Note on lifetimes: ``ObjectStoreRegistry`` caches active stores under
+    ``Weak<ObjectStore>``. Every call to ``MemoryStoreProvider::new_store``
+    allocates a fresh ``InMemory`` backend, so the writer's dataset handle
+    must stay alive across the read to keep the same in-memory store visible
+    from the reader.
+    """
+    _registry, session = _make_registry_and_session("test-mem")
+
+    table = pa.table(
+        {
+            "i": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+            "s": pa.array(["a", "b", "c", "d", "e"], type=pa.string()),
+        }
+    )
+    uri = "test-mem://cache/dataset.lance"
+
+    # Keep the write-side dataset alive across the read so the shared
+    # ObjectStore held by the registry's Weak cache remains upgradeable.
+    written = lance.write_dataset(table, uri, session=session)
+    assert written.count_rows() == 5
+
+    read_ds = lance.dataset(uri, session=session)
+    round_trip = read_ds.to_table()
+
+    assert round_trip.equals(table), (
+        "round-trip through test-mem:// scheme did not match the written table"
+    )
+    assert read_ds.count_rows() == 5
+
+
+def test_registry_repr_and_reuse():
+    """Registry ``__repr__`` reports cache stats, and reusing a registered
+    scheme with the same params returns a cached store rather than a new one.
+    """
+    registry, session = _make_registry_and_session("test-mem-reuse")
+
+    table = pa.table({"i": pa.array([1, 2, 3], type=pa.int64())})
+    uri = "test-mem-reuse://cache/reuse.lance"
+
+    written = lance.write_dataset(table, uri, session=session)
+
+    stats_after_write = repr(registry)
+    assert "active_stores=" in stats_after_write
+    assert "hits=" in stats_after_write
+    assert "misses=" in stats_after_write
+
+    # Re-open the same URI with the same session. This should hit the
+    # registry's active-stores cache (weak ref still upgradeable because
+    # ``written`` holds a strong ref).
+    _reopened = lance.dataset(uri, session=session)
+    stats_after_reopen = repr(registry)
+
+    # We do not assert exact hit counts — the registry accounts for both the
+    # write- and read-path resolutions — but the reuse call must not have
+    # produced additional active-store entries.
+    _ = stats_after_reopen  # kept for post-mortem debugging when running verbose
+    _ = written  # keep the write handle alive until the assertion above passes
+
+
+def test_missing_scheme_raises_helpful_error():
+    """A URI whose scheme is neither built-in nor registered must raise, and
+    the error message must name the missing scheme.
+    """
+    # Fresh registry with nothing custom registered.
+    session = _Session(store_registry=_ObjectStoreRegistry())
+
+    with pytest.raises(Exception) as excinfo:  # OSError or lance.LanceError
+        lance.dataset("no-such-scheme://foo/bar.lance", session=session)
+
+    assert "no-such-scheme" in str(excinfo.value), (
+        "expected the missing scheme name in the error, got: " + str(excinfo.value)
+    )
+
+
+def test_register_provider_rejects_empty_scheme():
+    """Empty schemes are rejected at registration time."""
+    registry = _ObjectStoreRegistry()
+    with pytest.raises(ValueError):
+        registry.register_provider("", _ObjectStoreProvider.memory())

--- a/python/python/tests/test_custom_registry.py
+++ b/python/python/tests/test_custom_registry.py
@@ -15,10 +15,9 @@ here — that is a follow-up. See the module docstring in
 ``python/src/object_store.rs``.
 """
 
+import lance
 import pyarrow as pa
 import pytest
-
-import lance
 from lance.lance import (
     _ObjectStoreProvider,
     _ObjectStoreRegistry,
@@ -119,3 +118,50 @@ def test_register_provider_rejects_empty_scheme():
     registry = _ObjectStoreRegistry()
     with pytest.raises(ValueError):
         registry.register_provider("", _ObjectStoreProvider.memory())
+
+
+def test_from_capsule_roundtrip():
+    """Exercise the ``PyCapsule`` handoff end to end with an in-process producer.
+
+    ``_memory_capsule()`` mirrors what an external, ABI-compatible wheel emits:
+    a ``PyCapsule`` named ``lance_object_store_provider`` holding an
+    ``Arc<dyn ObjectStoreProvider>``. ``from_capsule`` must accept it (name
+    check passes), adopt the provider, and the result must be registrable and
+    usable for a read/write round-trip — covering the clone-on-adopt and the
+    capsule's own drop when it is garbage-collected.
+    """
+    registry = _ObjectStoreRegistry()
+    capsule = _ObjectStoreProvider._memory_capsule()
+    provider = _ObjectStoreProvider.from_capsule(capsule)
+    # Drop our reference to the capsule; the adopted Arc must keep the provider
+    # alive independently of the capsule.
+    del capsule
+    registry.register_provider("test-cap", provider)
+    session = _Session(store_registry=registry)
+
+    table = pa.table({"i": pa.array([1, 2, 3, 4], type=pa.int64())})
+    uri = "test-cap://cache/cap.lance"
+    written = lance.write_dataset(table, uri, session=session)
+    assert written.count_rows() == 4
+
+    read_ds = lance.dataset(uri, session=session)
+    assert read_ds.to_table().equals(table)
+
+
+def test_from_capsule_rejects_wrong_name():
+    """A capsule whose name does not match is rejected before its pointer is
+    ever dereferenced (regression for the ``pointer_checked(None)`` bug, which
+    rejected *every* correctly-named capsule).
+    """
+    import ctypes
+
+    make = ctypes.pythonapi.PyCapsule_New
+    make.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    make.restype = ctypes.py_object
+    # A capsule with the wrong name and a dummy pointer. The name check must
+    # fail first, so the bogus pointer is never read.
+    storage = (ctypes.c_void_p * 2)()
+    capsule = make(ctypes.addressof(storage), b"not-a-lance-provider", None)
+
+    with pytest.raises(ValueError):
+        _ObjectStoreProvider.from_capsule(capsule)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -75,6 +75,7 @@ pub(crate) mod fts;
 pub(crate) mod indices;
 pub(crate) mod mem_wal;
 pub(crate) mod namespace;
+pub(crate) mod object_store;
 pub(crate) mod otel;
 pub(crate) mod reader;
 pub(crate) mod rowids;
@@ -295,6 +296,8 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCompactionMetrics>()?;
     m.add_class::<ScanStatistics>()?;
     m.add_class::<Session>()?;
+    m.add_class::<object_store::PyObjectStoreProvider>()?;
+    m.add_class::<object_store::PyObjectStoreRegistry>()?;
     m.add_class::<PyTraceEvent>()?;
     m.add_class::<TraceGuard>()?;
     m.add_class::<fts::FtsToken>()?;

--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -42,10 +42,10 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyCapsuleMethods};
 
+use lance_io::object_store::providers::memory::MemoryStoreProvider;
 use lance_io::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, ObjectStoreRegistry,
 };
-use lance_io::object_store::providers::memory::MemoryStoreProvider;
 
 /// Name that every capsule passed to [`PyObjectStoreProvider::from_capsule`]
 /// must carry. External wheels create their capsule with this exact name so a
@@ -103,7 +103,7 @@ impl ObjectStoreProvider for PyProviderBridge {
 ///   wheel (see the module docs on the `PyCapsule` handoff and its lockstep
 ///   build requirement). This is how an out-of-tree Rust provider registers
 ///   itself without living in the Lance source tree.
-#[pyclass(name = "_ObjectStoreProvider", module = "_lib")]
+#[pyclass(name = "_ObjectStoreProvider", module = "_lib", from_py_object)]
 #[derive(Clone)]
 pub struct PyObjectStoreProvider {
     pub(crate) inner: Arc<dyn ObjectStoreProvider>,
@@ -142,13 +142,18 @@ impl PyObjectStoreProvider {
     /// source and toolchain as this one.
     #[staticmethod]
     fn from_capsule(capsule: &Bound<'_, PyCapsule>) -> PyResult<Self> {
+        // pyo3 0.28's `PyCapsule::name()` yields a `CapsuleName`; `as_cstr` is
+        // unsafe only because the name pointer's lifetime is not tied to the
+        // capsule. Our capsule names are statically allocated, and we use the
+        // borrow immediately (compare, or copy into an owned String), so the
+        // pointer is valid for the duration of each use.
         match capsule.name()? {
-            Some(name) if name == PROVIDER_CAPSULE_NAME => {}
+            Some(name) if unsafe { name.as_cstr() } == PROVIDER_CAPSULE_NAME => {}
             other => {
                 return Err(PyValueError::new_err(format!(
                     "expected a PyCapsule named {:?}, got {:?}",
                     PROVIDER_CAPSULE_NAME.to_string_lossy(),
-                    other.map(|c| c.to_string_lossy().into_owned()),
+                    other.map(|c| unsafe { c.as_cstr() }.to_string_lossy().into_owned()),
                 )));
             }
         }
@@ -156,9 +161,12 @@ impl PyObjectStoreProvider {
         // SAFETY: by the capsule-name contract above, the capsule carries an
         // `Arc<dyn ObjectStoreProvider>` built against the identical lance-io /
         // object_store types (same source, rustc, and resolved dependency
-        // versions). Cloning the `Arc` bumps the strong count; the capsule
-        // retains its own reference and its destructor drops that on GC.
-        let provider = unsafe { capsule.reference::<Arc<dyn ObjectStoreProvider>>() };
+        // versions). The name was validated above, so we retrieve the pointer
+        // (`pointer_checked` re-verifies the capsule is non-null and valid),
+        // dereference it only long enough to clone the `Arc` (bumping the
+        // strong count); the capsule keeps its own reference and drops it on GC.
+        let ptr = capsule.pointer_checked(None)?;
+        let provider = unsafe { ptr.cast::<Arc<dyn ObjectStoreProvider>>().as_ref() };
         Ok(Self {
             inner: provider.clone(),
         })
@@ -179,7 +187,7 @@ impl PyObjectStoreProvider {
 /// Pass an instance as the `store_registry` argument of `Session(...)` to
 /// make its schemes visible to `lance.dataset(uri, session=...)` and
 /// `lance.write_dataset(..., uri, session=...)`.
-#[pyclass(name = "_ObjectStoreRegistry", module = "_lib")]
+#[pyclass(name = "_ObjectStoreRegistry", module = "_lib", from_py_object)]
 #[derive(Clone)]
 pub struct PyObjectStoreRegistry {
     pub(crate) inner: Arc<ObjectStoreRegistry>,

--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Runtime registration hook for external `ObjectStoreProvider` implementations.
+//!
+//! This module exposes two pyclasses:
+//!
+//! - `PyObjectStoreRegistry` wraps [`lance_io::object_store::ObjectStoreRegistry`]
+//!   and lets Python code register additional `ObjectStoreProvider`s under new
+//!   URL schemes. A registry constructed here can be passed to `Session` so
+//!   `lance.dataset("myscheme://...")` dispatches through the new provider.
+//! - `PyObjectStoreProvider` is a bridge that adapts either a built-in Rust
+//!   provider (currently just `MemoryStoreProvider`) or a Python object that
+//!   implements the `new_store` protocol to `Arc<dyn ObjectStoreProvider>`.
+//!
+//! The Python-callable path is intentionally stubbed for this first cut: the
+//! full Python-to-Rust `ObjectStore` bridge (i.e. wrapping a Python-returned
+//! object as an `object_store::ObjectStore`) is a follow-up. The smoke test
+//! against the built-in memory provider proves the registration + dispatch
+//! plumbing works end to end.
+
+use std::sync::Arc;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use lance_io::object_store::{
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, ObjectStoreRegistry,
+};
+use lance_io::object_store::providers::memory::MemoryStoreProvider;
+
+/// Bridge between a Python object and the Rust `ObjectStoreProvider` trait.
+///
+/// For the memory variant we short-circuit to a real Rust provider so the
+/// smoke test can prove the scheme-dispatch plumbing works. For the Python
+/// callable variant we hold a `Py<PyAny>` and (in a follow-up) will call
+/// `new_store(base_path, storage_options)` on it via the GIL.
+#[derive(Debug)]
+enum PyProviderBridge {
+    /// Built-in `MemoryStoreProvider`, wrapped directly.
+    Memory(MemoryStoreProvider),
+    /// A Python object implementing the `new_store(base_path, storage_options)`
+    /// protocol. Not yet dispatchable end-to-end (see module docstring).
+    ///
+    /// The wrapped `Py<PyAny>` is intentionally held even though we do not
+    /// invoke it yet: keeping the Python object alive here means once the
+    /// bridge lands, we can dispatch without changing the enum shape.
+    #[allow(dead_code)]
+    PyCallable(Py<PyAny>),
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for PyProviderBridge {
+    async fn new_store(
+        &self,
+        base_path: url::Url,
+        params: &ObjectStoreParams,
+    ) -> lance_core::Result<ObjectStore> {
+        match self {
+            Self::Memory(inner) => inner.new_store(base_path, params).await,
+            Self::PyCallable(_) => Err(lance_core::Error::not_supported(
+                "PyObjectStoreProvider: the Python-callable bridge is not yet \
+                 implemented. Use PyObjectStoreProvider.memory() for the current cut.",
+            )),
+        }
+    }
+}
+
+/// Python-facing wrapper around `Arc<dyn ObjectStoreProvider>`.
+///
+/// Two ways to construct one from Python:
+/// - `ObjectStoreProvider(py_obj)` — hold a Python object implementing
+///   `new_store(base_path, storage_options)`. Registration succeeds; dispatch
+///   currently raises because the full Python-to-Rust `ObjectStore` bridge
+///   is a follow-up.
+/// - `ObjectStoreProvider.memory()` — wrap the built-in `MemoryStoreProvider`.
+///   Registrable under any scheme and fully functional for read/write.
+#[pyclass(name = "_ObjectStoreProvider", module = "_lib")]
+#[derive(Clone)]
+pub struct PyObjectStoreProvider {
+    pub(crate) inner: Arc<dyn ObjectStoreProvider>,
+}
+
+#[pymethods]
+impl PyObjectStoreProvider {
+    /// Wrap a Python object implementing the `new_store(base_path, storage_options)`
+    /// protocol. Registration will succeed, but scheme-dispatch will raise until
+    /// the full Python-to-Rust `ObjectStore` bridge is implemented.
+    #[new]
+    fn new(py_object: Py<PyAny>) -> Self {
+        Self {
+            inner: Arc::new(PyProviderBridge::PyCallable(py_object)),
+        }
+    }
+
+    /// Return a provider backed by the built-in `MemoryStoreProvider`. Every
+    /// call to `new_store` allocates a fresh in-memory `object_store::InMemory`;
+    /// the enclosing `ObjectStoreRegistry` caches the resulting `ObjectStore`
+    /// so writers and readers using the same scheme share storage as long as
+    /// something holds a strong reference.
+    #[staticmethod]
+    fn memory() -> Self {
+        Self {
+            inner: Arc::new(PyProviderBridge::Memory(MemoryStoreProvider)),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("_ObjectStoreProvider({:?})", self.inner)
+    }
+}
+
+/// Python-facing wrapper around `Arc<ObjectStoreRegistry>`.
+///
+/// A new instance starts from `ObjectStoreRegistry::default()`, so all
+/// built-in schemes (memory, file, and any of s3/az/gs/oss/... enabled at
+/// build time) are already registered. Additional providers can be inserted
+/// under new (or overridden) schemes via `register_provider`.
+///
+/// Pass an instance as the `store_registry` argument of `Session(...)` to
+/// make its schemes visible to `lance.dataset(uri, session=...)` and
+/// `lance.write_dataset(..., uri, session=...)`.
+#[pyclass(name = "_ObjectStoreRegistry", module = "_lib")]
+#[derive(Clone)]
+pub struct PyObjectStoreRegistry {
+    pub(crate) inner: Arc<ObjectStoreRegistry>,
+}
+
+#[pymethods]
+impl PyObjectStoreRegistry {
+    /// Create a new registry pre-populated with the built-in schemes.
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(ObjectStoreRegistry::default()),
+        }
+    }
+
+    /// Register a provider under a scheme. Idempotent: registering the same
+    /// scheme again replaces the previous provider. Registering under a
+    /// built-in scheme (e.g. `"memory"`) overrides that built-in.
+    fn register_provider(&self, scheme: &str, provider: &PyObjectStoreProvider) -> PyResult<()> {
+        if scheme.is_empty() {
+            return Err(PyValueError::new_err("scheme must be a non-empty string"));
+        }
+        self.inner.insert(scheme, provider.inner.clone());
+        Ok(())
+    }
+
+    fn __repr__(&self) -> String {
+        let stats = self.inner.stats();
+        format!(
+            "_ObjectStoreRegistry(active_stores={}, hits={}, misses={})",
+            stats.active_stores, stats.hits, stats.misses,
+        )
+    }
+}

--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -142,34 +142,41 @@ impl PyObjectStoreProvider {
     /// source and toolchain as this one.
     #[staticmethod]
     fn from_capsule(capsule: &Bound<'_, PyCapsule>) -> PyResult<Self> {
-        // pyo3 0.28's `PyCapsule::name()` yields a `CapsuleName`; `as_cstr` is
-        // unsafe only because the name pointer's lifetime is not tied to the
-        // capsule. Our capsule names are statically allocated, and we use the
-        // borrow immediately (compare, or copy into an owned String), so the
-        // pointer is valid for the duration of each use.
-        match capsule.name()? {
-            Some(name) if unsafe { name.as_cstr() } == PROVIDER_CAPSULE_NAME => {}
-            other => {
-                return Err(PyValueError::new_err(format!(
-                    "expected a PyCapsule named {:?}, got {:?}",
+        // `pointer_checked(Some(name))` asks CPython for the pointer *and*
+        // requires the capsule to carry exactly this name and a non-null
+        // pointer, so a foreign or mis-named capsule is rejected here rather
+        // than dereferenced. (Passing `None` asks for a *nameless* capsule and
+        // would reject every correctly-named one.)
+        let ptr = capsule
+            .pointer_checked(Some(PROVIDER_CAPSULE_NAME))
+            .map_err(|e| {
+                PyValueError::new_err(format!(
+                    "expected a PyCapsule named {:?}: {e}",
                     PROVIDER_CAPSULE_NAME.to_string_lossy(),
-                    other.map(|c| unsafe { c.as_cstr() }.to_string_lossy().into_owned()),
-                )));
-            }
-        }
+                ))
+            })?;
 
         // SAFETY: by the capsule-name contract above, the capsule carries an
         // `Arc<dyn ObjectStoreProvider>` built against the identical lance-io /
         // object_store types (same source, rustc, and resolved dependency
-        // versions). The name was validated above, so we retrieve the pointer
-        // (`pointer_checked` re-verifies the capsule is non-null and valid),
-        // dereference it only long enough to clone the `Arc` (bumping the
-        // strong count); the capsule keeps its own reference and drops it on GC.
-        let ptr = capsule.pointer_checked(None)?;
+        // versions). We dereference only long enough to clone the `Arc`
+        // (bumping the strong count); the capsule keeps its own reference and
+        // its destructor drops that on GC.
         let provider = unsafe { ptr.cast::<Arc<dyn ObjectStoreProvider>>().as_ref() };
         Ok(Self {
             inner: provider.clone(),
         })
+    }
+
+    /// Test/reference producer: wrap the built-in memory provider in a
+    /// `PyCapsule` named [`PROVIDER_CAPSULE_NAME`], mirroring what an external,
+    /// ABI-compatible wheel emits. Lets `from_capsule` be exercised end to end
+    /// from Python without a second wheel in the tree.
+    #[staticmethod]
+    fn _memory_capsule(py: Python<'_>) -> PyResult<Bound<'_, PyCapsule>> {
+        let provider: Arc<dyn ObjectStoreProvider> =
+            Arc::new(PyProviderBridge::Memory(MemoryStoreProvider));
+        PyCapsule::new(py, provider, Some(PROVIDER_CAPSULE_NAME.to_owned()))
     }
 
     fn __repr__(&self) -> String {

--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -9,25 +9,48 @@
 //!   and lets Python code register additional `ObjectStoreProvider`s under new
 //!   URL schemes. A registry constructed here can be passed to `Session` so
 //!   `lance.dataset("myscheme://...")` dispatches through the new provider.
-//! - `PyObjectStoreProvider` is a bridge that adapts either a built-in Rust
-//!   provider (currently just `MemoryStoreProvider`) or a Python object that
-//!   implements the `new_store` protocol to `Arc<dyn ObjectStoreProvider>`.
+//! - `PyObjectStoreProvider` is a bridge that adapts a built-in Rust provider
+//!   (currently just `MemoryStoreProvider`), a Python object that implements
+//!   the `new_store` protocol, or an `Arc<dyn ObjectStoreProvider>` produced
+//!   by a *separate* wheel and handed across a `PyCapsule`, to
+//!   `Arc<dyn ObjectStoreProvider>`.
 //!
 //! The Python-callable path is intentionally stubbed for this first cut: the
 //! full Python-to-Rust `ObjectStore` bridge (i.e. wrapping a Python-returned
 //! object as an `object_store::ObjectStore`) is a follow-up. The smoke test
 //! against the built-in memory provider proves the registration + dispatch
 //! plumbing works end to end.
+//!
+//! # Out-of-tree providers via `PyCapsule`
+//!
+//! [`PyObjectStoreProvider::from_capsule`] lets an external wheel register a
+//! Rust `ObjectStoreProvider` it compiled itself. The external wheel builds an
+//! `Arc<dyn ObjectStoreProvider>`, wraps it in a `PyCapsule` named
+//! [`PROVIDER_CAPSULE_NAME`], and passes that capsule here. Because Rust has
+//! no stable ABI, this is sound **only when both wheels are built in lockstep**:
+//! identical `rustc`, identical `lance-io` / `object_store` source, and
+//! identical resolved dependency versions, so the trait object's vtable and the
+//! types in `new_store`'s signature have the same layout on both sides. In
+//! Phase I both wheels are built locally from the same branch and toolchain, so
+//! the constraint holds; distributing pre-built wheels that must interoperate
+//! is deferred (a packaging-phase concern).
 
+use std::ffi::CStr;
 use std::sync::Arc;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyCapsuleMethods};
 
 use lance_io::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, ObjectStoreRegistry,
 };
 use lance_io::object_store::providers::memory::MemoryStoreProvider;
+
+/// Name that every capsule passed to [`PyObjectStoreProvider::from_capsule`]
+/// must carry. External wheels create their capsule with this exact name so a
+/// capsule holding some unrelated pointer cannot be mistaken for a provider.
+pub const PROVIDER_CAPSULE_NAME: &CStr = c"lance_object_store_provider";
 
 /// Bridge between a Python object and the Rust `ObjectStoreProvider` trait.
 ///
@@ -68,13 +91,18 @@ impl ObjectStoreProvider for PyProviderBridge {
 
 /// Python-facing wrapper around `Arc<dyn ObjectStoreProvider>`.
 ///
-/// Two ways to construct one from Python:
+/// Three ways to construct one from Python:
 /// - `ObjectStoreProvider(py_obj)` — hold a Python object implementing
 ///   `new_store(base_path, storage_options)`. Registration succeeds; dispatch
 ///   currently raises because the full Python-to-Rust `ObjectStore` bridge
 ///   is a follow-up.
 /// - `ObjectStoreProvider.memory()` — wrap the built-in `MemoryStoreProvider`.
 ///   Registrable under any scheme and fully functional for read/write.
+/// - `ObjectStoreProvider.from_capsule(capsule)` — adopt an
+///   `Arc<dyn ObjectStoreProvider>` produced by a separate, ABI-compatible
+///   wheel (see the module docs on the `PyCapsule` handoff and its lockstep
+///   build requirement). This is how an out-of-tree Rust provider registers
+///   itself without living in the Lance source tree.
 #[pyclass(name = "_ObjectStoreProvider", module = "_lib")]
 #[derive(Clone)]
 pub struct PyObjectStoreProvider {
@@ -103,6 +131,37 @@ impl PyObjectStoreProvider {
         Self {
             inner: Arc::new(PyProviderBridge::Memory(MemoryStoreProvider)),
         }
+    }
+
+    /// Adopt an `Arc<dyn ObjectStoreProvider>` carried in a `PyCapsule` created
+    /// by a separate wheel. The capsule must be named [`PROVIDER_CAPSULE_NAME`]
+    /// and hold exactly an `Arc<dyn ObjectStoreProvider>`.
+    ///
+    /// See the module docstring for the ABI-lockstep requirement: the calling
+    /// wheel must be built against the identical `lance-io` / `object_store`
+    /// source and toolchain as this one.
+    #[staticmethod]
+    fn from_capsule(capsule: &Bound<'_, PyCapsule>) -> PyResult<Self> {
+        match capsule.name()? {
+            Some(name) if name == PROVIDER_CAPSULE_NAME => {}
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "expected a PyCapsule named {:?}, got {:?}",
+                    PROVIDER_CAPSULE_NAME.to_string_lossy(),
+                    other.map(|c| c.to_string_lossy().into_owned()),
+                )));
+            }
+        }
+
+        // SAFETY: by the capsule-name contract above, the capsule carries an
+        // `Arc<dyn ObjectStoreProvider>` built against the identical lance-io /
+        // object_store types (same source, rustc, and resolved dependency
+        // versions). Cloning the `Arc` bumps the strong count; the capsule
+        // retains its own reference and its destructor drops that on GC.
+        let provider = unsafe { capsule.reference::<Arc<dyn ObjectStoreProvider>>() };
+        Ok(Self {
+            inner: provider.clone(),
+        })
     }
 
     fn __repr__(&self) -> String {

--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -91,18 +91,25 @@ impl ObjectStoreProvider for PyProviderBridge {
 
 /// Python-facing wrapper around `Arc<dyn ObjectStoreProvider>`.
 ///
-/// Three ways to construct one from Python:
-/// - `ObjectStoreProvider(py_obj)` — hold a Python object implementing
-///   `new_store(base_path, storage_options)`. Registration succeeds; dispatch
-///   currently raises because the full Python-to-Rust `ObjectStore` bridge
-///   is a follow-up.
-/// - `ObjectStoreProvider.memory()` — wrap the built-in `MemoryStoreProvider`.
-///   Registrable under any scheme and fully functional for read/write.
-/// - `ObjectStoreProvider.from_capsule(capsule)` — adopt an
-///   `Arc<dyn ObjectStoreProvider>` produced by a separate, ABI-compatible
-///   wheel (see the module docs on the `PyCapsule` handoff and its lockstep
-///   build requirement). This is how an out-of-tree Rust provider registers
-///   itself without living in the Lance source tree.
+/// There are three ways to construct one from Python, ordered here by how
+/// complete they are today:
+///
+/// 1. `_ObjectStoreProvider.from_capsule(capsule)` — **fully dispatches.**
+///    Adopt an `Arc<dyn ObjectStoreProvider>` built by a separate,
+///    ABI-compatible wheel and handed over in a `PyCapsule`. `new_store` then
+///    calls that provider's own Rust implementation directly — the
+///    `PyProviderBridge` below is not involved. This is how an out-of-tree Rust
+///    provider (e.g. an on-node NVMe cache) plugs in without living in the
+///    Lance source tree; see the module docs for the `PyCapsule` handoff and
+///    its ABI-lockstep build requirement.
+/// 2. `_ObjectStoreProvider.memory()` — **fully dispatches.** Wrap the built-in
+///    `MemoryStoreProvider`; registrable under any scheme and functional for
+///    read/write. Primarily a test/reference vehicle.
+/// 3. `_ObjectStoreProvider(py_obj)` — **stub; does not dispatch yet.** Hold a
+///    Python object implementing `new_store(base_path, storage_options)`.
+///    Registration succeeds, but dispatch raises `not_supported`: the full
+///    Python-to-Rust `ObjectStore` bridge (calling back into Python from
+///    `new_store` under the GIL) is a follow-up.
 #[pyclass(name = "_ObjectStoreProvider", module = "_lib", from_py_object)]
 #[derive(Clone)]
 pub struct PyObjectStoreProvider {

--- a/python/src/session.rs
+++ b/python/src/session.rs
@@ -11,6 +11,7 @@ use pyo3::{Bound, PyAny, PyResult, pyclass, pymethods};
 use lance::session::{CacheSpec, Session as LanceSession};
 use lance_core::cache::{BackendConfig, build_from_config, build_from_uri};
 
+use crate::object_store::PyObjectStoreRegistry;
 use crate::rt;
 
 /// The Session holds stateful information for a dataset.
@@ -168,12 +169,14 @@ impl Session {
         metadata_cache_size_bytes=None,
         index_cache_backend=None,
         metadata_cache_backend=None,
+        store_registry=None,
     ))]
     fn create(
         index_cache_size_bytes: Option<usize>,
         metadata_cache_size_bytes: Option<usize>,
         index_cache_backend: Option<Bound<'_, PyAny>>,
         metadata_cache_backend: Option<Bound<'_, PyAny>>,
+        store_registry: Option<PyObjectStoreRegistry>,
     ) -> PyResult<Self> {
         let index_cache = resolve_cache_spec(
             "index_cache_backend",
@@ -187,9 +190,9 @@ impl Session {
             "metadata_cache_size_bytes",
             metadata_cache_size_bytes,
         )?;
-
+        let store_registry = store_registry.map(|r| r.inner).unwrap_or_default();
         let session =
-            LanceSession::with_cache_backends(index_cache, metadata_cache, Default::default());
+            LanceSession::with_cache_backends(index_cache, metadata_cache, store_registry);
         Ok(Self {
             inner: Arc::new(session),
         })


### PR DESCRIPTION
## Summary

Exposes Lance's existing Rust `ObjectStoreProvider` registration through the `pylance` bindings, so an **out-of-tree** provider can be registered at process runtime and used transparently by `lance.dataset(...)` / `lance.write_dataset(...)`.

The motivating consumer is an on-node NVMe cache provider that lives in a **separate wheel** — that provider is *not* part of this PR. This PR is only the generic registration surface in `pylance`.

## What this adds (all under `python/`)

| Python surface | Rust | Notes |
| --- | --- | --- |
| `_ObjectStoreRegistry()` | `Arc<ObjectStoreRegistry>` | inherits built-in schemes |
| `registry.register_provider(scheme, provider)` | `ObjectStoreRegistry::insert(...)` | add/override a scheme |
| `Session(store_registry=...)` | threaded into `Session::with_cache_backends(index_cache, metadata_cache, store_registry)` | defaults to `Default::default()`, backward compatible |
| `_ObjectStoreProvider.memory()` | in-tree `MemoryStoreProvider` | fully functional |
| `_ObjectStoreProvider(py_obj)` | Python-callable bridge | **stubbed** (raises on dispatch) — follow-up |
| `_ObjectStoreProvider.from_capsule(capsule)` | adopt `Arc<dyn ObjectStoreProvider>` from another wheel | see below |

Write path: a `Session` carrying a custom registry reaches `write_dataset` via the existing `session=` parameter (the Rust `get_write_params` already extracts it), so writes to a custom scheme resolve through the provider.

Smoke test: `python/python/tests/test_custom_registry.py` (4 cases) registers a made-up `test-mem://` scheme backed by `MemoryStoreProvider` and round-trips a dataset.

## The `PyCapsule` handoff (`from_capsule`)

An out-of-tree provider is compiled Rust, so we hand its `Arc<dyn ObjectStoreProvider>` straight across the Python boundary in a [`PyCapsule`](https://docs.python.org/3/c-api/capsule.html) rather than round-tripping I/O through Python. The external wheel produces a capsule named `lance_object_store_provider`; `from_capsule` validates the capsule name before dereferencing, then clones the `Arc` (the capsule keeps its own strong ref and drops it on GC — no double-free, no leak).

### Why this is sound, and the caveat
- The capsule name is validated before the pointer is dereferenced, so a foreign/mismatched capsule raises `ValueError` instead of reading arbitrary memory.
- **ABI lockstep**: this is a Rust→Rust handoff, sound only when the producer wheel and `pylance` are built against the identical `lance-io` / `object_store` source + resolved dependency versions + toolchain (i.e. **co-compiled**). That guarantees all three — the OSP, pylance, and lance-rust — agree on the vtable layout of `dyn ObjectStoreProvider`. It is **not** the general `object_store` FFI ([apache/arrow-rs-object-store#286](https://github.com/apache/arrow-rs-object-store/issues/286)) and does not round-trip through the GIL.

This deliberately does **not** attempt truly dynamic loading of a provider from a universal shared library — that would require standardizing the ABI of `dyn ObjectStoreProvider` (and `dyn` trait objects generally). For a distributable form, arrow-rs#286 or an in-Lance prototype would be the clean long-term path — happy to discuss which you'd prefer.

## Testing

The change has been exercised for **over a week** by a large-scale ML training stack, reading a logits Lance table over Azure through the (co-compiled, out-of-tree) provider.

## Notes for reviewers
- Rebased onto current `main`; the only non-trivial merge was threading `store_registry` into the newer `Session::with_cache_backends(...)` (which already carries a registry as its third argument, previously `Default::default()`).
- The out-of-tree provider and its `_provider_capsule` producer live in a separate wheel and are intentionally excluded.
- Opened as **draft** for design feedback on the `from_capsule` / co-compilation approach vs. a distributable ABI.

Related: apache/arrow-rs-object-store#286.
