### PR TITLE
feat(compaction): support excluding fragments from planning

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3332,6 +3332,14 @@ fn convert_java_compaction_options_to_rust(
             &[],
         )?
         .l()?;
+    let excluded_fragment_ids = env
+        .call_method(
+            &java_options,
+            "getExcludedFragmentIds",
+            "()Ljava/util/List;",
+            &[],
+        )?
+        .l()?;
 
     build_compaction_options(
         env,
@@ -3348,6 +3356,7 @@ fn convert_java_compaction_options_to_rust(
         &max_source_fragments,
         &max_source_rows,
         &max_source_bytes,
+        &excluded_fragment_ids,
         config,
     )
 }

--- a/java/lance-jni/src/optimize.rs
+++ b/java/lance-jni/src/optimize.rs
@@ -23,8 +23,8 @@ use crate::{
         FromJObjectWithEnv, IntoJava, export_vec, import_vec_from_method, import_vec_to_rust,
     },
     utils::{
-        build_compaction_options, to_java_boolean_obj, to_java_float_obj, to_java_long_obj,
-        to_java_optional,
+        build_compaction_options, to_java_boolean_obj, to_java_float_obj, to_java_list,
+        to_java_long_obj, to_java_optional,
     },
 };
 
@@ -48,6 +48,7 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -66,7 +67,8 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
             binary_copy_read_batch_bytes,
             max_source_fragments,
             max_source_rows,
-            max_source_bytes
+            max_source_bytes,
+            excluded_fragment_ids
         ),
         JObject::null()
     )
@@ -89,6 +91,7 @@ fn inner_plan_compaction<'local>(
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> Result<JObject<'local>> {
     let config = {
         let dataset =
@@ -110,6 +113,7 @@ fn inner_plan_compaction<'local>(
         &max_source_fragments,
         &max_source_rows,
         &max_source_bytes,
+        &excluded_fragment_ids,
         &config,
     )?;
 
@@ -140,6 +144,7 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativeCommitCompacti
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -160,6 +165,7 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativeCommitCompacti
             max_source_fragments,
             max_source_rows,
             max_source_bytes,
+            excluded_fragment_ids,
         ),
         JObject::null()
     )
@@ -183,6 +189,7 @@ fn inner_commit_compaction<'local>(
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> Result<JObject<'local>> {
     let config = {
         let dataset =
@@ -204,6 +211,7 @@ fn inner_commit_compaction<'local>(
         &max_source_fragments,
         &max_source_rows,
         &max_source_bytes,
+        &excluded_fragment_ids,
         &config,
     )?;
     let completed_tasks = import_vec_to_rust(env, &rewrite_results, |env, rewrite_result| {
@@ -243,6 +251,7 @@ pub extern "system" fn Java_org_lance_compaction_CompactionTask_nativeExecute<'l
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -263,7 +272,8 @@ pub extern "system" fn Java_org_lance_compaction_CompactionTask_nativeExecute<'l
             binary_copy_read_batch_bytes,
             max_source_fragments,
             max_source_rows,
-            max_source_bytes
+            max_source_bytes,
+            excluded_fragment_ids
         ),
         JObject::null()
     )
