### PR TITLE
feat(python): expose frozen memtable metrics in memtable_stats

### DIFF
--- a/python/python/lance/mem_wal.py
+++ b/python/python/lance/mem_wal.py
@@ -283,7 +283,7 @@ class ShardWriter:
         -------
         dict
             Keys: ``row_count``, ``batch_count``, ``estimated_size_bytes``,
-            ``generation``.
+            ``generation``, ``frozen_count``, ``frozen_bytes``.
         """
         return self._raw.memtable_stats()
 

--- a/python/python/tests/test_mem_wal.py
+++ b/python/python/tests/test_mem_wal.py
@@ -392,6 +392,9 @@ def test_shard_writer_e2e_correctness(tmp_path):
     assert closed_memtable_stats["row_count"] == 0
     assert closed_memtable_stats["batch_count"] == 0
     assert closed_memtable_stats["generation"] >= 1
+    assert "frozen_count" in closed_memtable_stats
+    # close() flushes every frozen memtable, so nothing is still owed to flush.
+    assert closed_memtable_stats["frozen_bytes"] == 0
 
     # === File-system layout ===
     mem_wal_dir = os.path.join(ds_path, "_mem_wal", shard_id)

--- a/python/src/mem_wal.rs
+++ b/python/src/mem_wal.rs
@@ -966,6 +966,8 @@ fn memtable_stats_to_pydict(py: Python<'_>, stats: &MemTableStats) -> PyResult<P
         "pending_wal_estimated_bytes",
         stats.pending_wal_estimated_bytes,
     )?;
+    dict.set_item("frozen_count", stats.frozen_count)?;
+    dict.set_item("frozen_bytes", stats.frozen_bytes)?;
     Ok(dict.into_any().unbind())
 }
 


### PR DESCRIPTION
`MemTableStats` already tracks `frozen_count` and `frozen_bytes`, but the Python binding dropped them on the way out. This adds both keys to the dict returned by `ShardWriter.memtable_stats()`.

- `frozen_count` — frozen memtables in the read view: sealed-awaiting-flush, plus flushed ones still inside `frozen_memtable_grace`.
- `frozen_bytes` — heap bytes still owed to flush. Together with the active memtable's `estimated_size_bytes`, this approximates what backpressure meters against `max_unflushed_memtable_bytes`.

## Testing

Extends the closed-writer stats assertions in `test_mem_wal.py` to cover both keys. Not run locally — no built extension in this worktree, so CI is the first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)