### PR TITLE
fix(linalg): validate multivec_distance input instead of panicking

### DIFF
--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -322,23 +322,69 @@ pub fn multivec_distance(
     vectors: &ListArray,
     distance_type: DistanceType,
 ) -> Result<Vec<f32>> {
-    let dim = if let DataType::FixedSizeList(_, dim) = vectors.value_type() {
-        dim as usize
-    } else {
-        return Err(ArrowError::InvalidArgumentError(
-            "vectors must be a list of fixed size list".to_string(),
-        ));
-    };
-
-    // check the query vectors type first
-    // because we don't want to check the vectors type for each vector
-    match query.data_type() {
-        DataType::Float16 | DataType::Float32 | DataType::Float64 | DataType::UInt8 => {}
+    let (element_type, dim) = match vectors.value_type() {
+        DataType::FixedSizeList(field, dim) => (field.data_type().clone(), dim as usize),
         _ => {
             return Err(ArrowError::InvalidArgumentError(
-                "query must be a float array or binary array".to_string(),
+                "vectors must be a list of fixed size list".to_string(),
             ));
         }
+    };
+
+    // Validate the query once, up front, rather than per vector. The type and
+    // metric checks below prevent an arrow downcast panic or the `unreachable!`
+    // dispatch arm — the dispatch picks its kernel type from the query's dtype
+    // and then downcasts the *stored* values to that same type. The dim, null
+    // and length checks prevent a `chunks_exact` panic and, worse, silently
+    // wrong results: a short query yields no sub-vectors and scores every row
+    // `1.0`, and a null slot is scored from whatever the values buffer holds.
+    let query_type = query.data_type();
+    // Which element types have a kernel here at all. `Int8` is a valid vector
+    // element type elsewhere in the stack (`l2_distance_arrow_batch` and its
+    // siblings have an `Int8` arm) but has no multivector kernel, so it is
+    // rejected for the type, not the metric.
+    let type_supported = matches!(
+        query_type,
+        DataType::UInt8 | DataType::Float16 | DataType::Float32 | DataType::Float64
+    );
+    if !type_supported {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "multivec_distance: unsupported vector element type {query_type}"
+        )));
+    }
+    let metric_supported = match query_type {
+        DataType::UInt8 => distance_type == DistanceType::Hamming,
+        _ => matches!(
+            distance_type,
+            DistanceType::L2 | DistanceType::Cosine | DistanceType::Dot
+        ),
+    };
+    if !metric_supported {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "multivec_distance: distance type {distance_type} does not support query type {query_type}"
+        )));
+    }
+    if *query_type != element_type {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "multivec_distance: query type {query_type} does not match the stored vector type {element_type}"
+        )));
+    }
+    if dim == 0 {
+        return Err(ArrowError::InvalidArgumentError(
+            "multivec_distance: stored vectors have dimension 0".to_string(),
+        ));
+    }
+    if query.null_count() > 0 {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "multivec_distance: query must not contain nulls, got {} null(s)",
+            query.null_count()
+        )));
+    }
+    if query.is_empty() || !query.len().is_multiple_of(dim) {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "multivec_distance: query length {} must be a positive multiple of the vector dimension {dim}",
+            query.len()
+        )));
     }
 
     let mut dists = Vec::with_capacity(vectors.len());
