### PR TITLE
chore: update lance-namespace-reqwest-client to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -8798,7 +8798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ lance-io = { version = "=11.0.0-beta.11", path = "./rust/lance-io", default-feat
 lance-linalg = { version = "=11.0.0-beta.11", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=11.0.0-beta.11", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=11.0.0-beta.11", path = "./rust/lance-namespace-impls" }
-lance-namespace-reqwest-client = "0.8.6"
+lance-namespace-reqwest-client = "0.11.0"
 lance-select = { version = "=11.0.0-beta.11", path = "./rust/lance-select" }
 lance-tokenizer = { version = "=11.0.0-beta.11", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=11.0.0-beta.11", path = "./rust/lance-table" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4183,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -5508,7 +5508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -5527,7 +5527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4490,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -6010,7 +6010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6029,7 +6029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7819,7 +7819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1685,6 +1685,7 @@ impl DirectoryNamespace {
                 timestamp_millis: None,
                 metadata: None,
             })),
+            ..Default::default()
         }
     }
 
@@ -2555,6 +2556,7 @@ impl DirectoryNamespace {
         DescribeTransactionResponse {
             status: effective_status,
             properties: Some(properties),
+            ..Default::default()
         }
     }
 
@@ -2581,6 +2583,7 @@ impl DirectoryNamespace {
             num_indexed_rows: get_i64("num_indexed_rows"),
             num_unindexed_rows: get_i64("num_unindexed_rows"),
             num_indices: get_i64("num_indices").and_then(|value| i32::try_from(value).ok()),
+            ..Default::default()
         }
     }
 
@@ -3915,6 +3918,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(ListTableVersionsResponse {
             versions: table_versions,
             page_token: None,
+            ..Default::default()
         })
     }
 
@@ -4108,6 +4112,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(DescribeTableVersionResponse {
             version: Box::new(table_version),
+            ..Default::default()
         })
     }
 
@@ -4161,6 +4166,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(BatchDeleteTableVersionsResponse {
             deleted_count: Some(total_deleted_count),
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -4230,7 +4236,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|transaction| transaction.uuid);
 
-        Ok(CreateTableIndexResponse { transaction_id })
+        Ok(CreateTableIndexResponse {
+            transaction_id,
+            ..Default::default()
+        })
     }
 
     async fn list_table_indices(
@@ -4325,6 +4334,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(ListTableIndicesResponse {
             indexes: indices,
             page_token,
+            ..Default::default()
         })
     }
 
@@ -4616,6 +4626,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(AlterTransactionResponse {
             status: final_status,
             properties: response.properties,
+            ..Default::default()
         })
     }
 
@@ -4638,6 +4649,7 @@ impl LanceNamespace for DirectoryNamespace {
         let response = self.create_table_index(request).await?;
         Ok(CreateTableScalarIndexResponse {
             transaction_id: response.transaction_id,
+            ..Default::default()
         })
     }
 
@@ -4698,7 +4710,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|transaction| transaction.uuid);
 
-        Ok(DropTableIndexResponse { transaction_id })
+        Ok(DropTableIndexResponse {
+            transaction_id,
+            ..Default::default()
+        })
     }
 
     async fn list_all_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
@@ -4768,7 +4783,10 @@ impl LanceNamespace for DirectoryNamespace {
             })?
             .map(|t| t.uuid);
 
-        Ok(RestoreTableResponse { transaction_id })
+        Ok(RestoreTableResponse {
+            transaction_id,
+            ..Default::default()
+        })
     }
 
     async fn update_table_schema_metadata(
@@ -4811,6 +4829,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(UpdateTableSchemaMetadataResponse {
             metadata: Some(updated_metadata),
             transaction_id,
+            ..Default::default()
         })
     }
 
@@ -5036,6 +5055,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(InsertIntoTableResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -5067,6 +5087,7 @@ impl LanceNamespace for DirectoryNamespace {
                 num_inserted_rows: Some(num_rows as i64),
                 num_deleted_rows: Some(0),
                 version: Some(version),
+                ..Default::default()
             });
         }
 
@@ -5137,6 +5158,7 @@ impl LanceNamespace for DirectoryNamespace {
             num_inserted_rows: Some(stats.num_inserted_rows as i64),
             num_deleted_rows: Some(stats.num_deleted_rows as i64),
             version: Some(dataset.version().version as i64),
+            ..Default::default()
         })
     }
 
@@ -5221,6 +5243,7 @@ impl LanceNamespace for DirectoryNamespace {
             updated_rows: result.rows_updated as i64,
             version,
             properties: None,
+            ..Default::default()
         })
     }
 
@@ -5250,6 +5273,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(DeleteFromTableResponse {
             transaction_id: None,
             version: Some(result.new_dataset.version().version as i64),
+            ..Default::default()
         })
     }
 
@@ -5523,6 +5547,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(ListTableTagsResponse {
             tags,
             page_token: None,
+            ..Default::default()
         })
     }
 
@@ -5552,6 +5577,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(GetTableTagVersionResponse {
             version: contents.version as i64,
             branch: contents.branch,
+            ..Default::default()
         })
     }
 
@@ -5589,6 +5615,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(CreateTableTagResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -5617,6 +5644,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(DeleteTableTagResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -5654,6 +5682,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(UpdateTableTagResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -5723,6 +5752,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(CreateTableBranchResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 
@@ -5768,6 +5798,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(ListTableBranchesResponse {
             branches,
             page_token: None,
+            ..Default::default()
         })
     }
 
@@ -5804,6 +5835,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(DeleteTableBranchResponse {
             transaction_id: None,
+            ..Default::default()
         })
     }
 


### PR DESCRIPTION
Picks up the namespace spec computed column surface (AddColumnsEntry.computed,
backfill_column) for downstream SDKs. Every response model gained an optional
context map, so the directory namespace initializers fill remaining fields with
Default::default(); the new num_inserted_rows and version on
InsertIntoTableResponse stay unpopulated there for now.