@@ -288,6 +298,7 @@ fn inner_execute_task<'local>(
     max_source_fragments: JObject,            // Optional<Long>
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
+    excluded_fragment_ids: JObject,           // List<Long>
 ) -> Result<JObject<'local>> {
     let task_data: TaskData = task_data.extract_object(env)?;
     let config = {
@@ -310,6 +321,7 @@ fn inner_execute_task<'local>(
         &max_source_fragments,
         &max_source_rows,
         &max_source_bytes,
+        &excluded_fragment_ids,
         &config,
     )?;
     let compaction_task = CompactionTask {
@@ -337,7 +349,7 @@ const REWRITE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/compaction/CompactionMetrics;Ljava/util/List;Ljava/util/List;J[B)V";
 const COMPACTION_OPTIONS_CLASS: &str = "org/lance/compaction/CompactionOptions";
 const COMPACTION_MODE_CLASS: &str = "org/lance/compaction/CompactionMode";
-const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V";
+const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/List;)V";
 
 impl IntoJava for &TaskData {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
@@ -413,6 +425,12 @@ impl IntoJava for &CompactionOptions {
         let max_source_rows_opt = to_java_optional(env, max_source_rows)?;
         let max_source_bytes = to_java_long_obj(env, self.max_source_bytes.map(|v| v as i64))?;
         let max_source_bytes_opt = to_java_optional(env, max_source_bytes)?;
+        let excluded_fragment_ids = self
+            .excluded_fragment_ids
+            .iter()
+            .map(|fragment_id| to_java_long_obj(env, Some(*fragment_id as i64)))
+            .collect::<Result<Vec<_>>>()?;
+        let excluded_fragment_ids = to_java_list(env, &excluded_fragment_ids)?;
 
         Ok(env.new_object(
             COMPACTION_OPTIONS_CLASS,
@@ -431,6 +449,7 @@ impl IntoJava for &CompactionOptions {
                 JValueGen::Object(&max_source_fragments_opt),
                 JValueGen::Object(&max_source_rows_opt),
                 JValueGen::Object(&max_source_bytes_opt),
+                JValueGen::Object(&excluded_fragment_ids),
             ],
         )?)
     }

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -193,6 +193,7 @@ pub fn build_compaction_options(
     max_source_fragments: &JObject,            // Optional<Long>
     max_source_rows: &JObject,                 // Optional<Long>
     max_source_bytes: &JObject,                // Optional<Long>
+    excluded_fragment_ids: &JObject,           // List<Long>
     config: &std::collections::HashMap<String, String>,
 ) -> Result<CompactionOptions> {
     let mut compaction_options = CompactionOptions::from_dataset_config(config)?;
@@ -242,6 +243,19 @@ pub fn build_compaction_options(
     if let Some(max_source_bytes_val) = env.get_long_opt(max_source_bytes)? {
         compaction_options.max_source_bytes = Some(max_source_bytes_val as u64);
     }
+    compaction_options.excluded_fragment_ids = env
+        .get_longs(excluded_fragment_ids)?
+        .into_iter()
+        .map(|fragment_id| {
+            u32::try_from(fragment_id).map_err(|_| {
+                Error::input_error(format!(
+                    "excluded_fragment_ids must contain values between 0 and {}, got {}",
+                    u32::MAX,
+                    fragment_id
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(compaction_options)
 }

--- a/java/src/main/java/org/lance/compaction/Compaction.java
+++ b/java/src/main/java/org/lance/compaction/Compaction.java
@@ -46,7 +46,8 @@ public class Compaction {
         compactionOptions.getBinaryCopyReadBatchBytes(),
         compactionOptions.getMaxSourceFragments(),
         compactionOptions.getMaxSourceRows(),
-        compactionOptions.getMaxSourceBytes());
+        compactionOptions.getMaxSourceBytes(),
+        compactionOptions.getExcludedFragmentIds());
   }
 
   public static CompactionMetrics commitCompaction(
@@ -69,7 +70,8 @@ public class Compaction {
         compactionOptions.getBinaryCopyReadBatchBytes(),
         compactionOptions.getMaxSourceFragments(),
         compactionOptions.getMaxSourceRows(),
-        compactionOptions.getMaxSourceBytes());
+        compactionOptions.getMaxSourceBytes(),
+        compactionOptions.getExcludedFragmentIds());
   }
 
   public static native CompactionMetrics nativeCommitCompaction(
@@ -87,7 +89,8 @@ public class Compaction {
       Optional<Long> binaryCopyReadBatchBytes,
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
-      Optional<Long> maxSourceBytes);
+      Optional<Long> maxSourceBytes,
+      List<Long> excludedFragmentIds);
 
   private static native CompactionPlan nativePlanCompaction(
       Dataset dataset,
@@ -103,5 +106,6 @@ public class Compaction {
       Optional<Long> binaryCopyReadBatchBytes,
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
-      Optional<Long> maxSourceBytes);
+      Optional<Long> maxSourceBytes,
+      List<Long> excludedFragmentIds);
 }

--- a/java/src/main/java/org/lance/compaction/CompactionOptions.java
+++ b/java/src/main/java/org/lance/compaction/CompactionOptions.java
@@ -20,6 +20,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OptionalDataException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -47,6 +50,7 @@ public class CompactionOptions implements Serializable {
   private Optional<Long> maxSourceFragments;
   private Optional<Long> maxSourceRows;
   private Optional<Long> maxSourceBytes;
+  private List<Long> excludedFragmentIds;
 
   private CompactionOptions(
       Optional<Long> targetRowsPerFragment,
@@ -61,7 +65,8 @@ public class CompactionOptions implements Serializable {
       Optional<Long> binaryCopyReadBatchBytes,
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
-      Optional<Long> maxSourceBytes) {
+      Optional<Long> maxSourceBytes,
+      List<Long> excludedFragmentIds) {
     this.targetRowsPerFragment = targetRowsPerFragment;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
@@ -75,6 +80,7 @@ public class CompactionOptions implements Serializable {
     this.maxSourceFragments = maxSourceFragments;
     this.maxSourceRows = maxSourceRows;
     this.maxSourceBytes = maxSourceBytes;
+    this.excludedFragmentIds = List.copyOf(excludedFragmentIds);
   }
 
   public Optional<Boolean> getDeferIndexRemap() {
@@ -100,6 +106,10 @@ public class CompactionOptions implements Serializable {
 
   public Optional<Long> getMaxSourceBytes() {
     return maxSourceBytes;
+  }
+
+  public List<Long> getExcludedFragmentIds() {
+    return excludedFragmentIds;
   }
 
   public Optional<Boolean> getMaterializeDeletions() {
@@ -150,6 +160,7 @@ public class CompactionOptions implements Serializable {
         .add("maxSourceFragments", maxSourceFragments.orElse(null))
         .add("maxSourceRows", maxSourceRows.orElse(null))
         .add("maxSourceBytes", maxSourceBytes.orElse(null))
+        .add("excludedFragmentIds", excludedFragmentIds)
         .toString();
   }
 
@@ -167,6 +178,7 @@ public class CompactionOptions implements Serializable {
     output.writeObject(maxSourceFragments.orElse(null));
     output.writeObject(maxSourceRows.orElse(null));
     output.writeObject(maxSourceBytes.orElse(null));
+    output.writeObject(excludedFragmentIds);
   }
 
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
@@ -192,6 +204,7 @@ public class CompactionOptions implements Serializable {
     this.maxSourceFragments = Optional.ofNullable((Long) input.readObject());
     this.maxSourceRows = readTrailingLong(input);
     this.maxSourceBytes = readTrailingLong(input);
+    this.excludedFragmentIds = readTrailingLongList(input);
   }
 
   /**
@@ -211,6 +224,20 @@ public class CompactionOptions implements Serializable {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private static List<Long> readTrailingLongList(ObjectInputStream input)
+      throws IOException, ClassNotFoundException {
+    try {
+      List<Long> fragmentIds = (List<Long>) input.readObject();
+      return fragmentIds == null ? Collections.emptyList() : List.copyOf(fragmentIds);
+    } catch (OptionalDataException e) {
+      if (!e.eof) {
+        throw e;
+      }
+      return Collections.emptyList();
+    }
+  }
+
   /** Builder for CompactionOptions. */
   public static class Builder {
     private Optional<Long> targetRowsPerFragment = Optional.empty();
@@ -226,6 +253,7 @@ public class CompactionOptions implements Serializable {
     private Optional<Long> maxSourceFragments = Optional.empty();
     private Optional<Long> maxSourceRows = Optional.empty();
     private Optional<Long> maxSourceBytes = Optional.empty();
+    private List<Long> excludedFragmentIds = Collections.emptyList();
 
     private Builder() {}
 
@@ -318,6 +346,26 @@ public class CompactionOptions implements Serializable {
     }
 
     /**
+     * Fragment IDs to exclude from compaction planning. Excluded fragments remain unchanged and act
+     * as boundaries, so fragments on opposite sides are not combined into the same task. Duplicate
+     * and unknown IDs are ignored.
+     *
+     * @throws IllegalArgumentException if an ID is negative or exceeds the unsigned 32-bit range
+     */
+    public Builder withExcludedFragmentIds(List<Long> excludedFragmentIds) {
+      Objects.requireNonNull(excludedFragmentIds, "excludedFragmentIds");
+      for (Long fragmentId : excludedFragmentIds) {
+        if (fragmentId == null || fragmentId < 0 || fragmentId > 0xFFFF_FFFFL) {
+          throw new IllegalArgumentException(
+              "excludedFragmentIds must contain values between 0 and 4294967295, got "
+                  + fragmentId);
+        }
+      }
+      this.excludedFragmentIds = List.copyOf(excludedFragmentIds);
+      return this;
+    }
+
+    /**
      * A max source budget of zero admits no work and a negative value would wrap around to an
      * effectively unlimited budget on the Rust side, so both are rejected here. Leave the option
      * unset for no limit.
@@ -344,7 +392,8 @@ public class CompactionOptions implements Serializable {
           binaryCopyReadBatchBytes,
           maxSourceFragments,
           maxSourceRows,
-          maxSourceBytes);
+          maxSourceBytes,
+          excludedFragmentIds);
     }
   }
 }

--- a/java/src/main/java/org/lance/compaction/CompactionTask.java
+++ b/java/src/main/java/org/lance/compaction/CompactionTask.java
@@ -18,6 +18,7 @@ import org.lance.Dataset;
 import com.google.common.base.MoreObjects;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 
 /** The compaction task which can be sent across network and executed individually. */
@@ -58,7 +59,8 @@ public class CompactionTask implements Serializable {
         compactionOptions.getBinaryCopyReadBatchBytes(),
         compactionOptions.getMaxSourceFragments(),
         compactionOptions.getMaxSourceRows(),
-        compactionOptions.getMaxSourceBytes());
+        compactionOptions.getMaxSourceBytes(),
+        compactionOptions.getExcludedFragmentIds());
   }
 
   private native RewriteResult nativeExecute(
@@ -77,7 +79,8 @@ public class CompactionTask implements Serializable {
       Optional<Long> binaryCopyReadBatchBytes,
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
-      Optional<Long> maxSourceBytes);
+      Optional<Long> maxSourceBytes,
+      List<Long> excludedFragmentIds);
 
   public CompactionOptions getCompactionOptions() {
     return compactionOptions;

--- a/java/src/test/java/org/lance/CompactionTest.java
+++ b/java/src/test/java/org/lance/CompactionTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Optional;
@@ -147,6 +148,41 @@ public class CompactionTest {
     }
   }
 
+  @Test
+  public void testExcludedFragmentIds(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("test_excluded_fragment_ids").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      testDataset.write(1, 10).close();
+      testDataset.write(2, 10).close();
+      testDataset.write(3, 10).close();
+      try (Dataset dataset = testDataset.write(4, 10)) {
+        CompactionOptions options =
+            CompactionOptions.builder()
+                .withTargetRowsPerFragment(100)
+                .withExcludedFragmentIds(Arrays.asList(1L, 1L, 999L))
+                .build();
+
+        CompactionPlan plan = Compaction.planCompaction(dataset, options);
+
+        assertEquals(
+            Arrays.asList(1L, 1L, 999L), plan.getCompactionOptions().getExcludedFragmentIds());
+        assertEquals(1, plan.getCompactionTasks().size());
+        assertEquals(2, plan.getCompactionTasks().get(0).getTaskData().getFragments().size());
+        assertEquals(
+            2, plan.getCompactionTasks().get(0).getTaskData().getFragments().get(0).getId());
+        assertEquals(
+            3, plan.getCompactionTasks().get(0).getTaskData().getFragments().get(1).getId());
+
+        CompactionTask task = serializeAndDeserialize(plan.getCompactionTasks().get(0));
+        assertEquals(
+            Arrays.asList(1L, 1L, 999L), task.getCompactionOptions().getExcludedFragmentIds());
+      }
+    }
+  }
+
   @ParameterizedTest
   @EnumSource(CompactionMode.class)
   public void testCompactionModeRoundTrip(CompactionMode mode, @TempDir Path tempDir)
@@ -212,6 +248,7 @@ public class CompactionTest {
     // Fields absent from the old stream deserialize as unset.
     assertEquals(Optional.empty(), options.getMaxSourceRows());
     assertEquals(Optional.empty(), options.getMaxSourceBytes());
+    assertEquals(Collections.emptyList(), options.getExcludedFragmentIds());
   }
 
   private static <T> T serializeAndDeserialize(T object)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7149,6 +7149,7 @@ class DatasetOptimizer:
         max_source_fragments: Optional[int] = None,
         max_source_rows: Optional[int] = None,
         max_source_bytes: Optional[int] = None,
+        excluded_fragment_ids: Optional[list[int]] = None,
     ) -> CompactionMetrics:
         """Compacts small files in the dataset, reducing total number of files.
 
@@ -7253,6 +7254,11 @@ class DatasetOptimizer:
             would exceed this limit. Blob v2 payloads live in separate
             blob files and are not counted, so this is not a cap on total
             compaction I/O for datasets with blob columns.
+        excluded_fragment_ids: list[int], optional
+            Fragment IDs to exclude from compaction planning. Excluded
+            fragments remain unchanged and act as boundaries, so fragments
+            on opposite sides are not combined into the same compaction task.
+            Duplicate and unknown IDs are ignored.
 
         Returns
         -------
@@ -7279,6 +7285,7 @@ class DatasetOptimizer:
                 max_source_fragments=max_source_fragments,
                 max_source_rows=max_source_rows,
                 max_source_bytes=max_source_bytes,
+                excluded_fragment_ids=excluded_fragment_ids,
             ).items()
             if v is not None
         }

--- a/python/python/lance/optimize.py
+++ b/python/python/lance/optimize.py
@@ -114,3 +114,10 @@ class CompactionOptions(TypedDict):
     columns.
     (default: None, no limit)
     """
+    excluded_fragment_ids: Optional[list[int]]
+    """
+    Fragment IDs to exclude from compaction planning. Excluded fragments
+    remain unchanged and act as boundaries, so fragments on opposite sides
+    are not combined into the same task. Duplicate and unknown IDs are
+    ignored. (default: None)
+    """

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -583,6 +583,31 @@ def test_dataset_distributed_optimize(tmp_path: Path):
     assert plan.tasks[0].fragments == [frag.metadata for frag in fragments[0:2]]
     assert plan.tasks[1].fragments == [frag.metadata for frag in fragments[2:4]]
     assert repr(plan) == "CompactionPlan(read_version=1, tasks=<2 compaction tasks>)"
+
+    excluded_plan = Compaction.plan(
+        dataset,
+        options=dict(
+            target_rows_per_fragment=400,
+            excluded_fragment_ids=[1, 1, 999],
+            num_threads=1,
+        ),
+    )
+    assert excluded_plan.num_tasks() == 1
+    assert excluded_plan.tasks[0].fragments == [
+        frag.metadata for frag in fragments[2:4]
+    ]
+    assert pickle.loads(pickle.dumps(excluded_plan)) == excluded_plan
+
+    none_plan = Compaction.plan(
+        dataset,
+        options=dict(
+            target_rows_per_fragment=400,
+            excluded_fragment_ids=None,
+            num_threads=1,
+        ),
+    )
+    assert none_plan == plan
+
     # Plan can be pickled
     assert pickle.loads(pickle.dumps(plan)) == plan
 

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -41,6 +41,27 @@ def test_dataset_optimize(tmp_path: Path):
     assert dataset.version == 3
 
 
+def test_dataset_optimize_excluded_fragment_ids(tmp_path: Path):
+    dataset = lance.write_dataset(
+        pa.table({"a": range(800)}),
+        tmp_path / "dataset",
+        max_rows_per_file=200,
+    )
+    fragments = dataset.get_fragments()
+
+    metrics = dataset.optimize.compact_files(
+        target_rows_per_fragment=400,
+        excluded_fragment_ids=[1, 1, 999],
+        num_threads=1,
+    )
+
+    assert metrics.fragments_removed == 2
+    remaining_fragment_ids = {
+        fragment.fragment_id for fragment in dataset.get_fragments()
+    }
+    assert fragments[1].fragment_id in remaining_fragment_ids
+
+
 def test_compact_files_source_budgets(tmp_path: Path):
     base_dir = tmp_path / "dataset"
     data = pa.table({"a": range(1000), "b": range(1000)})

--- a/python/src/dataset/optimize.rs
+++ b/python/src/dataset/optimize.rs
@@ -82,6 +82,10 @@ fn parse_compaction_options(
             "max_source_bytes" => {
                 opts.max_source_bytes = value.extract()?;
             }
+            "excluded_fragment_ids" => {
+                opts.excluded_fragment_ids =
+                    value.extract::<Option<Vec<u32>>>()?.unwrap_or_default();
+            }
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "Invalid compaction option: {}",

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -285,6 +285,14 @@ pub struct CompactionOptions {
     /// columns.
     /// Defaults to `None` (no limit).
     pub max_source_bytes: Option<u64>,
+    /// Fragment IDs to exclude from compaction planning.
+    ///
+    /// Excluded fragments act as boundaries between adjacent compaction candidates,
+    /// so fragments on opposite sides of an exclusion are never combined into the
+    /// same task. IDs that are duplicated or absent from the dataset are ignored.
+    /// Defaults to an empty list.
+    #[serde(default)]
+    pub excluded_fragment_ids: Vec<u32>,
     /// Maximum number of data overlay files a fragment may carry before it is
     /// fully compacted. When set, any fragment with more than this many overlays
     /// is rewritten into a fresh fragment with its overlays (and deletions)
@@ -325,6 +333,7 @@ impl Default for CompactionOptions {
             max_source_fragments: None,
             max_source_rows: None,
             max_source_bytes: None,
+            excluded_fragment_ids: Vec::new(),
             max_overlays_per_fragment: Some(10),
             transaction_properties: None,
         }
@@ -709,12 +718,17 @@ pub trait CompactionPlanner: Send + Sync {
 #[derive(Debug, Clone, Default)]
 pub struct DefaultCompactionPlanner {
     options: CompactionOptions,
+    excluded_fragment_ids: RoaringBitmap,
 }
 
 impl DefaultCompactionPlanner {
     pub fn new(mut options: CompactionOptions) -> Result<Self> {
         options.validate()?;
-        Ok(Self { options })
+        let excluded_fragment_ids = options.excluded_fragment_ids.iter().copied().collect();
+        Ok(Self {
+            options,
+            excluded_fragment_ids,
+        })
     }
 }
 
@@ -739,10 +753,15 @@ impl CompactionPlanner for DefaultCompactionPlanner {
             "fragments in manifest are not sorted"
         );
         let mut fragment_metrics = futures::stream::iter(fragments)
-            .map(|fragment| async move {
-                match collect_metrics(&fragment).await {
-                    Ok(metrics) => Ok((fragment.metadata, metrics)),
-                    Err(e) => Err(e),
+            .map(|fragment| async {
+                if u32::try_from(fragment.id())
+                    .is_ok_and(|fragment_id| self.excluded_fragment_ids.contains(fragment_id))
+                {
+                    Ok(None)
+                } else {
+                    collect_metrics(&fragment)
+                        .await
+                        .map(|metrics| Some((fragment.metadata, metrics)))
                 }
             })
             .buffered(dataset.object_store.as_ref().io_parallelism());
@@ -762,7 +781,16 @@ impl CompactionPlanner for DefaultCompactionPlanner {
         let mut i = 0;
 
         while let Some(res) = fragment_metrics.next().await {
-            let (fragment, metrics) = res?;
+            let Some((fragment, metrics)) = res? else {
+                // Exclusions preserve adjacency semantics: they terminate the
+                // current bin instead of allowing candidates on either side to
+                // be planned together.
+                if let Some(bin) = current_bin.take() {
+                    candidate_bins.push(bin);
+                }
+                i += 1;
+                continue;
+            };
 
             let over_overlay_limit = self
                 .options
@@ -7657,6 +7685,50 @@ mod tests {
             1
         );
         dataset
+    }
+
+    #[tokio::test]
+    async fn test_excluded_fragments_are_planning_boundaries() {
+        let test_dir = TempStrDir::default();
+        let mut dataset = dataset_with_ten_small_fragments(&test_dir).await;
+        let excluded_fragment_id = 4;
+        let options = CompactionOptions {
+            target_rows_per_fragment: 250,
+            excluded_fragment_ids: vec![excluded_fragment_id, excluded_fragment_id, u32::MAX],
+            ..Default::default()
+        };
+
+        let plan = plan_compaction(&dataset, &options).await.unwrap();
+        let planned_fragment_ids = plan
+            .tasks()
+            .iter()
+            .map(|task| {
+                task.fragments
+                    .iter()
+                    .map(|fragment| fragment.id as u32)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            planned_fragment_ids,
+            vec![vec![0, 1, 2, 3], vec![5, 6, 7, 8, 9]]
+        );
+        assert!(
+            planned_fragment_ids
+                .iter()
+                .flatten()
+                .all(|fragment_id| *fragment_id != excluded_fragment_id)
+        );
+
+        let metrics = compact_files(&mut dataset, options, None).await.unwrap();
+        assert_eq!(metrics.fragments_removed, 9);
+        let remaining_fragment_ids = dataset
+            .get_fragments()
+            .iter()
+            .map(|fragment| fragment.id() as u32)
+            .collect::<Vec<_>>();
+        assert!(remaining_fragment_ids.contains(&excluded_fragment_id));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add `excluded_fragment_ids` to compaction planning options
- treat excluded fragments as hard planning boundaries and skip collecting their metrics
- expose the option consistently through Rust, Python (including `dataset.optimize.compact_files`), and Java/JNI
- preserve Java deserialization compatibility for older serialized compaction options

## Semantics

Excluded fragments remain unchanged. Fragments on opposite sides of an excluded fragment are not combined into the same compaction task. Duplicate and unknown IDs are ignored.

## Validation

- `cargo test -p lance dataset::optimize::tests` (123 passed)
- `cargo clippy -p lance --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `uv run pytest python/tests/test_optimize.py` (22 passed)
- `uv run make lint`
- `./mvnw -Dtest=CompactionTest test` (7 Java tests and 17 JNI Rust tests passed)
- `./mvnw spotless:apply`
- `cargo clippy --tests --manifest-path ./lance-jni/Cargo.toml`