@@ -430,10 +476,172 @@ mod tests {
 
     use std::sync::Arc;
 
-    use arrow_array::types::Float32Type;
-    use arrow_array::{Float32Array, ListArray};
+    use arrow_array::types::{Float16Type, Float32Type, Int8Type};
+    use arrow_array::{Float32Array, Int8Array, ListArray, PrimitiveArray, UInt8Array};
     use arrow_buffer::OffsetBuffer;
     use arrow_schema::Field;
+    use half::f16;
+
+    /// Build a single-row `List<FixedSizeList<T, dim>>` holding one sub-vector.
+    fn multivec_of<T: ArrowPrimitiveType>(values: Vec<T::Native>, dim: i32) -> ListArray {
+        let inner = PrimitiveArray::<T>::from_iter_values(values);
+        let fsl = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", T::DATA_TYPE, true)),
+            dim,
+            Arc::new(inner),
+            None,
+        )
+        .unwrap();
+        let offsets = OffsetBuffer::from_lengths([1_usize]);
+        let field = Arc::new(Field::new("item", fsl.data_type().clone(), true));
+        ListArray::try_new(field, offsets, Arc::new(fsl), None).unwrap()
+    }
+
+    /// The `(query dtype, distance type)` pre-check and the dispatch must agree.
+    /// `UInt8` is only valid with Hamming, and the float types only with the
+    /// float metrics; a mismatch must be an error rather than a panic in the
+    /// dispatch arm or inside an arrow downcast.
+    #[test]
+    fn test_multivec_distance_rejects_dtype_metric_mismatch() {
+        let f32_vectors = multivec_of::<Float32Type>(vec![1.0, 2.0], 2);
+        let u8_vectors = multivec_of::<UInt8Type>(vec![1, 2], 2);
+
+        let u8_query: Arc<dyn Array> = Arc::new(UInt8Array::from(vec![1_u8, 2]));
+        let f32_query: Arc<dyn Array> = Arc::new(Float32Array::from(vec![1.0_f32, 2.0]));
+
+        // Query and stored types MATCH in each case, so only the metric is wrong
+        // — otherwise the element-type check would reject these first and this
+        // test would pass with the metric guard deleted.
+        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
+            let err = multivec_distance(u8_query.as_ref(), &u8_vectors, dt).unwrap_err();
+            assert!(
+                matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("does not support query type")),
+                "UInt8 query with {dt} must be rejected for the metric, got: {err}"
+            );
+        }
+
+        let err =
+            multivec_distance(f32_query.as_ref(), &f32_vectors, DistanceType::Hamming).unwrap_err();
+        assert!(
+            matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("does not support query type")),
+            "Float32 query with hamming must be rejected for the metric, got: {err}"
+        );
+    }
+
+    /// `Int8` is a valid vector element type elsewhere in the crate but has no
+    /// multivector kernel, so it must be rejected for the type, not the metric.
+    #[test]
+    fn test_multivec_distance_rejects_unsupported_element_type() {
+        let i8_vectors = multivec_of::<Int8Type>(vec![1, 2], 2);
+        let i8_query: Arc<dyn Array> = Arc::new(Int8Array::from(vec![1_i8, 2]));
+
+        let err = multivec_distance(i8_query.as_ref(), &i8_vectors, DistanceType::L2).unwrap_err();
+        assert!(
+            matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("unsupported vector element type")),
+            "Int8 must be rejected for the element type, got: {err}"
+        );
+    }
+
+    /// The query's element type must match the stored vectors': the dispatch
+    /// picks `T` from the query and then downcasts the stored array to the same
+    /// `T` without checking it.
+    #[test]
+    fn test_multivec_distance_rejects_element_type_mismatch() {
+        let f16_vectors =
+            multivec_of::<Float16Type>(vec![f16::from_f32(1.0), f16::from_f32(2.0)], 2);
+        let f32_query: Arc<dyn Array> = Arc::new(Float32Array::from(vec![1.0_f32, 2.0]));
+
+        let err =
+            multivec_distance(f32_query.as_ref(), &f16_vectors, DistanceType::L2).unwrap_err();
+        assert!(
+            matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("does not match the stored vector type")),
+            "Float32 query against a Float16 column must be rejected, got: {err}"
+        );
+    }
+
+    /// A query length that is not a positive multiple of `dim` is structurally
+    /// invalid: `chunks_exact` would silently drop the tail, and a query shorter
+    /// than `dim` would yield no sub-vectors at all and score every row `1.0`.
+    #[test]
+    fn test_multivec_distance_rejects_bad_query_length() {
+        let vectors = multivec_of::<Float32Type>(vec![1.0, 2.0], 2);
+
+        for bad in [vec![7.0_f32], vec![7.0, 7.0, 999.0], vec![]] {
+            let len = bad.len();
+            let query: Arc<dyn Array> = Arc::new(Float32Array::from(bad));
+            let err = multivec_distance(query.as_ref(), &vectors, DistanceType::L2).unwrap_err();
+            assert!(
+                matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("must be a positive multiple")),
+                "query of length {len} against dim 2 must be rejected, got: {err}"
+            );
+        }
+    }
+
+    /// A zero-dimension column would panic in `chunks_exact(0)`; it gets its own
+    /// message rather than blaming the query's length.
+    #[test]
+    fn test_multivec_distance_rejects_zero_dim() {
+        let values = Float32Array::from(Vec::<f32>::new());
+        let fsl = FixedSizeListArray::try_new_with_length(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            0,
+            Arc::new(values),
+            None,
+            1,
+        )
+        .unwrap();
+        let field = Arc::new(Field::new("item", fsl.data_type().clone(), true));
+        let vectors = ListArray::try_new(
+            field,
+            OffsetBuffer::from_lengths([1_usize]),
+            Arc::new(fsl),
+            None,
+        )
+        .unwrap();
+        let query: Arc<dyn Array> = Arc::new(Float32Array::from(vec![1.0_f32, 2.0]));
+
+        let err = multivec_distance(query.as_ref(), &vectors, DistanceType::L2).unwrap_err();
+        assert!(
+            matches!(&err, ArrowError::InvalidArgumentError(m)
+                if m.contains("stored vectors have dimension 0")
+                    && !m.contains("positive multiple")),
+            "a zero-dim column must be rejected on its own terms, got: {err}"
+        );
+    }
+
+    /// A null query slot is read from the raw values buffer, so it would be
+    /// silently scored as whatever the buffer holds.
+    #[test]
+    fn test_multivec_distance_rejects_null_query() {
+        let vectors = multivec_of::<Float32Type>(vec![1.0, 2.0], 2);
+        let query: Arc<dyn Array> = Arc::new(Float32Array::from(vec![Some(1.0_f32), None]));
+
+        let err = multivec_distance(query.as_ref(), &vectors, DistanceType::L2).unwrap_err();
+        assert!(
+            matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("must not contain nulls")),
+            "a query with nulls must be rejected, got: {err}"
+        );
+    }
+
+    /// The guards must not reject the combinations that do work: `UInt8` with
+    /// Hamming is the one non-float path through this function.
+    ///
+    /// Note the expected value is `1.0 - hamming`, matching what the function
+    /// computes. Unlike the float paths — which accumulate `1.0 - distance` and
+    /// so end up with a distance again — the Hamming path accumulates a raw
+    /// distance, so `1.0 - sim` inverts its ranking. That inversion is
+    /// pre-existing and out of scope here; this test pins current behavior
+    /// rather than endorsing it.
+    #[test]
+    fn test_multivec_distance_accepts_u8_hamming() {
+        let vectors = multivec_of::<UInt8Type>(vec![0b0000_1111, 0b0000_0000], 2);
+        let query: Arc<dyn Array> = Arc::new(UInt8Array::from(vec![0b0000_1111_u8, 0b0000_0001]));
+
+        let dists = multivec_distance(query.as_ref(), &vectors, DistanceType::Hamming).unwrap();
+        assert_eq!(dists.len(), 1);
+        // One differing bit between the query and the single stored sub-vector.
+        assert_eq!(dists[0], 1.0 - 1.0);
+    }
 
     #[test]
     fn test_multivec_distance_empty_row_is_nan() {


### PR DESCRIPTION
## Summary

`multivec_distance` validated only the query's dtype, then dispatched on that dtype and used the resulting `T` to downcast the **stored** array as well. Three combinations reached a panic and two produced a silently wrong answer:

| input | before |
|---|---|
| `UInt8` query + a float metric | passes the dtype pre-check, then hits `unreachable!("missed to check query type")` — the non-Hamming arm only matches the three float types |
| float query + `Hamming` | the arm's unconditional `as_primitive::<UInt8Type>()` panics in arrow |
| query float width ≠ column's (e.g. f32 query, f16 column) | `T` comes from the query, then downcasts the stored f16 values to it — panics |
| query shorter than `dim` | no sub-vectors, `.sum()` over an empty iterator is `0.0`, every row scores `1.0 - 0.0` — an ordinary-looking distance for a structurally invalid query |
| query length not a multiple of `dim` | tail silently dropped |
| null slot in the query | read from the raw values buffer, scored as whatever it holds |

Six checks are hoisted ahead of the loop instead: the element type has a kernel here at all, the `(dtype, metric)` pair is valid, the query type equals the stored element type, `dim != 0`, the query has no nulls, and its length is a positive multiple of `dim`. Each returns `ArrowError::InvalidArgumentError` naming both operands — which is what the function already did for the two shape problems it *did* check.

`Int8` gets the type-level message rather than the metric one: it is a valid vector element type elsewhere in the stack (`l2_distance_arrow_batch` and its siblings have an `Int8` arm, and `validate_distance_type_for` accepts `Int8` with the float metrics) and only lacks a multivector kernel, so blaming the distance type would send a reader the wrong way.

## Nothing legitimate is rejected

`Scanner::nearest` coerces the query key to the column's element type before flat search — `scanner.rs:1715-1719`, where `element_type` comes from `infer_vector_element_type`, which unwraps `List<FixedSizeList<T>>` to the same `T` this function reads. So the "half-precision column, full-precision query" case keeps working; the type-equality check is a no-op there. The path that skips that coercion, `filter_query(QueryFilter::Vector(..))`, is exactly where the panics were reachable.

Every input that trips checks 0-3 previously panicked, so no currently-green caller or test can be turned red by them. The only behavior available to a previously-working caller is check 5 turning an all-`1.0` result into an error.

## Behavior change

These inputs now return `Err` where they previously panicked — surfacing through `spawn_blocking` as an opaque `LanceError(IO): task N panicked` — or returned a plausible-looking `1.0`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p lance-linalg --all-targets -- -D warnings`
- [x] `cargo test -p lance-linalg --lib` — 148 passed
- [x] `cargo check -p lance -p lance-index --tests`
- [x] `cargo test -p lance-index --lib vector::flat` — 7 passed

Six rejecting tests plus one positive. Each rejecting test pairs inputs so that **only** the guard under test can fire — the metric test uses matching query/stored types, so it would otherwise be absorbed by the type-equality check — and asserts on the error variant and its distinguishing message rather than `is_err()`, per `rust/AGENTS.md`. Verified that deleting any single guard turns its test red:

| guard | deleting it produces |
|---|---|
| element type has a kernel | `unreachable!` panic |
| dtype × metric | `unreachable!` panic (u8) / arrow downcast panic (f32+Hamming) |
| query type == stored type | arrow downcast panic |
| `dim != 0` | the length message, which the assertion explicitly excludes |
| no nulls | `Ok` with the buffer placeholder scored |
| length a positive multiple | `Ok([1.0])`, or `Ok` with the tail dropped |

The positive test covers `UInt8` + Hamming, the one non-float path through this function and the combination `flat.rs` actually uses.