### PR TITLE
perf(index): route fp16 IVF partition assignment through an AMX-FP16 GEMM

### DIFF
--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -488,3 +488,32 @@ rows with 768 dimensions and 1 bit per dimension:
 ```
 100M * (768 / 8 + 16) = ~10.8 GiB
 ```
+
+#### AMX Acceleration
+
+On Linux x86_64 with an AMX-FP16 CPU (Intel Granite Rapids / Xeon 6 and newer), a `float16`
+vector column indexed with `dot` distance uses the AMX tile instructions, provided the build
+machine had clang >= 16 or gcc >= 13 to compile the kernel. There is nothing to enable —
+Lance checks the CPU at run time and falls back to the previous implementation everywhere else.
+
+The accelerated paths are also shape-gated, because below these sizes a tile pass costs more
+than it saves and the kernel declines the work:
+
+| Condition | Why |
+|---|---|
+| `float16` vectors, `dot` distance | The kernel is fp16-specific; other types and metrics keep their existing paths |
+| `dimension >= 32` | One tile pass covers 32 dimensions; a shorter vector would be all scalar cleanup |
+| `num_centroids >= 32` | The GEMM steps its centroid loop by 32 and has no partial-tile path |
+
+Anything outside them behaves exactly as it does today, so a small dataset or a low-dimensional
+column simply keeps the previous implementation rather than changing behaviour.
+
+Index build also changes algorithm where all of the above hold: comparing every vector against
+every centroid becomes affordable, so partition assignment is exact instead of approximated with
+a graph search over the centroids. Recall improves, and partition assignments differ from what an
+older build produced.
+
+Set `LANCE_DISABLE_AMX=1` to take the AMX paths out of service without rebuilding — for
+A/B measurement, or to get the previous behaviour back. Because it also moves partition
+assignment back to the approximate path, an index built with it set is not equivalent to one
+built without it; compare recall, not just build time.

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -26,8 +26,12 @@ use arrow_array::{ArrowNumericType, UInt8Array};
 use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{ArrowError, DataType};
 use bitvec::prelude::*;
+use half::f16;
 use lance_arrow::FixedSizeListArrayExt;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_linalg::distance::dot_f16::{
+    PackedCentroidsF16, amx_fp16_available, amx_fp16_supported, dot_f16_batch_16,
+};
 use lance_linalg::distance::hamming::{hamming, hamming_distance_batch};
 use lance_linalg::distance::{DistanceType, Normalize, dot_distance_batch};
 use lance_linalg::kernels::{argmin_value_float, argmin_value_float_with_bias};
@@ -324,6 +328,112 @@ pub trait KMeansAlgo<T: Num> {
     ) -> KMeans;
 }
 
+/// Reads a `T::Native` slice as `f16` when — and only when — that is what it is.
+///
+/// The default body answers `None`, so every element type opts out until it
+/// says otherwise, and [`Float16Type`] is the one that overrides it with the
+/// identity. That keeps "is this f16?" a compile-time property of `T` for the
+/// dot-distance kernel below, rather than a `DataType` comparison paired with a
+/// transmute whose correctness the compiler cannot check.
+pub(crate) trait MaybeF16: ArrowNumericType {
+    fn as_f16_slice(_values: &[Self::Native]) -> Option<&[f16]> {
+        None
+    }
+}
+
+impl MaybeF16 for Float16Type {
+    fn as_f16_slice(values: &[f16]) -> Option<&[f16]> {
+        Some(values)
+    }
+}
+impl MaybeF16 for Float32Type {}
+impl MaybeF16 for Float64Type {}
+
+/// Per-thread score-buffer budget for [`dot_membership_amx_f16`], in f32
+/// values: 256 KB, sized to stay within a typical private L2 alongside the
+/// vectors and packed centroids a block streams past.
+const AMX_DOT_SCRATCH_F32: usize = 64 * 1024;
+
+/// Assigns each row of `data` (row-major `[_, dimension]`) to its nearest
+/// centroid under dot distance using the AMX-FP16 GEMM, scoring 32 vectors
+/// against every centroid per tile pass instead of one vector at a time.
+///
+/// `None` — the kernel is unavailable on this build or host, or the shape does
+/// not suit it — means the caller must run its own per-vector path. The output
+/// is otherwise identical in content and order to that path: `(centroid,
+/// distance)` per row, `None` for a row whose distances are all NaN.
+///
+/// Answers only "can this shape run here": the `LANCE_DISABLE_AMX` kill switch
+/// is checked by the caller, so the accelerated path stays directly testable
+/// while production traffic honours an operator who turned it off.
+fn dot_membership_amx_f16(
+    centroids: &[f16],
+    data: &[f16],
+    dimension: usize,
+    balance_factor: f32,
+    cluster_sizes: Option<&[usize]>,
+) -> Option<Vec<Option<(u32, f32)>>> {
+    let k = centroids.len() / dimension;
+    // Under one full 32-wide k-pass the GEMM degenerates to the kernel's scalar
+    // cleanup, and under one full 32-centroid block most of its work would be
+    // the zero padding. Neither is worth leaving the per-vector path for.
+    if dimension < 32 || k < 32 {
+        return None;
+    }
+    let packed = PackedCentroidsF16::new(centroids, k, dimension)?;
+    let n_padded = packed.num_centroids_padded();
+    // Rows per block: as many as the scratch budget buys, rounded down to the
+    // kernel's 32-row granularity, and capped so a large input still splits
+    // into enough blocks to spread across threads. Very large `k` blows the
+    // budget on a single row, hence the lower clamp back to one tile pass.
+    let block_rows = ((AMX_DOT_SCRATCH_F32 / n_padded) & !31).clamp(32, 512);
+    // Precomputed once, not per row. The bias depends only on the centroid, so
+    // rebuilding it inside the loop would repeat `k` multiplications for every
+    // one of the `n` vectors -- `n * k` of them across the call, against `k` here.
+    let biases: Option<Vec<f32>> = cluster_sizes.map(|sizes| {
+        sizes
+            .iter()
+            .map(|size| balance_factor * *size as f32)
+            .collect()
+    });
+    let biases = || biases.as_deref().map(|b| b.iter().copied());
+
+    Some(
+        data.par_chunks(block_rows * dimension)
+            .map_init(
+                || vec![0f32; block_rows * n_padded],
+                |scores, block| {
+                    let rows = block.len() / dimension;
+                    let tiled = rows - rows % 32;
+                    let mut assignments = Vec::with_capacity(rows);
+
+                    packed.score(block, tiled, dimension, scores, n_padded);
+                    for row in 0..tiled {
+                        // Only the first `k` columns. The rest score the zero
+                        // centroids padding `n` up to the kernel's block size,
+                        // at distance exactly 1.0 — which beats every real
+                        // centroid whose dot product happens to be negative.
+                        let dots = &scores[row * n_padded..row * n_padded + k];
+                        assignments.push(argmin_value_float_with_bias(
+                            dots.iter().map(|dot| 1.0 - dot),
+                            biases(),
+                        ));
+                    }
+                    // Rows past the last whole tile pass keep the per-vector path.
+                    for vector in block[tiled * dimension..].chunks(dimension) {
+                        assignments.push(argmin_value_float_with_bias(
+                            dot_distance_batch(vector, centroids, dimension),
+                            biases(),
+                        ));
+                    }
+                    assignments
+                },
+            )
+            .flatten_iter()
+            .collect(),
+    )
+}
+
 pub struct KMeansAlgoFloat<T: ArrowNumericType>
 where
     T::Native: Float + Num,
@@ -331,7 +441,7 @@ where
     phantom_data: std::marker::PhantomData<T>,
 }
 
-impl<T: ArrowNumericType> KMeansAlgo<T::Native> for KMeansAlgoFloat<T>
+impl<T: ArrowNumericType + MaybeF16> KMeansAlgo<T::Native> for KMeansAlgoFloat<T>
 where
     T::Native: Float + Dot + L2 + MulAssign + DivAssign + AddAssign + FromPrimitive + Sync,
     PrimitiveArray<T>: From<Vec<T::Native>>,
@@ -368,16 +478,34 @@ where
                         )
                     })
                     .collect::<Vec<_>>(),
