### PR TITLE
fix(build): fix build in main

### DIFF
--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -3403,6 +3403,7 @@ mod tests {
             prepared_metrics(),
             state.clone(),
             usize::MAX,
+            None,
         )
         .try_collect::<Vec<_>>();
 
@@ -3420,6 +3421,7 @@ mod tests {
             prepared_metrics(),
             state,
             usize::MAX,
+            None,
         )
         .try_collect::<Vec<_>>();
 


### PR DESCRIPTION
Main seems to break which affects my PR
```sh
error[E0061]: this function takes 9 arguments but 8 arguments were supplied
    --> rust/lance/src/io/exec/knn.rs:3414:23
     |
3414 |           let delta_b = ANNIvfSubIndexExec::late_search(
     |  _______________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
3415 | |             index_b,
3416 | |             query_b,
3417 | |             Arc::new(UInt32Array::from(vec![0, 1, 2, 3])),
...    |
3422 | |             usize::MAX,
3423 | |         )
     | |_________- argument #9 of type `std::option::Option<std::sync::Arc<lance_select::RowAddrMask>>` is missing
     |
note: associated function defined here
    --> rust/lance/src/io/exec/knn.rs:1680:8
     |
1680 |     fn late_search(
     |        ^^^^^^^^^^^
...
1689 |         seg_mask: Option<Arc<RowAddrMask>>,
     |         ----------------------------------
help: provide the argument
     |
3414 |         let delta_b = ANNIvfSubIndexExec::late_search(
 ...
3422 |             usize::MAX,
3423 ~             /* std::option::Option<std::sync::Arc<lance_select::RowAddrMask>> */,
3424 ~         )
     |
```