-                DistanceType::Dot => data
-                    .par_chunks(dimension)
-                    .map(|vec| {
-                        argmin_value_float_with_bias(
-                            dot_distance_batch(vec, centroids, dimension),
-                            cluster_sizes
-                                .map(|size| size.iter().map(|size| balance_factor * *size as f32)),
+                DistanceType::Dot => T::as_f16_slice(centroids)
+                    .zip(T::as_f16_slice(data))
+                    // The kill switch is enforced here rather than inside the
+                    // kernel wrapper: this is the one place production work is
+                    // routed onto the GEMM, and `prefers_flat_amx_assignment`
+                    // reads the same flag, so the two stay in lockstep.
+                    .filter(|_| amx_fp16_available())
+                    .and_then(|(centroids, data)| {
+                        dot_membership_amx_f16(
+                            centroids,
+                            data,
+                            dimension,
+                            balance_factor,
+                            cluster_sizes,
                         )
                     })
-                    .collect::<Vec<_>>(),
+                    .unwrap_or_else(|| {
+                        data.par_chunks(dimension)
+                            .map(|vec| {
+                                argmin_value_float_with_bias(
+                                    dot_distance_batch(vec, centroids, dimension),
+                                    cluster_sizes.map(|size| {
+                                        size.iter().map(|size| balance_factor * *size as f32)
+                                    }),
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    }),
                 _ => {
                     panic!(
                         "KMeans::find_partitions: {} is not supported",
@@ -1169,6 +1297,7 @@ impl KMeans {
 
         // Construct final KMeans model with all centroids
         let mut all_clusters: Vec<Cluster<T::Native>> = heap.into_vec();
+
         // Sort by ID to ensure consistent ordering
         all_clusters.sort_by_key(|c| c.id);
 
@@ -1268,12 +1397,22 @@ pub fn kmeans_find_partitions_arrow_array(
     }
 
     match (centroids.value_type(), query.data_type()) {
-        (DataType::Float16, DataType::Float16) => Ok(kmeans_find_partitions(
-            centroids.values().as_primitive::<Float16Type>().values(),
-            query.as_primitive::<Float16Type>().values(),
-            nprobes,
-            distance_type,
-        )?),
+        (DataType::Float16, DataType::Float16) => {
+            let centroids = centroids.values().as_primitive::<Float16Type>().values();
+            let query = query.as_primitive::<Float16Type>().values();
+            if distance_type == DistanceType::Dot
+                && amx_fp16_available()
+                && let Some(dists) = dot_f16_partitions_amx(centroids, query)
+            {
+                return smallest_nprobes(dists, nprobes);
+            }
+            Ok(kmeans_find_partitions(
+                centroids,
+                query,
+                nprobes,
+                distance_type,
+            )?)
+        }
         (DataType::Float32, DataType::Float32) => Ok(kmeans_find_partitions(
             centroids.values().as_primitive::<Float32Type>().values(),
             query.as_primitive::<Float32Type>().values(),
@@ -1303,6 +1442,69 @@ pub fn kmeans_find_partitions_arrow_array(
 /// KMeans finds N nearest partitions.
 ///
 /// Parameters:
+/// The `nprobes` smallest distances and the partitions they belong to.
+fn smallest_nprobes(
+    dists: Vec<f32>,
+    nprobes: usize,
+) -> arrow::error::Result<(UInt32Array, Float32Array)> {
+    // TODO: use heap to just keep nprobes smallest values.
+    let dists_arr = Float32Array::from(dists);
+    let indices = sort_to_indices(&dists_arr, None, Some(nprobes))?;
+    let dists = arrow::compute::take(&dists_arr, &indices, None)?
+        .as_primitive::<Float32Type>()
+        .clone();
+    Ok((indices, dists))
+}
+
+/// `Dot` distances from `query` to every centroid, through the AMX-FP16 kernel,
+/// or `None` when this build/CPU/shape cannot use it.
+///
+/// Partition selection is one query against every centroid, so on paper it needs
+/// well under 1% of this machine's arithmetic. It measured at 33% of a saturated
+/// IVF_HNSW_SQ query because `dot_f16_avx512` carries no vector instruction at
+/// all under GCC 13.4 -- disassembly shows 30 `vcvtsh2ss` / 15 `vmulss` /
+/// 14 `vaddss` and zero `zmm` operands, since GCC has no packed `_Float16` ->
+/// `float` widening pattern. The scalar loop, not the work, is the cost.
+///
+/// Sixteen centroids at a time rather than the `M x N` GEMM: the GEMM steps its
+/// centroid loop by 32 and would spend 31 of every 32 output columns on padding
+/// for a single query (16 MAC/cycle), while this shape wastes 15 of 16 and
+/// reaches 32 MAC/cycle. Those rates count tile work only; each call also pays
+/// one LDTILECFG plus one TILERELEASE, which at these shapes is the larger term.
+/// Beating either needs several queries scored together, which the per-query
+/// search API does not offer.
+fn dot_f16_partitions_amx(centroids: &[f16], query: &[f16]) -> Option<Vec<f32>> {
+    let dim = query.len();
+    // Below one full 32-wide k-pass the kernel is all scalar cleanup, so a dim
+    // that short would run at a loss. Support, not the `LANCE_DISABLE_AMX` kill
+    // switch: the caller has already decided to use AMX, and this only declines
+    // shapes the kernel cannot pay for.
+    if dim < 32 || !amx_fp16_supported() {
+        return None;
+    }
+    debug_assert_eq!(centroids.len() % dim, 0);
+
+    let mut dists = vec![0f32; centroids.len() / dim];
+    let row = |i: usize| &centroids[i * dim..(i + 1) * dim];
+    for (g, out) in dists.chunks_mut(16).enumerate() {
+        let base = g * 16;
+        // `dot_f16_batch_16` requires 16 slices of the query's length even when
+        // only `len` of them are scored, so the tail repeats a valid row; those
+        // lanes are computed and discarded.
+        let mut group: [&[f16]; 16] = [row(base); 16];
+        for (i, slot) in group.iter_mut().enumerate().take(out.len()) {
+            *slot = row(base + i);
+        }
+        // The kernel returns raw dot products; `Dot` distance is `1 - dot`, the
+        // same convention `dot_distance_batch` applies.
+        let dots = dot_f16_batch_16(query, &group, out.len());
+        for (d, dot) in out.iter_mut().zip(dots.iter()) {
+            *d = 1.0 - *dot;
+        }
+    }
+    Some(dists)
+}
+
 /// - *centroids*: a `k * dimension` floating array.
 /// - *query*: a `dimension` floating array.
 /// - *nprobes*: the number of partitions to find.
@@ -1328,13 +1530,7 @@ pub fn kmeans_find_partitions<T: Float + L2 + Dot>(
         }
     };
 
-    // TODO: use heap to just keep nprobes smallest values.
-    let dists_arr = Float32Array::from(dists);
-    let indices = sort_to_indices(&dists_arr, None, Some(nprobes))?;
-    let dists = arrow::compute::take(&dists_arr, &indices, None)?
-        .as_primitive::<Float32Type>()
-        .clone();
-    Ok((indices, dists))
+    smallest_nprobes(dists, nprobes)
 }
 
 pub fn kmeans_find_partitions_binary(
@@ -1559,8 +1755,46 @@ mod tests {
     use lance_testing::datagen::generate_random_array;
 
     use super::*;
+    use lance_linalg::distance::dot_f16::amx_fp16_supported;
     use lance_linalg::distance::l2;
     use lance_linalg::kernels::argmin;
+
+    /// The AMX partition path must pick the same partitions as the scalar one.
+    /// Exact equality on the distances is not required -- the kernel accumulates
+    /// in a different order -- but the chosen partition ids must match, since a
+    /// different choice silently changes which vectors a query can ever see.
+    #[test]
+    fn test_amx_find_partitions_matches_scalar() {
+        if !amx_fp16_supported() {
+            return;
+        }
+        // (dim, k): a production shape, one with a partial 16-group tail, and one
+        // whose dimension is not a multiple of the kernel's 32-wide k-pass.
+        for (dim, k) in [(768usize, 10_000usize), (768, 37), (133, 100)] {
+            let mut st = 0x9E37u64;
+            let mut next = || {
+                st = st.wrapping_mul(6364136223846793005).wrapping_add(1);
+                f16::from_f32(((st >> 33) as f32 / (1u64 << 31) as f32) - 0.5)
+            };
+            let centroids: Vec<f16> = (0..k * dim).map(|_| next()).collect();
+            let query: Vec<f16> = (0..dim).map(|_| next()).collect();
+
+            let amx = dot_f16_partitions_amx(&centroids, &query)
+                .expect("the AMX path declined a shape it should accept");
+            let scalar: Vec<f32> = dot_distance_batch(&query[..], &centroids[..], dim).collect();
+            assert_eq!(amx.len(), scalar.len(), "dim={dim} k={k}");
+
+            for nprobes in [1usize, 8, 32] {
+                let (amx_idx, _) = smallest_nprobes(amx.clone(), nprobes).unwrap();
+                let (scalar_idx, _) = smallest_nprobes(scalar.clone(), nprobes).unwrap();
+                assert_eq!(
+                    amx_idx.values(),
+                    scalar_idx.values(),
+                    "dim={dim} k={k} nprobes={nprobes} picked different partitions"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_train_with_small_dataset() {
@@ -1770,6 +2004,370 @@ mod tests {
             msg.contains("Cannot create") && msg.contains(&TARGET_K.to_string()),
             "unexpected error message: {msg}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // AMX-FP16 dot-distance assignment
+    // -----------------------------------------------------------------------
+
+    /// Relative tolerance between the AMX and per-vector distances. Both
+    /// accumulate f32-widened products and differ only in summation order, so
+    /// this is far looser than what they actually differ by (~1e-4) and far
+    /// tighter than fp16's own representational error.
+    const AMX_REL_TOL: f32 = 5e-3;
+
+    /// A vector this much nearer its best centroid than its runner-up cannot
+    /// change hands on summation order alone. Closer ties are allowed to
+    /// disagree — that is fp16 arithmetic, not a bug.
+    const AMX_TIE_GAP: f32 = 1e-2;
+
+    fn random_f16(count: usize, rng: &mut SmallRng) -> Vec<f16> {
+        (0..count)
+            .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+            .collect()
+    }
+
+    /// Assert the AMX dot path engages for this input and assigns every vector
+    /// where the per-vector path does.
+    fn assert_dot_paths_agree(
+        centroids: &[f16],
+        data: &[f16],
+        dimension: usize,
+        balance_factor: f32,
+        cluster_sizes: Option<&[usize]>,
+        ctx: &str,
+    ) {
+        let k = centroids.len() / dimension;
+        // The AMX path's own output, not `compute_membership_and_dist`'s: that
+        // entry point falls back to the per-vector path whenever this one
+        // declines, so going through it would silently degrade this into a
+        // scalar-against-scalar comparison on any host or build that lacks the
+        // kernel, and prove nothing about it.
+        let amx = dot_membership_amx_f16(centroids, data, dimension, balance_factor, cluster_sizes)
+            .unwrap_or_else(|| {
+                panic!("{ctx}: the AMX path declined this shape, so agreeing proves nothing")
+            });
+
+        for (i, vector) in data.chunks(dimension).enumerate() {
+            let row = dot_distance_batch(vector, centroids, dimension).collect::<Vec<_>>();
+            let want = argmin_value_float_with_bias(
+                row.iter().copied(),
+                cluster_sizes.map(|sizes| sizes.iter().map(|size| balance_factor * *size as f32)),
+            );
+            let got = amx[i];
+            let (Some((want_id, _)), Some((got_id, got_dist))) = (want, got) else {
+                assert_eq!(
+                    want.is_none(),
+                    got.is_none(),
+                    "{ctx}: row {i} is assigned by one path only: {want:?} vs {got:?}"
+                );
+                continue;
+            };
+
+            assert!(
+                (got_id as usize) < k,
+                "{ctx}: row {i} landed on centroid {got_id}, outside the {k} real ones"
+            );
+            // Check the reported distance against the reported centroid's own
+            // rather than against the winner's: on a near-tie the paths may
+            // pick different centroids, and then only this identity has to hold.
+            let want_dist = row[got_id as usize];
+            assert!(
+                (got_dist - want_dist).abs() <= AMX_REL_TOL * want_dist.abs() + 1e-3,
+                "{ctx}: row {i} centroid {got_id} distance {got_dist}, want {want_dist}"
+            );
+
+            let mut biased = row
+                .iter()
+                .enumerate()
+                .map(|(j, dist)| {
+                    dist + cluster_sizes.map_or(0.0, |sizes| balance_factor * sizes[j] as f32)
+                })
+                .collect::<Vec<_>>();
+            biased.sort_by(f32::total_cmp);
+            if biased[1] - biased[0] > AMX_TIE_GAP {
+                assert_eq!(
+                    got_id, want_id,
+                    "{ctx}: row {i} is not a tie ({} vs {}) but the paths disagree",
+                    biased[0], biased[1]
+                );
+            }
+        }
+    }
+
+    /// The two paths across the shapes that exercise each boundary: `k` on and
+    /// off the kernel's 32-centroid block (so with and without zero padding),
+    /// `dim` with and without the kernel's scalar tail, and row counts on and
+    /// off the 32-row tile pass (so with and without trailing fallback rows).
+    #[test]
+    fn test_dot_amx_matches_per_vector_path() {
+        if !amx_fp16_supported() {
+            return;
+        }
+        let mut rng = SmallRng::seed_from_u64(0xD07);
+        for k in [32usize, 64, 100] {
+            for dimension in [32usize, 64, 768] {
+                for n in [64usize, 100, 1000] {
+                    let centroids = random_f16(k * dimension, &mut rng);
+                    let data = random_f16(n * dimension, &mut rng);
+                    assert_dot_paths_agree(
+                        &centroids,
+                        &data,
+                        dimension,
+                        0.0,
+                        None,
+                        &format!("k={k} dim={dimension} n={n}"),
+                    );
+                }
+            }
+        }
+    }
+
+    /// The padding columns must be unreachable by the argmin.
+    ///
+    /// `k` is not a multiple of 32, so the GEMM's `n` block is filled out with
+    /// zero centroids, which score a dot product of 0 — distance exactly 1.0.
+    /// Here every real dot product is negative, so every real distance exceeds
+    /// 1.0 and a reduction over the padded row width would hand *every* vector
+    /// a cluster id past the end of the centroid set.
+    #[test]
+    fn test_dot_amx_padding_columns_never_win() {
+        if !amx_fp16_supported() {
+            return;
+        }
+        const K: usize = 100;
+        const DIM: usize = 64;
+        const N: usize = 128;
+
+        let mut rng = SmallRng::seed_from_u64(0xBAD5);
+        let negate = |v: &f16| f16::from_f32(-v.to_f32().abs() - 0.1);
+        let centroids = random_f16(K * DIM, &mut rng)
+            .iter()
+            .map(negate)
+            .collect::<Vec<_>>();
+        let data = random_f16(N * DIM, &mut rng)
+            .iter()
+            .map(|v| f16::from_f32(v.to_f32().abs() + 0.1))
+            .collect::<Vec<_>>();
+
+        for vector in data.chunks(DIM) {
+            assert!(
+                dot_distance_batch(vector, &centroids, DIM).all(|dist| dist > 1.0),
+                "premise broken: a real centroid is nearer than the zero padding"
+            );
+        }
+        assert_dot_paths_agree(&centroids, &data, DIM, 0.0, None, "padding");
+    }
+
+    /// The bias path. `argmin_value_float_with_bias` minimizes `distance +
+    /// bias` but reports the unbiased distance, so both halves of that have to
+    /// survive the AMX path; the balance factor is sized to actually move
+    /// assignments, which the test asserts rather than assumes.
+    #[test]
+    fn test_dot_amx_with_balance_bias() {
+        if !amx_fp16_supported() {
+            return;
+        }
+        const K: usize = 64;
+        const DIM: usize = 128;
+        const N: usize = 256;
+        const BALANCE_FACTOR: f32 = 0.02;
+
+        let mut rng = SmallRng::seed_from_u64(0xB1A5);
+        let centroids = random_f16(K * DIM, &mut rng);
+        let data = random_f16(N * DIM, &mut rng);
+        let cluster_sizes = (0..K).map(|id| id * 4).collect::<Vec<_>>();
+
+        assert_dot_paths_agree(
+            &centroids,
+            &data,
+            DIM,
+            BALANCE_FACTOR,
+            Some(&cluster_sizes),
+            "bias",
+        );
+
+        let assign = |balance_factor, sizes| {
+            KMeansAlgoFloat::<Float16Type>::compute_membership_and_dist(
+                &centroids,
+                &data,
+                DIM,
+                DistanceType::Dot,
+                balance_factor,
+                sizes,
+                None,
+            )
+            .0
+        };
+        assert_ne!(
+            assign(BALANCE_FACTOR, Some(cluster_sizes.as_slice())),
+            assign(0.0, None),
+            "the balance factor is too small to move any assignment"
+        );
+    }
+
+    /// A row of NaNs has no nearest centroid — `distance + bias < min` is false
+    /// for every centroid — and the AMX path has to reach the same `None` as
+    /// the per-vector one instead of defaulting to cluster 0. Covered in both
+    /// the tiled rows and the trailing rows that fall back per vector.
+    #[test]
+    fn test_dot_amx_all_nan_row_is_unassigned() {
+        if !amx_fp16_supported() {
+            return;
+        }
+        const K: usize = 64;
+        const DIM: usize = 64;
+        const N: usize = 100; // 3 full tile passes, then 4 fallback rows
+        const NAN_ROWS: [usize; 2] = [7, 98];
+
+        let mut rng = SmallRng::seed_from_u64(0x4A4);
+        let centroids = random_f16(K * DIM, &mut rng);
+        let mut data = random_f16(N * DIM, &mut rng);
+        for row in NAN_ROWS {
+            data[row * DIM..(row + 1) * DIM].fill(f16::NAN);
+        }
+
+        assert_dot_paths_agree(&centroids, &data, DIM, 0.0, None, "nan");
+
+        let (membership, _) = KMeansAlgoFloat::<Float16Type>::compute_membership_and_dist(
+            &centroids,
+            &data,
+            DIM,
+            DistanceType::Dot,
+            0.0,
+            None,
+            None,
+        );
+        for (row, cluster_id) in membership.iter().enumerate() {
+            assert_eq!(
+                cluster_id.is_none(),
+                NAN_ROWS.contains(&row),
+                "row {row} membership {cluster_id:?}"
+            );
+        }
+    }
+
+    /// Wall-clock throughput of the dot-distance assignment the AMX path above
+    /// accelerates, swept over `(threads, dim, k)`.
+    ///
+    /// The path is picked inside `compute_membership_and_dist` from run-time
+    /// capability and the data's shape, so there is nothing to toggle per
+    /// iteration: run this same binary twice — once as-is for the AMX path, once
+    /// with `LANCE_DISABLE_AMX=1` for the per-vector path — and divide. The
+    /// header line reports which path the process took, so the two outputs
+    /// cannot be confused.
+    ///
+    /// Each point runs for a wall-clock budget rather than a fixed pass count, so
+    /// a 1-thread point and an all-core point take comparable time and every
+    /// point averages over enough work to be stable.
+    ///
+    /// `#[ignore]` -- run:
+    ///   cargo test -p lance-index --release \
+    ///     kmeans_dot_f16_membership_bench -- --ignored --nocapture
+    /// Tune with `BENCH_N`, `BENCH_DIMS` / `BENCH_KS` / `BENCH_THREADS`
+    /// (comma-separated; threads default `<ncpu>,32,1`) and `BENCH_SECONDS` (the
+    /// wall-clock budget each measured point gets).
+    #[test]
+    #[ignore]
+    #[allow(clippy::print_stderr)]
+    fn kmeans_dot_f16_membership_bench() {
+        use std::time::{Duration, Instant};
+
+        let env_usize = |key: &str, default: usize| -> usize {
+            std::env::var(key)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(default)
+        };
+        let env_list = |key: &str, default: &[usize]| -> Vec<usize> {
+            std::env::var(key)
+                .ok()
+                .map(|s| s.split(',').filter_map(|t| t.trim().parse().ok()).collect())
+                .unwrap_or_else(|| default.to_vec())
+        };
+
+        let n = env_usize("BENCH_N", 65_536);
+        let dims = env_list("BENCH_DIMS", &[128, 768, 1536]);
+        let ks = env_list("BENCH_KS", &[32, 64, 128, 256, 1024, 4096]);
+        let ncpu = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        let thread_counts = env_list("BENCH_THREADS", &[ncpu, 32, 1]);
+        let budget = Duration::from_secs_f64(
+            std::env::var("BENCH_SECONDS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(3.0),
+        );
+
+        eprintln!(
+            "[kmeans_dot_f16_bench] n={n} ncpu={ncpu} budget={:.1}s amx_fp16_available={}",
+            budget.as_secs_f64(),
+            amx_fp16_available(),
+        );
+
+        let mut rng = SmallRng::seed_from_u64(0x9E37);
+        for &dimension in &dims {
+            // Random data *and* random centroids: with degenerate inputs every
+            // vector would reduce to the same centroid and the argmin's branches
+            // and the score buffer's access pattern would both be unrealistic.
+            let data = random_f16(n * dimension, &mut rng);
+            for &k in &ks {
+                if k >= n {
+                    eprintln!(
+                        "[kmeans_dot_f16_bench]   dim={dimension} k={k}: skipped, k must be < n={n}"
+                    );
+                    continue;
+                }
+                let centroids = random_f16(k * dimension, &mut rng);
+                for &nthreads in &thread_counts {
+                    if nthreads == 0 || nthreads > ncpu {
+                        eprintln!(
+                            "[kmeans_dot_f16_bench]   dim={dimension} k={k} threads={nthreads}: skipped, not in 1..={ncpu}"
+                        );
+                        continue;
+                    }
+                    // A private pool so the sweep sets the width exactly, without
+                    // reconfiguring (or being limited by) the global one.
+                    let pool = rayon::ThreadPoolBuilder::new()
+                        .num_threads(nthreads)
+                        .build()
+                        .unwrap();
+                    let run_pass = || {
+                        pool.install(|| {
+                            KMeansAlgoFloat::<Float16Type>::compute_membership_and_dist(
+                                &centroids,
+                                &data,
+                                dimension,
+                                DistanceType::Dot,
+                                0.0,
+                                None,
+                                None,
+                            )
+                        })
+                    };
+                    let warm = run_pass(); // page-in and thread spin-up, untimed
+                    std::hint::black_box(&warm);
+                    drop(warm);
+
+                    let t0 = Instant::now();
+                    let mut passes = 0usize;
+                    while t0.elapsed() < budget {
+                        let assigned = run_pass();
+                        std::hint::black_box(&assigned);
+                        passes += 1;
+                    }
+                    let elapsed = t0.elapsed().as_secs_f64();
+                    let vectors = passes * n;
+                    let vec_per_s = vectors as f64 / elapsed;
+                    eprintln!(
+                        "[kmeans_dot_f16_bench]   dim={dimension:>5} k={k:>5} threads={nthreads:>4} passes={passes:>6} vec_per_s={vec_per_s:>12.0} us_per_vec={:>9.4} Gpair_per_s={:>8.2}",
+                        1e6 / vec_per_s,
+                        vec_per_s * k as f64 / 1e9,
+                    );
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/vector/residual.rs
+++ b/rust/lance-index/src/vector/residual.rs
@@ -5,7 +5,7 @@ use std::ops::{AddAssign, DivAssign};
 use std::sync::Arc;
 use std::{iter, ops::MulAssign};
 
-use crate::vector::kmeans::{KMeansAlgoFloat, compute_partitions};
+use crate::vector::kmeans::{KMeansAlgoFloat, MaybeF16, compute_partitions};
 use arrow_array::ArrowNumericType;
 use arrow_array::{
     Array, FixedSizeListArray, PrimitiveArray, RecordBatch, UInt32Array,
@@ -53,7 +53,7 @@ impl ResidualTransform {
     }
 }
 
-fn do_compute_residual<T: ArrowNumericType>(
+fn do_compute_residual<T: ArrowNumericType + MaybeF16>(
     centroids: &FixedSizeListArray,
     vectors: &FixedSizeListArray,
     distance_type: Option<DistanceType>,

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -12,6 +12,7 @@ use arrow_schema::{DataType, Field};
 use lance_arrow::{BufferExt, DataTypeExt, FixedSizeListArrayExt};
 use lance_core::{Error, Result};
 use lance_linalg::distance::DistanceType;
+use lance_linalg::distance::dot_f16::amx_fp16_available;
 use prost::bytes;
 use std::sync::LazyLock;
 use std::{ops::Range, sync::Arc};
@@ -43,6 +44,49 @@ static USE_HNSW_SPEEDUP_INDEXING: LazyLock<SimpleIndexStatus> = LazyLock::new(||
         SimpleIndexStatus::Auto
     }
 });
+
+/// Whether partition assignment is better served by the exact flat path than by
+/// an approximate lookup through this index.
+///
+/// The index turns one `M x N` problem -- every vector against every centroid --
+/// into `M` independent top-1 graph searches. Each search walks its own path, so
+/// no two vectors share a candidate set and the AMX-FP16 kernel behind them can
+/// only ever score one query against a handful of neighbors: 32 MAC/cycle, one
+/// of the tile's 16 output columns. Keeping the problem in its matrix shape lets
+/// [`crate::vector::kmeans::compute_partitions`] reach the AMX-FP16 GEMM, which
+/// fills all four accumulator tiles at 512 MAC/cycle.
+///
+/// Measured on 100M x 768 fp16 (dot, node-local, m=20, ef_construction=150), the
+/// flat path won on both build time and recall at every `k` tried:
+///
+/// | k     | flat        | indexed     |
+/// |-------|-------------|-------------|
+/// | 10000 | 1965s / .980 | 2011s / .976 |
+/// | 20000 | 2494s / .964 | 2588s / .832 |
+/// | 40000 | 3730s / .970 | 3976s / .940 |
+///
+/// The recall gap is the larger effect: the graph lookup runs at `ef = 15`, so
+/// some vectors land in a partition that is not their nearest and no `nprobes`
+/// setting recovers them. Flat assignment is exact.
+///
+/// The conditions below must stay in lockstep with the AMX gate in
+/// `compute_membership_and_dist`; without the GEMM the flat path is ~2.7x slower
+/// than the index (5361s vs 2011s at k=10000), so a mismatch here is expensive.
+/// That includes the `LANCE_DISABLE_AMX` kill switch, which both consult through
+/// [`amx_fp16_available`]: an operator turning AMX off has to move this decision
+/// too, or the build would take the exact-assignment path with no GEMM under it.
+fn prefers_flat_amx_assignment(
+    centroid_type: &DataType,
+    num_centroids: usize,
+    dimension: usize,
+    distance_type: DistanceType,
+) -> bool {
+    centroid_type == &DataType::Float16
+        && distance_type == DistanceType::Dot
+        && dimension >= 32
+        && num_centroids >= 32
+        && amx_fp16_available()
+}
 
 #[derive(Debug)]
 pub struct SimpleIndex {
@@ -77,6 +121,7 @@ impl SimpleIndex {
     //  - `num_centroids * dimension >= 1_000_000`
     //      we benchmarked that it's 2x faster in the case of 1024 centroids and 1024 dimensions,
     //      so set the threshold to 1_000_000.
+    //  - the exact flat assignment is not already faster, see `prefers_flat_amx_assignment`
     pub fn may_train_index(
         centroids: ArrayRef,
         dimension: usize,
@@ -85,6 +130,14 @@ impl SimpleIndex {
         match *USE_HNSW_SPEEDUP_INDEXING {
             SimpleIndexStatus::Auto => {
                 if centroids.len() < 1_000_000 {
+                    return Ok(None);
+                }
+                if prefers_flat_amx_assignment(
+                    centroids.data_type(),
+                    centroids.len() / dimension,
+                    dimension,
+                    distance_type,
+                ) {
                     return Ok(None);
                 }
             }
@@ -408,5 +461,41 @@ mod tests {
 
         let error = FixedSizeListArray::try_from(&tensor).unwrap_err();
         assert!(error.to_string().contains("requires 8 bytes"));
+    }
+
+    /// Every shape the AMX-FP16 GEMM cannot serve must keep the centroid index,
+    /// because without the GEMM the flat path it would fall back to is ~2.7x
+    /// slower than the index. These four are the exact complement of the gate in
+    /// `compute_membership_and_dist`.
+    #[rstest]
+    #[case::not_f16(&DataType::Float32, 10_000, 768, DistanceType::Dot)]
+    #[case::not_dot(&DataType::Float16, 10_000, 768, DistanceType::L2)]
+    #[case::dim_below_one_k_pass(&DataType::Float16, 10_000, 31, DistanceType::Dot)]
+    #[case::k_below_one_b_block(&DataType::Float16, 31, 768, DistanceType::Dot)]
+    fn test_flat_amx_assignment_declines_unsupported_shapes(
+        #[case] centroid_type: &DataType,
+        #[case] num_centroids: usize,
+        #[case] dimension: usize,
+        #[case] distance_type: DistanceType,
+    ) {
+        assert!(!prefers_flat_amx_assignment(
+            centroid_type,
+            num_centroids,
+            dimension,
+            distance_type
+        ));
+    }
+
+    /// On a supported shape the decision is exactly "is AMX-FP16 usable here",
+    /// which is a property of the build, the CPU and the `LANCE_DISABLE_AMX`
+    /// kill switch, so the expectation is derived rather than hardcoded -- the
+    /// same assertion has to hold with the switch set, on a machine without AMX,
+    /// and in a build whose toolchain could not compile the kernel.
+    #[test]
+    fn test_flat_amx_assignment_follows_amx_availability() {
+        assert_eq!(
+            prefers_flat_amx_assignment(&DataType::Float16, 10_000, 768, DistanceType::Dot),
+            amx_fp16_available()
+        );
     }
 }

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -17,12 +17,14 @@ fn main() -> Result<(), String> {
 
     // Let clippy know about our custom cfg attribute
     println!(
-        "cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512_f16\", \"avx512_bf16\", \"avx512_dist_table\"))"
+        "cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512_f16\", \"avx512_bf16\", \"avx512_dist_table\", \"amx_fp16\"))"
     );
 
     println!("cargo:rerun-if-changed=src/simd/f16.c");
     println!("cargo:rerun-if-changed=src/simd/bf16.c");
     println!("cargo:rerun-if-changed=src/simd/dist_table.c");
+    println!("cargo:rerun-if-changed=src/simd/amx_fp16.c");
+    println!("cargo:rerun-if-env-changed=LANCE_AMX_FP16_CC");
 
     // Important: we don't use `cfg!(target_arch)` here because that is the target_arch
     // for the build script, not the target_arch for the library. Similar story for
@@ -84,6 +86,28 @@ fn main() -> Result<(), String> {
         } else {
             println!("cargo:rustc-cfg=kernel_support=\"avx512_dist_table\"");
         };
+        // Build the AMX-FP16 batched f16 dot-product kernel (Granite Rapids+).
+        //
+        // No cargo feature of its own: whether it can be built is a property of
+        // the toolchain, not a choice the user makes. `-mamx-fp16` needs clang
+        // >= 16 or gcc >= 13, so a capable compiler is probed for below; if none
+        // is found we warn, skip the kernel, and leave `kernel_support` unset.
+        //
+        // Linux only: every Rust-side cfg gate on this kernel also demands
+        // `target_os = "linux"`, and entering it needs XTILEDATA from
+        // `arch_prctl(ARCH_REQ_XCOMP_PERM)`, which is Linux-specific.
+        if target_os == "linux" {
+            if let Err(err) =
+                build_amx_fp16_with_flags(&["-march=sapphirerapids", "-mamx-fp16", "-mamx-tile"])
+            {
+                println!(
+                    "cargo:warning=Skipping build of AMX-FP16 kernels. Error: {}",
+                    err
+                );
+            } else {
+                println!("cargo:rustc-cfg=kernel_support=\"amx_fp16\"");
+            };
+        }
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang
         // has support for __fp16 going back to at least clang 6.
@@ -195,4 +219,97 @@ fn build_dist_table_with_flags(suffix: &str, flags: &[&str]) -> Result<(), cc::E
         builder.flag(flag);
     }
     builder.try_compile(&format!("dist_table_{}", suffix))
+}
+
+/// Compile the AMX-FP16 kernel. Unlike the other kernels this may need a
+/// different C compiler: `_tile_dpfp16ps` / `-mamx-fp16` require clang >= 16 or
+/// gcc >= 13, which is often newer than the platform default `cc`. We probe for
+/// a capable compiler (respecting a `LANCE_AMX_FP16_CC` override) and use it
+/// only for this one file; everything else keeps using the default toolchain.
+fn build_amx_fp16_with_flags(flags: &[&str]) -> Result<(), String> {
+    let compiler = find_amx_fp16_compiler(flags).ok_or_else(|| {
+        "no C compiler supporting -mamx-fp16 found (need clang>=16 or gcc>=13; \
+         set LANCE_AMX_FP16_CC to override)"
+            .to_string()
+    })?;
+    let mut builder = cc::Build::new();
+    builder
+        .compiler(&compiler)
+        .std("c17")
+        .file("src/simd/amx_fp16.c")
+        .flag("-funroll-loops")
+        .flag("-O3")
+        .flag("-Wall")
+        .flag("-Wextra");
+    for flag in flags {
+        builder.flag(flag);
+    }
+    builder.try_compile("amx_fp16").map_err(|e| e.to_string())
+}
+
+/// Find a C compiler that can build the AMX-FP16 kernel with `flags`, in order:
+/// the `LANCE_AMX_FP16_CC` override, the default toolchain `cc`, then common
+/// modern clang names. Returns the first that compiles a `_tile_dpfp16ps` probe.
+fn find_amx_fp16_compiler(flags: &[&str]) -> Option<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(cc) = env::var("LANCE_AMX_FP16_CC") {
+        candidates.push(cc);
+    }
+    if let Ok(default_cc) = cc::Build::new()
+        .get_compiler()
+        .path()
+        .to_str()
+        .ok_or(())
+        .map(str::to_string)
+    {
+        candidates.push(default_cc);
+    }
+    for c in ["clang-18", "clang-17", "clang-16", "clang"] {
+        candidates.push(c.to_string());
+    }
+    candidates
+        .into_iter()
+        .find(|cc| cc_supports_amx_fp16(cc, flags))
+}
+
+/// True iff invoking `cc` with `flags` can compile a translation unit that uses
+/// `_tile_dpfp16ps`. `-Werror=implicit-function-declaration` turns gcc's
+/// "intrinsic not declared" *warning* (which otherwise still exits 0 on the
+/// too-old gcc that lacks amx-fp16) into a hard failure.
+fn cc_supports_amx_fp16(cc: &str, flags: &[&str]) -> bool {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let src = b"#include <immintrin.h>\n\
+        void t(const void* a, const void* b) {\n\
+        _tile_loadd(1, a, 64); _tile_loadd(2, b, 4);\n\
+        _tile_dpfp16ps(0, 1, 2); _tile_release(); }\n";
+    let out = env::var("OUT_DIR")
+        .map(|d| format!("{d}/amx_fp16_probe.o"))
+        .unwrap_or_else(|_| "/dev/null".to_string());
+
+    let mut cmd = Command::new(cc);
+    cmd.args(flags)
+        .args([
+            "-Werror=implicit-function-declaration",
+            "-x",
+            "c",
+            "-c",
+            "-",
+            "-o",
+        ])
+        .arg(&out)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let Ok(mut child) = cmd.spawn() else {
+        return false;
+    };
+    if let Some(mut stdin) = child.stdin.take()
+        && stdin.write_all(src).is_err()
+    {
+        return false;
+    }
+    child.wait().map(|s| s.success()).unwrap_or(false)
 }

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -19,6 +19,7 @@ use arrow_schema::{ArrowError, DataType};
 pub mod cosine;
 pub mod cosine_u8;
 pub mod dot;
+pub mod dot_f16;
 pub mod dot_u8;
 pub mod hamming;
 pub mod l2;

--- a/rust/lance-linalg/src/distance/dot_f16.rs
+++ b/rust/lance-linalg/src/distance/dot_f16.rs
@@ -1,0 +1,1299 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Batched f16 dot product with an optional AMX-FP16 tile backend.
+//!
+//! Used by IVF over an fp16 column under dot distance: [`dot_f16_batch_16`]
+//! scores one query against 16 centroids when choosing the partitions to probe,
+//! and the GEMM behind [`PackedCentroidsF16`] assigns vectors to partitions
+//! while an index is built.
+//!
+//! [`dot_f16_batch_16`] returns the 16 raw dot products `Σ query·candidate`
+//! (same value convention as [`crate::distance::dot()`]); the caller applies the
+//! `1.0 - dot` distance wrapping. On Linux/x86_64 hosts with AMX-FP16 it
+//! dispatches to a single tile pass; everywhere else (and on any AMX
+//! unavailability) it falls back to 16 independent [`crate::distance::dot()`]
+//! calls, which are bit-identical to the per-vector scalar path.
+//!
+//! Two gates cover all of this, and they are deliberately separate:
+//! [`amx_fp16_supported`] answers whether the tile instructions can run here at
+//! all, and [`amx_fp16_available`] adds the `LANCE_DISABLE_AMX` kill switch on
+//! top. The kernels here are guarded by the former so tests can always reach
+//! them; callers routing production work consult the latter. AMX is on by
+//! default — the switch exists for A/B measurement and for getting the previous
+//! path back without a rebuild.
+//!
+//! Unlike integer AMX kernels this is floating point: the AMX and fallback paths
+//! are **not** bit-for-bit identical (tile accumulation order rounds
+//! differently), but both accumulate products in f32 and agree to within fp16
+//! precision — a relative error on the order of 1e-4, far below fp16's own
+//! representational error, so recall is unaffected.
+
+use half::f16;
+
+use crate::distance::dot::dot;
+
+/// Batched f16 dot product: the raw dot products of one `query` against the
+/// first `len` of 16 `candidates`, in order. Every candidate slice must have the
+/// same length as `query`, and `len` must be in `1..=16`.
+///
+/// A batch is shorter than 16 only in the last group of a sweep, when the
+/// centroid count is not a multiple of 16. `len` keeps the `16 - len` padding
+/// rows out of the kernel's staging copy; with at most one short group per
+/// sweep that saves much less than it would for a caller whose batches were
+/// usually partial. Lanes `len..16` are returned as `0` rather than left
+/// unspecified, so both the AMX and fallback paths agree exactly on what a
+/// caller that reads past `len` sees.
+///
+/// Safe to call unconditionally: the caller never needs to know whether AMX is
+/// present. The function panics if any candidate has a different length from
+/// `query`, or if `len` is out of range, rather than allowing a malformed batch
+/// to reach the FFI kernel. See the module docs for the accuracy contract.
+#[inline]
+pub fn dot_f16_batch_16(query: &[f16], candidates: &[&[f16]; 16], len: usize) -> [f32; 16] {
+    assert!(
+        candidates
+            .iter()
+            .all(|candidate| candidate.len() == query.len()),
+        "all candidate vectors must have the same length as query"
+    );
+    assert!(
+        (1..=16).contains(&len),
+        "batch length must be in 1..=16, got {len}"
+    );
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    {
+        // AMX only earns its tile-config overhead once there is at least one
+        // full 32-wide pass; for tiny dims the fallback is cheaper anyway.
+        if query.len() >= 32 && crate::simd::amx_fp16::amx_supported() {
+            return unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(query, candidates, len) };
+        }
+    }
+    dot_f16_batch_16_fallback(query, candidates, len)
+}
+
+/// Fallback for [`dot_f16_batch_16`]: `len` independent [`crate::distance::dot()`]
+/// calls — bit-identical to the per-vector scalar path (both go through
+/// `f16::dot`) — and `0` for the remaining lanes, matching what the kernel
+/// leaves there. Exposed separately so tests can exercise it regardless of host.
+#[inline]
+pub(crate) fn dot_f16_batch_16_fallback(
+    query: &[f16],
+    candidates: &[&[f16]; 16],
+    len: usize,
+) -> [f32; 16] {
+    std::array::from_fn(|i| {
+        if i < len {
+            dot(query, candidates[i])
+        } else {
+            0.0
+        }
+    })
+}
+
+/// Centroids pre-packed into the layout the AMX-FP16 GEMM reads its B operand
+/// in, together with the scoring entry point that consumes them.
+///
+/// This type exists unconditionally, and construction is the only gate:
+/// [`PackedCentroidsF16::new`] returns `None` on a build or host without the
+/// kernel. Callers in other crates cannot see lance-linalg's `kernel_support`
+/// cfg, so an `Option` at run time is the only form of the gate they can branch
+/// on to keep their own fallback path.
+///
+/// Packing costs `O(k * dim)` and is done once here rather than per block of
+/// vectors, where it would outweigh the GEMM it feeds.
+pub struct PackedCentroidsF16(Packed);
+
+/// [`PackedCentroidsF16`]'s payload — and the reason that type needs no `cfg`
+/// of its own: without the kernel this is uninhabited, so `PackedCentroidsF16`
+/// is too. `new` provably cannot return `Some`, which is what lets the methods
+/// discharge their bodies against a value that cannot exist instead of carrying
+/// a fallback implementation that could never run.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+struct Packed {
+    /// Zero-padded `[n_padded, dim]` centroids, row-major and tight. Held
+    /// because the kernel reads the unpacked centroids directly for the
+    /// `dim % 32` tail dims, which are not part of the packed layout.
+    centroids: Vec<f16>,
+    /// `centroids` in the kernel's VNNI B-tile order.
+    packed: Vec<f16>,
+    n_padded: usize,
+    dim: usize,
+}
+
+#[cfg(not(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+)))]
+enum Packed {}
+
+/// How many elements a buffer must hold for `m` rows of `row_len`, `stride`
+/// apart — `(m - 1) * stride + row_len` — or `None` if that overflows `usize`.
+///
+/// The checked arithmetic is the point. Written inline, the expression wraps
+/// silently in release builds, and a wrapped requirement is *small*, so it
+/// satisfies the very length check it was computed for: `m = 32`,
+/// `stride = 595_056_260_442_243_601`, `row_len = 32` wraps to 47, admitting a
+/// 47-element slice into a kernel that then strides `data + i * stride` past its
+/// end. Every caller here is a safe function guarding an FFI boundary, so an
+/// overflow has to be rejected rather than folded into a comparison.
+///
+/// Zero rows need zero elements. Handling that here rather than leaving it to
+/// the caller keeps the function total: `m - 1` would underflow, which panics in
+/// debug builds and wraps to `usize::MAX` in release ones — the same class of
+/// silent wrap this function exists to prevent.
+pub(crate) fn strided_len(m: usize, stride: usize, row_len: usize) -> Option<usize> {
+    let Some(last_row) = m.checked_sub(1) else {
+        return Some(0);
+    };
+    last_row.checked_mul(stride)?.checked_add(row_len)
+}
+
+impl PackedCentroidsF16 {
+    /// Packs `n` row-major `dim`-dimensional `centroids` for repeated scoring.
+    ///
+    /// `None` means the GEMM is unavailable — this build has no kernel, this
+    /// host cannot run it (both are [`amx_fp16_supported`]), or the shape is
+    /// empty — and the caller must keep using its own path. There is no partial
+    /// mode. Whether an operator has taken the AMX paths out of service is a
+    /// separate question, answered by [`amx_fp16_available`] at the caller's
+    /// routing decision, so that tests can build one of these regardless.
+    ///
+    /// `n` is rounded up to a multiple of 32 with zero centroids, since the
+    /// kernel blocks its `n` loop by 32 and has no partial-tile path. The
+    /// padding is visible to [`score`](Self::score)'s output and callers must
+    /// account for it; see [`num_centroids_padded`](Self::num_centroids_padded).
+    ///
+    /// # Panics
+    /// If `centroids` does not hold exactly `n * dim` values.
+    pub fn new(centroids: &[f16], n: usize, dim: usize) -> Option<Self> {
+        let expected = n
+            .checked_mul(dim)
+            .unwrap_or_else(|| panic!("centroid shape n = {n} x dim = {dim} overflows usize"));
+        assert_eq!(
+            centroids.len(),
+            expected,
+            "centroids must hold n*dim = {expected} values, got {}",
+            centroids.len()
+        );
+        if n == 0 || dim == 0 || !amx_fp16_supported() {
+            return None;
+        }
+        #[cfg(all(
+            kernel_support = "amx_fp16",
+            target_arch = "x86_64",
+            target_os = "linux"
+        ))]
+        {
+            // Same checked-size contract as the length guards below: this
+            // allocation is what the kernel later reads through a raw pointer,
+            // so a shape whose padded size is not representable is rejected
+            // here rather than wrapped into an allocation smaller than the rows
+            // the kernel will address. `packed_centroids_len` needs no separate
+            // check -- `(dim / 32) * (n_padded / 16) * 512 <= n_padded * dim`
+            // for every input, so it cannot overflow once this one holds.
+            let n_padded = n.checked_next_multiple_of(32).unwrap_or_else(|| {
+                panic!("padding n = {n} up to a multiple of 32 overflows usize")
+            });
+            let padded_len = n_padded.checked_mul(dim).unwrap_or_else(|| {
+                panic!("padded centroid shape {n_padded} x dim = {dim} overflows usize")
+            });
+            let mut padded = vec![f16::ZERO; padded_len];
+            padded[..centroids.len()].copy_from_slice(centroids);
+            let mut packed =
+                Vec::with_capacity(crate::simd::amx_fp16::packed_centroids_len(n_padded, dim));
+            crate::simd::amx_fp16::pack_centroids_vnni(&padded, n_padded, dim, &mut packed);
+            return Some(Self(Packed {
+                centroids: padded,
+                packed,
+                n_padded,
+                dim,
+            }));
+        }
+        #[allow(unreachable_code)]
+        None
+    }
+
+    /// The centroid count [`score`](Self::score) actually writes per row: the
+    /// `n` given to [`new`](Self::new) rounded up to a multiple of 32.
+    pub fn num_centroids_padded(&self) -> usize {
+        self.shape().0
+    }
+
+    /// `(padded centroid count, dim)`. The single place the uninhabited-payload
+    /// build is discharged, so the methods above it read as ordinary code.
+    fn shape(&self) -> (usize, usize) {
+        #[cfg(all(
+            kernel_support = "amx_fp16",
+            target_arch = "x86_64",
+            target_os = "linux"
+        ))]
+        {
+            (self.0.n_padded, self.0.dim)
+        }
+        #[cfg(not(all(
+            kernel_support = "amx_fp16",
+            target_arch = "x86_64",
+            target_os = "linux"
+        )))]
+        {
+            match self.0 {}
+        }
+    }
+
+    /// Scores `m` vectors against every centroid: `out[i * out_stride + j]` is
+    /// the raw dot product `Σ data_i·centroid_j` — the same value convention as
+    /// [`crate::distance::dot()`], with no `1.0 - d` distance wrapping.
+    ///
+    /// Row `i` of `data` starts at `i * data_stride`, so both buffers may be
+    /// windows of larger ones. Columns `n..num_centroids_padded()` are the zero
+    /// padding centroids' scores; they are `0.0` for any finite input, which
+    /// *beats* a real centroid whose dot product is negative. A caller reducing
+    /// across a row must therefore stop at its own centroid count.
+    ///
+    /// See the module docs for the accuracy contract against the scalar path.
+    ///
+    /// # Panics
+    /// If `m` is not a multiple of 32 (the kernel blocks its `m` loop by 32 and
+    /// has no partial-tile path), if either stride is too small, or if either
+    /// slice is too short for the last row its stride reaches.
+    pub fn score(
+        &self,
+        data: &[f16],
+        m: usize,
+        data_stride: usize,
+        out: &mut [f32],
+        out_stride: usize,
+    ) {
+        let (n_padded, dim) = self.shape();
+        assert_eq!(m % 32, 0, "m ({m}) must be a multiple of 32");
+        assert!(
+            data_stride >= dim,
+            "data_stride ({data_stride}) is below dim ({dim})"
+        );
+        assert!(
+            out_stride >= n_padded,
+            "out_stride ({out_stride}) is below the padded centroid count ({n_padded})"
+        );
+        if m == 0 {
+            return;
+        }
+        let data_needed = strided_len(m, data_stride, dim).unwrap_or_else(|| {
+            panic!("m = {m} rows of dim {dim} at stride {data_stride} overflow usize")
+        });
+        assert!(
+            data.len() >= data_needed,
+            "data ({}) holds fewer than m = {m} rows of dim {dim} at stride {data_stride}",
+            data.len()
+        );
+        let out_needed = strided_len(m, out_stride, n_padded).unwrap_or_else(|| {
+            panic!("m = {m} rows of {n_padded} at stride {out_stride} overflow usize")
+        });
+        assert!(
+            out.len() >= out_needed,
+            "out ({}) holds fewer than m = {m} rows of {n_padded} at stride {out_stride}",
+            out.len()
+        );
+        #[cfg(all(
+            kernel_support = "amx_fp16",
+            target_arch = "x86_64",
+            target_os = "linux"
+        ))]
+        // SAFETY: the kernel's preconditions are exactly the asserts above plus
+        // AMX availability. `n_padded % 32 == 0` and the packing / length
+        // agreement between `packed`, `centroids`, `n_padded` and `dim` hold by
+        // construction in `new`, which also proved `amx_fp16_supported()` — a
+        // process-wide, monotonic property (CPUID plus a one-time, idempotent
+        // XTILEDATA grant), so it cannot have lapsed since.
+        unsafe {
+            crate::simd::amx_fp16::dot_f16_gemm_amx(
+                data,
+                m,
+                data_stride,
+                &self.0.packed,
+                &self.0.centroids,
+                n_padded,
+                dim,
+                out,
+                out_stride,
+            );
+        }
+    }
+}
+
+/// Whether this process *can* execute the AMX-FP16 kernels at all. True when
+/// all of the following hold:
+///
+/// - the kernel was compiled in, i.e. `build.rs` found a C compiler accepting
+///   `-mamx-fp16` (clang >= 16 or gcc >= 13) and set `kernel_support`;
+/// - the target is Linux/x86_64;
+/// - the CPU reports both the amx-tile and the amx-fp16 CPUID bits;
+/// - the one-time XTILEDATA `arch_prctl` grant succeeded.
+///
+/// This is the safety question — without the `arch_prctl` grant the first tile
+/// instruction would SIGILL — so no tile instruction in this module runs until
+/// it holds. It deliberately ignores [`LANCE_DISABLE_AMX`][amx_fp16_available],
+/// so kernel-level tests can exercise the kernels on any host that can run them
+/// even when an operator has turned the production paths off.
+///
+/// Callers choosing between the AMX path and their fallback want
+/// [`amx_fp16_available`] instead.
+///
+/// Evaluated once and cached by the hardware probe underneath; nothing is
+/// recomputed per call.
+pub fn amx_fp16_supported() -> bool {
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    {
+        return crate::simd::amx_fp16::amx_supported();
+    }
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Whether production work should be routed onto the AMX-FP16 kernels: this
+/// host can run them ([`amx_fp16_supported`]) and no operator has turned them
+/// off.
+///
+/// **AMX is on by default.** Dispatch is a run-time decision made from CPU
+/// capability alone, so a host with the silicon uses it with nothing to enable —
+/// there is no Cargo feature and no opt-in variable. `LANCE_DISABLE_AMX` is the
+/// escape hatch for the cases where a capability probe is not the whole story:
+/// A/B measurement, and an operator who needs the previous code path back
+/// without rebuilding. Set it to `1`, `true` or `on` (case-insensitive,
+/// surrounding whitespace ignored) to take the AMX paths out of service; every
+/// other value, and an unset variable, leave them in.
+///
+/// Note this changes *which algorithm* an index build uses, not just how fast it
+/// runs: without the GEMM, partition assignment falls back to an approximate
+/// graph lookup (see `lance_index`'s `prefers_flat_amx_assignment`). Two indexes
+/// built on either side of this variable are not interchangeable.
+pub fn amx_fp16_available() -> bool {
+    !amx_fp16_disabled() && amx_fp16_supported()
+}
+
+/// The `LANCE_DISABLE_AMX` kill switch on its own, read once and cached. Cached
+/// because the routing decisions that consult it run per block of vectors, and
+/// because a build that flipped behaviour halfway through would be far harder to
+/// reason about than one that reads the environment at startup.
+fn amx_fp16_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("LANCE_DISABLE_AMX").is_ok_and(|value| is_amx_disable_value(&value))
+    })
+}
+
+/// The accepted spellings of "off". Anything else — including `0`, `false` and
+/// the empty string — leaves AMX enabled, because an unrecognised value must not
+/// silently disable a path the operator did not clearly ask to disable.
+fn is_amx_disable_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    /// Dims covering: < 32 (no tile pass, pure fallback), exactly 32 (one pass,
+    /// no tail), non-multiples of 32 (exercise the AMX tail), and larger dims
+    /// (multiple passes).
+    const BATCH_DIMS: &[usize] = &[
+        1, 7, 31, 32, 33, 47, 64, 96, 100, 127, 128, 200, 256, 384, 768, 1000, 1536,
+    ];
+
+    fn make_batch(dim: usize, rng: &mut StdRng) -> (Vec<f16>, Vec<Vec<f16>>) {
+        let gen_vec = |rng: &mut StdRng| -> Vec<f16> {
+            (0..dim)
+                .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+                .collect()
+        };
+        let query = gen_vec(rng);
+        let candidates = (0..16).map(|_| gen_vec(rng)).collect();
+        (query, candidates)
+    }
+
+    /// f32-accumulated reference dot product — the semantic contract both the
+    /// AMX and fallback paths approximate. `f16::dot` itself accumulates in f32.
+    fn ref_dot_f32(query: &[f16], cand: &[f16]) -> f32 {
+        query
+            .iter()
+            .zip(cand.iter())
+            .map(|(&q, &c)| q.to_f32() * c.to_f32())
+            .sum()
+    }
+
+    /// Relative-error tolerance justification: fp16 carries ~11 bits of mantissa
+    /// (~3 decimal digits). The AMX path and the f32 reference differ only in
+    /// summation order of f32-widened products, so the error is many orders
+    /// tighter than fp16's own representational error; 5e-3 relative is a very
+    /// safe bound (observed worst case is ~2e-4).
+    const REL_TOL: f32 = 5e-3;
+
+    fn assert_close(got: f32, want: f32, ctx: &str) {
+        let rel = (got - want).abs() / (want.abs() + 1e-6);
+        assert!(
+            rel <= REL_TOL || (got - want).abs() <= 1e-3,
+            "{ctx}: got {got} want {want} rel_err {rel}"
+        );
+    }
+
+    #[test]
+    fn fallback_matches_reference() {
+        let mut rng = StdRng::seed_from_u64(0xF16);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let got = dot_f16_batch_16_fallback(&query, &candidates, 16);
+            for i in 0..16 {
+                assert_close(
+                    got[i],
+                    ref_dot_f32(&query, &cands[i]),
+                    &format!("fb dim={dim} i={i}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dispatch_matches_reference() {
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let got = dot_f16_batch_16(&query, &candidates, 16);
+            for i in 0..16 {
+                assert_close(
+                    got[i],
+                    ref_dot_f32(&query, &cands[i]),
+                    &format!("disp dim={dim} i={i}"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "all candidate vectors must have the same length")]
+    fn rejects_mismatched_candidate_length() {
+        let query = vec![f16::from_f32(1.0); 32];
+        let short = vec![f16::from_f32(1.0); 31];
+        let candidates: [&[f16]; 16] = std::array::from_fn(|i| {
+            if i == 0 {
+                short.as_slice()
+            } else {
+                query.as_slice()
+            }
+        });
+        let _ = dot_f16_batch_16(&query, &candidates, 16);
+    }
+
+    /// A live lane must be bit-identical whatever `len` the batch was issued at.
+    /// Shortening the batch changes only how many rows are gathered, never a
+    /// row's contents nor the order the tile passes accumulate them, so anything
+    /// less than bit-exact here would mean a staging offset moved with `len` —
+    /// exactly the bug a tolerance would hide. Lanes past `len` must read 0 on
+    /// both paths: dispatch is host-dependent, so a caller must not be able to
+    /// tell which one ran.
+    #[test]
+    fn partial_len_matches_full_batch_and_zeroes_the_rest() {
+        let mut rng = StdRng::seed_from_u64(0x1EE);
+        for &dim in BATCH_DIMS {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let full = dot_f16_batch_16(&query, &candidates, 16);
+            let full_fb = dot_f16_batch_16_fallback(&query, &candidates, 16);
+            for len in 1..=16 {
+                let got = dot_f16_batch_16(&query, &candidates, len);
+                let got_fb = dot_f16_batch_16_fallback(&query, &candidates, len);
+                for i in 0..len {
+                    assert_eq!(
+                        got[i].to_bits(),
+                        full[i].to_bits(),
+                        "dim={dim} len={len} i={i}: {} vs {}",
+                        got[i],
+                        full[i]
+                    );
+                    assert_eq!(
+                        got_fb[i].to_bits(),
+                        full_fb[i].to_bits(),
+                        "fb dim={dim} i={i}"
+                    );
+                }
+                for i in len..16 {
+                    assert_eq!(got[i], 0.0, "dim={dim} len={len}: lane {i} must be 0");
+                    assert_eq!(got_fb[i], 0.0, "fb dim={dim} len={len}: lane {i} must be 0");
+                }
+            }
+        }
+    }
+
+    /// `len` is rejected, never clamped: the kernel indexes its staging buffer
+    /// by it, and a caller that meant 16 and passed 17 should hear about it.
+    #[rstest::rstest]
+    #[case::zero(0)]
+    #[case::seventeen(17)]
+    #[should_panic(expected = "batch length must be in 1..=16")]
+    fn rejects_out_of_range_len(#[case] len: usize) {
+        let query = vec![f16::from_f32(1.0); 32];
+        let candidates: [&[f16]; 16] = std::array::from_fn(|_| query.as_slice());
+        let _ = dot_f16_batch_16(&query, &candidates, len);
+    }
+
+    /// The `LANCE_DISABLE_AMX` truth table, pinned in one place.
+    ///
+    /// Which spellings mean "off" is an operator-facing contract, and both ways
+    /// of getting it wrong are silent. A typo accepted as a kill switch —
+    /// `LANCE_DISABLE_AMX=disable` — would quietly change which algorithm an
+    /// index build uses, and the only visible trace would be a recall number
+    /// nobody was comparing. A deliberate `1` rejected would leave an operator
+    /// who needs the old path back believing they have it.
+    ///
+    /// The asymmetry with the enable direction is deliberate: an unrecognised
+    /// value leaves AMX **on**, because the default is on and an unparsable
+    /// request to deviate from it should not be honoured by halves.
+    #[test]
+    fn amx_disable_flag_accepts_only_explicit_on() {
+        for value in ["1", "true", "on", "TRUE", "On", " 1 ", "true\n"] {
+            assert!(is_amx_disable_value(value), "{value:?} should disable AMX");
+        }
+        for value in ["", " ", "0", "false", "off", "no", "yes", "2", "disable"] {
+            assert!(
+                !is_amx_disable_value(value),
+                "{value:?} should not disable AMX"
+            );
+        }
+    }
+
+    /// With the kill switch unset, availability is exactly hardware support.
+    ///
+    /// This is the "on by default" contract itself: the assertion that would
+    /// fail if a Cargo feature or an opt-in variable ever crept back in front of
+    /// the dispatch decision. It is derived rather than hardcoded so it holds
+    /// identically on a host without AMX and in a build whose toolchain could
+    /// not compile the kernel.
+    #[test]
+    fn amx_is_available_by_default_wherever_it_is_supported() {
+        if std::env::var_os("LANCE_DISABLE_AMX").is_some() {
+            return; // the switch is under test elsewhere; respect it here
+        }
+        assert_eq!(amx_fp16_available(), amx_fp16_supported());
+    }
+
+    /// The length arithmetic guarding the GEMM's FFI boundary must reject a
+    /// shape it cannot represent, not wrap it into a small number.
+    ///
+    /// The first case is the one that made this necessary: unchecked,
+    /// `(32 - 1) * 595_056_260_442_243_601 + 32` wraps to **47**, so a
+    /// 47-element slice satisfied a check that meant to demand ~1.8e19
+    /// elements — and the kernel then strode `data + i * stride` far past the
+    /// end of it. A wrapped requirement is dangerous precisely because it comes
+    /// out *small* enough to pass.
+    ///
+    /// Deliberately a plain-function test: it runs on every host, including
+    /// those where `PackedCentroidsF16` cannot be constructed at all.
+    #[test]
+    fn strided_len_rejects_shapes_it_cannot_represent() {
+        assert_eq!(strided_len(32, 595_056_260_442_243_601, 32), None);
+        assert_eq!(strided_len(2, usize::MAX, 1), None);
+        assert_eq!(strided_len(usize::MAX, 2, 0), None);
+        // Representable shapes still come through, including the degenerate
+        // single-row case where the stride is never applied.
+        assert_eq!(strided_len(32, 768, 768), Some(31 * 768 + 768));
+        assert_eq!(strided_len(1, usize::MAX, 5), Some(5));
+        // Zero rows need zero elements, and must not underflow `m - 1`.
+        assert_eq!(strided_len(0, usize::MAX, usize::MAX), Some(0));
+    }
+
+    /// End to end: the safe `score` wrapper must panic on the overflowing
+    /// shape rather than hand the undersized slice to the C kernel.
+    ///
+    /// `strided_len_rejects_shapes_it_cannot_represent` pins the arithmetic;
+    /// this pins that `score` actually consults it before the `unsafe` block.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn score_rejects_overflowing_stride_before_ffi() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let centroids = vec![f16::ONE; 32 * 32];
+        let Some(packed) = PackedCentroidsF16::new(&centroids, 32, 32) else {
+            return; // no AMX on this host; the arithmetic test above still ran
+        };
+        let data = vec![f16::ZERO; 47];
+        let mut out = vec![0f32; 32 * 32];
+
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // the panic is the expected result
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            packed.score(&data, 32, 595_056_260_442_243_601, &mut out, 32);
+        }));
+        std::panic::set_hook(hook);
+
+        assert!(
+            result.is_err(),
+            "score accepted a 47-element slice for a stride whose row count overflows usize"
+        );
+    }
+
+    /// On AMX-FP16 hardware, assert the AMX branch is actually selected (not a
+    /// silent fallback) and agrees with the f32 reference within tolerance.
+    /// Reaching the end without a SIGILL is itself proof the tile path executed.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn amx_path_is_active_and_close() {
+        if !crate::simd::amx_fp16::amx_supported() {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xA11);
+        let mut worst = 0f32;
+        for &dim in BATCH_DIMS.iter().filter(|&&d| d >= 32) {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let amx =
+                unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates, 16) };
+            for i in 0..16 {
+                let want = ref_dot_f32(&query, &cands[i]);
+                assert_close(amx[i], want, &format!("amx dim={dim} i={i}"));
+                let rel = (amx[i] - want).abs() / (want.abs() + 1e-6);
+                worst = worst.max(rel);
+            }
+        }
+        assert!(worst <= REL_TOL, "worst AMX relative error: {worst:.2e}");
+    }
+
+    /// Another AMX user on this thread retiring the tile configuration must not
+    /// break the next kernel call.
+    ///
+    /// Regression for a stale-cache bug: the kernels used to remember which
+    /// configuration they had loaded and skip LDTILECFG when it matched, but that
+    /// record was private to Lance while LDTILECFG and TILERELEASE are
+    /// architectural per-logical-processor state. After a foreign TILERELEASE the
+    /// record still said "SEARCH is live" and the hardware was back in INIT, so
+    /// the kernel skipped the load and its first tile op raised #UD. Reloading on
+    /// every entry is the fix; this is what would fail if a cache came back.
+    ///
+    /// Both halves of that design are checked here, and only one of them has any
+    /// other symptom. The reload shows up as the kernel surviving a clobber; the
+    /// release on exit shows up nowhere but in the tile unit itself, read back at
+    /// the end.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn kernel_reconfigures_after_foreign_tile_release() {
+        use crate::simd::amx_fp16::{
+            amx_supported, clobber_tile_state_for_test, dot_f16_batch_16_amx,
+            tile_config_is_live_for_test,
+        };
+
+        if !amx_supported() {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0xC10B);
+        let (query, cands) = make_batch(256, &mut rng);
+        let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+
+        let before = unsafe { dot_f16_batch_16_amx(&query, &candidates, 16) };
+        // SAFETY: the `amx_supported()` check above granted XTILEDATA, so
+        // TILERELEASE is legal here.
+        unsafe { clobber_tile_state_for_test() };
+        // Reaching the end of this call at all is the assertion that matters:
+        // under the bug it raised #UD and killed the test process. Comparing the
+        // results additionally catches the quieter variant, where a foreign
+        // configuration supplies the wrong shapes instead of none.
+        let after = unsafe { dot_f16_batch_16_amx(&query, &candidates, 16) };
+        assert_eq!(
+            before, after,
+            "kernel output changed after a foreign TILERELEASE"
+        );
+
+        // Everything above only asks "did it crash". That is too weak on its own:
+        // `lance_amx_tile_ensure` reloading on entry is by itself enough to keep
+        // results right, so deleting `lance_amx_tile_done`'s TILERELEASE would
+        // leave every assertion so far green while the tile unit stayed held
+        // against the next AMX user on this thread. Reading the hardware is what
+        // catches that.
+        assert!(
+            !tile_config_is_live_for_test(),
+            "a kernel left its tile configuration loaded after returning"
+        );
+    }
+
+    /// The batch-16 kernel's tile shape, pinned byte for byte.
+    ///
+    /// The shape is the one thing a refactor of `amx_fp16.c` can change with no
+    /// visible symptom until it runs on AMX hardware, where a wrong shape is a
+    /// #UD or wrong results rather than a clean failure. Reading the
+    /// configuration image back is a way to check it without executing a single
+    /// tile instruction.
+    ///
+    /// It still needs the `amx_supported()` guard, which is easy to mistake for
+    /// redundant: `lance_amx_tilecfg_image` only fills a 64-byte struct. But
+    /// `amx_fp16.c` is compiled as one translation unit with
+    /// `-march=sapphirerapids`, so the compiler may use instructions from that
+    /// baseline anywhere in the file — entering *any* function in it faults on
+    /// an older CPU. Under `qemu -cpu Nehalem` that is a SIGILL, which is
+    /// exactly what the `pre-Haswell SIGILL check` in CI runs.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn search_tile_config_image_is_pinned() {
+        use crate::simd::amx_fp16::{AMX_CFG_SEARCH, amx_supported, tilecfg_image};
+
+        if !amx_supported() {
+            return;
+        }
+
+        // Image layout per Intel SDM: palette_id, start_row, 14 reserved bytes,
+        // a u16 colsb[16] array, then a u8 rows[16] array.
+        const COLSB: usize = 16;
+        const ROWS: usize = 48;
+
+        let mut want = [0u8; 64];
+        want[0] = 1; // palette_id
+        // C = tmm0: 16 x 1 fp32, fed by three independent (A, B) pairs so three
+        // TDPFP16PS can be in flight at once: A = tmm1/3/5, each 16 x 32 fp16;
+        // B = tmm2/4/6, each 16 x 2 fp16. tmm7 is left unconfigured.
+        for (tmm, colsb) in [
+            (0usize, 4u16),
+            (1, 64),
+            (2, 4),
+            (3, 64),
+            (4, 4),
+            (5, 64),
+            (6, 4),
+        ] {
+            want[COLSB + tmm * 2..COLSB + tmm * 2 + 2].copy_from_slice(&colsb.to_le_bytes());
+            want[ROWS + tmm] = 16;
+        }
+
+        let got = tilecfg_image(AMX_CFG_SEARCH).expect("search config kind must be known");
+        assert_eq!(got, want, "batch-16 tile configuration changed");
+    }
+
+    /// An unknown config kind must be rejected rather than answered with a
+    /// zeroed image: an all-zero (unconfigured) shape #UDs on the first tile op.
+    ///
+    /// Guarded for the same reason as the test above: reaching the C side at
+    /// all requires a CPU that can run its `-march=sapphirerapids` code.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn unknown_tile_config_kind_is_rejected() {
+        if !crate::simd::amx_fp16::amx_supported() {
+            return;
+        }
+        assert!(crate::simd::amx_fp16::tilecfg_image(-1).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // AMX-FP16 m x n GEMM
+    // -----------------------------------------------------------------------
+
+    /// `[m, dim]` vectors and `[n, dim]` centroids, both row-major and tightly
+    /// packed. Separate rngs per role would make a transposition bug harder to
+    /// spot, so both come off one stream.
+    fn make_gemm(m: usize, n: usize, dim: usize, rng: &mut StdRng) -> (Vec<f16>, Vec<f16>) {
+        let mut sample = |count: usize| -> Vec<f16> {
+            (0..count)
+                .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+                .collect()
+        };
+        (sample(m * dim), sample(n * dim))
+    }
+
+    /// f32-accumulated reference GEMM — the same semantic contract as
+    /// [`ref_dot_f32`], extended to every (vector, centroid) pair.
+    fn ref_gemm(
+        data: &[f16],
+        m: usize,
+        data_stride: usize,
+        centroids: &[f16],
+        n: usize,
+        dim: usize,
+    ) -> Vec<f32> {
+        let mut out = vec![0f32; m * n];
+        for i in 0..m {
+            let row = &data[i * data_stride..i * data_stride + dim];
+            for j in 0..n {
+                out[i * n + j] = ref_dot_f32(row, &centroids[j * dim..j * dim + dim]);
+            }
+        }
+        out
+    }
+
+    /// Pack + run the GEMM kernel, returning an `[m, out_stride]` buffer.
+    ///
+    /// The destination starts as NaN rather than 0 so a tile store that never
+    /// lands (wrong stride, wrong tile index) fails the comparison instead of
+    /// passing on a coincidentally-correct zero.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    fn run_gemm(
+        data: &[f16],
+        m: usize,
+        data_stride: usize,
+        centroids: &[f16],
+        n: usize,
+        dim: usize,
+        out_stride: usize,
+    ) -> Vec<f32> {
+        use crate::simd::amx_fp16::{dot_f16_gemm_amx, pack_centroids_vnni};
+        let mut packed = Vec::new();
+        pack_centroids_vnni(centroids, n, dim, &mut packed);
+        let mut out = vec![f32::NAN; m * out_stride];
+        unsafe {
+            dot_f16_gemm_amx(
+                data,
+                m,
+                data_stride,
+                &packed,
+                centroids,
+                n,
+                dim,
+                &mut out,
+                out_stride,
+            );
+        }
+        out
+    }
+
+    /// Compare a `[m, out_stride]` kernel result against a tightly-packed
+    /// `[m, n]` reference.
+    fn assert_gemm_close(
+        got: &[f32],
+        want: &[f32],
+        m: usize,
+        n: usize,
+        out_stride: usize,
+        ctx: &str,
+    ) {
+        for i in 0..m {
+            for j in 0..n {
+                assert_close(
+                    got[i * out_stride + j],
+                    want[i * n + j],
+                    &format!("{ctx} [{i}][{j}]"),
+                );
+            }
+        }
+    }
+
+    /// The VNNI interleave, checked against the identity it exists to satisfy.
+    ///
+    /// This is the one part of the GEMM with no cheap sanity signal: a wrong
+    /// permutation still produces plausible-looking finite numbers, and on a
+    /// host without AMX nothing else here can run at all. Asserting the
+    /// element-for-element mapping keeps the layout pinned everywhere.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn packed_centroid_layout_matches_tile_operand_order() {
+        use crate::simd::amx_fp16::{pack_centroids_vnni, packed_centroids_len};
+
+        // Reused across shapes to also pin that packing clears rather than
+        // appends — a stale prefix would silently offset every B tile.
+        let mut packed = Vec::new();
+        let mut rng = StdRng::seed_from_u64(0x9EC7);
+        for (n, dim) in [(16usize, 32usize), (32, 64), (48, 100), (32, 31), (32, 768)] {
+            let centroids: Vec<f16> = (0..n * dim)
+                .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+                .collect();
+            pack_centroids_vnni(&centroids, n, dim, &mut packed);
+            assert_eq!(
+                packed.len(),
+                packed_centroids_len(n, dim),
+                "n={n} dim={dim}"
+            );
+
+            for kb in 0..dim / 32 {
+                for jb in 0..n / 16 {
+                    for k in 0..16 {
+                        for nn in 0..16 {
+                            for p in 0..2 {
+                                let at = ((kb * (n / 16)) + jb) * 512 + k * 32 + nn * 2 + p;
+                                let from = (jb * 16 + nn) * dim + kb * 32 + 2 * k + p;
+                                assert_eq!(
+                                    packed[at], centroids[from],
+                                    "n={n} dim={dim} kb={kb} jb={jb} k={k} nn={nn} p={p}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// GEMM results against the f32 reference across the shapes that exercise
+    /// each loop boundary: one vs. several 32-row/32-column register blocks,
+    /// one vs. many k-passes, dims with and without a scalar tail, dims too
+    /// short for any tile pass at all, and a case with padded row strides on
+    /// both the input and the output.
+    ///
+    /// Dims below 32 matter disproportionately: the kernel skips the tile loop
+    /// entirely, so `out` is never written by a tile store and the scalar tail
+    /// has to zero it first. Accumulating onto uninitialized memory instead
+    /// would still look plausible on a freshly-allocated buffer.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn gemm_matches_reference() {
+        if !crate::simd::amx_fp16::amx_supported() {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0x6E33);
+        for &m in &[32usize, 64] {
+            for &n in &[32usize, 64] {
+                for &dim in &[1usize, 16, 31, 32, 33, 64, 100, 768, 1000, 1536] {
+                    let (data, centroids) = make_gemm(m, n, dim, &mut rng);
+                    let want = ref_gemm(&data, m, dim, &centroids, n, dim);
+                    let got = run_gemm(&data, m, dim, &centroids, n, dim, n);
+                    assert_gemm_close(&got, &want, m, n, n, &format!("gemm m={m} n={n} dim={dim}"));
+                }
+            }
+        }
+
+        // Padded strides: the kernel must address rows by the caller's stride,
+        // not by `dim` / `n`, so it can score a window of a larger buffer.
+        let (m, n, dim) = (64usize, 32usize, 100usize);
+        let (data_stride, out_stride) = (dim + 7, n + 5);
+        let mut data: Vec<f16> = vec![f16::from_f32(f32::MAX); m * data_stride];
+        let (tight, centroids) = make_gemm(m, n, dim, &mut rng);
+        for i in 0..m {
+            data[i * data_stride..i * data_stride + dim]
+                .copy_from_slice(&tight[i * dim..(i + 1) * dim]);
+        }
+        let want = ref_gemm(&data, m, data_stride, &centroids, n, dim);
+        let got = run_gemm(&data, m, data_stride, &centroids, n, dim, out_stride);
+        assert_gemm_close(&got, &want, m, n, out_stride, "gemm padded strides");
+    }
+
+    /// The safe wrapper, over centroid counts that do and do not divide 32.
+    ///
+    /// Padding is the part a caller cannot see and must still reason about: the
+    /// real centroids have to score exactly as they would unpadded, and the
+    /// columns beyond them have to be the zeros that make a caller's argmin
+    /// bound (`< n`) load-bearing rather than decorative.
+    #[test]
+    fn packed_centroids_pad_to_the_kernel_block() {
+        let mut rng = StdRng::seed_from_u64(0x9AD);
+        for (n, dim) in [(32usize, 64usize), (100, 100), (48, 768)] {
+            let m = 64;
+            let (data, centroids) = make_gemm(m, n, dim, &mut rng);
+            let Some(packed) = PackedCentroidsF16::new(&centroids, n, dim) else {
+                return; // no AMX-FP16 on this build or host
+            };
+            let n_padded = packed.num_centroids_padded();
+            assert_eq!(n_padded, n.next_multiple_of(32), "n={n}");
+
+            // A wider output stride than the padded width, so a row's tail is
+            // untouched memory rather than the next row's scores.
+            let out_stride = n_padded + 3;
+            let mut out = vec![f32::NAN; m * out_stride];
+            packed.score(&data, m, dim, &mut out, out_stride);
+
+            let want = ref_gemm(&data, m, dim, &centroids, n, dim);
+            assert_gemm_close(&out, &want, m, n, out_stride, &format!("packed n={n}"));
+            for i in 0..m {
+                for j in n..n_padded {
+                    assert_eq!(out[i * out_stride + j], 0.0, "padding n={n} [{i}][{j}]");
+                }
+            }
+        }
+    }
+
+    /// The GEMM kernel's tile shape, pinned byte for byte, for the same reason
+    /// as [`search_tile_config_image_is_pinned`].
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn gemm_tile_config_image_is_pinned() {
+        use crate::simd::amx_fp16::{AMX_CFG_GEMM, amx_supported, tilecfg_image};
+
+        if !amx_supported() {
+            return;
+        }
+
+        const COLSB: usize = 16;
+        const ROWS: usize = 48;
+
+        let mut want = [0u8; 64];
+        want[0] = 1; // palette_id
+        // All eight tiles at the architectural maximum 16 x 64 B: four fp32
+        // accumulators, two A panels, two VNNI-packed B panels.
+        for tmm in 0..8usize {
+            want[COLSB + tmm * 2..COLSB + tmm * 2 + 2].copy_from_slice(&64u16.to_le_bytes());
+            want[ROWS + tmm] = 16;
+        }
+
+        let got = tilecfg_image(AMX_CFG_GEMM).expect("gemm config kind must be known");
+        assert_eq!(got, want, "gemm tile configuration changed");
+    }
+
+    /// Alternate the two kernels on one thread and check both stay correct.
+    ///
+    /// They ask for incompatible tile shapes (7 tiles, four of them 16x4, vs. 8
+    /// tiles all 16x64), so each call has to install its own shape over the one
+    /// the previous call left. That is what this pins: a kernel running against
+    /// the other one's tile shape reads garbage or #UDs, and only alternating
+    /// the two shapes can expose it. It says nothing about how the configuration
+    /// got there — `kernel_reconfigures_after_foreign_tile_release` is the test
+    /// that pins the reload itself.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn interleaved_search_and_gemm_stay_correct() {
+        if !crate::simd::amx_fp16::amx_supported() {
+            return;
+        }
+        let mut rng = StdRng::seed_from_u64(0x11E12EA5);
+        let (m, n, dim) = (32usize, 32usize, 96usize);
+        for round in 0..20 {
+            let (query, cands) = make_batch(dim, &mut rng);
+            let candidates: [&[f16]; 16] = std::array::from_fn(|i| cands[i].as_slice());
+            let batch =
+                unsafe { crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates, 16) };
+            for i in 0..16 {
+                assert_close(
+                    batch[i],
+                    ref_dot_f32(&query, &cands[i]),
+                    &format!("interleaved batch round={round} i={i}"),
+                );
+            }
+
+            let (data, centroids) = make_gemm(m, n, dim, &mut rng);
+            let want = ref_gemm(&data, m, dim, &centroids, n, dim);
+            let got = run_gemm(&data, m, dim, &centroids, n, dim, n);
+            assert_gemm_close(
+                &got,
+                &want,
+                m,
+                n,
+                n,
+                &format!("interleaved gemm round={round}"),
+            );
+        }
+    }
+
+    /// Both kernels running concurrently on different threads.
+    ///
+    /// LDTILECFG is per-logical-processor state, so correctness here rests on
+    /// each call building its configuration image on its own stack. A shared or
+    /// `static` image would let one thread's shape reach another's tile ops,
+    /// which this catches and a single-threaded test cannot.
+    #[cfg(all(
+        kernel_support = "amx_fp16",
+        target_arch = "x86_64",
+        target_os = "linux"
+    ))]
+    #[test]
+    fn concurrent_search_and_gemm_stay_correct() {
+        if !crate::simd::amx_fp16::amx_supported() {
+            return;
+        }
+        const THREADS: u64 = 8;
+        std::thread::scope(|scope| {
+            for t in 0..THREADS {
+                scope.spawn(move || {
+                    let mut rng = StdRng::seed_from_u64(0xC0FFEE + t);
+                    let dim = 128;
+                    for round in 0..25 {
+                        if t % 2 == 0 {
+                            let (query, cands) = make_batch(dim, &mut rng);
+                            let candidates: [&[f16]; 16] =
+                                std::array::from_fn(|i| cands[i].as_slice());
+                            let batch = unsafe {
+                                crate::simd::amx_fp16::dot_f16_batch_16_amx(&query, &candidates, 16)
+                            };
+                            for i in 0..16 {
+                                assert_close(
+                                    batch[i],
+                                    ref_dot_f32(&query, &cands[i]),
+                                    &format!("concurrent batch t={t} round={round} i={i}"),
+                                );
+                            }
+                        } else {
+                            let (m, n) = (32usize, 32usize);
+                            let (data, centroids) = make_gemm(m, n, dim, &mut rng);
+                            let want = ref_gemm(&data, m, dim, &centroids, n, dim);
+                            let got = run_gemm(&data, m, dim, &centroids, n, dim, n);
+                            assert_gemm_close(
+                                &got,
+                                &want,
+                                m,
+                                n,
+                                n,
+                                &format!("concurrent gemm t={t} round={round}"),
+                            );
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    /// The two costs a membership-level benchmark cannot separate: packing the
+    /// centroids, which happens once per call and is amortized over every block
+    /// of vectors, and the GEMM's throughput as a function of the block height
+    /// `m` its caller chooses.
+    ///
+    /// `m` sets how much f32 scratch one block writes (`m * n_padded * 4` bytes,
+    /// reported per row), which is what decides whether the reduction that
+    /// follows reads it out of L2 or out of memory. A caller sizing its blocks
+    /// from a scratch budget is making exactly this trade, so sweeping `m` here
+    /// says whether it lands on the right side of it. No knob is needed in the
+    /// production path for that — `score` takes `m` directly.
+    ///
+    /// `#[ignore]` -- run:
+    ///   cargo test -p lance-linalg --release \
+    ///     packed_centroids_gemm_shape_bench -- --ignored --nocapture
+    /// Tune with `BENCH_DIMS` / `BENCH_KS` (comma-separated) and `BENCH_SECONDS`
+    /// (the wall-clock budget each measured point gets).
+    #[test]
+    #[ignore]
+    #[allow(clippy::print_stderr)]
+    // Without the kernel `PackedCentroidsF16` is uninhabited, so the first
+    // `expect` below has type `!` and everything after it is provably dead. That
+    // is the property the type is designed to have; it is not a sign the bench is
+    // wrong.
+    #[allow(unreachable_code, unused_variables)]
+    fn packed_centroids_gemm_shape_bench() {
+        use std::time::{Duration, Instant};
+
+        // Multiples of 32 (the kernel's `m` granularity) spanning scratch that
+        // fits a private L2 up to scratch that cannot.
+        const BLOCK_ROWS: &[usize] = &[32, 64, 128, 256, 512, 1024, 2048];
+
+        if !amx_fp16_supported() {
+            eprintln!("[gemm_shape_bench] skipped: amx_fp16_supported=false on this build or host");
+            return;
+        }
+
+        let env_list = |key: &str, default: &[usize]| -> Vec<usize> {
+            std::env::var(key)
+                .ok()
+                .map(|s| s.split(',').filter_map(|t| t.trim().parse().ok()).collect())
+                .unwrap_or_else(|| default.to_vec())
+        };
+        let dims = env_list("BENCH_DIMS", &[768]);
+        let ks = env_list("BENCH_KS", &[256, 4096]);
+        let budget = Duration::from_secs_f64(
+            std::env::var("BENCH_SECONDS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(3.0),
+        );
+
+        let mut rng = StdRng::seed_from_u64(0x6E33);
+        let mut random_f16 = |count: usize| -> Vec<f16> {
+            (0..count)
+                .map(|_| f16::from_f32(rng.random_range(-1.0f32..1.0)))
+                .collect()
+        };
+
+        eprintln!(
+            "[gemm_shape_bench] budget={:.1}s amx_fp16_supported=true",
+            budget.as_secs_f64()
+        );
+        for &dim in &dims {
+            for &k in &ks {
+                let centroids = random_f16(k * dim);
+
+                let mut packs = 0usize;
+                let t0 = Instant::now();
+                while t0.elapsed() < budget {
+                    let packed = PackedCentroidsF16::new(&centroids, k, dim);
+                    std::hint::black_box(&packed);
+                    packs += 1;
+                }
+                let pack_us = t0.elapsed().as_secs_f64() * 1e6 / packs as f64;
+
+                let packed = PackedCentroidsF16::new(&centroids, k, dim)
+                    .expect("availability was just checked");
+                let n_padded = packed.num_centroids_padded();
+                eprintln!(
+                    "[gemm_shape_bench] dim={dim} k={k} n_padded={n_padded} pack_calls={packs} pack_us={pack_us:.1}"
+                );
+
+                let mut best_vec_per_s = 0f64;
+                for &m in BLOCK_ROWS {
+                    let data = random_f16(m * dim);
+                    let mut out = vec![0f32; m * n_padded];
+                    packed.score(&data, m, dim, &mut out, n_padded); // untimed warm-up
+
+                    let t1 = Instant::now();
+                    let mut iters = 0usize;
+                    while t1.elapsed() < budget {
+                        packed.score(&data, m, dim, &mut out, n_padded);
+                        iters += 1;
+                    }
+                    let elapsed = t1.elapsed().as_secs_f64();
+                    std::hint::black_box(&out);
+
+                    let vec_per_s = (iters * m) as f64 / elapsed;
+                    best_vec_per_s = best_vec_per_s.max(vec_per_s);
+                    eprintln!(
+                        // Pairs count the padding columns, since the kernel does
+                        // the work either way — this is its true rate, not the
+                        // caller's useful fraction of it.
+                        "[gemm_shape_bench]   m={m:>5} scratch_kb={:>7} iters={iters:>8} vec_per_s={vec_per_s:>12.0} us_per_vec={:>8.4} Gpair_per_s={:>8.2}",
+                        m * n_padded * 4 / 1024,
+                        1e6 / vec_per_s,
+                        vec_per_s * n_padded as f64 / 1e9,
+                    );
+                }
+                eprintln!(
+                    "[gemm_shape_bench]   pack_us={pack_us:.1} buys {:.0} vectors of scoring at the best m: packing is amortized above that",
+                    pack_us * 1e-6 * best_vec_per_s,
+                );
+            }
+        }
+    }
+}

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -14,6 +14,7 @@
 
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 
+pub mod amx_fp16;
 pub mod dist_table;
 pub mod f32;
 pub mod f64;

--- a/rust/lance-linalg/src/simd/amx_fp16.c
+++ b/rust/lance-linalg/src/simd/amx_fp16.c
@@ -1,0 +1,727 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+// AMX-FP16 tile kernels, and the tile-configuration plumbing they share.
+//
+// Every kernel here computes fp16 x fp16 dot products with TDPFP16PS
+// (fp16 x fp16 -> fp32 accumulate). The tile *shapes* differ per kernel and are
+// declared next to each one; the code that turns a shape into a loaded
+// LDTILECFG image is shared, because the one subtle step in it (the
+// dead-store barrier below) fails silently and only on some compilers, so it
+// must exist exactly once.
+//
+// Two kernels:
+//   * `lance_amx_dot_f16_batch_16` -- one query against 16 candidates, for
+//     choosing the IVF partitions a query probes (16 centroids per call).
+//     Ported in spirit from FAISS PR
+//     facebookresearch/faiss#5235's AMX-BF16 kernel: fp16 and bf16 are both
+//     2-byte tile elements consumed by the same `_tile_dp*ps` shape, so only the
+//     instruction (`_tile_dpbf16ps` -> `_tile_dpfp16ps`) and the element ->
+//     float conversion (bf16 bit-shift -> real IEEE fp16 via F16C `_cvtsh_ss`)
+//     differ. Its C tile is fed by three independent (A, B) tile pairs so three
+//     TDPFP16PS can be in flight at once; see the tile roles below.
+//   * `lance_amx_dot_f16_gemm` -- an m x n GEMM, for scoring many vectors
+//     against many centroids at once (k-means assignment). Uses all eight tiles
+//     as a 2x2 register-blocked accumulator.
+//
+// ## Tile configuration is reloaded on every call
+//
+// Each kernel has one compile-time tile shape (`SEARCH_TILES` / `GEMM_TILES`),
+// so caching its LDTILECFG is tempting: that reconfiguration costs a few
+// hundred cycles, against the ~64 cycles of useful tile work a dim-128 search
+// call performs. It is still wrong, because Lance does not own the tile unit:
+// LDTILECFG and TILERELEASE are architectural per-logical-processor state, so
+// another AMX user on the thread (oneDNN under PyTorch, ONNX Runtime, same
+// Python process) can retire or reshape a configuration Lance believes is live
+// -- a foreign TILERELEASE leaves the tiles in INIT and the next tile op raises
+// #UD, a foreign LDTILECFG silently substitutes wrong shapes. Neither is
+// observable from here, and a kernel reached from arbitrary Rust and C cannot
+// bound what runs between two of its own calls.
+//
+// So nothing is cached: every kernel configures the tiles on entry and releases
+// them on exit, and pays that per call. Against a GEMM over a whole block of
+// vectors it is noise; against a batch-16 search it is most of the call, and is
+// spent anyway, because the alternative is a configuration whose validity this
+// file has no way to establish.
+//
+// ## Thread safety
+//
+// LDTILECFG sets per-logical-processor state, and nothing here is shared
+// mutably: the spec tables are `static const` and the 64-byte config *image* is
+// built on the calling thread's stack, so one thread's shape can never reach
+// another's tile ops -- as with the XTILECFG it is loaded into, which rides in
+// the thread's own XSAVE area. That says nothing about what *other* libraries
+// on this thread have done to the tile unit, which is what reconfiguring on
+// every entry is for.
+//
+// SAFETY: executing any AMX tile instruction without first (a) confirming the
+// amx-tile + amx-fp16 CPUID bits and (b) obtaining XTILEDATA permission from
+// the kernel raises SIGILL. Both are the Rust caller's responsibility (see
+// `simd/amx_fp16.rs`); `lance_amx_fp16_request_perm` below performs (b).
+
+// Must precede all includes: exposes the glibc `syscall()` prototype from
+// <unistd.h>, which -std=c17 otherwise hides.
+#define _GNU_SOURCE
+
+#include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// XTILEDATA permission
+// ---------------------------------------------------------------------------
+
+// Ask the kernel to enable AMX tile data state for this process, via
+// arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA). Returns 0 on success,
+// non-zero otherwise. Requesting XTILEDATA (18) implicitly also grants
+// XTILECFG (17). Constants per Linux Documentation/arch/x86/xstate.rst.
+//
+// XTILEDATA is the single dynamically-enabled XSAVE state component backing the
+// physical TMM tile registers, shared by every AMX compute instruction
+// (TDPBUUD / TDPBF16PS / TDPFP16PS ...). The syscall is idempotent, so
+// requesting an already-granted permission is harmless.
+int lance_amx_fp16_request_perm(void) {
+#ifdef __linux__
+  const unsigned long ARCH_REQ_XCOMP_PERM = 0x1023;
+  const unsigned long XFEATURE_XTILEDATA = 18;
+  return (int)syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA);
+#else
+  return -1;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Shared tile configuration
+// ---------------------------------------------------------------------------
+
+// Tile configuration kinds. One per distinct tile shape, and the selector
+// `lance_amx_tilecfg_image` exposes to the Rust tests so they can pin a shape
+// without executing a tile instruction. Kept in sync with the `AMX_CFG_*`
+// constants in `simd/amx_fp16.rs`.
+#define LANCE_AMX_CFG_SEARCH 0
+#define LANCE_AMX_CFG_GEMM 1
+
+// The 64-byte tile configuration image loaded by LDTILECFG
+// (`_tile_loadconfig`). Layout per Intel SDM: palette_id, start_row, 14
+// reserved bytes, then a u16 colsb[16] (bytes-per-row) array and a u8 rows[16]
+// array. Slots not named by a kernel's spec table stay zero.
+//
+// 64-byte aligned so the configuration load does not straddle a cache line.
+typedef struct __attribute__((packed, aligned(64))) {
+  uint8_t palette_id;
+  uint8_t start_row;
+  uint8_t reserved[14];
+  uint16_t colsb[16];
+  uint8_t rows[16];
+} lance_amx_tilecfg;
+
+// The image LDTILECFG reads is exactly 64 bytes; a layout change that altered
+// the size would silently feed the instruction garbage.
+_Static_assert(sizeof(lance_amx_tilecfg) == 64,
+               "LDTILECFG image must be exactly 64 bytes");
+
+// One tile register's shape. `tmm` is the register index (0..7), `colsb` its
+// bytes per row, `rows` its row count.
+typedef struct {
+  uint8_t tmm;
+  uint8_t rows;
+  uint16_t colsb;
+} lance_amx_tile_spec;
+
+#define LANCE_AMX_TILE_COUNT(specs) (sizeof(specs) / sizeof((specs)[0]))
+
+// Fill `cfg` with the LDTILECFG image described by `specs`, without loading it.
+// Split from the load so `lance_amx_tilecfg_image` can hand the Rust tests the
+// exact bytes a kernel would configure.
+static void lance_amx_tilecfg_build(lance_amx_tilecfg *cfg,
+                                    const lance_amx_tile_spec *specs,
+                                    size_t n) {
+  memset(cfg, 0, sizeof(*cfg));
+  cfg->palette_id = 1;
+  for (size_t i = 0; i < n; i++) {
+    cfg->rows[specs[i].tmm] = specs[i].rows;
+    cfg->colsb[specs[i].tmm] = specs[i].colsb;
+  }
+}
+
+// Load the tile configuration described by `specs`. Unconditional: see the file
+// header for why no state is kept about what is already loaded.
+//
+// The barrier is not optional: some GCC versions do not model
+// _tile_loadconfig as reading the 64-byte cfg image, dead-store-eliminate the
+// rows/colsb writes, and load an all-zero (unconfigured) tile shape -> #UD on
+// the first tile op (documented in FAISS #5235). Keeping it here, in the one
+// function that owns the image, is why kernels do not build configurations
+// themselves. Harmless under clang.
+static inline void lance_amx_tile_ensure(const lance_amx_tile_spec *specs,
+                                         size_t n) {
+  lance_amx_tilecfg cfg;
+  lance_amx_tilecfg_build(&cfg, specs, n);
+  __asm__ volatile("" : : "m"(cfg) : "memory");
+  _tile_loadconfig(&cfg);
+}
+
+// Hand the tile unit back at the end of a kernel. Pairs with
+// `lance_amx_tile_ensure`, and must run on every exit path of a kernel that
+// configured tiles.
+//
+// Not for Lance's own benefit -- `lance_amx_tile_ensure` reloads on every entry,
+// so a stale configuration could never reach one of these kernels either way. It
+// is for everyone else on the thread: a live tile configuration keeps 8 KB of
+// XTILEDATA in this thread's XSAVE area across every context switch, and leaves
+// a shape another AMX user did not ask for sitting on hardware it also uses.
+//
+// Because it is nobody's correctness but the neighbours', deleting it leaves
+// every result right and every "did it crash?" test green. Only
+// `lance_amx_tilecfg_current_for_test`, which reads the hardware, notices.
+static inline void lance_amx_tile_done(void) { _tile_release(); }
+
+// Test hook: retire the tile configuration the way a *foreign* AMX user on this
+// thread would, so a test can put the tile unit in INIT under a kernel that is
+// about to run and check the kernel reconfigures instead of assuming.
+//
+// Hidden visibility because this manufactures the state the rest of this file
+// exists to prevent: it is linked into the crate for its regression test, but is
+// not something a shipped shared object should offer to whatever else is in the
+// process.
+//
+// TILERELEASE needs no XTILEDATA grant of its own -- XFD traps only instructions
+// that touch a TMM register -- but a test calling this is about to call a kernel
+// that does, so it should have gone through `amx_supported()` anyway.
+__attribute__((visibility("hidden"))) void lance_amx_tile_clobber_for_test(void) {
+  _tile_release();
+}
+
+// Test hook: copy this logical processor's *live* tile configuration into the
+// 64 bytes at `out`, via STTILECFG. A `palette_id` of 0 means the tile unit is
+// in INIT state -- nothing configured.
+//
+// This reads the hardware rather than any record Lance keeps, which is what
+// makes it able to catch the half of this design that has no other symptom:
+// `lance_amx_tile_ensure` reloading on every entry is what keeps results
+// correct, so dropping `lance_amx_tile_done`'s release leaves behaviour right
+// and every "did it crash?" test passing, and only a live `palette_id` reported
+// back here says the tile unit was never handed over.
+//
+// STTILECFG does not touch a TMM register, so unlike the kernels it is legal
+// without the XTILEDATA grant. Hidden for the same reason as the clobber hook.
+__attribute__((visibility("hidden"))) void lance_amx_tilecfg_current_for_test(
+    uint8_t *out) {
+  lance_amx_tilecfg cfg;
+  _tile_storeconfig(&cfg);
+  memcpy(out, &cfg, sizeof(cfg));
+}
+
+// ---------------------------------------------------------------------------
+// Kernel: batch-16 search (one query x 16 candidates)
+// ---------------------------------------------------------------------------
+
+// Tile roles. These are immediate operands of the tile intrinsics, so they must
+// be compile-time constants; `#define` rather than `enum` avoids relying on how
+// strictly a compiler treats enum constants as immediates.
+//
+// One TDPFP16PS pass covers K = 32 fp16 dims. With N = 1 the query needs no
+// VNNI repacking: B.row[k].fp16[i] = query[k*2 + i] is just the contiguous
+// query halfwords, obtained by loading with a 4-byte row stride. The candidates
+// form the A tile's rows; they live at unrelated addresses, so this kernel
+// stages them a few k-blocks at a time into a fixed-stride scratch buffer that
+// the tile load can read (see `lance_amx_stage_rows`).
+//
+// Three (A, B) pairs, not one. A single pair would make the loop strictly
+// serial -- every TDPFP16PS waiting on the two loads that just overwrote its
+// own operands -- so the tile unit would idle through each load's latency.
+// Three independent pairs let three k-blocks' loads issue before the first
+// TDPFP16PS needs its result, which is enough to keep the dp ops back to back.
+// Seven tiles is what that costs; tmm7 is left unconfigured.
+#define SEARCH_TMM_C 0   // 16 results x 1 fp32
+#define SEARCH_TMM_A0 1  // 16 candidate rows x 32 fp16, k-block 3t
+#define SEARCH_TMM_B0 2  // query, VNNI-packed at N = 1, k-block 3t
+#define SEARCH_TMM_A1 3  // k-block 3t + 1
+#define SEARCH_TMM_B1 4
+#define SEARCH_TMM_A2 5  // k-block 3t + 2
+#define SEARCH_TMM_B2 6
+
+static const lance_amx_tile_spec SEARCH_TILES[] = {
+    {SEARCH_TMM_C, 16, 4},   {SEARCH_TMM_A0, 16, 64}, {SEARCH_TMM_B0, 16, 4},
+    {SEARCH_TMM_A1, 16, 64}, {SEARCH_TMM_B1, 16, 4},  {SEARCH_TMM_A2, 16, 64},
+    {SEARCH_TMM_B2, 16, 4},
+};
+
+// Halfwords of one k-block: 32 fp16 dims, the K a single TDPFP16PS covers.
+#define SEARCH_K_BLOCK 32
+
+// Bytes one tile row spans in one k-block: 32 fp16, the A tile's full row width.
+#define SEARCH_ROW_BYTES (SEARCH_K_BLOCK * (int)sizeof(uint16_t))
+
+// K-blocks gathered per staging step. Three, so one staged buffer feeds exactly
+// the three (A, B) pairs the main loop issues together.
+#define SEARCH_STAGE_BLOCKS 3
+#define SEARCH_STAGE_ROW_BYTES (SEARCH_STAGE_BLOCKS * SEARCH_ROW_BYTES)
+
+// One staging buffer: the 16 rows a tile load always reads, whatever the batch
+// actually holds.
+#define SEARCH_STAGE_BYTES (16 * SEARCH_STAGE_ROW_BYTES)
+
+// The furthest-reaching tile load is A2: 64 bytes at offset 128 of the last of
+// 16 rows, so the last byte it touches is at 128 + 15*192 + 63 and the span it
+// covers is exactly SEARCH_STAGE_BYTES. Asserted because an overrun here would
+// be a stack smash with no other symptom.
+//
+// What this actually pins is that the three A tiles tile one staging row with
+// no gap and no overlap, i.e. SEARCH_STAGE_BLOCKS == 3; it does not check
+// SEARCH_K_BLOCK, nor the 64-byte A-tile width, which is hardcoded separately
+// in SEARCH_TILES.
+_Static_assert(2 * SEARCH_ROW_BYTES + 15 * SEARCH_STAGE_ROW_BYTES +
+                       SEARCH_ROW_BYTES ==
+                   SEARCH_STAGE_BYTES,
+               "the three A tiles must tile a staging row exactly");
+
+// Gather `row_bytes` starting at k-block `kb` out of each of the first `count`
+// candidates into `dst`, one candidate per row.
+//
+// Rows are SEARCH_STAGE_ROW_BYTES apart even when `row_bytes` is smaller: an A
+// tile only reads 64 bytes at its own offset within a row, so a wider stride
+// simply leaves the trailing bytes unread. Keeping the stride fixed across
+// every staging step is what lets rows [count, 16) be zeroed once per call --
+// each step then rewrites the same rows at the same addresses.
+//
+// The k-blocks a row covers are adjacent inside the candidate vector, so each
+// candidate costs exactly one straight-line copy no matter how many k-blocks the
+// step covers. `row_bytes` should stay a compile-time constant at every call
+// site: a constant size expands to inline wide moves, while a variable one
+// becomes a libc `memcpy` call that `-funroll-loops` then multiplies (five PLT
+// calls for the one remainder loop, measured under clang-16).
+//
+// Zeroing the padding rows is deliberately *not* routed through here: it writes
+// rows [count, 16) rather than [0, count), and when the rows are full width it
+// is one contiguous `memset` rather than a per-row loop.
+static inline void lance_amx_stage_rows(uint8_t *dst,
+                                        const uint16_t *const *candidates,
+                                        size_t count, size_t kb,
+                                        size_t row_bytes) {
+  for (size_t n = 0; n < count; n++) {
+    memcpy(dst + n * SEARCH_STAGE_ROW_BYTES,
+           candidates[n] + kb * SEARCH_K_BLOCK, row_bytes);
+  }
+}
+
+// out[i] = sum_{d in 0..dim} f32(query[d]) * f32(candidates[i][d]), i < count.
+//
+// `query`      -- IEEE-754 binary16 values as raw uint16_t bit patterns
+//                 (half::f16 has identical layout); `dim` valid halfwords.
+// `candidates` -- pointers to `dim` halfwords each; only the first `count` are
+//                 read. The vectors live wherever the storage put them; this
+//                 kernel owns the gather.
+// `count`      -- candidates carrying a real vector. **Precondition:
+//                 1 <= count <= 16**, rejected at the Rust boundary
+//                 (`dot_f16_batch_16`) rather than clamped here; a larger value
+//                 would run the gather off the end of a staging buffer.
+// `dim`        -- vector dimension.
+// `out`        -- destination for 16 fp32 dot products. Lanes [count, 16) are
+//                 written as 0, not left untouched.
+//
+// ## Why `count` rather than always 16
+//
+// The caller sweeps centroids 16 at a time, so when their count is not a
+// multiple of 16 the last group is short and it fills the spare slots by
+// repeating a row it already holds. Staging all 16 rows would copy that row an
+// extra 16 - count times; skipping them saves that much of a memcpy on at most
+// one group per sweep, so `count` buys far less here than it did for a caller
+// whose batches were usually partial. Only rows [0, count) are gathered, so the
+// copying scales with the vectors actually scored while the tile work stays one
+// fixed-cost pass. The padded rows still have to exist, since a tile load reads
+// 16 rows unconditionally; they are zeroed once per call, and an all-zero A row
+// yields a zero dot product.
+//
+// ## Why the gather is here and not in the caller
+//
+// A tile load reads 16 rows at one fixed stride from one base pointer, and no
+// stride is guaranteed between this kernel's 16 candidate pointers, so their
+// bytes have to be brought together somewhere. Doing it in the caller means
+// copying 16 * dim * 2 bytes -- 24 KB at dim 768, 32 KB at dim 1024 -- and every
+// one of those bytes has to land before the first TDPFP16PS can issue. Against a
+// 48 KB L1D that buffer alone is half the cache, and the copy is pure exposed
+// latency: nothing overlaps it.
+//
+// Staging inside the k-block loop instead keeps the working buffer at 3 KB and
+// lets the copies for one triple run underneath the tile ops of the previous
+// one. The bytes moved are identical; what changes is that they move while the
+// tile unit is busy rather than before it starts. (Measured on the caller-side
+// version at dim 1024: __memmove 3.7M cycles/query against 0.5M for the scalar
+// kernel, IPC 1.70 -> 1.17, and a critical path 18% longer even though total CPU
+// work per query was 6.5% lower. The same structure is what
+// epeshared/hnswlib-amx uses for its AMX-BF16 kernel.)
+//
+// For dim > 32 we accumulate across floor(dim/32) tile passes into the same C
+// tile, three k-blocks at a time. The tail (dim % 32 dims) is computed in
+// scalar fp32 afterwards. The result is NOT bit-exact against a sequential
+// scalar loop: floating-point tile-order accumulation rounds differently. It
+// matches an f32-accumulated reference dot product to within fp16 precision,
+// which is all the fp16 distance path requires (see amx_fp16.rs / the Rust-side
+// tests).
+void lance_amx_dot_f16_batch_16(const uint16_t *query,
+                                const uint16_t *const *candidates, size_t count,
+                                size_t dim, float *out) {
+  const size_t blocks = dim / SEARCH_K_BLOCK;   // whole 32-wide tile passes
+  const size_t full = blocks * SEARCH_K_BLOCK;  // dims they cover
+
+  if (blocks > 0) {
+    lance_amx_tile_ensure(SEARCH_TILES, LANCE_AMX_TILE_COUNT(SEARCH_TILES));
+
+    // Two staging buffers, 16 rows x 192 bytes each. Double buffered so a
+    // triple's gather can be issued a whole triple before the tile loads that
+    // read it: a tile load cannot take its data from the store buffer, so the
+    // gather's stores have to reach L1 first, and with one buffer there is
+    // nothing to overlap that drain with. 3 KB each, so both sit in L1D
+    // alongside the candidate rows streaming through it.
+    __attribute__((aligned(64))) uint8_t stage[2][SEARCH_STAGE_BYTES];
+
+    const size_t triples = blocks / SEARCH_STAGE_BLOCKS;
+    const size_t rem = blocks % SEARCH_STAGE_BLOCKS;
+
+    // Rows [count, 16) are padding that a tile load reads but no candidate
+    // fills, so they are zeroed here and an all-zero A row then contributes a
+    // zero dot product. Once per call is enough: every staging step below
+    // writes rows [0, count) only, always at the same row stride, so nothing
+    // disturbs the padding again.
+    //
+    // Only bytes some tile load actually reads are zeroed. This cost is the one
+    // part of the call that does not shrink with `dim`, so zeroing the full
+    // 2 x 15 x 192 bytes unconditionally would dominate short vectors:
+    //   * `stage[1]` is tile-loaded only if the main loop reaches a second
+    //     iteration, or the remainder lands on it (an odd `triples`). A single
+    //     triple with no remainder never reads it at all.
+    //   * A padding row is read to its full width only by the main loop. With
+    //     `triples == 0` the remainder is the only reader, and it loads A0 --
+    //     plus A1 when `rem == 2` -- so only the first `rem` k-block slots of
+    //     each row are ever seen.
+    if (count < 16) {
+      const size_t pad_off = count * SEARCH_STAGE_ROW_BYTES;
+      if (triples > 0) {
+        // Full-width padding rows are contiguous: one memset covers them all.
+        memset(stage[0] + pad_off, 0, SEARCH_STAGE_BYTES - pad_off);
+        if (triples > 1 || rem > 0) {
+          memset(stage[1] + pad_off, 0, SEARCH_STAGE_BYTES - pad_off);
+        }
+      } else {
+        for (size_t n = count; n < 16; n++) {
+          memset(stage[0] + n * SEARCH_STAGE_ROW_BYTES, 0,
+                 rem * (size_t)SEARCH_ROW_BYTES);
+        }
+      }
+    }
+
+    _tile_zero(SEARCH_TMM_C);
+
+    // Take ownership of the destination line now (PREFETCHW), so the RFO
+    // overlaps the tile work instead of stalling TILESTORED at the end. The
+    // store is 64 bytes issued as one instruction, and waiting on the RFO there
+    // backs up the store queue: measured on the FAISS #5235 BF16 kernel as
+    // SQ_Full 28.9% of cycles, with XQ.FULL_CYCLES 56x an AVX-512 baseline.
+    _mm_prefetch((const char *)out, _MM_HINT_ET0);
+
+    // Prologue of the software pipeline below, and the one gather in the call
+    // with no tile work ahead of it to hide behind.
+    if (triples > 0) {
+      lance_amx_stage_rows(stage[0], candidates, count, 0,
+                           SEARCH_STAGE_ROW_BYTES);
+
+      // The in-loop prefetch below runs two triples ahead, so k-blocks
+      // [3, 6) -- read by the very first iteration's gather -- would otherwise
+      // be touched by nothing. Guarded on the address staying inside the
+      // vectors, which also covers a remainder that follows a single triple.
+      if (SEARCH_STAGE_BLOCKS < blocks) {
+        for (size_t n = 0; n < count; n++) {
+          _mm_prefetch(
+              (const char *)(candidates[n] +
+                             SEARCH_STAGE_BLOCKS * (size_t)SEARCH_K_BLOCK),
+              _MM_HINT_T0);
+        }
+      }
+    }
+
+    size_t kb = 0;
+    for (size_t t = 0; t < triples; t++, kb += SEARCH_STAGE_BLOCKS) {
+      const uint8_t *st = stage[t & 1];
+
+      // Gather the *next* triple before issuing this one's tile ops, into the
+      // buffer the previous iteration's tile loads have already consumed. Those
+      // stores then have a full triple of tile work to commit to L1 under,
+      // instead of the tile load immediately below them waiting on the drain.
+      if (t + 1 < triples) {
+        // Open the candidate streams the iteration after this one will copy
+        // from, so that copy finds them resident. With the rows at 16 unrelated
+        // addresses there is no single stride for a hardware prefetcher to
+        // latch onto; what it can do is run each candidate forward once that
+        // candidate has been touched, and these touches are what start it.
+        // (Measured on the FAISS #5235 BF16 kernel without any prefetch: L1D MPI
+        // 2.6x and DTLB load MPI 14.6x an AVX-512 baseline.) Guarded so the last
+        // iterations stay inside the vectors.
+        if (kb + 2 * SEARCH_STAGE_BLOCKS < blocks) {
+          const size_t ahead = (kb + 2 * SEARCH_STAGE_BLOCKS) * SEARCH_K_BLOCK;
+          for (size_t n = 0; n < count; n++) {
+            _mm_prefetch((const char *)(candidates[n] + ahead), _MM_HINT_T0);
+          }
+        }
+        lance_amx_stage_rows(stage[(t + 1) & 1], candidates, count,
+                             kb + SEARCH_STAGE_BLOCKS, SEARCH_STAGE_ROW_BYTES);
+      }
+
+      // All six loads first: they are independent, so the three dp ops below
+      // issue back to back rather than each waiting on its own operands.
+      _tile_loadd(SEARCH_TMM_A0, st + 0 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B0, query + kb * SEARCH_K_BLOCK, 4);
+      _tile_loadd(SEARCH_TMM_A1, st + 1 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B1, query + (kb + 1) * SEARCH_K_BLOCK, 4);
+      _tile_loadd(SEARCH_TMM_A2, st + 2 * SEARCH_ROW_BYTES,
+                  SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B2, query + (kb + 2) * SEARCH_K_BLOCK, 4);
+
+      // C += A * B  (fp16 x fp16 -> fp32)
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A0, SEARCH_TMM_B0);
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A1, SEARCH_TMM_B1);
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A2, SEARCH_TMM_B2);
+    }
+
+    // The 1 or 2 k-blocks left over when `blocks` is not a multiple of three.
+    // `stage[triples & 1]` is the buffer the loop above neither wrote nor read
+    // last, so filling it now cannot collide with a tile load still in flight.
+    if (rem > 0) {
+      uint8_t *st = stage[triples & 1];
+      // Two constant-size cases rather than one `rem * 64` copy, because a
+      // variable-length memcpy here does not stay one instruction: clang-16
+      // emits a libc call and `-funroll-loops` then multiplies it, measured as
+      // five `memcpy@PLT` calls for this one loop (the pre-`count` kernel,
+      // whose loop ran to 16, paid sixteen). The main loop's gather is
+      // unaffected either way -- it keeps its inline wide moves -- so this is
+      // about the remainder alone. The branch costs one predictable compare.
+      if (rem == 2) {
+        lance_amx_stage_rows(st, candidates, count, kb, 2 * SEARCH_ROW_BYTES);
+      } else {
+        lance_amx_stage_rows(st, candidates, count, kb, SEARCH_ROW_BYTES);
+      }
+
+      // Loaded at the main loop's row stride even though only `rem` k-blocks are
+      // live: A0 and A1 read their own 64 bytes at offsets 0 and 64, which is
+      // what the staging step just filled, and the padding rows are already zero
+      // at exactly this stride.
+      _tile_loadd(SEARCH_TMM_A0, st, SEARCH_STAGE_ROW_BYTES);
+      _tile_loadd(SEARCH_TMM_B0, query + kb * SEARCH_K_BLOCK, 4);
+      if (rem == 2) {
+        _tile_loadd(SEARCH_TMM_A1, st + SEARCH_ROW_BYTES,
+                    SEARCH_STAGE_ROW_BYTES);
+        _tile_loadd(SEARCH_TMM_B1, query + (kb + 1) * SEARCH_K_BLOCK, 4);
+      }
+      _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A0, SEARCH_TMM_B0);
+      if (rem == 2) {
+        _tile_dpfp16ps(SEARCH_TMM_C, SEARCH_TMM_A1, SEARCH_TMM_B1);
+      }
+    }
+
+    _tile_stored(SEARCH_TMM_C, out, 4);  // 16 fp32, row stride 4 bytes
+    // Last tile op in this call; the tail below is scalar. Hands the tile unit
+    // back so an interleaved AMX user on this thread cannot be surprised by a
+    // configuration it did not ask for.
+    lance_amx_tile_done();
+  } else {
+    for (int i = 0; i < 16; i++) out[i] = 0.0f;
+  }
+
+  // Tail: the dims not covered by a full 32-wide tile, in scalar fp32. F16C
+  // `_cvtsh_ss` is an exact (lossless) binary16 -> binary32 widening. Lanes at
+  // or past `count` are skipped rather than accumulated onto: they are already
+  // 0 (zeroed staging rows, or the no-tile-pass branch above) and must stay so.
+  const size_t tail = dim - full;
+  if (tail > 0) {
+    for (size_t i = 0; i < count; i++) {
+      float acc = 0.0f;
+      const uint16_t *row = candidates[i];
+      for (size_t d = full; d < dim; d++) {
+        acc += _cvtsh_ss(row[d]) * _cvtsh_ss(query[d]);
+      }
+      out[i] += acc;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Kernel: M x N GEMM (many vectors x many centroids)
+// ---------------------------------------------------------------------------
+
+// Tile roles for the 2x2-register-blocked GEMM. Two A tiles (32 vectors) and
+// two B tiles (32 centroids) feed four C accumulators, so one k-pass issues 4
+// TDPFP16PS against 4 tile loads -- the highest compute-per-load ratio the 8
+// physical tiles allow, and the reason all 8 are claimed here.
+#define GEMM_TMM_C00 0  // 16 vectors x 16 centroids, fp32
+#define GEMM_TMM_C01 1
+#define GEMM_TMM_C10 2
+#define GEMM_TMM_C11 3
+#define GEMM_TMM_A0 4  // 16 vector rows x 32 fp16 dims
+#define GEMM_TMM_A1 5
+#define GEMM_TMM_B0 6  // 32 dims x 16 centroids, VNNI-interleaved
+#define GEMM_TMM_B1 7
+
+// All eight at the architectural maximum (16 rows x 64 bytes = 1 KB), which is
+// exactly the 8 KB of tile state AMX provides.
+static const lance_amx_tile_spec GEMM_TILES[] = {
+    {GEMM_TMM_C00, 16, 64}, {GEMM_TMM_C01, 16, 64}, {GEMM_TMM_C10, 16, 64},
+    {GEMM_TMM_C11, 16, 64}, {GEMM_TMM_A0, 16, 64},  {GEMM_TMM_A1, 16, 64},
+    {GEMM_TMM_B0, 16, 64},  {GEMM_TMM_B1, 16, 64},
+};
+
+// Halfwords per packed B block: 16 tile rows x 32 halfwords per row.
+#define GEMM_B_BLOCK 512
+
+// out[i*out_stride + j] = sum_{d in 0..dim} f32(data[i*data_stride + d]) *
+//                                           f32(centroids[j*dim + d]).
+//
+// `data`        -- [m, dim] row-major fp16 bit patterns, rows `data_stride`
+//                  halfwords apart (`data_stride >= dim`).
+// `m`           -- number of vectors; **must be a multiple of 32**.
+// `packed_b`    -- centroids pre-interleaved by `pack_centroids_vnni` (see
+//                  `amx_fp16.rs`), holding only the floor(dim/32) whole
+//                  32-dim k-blocks.
+// `centroids`   -- the same [n, dim] row-major centroids `packed_b` was built
+//                  from. Read only for the `dim % 32` tail dims, which are not
+//                  worth a tile pass and so are never packed; still required
+//                  when dim % 32 == 0, where it goes unread.
+// `n`           -- number of centroids; **must be a multiple of 32**.
+// `dim`         -- vector dimension; any value, the tail runs scalar.
+// `out`         -- [m, n] row-major fp32, rows `out_stride` floats apart
+//                  (`out_stride >= n`).
+//
+// The m and n multiple-of-32 requirements are preconditions, not something this
+// kernel checks or works around: they let the register-blocked loop run with no
+// edge cases, and the Rust caller is the layer that knows how to pad or split.
+//
+// The k dimension carries no such requirement. TDPFP16PS accumulation rounds
+// differently from a sequential scalar loop, so results match an f32-accumulated
+// reference to fp16 precision rather than bit-exactly -- same contract as
+// `lance_amx_dot_f16_batch_16`.
+//
+// B's VNNI interleave is what makes A loadable straight out of `data`: with
+//   packed_b[((kb*(n/16) + jb)*512) + k*32 + nn*2 + p]
+//       == centroids[(jb*16 + nn)*dim + kb*32 + 2*k + p]
+// TDPFP16PS's b.row[k].fp16[2*nn+p] lands on centroid (jb*16+nn) dim
+// (kb*32+2*k+p), pairing it with a.row[mm].fp16[2*k+p] = the same dim of vector
+// (i+mm). k-blocks are the outer index so one k-pass reads the two B tiles it
+// needs from adjacent memory.
+void lance_amx_dot_f16_gemm(const uint16_t *data, size_t m, size_t data_stride,
+                            const uint16_t *packed_b, const uint16_t *centroids,
+                            size_t n, size_t dim, float *out,
+                            size_t out_stride) {
+  const size_t full = (dim / 32) * 32;  // dims covered by full 32-wide passes
+
+  if (full > 0) {
+    lance_amx_tile_ensure(GEMM_TILES, LANCE_AMX_TILE_COUNT(GEMM_TILES));
+
+    const size_t a_stride_bytes = data_stride * sizeof(uint16_t);
+    const size_t c_stride_bytes = out_stride * sizeof(float);
+    const size_t b_blocks_per_k = n / 16;
+
+    for (size_t i = 0; i < m; i += 32) {
+      const uint16_t *a0 = data + i * data_stride;
+      const uint16_t *a1 = a0 + 16 * data_stride;
+      float *c0 = out + i * out_stride;
+      float *c1 = c0 + 16 * out_stride;
+
+      for (size_t j = 0; j < n; j += 32) {
+        _tile_zero(GEMM_TMM_C00);
+        _tile_zero(GEMM_TMM_C01);
+        _tile_zero(GEMM_TMM_C10);
+        _tile_zero(GEMM_TMM_C11);
+
+        for (size_t kbase = 0; kbase < full; kbase += 32) {
+          // The B tiles for centroid blocks j/16 and j/16+1 are adjacent
+          // because jb is the inner index of the packed layout.
+          const uint16_t *b =
+              packed_b + ((kbase / 32) * b_blocks_per_k + j / 16) * GEMM_B_BLOCK;
+          _tile_loadd(GEMM_TMM_A0, a0 + kbase, a_stride_bytes);
+          _tile_loadd(GEMM_TMM_A1, a1 + kbase, a_stride_bytes);
+          _tile_loadd(GEMM_TMM_B0, b, 64);
+          _tile_loadd(GEMM_TMM_B1, b + GEMM_B_BLOCK, 64);
+          _tile_dpfp16ps(GEMM_TMM_C00, GEMM_TMM_A0, GEMM_TMM_B0);
+          _tile_dpfp16ps(GEMM_TMM_C01, GEMM_TMM_A0, GEMM_TMM_B1);
+          _tile_dpfp16ps(GEMM_TMM_C10, GEMM_TMM_A1, GEMM_TMM_B0);
+          _tile_dpfp16ps(GEMM_TMM_C11, GEMM_TMM_A1, GEMM_TMM_B1);
+        }
+
+        _tile_stored(GEMM_TMM_C00, c0 + j, c_stride_bytes);
+        _tile_stored(GEMM_TMM_C01, c0 + j + 16, c_stride_bytes);
+        _tile_stored(GEMM_TMM_C10, c1 + j, c_stride_bytes);
+        _tile_stored(GEMM_TMM_C11, c1 + j + 16, c_stride_bytes);
+      }
+    }
+    // Last tile op in this call; the tail below is scalar. One LDTILECFG plus
+    // one TILERELEASE against an m x n GEMM is why the per-call reconfiguration
+    // the file header argues for costs this kernel nothing.
+    lance_amx_tile_done();
+  } else {
+    // dim < 32: no tile ever stores to `out`, so the scalar tail below has to
+    // accumulate onto a known-zero destination rather than whatever was there.
+    for (size_t i = 0; i < m; i++) {
+      memset(out + i * out_stride, 0, n * sizeof(float));
+    }
+  }
+
+  const size_t tail = dim - full;
+  if (tail > 0) {
+    for (size_t i = 0; i < m; i++) {
+      // Widen this vector's tail once per row instead of once per (row,
+      // centroid) pair; `tail` is at most 31 so the buffer is a fixed 32.
+      float vec_tail[32];
+      const uint16_t *row = data + i * data_stride + full;
+      for (size_t d = 0; d < tail; d++) vec_tail[d] = _cvtsh_ss(row[d]);
+
+      float *out_row = out + i * out_stride;
+      for (size_t j = 0; j < n; j++) {
+        const uint16_t *cent = centroids + j * dim + full;
+        float acc = 0.0f;
+        for (size_t d = 0; d < tail; d++) acc += vec_tail[d] * _cvtsh_ss(cent[d]);
+        out_row[j] += acc;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration introspection
+// ---------------------------------------------------------------------------
+
+// Write the 64-byte LDTILECFG image for `cfg_kind` (a `LANCE_AMX_CFG_*`
+// constant) into `out`, without loading it. Returns 0 on success, -1 for an
+// unknown `cfg_kind`.
+//
+// Exposed so the Rust tests can pin each kernel's tile shape byte for byte. A
+// wrong shape does not fail cleanly — it is a #UD or silently wrong results —
+// so the shape is asserted directly rather than inferred from kernel output.
+int lance_amx_tilecfg_image(int cfg_kind, uint8_t *out) {
+  const lance_amx_tile_spec *specs;
+  size_t n;
+
+  switch (cfg_kind) {
+    case LANCE_AMX_CFG_SEARCH:
+      specs = SEARCH_TILES;
+      n = LANCE_AMX_TILE_COUNT(SEARCH_TILES);
+      break;
+    case LANCE_AMX_CFG_GEMM:
+      specs = GEMM_TILES;
+      n = LANCE_AMX_TILE_COUNT(GEMM_TILES);
+      break;
+    default:
+      return -1;
+  }
+
+  lance_amx_tilecfg cfg;
+  lance_amx_tilecfg_build(&cfg, specs, n);
+  memcpy(out, &cfg, sizeof(cfg));
+  return 0;
+}

--- a/rust/lance-linalg/src/simd/amx_fp16.rs
+++ b/rust/lance-linalg/src/simd/amx_fp16.rs
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! AMX-FP16 accelerated f16 x f16 dot products.
+//!
+//! Two shapes: `dot_f16_batch_16_amx` (one query against 16 candidates, for
+//! choosing the partitions a query probes) and `dot_f16_gemm_amx` (an m x n
+//! GEMM, for scoring many vectors against many centroids). Both are named in
+//! plain code spans rather than intra-doc links: they are
+//! `kernel_support = "amx_fp16"`-gated, so a link from these unconditional
+//! module docs is unresolved — and hence a rustdoc error under `-D warnings` —
+//! on any build without the kernel.
+//!
+//! The tile math lives in `amx_fp16.c` (compiled by `build.rs` with a compiler
+//! new enough for `-mamx-fp16`, which sets `kernel_support = "amx_fp16"`). This
+//! module holds the FFI declarations, the B-operand packing the GEMM's tile
+//! layout requires, and the runtime safety gate. Everything here is
+//! crate-internal; the safe public entry points are
+//! [`crate::distance::dot_f16::dot_f16_batch_16`] for the batch-16 shape and
+//! `PackedCentroidsF16` for the GEMM (named, not linked, for the same reason as
+//! the kernels above). The latter owns what this layer deliberately does not:
+//! padding `n` up to a multiple of 32, holding the packed B operand across
+//! calls, and turning the absence of AMX into an `Option` its caller — k-means
+//! assignment, in another crate that cannot see `kernel_support` — can branch
+//! on. Every kernel here is guarded by
+//! [`crate::distance::dot_f16::amx_fp16_supported`], which is also what callers
+//! consult before routing work here: one gate, decided by run-time capability
+//! alone.
+//!
+//! ## Safety gate
+//!
+//! A set CPUID bit is not sufficient to run AMX tile instructions on Linux:
+//! the OS must first grant the extended (XTILEDATA)
+//! state via `arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA)`; skipping
+//! that SIGILLs the first tile instruction. `amx_supported` requires, and
+//! caches process-wide, all of:
+//!   1. `target_arch = "x86_64"` and `target_os = "linux"` (compile-time cfg),
+//!   2. the amx-tile CPUID bit (leaf 7, sub-leaf 0, EDX bit 24) **and** the
+//!      amx-fp16 CPUID bit (leaf 7, sub-leaf 1, EAX bit 21),
+//!   3. a successful one-time `arch_prctl` permission request.
+//!
+//! On any failure the caller falls back to the existing AVX-512-FP16 / scalar
+//! `f16::dot` path, so results are unchanged (both accumulate in f32; only the
+//! summation order — hence fp16-level rounding — differs).
+//!
+//! ## XTILEDATA is a shared AMX state permission
+//!
+//! XTILEDATA (component 18) is the single dynamically-enabled XSAVE state
+//! backing the physical TMM tile registers; it is requested per-*state*, not
+//! per-*instruction*, so one grant covers every AMX compute instruction — see
+//! Linux `Documentation/arch/x86/xstate.rst` ("Dynamically Enabled XSAVE
+//! Features", AMX example) and Intel SDM Vol.1 §13.3. The syscall is
+//! idempotent, so requesting an already-granted permission again is harmless.
+
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+use crate::distance::dot_f16::strided_len;
+use half::f16;
+
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+unsafe extern "C" {
+    /// arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA); 0 on success.
+    fn lance_amx_fp16_request_perm() -> i32;
+
+    /// out[i] = sum_d f32(query[d]) * f32(candidates[i][d]), i in 0..count;
+    /// out[count..16] = 0. `query` is `dim` IEEE binary16 bit patterns;
+    /// `candidates` is 16 pointers to `dim` of them each, of which only the
+    /// first `count` (1..=16) are read; `out` holds 16 f32. The kernel gathers
+    /// the rows itself, k-block by k-block. See `amx_fp16.c`.
+    fn lance_amx_dot_f16_batch_16(
+        query: *const u16,
+        candidates: *const *const u16,
+        count: usize,
+        dim: usize,
+        out: *mut f32,
+    );
+
+    /// out[i*out_stride + j] = sum_d f32(data[i*data_stride + d]) *
+    /// f32(centroids[j*dim + d]), for i in 0..m, j in 0..n. `packed_b` is
+    /// [`pack_centroids_vnni`]'s output for the same centroids; `centroids`
+    /// itself is read only for the `dim % 32` unpacked tail dims. `m` and `n`
+    /// must both be multiples of 32. See `amx_fp16.c`.
+    fn lance_amx_dot_f16_gemm(
+        data: *const u16,
+        m: usize,
+        data_stride: usize,
+        packed_b: *const u16,
+        centroids: *const u16,
+        n: usize,
+        dim: usize,
+        out: *mut f32,
+        out_stride: usize,
+    );
+
+    /// Writes the 64-byte LDTILECFG image for `cfg_kind` into `out` without
+    /// loading it; 0 on success, -1 for an unknown kind. See `amx_fp16.c`.
+    #[cfg(test)]
+    fn lance_amx_tilecfg_image(cfg_kind: i32, out: *mut u8) -> i32;
+
+    /// Retires the tile configuration the way a foreign AMX user sharing this
+    /// thread would. See `amx_fp16.c`.
+    #[cfg(test)]
+    fn lance_amx_tile_clobber_for_test();
+
+    /// Writes this logical processor's live 64-byte tile configuration to `out`
+    /// via STTILECFG; `palette_id` (byte 0) is 0 when nothing is configured.
+    /// See `amx_fp16.c`.
+    #[cfg(test)]
+    fn lance_amx_tilecfg_current_for_test(out: *mut u8);
+}
+
+/// Test-only: retire this thread's tile configuration the way another AMX user
+/// on the same thread would, leaving the tile unit in INIT under a kernel that
+/// is about to run.
+///
+/// # Safety
+/// Executes TILERELEASE, so [`amx_supported`] must have returned `true` first.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) unsafe fn clobber_tile_state_for_test() {
+    unsafe { lance_amx_tile_clobber_for_test() };
+}
+
+/// Test-only: `true` when a tile configuration is currently live on this logical
+/// processor, read straight off the hardware with STTILECFG.
+///
+/// This is what distinguishes a working release path from a deleted one.
+/// `lance_amx_tile_ensure` reloads on every kernel entry, so results stay right
+/// with `lance_amx_tile_done`'s TILERELEASE gone and no "did it crash?" test
+/// notices; what is lost is only the promise made to whoever shares the thread,
+/// and that is visible nowhere but here.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn tile_config_is_live_for_test() -> bool {
+    let mut image = [0u8; 64];
+    // SAFETY: the C side writes exactly 64 bytes, and STTILECFG touches no TMM
+    // register so it is legal without the XTILEDATA grant.
+    unsafe { lance_amx_tilecfg_current_for_test(image.as_mut_ptr()) };
+    image[0] != 0
+}
+
+/// Config kind for [`tilecfg_image`]: the batch-16 search kernel's tile shape.
+/// Must match `LANCE_AMX_CFG_SEARCH` in `amx_fp16.c`.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) const AMX_CFG_SEARCH: i32 = 0;
+
+/// Config kind for [`tilecfg_image`]: the GEMM kernel's tile shape.
+/// Must match `LANCE_AMX_CFG_GEMM` in `amx_fp16.c`.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) const AMX_CFG_GEMM: i32 = 1;
+
+/// The 64-byte LDTILECFG image a kernel would configure, without loading it.
+/// `None` if `cfg_kind` is not one of the `AMX_CFG_*` constants.
+///
+/// Exists for the tests: a wrong tile shape never surfaces as a clean error —
+/// it is a #UD or silently wrong results — so the shape is pinned directly
+/// rather than inferred from kernel output.
+#[cfg(all(
+    test,
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn tilecfg_image(cfg_kind: i32) -> Option<[u8; 64]> {
+    let mut image = [0u8; 64];
+    // SAFETY: the C side writes exactly `sizeof(lance_amx_tilecfg)` bytes, which
+    // a `_Static_assert` there pins to 64 — the length of `image`.
+    let rc = unsafe { lance_amx_tilecfg_image(cfg_kind, image.as_mut_ptr()) };
+    (rc == 0).then_some(image)
+}
+
+/// True iff AMX-FP16 tile instructions can be executed safely in this process.
+/// Evaluated once and cached; the `arch_prctl` permission request (a syscall)
+/// happens at most once, process-wide.
+///
+/// This is a hardware question only — a pure "would a tile instruction fault
+/// here?" — so that kernel-level tests can exercise the kernels on any host
+/// that can run them.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn amx_supported() -> bool {
+    static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        if !detect_amx_fp16() {
+            return false;
+        }
+        // Request XTILEDATA permission; without a 0 return, any tile instruction
+        // would SIGILL, so treat anything else as unavailable.
+        unsafe { lance_amx_fp16_request_perm() == 0 }
+    })
+}
+
+/// AMX-TILE = CPUID leaf 7, sub-leaf 0, EDX bit 24. AMX-FP16 = CPUID leaf 7,
+/// sub-leaf 1, EAX bit 21. Both required.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+fn detect_amx_fp16() -> bool {
+    use std::arch::x86_64::__cpuid_count;
+    // `__cpuid_count` is safe on nightly but `unsafe` on stable; allow both.
+    #[allow(unused_unsafe)]
+    let leaf7_0 = unsafe { __cpuid_count(7, 0) };
+    let amx_tile = (leaf7_0.edx & (1 << 24)) != 0;
+    #[allow(unused_unsafe)]
+    let leaf7_1 = unsafe { __cpuid_count(7, 1) };
+    let amx_fp16 = (leaf7_1.eax & (1 << 21)) != 0;
+    amx_tile && amx_fp16
+}
+
+/// Batched AMX-FP16 dot product: one query against the first `len` of 16
+/// candidates. Returns the 16 raw dot products (`Σ query·candidate`, no `1.0 -`
+/// distance wrapping); lanes `len..16` are 0.
+///
+/// Hands the kernel 16 pointers rather than a packed `16 x dim` buffer. The
+/// candidates still have to be brought together for a tile load, but the kernel
+/// does it one k-block at a time into 3 KB of stack, which overlaps the copies
+/// with the tile ops; packing all `16 * dim * 2` bytes here first could not
+/// overlap with anything, and at dim 1024 that is 32 KB against a 48 KB L1D.
+/// See the kernel comment in `amx_fp16.c` for the measurements behind this.
+///
+/// `len` is what keeps a partial batch cheap: the tile pass is a fixed cost for
+/// 16 lanes either way, but only `len` rows are gathered.
+///
+/// # Safety
+/// `amx_supported` must have returned `true`. `len` must be in `1..=16` — the
+/// kernel does not clamp it, and a larger value walks its staging buffer off the
+/// end; [`crate::distance::dot_f16::dot_f16_batch_16`] is where that is
+/// rejected. Every candidate slice must have length `query.len()`, and must
+/// outlive the call.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) unsafe fn dot_f16_batch_16_amx(
+    query: &[f16],
+    candidates: &[&[f16]; 16],
+    len: usize,
+) -> [f32; 16] {
+    debug_assert!((1..=16).contains(&len), "len ({len}) must be in 1..=16");
+    let dim = query.len();
+    // half::f16 is #[repr(transparent)] over u16, so the casts below reinterpret
+    // the identical IEEE binary16 bit patterns the kernel expects. All 16 slots
+    // are filled even though the kernel reads only `len` of them: the caller
+    // already holds 16 valid slices, so there is nothing to gain from leaving
+    // the tail of the array undefined.
+    let mut rows = [std::ptr::null::<u16>(); 16];
+    for (i, cand) in candidates.iter().enumerate() {
+        debug_assert_eq!(
+            cand.len(),
+            dim,
+            "candidate {i} length must equal query length"
+        );
+        rows[i] = cand.as_ptr() as *const u16;
+    }
+    let mut out = [0f32; 16];
+    unsafe {
+        lance_amx_dot_f16_batch_16(
+            query.as_ptr() as *const u16,
+            rows.as_ptr(),
+            len,
+            dim,
+            out.as_mut_ptr(),
+        );
+    }
+    out
+}
+
+/// Halfwords in one packed B block: 16 tile rows x 32 halfwords per row.
+/// Mirrors `GEMM_B_BLOCK` in `amx_fp16.c`.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+const GEMM_B_BLOCK: usize = 512;
+
+/// Number of `f16` [`pack_centroids_vnni`] writes for `n` centroids of `dim`
+/// dims. Only whole 32-dim k-blocks are packed; the `dim % 32` tail is left to
+/// the kernel's scalar cleanup, which reads the unpacked centroids directly.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn packed_centroids_len(n: usize, dim: usize) -> usize {
+    (dim / 32) * (n / 16) * GEMM_B_BLOCK
+}
+
+/// Interleave `[n, dim]` row-major `centroids` into the VNNI order
+/// [`dot_f16_gemm_amx`]'s B tiles are loaded in, replacing `out`'s contents.
+///
+/// The layout is dictated by TDPFP16PS, which reads its B operand as
+/// `b.row[k].fp16[2*nn + p]` and pairs it with `a.row[mm].fp16[2*k + p]`. Since
+/// A is loaded straight out of the vector buffer — `a.row[mm].fp16[2*k+p]` is
+/// dim `kb*32 + 2*k + p` of vector `mm` — B must satisfy
+///
+/// ```text
+/// out[((kb * (n/16)) + jb) * 512 + k*32 + nn*2 + p]
+///     == centroids[(jb*16 + nn) * dim + kb*32 + 2*k + p]
+/// ```
+///
+/// with `kb` the 32-dim k-block and `jb` the 16-centroid block. `jb` is the
+/// inner index so that the two B tiles a single k-pass consumes are adjacent.
+///
+/// `n` must be a multiple of 16 (one B tile covers exactly 16 centroids);
+/// `centroids` must hold `n * dim` values.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+pub(crate) fn pack_centroids_vnni(centroids: &[f16], n: usize, dim: usize, out: &mut Vec<f16>) {
+    debug_assert_eq!(n % 16, 0, "n ({n}) must be a multiple of 16");
+    debug_assert_eq!(
+        centroids.len(),
+        n * dim,
+        "centroids must hold n*dim = {} values",
+        n * dim
+    );
+    out.clear();
+    out.reserve(packed_centroids_len(n, dim));
+    for kb in 0..dim / 32 {
+        for jb in 0..n / 16 {
+            for k in 0..16 {
+                for nn in 0..16 {
+                    for p in 0..2 {
+                        out.push(centroids[(jb * 16 + nn) * dim + kb * 32 + 2 * k + p]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// AMX-FP16 `[m, dim] x [n, dim]^T -> [m, n]` dot-product GEMM: scores every
+/// row of `data` against every centroid, writing raw dot products (no distance
+/// wrapping) into `out`.
+///
+/// `packed_b` must come from [`pack_centroids_vnni`] over the same `centroids`,
+/// `n` and `dim`; `centroids` is additionally passed through because the
+/// `dim % 32` tail dims are not packed and the kernel finishes them in scalar
+/// fp32. Rows of `data` are `data_stride` halfwords apart and rows of `out` are
+/// `out_stride` floats apart, so a caller can hand over a window of a larger
+/// buffer without copying.
+///
+/// Accuracy matches [`dot_f16_batch_16_amx`]'s contract: f32-accumulated to
+/// within fp16 precision, not bit-exact against a sequential scalar loop.
+///
+/// # Safety
+/// * [`crate::distance::dot_f16::amx_fp16_supported`] must have returned `true`.
+/// * `m % 32 == 0` and `n % 32 == 0`. The kernel has no edge-case path for
+///   partial tiles and would read and write past the ends of its buffers.
+/// * `data_stride >= dim` and `out_stride >= n`, and the slices must be long
+///   enough for the last row those strides reach.
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe fn dot_f16_gemm_amx(
+    data: &[f16],
+    m: usize,
+    data_stride: usize,
+    packed_b: &[f16],
+    centroids: &[f16],
+    n: usize,
+    dim: usize,
+    out: &mut [f32],
+    out_stride: usize,
+) {
+    debug_assert_eq!(m % 32, 0, "m ({m}) must be a multiple of 32");
+    debug_assert_eq!(n % 32, 0, "n ({n}) must be a multiple of 32");
+    debug_assert!(
+        data_stride >= dim,
+        "data_stride ({data_stride}) < dim ({dim})"
+    );
+    debug_assert!(out_stride >= n, "out_stride ({out_stride}) < n ({n})");
+    // Through `strided_len` rather than inline arithmetic, for the same reason
+    // the safe caller uses it: `(m - 1) * stride + row_len` wraps in release
+    // builds, and a wrapped requirement is small enough to satisfy the very
+    // check it was computed for. These are `debug_assert`s restating a contract
+    // the caller already enforced, but they should fail loudly on the
+    // overflowing shape rather than quietly agree with it.
+    debug_assert!(
+        strided_len(m, data_stride, dim).is_some_and(|need| data.len() >= need),
+        "data too short"
+    );
+    debug_assert!(
+        strided_len(m, out_stride, n).is_some_and(|need| out.len() >= need),
+        "out too short"
+    );
+    debug_assert_eq!(
+        Some(centroids.len()),
+        n.checked_mul(dim),
+        "centroids must hold n*dim values"
+    );
+    debug_assert_eq!(
+        packed_b.len(),
+        packed_centroids_len(n, dim),
+        "packed_b must be pack_centroids_vnni's output for this n and dim"
+    );
+    // half::f16 is #[repr(transparent)] over u16, so these casts reinterpret the
+    // identical IEEE binary16 bit patterns the kernel expects.
+    unsafe {
+        lance_amx_dot_f16_gemm(
+            data.as_ptr() as *const u16,
+            m,
+            data_stride,
+            packed_b.as_ptr() as *const u16,
+            centroids.as_ptr() as *const u16,
+            n,
+            dim,
+            out.as_mut_ptr(),
+            out_stride,
+        );
+    }
+}


### PR DESCRIPTION
## The problem

When lance builds an IVF index, it has to decide which partition every vector goes into.

Doing that exactly means comparing all 100M vectors against all 10k centroids. That was too slow, so today lance takes a shortcut: it builds a small HNSW graph over the centroids and searches that instead of comparing against all of them.

The shortcut gets some vectors wrong. A vector that belongs in partition 37 lands in partition 52.

**And you can never recover from that.** At query time you can scan partition 37 as hard as you like — the vector isn't there. Turning up `nprobes` doesn't help, because the problem isn't that you searched too few partitions, it's that the vector was filed in the wrong one at build time.

## The fix

Do it exactly, and use AMX to make that affordable.

Why AMX makes the difference: an AMX instruction computes a 16×16 block of results at once. The shortcut asks it to score one vector against a few graph neighbours, which fills 1 column out of 16 — you get 32 MAC/cycle out of the hardware. Comparing a batch of vectors against all centroids is a matrix multiply, which fills all 16 — 512 MAC/cycle.

**Same hardware, 16× the useful work.** That's enough to make the exact path faster than the shortcut it was invented to avoid.

## What you get

LAION 100M, 768-dim fp16, 10k partitions, dot distance, one 128-core NUMA node. **Five full runs**; every figure below is the range across them, not an error bar.

Measured with this branch based on `2bd8fccf8`; it has since been rebased onto current `main`. The rebase was clean and touches none of the AMX paths, and both arms of every run are the same binary with one environment variable flipped, so the ratios carry over even if absolute wall-clock on a newer base would differ.

| | exact (AMX) | shortcut (HNSW) | |
|---|---|---|---|
| **partition assignment (`shuffle` stage)** | **465–472 s** | 542–553 s | **13.0–15.8% faster** |
| index build, end to end | 1280–1331 s | 1387–1408 s | 4.2–9.1% faster |
| k-means loss per vector | 0.3438–0.3463 | 0.3493–0.3527 | 0.9–2.2% lower |
| recall@10 at the same `nprobes` | — | — | +1.2 to +4.8 points |
| p50 latency at 0.90 recall (128 concurrent) | — | — | 1.33–2.30× faster (median 1.81×) |
| QPS at 0.90 recall (128 concurrent) | — | — | 1.32–5.24× (median 1.90×) |

So the exact path is **faster to build and better to search** — you don't trade one for the other.

Three notes on how solid these numbers are.

**The build rows are stable; the query rows are not.** `shuffle` is where partition assignment actually runs, and its ten measurements across five runs span 464.8–472 s and 542.2–552.8 s — a 1.5% spread on the AMX arm. End-to-end build time is noisier because it also contains `train_ivf` and `merge_partitions`, neither of which the GEMM touches.

**The query ratios move a lot between runs, and I would rather show that than pick a run.** Earlier revisions of this PR quoted 2.06×, then 1.6–2.1×. Five runs give 2.06 / 1.90 / 1.60 / 1.32 / 5.24× at 0.90 recall. The cause is that lance's k-means has no seeded RNG (`kmeans.rs`: `// TODO: use seed for Rng.`), so each run draws a different index — and two properties of that draw pull the ratio in opposite directions:

- *Centroid quality.* The loss gap between the arms ranged 0.86–2.22%. A smaller gap means the shortcut's recall is closer to exact, so the advantage shrinks.
- *Partition skew.* `max/mean` on the shortcut arm ranged 98 to **487**. The 5.24× run drew a single partition holding 4.87M vectors — 4.9% of the dataset — so any query probing it scans a huge slice and throughput collapses.

The run with the *smallest* loss gap also had the *worst* skew, which is why its ratio came out highest rather than lowest. **Treat any single run's query ratio as one draw from a wide distribution; the medians are 1.81× (p50) and 1.90× (QPS).** The build-side numbers do not have this problem, because the GEMM's work is fixed at 100M × 10k regardless of how the partitions end up distributed.

**The query speedup is indirect, and I would rather say so than have you find it in review.** At the same `nprobes` both paths take the same time per query (117.8 ms vs 117.2 ms) — a search is one query against M candidates, so it cannot fill the tile either and AMX does nothing for it. What changes is that correct partition assignment reaches 0.90 recall at a lower `nprobes`, so there is less data to scan. It wins by having less work to do, not by doing the same work faster.

## It's on by default

There is no cargo feature and no opt-in variable. Both `Cargo.toml` files are byte-identical to upstream — this PR doesn't touch build configuration at all.

Dispatch is one run-time question, `amx_fp16_supported()`, and all of it has to hold:

1. **The kernel is in the binary.** `build.rs` probes for a C compiler accepting `-mamx-fp16` (Clang ≥ 16 or GCC ≥ 13) on every Linux x86_64 build. Whether the kernel *can* be built is a property of the toolchain rather than a choice, so it is probed rather than gated; no capable compiler means a `cargo:warning` and a skip, not a failed build. `LANCE_AMX_FP16_CC` overrides the search.
2. **The CPU can run it.** The `amx-tile` and `amx-fp16` CPUID bits, then a one-time `XTILEDATA` `arch_prctl`. Either failing means fall back, so the same binary is safe to ship to machines without AMX.

A machine with the silicon uses the kernel with nothing to enable. Everything else keeps today's behaviour.

**`LANCE_DISABLE_AMX=1` takes the AMX paths out of service without a rebuild.** It is a kill switch, not a gate — unset means enabled. It exists because this change swaps the partition-assignment *algorithm*, not just its speed, so an operator who hits a problem needs the previous path back without rebuilding; and because A/B measurement otherwise needs two differently-built binaries, which mixes the AMX switch with the compiler that built them. It follows the `LANCE_USE_HNSW_SPEEDUP_INDEXING` pattern already in `may_train_index`: same function, same decision, auto by default with an explicit override. An unrecognised value leaves AMX **on** — the default is on, and an unparseable request to deviate from it shouldn't be honoured by halves.

Two functions, because there are two questions: `amx_fp16_supported()` is "can this machine run it", `amx_fp16_available()` adds "and has the operator not turned it off". Routing uses the second. Kernel internals and unit tests use the first, so AMX correctness tests still exercise the tile path on capable hardware even when an operator has switched the production paths off.

**Scope:** the exact path is only taken when fp16 centroids, dot distance, `dim >= 32`, at least 32 centroids, the kernel compiled in, and the CPU check all line up. Anything else behaves exactly as it does today.

**Size checks:** every length the safe wrappers verify before the FFI call is computed with checked arithmetic. Written inline, `(m - 1) * stride + row_len` wraps in release builds, and a wrapped requirement comes out *small* enough to satisfy the very check it was computed for — `m = 32`, `stride = 595_056_260_442_243_601`, `row_len = 32` wraps to 47, which would admit a 47-element slice into a kernel that strides `data + i * stride` past its end. `strided_len` returns `None` on overflow and every caller rejects it; the constructor applies the same contract to `n * dim`, the padding, and the padded allocation.

**Tile state:** the kernels reload their tile configuration on every entry and release it on exit, rather than caching it per thread. lance doesn't own the tile unit — another AMX user on the same thread (oneDNN under PyTorch, ONNX Runtime in the same process) can retire or reshape a configuration lance believes is live, and nothing inside the kernel can observe that. `kernel_reconfigures_after_foreign_tile_release` pins this: it clobbers the tile state through a bare `TILERELEASE` and then calls the kernel, and it reads the live configuration back with `STTILECFG`, because the release on exit has no other symptom.

## Relationship to #7933

**The kernel files here overlap with #7933** (`simd/amx_fp16.rs`, `simd/amx_fp16.c`, `distance/dot_f16.rs`).

I made this PR self-contained so it can be reviewed on its own instead of stacked on top. It contains the kernel plus the IVF routing and nothing else — it does **not** include the HNSW search changes from #7933 (`graph.rs`, `flat/storage.rs`, `storage.rs`).

If #7933 merges first I'll rebase this and drop the duplicate kernel commit. If you'd prefer the opposite order, #7933 can rebase onto this one. Either is fine — just tell me which you want.

One difference worth flagging: this PR dispatches on run-time capability with a `LANCE_DISABLE_AMX` kill switch; #7933 currently has no such switch. If both land, that switch should probably cover the HNSW path too.

## Testing

```bash
cargo test  -p lance-linalg --release dot_f16          # 19 passed
cargo test  -p lance-index  --release --lib vector::kmeans   # 15 passed
cargo clippy -p lance-linalg -p lance-index --tests --benches -- -D warnings
cargo fmt --all -- --check
```

The AMX correctness tests compare tile-kernel output against the per-vector reference path, and they **fail** rather than skip if the kernel turns down a shape — so a green run on AMX hardware means the tile path actually executed. Verified with both Clang 16 and GCC 13.4 building the kernel.

### Dispatch, on real hardware both ways

"Falls back safely" is easy to claim and easy to get wrong, so it is measured rather than asserted — on a host with no AMX of any kind (kernel 6.8) as well as this AMX-FP16 one:

| | build | run | result |
|---|---|---|---|
| AMX host, clang-16 | kernel compiled in (3 AMX symbols) | `supported=true` | 21 passed; GEMM actually executes |
| **same binary → non-AMX host** | — | `supported=false` | **21 passed, exit 0, no SIGILL** |
| non-AMX host, gcc 13.3 locally | compiles AMX code fine | — | probe `.o` produced on a CPU with no AMX |
| gcc 12.3, no clang on PATH | `cargo:warning`, skipped | always false | 11 passed, **0 AMX symbols in the binary** |

Row 3 is the CI case: build-time detection probes the *toolchain*, never the host CPU (`build.rs` contains no CPUID or `/proc/cpuinfo` read), so a machine without AMX still produces a binary that uses it elsewhere. Row 4 is the honest-fallback case: with no capable compiler the kernel is absent rather than present-but-unused, so the `cfg`-gated code and its tests are not compiled at all — hence 11 tests instead of 21.

Incidental, but worth knowing: on this host `lscpu` reports `amx_bf16 amx_tile amx_int8` but **not** `amx_fp16`, while CPUID leaf 7 sub-leaf 1 EAX bit 21 reads 1 — the 5.15 kernel does not know the flag name. Anything checking `/proc/cpuinfo` for AMX-FP16 will get this wrong; the code reads CPUID directly and is unaffected.

One lint caveat: `cargo clippy --all --tests --benches -- -D warnings` does not pass on this branch's base — `rust/lance-file/src/reader.rs:2462` re-imports `LanceFileVersion` (E0252). That file is untouched here; the two crates this PR changes are clean.
