### PR TITLE
feat(java): add combined_fields (BM25F) full-text query

### DIFF
--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -21,9 +21,9 @@ use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
     DocumentGranularity,
     query::{
-        BooleanQuery as FtsBooleanQuery, BoostQuery as FtsBoostQuery, FtsQuery,
-        MatchQuery as FtsMatchQuery, MultiMatchQuery as FtsMultiMatchQuery, Occur as FtsOccur,
-        PhraseQuery as FtsPhraseQuery,
+        BooleanQuery as FtsBooleanQuery, BoostQuery as FtsBoostQuery,
+        CombinedFieldsQuery as FtsCombinedFieldsQuery, FtsQuery, MatchQuery as FtsMatchQuery,
+        MultiMatchQuery as FtsMultiMatchQuery, Occur as FtsOccur, PhraseQuery as FtsPhraseQuery,
     },
 };
 use lance_io::ffi::to_ffi_arrow_array_stream;
@@ -172,6 +172,33 @@ pub(crate) fn build_full_text_search_query<'a>(
             query = query.with_operator(operator);
 
             Ok(FtsQuery::MultiMatch(query))
+        }
+        "COMBINED_FIELDS" => {
+            let query_text = env.get_string_from_method(&java_obj, "getQueryText")?;
+            let columns: Vec<String> =
+                import_vec_from_method(env, &java_obj, "getColumns", |env, elem| {
+                    let jstr = JString::from(elem);
+                    let value: String = env.get_string(&jstr)?.into();
+                    Ok(value)
+                })?;
+
+            let boosts: Option<Vec<f32>> =
+                env.get_optional_from_method(&java_obj, "getBoosts", |env, list_obj| {
+                    import_vec_to_rust(env, &list_obj, |env, elem| {
+                        env.get_f32_from_method(&elem, "floatValue")
+                    })
+                })?;
+            let operator = env.get_fts_operator_from_method(&java_obj)?;
+
+            // Column uniqueness and boost (>= 1) validation live in the Rust core;
+            // `?` surfaces those errors across the JNI boundary.
+            let mut query = FtsCombinedFieldsQuery::try_new(query_text, columns)?;
+            if let Some(boosts) = boosts {
+                query = query.try_with_boosts(boosts)?;
+            }
+            query = query.with_operator(operator);
+
+            Ok(FtsQuery::CombinedFields(query))
         }
         "BOOST" => {
             let positive_obj = env

--- a/java/src/main/java/org/lance/ipc/FullTextQuery.java
+++ b/java/src/main/java/org/lance/ipc/FullTextQuery.java
@@ -36,6 +36,7 @@ public abstract class FullTextQuery {
     MATCH_PHRASE,
     BOOST,
     MULTI_MATCH,
+    COMBINED_FIELDS,
     BOOLEAN
   }
 
@@ -154,6 +155,15 @@ public abstract class FullTextQuery {
   public static FullTextQuery multiMatch(
       String queryText, List<String> columns, List<Float> boosts, Operator operator) {
     return new MultiMatchQuery(queryText, columns, boosts, operator);
+  }
+
+  public static FullTextQuery combinedFields(String queryText, List<String> columns) {
+    return combinedFields(queryText, columns, null, Operator.OR);
+  }
+
+  public static FullTextQuery combinedFields(
+      String queryText, List<String> columns, List<Float> boosts, Operator operator) {
+    return new CombinedFieldsQuery(queryText, columns, boosts, operator);
   }
 
   public static FullTextQuery boost(FullTextQuery positive, FullTextQuery negative) {
@@ -408,6 +418,93 @@ public abstract class FullTextQuery {
       if (this == o) return true;
       if (!(o instanceof MultiMatchQuery)) return false;
       MultiMatchQuery other = (MultiMatchQuery) o;
+      return operator == other.operator
+          && Objects.equals(queryText, other.queryText)
+          && Objects.equals(columns, other.columns)
+          && Objects.equals(boosts, other.boosts);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(queryText, columns, operator, boosts);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("type", getType())
+          .add("queryText", queryText)
+          .add("columns", columns)
+          .add("boosts", boosts)
+          .add("operator", operator)
+          .toString();
+    }
+  }
+
+  /**
+   * Combined-fields (BM25F) query across multiple columns.
+   *
+   * <p>Unlike {@link MultiMatchQuery}, which scores each column independently and keeps the best
+   * field, this query treats the target columns as a single virtual field so that term statistics
+   * are blended across fields (Lucene {@code CombinedFieldQuery}). A term that is rare in one field
+   * but common in another then scores consistently, and a single query term can match across fields
+   * (for example a first name in one column and a last name in another).
+   *
+   * <p>Target columns must be unique and share the same tokenizer/index configuration. When {@code
+   * boosts} is given, its length must equal the number of columns and each per-column weight must
+   * be finite and {@code >= 1} (fractional weights allowed); when {@code null}, every column
+   * defaults to {@code 1.0}. A {@code null} operator defaults to {@link Operator#OR}. These
+   * constraints are validated in the Rust core and surface as an exception when the query runs.
+   */
+  public static final class CombinedFieldsQuery extends FullTextQuery {
+    private final String queryText;
+    private final List<String> columns;
+    private final Optional<List<Float>> boosts;
+    private final Operator operator;
+
+    CombinedFieldsQuery(
+        String queryText, List<String> columns, List<Float> boosts, Operator operator) {
+      Preconditions.checkArgument(
+          queryText != null && !queryText.isEmpty(), "queryText must not be null or empty");
+      Preconditions.checkArgument(
+          columns != null && !columns.isEmpty(), "columns must not be null or empty");
+
+      this.queryText = queryText;
+      this.columns =
+          Collections.unmodifiableList(new java.util.ArrayList<>(Objects.requireNonNull(columns)));
+      this.boosts =
+          boosts == null
+              ? Optional.empty()
+              : Optional.of(Collections.unmodifiableList(new java.util.ArrayList<>(boosts)));
+      this.operator = operator == null ? Operator.OR : operator;
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COMBINED_FIELDS;
+    }
+
+    public String getQueryText() {
+      return queryText;
+    }
+
+    public List<String> getColumns() {
+      return columns;
+    }
+
+    public Optional<List<Float>> getBoosts() {
+      return boosts;
+    }
+
+    public Operator getOperator() {
+      return operator;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof CombinedFieldsQuery)) return false;
+      CombinedFieldsQuery other = (CombinedFieldsQuery) o;
       return operator == other.operator
           && Objects.equals(queryText, other.queryText)
           && Objects.equals(columns, other.columns)

--- a/java/src/test/java/org/lance/ipc/FullTextQueryTest.java
+++ b/java/src/test/java/org/lance/ipc/FullTextQueryTest.java
@@ -332,6 +332,101 @@ public class FullTextQueryTest {
   }
 
   @Test
+  void testCombinedFieldsWithoutBoosts() {
+    FullTextQuery.CombinedFieldsQuery q =
+        (FullTextQuery.CombinedFieldsQuery)
+            FullTextQuery.combinedFields("hello", Arrays.asList("title", "body"));
+
+    assertEquals(FullTextQuery.Type.COMBINED_FIELDS, q.getType());
+    assertEquals("hello", q.getQueryText());
+    assertEquals(Arrays.asList("title", "body"), q.getColumns());
+    assertFalse(q.getBoosts().isPresent());
+    assertEquals(FullTextQuery.Operator.OR, q.getOperator());
+  }
+
+  @Test
+  void testCombinedFieldsWithBoosts() {
+    FullTextQuery.CombinedFieldsQuery q =
+        (FullTextQuery.CombinedFieldsQuery)
+            FullTextQuery.combinedFields(
+                "hello",
+                Arrays.asList("title", "body"),
+                Arrays.asList(2.0f, 1.0f),
+                FullTextQuery.Operator.AND);
+
+    assertEquals(FullTextQuery.Type.COMBINED_FIELDS, q.getType());
+    assertTrue(q.getBoosts().isPresent());
+    assertEquals(2, q.getBoosts().get().size());
+    assertEquals(2.0f, q.getBoosts().get().get(0));
+    assertEquals(1.0f, q.getBoosts().get().get(1));
+    assertEquals(FullTextQuery.Operator.AND, q.getOperator());
+    assertNotNull(q.toString());
+  }
+
+  @Test
+  void testCombinedFieldsQueryEquality() {
+    FullTextQuery a = FullTextQuery.combinedFields("hello", Arrays.asList("title", "body"));
+    FullTextQuery b = FullTextQuery.combinedFields("hello", Arrays.asList("title", "body"));
+    assertEquals(a, b, "Two CombinedFieldsQuery instances with the same fields must be equal");
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void testCombinedFieldsQueryInequalityDifferentOperator() {
+    FullTextQuery a =
+        FullTextQuery.combinedFields(
+            "hello", Arrays.asList("title", "body"), null, FullTextQuery.Operator.AND);
+    FullTextQuery b =
+        FullTextQuery.combinedFields(
+            "hello", Arrays.asList("title", "body"), null, FullTextQuery.Operator.OR);
+    assertFalse(
+        a.equals(b), "CombinedFieldsQuery instances with different operator must not be equal");
+  }
+
+  @Test
+  void testCombinedFieldsQueryInequalityDifferentBoosts() {
+    FullTextQuery a =
+        FullTextQuery.combinedFields(
+            "hello",
+            Arrays.asList("title", "body"),
+            Arrays.asList(2.0f, 1.0f),
+            FullTextQuery.Operator.OR);
+    FullTextQuery b =
+        FullTextQuery.combinedFields(
+            "hello",
+            Arrays.asList("title", "body"),
+            Arrays.asList(1.0f, 1.0f),
+            FullTextQuery.Operator.OR);
+    assertFalse(
+        a.equals(b), "CombinedFieldsQuery instances with different boosts must not be equal");
+  }
+
+  @Test
+  void testCombinedFieldsNotEqualMultiMatch() {
+    FullTextQuery combined = FullTextQuery.combinedFields("hello", Arrays.asList("title", "body"));
+    FullTextQuery multi = FullTextQuery.multiMatch("hello", Arrays.asList("title", "body"));
+    assertFalse(
+        combined.equals(multi),
+        "CombinedFieldsQuery and MultiMatchQuery must not be equal even with same fields");
+  }
+
+  @Test
+  void testCombinedFieldsBoostsDefensivelyCopied() {
+    java.util.List<Float> boosts = new java.util.ArrayList<>(Arrays.asList(2.0f, 1.0f));
+    FullTextQuery.CombinedFieldsQuery q =
+        (FullTextQuery.CombinedFieldsQuery)
+            FullTextQuery.combinedFields(
+                "hello", Arrays.asList("title", "body"), boosts, FullTextQuery.Operator.OR);
+
+    // Mutating the caller-provided list must not change the stored query.
+    boosts.set(0, 9.0f);
+    boosts.clear();
+
+    assertTrue(q.getBoosts().isPresent());
+    assertEquals(Arrays.asList(2.0f, 1.0f), q.getBoosts().get());
+  }
+
+  @Test
   void testDifferentSubtypesNotEqual() {
     FullTextQuery match = FullTextQuery.match("hello", "body");
     FullTextQuery phrase = FullTextQuery.phrase("hello", "body");

--- a/java/src/test/java/org/lance/ipc/LanceScannerFullTextSearchTest.java
+++ b/java/src/test/java/org/lance/ipc/LanceScannerFullTextSearchTest.java
@@ -49,6 +49,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LanceScannerFullTextSearchTest {
 
+  private static final List<String> DEFAULT_DOCUMENTS =
+      Arrays.asList("hello world", "hello lance", "other text");
+
+  private static ScalarIndexParams defaultIndexParams() {
+    return ScalarIndexParams.create(
+        "inverted",
+        "{\"base_tokenizer\":\"simple\",\"language\":\"English\",\"with_position\":true}");
+  }
+
   @Test
   void testMatchQuery() throws Exception {
     runFtsQuery(
@@ -121,6 +130,55 @@ class LanceScannerFullTextSearchTest {
   }
 
   @Test
+  void testCombinedFields() throws Exception {
+    // "hello" appears in doc or title of every row, so all 3 match.
+    FullTextQuery combined = FullTextQuery.combinedFields("hello", Arrays.asList("doc", "title"));
+    runFtsQuery("memory://fts_java_combined", combined, 3);
+  }
+
+  @Test
+  void testCombinedFieldsWithBoosts() throws Exception {
+    FullTextQuery combined =
+        FullTextQuery.combinedFields(
+            "hello",
+            Arrays.asList("doc", "title"),
+            Arrays.asList(2.0f, 1.0f),
+            FullTextQuery.Operator.OR);
+    runFtsQuery("memory://fts_java_combined_boosts", combined, 3);
+  }
+
+  @Test
+  void testCombinedFieldsInvalidBoostPropagates() throws Exception {
+    // Per-column weights must be >= 1. The check lives in the Rust core and must
+    // surface across the JNI boundary when the query runs.
+    FullTextQuery combined =
+        FullTextQuery.combinedFields(
+            "hello",
+            Arrays.asList("doc", "title"),
+            Arrays.asList(0.5f, 1.0f),
+            FullTextQuery.Operator.OR);
+    withIndexedDataset(
+        "memory://fts_java_combined_bad_boost",
+        dataset -> {
+          ScanOptions scanOptions = new ScanOptions.Builder().fullTextQuery(combined).build();
+          IllegalArgumentException ex =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () -> {
+                    try (LanceScanner scanner = dataset.newScan(scanOptions);
+                        ArrowReader arrowReader = scanner.scanBatches()) {
+                      while (arrowReader.loadNextBatch()) {
+                        // Drain batches to force query execution.
+                      }
+                    }
+                  });
+          assertTrue(
+              ex.getMessage().contains("combined_fields boost for column 'doc'"),
+              "expected invalid-boost validation error, got: " + ex.getMessage());
+        });
+  }
+
+  @Test
   void testBooleanQuery() throws Exception {
     FullTextQuery.MatchQuery shouldMatch =
         (FullTextQuery.MatchQuery) FullTextQuery.match("hello", "doc");
@@ -139,16 +197,7 @@ class LanceScannerFullTextSearchTest {
   }
 
   private void runFtsQuery(String uri, FullTextQuery query, long expectedTotal) throws Exception {
-    ScalarIndexParams indexParams =
-        ScalarIndexParams.create(
-            "inverted",
-            "{\"base_tokenizer\":\"simple\",\"language\":\"English\",\"with_position\":true}");
-    runFtsQuery(
-        uri,
-        query,
-        expectedTotal,
-        Arrays.asList("hello world", "hello lance", "other text"),
-        indexParams);
+    runFtsQuery(uri, query, expectedTotal, DEFAULT_DOCUMENTS, defaultIndexParams());
   }
 
   private void runFtsQuery(
@@ -158,7 +207,41 @@ class LanceScannerFullTextSearchTest {
       List<String> documents,
       ScalarIndexParams scalarParams)
       throws Exception {
+    withIndexedDataset(
+        uri,
+        documents,
+        scalarParams,
+        dataset -> {
+          ScanOptions scanOptions = new ScanOptions.Builder().fullTextQuery(query).build();
 
+          try (LanceScanner scanner = dataset.newScan(scanOptions)) {
+            long total = 0L;
+            try (ArrowReader arrowReader = scanner.scanBatches()) {
+              while (arrowReader.loadNextBatch()) {
+                total += arrowReader.getVectorSchemaRoot().getRowCount();
+              }
+            }
+            assertEquals(expectedTotal, total);
+          }
+        });
+  }
+
+  /** Same dataset as the three-argument {@link #runFtsQuery}, without running a query on it. */
+  private void withIndexedDataset(String uri, IndexedDatasetConsumer consumer) throws Exception {
+    withIndexedDataset(uri, DEFAULT_DOCUMENTS, defaultIndexParams(), consumer);
+  }
+
+  /**
+   * Create an in-memory dataset with two text columns ({@code doc}, {@code title}), each backed by
+   * an inverted index, and hand it to {@code consumer}. Resources are released when the consumer
+   * returns.
+   */
+  private void withIndexedDataset(
+      String uri,
+      List<String> documents,
+      ScalarIndexParams scalarParams,
+      IndexedDatasetConsumer consumer)
+      throws Exception {
     Schema schema =
         new Schema(
             Arrays.asList(
@@ -212,20 +295,15 @@ class LanceScannerFullTextSearchTest {
                     .withIndexName("title_idx")
                     .build());
 
-            ScanOptions scanOptions = new ScanOptions.Builder().fullTextQuery(query).build();
-
-            try (LanceScanner scanner = dataset.newScan(scanOptions)) {
-              long total = 0L;
-              try (ArrowReader arrowReader = scanner.scanBatches()) {
-                while (arrowReader.loadNextBatch()) {
-                  total += arrowReader.getVectorSchemaRoot().getRowCount();
-                }
-              }
-              assertEquals(expectedTotal, total);
-            }
+            consumer.accept(dataset);
           }
         }
       }
     }
+  }
+
+  @FunctionalInterface
+  private interface IndexedDatasetConsumer {
+    void accept(Dataset dataset) throws Exception;
   }
 }

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -96,6 +96,9 @@ jieba-rs = ["tokenizer-jieba"]
 lindera = ["tokenizer-lindera"]
 tokenizer-lindera = ["lance-tokenizer/tokenizer-lindera"]
 tokenizer-jieba = ["dep:jieba-rs", "lance-tokenizer/tokenizer-jieba"]
+# Exposes `scalar::inverted::oracle`, the brute-force scoring reference, to
+# downstream test and bench targets. Enable it as a dev-dependency feature only.
+test-oracle = []
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -14,6 +14,8 @@ mod iter;
 pub mod json;
 /// Brute-force scoring reference for tests and benches. Never built normally; see
 /// the module docs for the gating.
+#[cfg(any(test, feature = "test-oracle"))]
+pub mod oracle;
 pub mod parser;
 pub mod query;
 mod scorer;

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -3,6 +3,7 @@
 
 pub mod builder;
 mod cache_codec;
+mod combined;
 mod compound;
 mod cross_column;
 mod documents;
@@ -11,6 +12,8 @@ mod impact;
 mod index;
 mod iter;
 pub mod json;
+/// Brute-force scoring reference for tests and benches. Never built normally; see
+/// the module docs for the gating.
 pub mod parser;
 pub mod query;
 mod scorer;
@@ -23,6 +26,10 @@ use std::sync::{Arc, LazyLock};
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
+pub use combined::{
+    CombinedFieldColumn, build_combined_bm25_scorer, combined_fields_search,
+    validate_combined_tokenizers,
+};
 pub use compound::{
     compound_search, compound_search_prepared_match,
     compound_search_prepared_match_with_score_floor, compound_search_with_base_scorer,
@@ -35,7 +42,7 @@ use datafusion::execution::SendableRecordBatchStream;
 pub use index::*;
 use lance_core::{Result, cache::LanceCache};
 pub use lance_tokenizer::Language;
-pub use scorer::{MemBM25Scorer, Scorer};
+pub use scorer::{CombinedFieldsBM25Scorer, MemBM25Scorer, Scorer};
 pub use tokenizer::*;
 
 use crate::scalar::inverted::query::{FtsSearchParams, Tokens, uses_fuzzy_expansion};

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -29,8 +29,8 @@ use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
 pub use combined::{
-    CombinedFieldColumn, build_combined_bm25_scorer, combined_fields_search,
-    validate_combined_tokenizers,
+    CombinedCorpusStats, CombinedFieldColumn, FlatFieldStats, build_combined_bm25_scorer,
+    combined_fields_search, flat_combined_fields_search_stream, validate_combined_tokenizers,
 };
 pub use compound::{
     compound_search, compound_search_prepared_match,

--- a/rust/lance-index/src/scalar/inverted/combined.rs
+++ b/rust/lance-index/src/scalar/inverted/combined.rs
@@ -25,6 +25,8 @@
 mod cursor;
 mod search;
 mod stats;
+#[cfg(test)]
+mod testing;
 
 use std::sync::Arc;
 

--- a/rust/lance-index/src/scalar/inverted/combined.rs
+++ b/rust/lance-index/src/scalar/inverted/combined.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Cross-field BM25F scoring (`combined_fields`).
+//!
+//! The target columns are treated as one virtual field so that term statistics
+//! are blended across fields instead of scored independently (contrast the
+//! field-centric `best_fields` fusion of a `MultiMatch` query). The blend rules
+//! are Lucene's `CombinedFieldQuery`:
+//!
+//! ```text
+//! tf'(t, d)      = Σ_f w_f · tf_f(t, d)              (weighted sum)
+//! dl'(d)         = Σ_f w_f · dl_f(d)                 (weighted sum)
+//! docFreq'(t)    = max_f docFreq_f(t)                (max)
+//! docCount'      = max_f docCount_f                  (max)
+//! sumTotalTermFreq' = Σ_f w_f · sumTotalTermFreq_f   (weighted sum)
+//! avgdl'         = sumTotalTermFreq' / docCount'
+//! score(t, d)    = idf'(t) · (k1 + 1) · tf' / (tf' + k1·(1 - b + b·dl'/avgdl'))
+//! ```
+//!
+//! Scoring uses exact (non-quantized) document lengths and a shared tokenizer
+//! across columns. Every candidate in the union of the query terms' postings is
+//! scored; see [`combined_fields_search`].
+
+mod cursor;
+mod search;
+mod stats;
+
+use std::sync::Arc;
+
+use lance_core::{Error, Result};
+
+pub use search::combined_fields_search;
+pub use stats::build_combined_bm25_scorer;
+
+use super::index::InvertedIndex;
+use super::query::Tokens;
+
+/// One target column of a `combined_fields` query: its per-column weight and
+/// the opened FTS segments (one per committed segment; usually a single one).
+pub struct CombinedFieldColumn {
+    /// Column name, used only for error messages.
+    pub column: String,
+    /// Per-column BM25F weight `w_f` (`>= 1`, validated at query construction).
+    pub weight: f32,
+    /// Opened inverted-index segments for this column.
+    pub indices: Vec<Arc<InvertedIndex>>,
+}
+
+/// Deduplicate the query tokens into the unique terms of the virtual field,
+/// preserving first-seen order. Duplicate terms collapse to one (mirrors the
+/// per-column `load_posting_lists` dedup), so each term is scored once.
+fn unique_terms(tokens: &Tokens) -> Vec<String> {
+    let mut terms = Vec::with_capacity(tokens.len());
+    let mut seen = std::collections::HashSet::new();
+    for token in tokens {
+        if seen.insert(token.as_str()) {
+            terms.push(token.clone());
+        }
+    }
+    terms
+}
+
+/// Reject a `combined_fields` query whose target columns do not share an
+/// identical index/tokenizer configuration. BM25F is only well-defined when the
+/// fields tokenize the same way, so mixing configurations is an error rather
+/// than a silently wrong score. The error lists the offending columns.
+pub fn validate_combined_tokenizers(columns: &[CombinedFieldColumn]) -> Result<()> {
+    // A column with no index has no tokenizer to disagree with, so it is skipped.
+    let mut indexed = columns
+        .iter()
+        .filter_map(|column| Some((column, column.indices.first()?)));
+    let Some((reference, reference_index)) = indexed.next() else {
+        return Ok(());
+    };
+    // Compare only the tokenization-affecting params: two columns may differ in
+    // storage/layout knobs (e.g. `with_position`) yet still tokenize identically,
+    // which is all BM25F requires.
+    let offending: Vec<&str> = indexed
+        .filter(|(_, index)| !reference_index.params().same_tokenization(index.params()))
+        .map(|(column, _)| column.column.as_str())
+        .collect();
+    if !offending.is_empty() {
+        return Err(Error::invalid_input(format!(
+            "combined_fields requires every target column to share the same tokenizer/index \
+             configuration; column(s) {:?} differ from column '{}'",
+            offending, reference.column
+        )));
+    }
+    Ok(())
+}

--- a/rust/lance-index/src/scalar/inverted/combined.rs
+++ b/rust/lance-index/src/scalar/inverted/combined.rs
@@ -23,6 +23,7 @@
 //! scored; see [`combined_fields_search`].
 
 mod cursor;
+mod flat;
 mod search;
 mod stats;
 #[cfg(test)]
@@ -32,8 +33,9 @@ use std::sync::Arc;
 
 use lance_core::{Error, Result};
 
+pub use flat::flat_combined_fields_search_stream;
 pub use search::combined_fields_search;
-pub use stats::build_combined_bm25_scorer;
+pub use stats::{CombinedCorpusStats, FlatFieldStats, build_combined_bm25_scorer};
 
 use super::index::InvertedIndex;
 use super::query::Tokens;

--- a/rust/lance-index/src/scalar/inverted/combined/cursor.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/cursor.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Per-term cross-column postings for `combined_fields`: one term's postings
+//! merged across every target column into the shared row-id space, and the
+//! loaded posting sources they are built from.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lance_select::RowAddrMask;
+
+use super::super::documents::AddressKeyedDocuments;
+use super::super::index::{PostingList, live_posting_rows};
+use super::super::scorer::CombinedFieldsBM25Scorer;
+
+/// One query term's postings, merged across every target column/partition into
+/// the shared row-id space.
+///
+/// Entries are unique row ids sorted ascending, each carrying the blended term
+/// frequency `tf'(t, d) = Σ_f w_f · freq_f(t, d)`.
+pub(super) struct CombinedTermPostings {
+    pub(super) idf: f32,
+    pub(super) postings: Vec<(u64, f32)>,
+}
+
+impl CombinedTermPostings {
+    /// `tf'` for `row_id`, or 0 when the term does not occur in the document.
+    #[inline]
+    pub(super) fn tf_prime(&self, row_id: u64) -> f32 {
+        match self.postings.binary_search_by_key(&row_id, |(id, _)| *id) {
+            Ok(idx) => self.postings[idx].1,
+            Err(_) => 0.0,
+        }
+    }
+}
+
+/// A `(column, index, partition)` posting source loaded for one term.
+pub(super) struct LoadedSource {
+    pub(super) weight: f32,
+    pub(super) docs: AddressKeyedDocuments,
+    pub(super) is_legacy: bool,
+    pub(super) posting: PostingList,
+}
+
+/// Merge every source's postings for `term` into the shared row-id space,
+/// accumulating `tf'` in the canonical order.
+pub(super) fn build_term_postings(
+    term: &str,
+    sources: Vec<LoadedSource>,
+    mask: &Arc<RowAddrMask>,
+    scorer: &CombinedFieldsBM25Scorer,
+) -> CombinedTermPostings {
+    let mut acc: HashMap<u64, f32> = HashMap::new();
+    for source in &sources {
+        for (row_id, freq) in live_posting_rows(&source.posting, &source.docs, source.is_legacy) {
+            if !mask.selected(row_id) {
+                continue;
+            }
+            *acc.entry(row_id).or_insert(0.0) += source.weight * freq as f32;
+        }
+    }
+    let idf = scorer.query_weight(term);
+    let mut postings: Vec<(u64, f32)> = acc.into_iter().collect();
+    postings.sort_unstable_by_key(|(row_id, _)| *row_id);
+    CombinedTermPostings { idf, postings }
+}

--- a/rust/lance-index/src/scalar/inverted/combined/cursor.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/cursor.rs
@@ -65,3 +65,90 @@ pub(super) fn build_term_postings(
     postings.sort_unstable_by_key(|(row_id, _)| *row_id);
     CombinedTermPostings { idf, postings }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::testing::{compressed_list, modern_identity_docs};
+    use super::*;
+    use lance_core::utils::address::RowAddress;
+    use lance_select::RowAddrTreeMap;
+
+    #[tokio::test]
+    async fn test_build_term_postings_merges_legacy_and_compressed() {
+        // A legacy (Plain, row-id-keyed, list-multiplicity)
+        // source and a compressed source merge into one ordered `tf'` stream,
+        // masked rows dropped and contributions summed in column order.
+        use super::super::super::index::PlainPostingList;
+        use arrow::buffer::ScalarBuffer;
+
+        let scorer = CombinedFieldsBM25Scorer::new(1000, 12.0, HashMap::new());
+        // Legacy column (weight 2): the posting keys directly on row ids; row 20
+        // appears twice (list multiplicity), so its contributions sum.
+        let legacy = PostingList::Plain(PlainPostingList::new(
+            ScalarBuffer::from(vec![10u64, 20, 20, 30]),
+            ScalarBuffer::from(vec![1.0f32, 2.0, 3.0, 1.0]),
+            Some(0.0),
+            None,
+        ));
+        // Compressed column (weight 1): doc id 20 maps through the modern
+        // projection (the only representation a compressed posting is loaded
+        // alongside) to row 20; row 42 is blocked by the mask below.
+        let compressed = PostingList::Compressed(compressed_list(&[(20, 5), (42, 7)]));
+        let docs = modern_identity_docs(&vec![1u32; 64], &[]).await;
+        let sources = vec![
+            LoadedSource {
+                weight: 2.0,
+                docs: docs.clone(),
+                is_legacy: true,
+                posting: legacy,
+            },
+            LoadedSource {
+                weight: 1.0,
+                docs,
+                is_legacy: false,
+                posting: compressed,
+            },
+        ];
+        let mask = Arc::new(RowAddrMask::all_rows().also_block(RowAddrTreeMap::from_iter([42u64])));
+        let term = build_term_postings("t", sources, &mask, &scorer);
+
+        // row 10: 2*1 = 2; row 20: 2*2 + 2*3 + 1*5 = 15; row 30: 2*1 = 2.
+        // Row 42 is masked out entirely.
+        assert_eq!(term.postings, vec![(10, 2.0), (20, 15.0), (30, 2.0)]);
+    }
+
+    #[tokio::test]
+    async fn test_build_term_postings_skips_tombstoned_addresses() {
+        // A remapped partition keeps a deleted document's DocId slot so the
+        // posting lists stay aligned and answers `TOMBSTONE_ROW` for its address.
+        // Nothing else stops that address: a default mask is an empty block list,
+        // which selects it, and `doc_length_at(TOMBSTONE_ROW) == 0` would give it
+        // the largest `doc_weight` there is, so it must be dropped at the source.
+        const DEAD_ROW: u64 = 20;
+        let scorer = CombinedFieldsBM25Scorer::new(1000, 12.0, HashMap::new());
+        let docs = modern_identity_docs(&[4u32; 40], &[DEAD_ROW]).await;
+        assert_eq!(
+            docs.row_address(DEAD_ROW as u32),
+            RowAddress::TOMBSTONE_ROW,
+            "the deleted document must keep its slot as a tombstone"
+        );
+        assert_eq!(docs.doc_length_at(RowAddress::TOMBSTONE_ROW), 0);
+        let sources = vec![LoadedSource {
+            weight: 2.0,
+            docs,
+            is_legacy: false,
+            posting: PostingList::Compressed(compressed_list(&[
+                (10, 1),
+                (DEAD_ROW as u32, 7),
+                (30, 3),
+            ])),
+        }];
+        let term = build_term_postings("t", sources, &Arc::new(RowAddrMask::default()), &scorer);
+        assert_eq!(
+            term.postings,
+            vec![(10, 2.0), (30, 6.0)],
+            "the tombstoned address must never be accumulated, and the live rows \
+             must keep their exact contributions"
+        );
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/combined/flat.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/flat.rs
@@ -244,3 +244,229 @@ fn flat_combined_score(
         ],
     )?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::tokenizer::InvertedIndexParams;
+    use super::super::super::tokenizer::document_tokenizer::DocType;
+    use super::super::testing::{flat_columns, flat_input, flat_scores};
+    use super::*;
+    use lance_select::RowAddrTreeMap;
+    use rstest::rstest;
+
+    /// Golden `(row_id, score)` for the flat BM25F scan, compared bit-for-bit.
+    ///
+    /// The blend `dl' = Σ_f w_f·dl_f` and `tf'_t = Σ_f w_f·tf_f,t` accumulates in
+    /// f32, which is not associative, and the corpus statistics it feeds are
+    /// derived from the same rows. Any change to how or where the per-column
+    /// contributions are summed has to leave these exact bits alone, so they are
+    /// pinned here rather than compared with a tolerance.
+    ///
+    /// The fixture exercises the parts that a plausible rewrite gets wrong:
+    /// non-unit and unequal weights, a row empty in one column but not the other,
+    /// a null, a row empty everywhere (dropped), and a `stats_masks` entry that
+    /// keeps one row out of one column's corpus totals.
+    #[tokio::test]
+    async fn test_flat_combined_fields_golden_scores() {
+        let row_ids: Vec<u64> = (0..7).collect();
+        let docs = vec![
+            vec![
+                Some("cat"),
+                Some("dog cat"),
+                None,
+                Some("bird"),
+                Some("cat cat dog"),
+                Some(""),
+                Some("cat dog bird"),
+            ],
+            vec![
+                Some("dog"),
+                None,
+                Some("cat dog dog"),
+                Some("fish"),
+                Some("cat"),
+                Some(""),
+                Some("bird bird"),
+            ],
+        ];
+        let weights = [1.0f32, 2.5];
+        let columns = flat_columns(&weights);
+        let tokens = Tokens::new(vec!["cat".to_string(), "dog".to_string()], DocType::Text);
+        let tokenizer = InvertedIndexParams::default().build().unwrap();
+        // Column 1 must not fold row 4 into its corpus totals (its index already
+        // holds that row); column 0 folds everything.
+        let stats_masks = vec![
+            Arc::new(RowAddrMask::all_rows()),
+            Arc::new(RowAddrMask::all_rows().also_block(RowAddrTreeMap::from_iter([4u64]))),
+        ];
+
+        let stream = flat_combined_fields_search_stream(
+            flat_input(&row_ids, &docs, 1),
+            &columns,
+            vec![1, 2],
+            &stats_masks,
+            /*emit_mask=*/ None,
+            /*flat_covers_whole_corpus=*/ false,
+            &tokens,
+            tokenizer,
+            Operator::Or,
+            3,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .0;
+        let (batch_sizes, scored) = flat_scores(stream).await;
+
+        // Row 5 is empty in both columns, so it never reaches the scorer, and row 3
+        // ("bird" / "fish") carries no query term, so it scores 0 and is dropped.
+        // `target_batch_size` of 3 splits the 5 survivors into 3 + 2.
+        assert_eq!(batch_sizes, vec![3, 2]);
+        assert_eq!(
+            scored,
+            vec![
+                (0, 0x3f9b_c3cf),
+                (1, 0x3f8f_0e96),
+                (2, 0x3fa6_8e68),
+                (4, 0x3f84_f2a6),
+                (6, 0x3f32_7287),
+            ]
+        );
+    }
+
+    /// The retained per-row payload must not grow with the number of target
+    /// columns. That independence is the whole point of blending during
+    /// tokenization: a `combined_fields` query over a wide column list routes the
+    /// entire dataset down this path as soon as one column's index is stale, and
+    /// the accumulation lives until the corpus statistics are complete.
+    ///
+    /// The input arrives as several batches, so this also covers the per-batch
+    /// statistics fold and that the retained rows stay in scan order across chunks.
+    #[tokio::test]
+    async fn test_flat_combined_fields_retention_is_independent_of_column_count() {
+        let row_ids: Vec<u64> = (0..64).collect();
+        let column = vec![Some("cat dog bird"); 64];
+        let tokens = Arc::new(Tokens::new(
+            vec!["cat".to_string(), "dog".to_string(), "bird".to_string()],
+            DocType::Text,
+        ));
+        let num_terms = tokens.len();
+
+        let mut footprints = Vec::new();
+        for num_columns in 1..=4usize {
+            let docs = vec![column.clone(); num_columns];
+            let (chunks, stats) = tokenize_and_blend_multi(
+                flat_input(&row_ids, &docs, 5),
+                InvertedIndexParams::default().build().unwrap(),
+                tokens.clone(),
+                Arc::new((1..=num_columns).collect()),
+                Arc::new(vec![1.0; num_columns]),
+                Arc::new(
+                    (0..num_columns)
+                        .map(|_| Arc::new(RowAddrMask::all_rows()))
+                        .collect(),
+                ),
+                None,
+            )
+            .await
+            .unwrap();
+
+            let retained: usize = chunks
+                .iter()
+                .map(|chunk| {
+                    chunk.row_ids.len() * size_of::<u64>()
+                        + (chunk.doc_lengths.len() + chunk.term_freqs.len()) * size_of::<f32>()
+                })
+                .sum();
+            let retained_row_ids: Vec<u64> = chunks
+                .iter()
+                .flat_map(|chunk| &chunk.row_ids)
+                .copied()
+                .collect();
+            assert!(chunks.len() > 1, "expected several chunks to fold");
+            assert_eq!(retained_row_ids, row_ids);
+            let rows = retained_row_ids.len();
+            // 8 bytes of row id plus `dl'` and one `tf'` per term, all f32.
+            assert_eq!(retained, rows * (8 + 4 * (1 + num_terms)));
+            footprints.push(retained);
+
+            // Every column sees the same three-token doc, so the statistics scale
+            // with the column count while the retained payload does not.
+            assert_eq!(stats.doc_counts, vec![rows; num_columns]);
+            assert_eq!(stats.total_tokens, vec![3 * rows as u64; num_columns]);
+            assert_eq!(stats.doc_freqs, vec![vec![rows; num_terms]; num_columns]);
+        }
+        assert!(footprints.windows(2).all(|pair| pair[0] == pair[1]));
+    }
+
+    /// A flat scan can legitimately see no batches at all (every scanned fragment
+    /// empty, or a prefilter that keeps nothing). The statistics fold still owes the
+    /// caller a scorer, so it reports all-zero totals rather than nothing.
+    #[tokio::test]
+    async fn test_flat_combined_fields_empty_scan_still_builds_a_scorer() {
+        let docs = vec![Vec::<Option<&str>>::new(), Vec::new()];
+        let stream = flat_combined_fields_search_stream(
+            flat_input(&[], &docs, 1),
+            &flat_columns(&[1.0, 2.5]),
+            vec![1, 2],
+            &[
+                Arc::new(RowAddrMask::all_rows()),
+                Arc::new(RowAddrMask::all_rows()),
+            ],
+            /*emit_mask=*/ None,
+            /*flat_covers_whole_corpus=*/ false,
+            &Tokens::new(vec!["cat".to_string()], DocType::Text),
+            InvertedIndexParams::default().build().unwrap(),
+            Operator::Or,
+            16,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .0;
+
+        let (batch_sizes, scored) = flat_scores(stream).await;
+        assert!(batch_sizes.is_empty());
+        assert!(scored.is_empty());
+    }
+
+    /// A caller that hands over the wrong number of document columns or statistics
+    /// masks has a bug, and it must surface whatever the query tokenizes to. The
+    /// empty-token case is the one that used to slip through, because matching
+    /// nothing short circuits before any per-column work happens.
+    #[rstest]
+    #[case::empty_query(Vec::new())]
+    #[case::one_term(vec!["cat".to_string()])]
+    #[tokio::test]
+    async fn test_flat_combined_fields_rejects_mismatched_arity(#[case] tokens: Vec<String>) {
+        let docs = vec![Vec::<Option<&str>>::new(), Vec::new()];
+        let result = flat_combined_fields_search_stream(
+            flat_input(&[], &docs, 1),
+            &flat_columns(&[1.0, 2.5]),
+            // Two target columns, but one document column and one mask.
+            vec![1],
+            &[Arc::new(RowAddrMask::all_rows())],
+            /*emit_mask=*/ None,
+            /*flat_covers_whole_corpus=*/ false,
+            &Tokens::new(tokens, DocType::Text),
+            InvertedIndexParams::default().build().unwrap(),
+            Operator::Or,
+            16,
+            None,
+            None,
+        )
+        .await;
+
+        let Err(error) = result else {
+            panic!("mismatched arity must be rejected");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("got 1 document columns and 1 statistics masks for 2 target columns"),
+            "unexpected error: {error}",
+        );
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/combined/flat.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/flat.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The unindexed `combined_fields` plan: blend the scanned column values into
+//! `dl'`/`tf'` and score the rows no target column's index covers.
+
+use std::sync::Arc;
+
+use arrow::array::{Float32Builder, UInt64Builder};
+use arrow_array::{ArrayRef, RecordBatch};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::metrics::Time;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::{FutureExt, stream};
+use lance_core::Error;
+use lance_core::error::DataFusionResult;
+use lance_core::utils::tokio::spawn_cpu;
+use lance_select::RowAddrMask;
+
+use super::super::index::{BlendedRows, FTS_SCHEMA, slice_into_batches, tokenize_and_blend_multi};
+use super::super::query::{Operator, Tokens};
+use super::super::scorer::CombinedFieldsBM25Scorer;
+use super::super::tokenizer::document_tokenizer::LanceTokenizer;
+use super::stats::{CombinedCorpusStats, FlatFieldStats, build_combined_bm25_scorer};
+use super::{CombinedFieldColumn, unique_terms};
+use crate::metrics::MetricsCollector;
+
+/// Exact cross-field BM25F search over rows that no index covers.
+///
+/// The indexed [`combined_fields_search`](super::combined_fields_search) can
+/// only score a row whose fragment
+/// every target column's index covers; otherwise `dl'` and `tf'` would be missing
+/// a column's contribution. This scores the remaining rows straight from their
+/// column values, so the two plans together cover the whole dataset.
+///
+/// `input` must carry `_rowid` plus every target column, in `columns` order.
+/// Query terms are deduplicated exactly as
+/// [`combined_fields_search`](super::combined_fields_search) does, and
+/// `operator` applies across the virtual field: `And` requires every term to
+/// appear in at least one target column.
+///
+/// The blended scorer folds these rows' own per-column statistics in through
+/// [`FlatFieldStats`](super::FlatFieldStats), so `avgdl'` and `idf'` reflect the
+/// scanned rows rather than only the indexed ones. `stats_masks` keeps that fold
+/// from double counting rows a column's index already holds. `metrics` covers
+/// only that scorer build's index reads; the plan already accounts for the input
+/// stream's IO.
+///
+/// `emit_mask`, when set, selects the rows to emit. The caller reads `input`
+/// unfiltered in that case, so the fold sees rows the query filtered out and a folded
+/// row's contribution does not move with the filter.
+///
+/// `flat_covers_whole_corpus` drops the index statistics in favour of this scan's own;
+/// see [`CombinedCorpusStats::FlatOnly`].
+///
+/// Returns the scorer alongside the stream. The whole input is consumed before
+/// the first output batch, so by then the blend describes the entire scanned
+/// corpus and an indexed sibling can score against the same statistics.
+#[allow(clippy::too_many_arguments)]
+pub async fn flat_combined_fields_search_stream(
+    input: SendableRecordBatchStream,
+    columns: &[CombinedFieldColumn],
+    doc_col_indices: Vec<usize>,
+    stats_masks: &[Arc<RowAddrMask>],
+    emit_mask: Option<Arc<RowAddrMask>>,
+    flat_covers_whole_corpus: bool,
+    tokens: &Tokens,
+    tokenizer: Box<dyn LanceTokenizer>,
+    operator: Operator,
+    target_batch_size: usize,
+    elapsed_compute: Option<Time>,
+    metrics: Option<&dyn MetricsCollector>,
+) -> DataFusionResult<(SendableRecordBatchStream, Arc<CombinedFieldsBM25Scorer>)> {
+    let terms = unique_terms(tokens);
+    // Check the caller's arity first: a call with the wrong number of columns is a
+    // bug whatever the query tokenizes to, and reporting it only for non-empty
+    // queries would let it through intermittently.
+    if doc_col_indices.len() != columns.len() || stats_masks.len() != columns.len() {
+        return Err(Error::invalid_input(format!(
+            "combined_fields flat scan got {} document columns and {} statistics masks for {} \
+             target columns",
+            doc_col_indices.len(),
+            stats_masks.len(),
+            columns.len()
+        ))
+        .into());
+    }
+    // A query that tokenizes to nothing matches nothing; mirrors the indexed path.
+    // The scorer is still built and returned: an indexed sibling waits for it, and
+    // over no terms it costs nothing.
+    if terms.is_empty() || columns.is_empty() {
+        // An empty fold, so whole-corpus mode reads no index statistics here either.
+        // Over no terms both variants give the same scorer.
+        let empty = FlatFieldStats::zeros(columns.len(), 0);
+        let scorer = Arc::new(
+            build_combined_bm25_scorer(
+                columns,
+                tokens,
+                CombinedCorpusStats::for_flat_scan(&empty, flat_covers_whole_corpus),
+                metrics,
+            )
+            .boxed()
+            .await?,
+        );
+        return Ok((
+            Box::pin(RecordBatchStreamAdapter::new(
+                FTS_SCHEMA.clone(),
+                stream::empty::<DataFusionResult<RecordBatch>>(),
+            )),
+            scorer,
+        ));
+    }
+
+    // Pre-await synchronous work: chunk-stream setup.
+    let pre_await_start = std::time::Instant::now();
+    let input_schema = input.schema();
+    // `tf'` is one value per deduplicated term, so the counter must see the same
+    // deduplicated list the indexed scan scores.
+    let unique_tokens = Arc::new(Tokens::new(terms.clone(), tokens.token_type().clone()));
+    // Same thresholds as the single-column flat path: tokenization is CPU-bound,
+    // so batches are accumulated before a task is dispatched.
+    const ACCUMULATE_BYTES: usize = 256 * 1024;
+    const SLICE_BYTES: usize = 512 * 1024;
+    let chunked = lance_arrow::stream::rechunk_stream_by_size(
+        input,
+        input_schema,
+        ACCUMULATE_BYTES,
+        SLICE_BYTES,
+    );
+    if let Some(t) = &elapsed_compute {
+        t.add_duration(pre_await_start.elapsed());
+    }
+
+    let weights: Vec<f32> = columns.iter().map(|column| column.weight).collect();
+    // The per-column statistics fold happens inside the tokenization tasks. The
+    // copy is of the `Arc`s alone: a `RowAddrMask` wraps a roaring bitmap, so
+    // cloning one per column per query would be a deep copy.
+    let (blended, flat_stats) = tokenize_and_blend_multi(
+        chunked,
+        tokenizer,
+        unique_tokens,
+        Arc::new(doc_col_indices),
+        Arc::new(weights),
+        Arc::new(stats_masks.to_vec()),
+        elapsed_compute.clone(),
+    )
+    .await?;
+
+    // Time the scorer build and the scoring loop together.
+    let post_await_start = std::time::Instant::now();
+    let scorer = Arc::new(
+        build_combined_bm25_scorer(
+            columns,
+            tokens,
+            CombinedCorpusStats::for_flat_scan(&flat_stats, flat_covers_whole_corpus),
+            metrics,
+        )
+        .boxed()
+        .await?,
+    );
+    // `rows x terms` synchronous work. Offload it so a large flat scan cannot
+    // occupy a DataFusion worker past a stream drop or task cancellation, matching
+    // how the indexed per-partition scoring loop is dispatched.
+    let scores = {
+        let terms_for_scoring = terms.clone();
+        let scorer_for_scoring = scorer.clone();
+        let require_all_terms = operator == Operator::And;
+        spawn_cpu(move || {
+            flat_combined_score(
+                &terms_for_scoring,
+                blended,
+                scorer_for_scoring.as_ref(),
+                require_all_terms,
+                emit_mask.as_deref(),
+            )
+        })
+        .await?
+    };
+
+    let batches = slice_into_batches(scores, target_batch_size);
+    if let Some(t) = &elapsed_compute {
+        t.add_duration(post_await_start.elapsed());
+    }
+    Ok((
+        Box::pin(RecordBatchStreamAdapter::new(
+            FTS_SCHEMA.clone(),
+            stream::iter(batches),
+        )),
+        scorer,
+    ))
+}
+
+/// Score every retained flat row from its blended `dl'`/`tf'`, emitting
+/// `(ROW_ID, SCORE)` in [`FTS_SCHEMA`].
+///
+/// Takes the chunks by value and drops each one as it is scored, so the blend and
+/// the output arrays are never both fully resident.
+///
+/// `emit_mask` drops rows the query filtered out. It is applied here rather than to
+/// `input` so that the statistics the scorer was built from still cover the corpus.
+fn flat_combined_score(
+    terms: &[String],
+    blended: Vec<BlendedRows>,
+    scorer: &CombinedFieldsBM25Scorer,
+    require_all_terms: bool,
+    emit_mask: Option<&RowAddrMask>,
+) -> DataFusionResult<RecordBatch> {
+    let num_terms = terms.len();
+    let num_rows = blended.iter().map(|chunk| chunk.row_ids.len()).sum();
+    let mut row_ids = UInt64Builder::with_capacity(num_rows);
+    let mut scores = Float32Builder::with_capacity(num_rows);
+    for chunk in blended {
+        for (row, (input_row_id, dl_prime)) in
+            chunk.row_ids.iter().zip(&chunk.doc_lengths).enumerate()
+        {
+            if emit_mask.is_some_and(|mask| !mask.selected(*input_row_id)) {
+                continue;
+            }
+            let tf_prime = &chunk.term_freqs[row * num_terms..(row + 1) * num_terms];
+            // `And` spans the virtual field: a term counts when it occurs in at
+            // least one target column, so the check runs on the blended `tf'`,
+            // the same condition the indexed `combined_fields_search` applies
+            // through its `missing_term` flag.
+            if require_all_terms && tf_prime.iter().any(|tf| *tf <= 0.0) {
+                continue;
+            }
+            let score: f32 = terms
+                .iter()
+                .zip(tf_prime)
+                .map(|(term, tf)| scorer.query_weight(term) * scorer.doc_weight(*tf, *dl_prime))
+                .sum();
+            if score > 0.0 {
+                row_ids.append_value(*input_row_id);
+                scores.append_value(score);
+            }
+        }
+    }
+
+    Ok(RecordBatch::try_new(
+        FTS_SCHEMA.clone(),
+        vec![
+            Arc::new(row_ids.finish()) as ArrayRef,
+            Arc::new(scores.finish()) as ArrayRef,
+        ],
+    )?)
+}

--- a/rust/lance-index/src/scalar/inverted/combined/search.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/search.rs
@@ -183,7 +183,7 @@ mod tests {
     use super::super::super::index::InvertedListFormatVersion;
     use super::super::super::scorer::idf;
     use super::super::super::tokenizer::document_tokenizer::DocType;
-    use super::super::stats::build_combined_bm25_scorer;
+    use super::super::stats::{CombinedCorpusStats, build_combined_bm25_scorer};
     use super::super::testing::{
         ElementRows, as_row_documents, combined_columns, combined_top_k, element_document_index,
     };
@@ -404,6 +404,7 @@ mod tests {
         let scorer = build_combined_bm25_scorer(
             &columns,
             &Tokens::new(vec!["alpha".to_owned(), "beta".to_owned()], DocType::Text),
+            CombinedCorpusStats::IndexOnly,
             None,
         )
         .await

--- a/rust/lance-index/src/scalar/inverted/combined/search.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/search.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The indexed `combined_fields` entry point: load every term's postings across
+//! the target columns, merge them into the shared row-id space, and score every
+//! candidate.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+use std::sync::Arc;
+
+use lance_core::Result;
+use lance_core::utils::tokio::spawn_cpu;
+
+use super::super::documents::AddressKeyedDocuments;
+use super::super::query::{FtsSearchParams, Operator, Tokens};
+use super::super::scorer::CombinedFieldsBM25Scorer;
+use super::cursor::{CombinedTermPostings, LoadedSource, build_term_postings};
+use super::{CombinedFieldColumn, unique_terms};
+use crate::metrics::MetricsCollector;
+use crate::prefilter::PreFilter;
+use crate::vector::graph::OrderedFloat;
+
+/// A scored candidate ordered the way callers read results: `score DESC, row_id
+/// ASC`, the same order the single-column path imposes in
+/// `classify_wand_exactness_certificate`.
+///
+/// [`ScoredDoc`](super::super::builder::ScoredDoc) compares on score alone, which
+/// is not enough for a bounded heap: among equal scores it evicts whichever row
+/// the heap happens to hold at the bottom, so rows that belong in the top-k are
+/// dropped and no later sort can bring them back. A fully covered plan returns
+/// this search's output directly, with no `SortExec` above it, so the order and
+/// the membership both have to be settled here.
+///
+/// `row_id` is stored reversed so that the derived lexicographic ordering ranks a
+/// higher row id lower. The heap's smallest element is then the lowest score with
+/// the highest row id, which is exactly the candidate a full heap should evict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RankedDoc {
+    score: OrderedFloat,
+    row_id: Reverse<u64>,
+}
+
+impl RankedDoc {
+    fn new(row_id: u64, score: f32) -> Self {
+        Self {
+            score: OrderedFloat(score),
+            row_id: Reverse(row_id),
+        }
+    }
+}
+
+/// Exact cross-field BM25F search over the target columns.
+///
+/// Loads each query term's postings across every column and partition, then
+/// scores the union of those postings and keeps a bounded top-k. Every candidate
+/// is scored; there is no pruning, so the result is exact by construction.
+/// Results come back ordered by `score DESC, row_id ASC`, which is a total order,
+/// so the same data always yields the same top-k even when scores tie.
+///
+/// `operator` applies across the virtual field: `And` keeps only docs where
+/// every query term appears in at least one column; `Or` keeps docs matching
+/// any term. Per-column `boost` is folded into `tf'`.
+pub async fn combined_fields_search(
+    columns: &[CombinedFieldColumn],
+    tokens: &Tokens,
+    params: &FtsSearchParams,
+    operator: Operator,
+    scorer: &CombinedFieldsBM25Scorer,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: &dyn MetricsCollector,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    let terms = unique_terms(tokens);
+    let limit = params.limit.unwrap_or(usize::MAX);
+    if terms.is_empty() || limit == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let mask = prefilter.mask();
+    let require_all_terms = operator == Operator::And;
+
+    // Load every term's postings across all columns, in the canonical
+    // column → index → partition order. The length sources are collected in that
+    // same order so `dl'` sums in the exact scan's order too (float addition is
+    // order-sensitive; matching the order keeps every score bit-identical).
+    let mut loaded: Vec<Vec<LoadedSource>> = (0..terms.len()).map(|_| Vec::new()).collect();
+    let mut length_sources: Vec<(f32, AddressKeyedDocuments)> = Vec::new();
+    for column in columns {
+        let weight = column.weight;
+        for index in &column.indices {
+            for partition in &index.partitions {
+                let docs = partition.docs.address_keyed().await?;
+                let is_legacy = partition.is_legacy();
+                for (term_index, term) in terms.iter().enumerate() {
+                    let Some(token_id) = partition.tokens.get(term) else {
+                        continue;
+                    };
+                    let posting = partition
+                        .inverted_list
+                        .posting_list(token_id, false, metrics)
+                        .await?;
+                    loaded[term_index].push(LoadedSource {
+                        weight,
+                        docs: docs.clone(),
+                        is_legacy,
+                        posting,
+                    });
+                }
+                length_sources.push((weight, docs));
+            }
+        }
+    }
+    // Everything past the loads is uninterruptible CPU work: building and sorting
+    // a per-term `HashMap`, then the whole scoring loop with no await. Offload it
+    // so a large query cannot hold a DataFusion
+    // worker past a stream drop or task cancellation, matching how the
+    // single-column `InvertedIndex::bm25_search` dispatches its per-partition
+    // scoring and how `flat_combined_fields_search_stream` dispatches its own
+    // scoring loop. The `'static` closure clones the borrowed `scorer` (a handful
+    // of per-term statistics) and moves everything else in.
+    let scorer = Arc::new(scorer.clone());
+    let top = spawn_cpu(move || {
+        let dl_prime = |row_id: u64| -> f32 {
+            length_sources
+                .iter()
+                .map(|(weight, docs)| weight * docs.doc_length_at(row_id) as f32)
+                .sum()
+        };
+        let terms: Vec<CombinedTermPostings> = terms
+            .iter()
+            .zip(loaded)
+            .map(|(term, sources)| build_term_postings(term, sources, &mask, scorer.as_ref()))
+            .collect();
+
+        // Score every candidate: the union of the terms' postings for `Or`, and the
+        // same union filtered to the documents holding every term for `And`. A row
+        // absent from a term contributes no `tf'`, so it is skipped rather than
+        // scored as zero.
+        //
+        // Ties are settled by [`RankedDoc`], not left to the heap: it orders on
+        // `(score, row_id)` as a whole, so both which rows survive the k-th score and
+        // the order they come back in are fixed by the data alone.
+        let candidates: BTreeSet<u64> = terms
+            .iter()
+            .flat_map(|term| term.postings.iter().map(|(row_id, _)| *row_id))
+            .collect();
+        let mut top: BinaryHeap<Reverse<RankedDoc>> = BinaryHeap::new();
+        for row_id in candidates {
+            let dl = dl_prime(row_id);
+            let mut score = 0.0f32;
+            let mut missing_term = false;
+            for term in &terms {
+                let tf = term.tf_prime(row_id);
+                if tf <= 0.0 {
+                    missing_term = true;
+                    continue;
+                }
+                score += term.idf * scorer.doc_weight(tf, dl);
+            }
+            if require_all_terms && missing_term {
+                continue;
+            }
+            top.push(Reverse(RankedDoc::new(row_id, score)));
+            if top.len() > limit {
+                top.pop();
+            }
+        }
+        Result::Ok(top)
+    })
+    .await?;
+
+    // Ascending in `Reverse<RankedDoc>` is descending in `RankedDoc`, i.e. best
+    // first: highest score, and within a score the lowest row id.
+    Ok(top
+        .into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(doc)| (doc.row_id.0, doc.score.0))
+        .unzip())
+}

--- a/rust/lance-index/src/scalar/inverted/combined/search.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/search.rs
@@ -177,3 +177,261 @@ pub async fn combined_fields_search(
         .map(|Reverse(doc)| (doc.row_id.0, doc.score.0))
         .unzip())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::index::InvertedListFormatVersion;
+    use super::super::super::scorer::idf;
+    use super::super::super::tokenizer::document_tokenizer::DocType;
+    use super::super::stats::build_combined_bm25_scorer;
+    use super::super::testing::{
+        ElementRows, as_row_documents, combined_columns, combined_top_k, element_document_index,
+    };
+    use super::*;
+    use crate::metrics::NoOpMetricsCollector;
+    use crate::prefilter::NoFilter;
+    use rstest::rstest;
+
+    /// `title` is a `List<String>` where row 0 holds ten `"alpha"` elements, row 1
+    /// one `"beta"`, and rows 2..10 one `"gamma"`; `body` holds one `"zzz"` per
+    /// row. Row 0 matches `"alpha"` ten times over, so it must win
+    /// `"alpha beta"` at `limit = 1`.
+    ///
+    /// With document-granularity statistics it does not: `docCount'` counts the
+    /// 19 title elements instead of the 10 rows and `docFreq'("alpha")` counts 10
+    /// element postings instead of 1 row, which collapses `alpha`'s `idf'` and
+    /// inflates `beta`'s enough to invert the ranking (row 1 at ~2.2984569). Row
+    /// granularity restores row 0 at ~3.1963050, bit-identical to the same data
+    /// indexed one document per row.
+    #[rstest]
+    #[case::v1(InvertedListFormatVersion::V1)]
+    #[case::v2(InvertedListFormatVersion::V2)]
+    #[tokio::test]
+    async fn test_combined_fields_scores_legacy_list_elements_by_row(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let vocab = ["alpha", "beta", "gamma", "zzz"];
+        let mut title: ElementRows = vec![vec![vec!["alpha"]; 10], vec![vec!["beta"]]];
+        title.extend((2..10).map(|_| vec![vec!["gamma"]]));
+        let body: ElementRows = (0..10).map(|_| vec![vec!["zzz"]]).collect();
+
+        let (title_index, _title_dir) =
+            element_document_index(format_version, &vocab, &title).await;
+        let (body_index, _body_dir) = element_document_index(format_version, &vocab, &body).await;
+
+        // Precondition: the fixture really is element-per-document, or the test
+        // covers nothing.
+        let title_docs = title_index.partitions[0]
+            .docs
+            .address_keyed()
+            .await
+            .unwrap();
+        assert_eq!(title_docs.len(), 19, "one document per title list element");
+        assert_eq!(title_docs.num_distinct_rows(), 10);
+
+        // The single-column path reads document granularity; only the cross-field
+        // path reads row granularity.
+        let terms = ["alpha".to_owned(), "beta".to_owned()];
+        assert_eq!(
+            title_index
+                .bm25_stats_for_terms(&terms, None)
+                .await
+                .unwrap(),
+            (19, 19, vec![10, 1]),
+            "document-granularity statistics must keep counting elements",
+        );
+        assert_eq!(
+            title_index
+                .bm25_row_stats_for_terms(&terms, None)
+                .await
+                .unwrap(),
+            (19, 10, vec![1, 1]),
+            "row-granularity statistics must count distinct row ids",
+        );
+
+        let legacy = combined_top_k(
+            &combined_columns(vec![title_index, body_index]),
+            &["alpha", "beta"],
+            1,
+        )
+        .await;
+        assert_eq!(legacy.len(), 1);
+        assert_eq!(legacy[0].0, 0, "row 0 matches `alpha` ten times over");
+        assert!(
+            (legacy[0].1 - 3.196_305).abs() < 1e-5,
+            "unexpected score {}",
+            legacy[0].1
+        );
+
+        // Reindexing the same data one document per row must agree bit for bit.
+        let (row_title, _row_title_dir) = element_document_index(
+            InvertedListFormatVersion::V3,
+            &vocab,
+            &as_row_documents(&title),
+        )
+        .await;
+        let (row_body, _row_body_dir) = element_document_index(
+            InvertedListFormatVersion::V3,
+            &vocab,
+            &as_row_documents(&body),
+        )
+        .await;
+        let rebuilt = combined_top_k(
+            &combined_columns(vec![row_title, row_body]),
+            &["alpha", "beta"],
+            1,
+        )
+        .await;
+        assert_eq!(
+            legacy
+                .iter()
+                .map(|(row_id, score)| (*row_id, score.to_bits()))
+                .collect::<Vec<_>>(),
+            rebuilt
+                .iter()
+                .map(|(row_id, score)| (*row_id, score.to_bits()))
+                .collect::<Vec<_>>(),
+            "legacy index must score like the same data reindexed per row",
+        );
+    }
+
+    /// The single-column path stays at document granularity. It reads
+    /// [`InvertedIndex::bm25_stats_for_terms`] via `build_global_bm25_scorer` and
+    /// wand scores one posting per document, so a legacy list index is
+    /// self-consistent there: `docCount` and `docFreq` count elements, `tf` is one
+    /// element's frequency and `dl` one element's length. V1/V2 are released
+    /// stable formats, so these `(row_id, score)` bits pin that behavior; moving
+    /// it is a separate compatibility decision.
+    ///
+    /// The element domain also shows through in the results: row 0's ten `"alpha"`
+    /// documents surface as ten separate hits at the same row id.
+    #[rstest]
+    #[case::v1(InvertedListFormatVersion::V1)]
+    #[case::v2(InvertedListFormatVersion::V2)]
+    #[tokio::test]
+    async fn test_single_column_search_keeps_element_granularity(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let vocab = ["alpha", "beta", "gamma"];
+        let mut title: ElementRows = vec![vec![vec!["alpha"]; 10], vec![vec!["beta"]]];
+        title.extend((2..10).map(|_| vec![vec!["gamma"]]));
+        let (index, _dir) = element_document_index(format_version, &vocab, &title).await;
+
+        let terms = ["alpha".to_owned(), "beta".to_owned()];
+        assert_eq!(
+            index.bm25_stats_for_terms(&terms, None).await.unwrap(),
+            (19, 19, vec![10, 1]),
+            "the single-column path's statistics stay at document granularity",
+        );
+
+        let tokens = Arc::new(Tokens::new(terms.to_vec(), DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(4)));
+        let scorer = crate::scalar::inverted::build_global_bm25_scorer(
+            std::slice::from_ref(&index),
+            &tokens,
+            &params,
+            None,
+        )
+        .await
+        .unwrap();
+        let (row_ids, scores) = index
+            .bm25_search(
+                tokens,
+                params,
+                Operator::Or,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+                Some(&scorer),
+            )
+            .await
+            .unwrap();
+        // `beta` (row 1) leads on its inflated element-level idf, and row 0
+        // repeats once per matching element: the element domain showing through
+        // in the hits themselves.
+        assert_eq!(row_ids, vec![1, 0, 0, 0]);
+        // Every element is one token long and `avgdl` is the element average
+        // (19 tokens / 19 documents), so `doc_weight` is exactly 1 and each score
+        // is the bare element-granularity `idf`: `ln(1 + (19 - df + 0.5)/(df + 0.5))`
+        // with df = 1 for `beta` and df = 10 for `alpha`.
+        assert_eq!(
+            scores.iter().map(|s| s.to_bits()).collect::<Vec<_>>(),
+            vec![0x4025_c6f0, 0x3f24_f495, 0x3f24_f495, 0x3f24_f495],
+        );
+        assert_eq!(scores[0].to_bits(), idf(1, 19).to_bits());
+        assert_eq!(scores[1].to_bits(), idf(10, 19).to_bits());
+    }
+
+    /// One legacy element-per-document column and one modern row-per-document
+    /// column in the same query. `docCount'` and `docFreq'` are a `max_f` across
+    /// columns, so a column left at element granularity poisons the blend even
+    /// when the other column is fine. The whole query must score as if the legacy
+    /// column had been reindexed per row.
+    #[tokio::test]
+    async fn test_combined_fields_mixes_legacy_and_modern_columns() {
+        let vocab = ["alpha", "beta"];
+        let legacy_rows: ElementRows = vec![
+            vec![vec!["alpha"]; 6],
+            vec![vec!["beta"]],
+            vec![vec!["beta"]],
+            vec![vec!["beta"]],
+        ];
+        let modern_rows: ElementRows = (0..4).map(|_| vec![vec!["alpha", "beta"]]).collect();
+
+        let (legacy, _legacy_dir) =
+            element_document_index(InvertedListFormatVersion::V2, &vocab, &legacy_rows).await;
+        let (modern, _modern_dir) =
+            element_document_index(InvertedListFormatVersion::V3, &vocab, &modern_rows).await;
+
+        let terms = ["alpha".to_owned(), "beta".to_owned()];
+        assert_eq!(
+            legacy.bm25_stats_for_terms(&terms, None).await.unwrap(),
+            (9, 9, vec![6, 3]),
+            "the fixture must still be element-per-document",
+        );
+        assert_eq!(
+            legacy.bm25_row_stats_for_terms(&terms, None).await.unwrap(),
+            (9, 4, vec![1, 3]),
+        );
+        assert_eq!(
+            modern.bm25_row_stats_for_terms(&terms, None).await.unwrap(),
+            modern.bm25_stats_for_terms(&terms, None).await.unwrap(),
+            "a row-per-document index must be untouched",
+        );
+
+        let columns = combined_columns(vec![legacy, modern.clone()]);
+        let mixed = combined_top_k(&columns, &["alpha", "beta"], 4).await;
+        // `docCount'` is the 4 rows, not the legacy column's 9 elements.
+        let scorer = build_combined_bm25_scorer(
+            &columns,
+            &Tokens::new(vec!["alpha".to_owned(), "beta".to_owned()], DocType::Text),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(scorer.doc_count(), 4);
+
+        let (rebuilt_legacy, _rebuilt_dir) = element_document_index(
+            InvertedListFormatVersion::V3,
+            &vocab,
+            &as_row_documents(&legacy_rows),
+        )
+        .await;
+        let rebuilt = combined_top_k(
+            &combined_columns(vec![rebuilt_legacy, modern]),
+            &["alpha", "beta"],
+            4,
+        )
+        .await;
+        assert_eq!(mixed.len(), 4);
+        assert_eq!(
+            mixed
+                .iter()
+                .map(|(row_id, score)| (*row_id, score.to_bits()))
+                .collect::<Vec<_>>(),
+            rebuilt
+                .iter()
+                .map(|(row_id, score)| (*row_id, score.to_bits()))
+                .collect::<Vec<_>>(),
+        );
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/combined/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/stats.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Corpus statistics for `combined_fields`: the cross-column BM25F scorer
+//! build.
+
+use std::collections::HashMap;
+
+use lance_core::Result;
+
+use super::super::query::Tokens;
+use super::super::scorer::CombinedFieldsBM25Scorer;
+use super::{CombinedFieldColumn, unique_terms};
+use crate::metrics::MetricsCollector;
+
+/// Fold the target columns' segment statistics into a single [`CombinedFieldsBM25Scorer`].
+///
+/// Generalizes [`build_global_bm25_scorer`](super::super::build_global_bm25_scorer)
+/// (which folds segments of one column) to fold across columns too, with
+/// per-column weights and the BM25F blend:
+/// `docCount'`/`docFreq'` take the max across columns while `sumTotalTermFreq'`
+/// is the weighted sum. The query terms are deduplicated the same way the scan
+/// deduplicates them, so the resulting per-term `docFreq'` covers exactly the
+/// terms [`combined_fields_search`](super::combined_fields_search) scores.
+///
+/// `metrics`, when provided, receives the per-token posting-metadata cache
+/// lookups this fold triggers, exactly as
+/// [`build_global_bm25_scorer`](super::super::build_global_bm25_scorer)
+/// reports them on the single-column path. Without it a cold cross-field query
+/// undercounts `index_cache_misses` by one lookup per (term, partition, column).
+pub async fn build_combined_bm25_scorer(
+    columns: &[CombinedFieldColumn],
+    tokens: &Tokens,
+    metrics: Option<&dyn MetricsCollector>,
+) -> Result<CombinedFieldsBM25Scorer> {
+    let terms = unique_terms(tokens);
+    let mut doc_count = 0usize;
+    let mut sum_total_term_freq = 0f64;
+    let mut doc_freq: HashMap<String, usize> = terms.iter().map(|t| (t.clone(), 0)).collect();
+
+    for column in columns {
+        let mut column_num_docs = 0usize;
+        let mut column_total_tokens = 0u64;
+        let mut column_doc_freq = vec![0usize; terms.len()];
+        {
+            for index in &column.indices {
+                // Row granularity, not document granularity: `combined_fields_search`
+                // blends every posting a row owns into one `tf'` and every document
+                // length it owns into one `dl'`, and released V1/V2 indexes may hold
+                // one document per list element. See
+                // [`InvertedIndex::bm25_row_stats_for_terms`].
+                let (total_tokens, num_docs, token_docs) =
+                    index.bm25_row_stats_for_terms(&terms, metrics).await?;
+                column_total_tokens += total_tokens;
+                column_num_docs += num_docs;
+                for (slot, df) in token_docs.into_iter().enumerate() {
+                    column_doc_freq[slot] += df;
+                }
+            }
+        }
+
+        doc_count = doc_count.max(column_num_docs);
+        sum_total_term_freq += column.weight as f64 * column_total_tokens as f64;
+        for (term, df) in terms.iter().zip(column_doc_freq) {
+            let entry = doc_freq
+                .get_mut(term)
+                .expect("doc_freq initialized for every term");
+            *entry = (*entry).max(df);
+        }
+    }
+
+    let avg_doc_length = if doc_count > 0 {
+        (sum_total_term_freq / doc_count as f64) as f32
+    } else {
+        0.0
+    };
+    Ok(CombinedFieldsBM25Scorer::new(
+        doc_count,
+        avg_doc_length,
+        doc_freq,
+    ))
+}

--- a/rust/lance-index/src/scalar/inverted/combined/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/stats.rs
@@ -80,3 +80,129 @@ pub async fn build_combined_bm25_scorer(
         doc_freq,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::index::InvertedListFormatVersion;
+    use super::super::super::tokenizer::document_tokenizer::DocType;
+    use super::super::testing::{ElementRows, combined_columns, element_document_index};
+    use super::*;
+    use crate::metrics::LocalMetricsCollector;
+    use rstest::rstest;
+
+    /// The scorer build must report its index cache lookups to the query's
+    /// collector, the way the single-column `build_global_bm25_scorer` does; see
+    /// [`build_combined_bm25_scorer`] for what goes wrong otherwise.
+    ///
+    /// The two format versions cover both statistics arms:
+    /// `bm25_row_stats_for_terms` delegates to the document-granularity path on
+    /// V3, and takes `InvertedPartition::row_stats_for_terms` on V1/V2, where this
+    /// element-per-document fixture makes it read the posting lists themselves.
+    #[rstest]
+    #[case::modern(InvertedListFormatVersion::V3)]
+    #[case::legacy_elements(InvertedListFormatVersion::V2)]
+    #[tokio::test]
+    async fn test_combined_scorer_build_reports_index_cache_lookups(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let vocab = ["alpha", "beta"];
+        // Row 0 owns two elements, so the legacy fixture is element-per-document
+        // and its row-granularity statistics take the deduplicating branch.
+        let rows: ElementRows = vec![vec![vec!["alpha"], vec!["beta"]], vec![vec!["alpha"]]];
+        let (first, _first_dir) = element_document_index(format_version, &vocab, &rows).await;
+        let (second, _second_dir) = element_document_index(format_version, &vocab, &rows).await;
+        let columns = combined_columns(vec![first, second]);
+        let tokens = Tokens::new(vec!["alpha".to_owned(), "beta".to_owned()], DocType::Text);
+        // One lookup per (term, column, partition), over 2 terms and the single
+        // partition each fixture index holds.
+        let expected_lookups = 2 * columns.len();
+
+        let indexed = LocalMetricsCollector::default();
+        build_combined_bm25_scorer(&columns, &tokens, Some(&indexed))
+            .await
+            .unwrap();
+        assert_eq!(
+            indexed.index_cache_hits() + indexed.index_cache_misses(),
+            expected_lookups,
+            "the scorer build must report every cache lookup it makes",
+        );
+    }
+
+    /// A legacy index whose documents already map one-to-one onto rows (a plain
+    /// `Utf8` column, or a list column with a single element per row) must be
+    /// completely unaffected: the row-granularity statistics equal the
+    /// document-granularity ones, so no score can move.
+    #[rstest]
+    #[case::v1(InvertedListFormatVersion::V1)]
+    #[case::v2(InvertedListFormatVersion::V2)]
+    #[case::v3(InvertedListFormatVersion::V3)]
+    #[tokio::test]
+    async fn test_row_stats_match_document_stats_without_list_multiplicity(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let vocab = ["alpha", "beta"];
+        // Row 0: a multi-token `Utf8` document. Row 1: a single-element list.
+        // Row 2: an empty list, so the row owns no document at all.
+        let rows: ElementRows = vec![
+            vec![vec!["alpha", "beta", "alpha"]],
+            vec![vec!["beta"]],
+            vec![Vec::new()],
+            vec![vec!["alpha"]],
+        ];
+        let (index, _dir) = element_document_index(format_version, &vocab, &rows).await;
+
+        let docs = index.partitions[0].docs.address_keyed().await.unwrap();
+        assert_eq!(docs.len(), 3, "the empty list must not become a document");
+        assert_eq!(docs.num_distinct_rows(), docs.len());
+        let terms = ["alpha".to_owned(), "beta".to_owned(), "absent".to_owned()];
+        let documents = index.bm25_stats_for_terms(&terms, None).await.unwrap();
+        assert_eq!(documents, (5, 3, vec![2, 2, 0]));
+        assert_eq!(
+            index.bm25_row_stats_for_terms(&terms, None).await.unwrap(),
+            documents
+        );
+    }
+
+    /// Rows a legacy list index never indexed (a null or empty list, a list of
+    /// empty strings) own no document, so they must not count toward
+    /// `docCount_f` or `docFreq_f`. This is the same rule the indexed and flat
+    /// sides already follow (`AddressKeyedDocuments::doc_length_at` reports 0 for them and
+    /// `FlatFieldStats::fold_row` skips a column with `dl_f == 0`), applied to
+    /// distinct-row counting.
+    #[rstest]
+    #[case::v1(InvertedListFormatVersion::V1)]
+    #[case::v2(InvertedListFormatVersion::V2)]
+    #[tokio::test]
+    async fn test_row_stats_skip_rows_a_legacy_list_index_never_indexed(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let vocab = ["alpha", "beta"];
+        let rows: ElementRows = vec![
+            // Several elements, one of them empty.
+            vec![vec!["alpha"], Vec::new(), vec!["alpha"], vec!["beta"]],
+            // A null or empty list.
+            Vec::new(),
+            vec![vec!["beta"]],
+            // A list of nothing but empty strings.
+            vec![Vec::new(), Vec::new()],
+        ];
+        let (index, _dir) = element_document_index(format_version, &vocab, &rows).await;
+
+        let docs = index.partitions[0].docs.address_keyed().await.unwrap();
+        assert_eq!(docs.len(), 4, "only rows 0 and 2 own documents");
+        assert_eq!(docs.num_distinct_rows(), 2);
+        for unindexed in [1u64, 3] {
+            assert_eq!(docs.doc_length_at(unindexed), 0);
+        }
+
+        let terms = ["alpha".to_owned(), "beta".to_owned()];
+        assert_eq!(
+            index.bm25_stats_for_terms(&terms, None).await.unwrap(),
+            (4, 4, vec![2, 2]),
+        );
+        assert_eq!(
+            index.bm25_row_stats_for_terms(&terms, None).await.unwrap(),
+            (4, 2, vec![1, 2]),
+        );
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/combined/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/stats.rs
@@ -1,17 +1,159 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Corpus statistics for `combined_fields`: the cross-column BM25F scorer
-//! build.
+//! Corpus statistics for `combined_fields`: the flat-scan contribution
+//! ([`FlatFieldStats`]) and the cross-column BM25F scorer build.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use lance_core::Result;
+use lance_core::{Error, Result};
+use lance_select::RowAddrMask;
 
 use super::super::query::Tokens;
 use super::super::scorer::CombinedFieldsBM25Scorer;
 use super::{CombinedFieldColumn, unique_terms};
 use crate::metrics::MetricsCollector;
+
+/// Per-column corpus contributions of the rows a `combined_fields` flat scan
+/// covers, i.e. rows in fragments that at least one target column's index is
+/// missing.
+///
+/// Folded into each column's own totals ahead of the BM25F cross-column blend so
+/// that `docCount'`, `docFreq'`, and `avgdl'` describe the whole scanned corpus
+/// rather than only its indexed part. Folding after the blend would be wrong:
+/// `docCount'`/`docFreq'` are a `max_f`, and `max_f(a_f) + max_f(b_f)` is not
+/// `max_f(a_f + b_f)`.
+///
+/// Every vector is indexed by the position of the column in the
+/// [`CombinedFieldColumn`] slice, and `doc_freqs[column]` is indexed by the
+/// deduplicated query term position (the order
+/// [`combined_fields_search`](super::combined_fields_search) uses).
+#[derive(Debug, Default, Clone)]
+pub struct FlatFieldStats {
+    /// Per column: flat docs with at least one token in that column.
+    pub doc_counts: Vec<usize>,
+    /// Per column: total tokens over all flat docs.
+    pub total_tokens: Vec<u64>,
+    /// `[column][term]`: flat docs containing that term in that column.
+    pub doc_freqs: Vec<Vec<usize>>,
+}
+
+impl FlatFieldStats {
+    /// An empty accumulator sized for `num_columns` columns and `num_terms`
+    /// deduplicated query terms.
+    pub(in crate::scalar::inverted) fn zeros(num_columns: usize, num_terms: usize) -> Self {
+        Self {
+            doc_counts: vec![0; num_columns],
+            total_tokens: vec![0; num_columns],
+            doc_freqs: vec![vec![0; num_terms]; num_columns],
+        }
+    }
+
+    /// Fold one flat row's per-column contribution in. The row's per-column
+    /// breakdown is then dropped: these fixed-size aggregates are all the scorer
+    /// needs from it.
+    ///
+    /// `doc_lengths` is `dl_f` per column and `term_counts` is `[column][term]`,
+    /// both for a single row. A row absent from a field (`dl_f == 0`) counts
+    /// toward neither `docCount_f` nor `docFreq_f`, matching the indexed side
+    /// where it owns no document in that field's index.
+    ///
+    /// `stats_masks[column]` selects the rows that column's index does not
+    /// already account for. The flat scan has to read every target column for
+    /// every scanned row, or `tf'`/`dl'` would be partial, yet a scanned fragment
+    /// may still be indexed for a subset of those columns. Folding such a row
+    /// into that column's statistics would double count it against the same
+    /// column's index statistics, inflating `docCount_f`, `sumTotalTermFreq_f`,
+    /// and `docFreq_f`.
+    ///
+    /// A mask may still admit an overlay-stale row on purpose, so that the current
+    /// value reaches `docFreq_f` at the price of that bounded inflation; the caller
+    /// owns that trade.
+    pub(in crate::scalar::inverted) fn fold_row(
+        &mut self,
+        row_id: u64,
+        stats_masks: &[Arc<RowAddrMask>],
+        doc_lengths: &[u64],
+        term_counts: &[u64],
+    ) {
+        let num_terms = self.doc_freqs.first().map_or(0, |freqs| freqs.len());
+        for (column, doc_count) in self.doc_counts.iter_mut().enumerate() {
+            if doc_lengths[column] == 0 || !stats_masks[column].selected(row_id) {
+                continue;
+            }
+            *doc_count += 1;
+            self.total_tokens[column] += doc_lengths[column];
+            let base = column * num_terms;
+            for (term, doc_freq) in self.doc_freqs[column].iter_mut().enumerate() {
+                if term_counts[base + term] > 0 {
+                    *doc_freq += 1;
+                }
+            }
+        }
+    }
+
+    /// Add another accumulator's totals. Every field is an integer count, so
+    /// merging per-batch folds is exact and order-independent, letting the fold run
+    /// inside the per-batch tokenization task rather than over one materialized
+    /// corpus.
+    pub(in crate::scalar::inverted) fn merge(&mut self, other: Self) {
+        for (total, part) in self.doc_counts.iter_mut().zip(other.doc_counts) {
+            *total += part;
+        }
+        for (total, part) in self.total_tokens.iter_mut().zip(other.total_tokens) {
+            *total += part;
+        }
+        for (total, part) in self.doc_freqs.iter_mut().zip(other.doc_freqs) {
+            for (total, part) in total.iter_mut().zip(part) {
+                *total += part;
+            }
+        }
+    }
+}
+
+/// Which statistics [`build_combined_bm25_scorer`] folds into the BM25F blend.
+#[derive(Debug, Clone, Copy)]
+pub enum CombinedCorpusStats<'a> {
+    /// Index statistics alone: every target column's index covers every scanned
+    /// fragment, so no row was flat-scanned.
+    IndexOnly,
+    /// Index statistics plus a flat scan's contribution for the rows no index
+    /// covers. The masks the fold applied decide which rows those are, and so
+    /// whether a row lands on one side or, deliberately, on both.
+    Blended(&'a FlatFieldStats),
+    /// A flat scan's statistics alone, covering the whole target corpus.
+    ///
+    /// For a column with overlay-stale index entries: the index still counts the
+    /// pre-overlay document and the flat scan cannot subtract it, so neither
+    /// folding the row in nor leaving it out describes current data. Measuring the
+    /// whole corpus from the scanned values sidesteps that.
+    FlatOnly(&'a FlatFieldStats),
+}
+
+impl<'a> CombinedCorpusStats<'a> {
+    /// The variant for a flat scan's statistics, by whether the scan read every
+    /// target fragment or only the rows no index covers.
+    pub fn for_flat_scan(flat: &'a FlatFieldStats, covers_whole_corpus: bool) -> Self {
+        if covers_whole_corpus {
+            Self::FlatOnly(flat)
+        } else {
+            Self::Blended(flat)
+        }
+    }
+
+    /// The flat contribution, for the arity checks the caller cannot make.
+    fn flat(&self) -> Option<&'a FlatFieldStats> {
+        match self {
+            Self::IndexOnly => None,
+            Self::Blended(flat) | Self::FlatOnly(flat) => Some(flat),
+        }
+    }
+
+    fn folds_index_stats(&self) -> bool {
+        !matches!(self, Self::FlatOnly(_))
+    }
+}
 
 /// Fold the target columns' segment statistics into a single [`CombinedFieldsBM25Scorer`].
 ///
@@ -23,26 +165,52 @@ use crate::metrics::MetricsCollector;
 /// deduplicates them, so the resulting per-term `docFreq'` covers exactly the
 /// terms [`combined_fields_search`](super::combined_fields_search) scores.
 ///
+/// `corpus` selects which statistics the blend is built from; see
+/// [`CombinedCorpusStats`].
+///
 /// `metrics`, when provided, receives the per-token posting-metadata cache
 /// lookups this fold triggers, exactly as
 /// [`build_global_bm25_scorer`](super::super::build_global_bm25_scorer)
 /// reports them on the single-column path. Without it a cold cross-field query
 /// undercounts `index_cache_misses` by one lookup per (term, partition, column).
+/// [`CombinedCorpusStats::FlatOnly`] reads none, so it reports none.
 pub async fn build_combined_bm25_scorer(
     columns: &[CombinedFieldColumn],
     tokens: &Tokens,
+    corpus: CombinedCorpusStats<'_>,
     metrics: Option<&dyn MetricsCollector>,
 ) -> Result<CombinedFieldsBM25Scorer> {
     let terms = unique_terms(tokens);
+    if let Some(flat) = corpus.flat() {
+        if flat.doc_counts.len() != columns.len()
+            || flat.total_tokens.len() != columns.len()
+            || flat.doc_freqs.len() != columns.len()
+        {
+            return Err(Error::invalid_input(format!(
+                "combined_fields flat statistics cover {} / {} / {} columns but the query has {}",
+                flat.doc_counts.len(),
+                flat.total_tokens.len(),
+                flat.doc_freqs.len(),
+                columns.len()
+            )));
+        }
+        if let Some(bad) = flat.doc_freqs.iter().find(|df| df.len() != terms.len()) {
+            return Err(Error::invalid_input(format!(
+                "combined_fields flat document frequencies cover {} terms but the query has {}",
+                bad.len(),
+                terms.len()
+            )));
+        }
+    }
     let mut doc_count = 0usize;
     let mut sum_total_term_freq = 0f64;
     let mut doc_freq: HashMap<String, usize> = terms.iter().map(|t| (t.clone(), 0)).collect();
 
-    for column in columns {
+    for (column_slot, column) in columns.iter().enumerate() {
         let mut column_num_docs = 0usize;
         let mut column_total_tokens = 0u64;
         let mut column_doc_freq = vec![0usize; terms.len()];
-        {
+        if corpus.folds_index_stats() {
             for index in &column.indices {
                 // Row granularity, not document granularity: `combined_fields_search`
                 // blends every posting a row owns into one `tf'` and every document
@@ -56,6 +224,13 @@ pub async fn build_combined_bm25_scorer(
                 for (slot, df) in token_docs.into_iter().enumerate() {
                     column_doc_freq[slot] += df;
                 }
+            }
+        }
+        if let Some(flat) = corpus.flat() {
+            column_num_docs += flat.doc_counts[column_slot];
+            column_total_tokens += flat.total_tokens[column_slot];
+            for (slot, df) in flat.doc_freqs[column_slot].iter().enumerate() {
+                column_doc_freq[slot] += df;
             }
         }
 
@@ -84,13 +259,58 @@ pub async fn build_combined_bm25_scorer(
 #[cfg(test)]
 mod tests {
     use super::super::super::index::InvertedListFormatVersion;
+    use super::super::super::tokenizer::InvertedIndexParams;
     use super::super::super::tokenizer::document_tokenizer::DocType;
-    use super::super::testing::{ElementRows, combined_columns, element_document_index};
+    use super::super::flat::flat_combined_fields_search_stream;
+    use super::super::testing::{
+        ElementRows, combined_columns, element_document_index, flat_input, flat_scores,
+    };
     use super::*;
     use crate::metrics::LocalMetricsCollector;
+    use crate::scalar::inverted::query::Operator;
+    use lance_select::RowAddrTreeMap;
     use rstest::rstest;
 
-    /// The scorer build must report its index cache lookups to the query's
+    /// The statistics fold runs per batch and the partial results are merged, so
+    /// it must not matter how the scan is chunked.
+    #[test]
+    fn test_flat_field_stats_fold_is_split_invariant() {
+        // Two columns, two terms. Row 7 is empty in column 1 and row 9 is masked
+        // out of column 1, so neither contributes there.
+        let rows: [(u64, [u64; 2], [u64; 4]); 3] = [
+            (7, [4, 0], [1, 0, 0, 0]),
+            (8, [3, 5], [1, 1, 2, 0]),
+            (9, [2, 6], [0, 1, 1, 1]),
+        ];
+        let masks = vec![
+            Arc::new(RowAddrMask::all_rows()),
+            Arc::new(RowAddrMask::all_rows().also_block(RowAddrTreeMap::from_iter([9u64]))),
+        ];
+        let fold = |rows: &[(u64, [u64; 2], [u64; 4])]| {
+            let mut stats = FlatFieldStats::zeros(2, 2);
+            for (row_id, lengths, counts) in rows {
+                stats.fold_row(*row_id, &masks, lengths, counts);
+            }
+            stats
+        };
+
+        let whole = fold(&rows);
+        assert_eq!(whole.doc_counts, vec![3, 1]);
+        assert_eq!(whole.total_tokens, vec![9, 5]);
+        // Column 0: "cat" in rows 7 and 8, "dog" in rows 8 and 9.
+        // Column 1: only row 8 counts, with "cat" present and "dog" absent.
+        assert_eq!(whole.doc_freqs, vec![vec![2, 2], vec![1, 0]]);
+
+        for split in 0..=rows.len() {
+            let mut merged = fold(&rows[..split]);
+            merged.merge(fold(&rows[split..]));
+            assert_eq!(merged.doc_counts, whole.doc_counts, "split at {split}");
+            assert_eq!(merged.total_tokens, whole.total_tokens, "split at {split}");
+            assert_eq!(merged.doc_freqs, whole.doc_freqs, "split at {split}");
+        }
+    }
+
+    /// Both scorer builds must report their index cache lookups to the query's
     /// collector, the way the single-column `build_global_bm25_scorer` does; see
     /// [`build_combined_bm25_scorer`] for what goes wrong otherwise.
     ///
@@ -118,13 +338,49 @@ mod tests {
         let expected_lookups = 2 * columns.len();
 
         let indexed = LocalMetricsCollector::default();
-        build_combined_bm25_scorer(&columns, &tokens, Some(&indexed))
-            .await
-            .unwrap();
+        build_combined_bm25_scorer(
+            &columns,
+            &tokens,
+            CombinedCorpusStats::IndexOnly,
+            Some(&indexed),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             indexed.index_cache_hits() + indexed.index_cache_misses(),
             expected_lookups,
-            "the scorer build must report every cache lookup it makes",
+            "indexed scorer build must report every cache lookup it makes",
+        );
+
+        // The flat sibling folds the same per-column index statistics in, so its
+        // build reports the same lookups. An empty input isolates them: the
+        // scanned rows contribute no index reads at all.
+        let flat = LocalMetricsCollector::default();
+        let stream = flat_combined_fields_search_stream(
+            flat_input(&[], &[Vec::new(), Vec::new()], 1),
+            &columns,
+            vec![1, 2],
+            &[
+                Arc::new(RowAddrMask::all_rows()),
+                Arc::new(RowAddrMask::all_rows()),
+            ],
+            /*emit_mask=*/ None,
+            /*flat_covers_whole_corpus=*/ false,
+            &tokens,
+            InvertedIndexParams::default().build().unwrap(),
+            Operator::Or,
+            16,
+            None,
+            Some(&flat),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert!(flat_scores(stream).await.1.is_empty());
+        assert_eq!(
+            flat.index_cache_hits() + flat.index_cache_misses(),
+            expected_lookups,
+            "flat scorer build must report every cache lookup it makes",
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/combined/testing.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/testing.rs
@@ -8,9 +8,15 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use arrow::array::AsArray;
+use arrow::datatypes::{Float32Type, UInt64Type};
 use arrow_array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::stream;
 use lance_core::Result;
 use lance_core::cache::{LanceCache, WeakLanceCache};
+use lance_core::error::DataFusionResult;
 use lance_core::utils::tempfile::TempObjDir;
 use lance_io::object_store::ObjectStore;
 use lance_select::RowAddrTreeMap;
@@ -29,7 +35,9 @@ use super::super::index::{
 use super::super::query::{FtsSearchParams, Operator, Tokens};
 use super::super::tokenizer::document_tokenizer::DocType;
 use super::super::tokenizer::{InvertedIndexParams, LEGACY_BLOCK_SIZE};
-use super::{CombinedFieldColumn, build_combined_bm25_scorer, combined_fields_search};
+use super::{
+    CombinedCorpusStats, CombinedFieldColumn, build_combined_bm25_scorer, combined_fields_search,
+};
 use crate::metrics::NoOpMetricsCollector;
 use crate::prefilter::NoFilter;
 use crate::scalar::lance_format::LanceIndexStore;
@@ -133,6 +141,58 @@ pub(super) async fn modern_identity_docs(
     .address_keyed()
     .await
     .unwrap()
+}
+
+/// `_rowid` plus one `Utf8` document column per entry of `docs`
+/// (`docs[column][row]`), delivered as `num_batches` equal batches.
+pub(super) fn flat_input(
+    row_ids: &[u64],
+    docs: &[Vec<Option<&str>>],
+    num_batches: usize,
+) -> SendableRecordBatchStream {
+    use arrow_array::StringArray;
+    use arrow_schema::{DataType, Field, Schema};
+
+    let mut fields = vec![lance_core::ROW_ID_FIELD.clone()];
+    let mut arrays: Vec<ArrayRef> = vec![Arc::new(UInt64Array::from(row_ids.to_vec()))];
+    for (slot, column) in docs.iter().enumerate() {
+        fields.push(Field::new(format!("doc{slot}"), DataType::Utf8, true));
+        arrays.push(Arc::new(StringArray::from(column.clone())));
+    }
+    let schema = Arc::new(Schema::new(fields));
+    let batch = RecordBatch::try_new(schema.clone(), arrays).unwrap();
+    // No rows means no batches at all, the way an empty scan arrives.
+    let rows_per_batch = row_ids.len().div_ceil(num_batches.max(1));
+    let batches = (0..row_ids.len().div_ceil(rows_per_batch.max(1)))
+        .map(|i| {
+            let start = i * rows_per_batch;
+            let len = (row_ids.len() - start).min(rows_per_batch);
+            DataFusionResult::Ok(batch.slice(start, len))
+        })
+        .collect::<Vec<_>>();
+    Box::pin(RecordBatchStreamAdapter::new(schema, stream::iter(batches)))
+}
+
+/// Every `(row_id, score)` the flat scan emits, in emission order, with the
+/// score as raw bits so the comparison is exact.
+pub(super) async fn flat_scores(
+    stream: SendableRecordBatchStream,
+) -> (Vec<usize>, Vec<(u64, u32)>) {
+    use futures::TryStreamExt;
+
+    let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+    let sizes = batches.iter().map(|batch| batch.num_rows()).collect();
+    let scored = batches
+        .iter()
+        .flat_map(|batch| {
+            let row_ids = batch.column(0).as_primitive::<UInt64Type>();
+            let scores = batch.column(1).as_primitive::<Float32Type>();
+            (0..batch.num_rows())
+                .map(|i| (row_ids.value(i), scores.value(i).to_bits()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    (sizes, scored)
 }
 
 // Legacy element-per-document corpus statistics.
@@ -284,7 +344,7 @@ pub(super) async fn combined_top_k(
         terms.iter().map(|t| (*t).to_owned()).collect(),
         DocType::Text,
     );
-    let scorer = build_combined_bm25_scorer(columns, &tokens, None)
+    let scorer = build_combined_bm25_scorer(columns, &tokens, CombinedCorpusStats::IndexOnly, None)
         .await
         .unwrap();
     let params = FtsSearchParams::new().with_limit(Some(limit));

--- a/rust/lance-index/src/scalar/inverted/combined/testing.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/testing.rs
@@ -173,6 +173,18 @@ pub(super) fn flat_input(
     Box::pin(RecordBatchStreamAdapter::new(schema, stream::iter(batches)))
 }
 
+pub(super) fn flat_columns(weights: &[f32]) -> Vec<CombinedFieldColumn> {
+    weights
+        .iter()
+        .enumerate()
+        .map(|(slot, weight)| CombinedFieldColumn {
+            column: format!("doc{slot}"),
+            weight: *weight,
+            indices: Vec::new(),
+        })
+        .collect()
+}
+
 /// Every `(row_id, score)` the flat scan emits, in emission order, with the
 /// score as raw bits so the comparison is exact.
 pub(super) async fn flat_scores(

--- a/rust/lance-index/src/scalar/inverted/combined/testing.rs
+++ b/rust/lance-index/src/scalar/inverted/combined/testing.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Shared test fixtures for the `combined_fields` submodules: term cursors,
+//! document views, index and flat-scan corpora, and the exact reference scans
+//! the tests compare against.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array};
+use lance_core::Result;
+use lance_core::cache::{LanceCache, WeakLanceCache};
+use lance_core::utils::tempfile::TempObjDir;
+use lance_io::object_store::ObjectStore;
+use lance_select::RowAddrTreeMap;
+use roaring::RoaringTreemap;
+
+use super::super::builder::{BLOCK_SIZE, InnerBuilder, PositionRecorder};
+use super::super::documents::{AddressKeyedDocuments, PartitionDocuments};
+use super::super::encoding::{
+    MAX_POSTING_BLOCK_SIZE, compress_posting_list_with_tail_codec_and_block_size,
+};
+use super::super::index::{
+    CompressedPostingList, FTS_FORMAT_VERSION_KEY, InvertedIndex, InvertedListFormatVersion,
+    METADATA_FILE, NUM_TOKEN_COL, POSTING_BLOCK_SIZE_KEY, POSTING_TAIL_CODEC_KEY,
+    PostingListBuilder, PostingTailCodec, TOKEN_SET_FORMAT_KEY, TokenSetFormat,
+};
+use super::super::query::{FtsSearchParams, Operator, Tokens};
+use super::super::tokenizer::document_tokenizer::DocType;
+use super::super::tokenizer::{InvertedIndexParams, LEGACY_BLOCK_SIZE};
+use super::{CombinedFieldColumn, build_combined_bm25_scorer, combined_fields_search};
+use crate::metrics::NoOpMetricsCollector;
+use crate::prefilter::NoFilter;
+use crate::scalar::lance_format::LanceIndexStore;
+use crate::scalar::{IndexStore, RowIdRemapper};
+
+pub(super) fn compressed_list(postings: &[(u32, u32)]) -> CompressedPostingList {
+    let doc_ids: Vec<u32> = postings.iter().map(|(d, _)| *d).collect();
+    let freqs: Vec<u32> = postings.iter().map(|(_, f)| *f).collect();
+    let blocks = compress_posting_list_with_tail_codec_and_block_size(
+        doc_ids.len(),
+        doc_ids.iter(),
+        freqs.iter(),
+        std::iter::repeat(0.0f32),
+        PostingTailCodec::VarintDelta,
+        BLOCK_SIZE,
+    )
+    .unwrap();
+    CompressedPostingList::new(
+        blocks,
+        1.0,
+        doc_ids.len() as u32,
+        PostingTailCodec::VarintDelta,
+        BLOCK_SIZE,
+        None,
+        None,
+    )
+}
+
+#[derive(Debug)]
+struct DeletedRows(Vec<u64>);
+
+impl RowIdRemapper for DeletedRows {
+    fn remap_row_id(&self, row_id: u64) -> Option<u64> {
+        (!self.0.contains(&row_id)).then_some(row_id)
+    }
+
+    fn remap_row_addrs_tree_map(&self, _: &RowAddrTreeMap) -> RowAddrTreeMap {
+        unreachable!("document fixtures only remap single row ids")
+    }
+
+    fn remap_row_ids_roaring_tree_map(&self, _: &RoaringTreemap) -> RoaringTreemap {
+        unreachable!("document fixtures only remap single row ids")
+    }
+
+    fn remap_row_ids_record_batch(&self, _: RecordBatch, _: usize) -> Result<RecordBatch> {
+        unreachable!("document fixtures only remap single row ids")
+    }
+}
+
+/// Modern identity documents, written to a real store and loaded through
+/// [`PartitionDocuments::address_keyed`] so the fixture is the representation
+/// production scores against rather than a stand-in.
+///
+/// `dead_rows` are addresses a fragment-reuse remapper has deleted: the slot
+/// survives (posting lists key on its DocId positionally) but
+/// `row_address` answers [`RowAddress::TOMBSTONE_ROW`] for it. Every part of
+/// the returned view is resident, so the temporary store is dropped here.
+pub(super) async fn modern_identity_docs(
+    num_tokens: &[u32],
+    dead_rows: &[u64],
+) -> AddressKeyedDocuments {
+    const DOCS_PATH: &str = "combined_fixture_docs.lance";
+    let tmpdir = TempObjDir::default();
+    let cache = Arc::new(LanceCache::no_cache());
+    let store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        cache.clone(),
+    ));
+    let schema = Arc::new(arrow_schema::Schema::new(vec![
+        arrow_schema::Field::new(lance_core::ROW_ID, arrow_schema::DataType::UInt64, false),
+        arrow_schema::Field::new(NUM_TOKEN_COL, arrow_schema::DataType::UInt32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt64Array::from(
+                (0..num_tokens.len() as u64).collect::<Vec<_>>(),
+            )) as ArrayRef,
+            Arc::new(UInt32Array::from(num_tokens.to_vec())) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let mut writer = store.new_index_file(DOCS_PATH, schema).await.unwrap();
+    writer.write_record_batch(batch).await.unwrap();
+    writer.finish().await.unwrap();
+
+    let reader = store.open_index_file(DOCS_PATH).await.unwrap();
+    let remapper: Option<Arc<dyn RowIdRemapper>> = (!dead_rows.is_empty())
+        .then(|| Arc::new(DeletedRows(dead_rows.to_vec())) as Arc<dyn RowIdRemapper>);
+    PartitionDocuments::try_new(
+        store.clone(),
+        DOCS_PATH.to_owned(),
+        0,
+        WeakLanceCache::from(cache.as_ref()),
+        reader.as_ref(),
+        remapper,
+        false,
+    )
+    .unwrap()
+    .address_keyed()
+    .await
+    .unwrap()
+}
+
+// Legacy element-per-document corpus statistics.
+//
+// Released V1/V2 indexes indexed every `List<String>` element as its own document,
+// so one row there owns a run of documents. `combined_fields` scores at row level,
+// so `docCount'` / `docFreq'` must be row level too or `idf'` and `avgdl'` describe
+// a different corpus than the frequencies they divide. The current builder writes
+// one document per row, so these fixtures write the legacy partition files
+// directly, and assert that they really are element-per-document so the coverage
+// cannot lapse.
+
+/// A fixture corpus: `rows[row][element]` is one indexed element's tokens.
+pub(super) type ElementRows<'a> = Vec<Vec<Vec<&'a str>>>;
+
+/// Build a one-partition FTS index whose documents are the individual
+/// elements of `rows`, each carrying its row's id (row `r` has row id `r`).
+/// `vocab` fixes the token order; tokens absent from `rows` are left out of
+/// the token set, as the builder leaves them out. Elements that tokenize to
+/// nothing are skipped, also as the builder does.
+pub(super) async fn element_document_index(
+    format_version: InvertedListFormatVersion,
+    vocab: &[&str],
+    rows: &ElementRows<'_>,
+) -> (Arc<InvertedIndex>, TempObjDir) {
+    let vocab: Vec<&str> = vocab
+        .iter()
+        .copied()
+        .filter(|token| rows.iter().flatten().any(|element| element.contains(token)))
+        .collect();
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let block_size = match format_version {
+        InvertedListFormatVersion::V3 => MAX_POSTING_BLOCK_SIZE,
+        InvertedListFormatVersion::V1 | InvertedListFormatVersion::V2 => LEGACY_BLOCK_SIZE,
+    };
+    let posting_tail_codec = format_version.posting_tail_codec();
+    let mut builder = InnerBuilder::new_with_format_version_and_block_size(
+        0,
+        false,
+        TokenSetFormat::default(),
+        format_version,
+        block_size,
+    );
+    let mut postings: Vec<PostingListBuilder> = vocab
+        .iter()
+        .map(|token| {
+            builder.tokens.add((*token).to_owned());
+            PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                false,
+                posting_tail_codec,
+                block_size,
+            )
+        })
+        .collect();
+    let mut doc_id = 0u32;
+    for (row, elements) in rows.iter().enumerate() {
+        for element in elements {
+            if element.is_empty() {
+                continue;
+            }
+            for (token_id, token) in vocab.iter().enumerate() {
+                let freq = element.iter().filter(|t| *t == token).count() as u32;
+                if freq > 0 {
+                    postings[token_id].add(doc_id, PositionRecorder::Count(freq));
+                }
+            }
+            builder.docs.append(row as u64, element.len() as u32);
+            doc_id += 1;
+        }
+    }
+    builder.set_posting_lists(postings);
+    builder.write(store.as_ref()).await.unwrap();
+
+    let params = InvertedIndexParams::default()
+        .block_size(block_size)
+        .unwrap();
+    let metadata = HashMap::from([
+        (
+            "partitions".to_owned(),
+            serde_json::to_string(&vec![0u64]).unwrap(),
+        ),
+        ("params".to_owned(), serde_json::to_string(&params).unwrap()),
+        (
+            TOKEN_SET_FORMAT_KEY.to_owned(),
+            TokenSetFormat::default().to_string(),
+        ),
+        (
+            POSTING_TAIL_CODEC_KEY.to_owned(),
+            posting_tail_codec.as_str().to_owned(),
+        ),
+        (
+            FTS_FORMAT_VERSION_KEY.to_owned(),
+            format_version.index_version().to_string(),
+        ),
+        (POSTING_BLOCK_SIZE_KEY.to_owned(), block_size.to_string()),
+    ]);
+    let mut writer = store
+        .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+        .await
+        .unwrap();
+    writer.finish_with_metadata(metadata).await.unwrap();
+
+    let index = InvertedIndex::load(store, None, &LanceCache::no_cache())
+        .await
+        .unwrap();
+    (index, tmpdir)
+}
+
+/// The same corpus as one document per row: a row's elements joined into a
+/// single document, which is what the current builder writes for a
+/// `List<String>` column.
+pub(super) fn as_row_documents<'a>(rows: &ElementRows<'a>) -> ElementRows<'a> {
+    rows.iter()
+        .map(|elements| {
+            let joined: Vec<&str> = elements.iter().flatten().copied().collect();
+            if joined.is_empty() {
+                Vec::new()
+            } else {
+                vec![joined]
+            }
+        })
+        .collect()
+}
+
+pub(super) fn combined_columns(indices: Vec<Arc<InvertedIndex>>) -> Vec<CombinedFieldColumn> {
+    indices
+        .into_iter()
+        .enumerate()
+        .map(|(slot, index)| CombinedFieldColumn {
+            column: format!("col{slot}"),
+            weight: 1.0,
+            indices: vec![index],
+        })
+        .collect()
+}
+
+/// Run a `combined_fields` top-k over `columns`, returning `(row_id, score)`.
+pub(super) async fn combined_top_k(
+    columns: &[CombinedFieldColumn],
+    terms: &[&str],
+    limit: usize,
+) -> Vec<(u64, f32)> {
+    let tokens = Tokens::new(
+        terms.iter().map(|t| (*t).to_owned()).collect(),
+        DocType::Text,
+    );
+    let scorer = build_combined_bm25_scorer(columns, &tokens, None)
+        .await
+        .unwrap();
+    let params = FtsSearchParams::new().with_limit(Some(limit));
+    let (row_ids, scores) = combined_fields_search(
+        columns,
+        &tokens,
+        &params,
+        Operator::Or,
+        &scorer,
+        Arc::new(NoFilter),
+        &NoOpMetricsCollector,
+    )
+    .await
+    .unwrap();
+    row_ids.into_iter().zip(scores).collect()
+}

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -686,6 +686,7 @@ impl CompoundScorerPlan {
                     .map(|query| Self::from_query(query, num_leaves))
                     .collect::<Result<Vec<_>>>()?,
             }),
+            FtsQuery::CombinedFields(_) => Err(combined_fields_unsupported()),
         }
     }
 
@@ -3769,8 +3770,22 @@ pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>
                 collect_leaf_queries(child, leaves)?;
             }
         }
+        FtsQuery::CombinedFields(_) => return Err(combined_fields_unsupported()),
     }
     Ok(())
+}
+
+/// A `combined_fields` node reaching the compound scorer is a planner bug.
+///
+/// Every leaf here draws its postings from one column's index and scores them
+/// with a `MemBM25Scorer`, whereas BM25F blends `tf'`/`dl'`/`docFreq'` across
+/// several columns before scoring. The planner keeps such trees out via
+/// `supports_compound_scorer`, so this is an explicit error.
+fn combined_fields_unsupported() -> Error {
+    Error::not_supported(
+        "the compound FTS scorer cannot score a combined_fields (BM25F) node: its statistics \
+         are blended across columns and do not fit the single-index leaf protocol",
+    )
 }
 
 struct PreparedLeaf {

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -8,6 +8,7 @@
 //! never has to infer which value a numeric slot represents.
 
 use std::borrow::Cow;
+use std::ops::Range;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -28,7 +29,7 @@ use crate::FtsPrewarmDocumentStatus;
 use crate::scalar::{IndexReader, IndexStore, RowIdRemapper};
 
 use super::index::{
-    DocSet, NUM_TOKEN_COL, dequantize_doc_length, doc_index_storage_column,
+    DocSet, NUM_TOKEN_COL, count_row_id_runs, dequantize_doc_length, doc_index_storage_column,
     document_coordinate_rank, quantize_doc_length,
 };
 
@@ -301,6 +302,18 @@ impl AddressDocIdLookup {
         left
     }
 
+    /// The positions of every live DocId whose address falls in `start..=end`.
+    fn positions_in_address_range(
+        &self,
+        projection: &ResidentAddressProjection,
+        start: u64,
+        end: u64,
+    ) -> Range<usize> {
+        let first = self.partition_point(projection, |address| address < start);
+        let after_last = self.partition_point(projection, |address| address <= end);
+        first..after_last
+    }
+
     fn insert_address_range(
         &self,
         projection: &ResidentAddressProjection,
@@ -308,9 +321,7 @@ impl AddressDocIdLookup {
         end: u64,
         selected: &mut RoaringBitmap,
     ) {
-        let first = self.partition_point(projection, |address| address < start);
-        let after_last = self.partition_point(projection, |address| address <= end);
-        for position in first..after_last {
+        for position in self.positions_in_address_range(projection, start, end) {
             selected.insert(self.doc_id_at(position));
         }
     }
@@ -971,6 +982,28 @@ impl ResidentAddressProjection {
             .unwrap_or_else(|| (0..self.len() as u32).collect())
     }
 
+    /// True iff every slot is live and addresses ascend strictly with DocId.
+    ///
+    /// DocId order then equals address order and no two documents share a row,
+    /// so a contiguous DocId range spans a contiguous address interval. Row
+    /// granularity relies on the second half: cross-field statistics count
+    /// distinct rows, so an ascending partition can answer
+    /// [`AddressKeyedDocuments::num_distinct_rows`] without walking it.
+    ///
+    /// The ordering half is [`OrderedRowAddressProjection`], whose verdict this
+    /// projection already caches for the cross-column scorer. Density is the
+    /// extra condition: an ordered projection may still hold dead slots, and
+    /// those report [`RowAddress::TOMBSTONE_ROW`], which the block-skip cursor
+    /// cannot tell from an exhausted cursor. A remapper is attached whenever the
+    /// dataset carries a fragment reuse index, even when it retains every
+    /// document, so liveness has to be decided on cardinality.
+    fn dense_and_strictly_ascending(&self) -> bool {
+        match self.try_ordered_row_addresses() {
+            Ok(ordered) => !ordered.has_sparse_live_docs(),
+            Err(_) => false,
+        }
+    }
+
     async fn doc_ids_by_address(&self) -> Result<Arc<AddressDocIdLookup>> {
         self.projection
             .doc_ids_by_address
@@ -1186,6 +1219,7 @@ impl PartitionDocumentStore {
                 prewarm_complete: true,
                 scoring_ready: true,
                 reverse_lookup_ready: true,
+                ascending_addresses_ready: true,
                 projection_resident: true,
             },
             Self::Modern(docs) => docs.prewarm_status(),
@@ -1196,6 +1230,128 @@ impl PartitionDocumentStore {
         match self {
             Self::Legacy(docs) => Ok((**docs).clone()),
             Self::Modern(docs) => docs.load_build_docset().await,
+        }
+    }
+
+    /// This partition's documents keyed by row address; see
+    /// [`AddressKeyedDocuments`].
+    pub(crate) async fn address_keyed(&self) -> Result<AddressKeyedDocuments> {
+        match self {
+            Self::Legacy(docs) => Ok(AddressKeyedDocuments::from_docset(docs.clone())),
+            Self::Modern(docs) => docs.address_keyed().await,
+        }
+    }
+}
+
+/// One partition's documents keyed by row address instead of [`DocId`].
+///
+/// A scan that spans several columns can only join them on the row address:
+/// each column has its own index, its own partitioning and its own DocId space.
+/// Such a scan needs both directions: `DocId -> address` to place a posting,
+/// and `address -> length` to read a candidate row's contribution from a column
+/// it may hold no posting for at all, which rules out carrying a DocId through
+/// the merge instead.
+///
+/// The modern variant materializes nothing per query: it clones the partition's
+/// cached lengths, its resident address projection and the address-sorted DocId
+/// lookup, all of which are per-partition state that [`PartitionDocuments::prewarm`]
+/// fills and that outlives the query. It does keep the whole address column
+/// resident, unlike the single-column path which resolves addresses only for the
+/// final top-k, because every candidate row needs a length from every column.
+#[derive(Debug, Clone)]
+pub(super) struct AddressKeyedDocuments(AddressKeyedSource);
+
+#[derive(Debug, Clone)]
+enum AddressKeyedSource {
+    /// Legacy partitions already own a complete row-address-keyed [`DocSet`].
+    Legacy(Arc<DocSet>),
+    Modern {
+        projection: ResidentAddressProjection,
+        doc_ids_by_address: Arc<AddressDocIdLookup>,
+        lengths: Arc<DocLengths>,
+        /// Memoized per partition; see
+        /// [`ResidentAddressProjection::dense_and_strictly_ascending`].
+        strictly_ascending: bool,
+    },
+}
+
+impl AddressKeyedDocuments {
+    /// View a legacy partition's complete [`DocSet`], which is already keyed by
+    /// row address.
+    pub(crate) fn from_docset(docs: Arc<DocSet>) -> Self {
+        Self(AddressKeyedSource::Legacy(docs))
+    }
+
+    /// Number of documents, counting the dead slots a remapped partition keeps
+    /// so its DocIds stay aligned with the posting lists.
+    pub(crate) fn len(&self) -> usize {
+        match &self.0 {
+            AddressKeyedSource::Legacy(docs) => docs.len(),
+            AddressKeyedSource::Modern { lengths, .. } => lengths.len(),
+        }
+    }
+
+    /// Row address of `doc_id`, or [`RowAddress::TOMBSTONE_ROW`] when the slot is
+    /// not live.
+    #[inline]
+    pub(crate) fn row_address(&self, doc_id: u32) -> u64 {
+        match &self.0 {
+            AddressKeyedSource::Legacy(docs) => docs.row_id(doc_id),
+            AddressKeyedSource::Modern { projection, .. } => projection
+                .address(DocId::new(doc_id))
+                .unwrap_or(RowAddress::TOMBSTONE_ROW),
+        }
+    }
+
+    /// Total length of the row at `address`: the sum over every document the row
+    /// owns in this partition, or 0 when the partition holds none (an empty or
+    /// null field, a row outside the partition, or a dead slot).
+    ///
+    /// Released V1/V2 list indexes indexed each `List<String>` element as its own
+    /// document, so one row can own a whole run of documents and every one of
+    /// them contributes.
+    #[inline]
+    pub(crate) fn doc_length_at(&self, address: u64) -> u64 {
+        match &self.0 {
+            AddressKeyedSource::Legacy(docs) => docs.doc_length_by_row_id(address),
+            AddressKeyedSource::Modern {
+                projection,
+                doc_ids_by_address,
+                lengths,
+                ..
+            } => doc_ids_by_address
+                .positions_in_address_range(projection, address, address)
+                .map(|position| {
+                    u64::from(lengths.exact(DocId::new(doc_ids_by_address.doc_id_at(position))))
+                })
+                .sum(),
+        }
+    }
+
+    /// Number of distinct row addresses the live documents cover.
+    ///
+    /// Equal to [`Self::len`] whenever each row owns a single live document.
+    /// Row-granularity corpus statistics need this count; see
+    /// [`Self::doc_length_at`] for why the two can differ.
+    pub(crate) fn num_distinct_rows(&self) -> usize {
+        match &self.0 {
+            AddressKeyedSource::Legacy(docs) => docs.num_distinct_rows(),
+            AddressKeyedSource::Modern {
+                projection,
+                doc_ids_by_address,
+                strictly_ascending,
+                ..
+            } => {
+                if *strictly_ascending {
+                    return self.len();
+                }
+                // The lookup lists the live DocIds in address order, so the
+                // documents of one row form a contiguous run.
+                count_row_id_runs(
+                    (0..doc_ids_by_address.len(projection))
+                        .map(|position| doc_ids_by_address.address_at(projection, position)),
+                )
+            }
         }
     }
 }
@@ -1319,6 +1475,11 @@ impl PartitionDocuments {
                 .projection
                 .get()
                 .is_some_and(|projection| projection.doc_ids_by_address.initialized()),
+            ascending_addresses_ready: self.projection.get().is_some_and(|projection| {
+                CachedRowAddressOrder::from_raw(
+                    projection.ordered_validation.load(AtomicOrdering::Acquire),
+                ) != CachedRowAddressOrder::Unknown
+            }),
             projection_resident: self.projection_resident(),
         }
     }
@@ -1807,6 +1968,39 @@ impl PartitionDocuments {
         self.num_docs.saturating_mul(std::mem::size_of::<u64>())
     }
 
+    /// This partition's documents keyed by row address; see
+    /// [`AddressKeyedDocuments`].
+    ///
+    /// Every part is a per-partition cache, so a warm partition answers with
+    /// four `Arc` clones and no IO, CPU-pool work or per-query allocation. A cold
+    /// partition reads the two columns concurrently, since it needs both whatever
+    /// the outcome.
+    pub(crate) async fn address_keyed(&self) -> Result<AddressKeyedDocuments> {
+        let (lengths, projection) = futures::try_join!(self.lengths(), self.address_projection())?;
+        let doc_ids_by_address = projection.doc_ids_by_address().await?;
+        let strictly_ascending = self.strictly_ascending_addresses(&projection).await?;
+        Ok(AddressKeyedDocuments(AddressKeyedSource::Modern {
+            projection,
+            doc_ids_by_address,
+            lengths,
+            strictly_ascending,
+        }))
+    }
+
+    /// Answer to [`ResidentAddressProjection::dense_and_strictly_ascending`],
+    /// memoized by the projection's own ordering cache. The validation scan is
+    /// O(num_docs), so it belongs to prewarmed partition state.
+    async fn strictly_ascending_addresses(
+        &self,
+        projection: &ResidentAddressProjection,
+    ) -> Result<bool> {
+        if projection.cached_row_address_order() != CachedRowAddressOrder::Unknown {
+            return Ok(projection.dense_and_strictly_ascending());
+        }
+        let projection = projection.clone();
+        spawn_cpu(move || Result::Ok(projection.dense_and_strictly_ascending())).await
+    }
+
     /// Materialize the build-side table for rewrite/update operations.
     pub(crate) async fn load_build_docset(&self) -> Result<DocSet> {
         DocSet::load(self.reader().await?, false, self.remapper.clone()).await
@@ -1861,10 +2055,9 @@ impl PartitionDocuments {
                     Result::Ok(())
                 })
                 .await?;
-                self.address_projection()
-                    .await?
-                    .doc_ids_by_address()
-                    .await?;
+                let projection = self.address_projection().await?;
+                projection.doc_ids_by_address().await?;
+                self.strictly_ascending_addresses(&projection).await?;
                 Result::Ok(())
             })
             .await?;
@@ -2721,6 +2914,46 @@ mod tests {
         assert!(!projection.doc_ids_by_address.initialized());
     }
 
+    /// A remapped partition that kept every document must still pass the gate.
+    /// That is the common case: a fragment reuse index attaches a remapper on
+    /// every index load, whether or not it removes anything.
+    ///
+    /// A dead slot stores address 0, so `dead_first_slot` keeps the stored
+    /// addresses ascending and is rejected by the liveness half alone.
+    #[rstest::rstest]
+    #[case::no_remapper_ascending(vec![10, 20, 30], None, true)]
+    #[case::no_remapper_ties(vec![10, 20, 20], None, false)]
+    #[case::remapper_retains_every_document(vec![10, 20, 30], Some(vec![]), true)]
+    #[case::remapper_rewrites_in_order(vec![10, 20, 30], Some(vec![(20, Some(25))]), true)]
+    #[case::remapper_ties_addresses(vec![10, 20, 30], Some(vec![(20, Some(10))]), false)]
+    #[case::remapper_reverses_addresses(vec![10, 20, 30], Some(vec![(30, Some(5))]), false)]
+    #[case::dead_first_slot(vec![10, 20, 30], Some(vec![(10, None)]), false)]
+    #[case::dead_middle_slot(vec![10, 20, 30], Some(vec![(20, None)]), false)]
+    fn ascending_address_gate_requires_live_slots_and_strict_order(
+        #[case] raw: Vec<u64>,
+        #[case] remapping: Option<Vec<(u64, Option<u64>)>>,
+        #[case] expected: bool,
+    ) {
+        let raw = Arc::new(UInt64Array::from(raw));
+        let remapper = remapping.map(|entries| TestRemapper {
+            mapping: entries.into_iter().collect(),
+        });
+        let projection = Arc::new(
+            VersionAddressProjection::try_new(
+                raw.as_ref(),
+                raw.len(),
+                remapper
+                    .as_ref()
+                    .map(|remapper| remapper as &dyn RowIdRemapper),
+                "docs",
+            )
+            .expect("valid projection"),
+        );
+        let projection = projection.resident(Some(raw)).unwrap();
+
+        assert_eq!(projection.dense_and_strictly_ascending(), expected);
+    }
+
     #[test]
     fn doc_lengths_validate_shape_total_and_memory() {
         let mismatch = DocLengths::try_new(ScalarBuffer::from(vec![2, 3]), 3, None, false, "docs")
@@ -2871,6 +3104,104 @@ mod tests {
                 .await
                 .is_some()
         );
+        assert_eq!(
+            CachedRowAddressOrder::from_raw(
+                documents
+                    .projection
+                    .get()
+                    .unwrap()
+                    .ordered_validation
+                    .load(AtomicOrdering::Acquire)
+            ),
+            CachedRowAddressOrder::Ordered
+        );
+    }
+
+    /// Prewarm owns the O(num_docs) address scan, so the first cross-field query
+    /// against a prewarmed partition spends no CPU deciding the fast path.
+    #[rstest::rstest]
+    #[case::retains_every_document(vec![], true)]
+    #[case::deletes_a_document(vec![(20, None)], false)]
+    #[tokio::test]
+    async fn prewarm_answers_the_ascending_gate_for_a_remapped_partition(
+        #[case] remapping: Vec<(u64, Option<u64>)>,
+        #[case] strictly_ascending: bool,
+    ) {
+        let (_directory, store, cache) = test_store();
+        let path = "docs.lance";
+        write_documents(
+            store.as_ref(),
+            path,
+            UInt64Array::from(vec![10, 20, 30]),
+            UInt32Array::from(vec![2, 3, 5]),
+            Some("10"),
+        )
+        .await;
+        let remapper: Arc<dyn RowIdRemapper> = Arc::new(TestRemapper {
+            mapping: remapping.into_iter().collect(),
+        });
+        let documents = open_documents(store, path, cache.as_ref(), Some(remapper))
+            .await
+            .unwrap();
+
+        documents.prewarm().await.unwrap();
+
+        assert!(documents.query_ready());
+        assert_ne!(
+            CachedRowAddressOrder::from_raw(
+                documents
+                    .projection
+                    .get()
+                    .unwrap()
+                    .ordered_validation
+                    .load(AtomicOrdering::Acquire)
+            ),
+            CachedRowAddressOrder::Unknown,
+            "prewarm must leave the projection's ordering verdict cached"
+        );
+        let keyed = documents.address_keyed().await.unwrap();
+        assert_eq!(keyed.row_address(0), 10);
+        assert_eq!(keyed.doc_length_at(30), 5);
+        if strictly_ascending {
+            assert_eq!(keyed.num_distinct_rows(), 3);
+            assert_eq!(keyed.row_address(1), 20);
+            assert_eq!(keyed.doc_length_at(20), 3);
+        } else {
+            assert_eq!(keyed.num_distinct_rows(), 2);
+            assert_eq!(keyed.row_address(1), RowAddress::TOMBSTONE_ROW);
+            assert_eq!(keyed.doc_length_at(20), 0);
+        }
+    }
+
+    /// A partition holding no documents satisfies the cross-field fast-path gate
+    /// vacuously, and both document representations must say so: the gate is a
+    /// per-partition decision, so disagreeing here would make an empty legacy
+    /// partition alone force a whole query onto the full-read fallback.
+    #[tokio::test]
+    async fn the_ascending_gate_agrees_on_an_empty_partition() {
+        let (_directory, store, cache) = test_store();
+        let path = "docs.lance";
+        write_documents(
+            store.as_ref(),
+            path,
+            UInt64Array::from(Vec::<u64>::new()),
+            UInt32Array::from(Vec::<u32>::new()),
+            Some("0"),
+        )
+        .await;
+        let modern = open_documents(store, path, cache.as_ref(), None)
+            .await
+            .unwrap()
+            .address_keyed()
+            .await
+            .unwrap();
+
+        let legacy = AddressKeyedDocuments::from_docset(Arc::new(DocSet::default()));
+
+        for (label, keyed) in [("modern", &modern), ("legacy", &legacy)] {
+            assert_eq!(keyed.len(), 0, "{label}");
+            assert_eq!(keyed.num_distinct_rows(), 0, "{label}");
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -67,7 +67,9 @@ use super::encoding::{MAX_POSTING_BLOCK_SIZE, PositionBlockBuilder};
 use super::impact::{IMPACT_LEVEL1_BLOCKS, ImpactSkipData, ImpactSkipDataBuilder};
 use super::iter::PostingListIterator;
 use super::tokenizer::{LEGACY_BLOCK_SIZE, validate_block_size};
-use super::{DocumentGranularity, InvertedIndexBuilder, InvertedIndexParams, wand::*};
+use super::{
+    DocumentGranularity, FlatFieldStats, InvertedIndexBuilder, InvertedIndexParams, wand::*,
+};
 use super::{
     builder::{
         BLOCK_SIZE, ScoredDoc, doc_file_path,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -51,7 +51,7 @@ use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu};
 use lance_core::utils::tracing::{IO_TYPE_LOAD_SCALAR_PART, TRACE_IO_EVENTS};
 use lance_core::{Error, ROW_ID, ROW_ID_FIELD, Result};
 use lance_select::{RowAddrMask, RowAddrTreeMap};
-use roaring::RoaringBitmap;
+use roaring::{RoaringBitmap, RoaringTreemap};
 use std::sync::LazyLock;
 use tokio::{
     sync::{Mutex, OnceCell},
@@ -60,7 +60,8 @@ use tokio::{
 use tracing::{debug, info, instrument, warn};
 
 use super::documents::{
-    DocId, DocLengths, DocVisibility, PartitionDocumentStore, PartitionDocuments,
+    AddressKeyedDocuments, DocId, DocLengths, DocVisibility, PartitionDocumentStore,
+    PartitionDocuments,
 };
 use super::encoding::{MAX_POSTING_BLOCK_SIZE, PositionBlockBuilder};
 use super::impact::{IMPACT_LEVEL1_BLOCKS, ImpactSkipData, ImpactSkipDataBuilder};
@@ -125,6 +126,33 @@ pub use posting_reader::*;
 use prewarm::*;
 pub(super) use search_candidates::*;
 pub use token_set::*;
+
+/// Walk `posting` as `(row_id, frequency)` over the rows that still exist,
+/// translating each posting's key into a row id.
+///
+/// Compressed postings key on a partition-local doc id, so they go through
+/// `docs`; legacy plain postings key on the row id directly.
+///
+/// A remapped partition keeps a deleted document's slot so the posting lists stay
+/// aligned with its DocIds, and `row_address` answers `TOMBSTONE_ROW` for it.
+/// Those postings are dropped here: a default prefilter mask is an empty block
+/// list, which selects them, and `doc_length_at` reports 0 for them, which would
+/// hand them the largest `doc_weight` there is. The single-column `wand` cursor
+/// guards the same way.
+pub(in crate::scalar::inverted) fn live_posting_rows<'a>(
+    posting: &'a PostingList,
+    docs: &'a AddressKeyedDocuments,
+    is_legacy: bool,
+) -> impl Iterator<Item = (u64, u32)> + 'a {
+    posting.iter().filter_map(move |(posting_doc_id, freq, _)| {
+        let row_id = if is_legacy {
+            posting_doc_id
+        } else {
+            docs.row_address(posting_doc_id as u32)
+        };
+        (row_id != RowAddress::TOMBSTONE_ROW).then_some((row_id, freq))
+    })
+}
 
 #[cfg(test)]
 mod tests;

--- a/rust/lance-index/src/scalar/inverted/index/doc_set.rs
+++ b/rust/lance-index/src/scalar/inverted/index/doc_set.rs
@@ -237,6 +237,9 @@ pub struct DocSet {
     // partitions never set the flag and keep exact scoring.
     pub(super) scoring_quantized: bool,
     pub(super) norms: Arc<std::sync::OnceLock<Box<[u8]>>>,
+    // Memoized answer to `row_ids_strictly_ascending`. Filled on first query use;
+    // build-time appends happen before any query touches it.
+    row_ids_ascending: Arc<std::sync::OnceLock<bool>>,
 }
 
 impl DeepSizeOf for DocSet {
@@ -251,6 +254,21 @@ impl DeepSizeOf for DocSet {
                 .map(|slab| std::mem::size_of_val(slab.as_ref()))
                 .unwrap_or(0)
     }
+}
+
+/// Count the runs of equal values in a sequence sorted by row id, i.e. the
+/// number of distinct row ids it contains. Row addresses sort the same way, so
+/// the address-keyed document view shares it.
+pub(in crate::scalar::inverted) fn count_row_id_runs(row_ids: impl Iterator<Item = u64>) -> usize {
+    let mut distinct = 0;
+    let mut previous = None;
+    for row_id in row_ids {
+        if previous != Some(row_id) {
+            distinct += 1;
+            previous = Some(row_id);
+        }
+    }
+    distinct
 }
 
 impl DocSet {
@@ -307,13 +325,66 @@ impl DocSet {
         self.doc_indices.len()
     }
 
+    /// True iff `row_id(doc_id)` is strictly increasing in `doc_id`, i.e. the
+    /// per-doc `row_ids` array is sorted with no duplicates. This is the exact
+    /// condition the combined_fields read-pruning fast path requires: doc-id
+    /// order equals row-id order (so a posting block's row-id span is an
+    /// interval, letting a row-id seek skip whole blocks) and every row owns a
+    /// single doc (no list-element or legacy list multiplicity, so a term
+    /// contributes at most one posting per partition per row).
+    ///
+    /// This checks ascension only, not liveness. A tombstoned slot holds
+    /// [`RowAddress::TOMBSTONE_ROW`] (`u64::MAX`), which breaks ascension wherever
+    /// another slot follows it but not when it is the last one, so a set whose
+    /// final document is tombstoned still reports `true`. Only the build-side sets
+    /// (`PartitionDocuments::load_build_docset`) tombstone in place, and
+    /// `combined_fields_search` forces the full-read fallback for legacy
+    /// partitions regardless of this answer.
+    ///
+    /// Computed once per loaded set and memoized (shared across clones). An empty
+    /// set is vacuously ascending, matching the modern side's
+    /// `ResidentAddressProjection::dense_and_strictly_ascending`.
+    pub fn row_ids_strictly_ascending(&self) -> bool {
+        *self
+            .row_ids_ascending
+            .get_or_init(|| self.row_ids.windows(2).all(|w| w[0] < w[1]))
+    }
+
+    /// Number of distinct row ids this set covers, which row-granularity BM25F
+    /// statistics need.
+    ///
+    /// Equal to [`Self::len`] whenever each row owns a single document, and
+    /// strictly smaller on an `inv`-keyed set where a row owns a run of documents
+    /// (see [`Self::doc_ids`]).
+    ///
+    /// Linear in the number of documents, over an already-loaded set: both `inv`
+    /// and the legacy `row_ids` array are sorted by row id, so the documents of
+    /// one row form a contiguous run. Tombstoned (frag-reuse deleted) documents
+    /// are absent from `inv` and therefore uncounted, matching
+    /// [`Self::doc_length_by_row_id`], which reports 0 for them.
+    pub fn num_distinct_rows(&self) -> usize {
+        // Memoized and shared with the combined_fields fast-path check, so the
+        // one-document-per-row case answers without a scan after the first query.
+        if self.row_ids_strictly_ascending() {
+            return self.len();
+        }
+        if !self.inv.is_empty() {
+            return count_row_id_runs(self.inv.iter().map(|entry| entry.0));
+        }
+        count_row_id_runs(self.row_ids.iter().copied())
+    }
+
     /// Resolve a `row_id` to every `doc_id` it owns.
     ///
     /// Row-document indexes map each row to a single document. Element-document
     /// indexes (and older list indexes) can map one row to several documents,
     /// so a single `row_id` may own multiple `doc_id`s sharing that key in `inv`.
     /// The prefilter path (`flat_search`) walks an allow-list of row_ids and
-    /// must evaluate all legacy documents for that row.
+    /// must evaluate all of those documents for that row.
+    ///
+    /// Only the `inv` branch answers with several. A no-metadata legacy set
+    /// holds one document per row, so the branch below resolves it with a single
+    /// binary search.
     pub fn doc_ids(&self, row_id: u64) -> impl Iterator<Item = u64> + '_ {
         if self.inv.is_empty() {
             // in legacy format, the row id is doc id (one document per row)
@@ -455,6 +526,7 @@ impl DocSet {
             total_tokens,
             scoring_quantized: false,
             norms: Arc::new(std::sync::OnceLock::new()),
+            row_ids_ascending: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -519,6 +591,7 @@ impl DocSet {
                 total_tokens,
                 scoring_quantized: false,
                 norms: Arc::new(std::sync::OnceLock::new()),
+                row_ids_ascending: Arc::new(std::sync::OnceLock::new()),
             });
         }
 
@@ -563,6 +636,7 @@ impl DocSet {
                 total_tokens,
                 scoring_quantized: false,
                 norms: Arc::new(std::sync::OnceLock::new()),
+                row_ids_ascending: Arc::new(std::sync::OnceLock::new()),
             });
         }
 
@@ -585,6 +659,7 @@ impl DocSet {
             total_tokens,
             scoring_quantized: false,
             norms: Arc::new(std::sync::OnceLock::new()),
+            row_ids_ascending: Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -602,6 +677,7 @@ impl DocSet {
             .map(|_| Vec::with_capacity(len))
             .collect();
         self.invalidate_norms();
+        self.invalidate_row_ids_ascending();
         self.total_tokens = 0;
         for (doc_id, (row_id, num_token)) in std::iter::zip(row_ids, num_tokens).enumerate() {
             match mapping.get(row_id) {
@@ -681,6 +757,41 @@ impl DocSet {
             .unwrap_or(0)
     }
 
+    /// Total document length of `row_id`: the sum of `num_tokens` over every
+    /// document the row owns, or `0` when the row is absent (e.g. an empty or
+    /// null field that was never indexed).
+    ///
+    /// Lets cross-field BM25F read a candidate's per-column length with a
+    /// targeted lookup instead of scanning the whole `DocSet`. The result is
+    /// exact against a full `iter()` scan filtered to the row: every document
+    /// the row owns contributes, whether the row is resolved through the sorted
+    /// `inv` index or, on a legacy set, through the run of equal `row_ids`.
+    ///
+    /// A row owns several documents only on the `inv` path (see [`Self::doc_ids`]).
+    /// A no-metadata legacy set cannot reach that state, because the writer of that
+    /// era keyed its documents by row id in a map, so the elements of one row
+    /// collapsed before they were written. The legacy branch below sums a run
+    /// anyway, so the two paths answer alike whatever they are handed.
+    #[inline]
+    pub fn doc_length_by_row_id(&self, row_id: u64) -> u64 {
+        if self.inv.is_empty() {
+            // Legacy: row id == doc id, `row_ids` is sorted; duplicate row ids
+            // (one per indexed list element) form a contiguous run.
+            let lo = self.row_ids.partition_point(|&id| id < row_id);
+            let hi = self.row_ids.partition_point(|&id| id <= row_id);
+            (lo..hi).map(|doc_id| self.num_tokens[doc_id] as u64).sum()
+        } else {
+            // Compressed: `inv` is sorted by row id and holds one entry per
+            // document owned by the row.
+            let lo = self.inv.partition_point(|entry| entry.0 < row_id);
+            let hi = self.inv.partition_point(|entry| entry.0 <= row_id);
+            self.inv[lo..hi]
+                .iter()
+                .map(|entry| self.num_tokens[entry.1 as usize] as u64)
+                .sum()
+        }
+    }
+
     // append a document to the doc set
     // returns the doc_id (the number of documents before appending)
     pub fn append(&mut self, row_id: u64, num_tokens: u32) -> u32 {
@@ -688,6 +799,7 @@ impl DocSet {
         self.num_tokens.push(num_tokens);
         self.total_tokens += num_tokens as u64;
         self.invalidate_norms();
+        self.invalidate_row_ids_ascending();
         self.row_ids.len() as u32 - 1
     }
 
@@ -714,6 +826,7 @@ impl DocSet {
         }
         self.total_tokens += num_tokens as u64;
         self.invalidate_norms();
+        self.invalidate_row_ids_ascending();
         Ok(self.row_ids.len() as u32 - 1)
     }
 
@@ -722,6 +835,14 @@ impl DocSet {
     fn invalidate_norms(&mut self) {
         if self.norms.get().is_some() {
             self.norms = Arc::new(std::sync::OnceLock::new());
+        }
+    }
+
+    // Drop the memoized ascending-row_ids answer after a mutation; it
+    // recomputes on the next query use.
+    fn invalidate_row_ids_ascending(&mut self) {
+        if self.row_ids_ascending.get().is_some() {
+            self.row_ids_ascending = Arc::new(std::sync::OnceLock::new());
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/index/flat_search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/flat_search.rs
@@ -521,6 +521,216 @@ pub(super) fn tokenize_and_count_list<ListOffset: OffsetSizeTrait>(
     Ok(())
 }
 
+/// One chunk's worth of blended per-row BM25F scoring inputs.
+///
+/// This is everything [`super::super::combined::flat_combined_fields_search_stream`]
+/// retains until the corpus statistics are complete, and nothing more: scoring a
+/// row needs only its blended `dl'` and `tf'`, never the per-column breakdown
+/// they were summed from. Retaining the blend costs `8 + 4·(1 + t)` bytes per
+/// row, independent of the number of target columns, where the breakdown cost
+/// `8 + 8·n·(1 + t)`.
+pub(in super::super) struct BlendedRows {
+    /// `_rowid` of every retained row.
+    pub(in super::super) row_ids: Vec<u64>,
+    /// `dl'(d) = Σ_f w_f · dl_f(d)`, one per retained row.
+    pub(in super::super) doc_lengths: Vec<f32>,
+    /// `tf'(t, d) = Σ_f w_f · tf_f(t, d)`, `num_terms`-strided by row.
+    pub(in super::super) term_freqs: Vec<f32>,
+}
+
+/// Count the query tokens in every target column of a flat batch stream and blend
+/// them into per-row BM25F scoring inputs.
+///
+/// [`tokenize_and_count`] handles one column and drops any row that tokenizes to
+/// nothing. BM25F needs every target column's counts for the same row, and a
+/// row may be empty in one field while populated in another, so per-column runs
+/// cannot be aligned by position. This walks all target columns in a single pass
+/// and retains a row whenever any of them has tokens.
+///
+/// The per-column counts are blended into [`BlendedRows`] and then dropped with
+/// the batch. BM25 cannot score any row until the corpus statistics over every
+/// row are known, and the input is a one-shot stream, so something has to be kept
+/// across the whole scan; the blend is the smallest form that suffices. The only
+/// aggregate that needs the per-column breakdown is [`FlatFieldStats`], which is
+/// fixed size, so it is folded in here (and merged across batches) instead.
+///
+/// `stats_masks[column]` gates which rows may fold into that column's totals.
+pub(in super::super) async fn tokenize_and_blend_multi(
+    input: impl Stream<Item = DataFusionResult<RecordBatch>> + Send,
+    tokenizer: Box<dyn LanceTokenizer>,
+    query_tokens: Arc<Tokens>,
+    doc_col_indices: Arc<Vec<usize>>,
+    weights: Arc<Vec<f32>>,
+    stats_masks: Arc<Vec<Arc<RowAddrMask>>>,
+    elapsed_compute: Option<Time>,
+) -> DataFusionResult<(Vec<BlendedRows>, FlatFieldStats)> {
+    let num_columns = doc_col_indices.len();
+    let num_terms = query_tokens.len();
+    let retained_bytes_per_row = (size_of::<u64>() + (1 + num_terms) * size_of::<f32>()) as u64;
+    let query_token_indices = Arc::new(query_token_indices(query_tokens.as_ref()));
+    let bytes_accumulated = Arc::new(AtomicU64::new(0));
+    let bytes_warning_emitted = Arc::new(AtomicBool::new(false));
+
+    let tasks = input
+        .map(move |batch| {
+            let mut tokenizer = tokenizer.box_clone();
+            let query_token_indices = query_token_indices.clone();
+            let doc_col_indices = doc_col_indices.clone();
+            let weights = weights.clone();
+            let stats_masks = stats_masks.clone();
+            let bytes_accumulated = bytes_accumulated.clone();
+            let bytes_warning_emitted = bytes_warning_emitted.clone();
+            let elapsed_compute = elapsed_compute.clone();
+            spawn_cpu(move || {
+                let start = std::time::Instant::now();
+                let batch = batch?;
+                let num_rows = batch.num_rows();
+                let row_id_array = batch[ROW_ID].as_primitive::<UInt64Type>();
+
+                // Dense `(row, column)`-strided scratch, freed with the batch:
+                // whether a row is retained depends on all of its columns, so every
+                // column is counted before any row is filtered.
+                let mut all_tokens = vec![0u64; num_rows * num_columns];
+                let mut counts = vec![0u64; num_rows * num_columns * num_terms];
+                for (column_slot, doc_col_idx) in doc_col_indices.iter().enumerate() {
+                    count_column_into(
+                        batch.column(*doc_col_idx),
+                        num_columns,
+                        num_terms,
+                        column_slot,
+                        &mut tokenizer,
+                        &query_token_indices,
+                        &mut all_tokens,
+                        &mut counts,
+                    )?;
+                }
+
+                let mut blended = BlendedRows {
+                    row_ids: Vec::with_capacity(num_rows),
+                    doc_lengths: Vec::with_capacity(num_rows),
+                    term_freqs: Vec::with_capacity(num_rows * num_terms),
+                };
+                let mut stats = FlatFieldStats::zeros(num_columns, num_terms);
+                let counts_stride = num_columns * num_terms;
+                for row in 0..num_rows {
+                    let lengths = &all_tokens[row * num_columns..(row + 1) * num_columns];
+                    // Empty in every target column: `dl' == 0` and `tf' == 0`, so the
+                    // row cannot score. Dropping it here also keeps it out of the
+                    // corpus statistics, matching the indexed side (a row absent from
+                    // every field's DocSet contributes to no `docCount_f`).
+                    if lengths.iter().all(|length| *length == 0) {
+                        continue;
+                    }
+                    let row_id = row_id_array.value(row);
+                    let row_counts = &counts[row * counts_stride..(row + 1) * counts_stride];
+
+                    // Accumulate in column-slot order. f32 addition is not
+                    // associative, so this order is part of the contract: it keeps
+                    // the scores identical to summing the same contributions
+                    // downstream from a materialized breakdown.
+                    let terms_start = blended.term_freqs.len();
+                    blended.term_freqs.resize(terms_start + num_terms, 0.0);
+                    let term_freqs = &mut blended.term_freqs[terms_start..];
+                    let mut doc_length = 0f32;
+                    for (column, weight) in weights.iter().enumerate() {
+                        doc_length += weight * lengths[column] as f32;
+                        let base = column * num_terms;
+                        for (term, tf) in term_freqs.iter_mut().enumerate() {
+                            *tf += weight * row_counts[base + term] as f32;
+                        }
+                    }
+                    blended.row_ids.push(row_id);
+                    blended.doc_lengths.push(doc_length);
+
+                    stats.fold_row(row_id, &stats_masks, lengths, row_counts);
+                }
+
+                let bytes_accumulated = bytes_accumulated.fetch_add(
+                    blended.row_ids.len() as u64 * retained_bytes_per_row,
+                    Ordering::Relaxed,
+                );
+                if bytes_accumulated > BYTES_ACCUMULATED_WARNING_THRESHOLD
+                    && !bytes_warning_emitted.swap(true, Ordering::Relaxed)
+                {
+                    tracing::warn!(
+                        "Flat combined_fields search is accumulating a large number of bytes.  Consider indexing every target column instead."
+                    );
+                }
+                if let Some(t) = &elapsed_compute {
+                    t.add_duration(start.elapsed());
+                }
+                DataFusionResult::Ok((blended, stats))
+            })
+        })
+        .buffered(get_num_compute_intensive_cpus());
+
+    // Folded incrementally rather than collected and concatenated: the retained
+    // rows are already the whole accumulation, so a second contiguous copy would
+    // double the peak for nothing.
+    let mut tasks = std::pin::pin!(tasks);
+    let mut chunks = Vec::new();
+    // Seeded rather than taken from the first batch so that a scan with no batches
+    // at all still reports statistics, as all-zero totals.
+    let mut totals = FlatFieldStats::zeros(num_columns, num_terms);
+    while let Some(counted) = tasks.next().await {
+        let (blended, stats) = counted?;
+        totals.merge(stats);
+        chunks.push(blended);
+    }
+    Ok((chunks, totals))
+}
+
+/// Tokenize one column into the `(row, column_slot)`-strided slots of
+/// `all_tokens` / `counts`. Mirrors [`tokenize_and_count`]'s per-type handling: a
+/// list column sums over its elements and a null leaves the slots at zero.
+#[allow(clippy::too_many_arguments)]
+fn count_column_into(
+    doc_col: &ArrayRef,
+    num_columns: usize,
+    num_terms: usize,
+    column_slot: usize,
+    tokenizer: &mut Box<dyn LanceTokenizer>,
+    query_token_indices: &HashMap<String, Vec<usize>>,
+    all_tokens: &mut [u64],
+    counts: &mut [u64],
+) -> DataFusionResult<()> {
+    let mut record = |row: usize, doc: &str| {
+        let slot = row * num_columns + column_slot;
+        let base = slot * num_terms;
+        let mut stream = tokenizer.token_stream_for_doc(doc);
+        while let Some(token) = stream.next() {
+            all_tokens[slot] += 1;
+            if let Some(token_indices) = query_token_indices.get(&token.text) {
+                for token_index in token_indices {
+                    counts[base + *token_index] += 1;
+                }
+            }
+        }
+    };
+    match doc_col.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 => {
+            for (row, doc) in iter_str_array(doc_col.as_ref()).enumerate() {
+                if let Some(doc) = doc {
+                    record(row, doc);
+                }
+            }
+        }
+        // One string per row is the whole contract: a caller whose field path
+        // crosses a `List` owes a column already reduced to a row's document text
+        // (the planner uses `flatten_fts_document_column`), because reducing it
+        // here would count the elements separately and diverge from the single row
+        // document the index builder wrote.
+        data_type => {
+            return Err(datafusion_common::DataFusionError::Execution(format!(
+                "flat combined_fields search needs one string per row per column, got {}; \
+                 reduce a list-bearing field path to its row document first",
+                data_type
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn query_token_indices(query_tokens: &Tokens) -> HashMap<String, Vec<usize>> {
     let mut indices = HashMap::new();
     for idx in 0..query_tokens.len() {
@@ -948,13 +1158,7 @@ pub async fn flat_bm25_search_stream_with_options_and_scorer(
     )?;
 
     // Finally we emit batches according to the target batch size
-    let num_out_batches = scores.num_rows().div_ceil(target_batch_size);
-    let mut batches = Vec::with_capacity(num_out_batches);
-    for i in 0..num_out_batches {
-        let start = i * target_batch_size;
-        let len = (scores.num_rows() - start).min(target_batch_size);
-        batches.push(Ok(scores.slice(start, len)));
-    }
+    let batches = slice_into_batches(scores, target_batch_size);
     if let Some(t) = &elapsed_compute {
         t.add_duration(post_await_start.elapsed());
     }
@@ -965,6 +1169,23 @@ pub async fn flat_bm25_search_stream_with_options_and_scorer(
         )),
         scorer,
     ))
+}
+
+/// Cut one scored batch into the `target_batch_size` chunks a flat FTS scan
+/// emits. Slicing is zero-copy, so the whole scan's scores stay in one
+/// allocation.
+pub(in super::super) fn slice_into_batches(
+    batch: RecordBatch,
+    target_batch_size: usize,
+) -> Vec<DataFusionResult<RecordBatch>> {
+    let num_out_batches = batch.num_rows().div_ceil(target_batch_size);
+    let mut batches = Vec::with_capacity(num_out_batches);
+    for i in 0..num_out_batches {
+        let start = i * target_batch_size;
+        let len = (batch.num_rows() - start).min(target_batch_size);
+        batches.push(Ok(batch.slice(start, len)));
+    }
+    batches
 }
 
 pub fn is_phrase_query(query: &str) -> bool {

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -692,6 +692,56 @@ impl InvertedPartition {
         self.inverted_list.is_legacy_layout()
     }
 
+    /// This partition's `(num_rows, per_term_row_freq)` counted over distinct
+    /// row ids rather than documents. See
+    /// [`InvertedIndex::bm25_row_stats_for_terms`] for why the distinction
+    /// exists and when this runs.
+    ///
+    /// A partition whose documents map one-to-one onto rows takes the same
+    /// single-metadata-row `posting_len_for_token` lookup the document-granularity
+    /// statistics use, so only a partition that really indexed one document per
+    /// list element pays for reading posting lists.
+    pub(super) async fn row_stats_for_terms(
+        &self,
+        terms: &[String],
+        metrics: Option<&dyn MetricsCollector>,
+    ) -> Result<(usize, Vec<usize>)> {
+        let docs = self.docs.address_keyed().await?;
+        let num_rows = docs.num_distinct_rows();
+        let one_document_per_row = num_rows == docs.len();
+        let is_legacy = self.is_legacy();
+        let mut row_freqs = Vec::with_capacity(terms.len());
+        for term in terms {
+            let Some(token_id) = self.tokens.get(term) else {
+                row_freqs.push(0);
+                continue;
+            };
+            if one_document_per_row {
+                row_freqs.push(
+                    self.inverted_list
+                        .posting_len_for_token(token_id, metrics)
+                        .await?,
+                );
+                continue;
+            }
+            // Deduplicating needs the postings themselves; `posting_len_for_token`
+            // only knows how many documents there are. The read is cached, and a
+            // partition that reaches this branch forces the full-read fallback in
+            // `combined_fields_search` anyway (legacy layout or non-ascending
+            // row_ids), so nothing that would otherwise have been pruned is read.
+            let posting = self
+                .inverted_list
+                .posting_list(token_id, false, metrics.unwrap_or(&NoOpMetricsCollector))
+                .await?;
+            let mut rows = RoaringTreemap::new();
+            for (row_id, _) in live_posting_rows(&posting, &docs, is_legacy) {
+                rows.insert(row_id);
+            }
+            row_freqs.push(rows.len() as usize);
+        }
+        Ok((num_rows, row_freqs))
+    }
+
     pub async fn load(
         store: Arc<dyn IndexStore>,
         id: u64,

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -116,6 +116,10 @@ impl InvertedIndex {
         Ok(MemBM25Scorer::new(total_tokens, num_docs, token_docs))
     }
 
+    /// Corpus statistics at document granularity: `(total_tokens, docCount,
+    /// per_term_docFreq)`, where a document is one entry of a partition's
+    /// [`DocSet`]. This is what the single-column scoring path pairs with, since
+    /// wand scores one posting per document.
     pub async fn bm25_stats_for_terms(
         &self,
         terms: &[String],
@@ -177,6 +181,67 @@ impl InvertedIndex {
             token_docs.push(term_docs);
         }
         Ok(Some((total_tokens, num_docs, token_docs)))
+    }
+
+    /// Corpus statistics at row granularity: `(total_tokens, docCount,
+    /// per_term_docFreq)` counted over distinct row ids.
+    ///
+    /// Cross-field BM25F scores rows, not documents: `combined_fields_search`
+    /// sums all of a row's postings into one `tf'` and all of its document
+    /// lengths into one `dl'`. Released V1/V2 indexes indexed each
+    /// `List<String>` element as its own document, so pairing that row-granular
+    /// `tf'`/`dl'` with [`Self::bm25_stats_for_terms`] would measure it against a
+    /// corpus of a different size: `idf'` and `avgdl'` would describe elements
+    /// while the frequencies describe rows, shifting an old index's top-k relative
+    /// to the same data reindexed on a current build.
+    ///
+    /// V3 indexes always map one row to one document, so they delegate to
+    /// [`Self::bm25_stats_for_terms`] and keep its IO profile: no `DocSet` load,
+    /// one posting-metadata row per term and partition. `total_tokens` is
+    /// granularity-independent, so it comes from the shared
+    /// `aggregate_corpus_stats` cache either way.
+    ///
+    /// `metrics`, when provided, receives the posting-metadata cache lookups these
+    /// statistics trigger, so both granularities report comparable
+    /// `index_cache_hits`/`index_cache_misses`.
+    pub async fn bm25_row_stats_for_terms(
+        &self,
+        terms: &[String],
+        metrics: Option<&dyn MetricsCollector>,
+    ) -> Result<(u64, usize, Vec<usize>)> {
+        if !matches!(
+            self.format_version,
+            InvertedListFormatVersion::V1 | InvertedListFormatVersion::V2
+        ) {
+            return self.bm25_stats_for_terms(terms, metrics).await;
+        }
+
+        let (total_tokens, _) = self.aggregate_corpus_stats().await?;
+        let io_parallelism = self.store.io_parallelism();
+        let futures = self
+            .partitions
+            .iter()
+            .map(|partition| {
+                let partition = partition.clone();
+                async move { partition.row_stats_for_terms(terms, metrics).await }
+            })
+            .collect::<Vec<_>>();
+        let per_partition: Vec<(usize, Vec<usize>)> = stream::iter(futures)
+            .buffer_unordered(io_parallelism)
+            .try_collect()
+            .await?;
+
+        let mut num_rows = 0usize;
+        let mut row_freqs = vec![0usize; terms.len()];
+        for (partition_rows, partition_freqs) in per_partition {
+            // Partitions hold disjoint row sets, so per-partition distinct counts
+            // add up to the index's distinct count.
+            num_rows += partition_rows;
+            for (total, partition_freq) in row_freqs.iter_mut().zip(partition_freqs) {
+                *total += partition_freq;
+            }
+        }
+        Ok((total_tokens, num_rows, row_freqs))
     }
 
     /// Aggregate immutable per-partition corpus statistics.  New modern files

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -458,6 +458,67 @@ fn test_cached_num_tokens_uses_supplied_total_and_full_stays_owned() {
 }
 
 #[test]
+fn test_combined_fields_append_invalidates_row_ids_ascending_cache() {
+    let row_ids = UInt64Array::from(vec![10, 20, 30]);
+    let num_tokens = UInt32Array::from(vec![1, 1, 1]);
+    let mut docs = DocSet::from_columns(&row_ids, &num_tokens, false, None).unwrap();
+
+    // Memoize the ascending answer for the current (sorted) row_ids.
+    assert!(docs.row_ids_strictly_ascending());
+
+    // Appending a smaller row_id breaks the invariant; the cached answer
+    // must be dropped so the recomputed value reflects the mutation.
+    docs.append(5, 1);
+    assert!(!docs.row_ids_strictly_ascending());
+
+    // The element-document append is the same mutation and owes the same
+    // invalidation. A set built by `with_coordinate_rank` is shared by its
+    // clones, so a stale answer would outlive the builder that produced it.
+    let mut docs = DocSet::with_coordinate_rank(1);
+    for (doc_id, row_id) in [10u64, 20, 30].into_iter().enumerate() {
+        assert_eq!(
+            docs.append_with_doc_index(row_id, 1, &[doc_id as u32])
+                .unwrap(),
+            doc_id as u32
+        );
+    }
+    assert!(docs.row_ids_strictly_ascending());
+
+    docs.append_with_doc_index(5, 1, &[0]).unwrap();
+    assert!(!docs.row_ids_strictly_ascending());
+}
+
+#[test]
+fn test_doc_length_by_row_id_matches_scan() {
+    // Compressed layout: row ids are stored in doc-id order and resolved
+    // through `inv`. The targeted lookup must equal an `iter()` scan that
+    // sums the matching row's lengths, and return 0 for an absent row.
+    let row_ids = UInt64Array::from(vec![30, 10, 20]);
+    let num_tokens = UInt32Array::from(vec![8, 3, 5]);
+    let docs = DocSet::from_columns(&row_ids, &num_tokens, false, None).unwrap();
+    for target in [10u64, 20, 30, 99] {
+        let expected: u64 = docs
+            .iter()
+            .filter(|(id, _)| **id == target)
+            .map(|(_, nt)| *nt as u64)
+            .sum();
+        assert_eq!(docs.doc_length_by_row_id(target), expected, "row {target}");
+    }
+    assert_eq!(docs.doc_length_by_row_id(10), 3);
+    assert_eq!(docs.doc_length_by_row_id(99), 0);
+
+    // Legacy layout: row id == doc id, row ids are sorted, and a row indexed
+    // as several list documents forms a contiguous run whose lengths sum.
+    let legacy_row_ids = UInt64Array::from(vec![10, 10, 20]);
+    let legacy_num_tokens = UInt32Array::from(vec![3, 4, 5]);
+    let legacy = DocSet::from_columns(&legacy_row_ids, &legacy_num_tokens, true, None).unwrap();
+    assert!(legacy.inv.is_empty());
+    assert_eq!(legacy.doc_length_by_row_id(10), 7);
+    assert_eq!(legacy.doc_length_by_row_id(20), 5);
+    assert_eq!(legacy.doc_length_by_row_id(99), 0);
+}
+
+#[test]
 fn test_posting_builder_writes_impacts_for_supported_block_sizes() {
     for block_size in [128, 256] {
         let format_version = default_fts_format_version_for_block_size(block_size).unwrap();

--- a/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
@@ -331,6 +331,50 @@ async fn test_bm25_stats_for_terms_reuses_posting_metadata_cache() {
     );
 }
 
+/// Row-granularity statistics must not cost the posting file any extra IO
+/// when a partition's documents already map one-to-one onto rows, which is
+/// every V3 index and every V1/V2 index that is not a legacy list index. The
+/// deduplicating branch reads posting lists, so it has to stay behind the
+/// duplicate-row-id check rather than run for every legacy-format index.
+#[tokio::test]
+async fn test_bm25_row_stats_for_terms_keeps_the_lazy_posting_metadata_path() {
+    let (index, counter, _tmpdir) = load_counted_v2_index(100, LanceCache::no_cache()).await;
+    // A V3 index would take the delegating early return, which proves nothing
+    // about the legacy branch this test exists for.
+    assert!(
+        matches!(
+            index.format_version(),
+            InvertedListFormatVersion::V1 | InvertedListFormatVersion::V2
+        ),
+        "expected a legacy format version, got {:?}",
+        index.format_version(),
+    );
+
+    let terms = ["t0".to_string()];
+    let documents = index.bm25_stats_for_terms(&terms, None).await.unwrap();
+    assert_eq!(documents, (100, 100, vec![1]));
+    let metadata_rows = counter.metadata_rows_read();
+    let rows = counter.rows_read();
+    assert_eq!(metadata_rows, 1);
+
+    assert_eq!(
+        index.bm25_row_stats_for_terms(&terms, None).await.unwrap(),
+        documents,
+        "one document per row leaves the two granularities identical",
+    );
+    assert_eq!(
+        counter.metadata_rows_read() - metadata_rows,
+        1,
+        "row statistics should read one metadata row per (term, partition)",
+    );
+    assert_eq!(
+        counter.rows_read() - rows,
+        1,
+        "row statistics must not read the posting list itself (got {} extra rows)",
+        counter.rows_read() - rows,
+    );
+}
+
 #[tokio::test]
 async fn test_bm25_stats_for_terms_records_metadata_cache_stats() {
     let cache = LanceCache::with_capacity(1024 * 1024);
@@ -356,6 +400,48 @@ async fn test_bm25_stats_for_terms_records_metadata_cache_stats() {
         .await
         .unwrap();
     assert_eq!(warm_stats, cold_stats);
+    assert_eq!(warm.index_cache_misses(), 0);
+    assert_eq!(warm.index_cache_hits(), terms.len());
+}
+
+/// Row-granularity statistics go through `InvertedPartition::row_stats_for_terms`
+/// on a V1/V2 index, and its posting-metadata lookups must reach the caller's
+/// collector too: the cross-field scorer build is the only consumer, and it
+/// runs under an `ExecutionPlan` whose cache counters would otherwise miss
+/// them entirely.
+#[tokio::test]
+async fn test_bm25_row_stats_for_terms_records_metadata_cache_stats() {
+    let cache = LanceCache::with_capacity(1024 * 1024);
+    let (index, _counter, _tmpdir) = load_counted_v2_index(100, cache.clone()).await;
+    // A V3 index would delegate to the document-granularity path, which
+    // already has its own coverage.
+    assert!(
+        matches!(
+            index.format_version(),
+            InvertedListFormatVersion::V1 | InvertedListFormatVersion::V2
+        ),
+        "expected a legacy format version, got {:?}",
+        index.format_version(),
+    );
+
+    let terms = ["t0".to_string(), "t1".to_string(), "t2".to_string()];
+    let cold = LocalMetricsCollector::default();
+    let cold_stats = index
+        .bm25_row_stats_for_terms(&terms, Some(&cold))
+        .await
+        .unwrap();
+    assert_eq!(cold_stats, (100, 100, vec![1, 1, 1]));
+    assert_eq!(cold.index_cache_misses(), terms.len());
+    assert_eq!(cold.index_cache_hits(), 0);
+
+    let warm = LocalMetricsCollector::default();
+    assert_eq!(
+        index
+            .bm25_row_stats_for_terms(&terms, Some(&warm))
+            .await
+            .unwrap(),
+        cold_stats,
+    );
     assert_eq!(warm.index_cache_misses(), 0);
     assert_eq!(warm.index_cache_hits(), terms.len());
 }

--- a/rust/lance-index/src/scalar/inverted/oracle.rs
+++ b/rust/lance-index/src/scalar/inverted/oracle.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Brute-force BM25F reference for the `combined_fields` tests and bench.
+//!
+//! Re-derives every statistic from the raw text on each call, so it shares no code with
+//! the scan it checks. `cfg(test)` here and the `test-oracle` feature downstream keep it
+//! out of normal builds.
+
+use std::collections::HashSet;
+
+const K1: f32 = 1.2;
+const B: f32 = 0.75;
+
+/// Splits on whitespace only, while the `simple` tokenizer splits on every
+/// non-alphanumeric character. Keep test corpora alphanumeric or scores diverge.
+fn tokenize(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|word| word.to_lowercase())
+        .collect()
+}
+
+/// Exact BM25F: `docFreq'`/`docCount'` are the max across fields, `tf'`/`dl'`/
+/// `sumTotalTermFreq'` weighted sums, and the `(k1 + 1)` numerator is Lance's. `None`
+/// for a document that does not match. `columns` pairs each field's weight with its
+/// text, one entry per document.
+///
+/// A `""` value stands for anything that tokenizes to nothing (NULL, empty string,
+/// empty list): absent from that column's statistics, so it must not raise
+/// `docCount_f`/`docFreq_f`. List columns are their elements joined by a space.
+#[cfg_attr(coverage, coverage(off))]
+pub fn brute_force_bm25f(
+    columns: &[(f32, Vec<&str>)],
+    query: &str,
+    require_all_terms: bool,
+) -> Vec<Option<f32>> {
+    let mut seen = HashSet::new();
+    let terms: Vec<String> = tokenize(query)
+        .into_iter()
+        .filter(|term| seen.insert(term.clone()))
+        .collect();
+    let num_docs = columns[0].1.len();
+    let tokenized: Vec<Vec<Vec<String>>> = columns
+        .iter()
+        .map(|(_, texts)| texts.iter().map(|text| tokenize(text)).collect())
+        .collect();
+
+    // Zero-token documents are absent from a column's `DocSet`, and the flat scan's
+    // fold skips a column whose `dl_f == 0`, so they cannot raise `docCount_f` either.
+    let doc_count = tokenized
+        .iter()
+        .map(|column| column.iter().filter(|doc| !doc.is_empty()).count())
+        .max()
+        .unwrap_or(0);
+    let mut sum_total_term_freq = 0f64;
+    let mut doc_freq = vec![0usize; terms.len()];
+    for (column_index, (weight, _)) in columns.iter().enumerate() {
+        let total_tokens: usize = tokenized[column_index].iter().map(|doc| doc.len()).sum();
+        sum_total_term_freq += *weight as f64 * total_tokens as f64;
+        for (term_index, term) in terms.iter().enumerate() {
+            let df = tokenized[column_index]
+                .iter()
+                .filter(|doc| doc.contains(term))
+                .count();
+            doc_freq[term_index] = doc_freq[term_index].max(df);
+        }
+    }
+    let avgdl = if doc_count == 0 {
+        0.0
+    } else {
+        (sum_total_term_freq / doc_count as f64) as f32
+    };
+    let idf: Vec<f32> = doc_freq
+        .iter()
+        .map(|&df| {
+            if df == 0 {
+                0.0
+            } else {
+                ((doc_count as f32 - df as f32 + 0.5) / (df as f32 + 0.5) + 1.0).ln()
+            }
+        })
+        .collect();
+
+    (0..num_docs)
+        .map(|doc| {
+            let mut tf = vec![0f32; terms.len()];
+            let mut dl = 0f32;
+            for (column_index, (weight, _)) in columns.iter().enumerate() {
+                dl += weight * tokenized[column_index][doc].len() as f32;
+                for (term_index, term) in terms.iter().enumerate() {
+                    let count = tokenized[column_index][doc]
+                        .iter()
+                        .filter(|token| *token == term)
+                        .count();
+                    tf[term_index] += weight * count as f32;
+                }
+            }
+            let matched = if require_all_terms {
+                tf.iter().all(|&freq| freq > 0.0)
+            } else {
+                tf.iter().any(|&freq| freq > 0.0)
+            };
+            if !matched {
+                return None;
+            }
+            let mut score = 0.0;
+            for term_index in 0..terms.len() {
+                if tf[term_index] <= 0.0 {
+                    continue;
+                }
+                let doc_norm = K1 * (1.0 - B + B * dl / avgdl);
+                score +=
+                    idf[term_index] * (K1 + 1.0) * tf[term_index] / (tf[term_index] + doc_norm);
+            }
+            Some(score)
+        })
+        .collect()
+}
+
+/// The ids [`brute_force_bm25f`] matched.
+#[cfg_attr(coverage, coverage(off))]
+pub fn brute_force_ids(scores: &[Option<f32>]) -> HashSet<i32> {
+    (0..scores.len())
+        .filter(|&doc| scores[doc].is_some())
+        .map(|doc| doc as i32)
+        .collect()
+}
+
+/// The `k` highest-scoring ids, descending, id as tiebreak.
+#[cfg_attr(coverage, coverage(off))]
+pub fn brute_force_top_k(scores: &[Option<f32>], k: usize) -> Vec<i32> {
+    let mut ranked: Vec<(i32, f32)> = scores
+        .iter()
+        .enumerate()
+        .filter_map(|(doc, score)| score.map(|score| (doc as i32, score)))
+        .collect();
+    ranked.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
+    ranked.into_iter().take(k).map(|(doc, _)| doc).collect()
+}

--- a/rust/lance-index/src/scalar/inverted/parser.rs
+++ b/rust/lance-index/src/scalar/inverted/parser.rs
@@ -3,7 +3,8 @@
 
 use super::DocumentGranularity;
 use super::query::{
-    BooleanQuery, BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Occur, Operator, PhraseQuery,
+    BooleanQuery, BoostQuery, CombinedFieldsQuery, FtsQuery, MatchQuery, MultiMatchQuery, Occur,
+    Operator, PhraseQuery,
 };
 use lance_core::{Error, Result};
 use serde_json::Value;
@@ -128,6 +129,54 @@ impl JsonParser for MultiMatchQuery {
     }
 }
 
+impl JsonParser for CombinedFieldsQuery {
+    fn from_json(value: &Value) -> Result<Self> {
+        let terms = value["query"]
+            .as_str()
+            .ok_or_else(|| Error::invalid_input("missing query in combined_fields query"))?
+            .to_string();
+        let columns = value["columns"]
+            .as_array()
+            .ok_or_else(|| Error::invalid_input("missing columns in combined_fields query"))?
+            .iter()
+            .map(|v| {
+                v.as_str().map(String::from).ok_or_else(|| {
+                    Error::invalid_input(
+                        "columns must be an array of strings in combined_fields query",
+                    )
+                })
+            })
+            .collect::<Result<Vec<String>>>()?;
+
+        let query = Self::try_new(terms, columns)?;
+
+        let query = match value.get("boost") {
+            Some(Value::Array(boosts)) => {
+                let boosts = boosts
+                    .iter()
+                    .map(|v| {
+                        v.as_f64().map(|f| f as f32).ok_or_else(|| {
+                            Error::invalid_input(
+                                "boost must be an array of numbers in combined_fields query",
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<f32>>>()?;
+                query.try_with_boosts(boosts)?
+            }
+            _ => query,
+        };
+
+        let operator = value["operator"]
+            .as_str()
+            .map(Operator::try_from)
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(query.with_operator(operator))
+    }
+}
+
 impl JsonParser for BooleanQuery {
     fn from_json(value: &Value) -> Result<Self> {
         let mut clauses = Vec::new();
@@ -171,6 +220,9 @@ fn from_json_value(value: &Value) -> Result<FtsQuery> {
         "phrase" => Ok(FtsQuery::Phrase(PhraseQuery::from_json(query_val)?)),
         "boost" => Ok(FtsQuery::Boost(BoostQuery::from_json(query_val)?)),
         "multi_match" => Ok(FtsQuery::MultiMatch(MultiMatchQuery::from_json(query_val)?)),
+        "combined_fields" => Ok(FtsQuery::CombinedFields(CombinedFieldsQuery::from_json(
+            query_val,
+        )?)),
         "boolean" => Ok(FtsQuery::Boolean(BooleanQuery::from_json(query_val)?)),
         _ => Err(Error::invalid_input(format!(
             "unknown fts query type: {}",
@@ -343,5 +395,55 @@ mod tests {
             (Occur::Should, should_query),
         ]));
         assert_eq!(fts_query, expected_query);
+    }
+
+    #[test]
+    fn test_from_json_combined_fields() {
+        let json = r#"
+        {
+            "combined_fields": {
+                "query": "hello world",
+                "columns": ["title", "body"],
+                "boost": [2.0, 1.0],
+                "operator": "and"
+            }
+        }"#;
+        let fts_query = from_json(json).unwrap();
+        let expected = CombinedFieldsQuery::try_new(
+            "hello world".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap()
+        .try_with_boosts(vec![2.0, 1.0])
+        .unwrap()
+        .with_operator(Operator::And);
+        assert_eq!(fts_query, FtsQuery::CombinedFields(expected));
+    }
+
+    #[test]
+    fn test_from_json_combined_fields_defaults_and_validation() {
+        // boost + operator omitted: weights default to 1.0, operator to Or.
+        let json = r#"{ "combined_fields": { "query": "hi", "columns": ["a", "b"] } }"#;
+        let FtsQuery::CombinedFields(query) = from_json(json).unwrap() else {
+            panic!("expected combined_fields query");
+        };
+        assert_eq!(
+            query.weighted_columns().collect::<Vec<_>>(),
+            vec![("a", 1.0), ("b", 1.0)]
+        );
+        assert_eq!(query.operator(), Operator::Or);
+
+        // A weight below 1 is rejected.
+        let json = r#"{ "combined_fields": { "query": "hi", "columns": ["a", "b"], "boost": [0.5, 1.0] } }"#;
+        assert!(from_json(json).is_err());
+
+        // So is a weight above the upper bound that keeps the blended length
+        // finite.
+        let json = r#"{ "combined_fields": { "query": "hi", "columns": ["a", "b"], "boost": [1.0, 1e30] } }"#;
+        assert!(from_json(json).is_err());
+
+        // Empty columns are rejected.
+        let json = r#"{ "combined_fields": { "query": "hi", "columns": [] } }"#;
+        assert!(from_json(json).is_err());
     }
 }

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -164,6 +164,7 @@ pub enum FtsQuery {
     // compound queries
     Boost(BoostQuery),
     MultiMatch(MultiMatchQuery),
+    CombinedFields(CombinedFieldsQuery),
     Boolean(BooleanQuery),
 }
 
@@ -178,6 +179,7 @@ impl std::fmt::Display for FtsQuery {
                 query.positive, query.negative, query.negative_boost
             ),
             Self::MultiMatch(query) => write!(f, "MultiMatch({:?})", query),
+            Self::CombinedFields(query) => write!(f, "CombinedFields({:?})", query),
             Self::Boolean(query) => {
                 write!(
                     f,
@@ -206,6 +208,7 @@ impl FtsQueryNode for FtsQuery {
                 }
                 columns
             }
+            Self::CombinedFields(query) => query.columns(),
             Self::Boolean(query) => query.columns(),
         }
     }
@@ -218,6 +221,7 @@ impl FtsQuery {
             Self::Phrase(query) => format!("\"{}\"", query.terms), // Phrase queries are quoted
             Self::Boost(query) => query.positive.query(),
             Self::MultiMatch(query) => query.match_queries[0].terms.clone(),
+            Self::CombinedFields(query) => query.terms().to_string(),
             Self::Boolean(_) => {
                 // Bool queries don't have a single query string, they are composed of multiple queries
                 String::new()
@@ -233,6 +237,9 @@ impl FtsQuery {
                 query.positive.is_missing_column() || query.negative.is_missing_column()
             }
             Self::MultiMatch(query) => query.match_queries.iter().any(|q| q.column.is_none()),
+            // `try_new` rejects an empty column list, so the target columns of a
+            // combined_fields query are always known.
+            Self::CombinedFields(_) => false,
             Self::Boolean(query) => {
                 query.must.iter().any(|q| q.is_missing_column())
                     || query.should.iter().any(|q| q.is_missing_column())
@@ -261,6 +268,11 @@ impl FtsQuery {
                     .map(|q| q.with_column(Some(column.clone())))
                     .collect();
                 Self::MultiMatch(MultiMatchQuery { match_queries })
+            }
+            Self::CombinedFields(query) => {
+                // combined_fields carries all target columns (and their per-column
+                // boosts) at construction, so a single-column override is a no-op.
+                Self::CombinedFields(query)
             }
             Self::Boolean(query) => {
                 let must = query
@@ -309,6 +321,12 @@ impl From<BoostQuery> for FtsQuery {
 impl From<MultiMatchQuery> for FtsQuery {
     fn from(query: MultiMatchQuery) -> Self {
         Self::MultiMatch(query)
+    }
+}
+
+impl From<CombinedFieldsQuery> for FtsQuery {
+    fn from(query: CombinedFieldsQuery) -> Self {
+        Self::CombinedFields(query)
     }
 }
 
@@ -628,6 +646,202 @@ impl FtsQueryNode for MultiMatchQuery {
             columns.extend(query.columns());
         }
         columns
+    }
+}
+
+/// A cross-field (BM25F) full-text query, exposing Elasticsearch's
+/// `combined_fields` semantics: the target columns are treated as one virtual
+/// field so term statistics (document frequency, term frequency, and document
+/// length) are blended across fields rather than scored independently.
+///
+/// This contrasts with [`MultiMatchQuery`], which fans out into one
+/// [`MatchQuery`] per column and fuses the per-field scores by taking the
+/// maximum (Elasticsearch `best_fields`). A `CombinedFieldsQuery` stays a single
+/// node and is scored once over the blended statistics.
+///
+/// Per-column weights follow Lucene's `CombinedFieldQuery`; see
+/// [`Self::try_with_boosts`] for the accepted range.
+///
+/// Each column is stored together with its weight and every field is private, so
+/// the pairing cannot go out of sync: [`Self::try_new`] and
+/// [`Self::try_with_boosts`] are the only constructors and no accessor hands out a
+/// `&mut`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CombinedFieldsQuery {
+    /// The columns combined into the virtual field, each paired with its BM25F
+    /// weight `w_f`. Non-empty, column names unique, weights in
+    /// `[MIN_BOOST, MAX_BOOST]`.
+    weighted_columns: Vec<(String, f32)>,
+    /// The query string, tokenized once and matched against every target column.
+    terms: String,
+    /// How to combine terms: `And` (all terms must match) or `Or` (default).
+    operator: Operator,
+}
+
+impl CombinedFieldsQuery {
+    /// Minimum allowed per-column weight (Lucene `CombinedFieldQuery` constraint).
+    const MIN_BOOST: f32 = 1.0;
+
+    /// Maximum allowed per-column weight.
+    ///
+    /// The blended length `dl'(d) = Σ_f w_f · dl_f(d)` and the identically shaped
+    /// `tf'` are accumulated in `f32`, and a per-column document length is a `u32`
+    /// token count. One term of that sum is therefore at most
+    /// `2^20 · (2^32 - 1) < 2^52`, so with `f32::MAX ≈ 2^128` it would take more
+    /// than `2^76` maximally long columns to reach infinity. The column count is
+    /// bounded by the schema, many orders of magnitude below that, so an accepted
+    /// weight cannot turn a score into `Inf`/`NaN`.
+    const MAX_BOOST: f32 = 1_048_576.0; // 2^20
+
+    /// Create a combined-fields query over `columns`, with every weight
+    /// defaulting to `1.0` and the `Or` operator.
+    ///
+    /// Returns an error if `columns` is empty or contains duplicates.
+    pub fn try_new(terms: String, columns: Vec<String>) -> Result<Self> {
+        if columns.is_empty() {
+            return Err(Error::invalid_input(
+                "Cannot create CombinedFieldsQuery with no columns".to_string(),
+            ));
+        }
+        // A duplicate column would double-count its postings and inflate
+        // sum_total_term_freq, skewing the blended BM25F statistics.
+        let mut seen = HashSet::with_capacity(columns.len());
+        for column in &columns {
+            if !seen.insert(column.as_str()) {
+                return Err(Error::invalid_input(format!(
+                    "CombinedFieldsQuery columns must be unique, but '{}' is duplicated",
+                    column
+                )));
+            }
+        }
+        Ok(Self {
+            weighted_columns: columns
+                .into_iter()
+                .map(|column| (column, Self::MIN_BOOST))
+                .collect(),
+            terms,
+            operator: Operator::Or,
+        })
+    }
+
+    /// Set per-column weights, positionally aligned with the columns passed to
+    /// [`Self::try_new`].
+    ///
+    /// Returns an error if the number of boosts does not match the number of
+    /// columns, or if any weight falls outside `[1, 2^20]`. The lower bound
+    /// mirrors Lucene's `CombinedFieldQuery`, which requires `weight >= 1` so the
+    /// combined length norm stays additive; the upper bound keeps the blended
+    /// length finite in `f32`. `NaN` and infinities are outside the range and so
+    /// rejected too.
+    pub fn try_with_boosts(mut self, boosts: Vec<f32>) -> Result<Self> {
+        if boosts.len() != self.weighted_columns.len() {
+            return Err(Error::invalid_input(format!(
+                "The number of boosts ({}) must match the number of columns ({})",
+                boosts.len(),
+                self.weighted_columns.len()
+            )));
+        }
+        for ((column, _), &boost) in self.weighted_columns.iter().zip(&boosts) {
+            if !(Self::MIN_BOOST..=Self::MAX_BOOST).contains(&boost) {
+                return Err(Error::invalid_input(format!(
+                    "combined_fields boost for column '{}' must be a finite value in [{}, {}], got {}",
+                    column,
+                    Self::MIN_BOOST,
+                    Self::MAX_BOOST,
+                    boost
+                )));
+            }
+        }
+        for ((_, weight), boost) in self.weighted_columns.iter_mut().zip(boosts) {
+            *weight = boost;
+        }
+        Ok(self)
+    }
+
+    /// Set the operator used to combine terms.
+    pub fn with_operator(mut self, operator: Operator) -> Self {
+        self.operator = operator;
+        self
+    }
+
+    /// The query string, tokenized once and matched against every target column.
+    pub fn terms(&self) -> &str {
+        &self.terms
+    }
+
+    /// How the query terms are combined.
+    pub fn operator(&self) -> Operator {
+        self.operator
+    }
+
+    /// The target columns in query order.
+    pub fn column_names(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.weighted_columns
+            .iter()
+            .map(|(column, _)| column.as_str())
+    }
+
+    /// Each target column paired with its BM25F weight, in query order.
+    ///
+    /// Iterating the pairs is the only way to read the weights, so an execution
+    /// path cannot pair a column with the wrong weight or silently drop a column
+    /// that has no weight.
+    pub fn weighted_columns(&self) -> impl ExactSizeIterator<Item = (&str, f32)> {
+        self.weighted_columns
+            .iter()
+            .map(|(column, weight)| (column.as_str(), *weight))
+    }
+}
+
+impl Serialize for CombinedFieldsQuery {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("query", &self.terms)?;
+        map.serialize_entry("columns", &self.column_names().collect::<Vec<_>>())?;
+        map.serialize_entry(
+            "boost",
+            &self
+                .weighted_columns()
+                .map(|(_, weight)| weight)
+                .collect::<Vec<_>>(),
+        )?;
+        map.serialize_entry("operator", &self.operator)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CombinedFieldsQuery {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct CombinedFieldsQueryData {
+            query: String,
+            columns: Vec<String>,
+            boost: Option<Vec<f32>>,
+            #[serde(default)]
+            operator: Operator,
+        }
+
+        let data = CombinedFieldsQueryData::deserialize(deserializer)?;
+        let query = Self::try_new(data.query, data.columns).map_err(serde::de::Error::custom)?;
+        let query = match data.boost {
+            Some(boosts) => query
+                .try_with_boosts(boosts)
+                .map_err(serde::de::Error::custom)?,
+            None => query,
+        };
+        Ok(query.with_operator(data.operator))
+    }
+}
+
+impl FtsQueryNode for CombinedFieldsQuery {
+    fn columns(&self) -> HashSet<String> {
+        self.column_names().map(String::from).collect()
     }
 }
 
@@ -984,6 +1198,11 @@ pub fn fill_fts_query_column(
                 .collect();
             Ok(FtsQuery::MultiMatch(MultiMatchQuery { match_queries }))
        }
+        FtsQuery::CombinedFields(combined_query) => {
+            // combined_fields carries its target columns (and per-column boosts)
+            // at construction, so there is nothing to fill or replace.
+            Ok(FtsQuery::CombinedFields(combined_query.clone()))
+        }
         FtsQuery::Boolean(bool_query) => {
             let must = bool_query
                 .must
@@ -1317,5 +1536,204 @@ mod tests {
 
         let query = MatchQuery::new("hello".to_string());
         assert!(BooleanMatchPlan::try_build(&FtsQuery::Match(query)).is_none());
+    }
+
+    #[test]
+    fn test_combined_fields_query_serde() {
+        use super::*;
+        use serde_json::json;
+
+        let query = CombinedFieldsQuery::try_new(
+            "hello world".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap()
+        .try_with_boosts(vec![2.0, 1.0])
+        .unwrap()
+        .with_operator(Operator::And);
+
+        // Serializes with multi_match-style keys, plus a round-tripped operator.
+        let serialized = serde_json::to_value(&query).unwrap();
+        let expected = json!({
+            "query": "hello world",
+            "columns": ["title", "body"],
+            "boost": [2.0, 1.0],
+            "operator": "And",
+        });
+        assert_eq!(serialized, expected);
+
+        // The wire format is a contract, so pin the exact bytes (key order
+        // included), not just the equivalent `Value`.
+        assert_eq!(
+            serde_json::to_string(&query).unwrap(),
+            r#"{"query":"hello world","columns":["title","body"],"boost":[2.0,1.0],"operator":"And"}"#
+        );
+
+        let deserialized: CombinedFieldsQuery = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized, query);
+
+        // Round-trips as a wrapped FtsQuery variant under the "combined_fields" tag.
+        let wrapped = FtsQuery::CombinedFields(query);
+        let value = serde_json::to_value(&wrapped).unwrap();
+        assert!(value.get("combined_fields").is_some());
+        let round_trip: FtsQuery = serde_json::from_value(value).unwrap();
+        assert_eq!(round_trip, wrapped);
+    }
+
+    #[test]
+    fn test_combined_fields_query_defaults() {
+        use super::*;
+        use serde_json::json;
+
+        // Omitting boost + operator defaults weights to 1.0 and the operator to Or.
+        let value = json!({
+            "query": "hello",
+            "columns": ["title", "body"],
+        });
+        let query: CombinedFieldsQuery = serde_json::from_value(value).unwrap();
+        assert_eq!(query.terms(), "hello");
+        assert_eq!(
+            query.weighted_columns().collect::<Vec<_>>(),
+            vec![("title", 1.0), ("body", 1.0)]
+        );
+        assert_eq!(query.operator(), Operator::Or);
+    }
+
+    #[test]
+    fn test_combined_fields_query_validation() {
+        use super::*;
+
+        // Assert the result is an invalid-input error whose message names the
+        // rejected cause, not just that it failed.
+        let assert_invalid_input = |result: Result<CombinedFieldsQuery>, needle: &str| {
+            let err = result.unwrap_err();
+            assert!(
+                matches!(&err, Error::InvalidInput { .. }),
+                "expected InvalidInput, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(needle),
+                "error {err:?} should mention {needle:?}"
+            );
+        };
+
+        // Empty columns are rejected.
+        assert_invalid_input(
+            CombinedFieldsQuery::try_new("hello".to_string(), vec![]),
+            "no columns",
+        );
+
+        // Duplicate columns are rejected (they would double-count postings).
+        assert_invalid_input(
+            CombinedFieldsQuery::try_new(
+                "hello".to_string(),
+                vec!["title".to_string(), "title".to_string()],
+            ),
+            "duplicated",
+        );
+
+        let query = CombinedFieldsQuery::try_new(
+            "hello".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap();
+
+        // A boost count that does not match the column count is rejected in both
+        // directions, and the message names both lengths.
+        assert_invalid_input(
+            query.clone().try_with_boosts(vec![1.0]),
+            "number of boosts (1) must match the number of columns (2)",
+        );
+        assert_invalid_input(
+            query.clone().try_with_boosts(vec![1.0, 1.0, 1.0]),
+            "number of boosts (3) must match the number of columns (2)",
+        );
+
+        // Weights outside [1, 2^20] are rejected: below 1 breaks Lucene's
+        // additive length norm, above 2^20 could overflow the blended length.
+        // NaN and the infinities fall outside the range as well.
+        let out_of_range = "must be a finite value in [1, 1048576]";
+        for boosts in [
+            vec![1.0, 0.5],
+            vec![0.0, 1.0],
+            vec![f32::NAN, 1.0],
+            vec![f32::INFINITY, 1.0],
+            vec![f32::NEG_INFINITY, 1.0],
+            vec![1.0, f32::MAX],
+            vec![1.0, 1_048_577.0],
+        ] {
+            assert_invalid_input(query.clone().try_with_boosts(boosts), out_of_range);
+        }
+        // The message names the offending column and its value.
+        assert_invalid_input(query.clone().try_with_boosts(vec![1.0, 0.5]), "'body'");
+        assert_invalid_input(query.clone().try_with_boosts(vec![1.0, 0.5]), "got 0.5");
+
+        // Fractional weights >= 1 are accepted, and so is the upper bound itself.
+        assert!(query.clone().try_with_boosts(vec![1.5, 2.0]).is_ok());
+        assert!(query.try_with_boosts(vec![1.0, 1_048_576.0]).is_ok());
+    }
+
+    /// The columns and their weights cannot be desynced by any operation the type
+    /// permits, which is what the execution boundary relies on when it iterates
+    /// [`CombinedFieldsQuery::weighted_columns`].
+    ///
+    /// Field privacy carries the structural half and the compiler enforces it, so
+    /// the only thing left to check at runtime is that `try_new` and
+    /// `try_with_boosts`, the sole mutation paths, keep the pairs aligned.
+    #[test]
+    fn test_combined_fields_query_pairing_is_stable() {
+        use super::*;
+
+        let query = CombinedFieldsQuery::try_new(
+            "hello".to_string(),
+            vec!["title".to_string(), "body".to_string(), "tags".to_string()],
+        )
+        .unwrap();
+        // Defaults: one weight per column, in query order.
+        assert_eq!(
+            query.weighted_columns().collect::<Vec<_>>(),
+            vec![("title", 1.0), ("body", 1.0), ("tags", 1.0)]
+        );
+
+        let query = query.try_with_boosts(vec![3.0, 1.0, 2.5]).unwrap();
+        assert_eq!(
+            query.weighted_columns().collect::<Vec<_>>(),
+            vec![("title", 3.0), ("body", 1.0), ("tags", 2.5)]
+        );
+        // The name-only view and the pair view agree on order and length, so a
+        // consumer that reads either sees the same columns.
+        assert_eq!(
+            query.column_names().collect::<Vec<_>>(),
+            query
+                .weighted_columns()
+                .map(|(column, _)| column)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(query.column_names().len(), 3);
+        // The `FtsQueryNode` set view still reports the target columns, and is not
+        // shadowed by the inherent accessors.
+        assert_eq!(
+            FtsQueryNode::columns(&query),
+            HashSet::from(["title".to_string(), "body".to_string(), "tags".to_string()])
+        );
+
+        // A rejected boost list leaves no partially updated query behind: the
+        // builder consumes `self`, so the caller keeps the validated value.
+        let rejected = query.clone().try_with_boosts(vec![1.0, f32::MAX, 1.0]);
+        assert!(rejected.is_err());
+        assert_eq!(
+            query.weighted_columns().collect::<Vec<_>>(),
+            vec![("title", 3.0), ("body", 1.0), ("tags", 2.5)]
+        );
+
+        // Clone/PartialEq compare the pairs, so a differing weight is a differing
+        // query even when the column lists match.
+        assert_eq!(query.clone(), query);
+        let reweighted = query.clone().try_with_boosts(vec![3.0, 1.0, 2.0]).unwrap();
+        assert_ne!(reweighted, query);
+        // Debug renders the columns with their weights.
+        let debug = format!("{:?}", query);
+        assert!(debug.contains("title"), "unexpected Debug output: {debug}");
+        assert!(debug.contains("2.5"), "unexpected Debug output: {debug}");
     }
 }

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -239,6 +239,94 @@ pub fn idf(token_docs: usize, num_docs: usize) -> f32 {
     ((num_docs - token_docs as f32 + 0.5) / (token_docs as f32 + 0.5) + 1.0).ln()
 }
 
+/// BM25F scorer over a virtual field formed by combining several columns
+/// (Lucene `CombinedFieldQuery` / Elasticsearch `combined_fields`).
+///
+/// Where [`MemBM25Scorer`] / `IndexBM25Scorer` score one column against that
+/// column's own statistics, this scorer holds statistics blended across the
+/// target columns per the BM25F rules:
+/// - `doc_count` = `max_f docCount_f`
+/// - `avg_doc_length` = `sumTotalTermFreq' / doc_count`, where
+///   `sumTotalTermFreq' = Σ_f w_f · sumTotalTermFreq_f`
+/// - `doc_freq(t)` = `max_f docFreq_f(t)`
+///
+/// The caller supplies the blended term frequency `tf' = Σ_f w_f · tf_f(t, d)`
+/// and blended document length `dl' = Σ_f w_f · dl_f(d)` per candidate document;
+/// this type turns those into an IDF weight and a BM25 document weight. Lance's
+/// `(k1 + 1)` numerator is kept (a constant factor vs. Lucene that preserves
+/// ranking).
+#[derive(Debug, Clone)]
+pub struct CombinedFieldsBM25Scorer {
+    doc_count: usize,
+    avg_doc_length: f32,
+    doc_freq: HashMap<String, usize>,
+}
+
+impl CombinedFieldsBM25Scorer {
+    pub fn new(doc_count: usize, avg_doc_length: f32, doc_freq: HashMap<String, usize>) -> Self {
+        Self {
+            doc_count,
+            avg_doc_length,
+            doc_freq,
+        }
+    }
+
+    pub fn doc_count(&self) -> usize {
+        self.doc_count
+    }
+
+    pub fn avg_doc_length(&self) -> f32 {
+        self.avg_doc_length
+    }
+
+    /// Blended IDF for `term` over the virtual field. Returns `0.0` for a term
+    /// absent from every target column (`docFreq' == 0`), and for the inconsistent
+    /// statistics (`docFreq' > docCount'`) that drive `idf` negative or, once
+    /// `docFreq'` is large enough for the ratio to round to `-1`, to `-inf`. A
+    /// `-inf` weight times a zero document weight is `NaN`; see [`Self::doc_weight`]
+    /// for why no score may be non-finite.
+    pub fn query_weight(&self, term: &str) -> f32 {
+        match self.doc_freq.get(term).copied() {
+            Some(token_docs) if token_docs > 0 => {
+                let idf = idf(token_docs, self.doc_count);
+                if idf.is_finite() && idf > 0.0 {
+                    idf
+                } else {
+                    0.0
+                }
+            }
+            _ => 0.0,
+        }
+    }
+
+    /// BM25 term contribution for a document, given the blended term frequency
+    /// `tf'` and blended document length `dl'`.
+    ///
+    /// The result is always finite and within `[0, BM25_DOC_WEIGHT_UPPER_BOUND]`,
+    /// whatever reaches it. BM25 saturates the `tf'` factor at `K1 + 1` in exact
+    /// arithmetic, but the f32 evaluation can land above it: once `doc_norm` is
+    /// small relative to `ulp(tf')` the rounded `tf' + doc_norm` collapses back to
+    /// `tf'`, and `fl(fl((K1 + 1) · tf') / tf')` then rounds up. Large per-column
+    /// boosts can also push `tf'`, `dl'`, or `avgdl'` to infinity, and `Inf / Inf`
+    /// is `NaN`; one `NaN` contribution would poison a whole query's scores. The
+    /// clamp makes the ceiling hold by construction rather than by trusting the
+    /// query-level validation of the boosts.
+    pub fn doc_weight(&self, tf_prime: f32, dl_prime: f32) -> f32 {
+        if self.avg_doc_length <= 0.0 {
+            return 0.0;
+        }
+        let doc_norm = K1 * (1.0 - B + B * dl_prime / self.avg_doc_length);
+        let weight = (K1 + 1.0) * tf_prime / (tf_prime + doc_norm);
+        if weight.is_nan() {
+            // `Inf / Inf`, or a `NaN` that came in through `tf'` / `dl'` /
+            // `avgdl'`. There is no meaningful weight to report, and `clamp`
+            // would propagate the `NaN`.
+            return 0.0;
+        }
+        weight.clamp(0.0, BM25_DOC_WEIGHT_UPPER_BOUND)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -251,5 +339,86 @@ mod tests {
         assert_eq!(doc_weight.to_bits(), 0x400c_ccce);
         assert!(doc_weight > K1 + 1.0);
         assert!(scorer.doc_weight_upper_bound().unwrap() >= doc_weight);
+    }
+
+    #[test]
+    fn test_combined_scorer_query_weight_matches_blended_idf() {
+        let doc_freq = HashMap::from([("rare".to_string(), 2), ("common".to_string(), 800)]);
+        let scorer = CombinedFieldsBM25Scorer::new(1000, 12.0, doc_freq);
+
+        // IDF uses the blended docFreq' over the blended docCount'.
+        assert_eq!(scorer.query_weight("rare"), idf(2, 1000));
+        assert_eq!(scorer.query_weight("common"), idf(800, 1000));
+        // A rarer term outweighs a common one.
+        assert!(scorer.query_weight("rare") > scorer.query_weight("common"));
+        // A term absent from every field contributes nothing.
+        assert_eq!(scorer.query_weight("missing"), 0.0);
+    }
+
+    /// No corpus statistics and no blended `(tf', dl')` may produce a non-finite
+    /// term score. A `NaN` would order arbitrarily in the top-k heap, and a weight
+    /// above [`BM25_DOC_WEIGHT_UPPER_BOUND`] would break any pruning bound derived
+    /// from that ceiling.
+    #[test]
+    fn test_combined_scorer_stays_finite_for_extreme_statistics() {
+        // `docFreq' > docCount'` drives `idf` negative and then to `-inf`.
+        let doc_freq = HashMap::from([
+            ("ok".to_string(), 1),
+            ("over".to_string(), 2_000),
+            ("way_over".to_string(), usize::MAX),
+        ]);
+        let blends = [
+            (1.0f32, 8.0f32),
+            (0.0, 0.0),
+            (f32::MAX, f32::MAX),
+            (f32::INFINITY, f32::INFINITY),
+            (f32::INFINITY, 8.0),
+            (8.0, f32::INFINITY),
+            (f32::NAN, f32::NAN),
+            (-1.0, -1.0),
+        ];
+        for avg_doc_length in [10.0f32, 0.0, f32::MAX, f32::INFINITY, f32::NAN, -1.0] {
+            let scorer = CombinedFieldsBM25Scorer::new(1000, avg_doc_length, doc_freq.clone());
+            for term in ["ok", "over", "way_over", "missing"] {
+                let query_weight = scorer.query_weight(term);
+                assert!(
+                    query_weight.is_finite() && query_weight >= 0.0,
+                    "query_weight({term}) = {query_weight:e}"
+                );
+                for (tf_prime, dl_prime) in blends {
+                    let score = query_weight * scorer.doc_weight(tf_prime, dl_prime);
+                    assert!(
+                        score.is_finite() && score >= 0.0,
+                        "score for {term} at tf'={tf_prime:e} dl'={dl_prime:e} \
+                         avgdl'={avg_doc_length:e} was {score:e}"
+                    );
+                }
+            }
+        }
+        // The unclamped reference: `idf` really does leave the usable range for
+        // these statistics, so the clamp in `query_weight` is important. In the
+        // `-inf` case multiplied by a zero `doc_weight` it would yield `NaN`.
+        assert!(idf(2_000, 1000) < 0.0);
+        assert_eq!(idf(usize::MAX, 1000), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_combined_scorer_doc_weight_saturates_and_penalizes_length() {
+        let scorer = CombinedFieldsBM25Scorer::new(1000, 10.0, HashMap::new());
+
+        // Matches the BM25 formula (with Lance's (k1 + 1) numerator).
+        let expected = {
+            let doc_norm = K1 * (1.0 - B + B * 20.0 / 10.0);
+            (K1 + 1.0) * 3.0 / (3.0 + doc_norm)
+        };
+        assert!((scorer.doc_weight(3.0, 20.0) - expected).abs() < 1e-6);
+        // More term frequency scores higher, saturating below (k1 + 1).
+        assert!(scorer.doc_weight(5.0, 20.0) > scorer.doc_weight(1.0, 20.0));
+        assert!(scorer.doc_weight(1000.0, 20.0) < K1 + 1.0);
+        // A longer document is penalized for the same term frequency.
+        assert!(scorer.doc_weight(3.0, 40.0) < scorer.doc_weight(3.0, 5.0));
+        // A degenerate (empty) corpus scores zero rather than dividing by zero.
+        let empty = CombinedFieldsBM25Scorer::new(0, 0.0, HashMap::new());
+        assert_eq!(empty.doc_weight(3.0, 20.0), 0.0);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -733,6 +733,65 @@ impl InvertedIndexParams {
         Ok(self)
     }
 
+    /// Whether `self` and `other` tokenize text identically.
+    ///
+    /// Compares only the fields that affect how documents are turned into tokens
+    /// (tokenizer, language, casing, stemming, stop words, n-gram bounds,
+    /// code-analyzer splitting, ...). Storage/layout and build-time fields
+    /// (`with_position`, `block_size`, worker/memory/format settings) are ignored:
+    /// two columns can differ there yet still be safe to combine in a
+    /// `combined_fields` (BM25F) query. Used by cross-field FTS validation.
+    pub(crate) fn same_tokenization(&self, other: &Self) -> bool {
+        // Destructure exhaustively so that adding a new field forces an explicit
+        // decision here about whether it affects tokenization.
+        let Self {
+            lance_tokenizer,
+            base_tokenizer,
+            language,
+            max_token_length,
+            lower_case,
+            stem,
+            remove_stop_words,
+            custom_stop_words,
+            ascii_folding,
+            min_ngram_length,
+            max_ngram_length,
+            prefix_only,
+            // Code-analyzer tokenization options: change the emitted token stream.
+            split_identifiers,
+            split_on_numerics,
+            preserve_original,
+            index_operators,
+            // Not tokenization-affecting (storage/layout/build-time only):
+            with_position: _,
+            block_size: _,
+            memory_limit_mb: _,
+            num_workers: _,
+            format_version: _,
+            // Decides what a document is, not how its text is tokenized. Cross-field
+            // FTS checks it separately because it needs a different answer: the
+            // blend is per row, so a list-element index is rejected outright rather
+            // than merely required to match its siblings.
+            document_granularity: _,
+        } = self;
+        lance_tokenizer == &other.lance_tokenizer
+            && base_tokenizer == &other.base_tokenizer
+            && language == &other.language
+            && max_token_length == &other.max_token_length
+            && lower_case == &other.lower_case
+            && stem == &other.stem
+            && remove_stop_words == &other.remove_stop_words
+            && custom_stop_words == &other.custom_stop_words
+            && ascii_folding == &other.ascii_folding
+            && min_ngram_length == &other.min_ngram_length
+            && max_ngram_length == &other.max_ngram_length
+            && prefix_only == &other.prefix_only
+            && split_identifiers == &other.split_identifiers
+            && split_on_numerics == &other.split_on_numerics
+            && preserve_original == &other.preserve_original
+            && index_operators == &other.index_operators
+    }
+
     pub fn lance_tokenizer(mut self, lance_tokenizer: String) -> Self {
         self.lance_tokenizer = Some(lance_tokenizer);
         self
@@ -1170,6 +1229,22 @@ mod tests {
         assert!(json.get("memory_limit").is_none());
         assert!(json.get("num_workers").is_none());
         assert!(json.get("format_version").is_none());
+    }
+
+    #[test]
+    fn test_same_tokenization_ignores_storage_only_fields() {
+        let base = InvertedIndexParams::new("simple".to_string(), Language::English);
+
+        // Storage/layout-only differences keep the same tokenization.
+        assert!(base.same_tokenization(&base.clone().with_position(true)));
+
+        // Tokenizer-affecting differences are detected.
+        assert!(!base.same_tokenization(&base.clone().stem(!base.stem)));
+        assert!(!base.same_tokenization(&base.clone().lower_case(!base.lower_case)));
+        assert!(!base.same_tokenization(&InvertedIndexParams::new(
+            "whitespace".to_string(),
+            Language::English,
+        )));
     }
 
     #[test]

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -246,6 +246,9 @@ impl Display for FtsPrewarmPartitionStatus {
         if !self.documents.reverse_lookup_ready {
             missing.push("reverse document lookup");
         }
+        if !self.documents.ascending_addresses_ready {
+            missing.push("memoized ascending-address gate");
+        }
         if !self.documents.projection_resident {
             missing.push("resident row-address projection");
         }
@@ -278,6 +281,11 @@ pub struct FtsPrewarmDocumentStatus {
     pub prewarm_complete: bool,
     pub scoring_ready: bool,
     pub reverse_lookup_ready: bool,
+    /// Whether the memoized "are the stored addresses strictly ascending?"
+    /// answer is populated. Cross-field search reads it on every query, so a
+    /// prewarmed partition that left it empty would still pay an O(num_docs)
+    /// address scan on its first query.
+    pub ascending_addresses_ready: bool,
     pub projection_resident: bool,
 }
 
@@ -286,6 +294,7 @@ impl FtsPrewarmDocumentStatus {
         self.prewarm_complete
             && self.scoring_ready
             && self.reverse_lookup_ready
+            && self.ascending_addresses_ready
             && self.projection_resident
     }
 }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -117,6 +117,7 @@ all_asserts.workspace = true
 mock_instant.workspace = true
 lance-testing = { workspace = true }
 lance-io = { workspace = true, features = ["test-util"] }
+lance-index = { workspace = true, features = ["test-oracle"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 env_logger.workspace = true
 tempfile.workspace = true

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -1633,6 +1633,11 @@ impl FtsMemIndex {
                         visit(index, query, terms)?;
                     }
                 }
+                FtsQuery::CombinedFields(_) => {
+                    return Err(Error::invalid_input(
+                        "residual compound FTS does not support combined_fields (BM25F) leaves",
+                    ));
+                }
             }
             Ok(())
         }
@@ -1702,6 +1707,11 @@ impl FtsMemIndex {
                     {
                         visit(index, query, scorer, leaves)?;
                     }
+                }
+                FtsQuery::CombinedFields(_) => {
+                    return Err(Error::invalid_input(
+                        "residual compound FTS does not support combined_fields (BM25F) leaves",
+                    ));
                 }
             }
             Ok(())

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -118,6 +118,11 @@ fn requested_query_document_granularity(
                 }
                 Ok(())
             }
+            // BM25F blends the target columns per row, so combined_fields is
+            // row-granular by construction and carries no granularity field.
+            // Merging Row still catches a tree that mixes it with a
+            // list-element leaf.
+            IndexFtsQuery::CombinedFields(_) => merge(current, Some(DocumentGranularity::Row)),
         }
     }
 
@@ -156,6 +161,8 @@ fn set_query_document_granularity(
                 child.document_granularity = Some(document_granularity);
             }
         }
+        // Row-granular by construction, and it carries no field to set.
+        IndexFtsQuery::CombinedFields(_) => {}
     }
 }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -72,12 +72,12 @@ use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::expression::PlannerIndexExt;
 use lance_index::scalar::expression::ScalarIndexExpr;
 use lance_index::scalar::inverted::query::{
-    FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, Operator, PhraseQuery,
-    fill_fts_query_column,
+    CombinedFieldsQuery, FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, Operator,
+    PhraseQuery, fill_fts_query_column,
 };
 use lance_index::scalar::inverted::{
-    DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, INVERTED_INDEX_VERSION_V2,
-    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema,
+    CombinedFieldsBM25Scorer, DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity,
+    INVERTED_INDEX_VERSION_V2, INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema,
 };
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
@@ -103,7 +103,7 @@ use crate::index::DatasetIndexInternalExt;
 use crate::index::scalar::fetch_index_details;
 use crate::index::scalar::inverted::{
     fts_index_fragment_bitmap, load_segment_details, load_segments, normalize_inverted_details,
-    resolve_fts_field, resolve_query_document_granularity,
+    resolve_fts_field, resolve_query_document_granularity, validate_combined_fields_target_column,
 };
 use crate::index::scalar_logical::{load_named_scalar_segments, scalar_index_fragment_bitmap};
 use crate::index::vector::utils::{
@@ -113,9 +113,9 @@ use crate::io::exec::filtered_read::{
     FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
 };
 use crate::io::exec::fts::{
-    BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec, FlatMatchFilterExec,
-    FlatMatchQueryExec, FtsDocumentExec, HybridCompoundQueryExec, MatchQueryExec, PhraseQueryExec,
-    SharedFtsScorer,
+    BoostQueryExec, CombinedFieldsQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
+    FlatMatchFilterExec, FlatMatchQueryExec, FtsDocumentExec, HybridCompoundQueryExec,
+    MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -210,6 +210,13 @@ fn collect_fts_columns_in_order(query: &FtsQuery) -> Vec<String> {
                     visit(child, columns, seen);
                 }
             }
+            FtsQuery::CombinedFields(query) => {
+                for column in query.column_names() {
+                    if seen.insert(column.to_string()) {
+                        columns.push(column.to_string());
+                    }
+                }
+            }
         }
     }
 
@@ -240,7 +247,8 @@ fn collect_phrase_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
                 collect_phrase_columns(child, columns);
             }
         }
-        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) => {}
+        // combined_fields is term-based; it never needs positions.
+        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) | FtsQuery::CombinedFields(_) => {}
     }
 }
 
@@ -262,6 +270,10 @@ fn supports_compound_scorer(query: &FtsQuery) -> bool {
     fn supports_shape(query: &FtsQuery) -> bool {
         match query {
             FtsQuery::Match(_) | FtsQuery::Phrase(_) | FtsQuery::MultiMatch(_) => true,
+            // BM25F blends term statistics across columns, so it cannot be a leaf
+            // of the single-index compound scorer. Such trees keep the
+            // union/sort plan built by `plan_combined_fields_query`.
+            FtsQuery::CombinedFields(_) => false,
             FtsQuery::Boolean(query) => {
                 (!query.should.is_empty() || !query.must.is_empty())
                     && query
@@ -305,6 +317,9 @@ fn supports_indexed_stats_residual_compound(query: &FtsQuery) -> bool {
             .chain(&query.must)
             .chain(&query.must_not)
             .all(supports_indexed_stats_residual_compound),
+        // The compound scorer scores each leaf from one column's index, which a
+        // cross-field blend cannot be expressed as.
+        FtsQuery::CombinedFields(_) => false,
     }
 }
 
@@ -368,6 +383,11 @@ fn validate_fts_query_contract(query: &FtsQuery) -> Result<()> {
     match query {
         FtsQuery::Match(query) => validate_multiplier("MatchQuery boost", query.boost),
         FtsQuery::Phrase(_) => Ok(()),
+        // Nothing to re-check: the weights are private and every constructor,
+        // including `Deserialize`, goes through `try_with_boosts`, which enforces a
+        // finite value in `[MIN_BOOST, MAX_BOOST]`, stricter than the non-negative
+        // contract checked here.
+        FtsQuery::CombinedFields(_) => Ok(()),
         FtsQuery::Boost(query) => {
             validate_multiplier("BoostQuery negative_boost", query.negative_boost)?;
             validate_fts_query_contract(&query.positive)?;
@@ -407,7 +427,9 @@ fn normalize_fts_zero_boosts(query: &mut FtsQuery) {
 
     match query {
         FtsQuery::Match(query) => normalize_zero(&mut query.boost),
-        FtsQuery::Phrase(_) => {}
+        // combined_fields weights are validated into `[1.0, 2^20]`, so no zero
+        // to normalize.
+        FtsQuery::Phrase(_) | FtsQuery::CombinedFields(_) => {}
         FtsQuery::Boost(query) => {
             normalize_zero(&mut query.negative_boost);
             normalize_fts_zero_boosts(&mut query.positive);
@@ -443,7 +465,8 @@ fn apply_dataset_planner_auto_fuzziness_compatibility_gate(query: &mut FtsQuery)
         FtsQuery::Match(query) => {
             query.fuzziness.get_or_insert(0);
         }
-        FtsQuery::Phrase(_) => {}
+        // combined_fields matches terms exactly; it has no fuzziness setting.
+        FtsQuery::Phrase(_) | FtsQuery::CombinedFields(_) => {}
         FtsQuery::Boost(query) => {
             apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut query.positive);
             apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut query.negative);
@@ -3947,6 +3970,19 @@ impl Scanner {
                 )
                 .await
             }
+            FtsQuery::CombinedFields(combined) => {
+                // A doc's fragment must be covered by every target column's index
+                // for the prefilter to be exact, mirroring MultiMatch.
+                for column in combined.column_names() {
+                    if !self
+                        .fragments_covered_by_fts_leaf(column, DocumentGranularity::Row, accum)
+                        .await?
+                    {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
             FtsQuery::Boolean(bool_query) => {
                 for query in bool_query
                     .must
@@ -4083,6 +4119,17 @@ impl Scanner {
                     }
                     Ok(())
                 }
+                FtsQuery::CombinedFields(query) => {
+                    // BM25F sums each target column's contribution for one row,
+                    // so combined_fields is row-granular by construction. A
+                    // target column that only has a list-element index was
+                    // already rejected by
+                    // `resolve_fts_query_document_granularity`.
+                    for column in query.column_names() {
+                        add_leaf(schema, Some(column), Some(DocumentGranularity::Row), state)?;
+                    }
+                    Ok(())
+                }
             }
         }
 
@@ -4171,6 +4218,15 @@ impl Scanner {
                 }
                 Ok(FtsQuery::MultiMatch(query))
             }
+            FtsQuery::CombinedFields(query) => {
+                // There is nothing to resolve: a combined_fields query carries no
+                // granularity because BM25F only makes sense over row documents.
+                // Reject a target column that cannot supply them.
+                for column in query.column_names() {
+                    validate_combined_fields_target_column(self.dataset.as_ref(), column).await?;
+                }
+                Ok(FtsQuery::CombinedFields(query))
+            }
         }
     }
 
@@ -4210,6 +4266,8 @@ impl Scanner {
                         .get_or_insert(document_granularity);
                 }
             }
+            // Row-granular by construction, and it carries no field to fill in.
+            FtsQuery::CombinedFields(_) => {}
         }
     }
 
@@ -4236,6 +4294,7 @@ impl Scanner {
                     .document_granularity
                     .is_some_and(DocumentGranularity::is_list_element)
             }),
+            FtsQuery::CombinedFields(_) => false,
         }
     }
 
@@ -4678,26 +4737,15 @@ impl Scanner {
                     fts_node,
                     schema,
                 )?);
-                let sort_exprs = [
-                    PhysicalSortExpr {
-                        expr: expressions::col(SCORE_COL, fts_node.schema().as_ref())?,
-                        options: SortOptions {
-                            descending: true,
-                            nulls_first: false,
-                        },
-                    },
-                    PhysicalSortExpr {
-                        expr: expressions::col(ROW_ID, fts_node.schema().as_ref())?,
-                        options: SortOptions {
-                            descending: false,
-                            nulls_first: false,
-                        },
-                    },
-                ];
+                let sort_exprs = Self::fts_score_sort_exprs(fts_node.schema().as_ref())?;
 
                 // `params.limit` is the recursive planning contract. Compound
                 // parents pass `None` when they require every candidate.
                 Arc::new(SortExec::new(sort_exprs.into(), fts_node).with_fetch(params.limit))
+            }
+            FtsQuery::CombinedFields(query) => {
+                self.plan_combined_fields_query(query, params, prefilter_source)
+                    .await?
             }
             FtsQuery::Boolean(query) => {
                 // TODO: rewrite the query for better performance
@@ -5256,6 +5304,221 @@ impl Scanner {
             return Ok(Arc::new(RowAddrMaskFilterExec::new(flat_match_plan, mask)));
         }
         Ok(flat_match_plan)
+    }
+
+    /// Sort keys for an FTS plan whose scores come from more than one source, or
+    /// from a source that does not sort.
+    ///
+    /// `row_id ASC` is a required second key, not a nicety: a score-only sort over
+    /// concurrently read sources breaks ties by arrival order, so equal-scoring
+    /// documents would come back in a different order run to run and
+    /// `limit`/`offset` pagination could skip and repeat rows. `combined_fields`
+    /// needs it for the same reason: `combined_fields_search` visits candidates in
+    /// ascending row-id order, so its top-k is reproducible, but it does not order
+    /// ties itself (`ScoredDoc` compares on score alone), so this sort is what
+    /// decides which of two equal-scoring rows comes first.
+    fn fts_score_sort_exprs(schema: &ArrowSchema) -> Result<[PhysicalSortExpr; 2]> {
+        Ok([
+            PhysicalSortExpr {
+                expr: expressions::col(SCORE_COL, schema)?,
+                options: SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                },
+            },
+            PhysicalSortExpr {
+                expr: expressions::col(ROW_ID, schema)?,
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                },
+            },
+        ])
+    }
+
+    /// Plan a cross-field (BM25F) `combined_fields` query.
+    ///
+    /// Unlike a single-column match, coverage here is per column: a BM25F score is
+    /// only complete when every target column's index covers the row's fragment,
+    /// because `dl'` sums each column's document length and the per-column lookup
+    /// (`AddressKeyedDocuments::doc_length_at` over that partition's `DocLengths`)
+    /// returns 0 for a row that column's index holds no document for. So the
+    /// fragments the index scan must not touch are the union of the per-column
+    /// unindexed sets, not their intersection: a fragment indexed for `title` but
+    /// not `body` would otherwise be emitted with a partial `tf'`/`dl'`.
+    ///
+    /// The same union absorbs the fragments whose index entries a newer data
+    /// overlay made stale, per target column, so the indexed scan neither returns a
+    /// pre-overlay hit nor hides a new one. See [`Self::fts_overlay_plan`].
+    ///
+    /// A fragment any target column's index does not fully cover cannot be scored,
+    /// so the query is refused rather than answered from partial statistics.
+    async fn plan_combined_fields_query(
+        &self,
+        query: &CombinedFieldsQuery,
+        params: &FtsSearchParams,
+        prefilter_source: &PreFilterSource,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let target_fragments: &[Fragment] = self
+            .fragments
+            .as_deref()
+            .unwrap_or_else(|| self.dataset.fragments());
+        // An explicitly empty fragment list selects no rows. The prefilter would
+        // already reject every row, but without this the fully covered branch below
+        // still opens the segments, builds the scorer and runs a full scan to return
+        // nothing. `plan_match_query` and `plan_phrase_query` short-circuit the same way.
+        if self.fragments.as_ref().is_some_and(Vec::is_empty) {
+            return Ok(Arc::new(EmptyExec::new(fts_schema(
+                DocumentGranularity::Row,
+            ))));
+        }
+
+        let mut uncovered = RoaringBitmap::new();
+        let mut any_indexed = false;
+        for column in query.column_names() {
+            let column_uncovered: RoaringBitmap = match self
+                .dataset
+                .load_scalar_index(
+                    IndexCriteria::default()
+                        .for_column(column)
+                        .supports_fts()
+                        .with_fts_document_granularity(DocumentGranularity::Row),
+                )
+                .await?
+            {
+                Some(index) => {
+                    any_indexed = true;
+                    self.dataset
+                        .unindexed_fragments(&index.name)
+                        .await?
+                        .iter()
+                        .map(|fragment| fragment.id as u32)
+                        .collect()
+                }
+                // No index on this column at all, so no fragment is covered for it.
+                None => target_fragments
+                    .iter()
+                    .map(|fragment| fragment.id as u32)
+                    .collect(),
+            };
+
+            // Fragments this column's index holds documents for, but whose entries a
+            // newer data overlay made stale. The index cannot score them from its own
+            // statistics, so they count as uncovered.
+            //
+            // Coverage is decided per fragment, not per row: a BM25F score needs every
+            // target column's `tf_f`/`dl_f`, so a row must be scored wholly from the
+            // index or not at all, and the fragment is the granularity the indexed
+            // scan's prefilter restriction works at.
+            match self
+                .fts_overlay_plan(column, DocumentGranularity::Row, target_fragments)
+                .await?
+            {
+                FtsOverlayPlan::Unchanged(_) => {}
+                FtsOverlayPlan::RowLevel { stale_rows, .. } => {
+                    uncovered.extend(stale_rows.keys().copied());
+                }
+                // A legacy segment reports no fragment coverage, so no target fragment
+                // can be proven free of stale entries and no row can be named as one.
+                FtsOverlayPlan::FullScan => {
+                    uncovered.extend(target_fragments.iter().map(|fragment| fragment.id as u32));
+                }
+            }
+
+            uncovered |= &column_uncovered;
+        }
+
+        // BM25F needs one shared tokenizer configuration across the target columns
+        // (`validate_combined_tokenizers`), and it is read off an index. Error out
+        // when no target column has one rather than silently falling back to a
+        // default tokenizer that may not match the data.
+        if !any_indexed {
+            return Err(Error::invalid_input(format!(
+                "combined_fields requires an inverted index on at least one of {:?}",
+                query.column_names().collect::<Vec<_>>()
+            )));
+        }
+
+        let uncovered_fragments: Vec<Fragment> = target_fragments
+            .iter()
+            .filter(|fragment| uncovered.contains(fragment.id as u32))
+            .cloned()
+            .collect();
+        // The complement: fragments every target column indexes, and so the only
+        // ones the indexed scan can score completely.
+        let covered: RoaringBitmap = target_fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .filter(|fragment_id| !uncovered.contains(*fragment_id))
+            .collect();
+
+        // The only construction site for the indexed side, so the options every
+        // shape needs cannot be set on one path and forgotten on another.
+        //
+        // `covered` restricts the scan to the fragments every target column indexes
+        // and no overlay made stale; `None` means there is nothing to restrict.
+        // Segments stay unrestricted either way: the fragment restriction already
+        // keeps a stale row out of the results, and dropping a segment would drop
+        // its documents from the corpus statistics too.
+        //
+        // `shared_scorer` is set only when a flat sibling exists: that side alone
+        // sees the rows no index covers, so it publishes the corpus statistics both
+        // children must score against.
+        let index_exec = |covered: Option<RoaringBitmap>,
+                          shared_scorer: Option<Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>>|
+         -> Arc<dyn ExecutionPlan> {
+            let mut exec = CombinedFieldsQueryExec::new(
+                self.dataset.clone(),
+                query.clone(),
+                params.clone(),
+                prefilter_source.clone(),
+            )
+            .with_external_mask(self.external_row_mask.clone());
+            if let Some(covered) = covered {
+                exec = exec.with_covered_fragments(covered);
+            }
+            if let Some(shared_scorer) = shared_scorer {
+                exec = exec.with_shared_scorer(shared_scorer);
+            }
+            Arc::new(exec)
+        };
+
+        // Every target column covers every target fragment, with no overlay-stale
+        // entries anywhere: one unified scan that already emits merged hits sorted
+        // by score with the top-k limit applied, so no union/sort is needed, and
+        // there are no fragments to restrict the prefilter to.
+        if uncovered_fragments.is_empty() {
+            return Ok(index_exec(None, None));
+        }
+        // `fast_search` is index-only by contract, but must still drop the
+        // partially covered fragments so no partial score is emitted. When no
+        // fragment is covered the answer is definitionally empty, and the index
+        // exec would instead fail on the target column that has no segments.
+        if self.fast_search {
+            if covered.is_empty() {
+                return Ok(Arc::new(EmptyExec::new(fts_schema(
+                    DocumentGranularity::Row,
+                ))));
+            }
+            return Ok(index_exec(Some(covered), None));
+        }
+
+        // The flat scan that would score the rows no index covers is not part of
+        // this change, so a partial plan would silently drop them. Refuse instead,
+        // and name what is missing.
+        Err(Error::invalid_input(format!(
+            "combined_fields requires every target column to be indexed over every \
+             scanned fragment, but {} of {} fragments are not fully covered. Optimize \
+             the indexes on {} and retry.",
+            uncovered_fragments.len(),
+            target_fragments.len(),
+            query
+                .columns()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", "),
+        )))
     }
 
     // ANN/KNN search execution node with optional prefilter
@@ -7457,7 +7720,7 @@ mod test {
         fn boost_bits(query: &FtsQuery) -> Vec<u32> {
             match query {
                 FtsQuery::Match(query) => vec![query.boost.to_bits()],
-                FtsQuery::Phrase(_) => Vec::new(),
+                FtsQuery::Phrase(_) | FtsQuery::CombinedFields(_) => Vec::new(),
                 FtsQuery::Boost(query) => std::iter::once(query.negative_boost.to_bits())
                     .chain(boost_bits(&query.positive))
                     .chain(boost_bits(&query.negative))
@@ -7514,7 +7777,7 @@ mod test {
         fn collect_fuzziness(query: &FtsQuery, values: &mut Vec<Option<u32>>) {
             match query {
                 FtsQuery::Match(query) => values.push(query.fuzziness),
-                FtsQuery::Phrase(_) => {}
+                FtsQuery::Phrase(_) | FtsQuery::CombinedFields(_) => {}
                 FtsQuery::Boost(query) => {
                     collect_fuzziness(&query.positive, values);
                     collect_fuzziness(&query.negative, values);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -114,8 +114,8 @@ use crate::io::exec::filtered_read::{
 };
 use crate::io::exec::fts::{
     BoostQueryExec, CombinedFieldsQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
-    FlatMatchFilterExec, FlatMatchQueryExec, FtsDocumentExec, HybridCompoundQueryExec,
-    MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
+    FlatCombinedFieldsExec, FlatMatchFilterExec, FlatMatchQueryExec, FlatStatsCoverage,
+    FtsDocumentExec, HybridCompoundQueryExec, MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -168,6 +168,28 @@ enum FtsOverlayPlan {
         segments: Vec<IndexMetadata>,
     },
     FullScan,
+}
+
+/// Which rows a `combined_fields` flat scan may fold into each target column's
+/// corpus statistics. See [`Scanner::plan_flat_combined_fields_query`].
+enum FlatStatsScope {
+    /// Per target column, the rows its index does not already account for.
+    PerColumn(Vec<FlatStatsCoverage>),
+    /// Every target fragment, for every column, with the index statistics dropped.
+    /// A legacy segment reports no fragment coverage, so its stale rows cannot be
+    /// named and folded one by one and the corpus has to be re-measured whole.
+    WholeCorpus(RoaringBitmap),
+}
+
+/// How a `combined_fields` flat scan gets its rows and which of them it emits.
+enum FlatScanFilter<'a> {
+    /// Push the filter into the scan. Its statistics then describe only the rows
+    /// that survive, which is what the index already reports for everything else.
+    PushDown(&'a ExprFilterPlan),
+    /// Read unfiltered and pick emitted rows with this prefilter, as the indexed
+    /// side does. Needed once a stale row folds: with the filter on the scan, a
+    /// same-value overlay would move the corpus and with it the ranking.
+    AtEmission(PreFilterSource),
 }
 
 fn collect_fts_columns_in_order(query: &FtsQuery) -> Vec<String> {
@@ -4744,7 +4766,7 @@ impl Scanner {
                 Arc::new(SortExec::new(sort_exprs.into(), fts_node).with_fetch(params.limit))
             }
             FtsQuery::CombinedFields(query) => {
-                self.plan_combined_fields_query(query, params, prefilter_source)
+                self.plan_combined_fields_query(query, params, filter_plan, prefilter_source)
                     .await?
             }
             FtsQuery::Boolean(query) => {
@@ -5351,12 +5373,14 @@ impl Scanner {
     /// overlay made stale, per target column, so the indexed scan neither returns a
     /// pre-overlay hit nor hides a new one. See [`Self::fts_overlay_plan`].
     ///
-    /// A fragment any target column's index does not fully cover cannot be scored,
-    /// so the query is refused rather than answered from partial statistics.
+    /// Those fragments are routed to [`FlatCombinedFieldsExec`] instead, and the
+    /// two sides are unioned and re-sorted by score, mirroring
+    /// [`Self::plan_match_query`].
     async fn plan_combined_fields_query(
         &self,
         query: &CombinedFieldsQuery,
         params: &FtsSearchParams,
+        filter_plan: &ExprFilterPlan,
         prefilter_source: &PreFilterSource,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let target_fragments: &[Fragment] = self
@@ -5373,8 +5397,14 @@ impl Scanner {
             ))));
         }
 
+        // Per-column uncovered sets are kept separately: the flat scan reads every
+        // target column for the rows it covers, so only the columns whose index is
+        // actually missing a row may fold that row into their corpus statistics.
+        let mut per_column_coverage = Vec::with_capacity(query.column_names().len());
         let mut uncovered = RoaringBitmap::new();
         let mut any_indexed = false;
+        let mut any_overlay_stale = false;
+        let mut needs_whole_corpus = false;
         for column in query.column_names() {
             let column_uncovered: RoaringBitmap = match self
                 .dataset
@@ -5402,14 +5432,20 @@ impl Scanner {
                     .collect(),
             };
 
-            // Fragments this column's index holds documents for, but whose entries a
-            // newer data overlay made stale. The index cannot score them from its own
-            // statistics, so they count as uncovered.
+            // Fragments this column's index does hold documents for, but whose entries
+            // a newer data overlay made stale. They join the union so the indexed scan
+            // skips them and the flat sibling re-reads their current values, and the
+            // stale rows themselves also join this column's fold so a term the overlay
+            // introduced reaches `docFreq_f`. The index still counts their pre-overlay
+            // values, which it cannot be made to forget without reading them back, so
+            // the column is over-counted by at most the stale-row count.
             //
-            // Coverage is decided per fragment, not per row: a BM25F score needs every
-            // target column's `tf_f`/`dl_f`, so a row must be scored wholly from the
-            // index or not at all, and the fragment is the granularity the indexed
-            // scan's prefilter restriction works at.
+            // `plan_match_query` blocks the individual stale row addresses and takes
+            // them back on the flat side. BM25F cannot: a row's score needs every
+            // target column's `tf_f`/`dl_f`, so a row is scored on exactly one side,
+            // and the side is chosen per fragment because that is the granularity the
+            // indexed scan's prefilter restriction works at.
+            let mut column_stale_rows = RowAddrTreeMap::new();
             match self
                 .fts_overlay_plan(column, DocumentGranularity::Row, target_fragments)
                 .await?
@@ -5417,15 +5453,23 @@ impl Scanner {
                 FtsOverlayPlan::Unchanged(_) => {}
                 FtsOverlayPlan::RowLevel { stale_rows, .. } => {
                     uncovered.extend(stale_rows.keys().copied());
+                    column_stale_rows = self.stale_rows_in_id_domain(&stale_rows).await?;
+                    any_overlay_stale = true;
                 }
                 // A legacy segment reports no fragment coverage, so no target fragment
                 // can be proven free of stale entries and no row can be named as one.
                 FtsOverlayPlan::FullScan => {
                     uncovered.extend(target_fragments.iter().map(|fragment| fragment.id as u32));
+                    needs_whole_corpus = true;
+                    any_overlay_stale = true;
                 }
             }
 
             uncovered |= &column_uncovered;
+            per_column_coverage.push(FlatStatsCoverage {
+                fragments: column_uncovered,
+                stale_rows: column_stale_rows,
+            });
         }
 
         // BM25F needs one shared tokenizer configuration across the target columns
@@ -5503,22 +5547,190 @@ impl Scanner {
             return Ok(index_exec(Some(covered), None));
         }
 
-        // The flat scan that would score the rows no index covers is not part of
-        // this change, so a partial plan would silently drop them. Refuse instead,
-        // and name what is missing.
-        Err(Error::invalid_input(format!(
-            "combined_fields requires every target column to be indexed over every \
-             scanned fragment, but {} of {} fragments are not fully covered. Optimize \
-             the indexes on {} and retry.",
-            uncovered_fragments.len(),
-            target_fragments.len(),
-            query
-                .columns()
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", "),
-        )))
+        // A legacy segment names no stale rows, so nothing can be folded on top of the
+        // index and the corpus has to be re-measured from every target fragment. That
+        // is a full scan, so it stays confined to that case.
+        let (flat_fragments, stats_scope) = if needs_whole_corpus {
+            (
+                target_fragments.to_vec(),
+                FlatStatsScope::WholeCorpus(
+                    target_fragments
+                        .iter()
+                        .map(|fragment| fragment.id as u32)
+                        .collect(),
+                ),
+            )
+        } else {
+            (
+                uncovered_fragments,
+                FlatStatsScope::PerColumn(per_column_coverage),
+            )
+        };
+        // A folded stale row must not depend on the query's filter, or a same-value
+        // overlay would move the corpus. Reading unfiltered costs the flat side its
+        // pushdown, so it is confined to the scans that actually fold one.
+        //
+        // The emission prefilter is built over the fragments this scan reads, not
+        // reused from the indexed child. `prefilter_source` spans the fragments the
+        // target columns' indexes cover, so it names no row in an unindexed fragment,
+        // and an allow-list can only be narrowed afterwards
+        // (`build_prefilter_restricted_to_fragments`), never widened. Reusing it would
+        // drop every match an unindexed fragment holds as soon as an overlay routes
+        // the scan onto this path.
+        let scan_filter = if any_overlay_stale {
+            let flat_prefilter = self
+                .prefilter_source(
+                    filter_plan,
+                    flat_fragments
+                        .iter()
+                        .map(|fragment| fragment.id as u32)
+                        .collect(),
+                )
+                .await?;
+            FlatScanFilter::AtEmission(flat_prefilter)
+        } else {
+            FlatScanFilter::PushDown(filter_plan)
+        };
+        // Only a plan with both children needs the two to agree on a corpus, and a
+        // whole-corpus scan leaves no fragment for an indexed child.
+        let is_mixed = !needs_whole_corpus && flat_fragments.len() != target_fragments.len();
+        let shared_scorer = is_mixed.then(|| Arc::new(SharedFtsScorer::new()));
+        let flat_plan = self
+            .plan_flat_combined_fields_query(
+                flat_fragments,
+                stats_scope,
+                scan_filter,
+                query,
+                params,
+                shared_scorer.clone(),
+            )
+            .await?;
+        // The flat exec emits in scan order and applies no limit, so even with no
+        // index child the plan still needs the score sort and top-k fetch.
+        let scored_plan = if !is_mixed {
+            flat_plan
+        } else {
+            let union =
+                UnionExec::try_new(vec![index_exec(Some(covered), shared_scorer), flat_plan])?;
+            Arc::new(RepartitionExec::try_new(
+                union,
+                Partitioning::RoundRobinBatch(1),
+            )?)
+        };
+        Ok(Arc::new(
+            SortExec::new(
+                Self::fts_score_sort_exprs(scored_plan.schema().as_ref())?.into(),
+                scored_plan,
+            )
+            .with_fetch(params.limit),
+        ))
+    }
+
+    /// Plan the flat (unindexed) side of a `combined_fields` query: one scan over
+    /// `fragments` projecting every target column, scored as one virtual field.
+    ///
+    /// Emits in scan order with no limit applied; the caller supplies the score
+    /// sort and top-k fetch.
+    async fn plan_flat_combined_fields_query(
+        &self,
+        fragments: Vec<Fragment>,
+        stats_scope: FlatStatsScope,
+        scan_filter: FlatScanFilter<'_>,
+        query: &CombinedFieldsQuery,
+        params: &FtsSearchParams,
+        shared_scorer: Option<Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let unfiltered = ExprFilterPlan::default();
+        let (filter_plan, emit_prefilter) = match scan_filter {
+            FlatScanFilter::PushDown(filter_plan) => (filter_plan, None),
+            FlatScanFilter::AtEmission(prefilter) => (&unfiltered, Some(prefilter)),
+        };
+        // A path that continues past a `List` is not addressable by a projection,
+        // so such a column is scanned through its list root and walked down to the
+        // leaf by `FlatCombinedFieldsExec`, exactly as `plan_flat_match_query`
+        // does for a single column.
+        let resolved_fields = query
+            .column_names()
+            .map(|column| {
+                resolve_fts_field(self.dataset.schema(), column, DocumentGranularity::Row)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut columns = resolved_fields
+            .iter()
+            .map(|resolved| {
+                if resolved.has_lists() {
+                    resolved.root_column.clone()
+                } else {
+                    resolved.canonical_path.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+        if let Some(refine_expr) = filter_plan.refine_expr.as_ref() {
+            columns.extend(Planner::column_names_in_expr(refine_expr));
+        }
+        let scan_projection = self
+            .dataset
+            .empty_projection()
+            .with_row_id()
+            .union_columns(&columns, OnMissing::Error)?;
+
+        let scanned_fragments: RoaringBitmap = fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .collect();
+        let PlannedFilteredScan { mut plan, .. } = self
+            .filtered_read(
+                filter_plan,
+                scan_projection,
+                /*make_deletions_null=*/ false,
+                Some(Arc::new(fragments)),
+                None,
+                /*is_prefilter=*/ true,
+                None,
+            )
+            .await?;
+
+        if let Some(refine_expr) = filter_plan.refine_expr.as_ref() {
+            plan = Arc::new(LanceFilterExec::try_new(refine_expr.clone(), plan)?);
+        }
+        // A nested target column needs a flat alias so the exec can resolve it by
+        // name in the batch schema. A list-bearing one gets its flat column from
+        // the exec instead, since no projection can produce it.
+        for (column, resolved) in query.column_names().zip(&resolved_fields) {
+            if !resolved.has_lists() {
+                plan = self.ensure_column_alias(plan, column)?;
+            }
+        }
+
+        let num_columns = query.column_names().len();
+        let mut flat_plan =
+            FlatCombinedFieldsExec::new(self.dataset.clone(), query.clone(), params.clone(), plan)
+                .with_resolved_fields(resolved_fields);
+        flat_plan = match stats_scope {
+            FlatStatsScope::PerColumn(coverage) => flat_plan.with_stats_coverage(coverage),
+            FlatStatsScope::WholeCorpus(fragments) => flat_plan
+                .with_stats_coverage(vec![
+                    FlatStatsCoverage::for_fragments(fragments);
+                    num_columns
+                ])
+                .with_whole_corpus_stats(),
+        };
+        if let Some(prefilter) = emit_prefilter {
+            flat_plan = flat_plan.with_emit_prefilter(prefilter, scanned_fragments);
+        }
+        if let Some(shared_scorer) = shared_scorer {
+            flat_plan = flat_plan.with_shared_scorer(shared_scorer);
+        }
+        let flat_plan: Arc<dyn ExecutionPlan> = Arc::new(flat_plan);
+        // The rows this side scores never reach an index-side prefilter, so the
+        // external row-address mask is applied to its output here, as the flat
+        // MatchQuery branch does. It restricts what is emitted, not the corpus the
+        // scores are computed against, so both children of a mixed plan keep
+        // scoring against the same statistics.
+        if let Some(mask) = self.external_row_mask.clone() {
+            return Ok(Arc::new(RowAddrMaskFilterExec::new(flat_plan, mask)));
+        }
+        Ok(flat_plan)
     }
 
     // ANN/KNN search execution node with optional prefilter

--- a/rust/lance/src/dataset/tests/dataset_fts_combined_fields.rs
+++ b/rust/lance/src/dataset/tests/dataset_fts_combined_fields.rs
@@ -1,0 +1,952 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::{HashMap, HashSet};
+use std::vec;
+
+use crate::Dataset;
+
+use crate::dataset::write::{WriteMode, WriteParams};
+use crate::index::DatasetIndexExt;
+use crate::utils::test::copy_test_data_to_tmp;
+use arrow::array::AsArray;
+use arrow_array::RecordBatch;
+use arrow_array::record_batch;
+use arrow_array::{
+    RecordBatchIterator,
+    types::{Float32Type, Int32Type, Int64Type},
+};
+use lance_core::utils::tempfile::TempStrDir;
+use lance_index::IndexType;
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::inverted::{
+    Language,
+    query::{MatchQuery, Operator},
+    tokenizer::InvertedIndexParams,
+};
+
+use lance_index::scalar::inverted::builder::BLOCK_SIZE;
+use lance_index::scalar::inverted::oracle::{brute_force_bm25f, brute_force_ids};
+use lance_index::scalar::inverted::query::{CombinedFieldsQuery, FtsQuery, MultiMatchQuery};
+use rstest::rstest;
+
+/// Whitespace-tokenizing index params, so `brute_force_bm25f` can mirror them.
+fn combined_fields_test_params() -> InvertedIndexParams {
+    InvertedIndexParams::new("simple".to_string(), Language::English)
+        .lower_case(true)
+        .stem(false)
+        .remove_stop_words(false)
+        .ascii_folding(false)
+        .max_token_length(None)
+}
+
+/// The standard `id`/`title`/`body` batch these tests score over.
+fn combined_fields_batch(ids: Vec<i32>, titles: Vec<&str>, bodies: Vec<&str>) -> RecordBatch {
+    record_batch!(
+        ("id", Int32, ids),
+        ("title", Utf8, titles),
+        ("body", Utf8, bodies)
+    )
+    .unwrap()
+}
+
+/// Write one batch to `uri`, creating the dataset or appending to it.
+///
+/// `write_params` of `None` takes the write defaults: one fragment, row addresses
+/// rather than stable row ids. Pass a [`WriteParams`] to pick a fragment layout
+/// (`max_rows_per_file`), append instead of create (`mode`), or switch row-id
+/// scheme (`enable_stable_row_ids`).
+async fn write_fts_dataset(
+    uri: &str,
+    batch: RecordBatch,
+    write_params: Option<WriteParams>,
+) -> Dataset {
+    let schema = batch.schema();
+    Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        uri,
+        write_params,
+    )
+    .await
+    .unwrap()
+}
+
+/// Append one batch to an existing dataset. The appended fragments carry no
+/// index, which is what routes their rows to the flat scan.
+///
+/// `max_rows_per_file` of `None` takes the write default, i.e. one fragment for
+/// the whole batch; `Some(n)` spreads it over several.
+async fn append_fts_dataset(
+    uri: &str,
+    batch: RecordBatch,
+    max_rows_per_file: Option<usize>,
+) -> Dataset {
+    let mut params = WriteParams {
+        mode: WriteMode::Append,
+        ..Default::default()
+    };
+    if let Some(max_rows_per_file) = max_rows_per_file {
+        params.max_rows_per_file = max_rows_per_file;
+    }
+    write_fts_dataset(uri, batch, Some(params)).await
+}
+
+/// Build one inverted index per column in `columns`, at the dataset's current
+/// version. Call sites list the columns explicitly because which ones carry an
+/// index, and at which version, is what the coverage-skew tests vary.
+async fn create_inverted_indices(
+    dataset: &mut Dataset,
+    columns: &[&str],
+    params: &InvertedIndexParams,
+) {
+    for &column in columns {
+        dataset
+            .create_index(&[column], IndexType::Inverted, None, params, true)
+            .await
+            .unwrap();
+    }
+}
+
+/// Write `titles`/`bodies` as the standard `id`/`title`/`body` batch, ids running
+/// `0..titles.len()`, and index both text columns with [`combined_fields_test_params`].
+/// `max_rows_per_file` picks the fragment layout, `None` taking the default of one.
+///
+/// The returned [`TempStrDir`] owns the dataset directory, so the caller has to keep it
+/// bound while it reads the dataset; it is also what [`append_fts_dataset`] appends to.
+async fn indexed_two_column_dataset(
+    titles: &[&str],
+    bodies: &[&str],
+    max_rows_per_file: Option<usize>,
+) -> (TempStrDir, Dataset) {
+    let ids = (0..titles.len() as i32).collect();
+    let batch = combined_fields_batch(ids, titles.to_vec(), bodies.to_vec());
+    let write_params = max_rows_per_file.map(|max_rows_per_file| WriteParams {
+        max_rows_per_file,
+        ..Default::default()
+    });
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, write_params).await;
+    let params = combined_fields_test_params();
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+    (test_uri, dataset)
+}
+
+fn combined_query(terms: &str, operator: Operator) -> FtsQuery {
+    combined_query_with_boosts(terms, operator, None)
+}
+
+/// `boosts` of `None` leaves every weight at the default `1.0`. Explicit weights
+/// exercise the `w_f` factors in `tf'`/`dl'`, which are invisible at 1.0: an
+/// implementation that dropped `weight` still scores correctly with unit weights.
+fn combined_query_with_boosts(
+    terms: &str,
+    operator: Operator,
+    boosts: Option<Vec<f32>>,
+) -> FtsQuery {
+    combined_query_over(&["title", "body"], terms, operator, boosts)
+}
+
+/// Like [`combined_query_with_boosts`] but over an explicit column list, for the
+/// datasets that are not the two-column `title`/`body` shape.
+fn combined_query_over(
+    columns: &[&str],
+    terms: &str,
+    operator: Operator,
+    boosts: Option<Vec<f32>>,
+) -> FtsQuery {
+    let query = CombinedFieldsQuery::try_new(
+        terms.to_string(),
+        columns.iter().map(|c| c.to_string()).collect(),
+    )
+    .unwrap();
+    let query = match boosts {
+        Some(boosts) => query.try_with_boosts(boosts).unwrap(),
+        None => query,
+    };
+    FtsQuery::CombinedFields(query.with_operator(operator))
+}
+
+/// Run an unlimited full-text query and return the matched `id`s in result order.
+async fn fts_result_ids(dataset: &Dataset, query: FtsQuery) -> Vec<i32> {
+    fts_result_id_scores(dataset, query, None)
+        .await
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// Run a full-text query and return `(id, score)` pairs in result order.
+///
+/// `limit` is the query's top-k: `Some(k)` arms the pruning path, `None` takes the
+/// exact scan over every match.
+async fn fts_result_id_scores(
+    dataset: &Dataset,
+    query: FtsQuery,
+    limit: Option<i64>,
+) -> Vec<(i32, f32)> {
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query).limit(limit))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let ids = batch["id"].as_primitive::<Int32Type>();
+    let scores = batch["_score"].as_primitive::<Float32Type>();
+    (0..batch.num_rows())
+        .map(|i| (ids.value(i), scores.value(i)))
+        .collect()
+}
+
+/// The scan's ids as a set. A set compare on its own would hide a duplicate
+/// emission, so the count is pinned here.
+fn unique_ids(ids: Vec<i32>) -> HashSet<i32> {
+    let set: HashSet<i32> = ids.iter().copied().collect();
+    assert_eq!(set.len(), ids.len(), "duplicate row ids emitted: {ids:?}");
+    set
+}
+
+/// Assert a scan's `(id, score)` results are exactly the documents
+/// [`brute_force_bm25f`] matched, with scores equal to within 1e-3.
+///
+/// `context` names the invariant the call site is pinning down and is appended to
+/// every failure message, so a failure says which one broke.
+fn assert_matches_brute_force(actual: &[(i32, f32)], expected: &[Option<f32>], context: &str) {
+    let expected_ids = brute_force_ids(expected);
+    let actual_ids: HashSet<i32> = actual.iter().map(|(id, _)| *id).collect();
+    // A set compare would hide a duplicate emission, so pin the row count too.
+    assert_eq!(
+        actual.len(),
+        expected_ids.len(),
+        "duplicate row emitted ({context}): {actual:?}"
+    );
+    assert_eq!(actual_ids, expected_ids, "matched ids differ ({context})");
+    for (id, score) in actual {
+        let want = expected[*id as usize].expect("scan returned an unmatched doc");
+        assert!(
+            (score - want).abs() < 1e-3,
+            "score mismatch for id {id} ({context}): scan={score}, brute force={want}"
+        );
+    }
+}
+
+/// Assert `actual` is a valid exact top-`k` of `expected`: the right hit count, the exact
+/// ranking's scores, each returned doc carrying its own score, no duplicate or
+/// below-cutoff id. Identity is membership rather than an exact id set because ties at
+/// the k-th score make the winning set ambiguous.
+fn assert_topk_matches_brute_force(
+    actual: &[(i32, f32)],
+    expected: &[Option<f32>],
+    k: usize,
+    context: &str,
+) {
+    let mut expected_ranked: Vec<f32> = expected.iter().filter_map(|score| *score).collect();
+    expected_ranked.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    // Not an early return: an all-empty comparison satisfies everything below.
+    assert!(
+        !expected_ranked.is_empty(),
+        "the oracle matched nothing, so there is nothing to compare ({context})"
+    );
+
+    assert_eq!(
+        actual.len(),
+        expected_ranked.len().min(k),
+        "hit count mismatch for k={k} ({context})"
+    );
+
+    let mut actual_scores: Vec<f32> = actual.iter().map(|(_, score)| *score).collect();
+    actual_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    for (got, want) in actual_scores.iter().zip(&expected_ranked) {
+        assert!(
+            (got - want).abs() < 1e-3,
+            "top-{k} score mismatch ({context}): pruned={actual_scores:?} exact={expected_ranked:?}"
+        );
+    }
+
+    // Per id: sorted scores alone accept ids and scores paired up wrongly.
+    for (id, score) in actual {
+        let want = expected[*id as usize].expect("scan returned an unmatched doc");
+        assert!(
+            (score - want).abs() < 1e-3,
+            "score mismatch for id {id} at k={k} ({context}): scan={score}, brute force={want}"
+        );
+    }
+
+    let returned_ids = unique_ids(actual.iter().map(|(id, _)| *id).collect());
+    let cutoff = expected_ranked[actual.len() - 1];
+    for id in &returned_ids {
+        let want = expected[*id as usize].expect("scan returned an unmatched doc");
+        assert!(
+            want >= cutoff - 1e-3,
+            "id {id} scores {want}, below the top-{k} cutoff {cutoff} ({context})"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_cross_field_and() {
+    // combined_fields (BM25F) treats the target columns as one virtual field, so an
+    // AND query matches when each term appears in at least one field. best_fields
+    // (MultiMatch) evaluates AND per field, so it only matches a single field that
+    // contains every term.
+    let params = InvertedIndexParams::default();
+    // row 0: the two terms are split across the fields;
+    // row 1: both terms live in a single field;
+    // row 2: only one of the two terms appears anywhere.
+    let batch = combined_fields_batch(
+        vec![0, 1, 2],
+        vec!["john", "john smith", "john"],
+        vec!["smith", "foo", "alice"],
+    );
+    let test_uri = TempStrDir::default();
+    // Spread the rows across fragments so the merged scan exercises multi-fragment
+    // row-id resolution.
+    let mut dataset = write_fts_dataset(
+        &test_uri,
+        batch,
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await;
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+
+    let columns = vec!["title".to_string(), "body".to_string()];
+    let combined = |op| combined_query("john smith", op);
+    let multi = |op| {
+        FtsQuery::MultiMatch(
+            MultiMatchQuery::try_new("john smith".to_string(), columns.clone())
+                .unwrap()
+                .with_operator(op),
+        )
+    };
+
+    // AND over the virtual field: row 0 (john|title + smith|body) and row 1
+    // (both terms in title) match; row 2 (no "smith" anywhere) does not.
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, combined(Operator::And)).await),
+        HashSet::from([0, 1])
+    );
+    // best_fields AND matches only row 1, where a single field holds both terms.
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, multi(Operator::And)).await),
+        HashSet::from([1])
+    );
+
+    // OR matches any doc containing either term: every row has "john".
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, combined(Operator::Or)).await),
+        HashSet::from([0, 1, 2])
+    );
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, multi(Operator::Or)).await),
+        HashSet::from([0, 1, 2])
+    );
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_boost_ranking() {
+    // Per-column boosts move a document up the ranking in the BM25F direction:
+    // boosting the field a term lives in counts that term more. Stemming and
+    // stop words are disabled so the filler tokens contribute to document length
+    // ("other" is an English stop word).
+    let params = InvertedIndexParams::new("simple".to_string(), Language::English)
+        .stem(false)
+        .remove_stop_words(false);
+    // id 0 has the term only in `title`; id 1 has it only in the shorter `body`.
+    let batch = combined_fields_batch(
+        vec![0, 1],
+        vec!["lance", "other"],
+        vec!["other other other", "lance"],
+    );
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+
+    let combined =
+        |boosts: Vec<f32>| combined_query_with_boosts("lance", Operator::Or, Some(boosts));
+    // Compare by score rather than result row-order (FTS batch order is not a
+    // guaranteed ranking; only the scores are).
+    let scores = |ids: Vec<(i32, f32)>| ids.into_iter().collect::<HashMap<i32, f32>>();
+
+    // Equal weights: the shorter document (id 1, term in the 1-token body) wins.
+    let equal = scores(fts_result_id_scores(&dataset, combined(vec![1.0, 1.0]), None).await);
+    assert!(
+        equal[&1] > equal[&0],
+        "equal weights: {equal:?} should rank id 1 above id 0"
+    );
+    // Boosting `title` 3x lifts id 0 (term in title) above id 1.
+    let boosted = scores(fts_result_id_scores(&dataset, combined(vec![3.0, 1.0]), None).await);
+    assert!(
+        boosted[&0] > boosted[&1],
+        "title-boosted: {boosted:?} should rank id 0 above id 1"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_nulls() {
+    // NULL edge cases: a doc null in one field is still scored via the other; a
+    // doc null in every field never matches; an entirely-null column is a no-op.
+    let params = InvertedIndexParams::default();
+    let batch = record_batch!(
+        ("id", Int32, [0, 1, 2, 3]),
+        ("title", Utf8, [Some("lance"), None, None, Some("lance")]),
+        ("body", Utf8, [None, Some("lance"), None, Some("lance")]),
+        ("empty", Utf8, [None::<&str>, None, None, None])
+    )
+    .unwrap();
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+    create_inverted_indices(&mut dataset, &["title", "body", "empty"], &params).await;
+
+    // Null in one field (0, 1) is scored via the other; null in both (2) never
+    // matches; present in both (3) matches once.
+    let query = combined_query("lance", Operator::Or);
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, query).await),
+        HashSet::from([0, 1, 3])
+    );
+
+    // An entirely-null column contributes nothing (docCount' uses the max), so
+    // combining it with `title` matches exactly the `title` hits.
+    let with_empty = combined_query_over(&["title", "empty"], "lance", Operator::Or, None);
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, with_empty).await),
+        HashSet::from([0, 3])
+    );
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_matches_brute_force_bm25f() {
+    // Validate the combined-fields scan against an independent brute-force BM25F
+    // reference (the primary correctness oracle). Stemming and stop words are
+    // disabled so the reference can tokenize by whitespace.
+    let titles = vec!["aa bb", "aa", "cc dd", "aa aa bb", "cc"];
+    let bodies = vec!["cc", "bb cc dd", "aa", "dd", "aa bb"];
+    let (_test_uri, dataset) = indexed_two_column_dataset(&titles, &bodies, None).await;
+
+    let weights = [2.0f32, 1.0f32];
+    let query = combined_query_with_boosts("aa bb", Operator::Or, Some(weights.to_vec()));
+
+    let expected = brute_force_bm25f(
+        &[(weights[0], titles.clone()), (weights[1], bodies.clone())],
+        "aa bb",
+        false,
+    );
+    let actual = fts_result_id_scores(&dataset, query, None).await;
+    assert_matches_brute_force(&actual, &expected, "the fully-indexed two-column scan");
+}
+
+/// `combined_fields` against a real released-format index read from disk rather
+/// than a synthetic fixture, so the row-granularity statistics path
+/// ([`lance_index::scalar::inverted::index::InvertedIndex::bm25_row_stats_for_terms`])
+/// is exercised on actual V1 and V2 files.
+///
+/// The checked-in fixtures index a plain `Utf8` column, so every row owns exactly
+/// one document and they cannot reproduce the list-element multiplicity the
+/// row-granularity path exists for (that lives in `combined/search.rs`'s unit tests).
+/// What they do pin is that a released-format index scores against the
+/// brute-force BM25F reference.
+#[rstest]
+#[case::v1("v3.0.1/fts_v1", 1)]
+#[case::v2("v4.0.1/fts_v2", 2)]
+#[tokio::test]
+async fn test_fts_combined_fields_on_released_format_fixture(
+    #[case] fixture_path: &str,
+    #[case] expected_version: i32,
+) {
+    let test_dir = copy_test_data_to_tmp(fixture_path).unwrap();
+    let dataset = Dataset::open(&test_dir.path_str()).await.unwrap();
+    let indices = dataset.load_indices().await.unwrap();
+    assert_eq!(indices.len(), 1);
+    assert_eq!(indices[0].index_version, expected_version);
+
+    // `test_data/{v3.0.1,v4.0.1}/datagen.py` writes 300 rows of
+    // "lance database compatibility shared" for id % 3 == 0 and
+    // "database lance compatibility shared" otherwise.
+    const NUM_ROWS: usize = 300;
+    let texts: Vec<&str> = (0..NUM_ROWS)
+        .map(|id| {
+            if id % 3 == 0 {
+                "lance database compatibility shared"
+            } else {
+                "database lance compatibility shared"
+            }
+        })
+        .collect();
+    let expected = brute_force_bm25f(&[(1.0, texts)], "lance compatibility", false);
+
+    let query = combined_query_over(&["text"], "lance compatibility", Operator::Or, None);
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let ids = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<Int64Type>();
+    let scores = batch
+        .column_by_name("_score")
+        .unwrap()
+        .as_primitive::<Float32Type>();
+    assert_eq!(batch.num_rows(), NUM_ROWS);
+    for i in 0..batch.num_rows() {
+        let id = ids.value(i) as usize;
+        let want = expected[id].expect("every fixture row carries both query terms");
+        assert!(
+            (scores.value(i) - want).abs() < 1e-3,
+            "score mismatch for id {id}: scan={}, brute force={want}",
+            scores.value(i),
+        );
+    }
+}
+
+/// Drive the top-k path end-to-end through the scanner and confirm the pruned
+/// top-k equals the exact brute-force BM25F top-k for OR and AND across every k.
+///
+/// Only a limited query arms MAXSCORE pruning; an unlimited one takes the exact
+/// scan. The corpus is skewed, mixing a rare high-idf term ("zeta") with a common
+/// low-idf term ("beta"), so MAXSCORE makes "beta" non-essential. The OR query
+/// additionally carries an absent term ("missingterm", idf' == 0) to check the
+/// clamped-ceiling handling.
+///
+/// `max_rows_per_file` picks the partition layout, so the multi-partition case also
+/// exercises the cursors' cross-partition row-id merge.
+#[rstest]
+#[case::single_partition(None)]
+#[case::multi_partition(Some(7))]
+#[tokio::test]
+async fn test_fts_combined_fields_topk_matches_brute_force(
+    #[case] max_rows_per_file: Option<usize>,
+) {
+    let n = 40usize;
+    let titles: Vec<String> = (0..n)
+        .map(|i| {
+            if i % 9 == 0 {
+                "zeta gamma".to_string()
+            } else {
+                "gamma".to_string()
+            }
+        })
+        .collect();
+    let bodies: Vec<String> = (0..n)
+        .map(|i| {
+            // "beta" fills every body with a growing count (common, low idf);
+            // one body also carries the rare "zeta" so a doc can hold it in
+            // either field.
+            let beta = vec!["beta"; 1 + i % 3].join(" ");
+            if i == 3 { format!("{beta} zeta") } else { beta }
+        })
+        .collect();
+
+    let title_refs: Vec<&str> = titles.iter().map(|s| s.as_str()).collect();
+    let body_refs: Vec<&str> = bodies.iter().map(|s| s.as_str()).collect();
+    let (_test_uri, dataset) =
+        indexed_two_column_dataset(&title_refs, &body_refs, max_rows_per_file).await;
+
+    let weights = [2.0f32, 1.0f32];
+
+    for operator in [Operator::Or, Operator::And] {
+        let require_all = operator == Operator::And;
+        // The absent term is only valid for OR (AND with an absent term matches
+        // nothing); keep it out of the AND case.
+        let query_str = if require_all {
+            "zeta beta"
+        } else {
+            "zeta beta missingterm"
+        };
+        let expected = brute_force_bm25f(
+            &[
+                (weights[0], title_refs.clone()),
+                (weights[1], body_refs.clone()),
+            ],
+            query_str,
+            require_all,
+        );
+        for k in [1usize, 2, 3, 5, 10, 50] {
+            let query = combined_query_with_boosts(query_str, operator, Some(weights.to_vec()));
+            let actual = fts_result_id_scores(&dataset, query, Some(k as i64)).await;
+            assert_topk_matches_brute_force(&actual, &expected, k, &format!("op={operator:?}"));
+        }
+    }
+}
+
+/// Top-k recall where a term's postings span several [`BLOCK_SIZE`] blocks, so the
+/// cursors decode and merge across block boundaries. `beta` sits under `docCount'`
+/// (at equality its ceiling is 0 and pruning is trivial) with fewer `zeta`
+/// documents than `beta` has blocks.
+///
+/// `alpha` has no such margin and covers the same paths with pruning that cannot
+/// fire. `max_rows_per_file` varies fragments, not partitions.
+#[rstest]
+#[case::single_fragment(None)]
+#[case::multi_fragment(Some(BLOCK_SIZE))]
+#[tokio::test]
+async fn test_fts_combined_fields_topk_matches_brute_force_across_blocks(
+    #[case] max_rows_per_file: Option<usize>,
+) {
+    const CORPUS_BLOCKS: usize = 16;
+    let num_docs = CORPUS_BLOCKS * BLOCK_SIZE;
+
+    // Also derive the expected match counts, so corpus and expectations cannot drift.
+    // Three `zeta` probes leave most of `beta`'s ten blocks untouched, and the first is
+    // early so the threshold rises before much is decoded.
+    let has_zeta = |doc: usize| [3, 703, 1403].contains(&doc);
+    let has_beta = |doc: usize| doc % 5 >= 2;
+    let has_alpha = |doc: usize| doc.is_multiple_of(7);
+    // A subset, so its cursor merges two sources and no match count changes.
+    let has_beta_in_title = |doc: usize| doc % 5 == 3;
+    let count = |carries: &dyn Fn(usize) -> bool| (0..num_docs).filter(|&d| carries(d)).count();
+
+    // `gamma` and `delta` are filler: no query uses them, they just vary `dl'`.
+    let titles: Vec<String> = (0..num_docs)
+        .map(|doc| {
+            let mut title = if has_zeta(doc) {
+                "zeta gamma".to_string()
+            } else {
+                "gamma".to_string()
+            };
+            if has_beta_in_title(doc) {
+                title.push_str(" beta");
+            }
+            title
+        })
+        .collect();
+    let bodies: Vec<String> = (0..num_docs)
+        .map(|doc| {
+            let mut body = if has_beta(doc) {
+                vec!["beta"; 1 + doc % 3].join(" ")
+            } else {
+                "delta".to_string()
+            };
+            if has_alpha(doc) {
+                body.push_str(" alpha");
+            }
+            body
+        })
+        .collect();
+
+    // `beta` multi-block with a real ceiling, and rarer terms above it by ceiling.
+    let beta_docs = count(&has_beta);
+    let zeta_docs = count(&has_zeta);
+    let alpha_docs = count(&has_alpha);
+    assert!(
+        beta_docs > 4 * BLOCK_SIZE && beta_docs < num_docs,
+        "beta must span several blocks without covering the corpus, got {beta_docs} of {num_docs}"
+    );
+    assert!(
+        zeta_docs < beta_docs / BLOCK_SIZE,
+        "zeta ({zeta_docs} docs) must stay under beta's block count ({})",
+        beta_docs / BLOCK_SIZE
+    );
+    assert!(
+        2 * alpha_docs < beta_docs && 2 * zeta_docs < beta_docs,
+        "the rare terms must stay well below beta ({beta_docs}): zeta={zeta_docs} alpha={alpha_docs}"
+    );
+    let beta_title_docs = count(&has_beta_in_title);
+    assert!(
+        beta_title_docs > 0 && count(&|doc| has_beta_in_title(doc) && !has_beta(doc)) == 0,
+        "beta needs a second source in `title`, drawn from its own documents, got {beta_title_docs}"
+    );
+
+    let title_refs: Vec<&str> = titles.iter().map(|title| title.as_str()).collect();
+    let body_refs: Vec<&str> = bodies.iter().map(|body| body.as_str()).collect();
+    let (_test_uri, dataset) =
+        indexed_two_column_dataset(&title_refs, &body_refs, max_rows_per_file).await;
+
+    let weights = vec![2.0f32, 1.0f32];
+
+    for (terms, operator, want_matches) in [
+        (
+            "zeta beta",
+            Operator::Or,
+            count(&|doc| has_zeta(doc) || has_beta(doc)),
+        ),
+        (
+            "alpha beta",
+            Operator::Or,
+            count(&|doc| has_alpha(doc) || has_beta(doc)),
+        ),
+        (
+            "zeta beta",
+            Operator::And,
+            count(&|doc| has_zeta(doc) && has_beta(doc)),
+        ),
+    ] {
+        let expected = brute_force_bm25f(
+            &[
+                (weights[0], title_refs.clone()),
+                (weights[1], body_refs.clone()),
+            ],
+            terms,
+            operator == Operator::And,
+        );
+        // The oracle has to agree with the predicates the corpus was built from.
+        assert_eq!(
+            brute_force_ids(&expected).len(),
+            want_matches,
+            "corpus no longer matches as intended for {terms:?} {operator:?}"
+        );
+        assert!(want_matches > 0, "no matches for {terms:?} {operator:?}");
+        // Below, at, and above the match count, to cover the exhausted-cursor path.
+        for k in [1usize, 10, 100, num_docs] {
+            let query = combined_query_with_boosts(terms, operator, Some(weights.clone()));
+            let actual = fts_result_id_scores(&dataset, query, Some(k as i64)).await;
+            assert_topk_matches_brute_force(
+                &actual,
+                &expected,
+                k,
+                &format!("terms={terms:?} op={operator:?}"),
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_tokenizer_validation() {
+    // combined_fields accepts columns that differ only in storage-only params
+    // (e.g. with_position) but rejects columns configured with different
+    // tokenizers.
+    let with_pos = InvertedIndexParams::new("simple".to_string(), Language::English)
+        .with_position(true)
+        .stem(false)
+        .remove_stop_words(false);
+    let without_pos = InvertedIndexParams::new("simple".to_string(), Language::English)
+        .with_position(false)
+        .stem(false)
+        .remove_stop_words(false);
+    let whitespace = InvertedIndexParams::new("whitespace".to_string(), Language::English)
+        .stem(false)
+        .remove_stop_words(false);
+
+    let batch = record_batch!(
+        ("id", Int32, [0, 1]),
+        ("title", Utf8, ["aa", "bb"]),
+        ("body", Utf8, ["bb", "aa"]),
+        ("alt", Utf8, ["aa", "aa"])
+    )
+    .unwrap();
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+    // One index per column, each with its own tokenizer configuration, which is
+    // what the query-time validation reads back.
+    create_inverted_indices(&mut dataset, &["title"], &with_pos).await;
+    create_inverted_indices(&mut dataset, &["body"], &without_pos).await;
+    create_inverted_indices(&mut dataset, &["alt"], &whitespace).await;
+
+    // title (with positions) and body (without) tokenize identically: accepted.
+    let accepted = combined_query("aa", Operator::Or);
+    assert_eq!(
+        unique_ids(fts_result_ids(&dataset, accepted).await),
+        HashSet::from([0, 1])
+    );
+
+    // title (simple) and alt (whitespace) use different tokenizers: rejected.
+    let rejected = combined_query_over(&["title", "alt"], "aa", Operator::Or, None);
+    let result = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new_query(rejected))
+        .unwrap()
+        .try_into_batch()
+        .await;
+    let message = result
+        .expect_err("expected a tokenizer-mismatch error")
+        .to_string();
+    assert!(
+        message.contains("combined_fields") && message.contains("tokenizer"),
+        "unexpected error: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_concatenation_identity() {
+    // With integer weights, BM25F over (title^w_t, body^w_b) is identical to plain
+    // BM25 over a single column that concatenates title repeated w_t times with body
+    // repeated w_b times, as long as every title token also appears in body so the
+    // max-based docFreq' blend matches the concatenated union. This cross-checks the
+    // combined scan against Lance's own single-field BM25, an independent code path,
+    // catching spec-interpretation errors.
+    let params = combined_fields_test_params();
+    let titles = ["cat", "dog", "bird", "cat dog"];
+    let bodies = ["cat dog", "dog bird cat", "bird cat", "cat dog bird"];
+    let (w_title, w_body) = (2usize, 1usize);
+    let concat: Vec<String> = titles
+        .iter()
+        .zip(&bodies)
+        .map(|(title, body)| {
+            let mut parts: Vec<&str> = Vec::with_capacity(w_title + w_body);
+            for _ in 0..w_title {
+                parts.push(title);
+            }
+            for _ in 0..w_body {
+                parts.push(body);
+            }
+            parts.join(" ")
+        })
+        .collect();
+
+    let concat_refs: Vec<&str> = concat.iter().map(|s| s.as_str()).collect();
+    let batch = record_batch!(
+        ("id", Int32, (0..titles.len() as i32).collect::<Vec<_>>()),
+        ("title", Utf8, titles.to_vec()),
+        ("body", Utf8, bodies.to_vec()),
+        ("concat", Utf8, concat_refs)
+    )
+    .unwrap();
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+    create_inverted_indices(&mut dataset, &["title", "body", "concat"], &params).await;
+
+    let combined = combined_query_with_boosts(
+        "cat dog",
+        Operator::Or,
+        Some(vec![w_title as f32, w_body as f32]),
+    );
+    let plain = FtsQuery::Match(
+        MatchQuery::new("cat dog".to_string()).with_column(Some("concat".to_string())),
+    );
+
+    let combined_scores: HashMap<i32, f32> = fts_result_id_scores(&dataset, combined, None)
+        .await
+        .into_iter()
+        .collect();
+    let plain_scores: HashMap<i32, f32> = fts_result_id_scores(&dataset, plain, None)
+        .await
+        .into_iter()
+        .collect();
+
+    assert_eq!(
+        combined_scores.keys().copied().collect::<HashSet<_>>(),
+        plain_scores.keys().copied().collect::<HashSet<_>>(),
+    );
+    for (id, combined_score) in &combined_scores {
+        let plain_score = plain_scores[id];
+        assert!(
+            (combined_score - plain_score).abs() < 1e-3,
+            "id {id}: combined={combined_score}, concatenated single-field={plain_score}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_fast_search_without_full_coverage_is_empty() {
+    // `fast_search` is index-only. When a target column has no index at all no
+    // fragment is fully covered, so the answer is definitionally empty, and the
+    // indexed exec must not be built, because it requires every target column to
+    // have segments. Mirrors `plan_match_query`, which returns `EmptyExec` here.
+    let params = combined_fields_test_params();
+    let batch = combined_fields_batch(vec![0, 1], vec!["aa", "bb"], vec!["bb", "aa"]);
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+    create_inverted_indices(&mut dataset, &["title"], &params).await;
+
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .fast_search()
+        .try_into_batch()
+        .await
+        .expect("fast_search without full coverage should be empty, not an error");
+    assert_eq!(batch.num_rows(), 0);
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_fast_search_skips_uncovered_fragments() {
+    // `fast_search` is index-only by contract, so appended rows stay invisible. It
+    // must still exclude a fragment that not every target column indexes, otherwise
+    // those rows come back with a partial `tf'`/`dl'`.
+    let params = combined_fields_test_params();
+    let (test_uri, _indexed) = indexed_two_column_dataset(&["aa"], &["aa"], None).await;
+
+    let second = combined_fields_batch(vec![1], vec!["aa"], vec!["aa"]);
+    let mut dataset = append_fts_dataset(&test_uri, second, None).await;
+    // `title` now covers both fragments, `body` only the first.
+    create_inverted_indices(&mut dataset, &["title"], &params).await;
+
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .fast_search()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let ids = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<Int32Type>()
+        .values()
+        .to_vec();
+    assert_eq!(
+        ids,
+        vec![0],
+        "fast_search returned a row whose cross-field data is only partly indexed"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_empty_fragment_list_is_empty() {
+    // An explicitly empty fragment list selects no rows. The fully indexed plan
+    // carries no fragment restriction, so without an explicit short circuit the
+    // indexed scan answers from every fragment the index holds.
+    let (_test_uri, dataset) = indexed_two_column_dataset(&["aa", "bb"], &["bb", "aa"], None).await;
+
+    let mut scan = dataset.scan();
+    scan.project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .with_fragments(vec![]);
+    let plan = scan.explain_plan(false).await.unwrap();
+    assert!(plan.contains("EmptyExec"), "unexpected plan: {plan}");
+    assert_eq!(scan.try_into_batch().await.unwrap().num_rows(), 0);
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_requires_an_index() {
+    // BM25F reads its shared tokenizer configuration off an index, so a query
+    // whose target columns are all unindexed is rejected rather than scored with a
+    // default tokenizer that may not match how the data would be indexed.
+    let batch = combined_fields_batch(vec![0, 1], vec!["aa", "bb"], vec!["bb", "aa"]);
+    let test_uri = TempStrDir::default();
+    let dataset = write_fts_dataset(&test_uri, batch, None).await;
+
+    let result = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .try_into_batch()
+        .await;
+    let message = result.expect_err("expected an error").to_string();
+    assert!(
+        message.contains("combined_fields") && message.contains("inverted index"),
+        "unexpected error: {message}"
+    );
+}

--- a/rust/lance/src/dataset/tests/dataset_fts_combined_fields.rs
+++ b/rust/lance/src/dataset/tests/dataset_fts_combined_fields.rs
@@ -2,28 +2,38 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::vec;
+
+use super::dataset_index::nested_fts_batch;
 
 use crate::Dataset;
 
 use crate::dataset::write::{WriteMode, WriteParams};
 use crate::index::DatasetIndexExt;
 use crate::utils::test::copy_test_data_to_tmp;
-use arrow::array::AsArray;
+use arrow::array::{AsArray, GenericListBuilder, GenericStringBuilder};
+use arrow::datatypes::UInt64Type;
 use arrow_array::RecordBatch;
 use arrow_array::record_batch;
+use arrow_array::{Array, GenericStringArray, ListArray, StructArray};
 use arrow_array::{
-    RecordBatchIterator,
+    ArrayRef, Int32Array, RecordBatchIterator, StringArray,
     types::{Float32Type, Int32Type, Int64Type},
 };
+use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
+use lance_core::ROW_ID;
 use lance_core::utils::tempfile::TempStrDir;
-use lance_index::IndexType;
+use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::{
     Language,
     query::{MatchQuery, Operator},
     tokenizer::InvertedIndexParams,
 };
+use lance_index::{IndexType, scalar::ScalarIndexParams};
+use lance_select::{RowAddrMask, RowAddrTreeMap};
 
 use lance_index::scalar::inverted::builder::BLOCK_SIZE;
 use lance_index::scalar::inverted::oracle::{brute_force_bm25f, brute_force_ids};
@@ -836,6 +846,516 @@ async fn test_fts_combined_fields_concatenation_identity() {
     }
 }
 
+#[rstest]
+#[case::or(Operator::Or)]
+#[case::and(Operator::And)]
+#[tokio::test]
+async fn test_fts_combined_fields_covers_unindexed_fragments(#[case] operator: Operator) {
+    // A combined_fields query must not silently drop rows appended after the indexes
+    // were built. The indexed scan cannot score them (their fragment is in no
+    // index), so the planner has to union in a flat scan the same way a single
+    // MatchQuery does.
+    //
+    // Every row here matches, so both children of the union emit and the exact
+    // scores also pin down that they scored against a single shared corpus. Only the
+    // flat side sees the appended rows, so an indexed child that folded its own
+    // statistics would score row 0 on a 1-document corpus while rows 1 and 2 were
+    // scored on a 3-document one.
+    let titles = vec!["alpha", "alpha alpha", "gamma"];
+    let bodies = vec!["omega", "omega", "omega omega"];
+
+    let (test_uri, mut dataset) =
+        indexed_two_column_dataset(&titles[..1], &bodies[..1], None).await;
+
+    // Two appended fragments, so the flat side has to cover more than one.
+    for row in 1..3 {
+        let batch = combined_fields_batch(vec![row as i32], vec![titles[row]], vec![bodies[row]]);
+        dataset = append_fts_dataset(&test_uri, batch, Some(1)).await;
+    }
+
+    // A single-column match already falls back to a flat scan; combined_fields
+    // must reach the same rows.
+    let match_ids = fts_result_ids(
+        &dataset,
+        FtsQuery::Match(
+            MatchQuery::new("alpha".to_string()).with_column(Some("title".to_string())),
+        ),
+    )
+    .await;
+    // Score order, so compare as a set: both alpha-bearing rows must be reached.
+    assert_eq!(
+        match_ids.iter().copied().collect::<HashSet<_>>(),
+        HashSet::from([0, 1])
+    );
+
+    let expected = brute_force_bm25f(
+        &[(1.0, titles.clone()), (1.0, bodies.clone())],
+        "alpha omega",
+        operator == Operator::And,
+    );
+    let actual =
+        fts_result_id_scores(&dataset, combined_query("alpha omega", operator), None).await;
+    // Row 0 comes from the indexed child and rows 1 and 2 from the flat one, so
+    // matching the reference on all three proves the two share a corpus: the flat
+    // scan publishes the blend that folds in the appended rows, and the indexed scan
+    // waits for it instead of using its own `docCount'`/`docFreq'`/`avgdl'`.
+    assert_matches_brute_force(
+        &actual,
+        &expected,
+        "rows in unindexed fragments must be reached exactly once through the index/flat union",
+    );
+}
+
+/// An external row-address prefilter
+/// ([`Scanner::with_row_addr_prefilter`](crate::dataset::Scanner::with_row_addr_prefilter))
+/// must restrict a `combined_fields` result.
+///
+/// The two plan shapes reach it by different routes and are both checked: the
+/// fully covered one is a single indexed scan that ANDs the mask into its
+/// prefilter, while the mixed one adds a flat child whose rows never reach an
+/// index-side prefilter and so is masked on its output instead.
+///
+/// The mask picks what is emitted, not the corpus the scores are measured
+/// against, so the surviving rows keep the scores the unmasked query gave them.
+/// Folding it into the statistics would make a masked query rank its results
+/// differently from the same rows in an unmasked one.
+#[rstest]
+#[case::fully_indexed(false)]
+#[case::mixed_index_and_flat(true)]
+#[tokio::test]
+async fn test_fts_combined_fields_respects_external_row_mask(#[case] append_unindexed: bool) {
+    let titles = vec!["alpha", "alpha alpha", "gamma"];
+    let bodies = vec!["omega", "omega", "omega omega"];
+
+    let (_test_uri, mut dataset) = if append_unindexed {
+        // Index only row 0, then append the rest so the planner unions an indexed
+        // scan with a flat one.
+        let (test_uri, mut dataset) =
+            indexed_two_column_dataset(&titles[..1], &bodies[..1], None).await;
+        for row in 1..3 {
+            let batch =
+                combined_fields_batch(vec![row as i32], vec![titles[row]], vec![bodies[row]]);
+            dataset = append_fts_dataset(&test_uri, batch, Some(1)).await;
+        }
+        (test_uri, dataset)
+    } else {
+        indexed_two_column_dataset(&titles, &bodies, None).await
+    };
+    // Reload so the scanner sees the indices written above.
+    dataset.checkout_latest().await.unwrap();
+
+    // Row ids paired with the `id` values they carry, so the mask can be built in
+    // `_rowid` space while the assertions stay in terms of `id`.
+    let baseline = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "alpha omega",
+            Operator::Or,
+        )))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let baseline_ids = baseline["id"].as_primitive::<Int32Type>();
+    let baseline_row_ids = baseline[ROW_ID].as_primitive::<UInt64Type>();
+    let baseline_scores = baseline["_score"].as_primitive::<Float32Type>();
+    let baseline: Vec<(i32, u64, f32)> = (0..baseline.num_rows())
+        .map(|i| {
+            (
+                baseline_ids.value(i),
+                baseline_row_ids.value(i),
+                baseline_scores.value(i),
+            )
+        })
+        .collect();
+    assert_eq!(
+        baseline.iter().map(|(id, ..)| *id).collect::<HashSet<_>>(),
+        HashSet::from([0, 1, 2]),
+        "every row matches this query, so all three must be in the baseline"
+    );
+
+    let masked = |allowed: Vec<u64>| {
+        let dataset = dataset.clone();
+        async move {
+            let mut scan = dataset.scan();
+            scan.project(&["id"])
+                .unwrap()
+                .full_text_search(FullTextSearchQuery::new_query(combined_query(
+                    "alpha omega",
+                    Operator::Or,
+                )))
+                .unwrap()
+                .with_row_addr_prefilter(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(
+                    allowed,
+                )));
+            let batch = scan.try_into_batch().await.unwrap();
+            let ids = batch["id"].as_primitive::<Int32Type>();
+            let scores = batch["_score"].as_primitive::<Float32Type>();
+            (0..batch.num_rows())
+                .map(|i| (ids.value(i), scores.value(i)))
+                .collect::<Vec<_>>()
+        }
+    };
+
+    assert!(
+        masked(vec![]).await.is_empty(),
+        "an empty allow list must drop every combined_fields match"
+    );
+
+    // One row at a time, so both the indexed row (0) and the flat ones (1, 2) are
+    // each checked on their own.
+    for &(id, row_id, score) in &baseline {
+        let actual = masked(vec![row_id]).await;
+        assert_eq!(
+            actual.len(),
+            1,
+            "allowing only _rowid {row_id} must return exactly id {id}, got {actual:?}"
+        );
+        assert_eq!(actual[0].0, id);
+        assert!(
+            (actual[0].1 - score).abs() < 1e-3,
+            "masking must not move id {id}'s score: {} vs the unmasked {score}",
+            actual[0].1
+        );
+    }
+}
+
+/// Per-column index skew, over both row-id schemes.
+///
+/// The indexed scan is restricted to fragments every target column covers. That
+/// restriction has to be expressed in the same id space the index stores, and the
+/// inverted index trains with `_rowid` (`TrainingCriteria::with_row_id`), which is a
+/// logical stable id when the dataset uses stable row ids and a row address
+/// otherwise. A fragment-address block list therefore matches nothing under stable
+/// row ids, letting the indexed scan emit the very rows the flat scan also emits,
+/// the same duplicate-across-a-UNION failure `do_create_deletion_mask_row_id`
+/// documents for issue #6877.
+///
+/// `Operator::And` is checked here too: it decides matching across the virtual field
+/// as a whole, so a row whose terms are split between an indexed and a stale-indexed
+/// column must still be admitted, and the flat side has to evaluate the operator over
+/// the same blended `tf'` the indexed side does.
+#[rstest]
+#[case::or_row_addresses(false, Operator::Or)]
+#[case::or_stable_row_ids(true, Operator::Or)]
+#[case::and_row_addresses(false, Operator::And)]
+#[case::and_stable_row_ids(true, Operator::And)]
+#[tokio::test]
+async fn test_fts_combined_fields_per_column_index_skew(
+    #[case] stable_row_ids: bool,
+    #[case] operator: Operator,
+) {
+    // Columns indexed at different dataset versions: `title` covers every
+    // fragment, `body` only the first. A fragment indexed for some target columns
+    // but not others cannot be scored by the indexed scan at all, `dl'` sums each
+    // column's document length and a row missing from a column's DocSet
+    // contributes 0, so those fragments must be routed to the flat scan whole,
+    // not emitted with a partial `tf'`/`dl'`.
+    let params = combined_fields_test_params();
+    // Fragment 0 (rows 0-1) ends up indexed for both columns. Fragment 1 (rows
+    // 2-3) is indexed for `title` only: row 2 carries the term in `title`, which a
+    // partial score would rank wrongly, and row 3 carries it only in `body`, which
+    // a partial score would miss entirely.
+    let titles = vec!["aa bb", "cc", "aa aa", "dd"];
+    let bodies = vec!["cc dd", "aa bb", "dd", "aa bb bb"];
+    let write_params = |mode: WriteMode| WriteParams {
+        mode,
+        max_rows_per_file: 2,
+        enable_stable_row_ids: stable_row_ids,
+        ..Default::default()
+    };
+
+    let first = combined_fields_batch(
+        vec![0, 1],
+        vec![titles[0], titles[1]],
+        vec![bodies[0], bodies[1]],
+    );
+    let test_uri = TempStrDir::default();
+    let mut dataset =
+        write_fts_dataset(&test_uri, first, Some(write_params(WriteMode::Create))).await;
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+
+    let second = combined_fields_batch(
+        vec![2, 3],
+        vec![titles[2], titles[3]],
+        vec![bodies[2], bodies[3]],
+    );
+    let mut dataset =
+        write_fts_dataset(&test_uri, second, Some(write_params(WriteMode::Append))).await;
+    // Re-index `title` only, so the two columns disagree on fragment coverage.
+    create_inverted_indices(&mut dataset, &["title"], &params).await;
+    assert_eq!(
+        dataset.manifest.uses_stable_row_ids(),
+        stable_row_ids,
+        "row-id scheme precondition"
+    );
+
+    // Non-unit weights so `tf'`/`dl'` actually depend on `w_f` on the flat path.
+    // Two terms so `And` differs from `Or`: row 2 carries only "aa", so it drops out
+    // under `And` while every other matching row keeps both terms somewhere.
+    let weights = [3.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[(weights[0], titles.clone()), (weights[1], bodies.clone())],
+        "aa bb",
+        operator == Operator::And,
+    );
+    let expected_ids = brute_force_ids(&expected);
+
+    let actual = fts_result_id_scores(
+        &dataset,
+        combined_query_with_boosts("aa bb", operator, Some(weights.to_vec())),
+        None,
+    )
+    .await;
+    let actual_ids: HashSet<i32> = actual.iter().map(|(id, _)| *id).collect();
+    assert_eq!(
+        actual.len(),
+        expected_ids.len(),
+        "row emitted twice by both sides of the union: {actual:?}"
+    );
+    // Row 3 has "aa" only in `body`, whose index is missing fragment 1; an
+    // index-only plan cannot see it at all.
+    assert!(
+        actual_ids.contains(&3),
+        "row matching only through the column with stale index coverage was dropped: {actual_ids:?}"
+    );
+    assert_eq!(actual_ids, expected_ids);
+
+    // Rows 2 and 3 are scored by the flat side, which folds `body`'s missing
+    // fragment into the blended statistics, so it reaches the exact BM25F score.
+    // A partial `dl'` (missing `body`) would inflate row 2's score instead.
+    let scores: HashMap<i32, f32> = actual.into_iter().collect();
+    for id in [2, 3] {
+        match expected[id as usize] {
+            Some(want) => {
+                let got = scores[&id];
+                assert!(
+                    (got - want).abs() < 1e-3,
+                    "id {id} scored with partial cross-field data: scan={got}, brute force={want}"
+                );
+            }
+            None => assert!(
+                !scores.contains_key(&id),
+                "id {id} does not carry every term but {operator:?} returned it"
+            ),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_partially_indexed_columns() {
+    // Only `title` is indexed. Every fragment is then uncovered for `body`, so the
+    // whole scan takes the flat-only planner branch, with no index child at all. That
+    // branch is the only one that builds a `CombinedFieldColumn` with no segments,
+    // and the only one where a column contributes zero index statistics and its
+    // entire contribution comes from the flat scan.
+    let params = combined_fields_test_params();
+    let titles = vec!["aa bb", "cc", "aa aa", "dd"];
+    let bodies = vec!["cc dd", "aa bb", "dd", "aa bb bb"];
+    let batch = combined_fields_batch(vec![0, 1, 2, 3], titles.clone(), bodies.clone());
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(
+        &test_uri,
+        batch,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await;
+    create_inverted_indices(&mut dataset, &["title"], &params).await;
+
+    let weights = [2.0f32, 1.0f32];
+    let mut plan_scan = dataset.scan();
+    plan_scan
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query_with_boosts(
+            "aa",
+            Operator::Or,
+            Some(weights.to_vec()),
+        )))
+        .unwrap();
+    let plan = plan_scan.explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("FlatCombinedFields"),
+        "the flat-only branch must carry a flat child:\n{plan}"
+    );
+    assert!(
+        !plan.contains("CombinedFieldsQuery"),
+        "no fragment is covered for `body`, so nothing can be scored by an index \
+         child:\n{plan}"
+    );
+
+    let expected = brute_force_bm25f(
+        &[(weights[0], titles.clone()), (weights[1], bodies.clone())],
+        "aa",
+        false,
+    );
+    let actual = fts_result_id_scores(
+        &dataset,
+        combined_query_with_boosts("aa", Operator::Or, Some(weights.to_vec())),
+        None,
+    )
+    .await;
+    // The flat scan owns the entire corpus for `body` and reads `title` from its
+    // index, so the blended statistics are exact.
+    assert_matches_brute_force(
+        &actual,
+        &expected,
+        "the flat-only plan must score against the blend of its own corpus and \
+         `title`'s index",
+    );
+
+    // The flat exec emits in scan order and applies no limit, so this branch needs
+    // its own score sort: without one the rows come back unordered and `limit`
+    // truncates positionally instead of taking the top-k.
+    let scores: Vec<f32> = actual.iter().map(|(_, score)| *score).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] >= w[1]),
+        "flat-only plan is not score-ordered: {actual:?}"
+    );
+
+    let best = actual
+        .iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+        .map(|(id, _)| *id)
+        .unwrap();
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query_with_boosts(
+            "aa",
+            Operator::Or,
+            Some(weights.to_vec()),
+        )))
+        .unwrap()
+        .limit(Some(1), None)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let top = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<Int32Type>()
+        .values()
+        .to_vec();
+    assert_eq!(
+        top,
+        vec![best],
+        "limit=1 on the flat-only plan did not return the top-scoring row"
+    );
+}
+
+/// Every row scores identically, so the whole result is one tie and
+/// `(score DESC, row_id ASC)` fixes the answer completely: the top-5 is the five
+/// lowest row ids.
+///
+/// Both plan shapes are covered because they settle ties in different places, and
+/// only one of them has a sort at all:
+///
+/// - **mixed coverage** unions an indexed child with a flat scan, so ties would
+///   otherwise break by fragment arrival order. The plan's `row_id ASC` second
+///   sort key decides them.
+/// - **fully indexed** returns `CombinedFieldsQueryExec` directly with no
+///   `SortExec` above it, so nothing downstream can reorder or recover a row.
+///   `combined_fields_search`'s own `(score, row_id)` heap ordering has to be
+///   right, and its bounded heap must not evict a tied row that belongs in the
+///   top-k.
+///
+/// Without either, `limit`/`offset` pagination could skip and repeat rows.
+#[rstest]
+#[case::fully_indexed(true)]
+#[case::mixed_coverage(false)]
+#[tokio::test]
+async fn test_fts_combined_fields_tied_scores_are_deterministic(#[case] fully_indexed: bool) {
+    let rows = 24usize;
+    // Spread the rows over several fragments either way: on the mixed plan that
+    // makes the flat scan's arrival order genuinely nondeterministic, and on the
+    // fully indexed one it spreads the postings over several index partitions.
+    let (_test_uri, dataset) = if fully_indexed {
+        indexed_two_column_dataset(&vec!["aa"; rows], &vec!["aa"; rows], Some(3)).await
+    } else {
+        let (test_uri, _indexed) =
+            indexed_two_column_dataset(&["aa", "aa"], &["aa", "aa"], None).await;
+        let second = combined_fields_batch(
+            (2..rows as i32).collect(),
+            vec!["aa"; rows - 2],
+            vec!["aa"; rows - 2],
+        );
+        let dataset = append_fts_dataset(&test_uri, second, Some(3)).await;
+        (test_uri, dataset)
+    };
+
+    // The two shapes must really be the two shapes, or the fully indexed case
+    // silently gains a sort that would mask the heap's own ordering.
+    let mut plan_scan = dataset.scan();
+    plan_scan
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .limit(Some(5), None)
+        .unwrap();
+    let plan = plan_scan.explain_plan(true).await.unwrap();
+    assert_eq!(
+        plan.contains("FlatCombinedFields"),
+        !fully_indexed,
+        "wrong plan shape for fully_indexed={fully_indexed}:\n{plan}"
+    );
+    assert_eq!(
+        plan.contains("SortExec"),
+        !fully_indexed,
+        "fully indexed plan must settle ties in the search, not in a sort:\n{plan}"
+    );
+
+    // Rows were written in id order across fragments, so row-id order is id order.
+    // Asserting the five lowest ids pins the specification, rather than observing
+    // that repeated runs happen to agree.
+    let expected_top: Vec<i32> = (0..5).collect();
+    let mut seen = HashSet::new();
+    for _ in 0..8 {
+        let batch = dataset
+            .scan()
+            .project(&["id"])
+            .unwrap()
+            .full_text_search(FullTextSearchQuery::new_query(combined_query(
+                "aa",
+                Operator::Or,
+            )))
+            .unwrap()
+            .limit(Some(5), None)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .values()
+            .to_vec();
+        assert_eq!(
+            ids, expected_top,
+            "tied scores must break by ascending row id"
+        );
+        seen.insert(ids);
+    }
+    assert_eq!(
+        seen.len(),
+        1,
+        "top-k over tied scores is nondeterministic across runs: {seen:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_fts_combined_fields_fast_search_without_full_coverage_is_empty() {
     // `fast_search` is index-only. When a target column has no index at all no
@@ -862,6 +1382,44 @@ async fn test_fts_combined_fields_fast_search_without_full_coverage_is_empty() {
         .await
         .expect("fast_search without full coverage should be empty, not an error");
     assert_eq!(batch.num_rows(), 0);
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_unindexed_row_wins_topk() {
+    // The union applies the top-k limit after re-sorting both sides, so a row in an
+    // unindexed fragment must be able to take the single top slot. A plan that pushed
+    // the limit into the indexed side only would return the best row the index holds
+    // instead.
+    let titles = ["filler", "filler", "aa aa aa"];
+    let bodies = ["aa", "filler", "aa aa aa"];
+
+    let (test_uri, _indexed) = indexed_two_column_dataset(&titles[..2], &bodies[..2], None).await;
+
+    // Row 2 is the strongest match for "aa" but lands in an unindexed fragment.
+    let second = combined_fields_batch(vec![2], vec![titles[2]], vec![bodies[2]]);
+    let dataset = append_fts_dataset(&test_uri, second, None).await;
+
+    let batch = dataset
+        .scan()
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(combined_query(
+            "aa",
+            Operator::Or,
+        )))
+        .unwrap()
+        .limit(Some(1), None)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let ids = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<Int32Type>()
+        .values()
+        .to_vec();
+    assert_eq!(ids, vec![2], "top-1 was taken from the indexed side only");
 }
 
 #[tokio::test]
@@ -949,4 +1507,896 @@ async fn test_fts_combined_fields_requires_an_index() {
         message.contains("combined_fields") && message.contains("inverted index"),
         "unexpected error: {message}"
     );
+}
+
+/// Like [`combined_fields_batch`] but with optional text values, so a row can be
+/// NULL in one target column or in every one of them.
+fn nullable_combined_fields_batch(
+    ids: Vec<i32>,
+    titles: Vec<Option<&str>>,
+    bodies: Vec<Option<&str>>,
+) -> RecordBatch {
+    record_batch!(
+        ("id", Int32, ids),
+        ("title", Utf8, titles),
+        ("body", Utf8, bodies)
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_flat_nulls_and_empty_strings() {
+    // NULL / empty-string handling on the flat path, which has its own counting
+    // code: `count_column_into` leaves a row's slots at zero for a NULL,
+    // `tokenize_and_blend_multi` drops a row that is empty in all target columns,
+    // and `FlatFieldStats::fold_row` skips a column whose `dl_f == 0` so the row
+    // raises neither that column's `docCount_f` nor its `docFreq_f`. Unlike
+    // `test_fts_combined_fields_nulls`, which covers the fully-indexed path, this
+    // one also pins the exact scores, where a miscounted `docCount'` shows up.
+    let params = combined_fields_test_params();
+    // Rows 0-1 are indexed for both columns and carry no query term, so the indexed
+    // child emits nothing and every returned row comes from the flat scan, whose
+    // blended statistics must still fold in the indexed rows.
+    let titles = vec![
+        Some("zz zz"),
+        Some("zz"),
+        None,          // NULL in one column
+        Some("aa aa"), // paired with an empty string in the other column
+        None,          // NULL in every column: never scored
+        Some(""),      // empty in every column: never scored
+        Some("aa"),
+        None, // NULL in one column, and no query term anywhere
+    ];
+    let bodies = vec![
+        Some("zz"),
+        Some("zz zz"),
+        Some("aa"),
+        Some(""),
+        None,
+        Some(""),
+        Some("aa zz"),
+        Some("zz"),
+    ];
+
+    let first =
+        nullable_combined_fields_batch(vec![0, 1], titles[..2].to_vec(), bodies[..2].to_vec());
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, first, None).await;
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+
+    // Spread the appended rows over several fragments, one of which holds only
+    // rows that tokenize to nothing at all.
+    let second = nullable_combined_fields_batch(
+        (2..titles.len() as i32).collect(),
+        titles[2..].to_vec(),
+        bodies[2..].to_vec(),
+    );
+    let dataset = append_fts_dataset(&test_uri, second, Some(2)).await;
+
+    // A NULL and an empty string both tokenize to nothing, so the reference models
+    // either as `""`.
+    fn as_text<'a>(values: &[Option<&'a str>]) -> Vec<&'a str> {
+        values.iter().map(|v| v.unwrap_or("")).collect()
+    }
+    let weights = [2.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[
+            (weights[0], as_text(&titles)),
+            (weights[1], as_text(&bodies)),
+        ],
+        "aa",
+        false,
+    );
+    assert_eq!(
+        brute_force_ids(&expected),
+        HashSet::from([2, 3, 6]),
+        "reference corpus changed; the null rows must stay unmatched"
+    );
+
+    let actual = fts_result_id_scores(
+        &dataset,
+        combined_query_with_boosts("aa", Operator::Or, Some(weights.to_vec())),
+        None,
+    )
+    .await;
+    assert_matches_brute_force(
+        &actual,
+        &expected,
+        "a row empty in every target column must not be scored, and docCount' must \
+         count only rows with tokens in that column",
+    );
+}
+
+/// An `id` + `tags` (a list of strings) + `body` batch, for the list-valued target
+/// column cases. `ListOffset` picks `List` vs `LargeList` and `StringOffset` picks
+/// `Utf8` vs `LargeUtf8`, both for the list elements and for `body`. A `None` entry
+/// in `tags` is a NULL list, an empty `Vec` an empty one.
+fn list_column_batch<
+    ListOffset: arrow::array::OffsetSizeTrait,
+    StringOffset: arrow::array::OffsetSizeTrait,
+>(
+    ids: &[i32],
+    tags: &[Option<Vec<&str>>],
+    bodies: &[&str],
+) -> RecordBatch {
+    let mut builder =
+        GenericListBuilder::<ListOffset, _>::new(GenericStringBuilder::<StringOffset>::new());
+    for row in tags {
+        match row {
+            Some(elements) => {
+                for element in elements {
+                    builder.values().append_value(element);
+                }
+                builder.append(true);
+            }
+            None => builder.append(false),
+        }
+    }
+    let tags_col = Arc::new(builder.finish()) as ArrayRef;
+    let bodies_col =
+        Arc::new(GenericStringArray::<StringOffset>::from(bodies.to_vec())) as ArrayRef;
+    RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("tags", tags_col.data_type().clone(), true),
+            ArrowField::new("body", bodies_col.data_type().clone(), false),
+        ])),
+        vec![
+            Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
+            tags_col,
+            bodies_col,
+        ],
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_flat_list_column() {
+    assert_combined_fields_flat_list_column::<i32, i32>().await;
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_flat_large_list_column() {
+    assert_combined_fields_flat_list_column::<i64, i64>().await;
+}
+
+/// The flat scan must reduce a list column to a row's document text the same way
+/// the index builder does, which is to join the elements with a space.
+///
+/// Under `simple` the two readings agree, because counting each element on its own
+/// yields the same tokens as counting them joined; only a tokenizer that is
+/// sensitive to the element boundary can tell them apart. `raw` emits one token
+/// per document, so a 2-element list is `dl_f = 1` when joined and `dl_f = 2` when
+/// counted per element.
+///
+/// Scoring the same rows once through each side pins the agreement down without a
+/// hand-computed reference: with `tags` indexed the statistics come from the
+/// index, and with only `body` indexed they come from the flat fold instead.
+#[tokio::test]
+async fn test_fts_combined_fields_flat_list_matches_index_under_raw_tokenizer() {
+    let params = InvertedIndexParams::new("raw".to_string(), Language::English)
+        .lower_case(false)
+        .stem(false)
+        .remove_stop_words(false);
+
+    // Row 1 is the discriminator: joined, its tags are the single token
+    // "alpha beta gamma", which does not match, but counted per element it holds
+    // the token "alpha beta", which does. Rows 0 and 2 match either way and pin
+    // down the scores.
+    let tags: Vec<Option<Vec<&str>>> = vec![
+        Some(vec!["alpha beta"]),
+        Some(vec!["alpha beta", "gamma"]),
+        Some(vec!["gamma", "delta"]),
+    ];
+    let bodies = vec!["alpha beta", "gamma", "alpha beta"];
+
+    let build = |indexed_columns: &'static [&'static str]| {
+        let params = params.clone();
+        let tags = tags.clone();
+        let bodies = bodies.clone();
+        async move {
+            let batch = list_column_batch::<i32, i32>(
+                &(0..tags.len() as i32).collect::<Vec<_>>(),
+                &tags,
+                &bodies,
+            );
+            let test_uri = TempStrDir::default();
+            let mut dataset = write_fts_dataset(&test_uri, batch, None).await;
+            create_inverted_indices(&mut dataset, indexed_columns, &params).await;
+            let scored = fts_result_id_scores(
+                &dataset,
+                combined_query_over(&["tags", "body"], "alpha beta", Operator::Or, None),
+                None,
+            )
+            .await;
+            // Keep the temporary directory alive until the scan has finished.
+            drop(test_uri);
+            scored
+        }
+    };
+
+    // `tags` indexed: its statistics and per-row lengths come from the index.
+    let indexed = build(&["tags", "body"]).await;
+    // `tags` unindexed: every fragment is uncovered for it, so the flat scan reads
+    // the raw list and folds its own statistics in.
+    let flat = build(&["body"]).await;
+
+    assert_eq!(
+        indexed.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        vec![0, 2],
+        "row 1 only matches when its tag elements are counted separately"
+    );
+    assert_eq!(
+        indexed.len(),
+        flat.len(),
+        "flat={flat:?} indexed={indexed:?}"
+    );
+    for ((indexed_id, indexed_score), (flat_id, flat_score)) in indexed.iter().zip(&flat) {
+        assert_eq!(indexed_id, flat_id, "flat={flat:?} indexed={indexed:?}");
+        assert!(
+            (indexed_score - flat_score).abs() < 1e-5,
+            "id {indexed_id}: indexed={indexed_score}, flat={flat_score}; the flat scan must \
+             join a row's list elements the way the index builder does"
+        );
+    }
+}
+
+/// A list-valued target column on the flat path: the scan reduces the list to the
+/// row's document text and counts it as one document, so every element lands in
+/// the row's single `dl_f`/`tf_f`.
+async fn assert_combined_fields_flat_list_column<
+    ListOffset: arrow::array::OffsetSizeTrait,
+    StringOffset: arrow::array::OffsetSizeTrait,
+>() {
+    let params = combined_fields_test_params();
+    // `tags` is the list column. Row 2 spreads one term over two elements of
+    // differing length and row 3 repeats the term in two elements, so a reader that
+    // took only the first element, or treated each element as its own document,
+    // lands on a different `dl_f`/`tf_f` and a different score.
+    let tags: Vec<Option<Vec<&str>>> = vec![
+        Some(vec!["zz"]),
+        Some(vec!["zz", "zz"]),
+        Some(vec!["aa", "bb cc"]),
+        Some(vec!["aa", "aa"]),
+        None,         // NULL list
+        Some(vec![]), // empty list
+        Some(vec!["zz"]),
+    ];
+    let bodies = vec!["zz", "zz zz", "zz", "zz zz", "aa", "aa aa", "zz"];
+
+    // Rows 0-1 are indexed for both columns and match nothing, so every returned
+    // row is scored by the flat scan.
+    let first = list_column_batch::<ListOffset, StringOffset>(&[0, 1], &tags[..2], &bodies[..2]);
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, first, None).await;
+    create_inverted_indices(&mut dataset, &["tags", "body"], &params).await;
+
+    let second = list_column_batch::<ListOffset, StringOffset>(
+        &(2..tags.len() as i32).collect::<Vec<_>>(),
+        &tags[2..],
+        &bodies[2..],
+    );
+    let dataset = append_fts_dataset(&test_uri, second, Some(2)).await;
+
+    // The index joins list elements with a space before tokenizing, so the
+    // reference sees the same token counts either way.
+    let flattened: Vec<String> = tags
+        .iter()
+        .map(|row| row.as_ref().map(|e| e.join(" ")).unwrap_or_default())
+        .collect();
+    let weights = [2.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[
+            (weights[0], flattened.iter().map(|s| s.as_str()).collect()),
+            (weights[1], bodies.clone()),
+        ],
+        "aa",
+        false,
+    );
+    assert_eq!(brute_force_ids(&expected), HashSet::from([2, 3, 4, 5]));
+
+    let actual = fts_result_id_scores(
+        &dataset,
+        combined_query_over(
+            &["tags", "body"],
+            "aa",
+            Operator::Or,
+            Some(weights.to_vec()),
+        ),
+        None,
+    )
+    .await;
+    assert_matches_brute_force(
+        &actual,
+        &expected,
+        "a row's list elements must sum into one dl_f",
+    );
+}
+
+/// A target column reached through a list (`List<Struct<Utf8>>`) is a shape a Lance
+/// projection cannot address by its public path, so the flat side scans the list
+/// root and walks down to the leaf itself.
+#[tokio::test]
+async fn test_fts_combined_fields_column_under_a_list() {
+    let params = combined_fields_test_params();
+    // Rows 0-1 are indexed and match "aa" nowhere, so every "aa" hit comes from
+    // the flat side and its score is the exact blended BM25F. Row 2 spreads the
+    // term over two struct elements and row 4 pairs an empty list with a matching
+    // title, so a reader that stopped at the first element, treated each element
+    // as its own document, or skipped empty lists lands on a different score.
+    let docs: Vec<Vec<&str>> = vec![
+        vec!["zz"],
+        vec!["zz zz"],
+        vec!["aa", "bb aa"],
+        vec!["aa aa"],
+        vec![],
+    ];
+    let titles = vec!["zz", "zz", "zz", "aa", "aa aa"];
+
+    let nested_batch = |ids: &[i32], docs: &[Vec<&str>], titles: &[&str]| {
+        let content_field = Arc::new(ArrowField::new("content", DataType::Utf8, true));
+        let struct_fields = ArrowFields::from(vec![content_field]);
+        let contents = docs.iter().flatten().copied().collect::<Vec<_>>();
+        let struct_values = StructArray::new(
+            struct_fields.clone(),
+            vec![Arc::new(StringArray::from(contents)) as ArrayRef],
+            None,
+        );
+        let item = Arc::new(ArrowField::new(
+            "item",
+            DataType::Struct(struct_fields),
+            true,
+        ));
+        let mut offsets = Vec::with_capacity(docs.len() + 1);
+        offsets.push(0i32);
+        for row in docs {
+            offsets.push(offsets.last().unwrap() + row.len() as i32);
+        }
+        let docs_col = Arc::new(ListArray::new(
+            item,
+            OffsetBuffer::new(ScalarBuffer::from(offsets)),
+            Arc::new(struct_values),
+            None,
+        )) as ArrayRef;
+        RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                ArrowField::new("id", DataType::Int32, false),
+                ArrowField::new("docs", docs_col.data_type().clone(), true),
+                ArrowField::new("title", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
+                docs_col,
+                Arc::new(StringArray::from(titles.to_vec())) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    };
+
+    let first = nested_batch(&[0, 1], &docs[..2], &titles[..2]);
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, first, None).await;
+    create_inverted_indices(&mut dataset, &["docs.content", "title"], &params).await;
+
+    let weights = [2.0f32, 1.0f32];
+    // The index joins a row's list elements with a space before tokenizing, so the
+    // reference counts the same tokens either way.
+    let joined: Vec<String> = docs.iter().map(|row| row.join(" ")).collect();
+    let assert_scored_like_reference = |dataset: Dataset, terms: &'static str, rows: usize| {
+        let joined = joined.clone();
+        let titles = titles.clone();
+        async move {
+            let expected = brute_force_bm25f(
+                &[
+                    (
+                        weights[0],
+                        joined[..rows].iter().map(|s| s.as_str()).collect(),
+                    ),
+                    (weights[1], titles[..rows].to_vec()),
+                ],
+                terms,
+                false,
+            );
+            assert!(
+                !brute_force_ids(&expected).is_empty(),
+                "the reference must match something"
+            );
+            let actual = fts_result_id_scores(
+                &dataset,
+                combined_query_over(
+                    &["docs.content", "title"],
+                    terms,
+                    Operator::Or,
+                    Some(weights.to_vec()),
+                ),
+                None,
+            )
+            .await;
+            assert_matches_brute_force(
+                &actual,
+                &expected,
+                "a target column reached through a list must be walked down to its leaf",
+            );
+        }
+    };
+
+    // Fully indexed, so the indexed child owns every hit.
+    assert_scored_like_reference(dataset.clone(), "zz", 2).await;
+
+    // Appending fragments no index covers routes the new rows to the flat sibling,
+    // which has to reach `docs.content` without projecting it.
+    let second = nested_batch(
+        &(2..docs.len() as i32).collect::<Vec<_>>(),
+        &docs[2..],
+        &titles[2..],
+    );
+    let dataset = append_fts_dataset(&test_uri, second, Some(2)).await;
+
+    assert_scored_like_reference(dataset, "aa", docs.len()).await;
+}
+
+/// A `title`/`body`/`tags` batch, for the three-column stride case.
+fn three_column_batch(
+    ids: Vec<i32>,
+    titles: Vec<&str>,
+    bodies: Vec<&str>,
+    tags: Vec<&str>,
+) -> RecordBatch {
+    record_batch!(
+        ("id", Int32, ids),
+        ("title", Utf8, titles),
+        ("body", Utf8, bodies),
+        ("tags", Utf8, tags)
+    )
+    .unwrap()
+}
+
+/// Three columns and two terms, with distinct per-column weights.
+///
+/// Every per-row count is addressed as `(row * num_columns + column) * num_terms +
+/// term`. With two columns and two terms that stride is symmetric enough for a
+/// transposition to survive. The corpus places each term in a different column per
+/// row, so swapping the column and term strides permutes `tf'` and changes the
+/// scores.
+///
+/// Both cases share one corpus and one expected answer: the `flat_side` case only
+/// moves where the rows are scored, which also asserts that the flat scan
+/// reproduces the fully-indexed scores exactly.
+#[rstest]
+#[case::fully_indexed(false)]
+#[case::flat_side(true)]
+#[tokio::test]
+async fn test_fts_combined_fields_three_columns_two_terms(#[case] append_unindexed: bool) {
+    let params = combined_fields_test_params();
+    // Rows 0-1 carry no query term, so they are never returned and the `flat_side`
+    // case can be compared against the same exact scores as the indexed one.
+    let titles = vec!["zz", "zz zz", "aa", "bb bb", "zz", "aa aa"];
+    let bodies = vec!["zz zz", "zz", "bb", "zz", "aa bb", "zz zz"];
+    let tags = vec!["zz", "zz zz", "zz", "aa", "bb", "aa bb"];
+    let columns = ["title", "body", "tags"];
+    let weights = [3.0f32, 2.0f32, 1.0f32];
+
+    let test_uri = TempStrDir::default();
+    let write_params = |mode: WriteMode| WriteParams {
+        mode,
+        max_rows_per_file: 2,
+        ..Default::default()
+    };
+    let indexed_rows = if append_unindexed { 2 } else { titles.len() };
+    let first = three_column_batch(
+        (0..indexed_rows as i32).collect(),
+        titles[..indexed_rows].to_vec(),
+        bodies[..indexed_rows].to_vec(),
+        tags[..indexed_rows].to_vec(),
+    );
+    let mut dataset =
+        write_fts_dataset(&test_uri, first, Some(write_params(WriteMode::Create))).await;
+    create_inverted_indices(&mut dataset, &columns, &params).await;
+
+    let dataset = if append_unindexed {
+        let second = three_column_batch(
+            (indexed_rows as i32..titles.len() as i32).collect(),
+            titles[indexed_rows..].to_vec(),
+            bodies[indexed_rows..].to_vec(),
+            tags[indexed_rows..].to_vec(),
+        );
+        write_fts_dataset(&test_uri, second, Some(write_params(WriteMode::Append))).await
+    } else {
+        dataset
+    };
+
+    for operator in [Operator::Or, Operator::And] {
+        let expected = brute_force_bm25f(
+            &[
+                (weights[0], titles.clone()),
+                (weights[1], bodies.clone()),
+                (weights[2], tags.clone()),
+            ],
+            "aa bb",
+            operator == Operator::And,
+        );
+        assert_eq!(
+            brute_force_ids(&expected),
+            HashSet::from([2, 3, 4, 5]),
+            "reference corpus changed; rows 0-1 must stay unmatched"
+        );
+
+        let actual = fts_result_id_scores(
+            &dataset,
+            combined_query_over(&columns, "aa bb", operator, Some(weights.to_vec())),
+            None,
+        )
+        .await;
+        assert_matches_brute_force(
+            &actual,
+            &expected,
+            &format!("op={operator:?}: the three-column, two-term stride must not transpose"),
+        );
+    }
+}
+
+/// A `combined_fields` query with a filter, over a mixed-coverage dataset.
+///
+/// `plan_flat_combined_fields_query` threads the filter plan into
+/// `filtered_read(is_prefilter=true)`. When the filter needs a refine expression it
+/// also extends the scan projection with that expression's columns and wraps the
+/// read in a `LanceFilterExec`, which means the document columns no longer sit at
+/// the positions the query lists them in, so `doc_col_indices` has to resolve them
+/// by name.
+///
+/// Both cases filter to the same rows through different plan shapes: `id >= 4`
+/// resolves entirely through the scalar index (no refine), while `category` has no
+/// index so the whole predicate becomes a refine expression.
+#[rstest]
+#[case::scalar_index_prefilter("id >= 4", true)]
+#[case::refine_expression("category = 'keep'", false)]
+#[tokio::test]
+async fn test_fts_combined_fields_with_filter(
+    #[case] filter: &str,
+    #[case] index_filter_column: bool,
+) {
+    let params = combined_fields_test_params();
+    // Rows 0-1 are indexed for both text columns and match nothing, so every
+    // returned row comes from the flat side and its score can be checked exactly.
+    // Rows 2-3 match but are filtered out, so they contribute no corpus statistics
+    // either: the flat scan never sees them.
+    let titles = vec!["zz zz", "zz", "aa", "zz", "aa aa", "zz"];
+    let bodies = vec!["zz", "zz zz", "zz", "aa aa", "zz", "aa"];
+    let categories = ["keep", "keep", "drop", "drop", "keep", "keep"];
+    // `category` is placed ahead of the document columns, so the refine expression
+    // pulling it into the projection shifts their positions.
+    let batch = |ids: Vec<i32>, rows: std::ops::Range<usize>| {
+        record_batch!(
+            ("id", Int32, ids),
+            ("category", Utf8, categories[rows.clone()].to_vec()),
+            ("title", Utf8, titles[rows.clone()].to_vec()),
+            ("body", Utf8, bodies[rows].to_vec())
+        )
+        .unwrap()
+    };
+
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, batch(vec![0, 1], 0..2), None).await;
+    create_inverted_indices(&mut dataset, &["title", "body"], &params).await;
+    if index_filter_column {
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::BTree,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+    }
+
+    let dataset = append_fts_dataset(&test_uri, batch((2..6).collect(), 2..6), Some(2)).await;
+
+    // The corpus the scan can see: every row of the indexed fragment (the index
+    // statistics are not filtered) plus only the flat rows that survive the filter.
+    let stats_rows = [0usize, 1, 4, 5];
+    let pick = |values: &[&'static str]| {
+        stats_rows
+            .iter()
+            .map(|&row| values[row])
+            .collect::<Vec<_>>()
+    };
+    let weights = [2.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[(weights[0], pick(&titles)), (weights[1], pick(&bodies))],
+        "aa",
+        false,
+    );
+    let expected_scores: HashMap<i32, f32> = stats_rows
+        .iter()
+        .enumerate()
+        .filter_map(|(slot, &row)| expected[slot].map(|score| (row as i32, score)))
+        .collect();
+    assert_eq!(
+        expected_scores.keys().copied().collect::<HashSet<_>>(),
+        HashSet::from([4, 5]),
+        "reference corpus changed; only the kept rows may match"
+    );
+
+    let mut scan = dataset.scan();
+    scan.project(&["id"])
+        .unwrap()
+        .prefilter(true)
+        .full_text_search(FullTextSearchQuery::new_query(combined_query_with_boosts(
+            "aa",
+            Operator::Or,
+            Some(weights.to_vec()),
+        )))
+        .unwrap()
+        .filter(filter)
+        .unwrap();
+    let plan = scan.explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("FlatCombinedFields"),
+        "filtered plan lost its flat child:\n{plan}"
+    );
+    // Confirm the two cases really took the two different branches, rather than
+    // both landing on the same one.
+    if index_filter_column {
+        assert!(
+            plan.contains("ScalarIndexQuery") && plan.contains("refine_filter=--"),
+            "expected the filter to resolve entirely through the scalar index:\n{plan}"
+        );
+        assert!(
+            !plan.contains("category"),
+            "no refine expression, so `category` must stay out of the projection:\n{plan}"
+        );
+    } else {
+        assert!(
+            plan.contains("refine_filter=category") && plan.contains("FilterExec"),
+            "expected the filter to become a refine expression:\n{plan}"
+        );
+        assert!(
+            plan.contains("projection=[category, title, body]"),
+            "the refine expression's column must be added to the flat scan \
+             projection:\n{plan}"
+        );
+    }
+
+    let scan_batch = scan.try_into_batch().await.unwrap();
+    let ids = scan_batch
+        .column_by_name("id")
+        .unwrap()
+        .as_primitive::<Int32Type>();
+    let scores = scan_batch
+        .column_by_name("_score")
+        .unwrap()
+        .as_primitive::<Float32Type>();
+    let actual: Vec<(i32, f32)> = (0..scan_batch.num_rows())
+        .map(|i| (ids.value(i), scores.value(i)))
+        .collect();
+
+    assert_eq!(
+        actual.len(),
+        expected_scores.len(),
+        "filter did not restrict the result set:\n{plan}\n{actual:?}"
+    );
+    for (id, score) in actual {
+        let want = *expected_scores
+            .get(&id)
+            .unwrap_or_else(|| panic!("filtered-out row {id} was returned:\n{plan}"));
+        assert!(
+            (score - want).abs() < 1e-3,
+            "id {id}: scan={score}, brute force={want}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_deletions_then_optimize() {
+    // Deleted rows must disappear from both sides of the union: the indexed child
+    // sees them through the restricted deletion mask, and the flat child through
+    // its filtered read. The surviving scores must then be unchanged by
+    // `optimize_indices`, because folding a fragment's flat statistics in has to
+    // produce exactly the totals that indexing it produces.
+    let titles = vec!["aa", "aa aa", "zz", "aa aa aa", "aa", "zz zz"];
+    let bodies = vec!["zz", "zz", "aa aa", "zz", "aa aa", "aa"];
+
+    let (test_uri, _indexed) = indexed_two_column_dataset(&titles[..3], &bodies[..3], None).await;
+    let second = combined_fields_batch(vec![3, 4, 5], titles[3..].to_vec(), bodies[3..].to_vec());
+    let mut dataset = append_fts_dataset(&test_uri, second, None).await;
+
+    // One deletion in the indexed fragment, one in the appended (flat) fragment.
+    dataset.delete("id in (1, 4)").await.unwrap();
+
+    // Row 1 stays in the index's own statistics, because a delete does not rewrite
+    // the `DocSet`, while row 4 never reaches the flat counter, so it drops out of
+    // the corpus entirely.
+    let stats_rows = [0usize, 1, 2, 3, 5];
+    let pick = |values: &[&'static str]| {
+        stats_rows
+            .iter()
+            .map(|&row| values[row])
+            .collect::<Vec<_>>()
+    };
+    let weights = [2.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[(weights[0], pick(&titles)), (weights[1], pick(&bodies))],
+        "aa",
+        false,
+    );
+    let expected_scores: HashMap<i32, f32> = stats_rows
+        .iter()
+        .enumerate()
+        .filter_map(|(slot, &row)| expected[slot].map(|score| (row as i32, score)))
+        .collect();
+
+    let query = || combined_query_with_boosts("aa", Operator::Or, Some(weights.to_vec()));
+    let live_ids = HashSet::from([0, 2, 3, 5]);
+    let mut scan = dataset.scan();
+    scan.project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query()))
+        .unwrap();
+    let mixed_plan = scan.explain_plan(true).await.unwrap();
+    assert!(
+        mixed_plan.contains("FlatCombinedFields"),
+        "the appended fragment is unindexed, so the plan must have a flat child:\n{mixed_plan}"
+    );
+
+    let mixed = fts_result_id_scores(&dataset, query(), None).await;
+    assert_eq!(
+        mixed.iter().map(|(id, _)| *id).collect::<HashSet<_>>(),
+        live_ids,
+        "deleted rows leaked into the mixed index/flat plan: {mixed:?}"
+    );
+    assert_eq!(mixed.len(), live_ids.len(), "duplicate row: {mixed:?}");
+    // Rows 3 and 5 are the ones the flat child scores, so they see the blended
+    // statistics in full. Rows 0 and 2 come from the indexed child, which still
+    // scores against index-only statistics (a known gap documented at the union).
+    let mixed_scores: HashMap<i32, f32> = mixed.into_iter().collect();
+    for id in [3, 5] {
+        let want = expected_scores[&id];
+        let got = mixed_scores[&id];
+        assert!(
+            (got - want).abs() < 1e-3,
+            "id {id} after delete: scan={got}, brute force={want}"
+        );
+    }
+
+    // Indexing the appended fragment must leave those scores untouched, and the
+    // plan must collapse back to a single indexed scan.
+    dataset
+        .optimize_indices(&OptimizeOptions::default())
+        .await
+        .unwrap();
+    let mut scan = dataset.scan();
+    scan.project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query()))
+        .unwrap();
+    let plan = scan.explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("CombinedFieldsQuery"),
+        "expected an indexed combined-fields scan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("FlatCombinedFields"),
+        "every fragment is indexed but the plan still has a flat child:\n{plan}"
+    );
+
+    let optimized = fts_result_id_scores(&dataset, query(), None).await;
+    assert_eq!(
+        optimized.iter().map(|(id, _)| *id).collect::<HashSet<_>>(),
+        live_ids,
+        "deleted rows came back after optimize: {optimized:?}"
+    );
+    // Now that every row is indexed there is a single corpus, so every score has to
+    // match the reference, including the rows the mixed plan scored from the index
+    // only.
+    for (id, score) in optimized {
+        let want = expected_scores[&id];
+        assert!(
+            (score - want).abs() < 1e-3,
+            "id {id} after optimize: scan={score}, brute force={want}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fts_combined_fields_nested_columns() {
+    // Nested target columns: the flat plan projects the struct column from storage,
+    // so it calls `ensure_column_alias` once per target column to expose `s.a` and
+    // `s.b` as top-level names the exec can resolve. Both aliases survive only
+    // because one projection is nested inside the other.
+    let params = combined_fields_test_params();
+    let a_values = [
+        Some("zz zz"),
+        Some("zz"),
+        Some("aa"),
+        Some("zz"),
+        Some("aa aa"),
+    ];
+    let b_values = [
+        Some("zz"),
+        Some("zz zz"),
+        Some("zz"),
+        Some("aa aa"),
+        Some("aa"),
+    ];
+
+    let first = nested_fts_batch(vec![0, 1], a_values[..2].to_vec(), b_values[..2].to_vec());
+    let test_uri = TempStrDir::default();
+    let mut dataset = write_fts_dataset(&test_uri, first, None).await;
+    create_inverted_indices(&mut dataset, &["s.a", "s.b"], &params).await;
+    // Rows 0-1 are indexed and match nothing, so the appended rows are the ones
+    // returned and the flat path owns every score.
+    let second = nested_fts_batch(
+        vec![2, 3, 4],
+        a_values[2..].to_vec(),
+        b_values[2..].to_vec(),
+    );
+    let schema = second.schema();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![second].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let weights = [2.0f32, 1.0f32];
+    let expected = brute_force_bm25f(
+        &[
+            (
+                weights[0],
+                a_values.iter().map(|v| v.unwrap_or("")).collect(),
+            ),
+            (
+                weights[1],
+                b_values.iter().map(|v| v.unwrap_or("")).collect(),
+            ),
+        ],
+        "aa",
+        false,
+    );
+    let expected_ids: HashSet<u64> = (0..expected.len())
+        .filter(|&i| expected[i].is_some())
+        .map(|i| i as u64)
+        .collect();
+    assert_eq!(expected_ids, HashSet::from([2, 3, 4]));
+
+    let mut scan = dataset.scan();
+    scan.full_text_search(FullTextSearchQuery::new_query(combined_query_over(
+        &["s.a", "s.b"],
+        "aa",
+        Operator::Or,
+        Some(weights.to_vec()),
+    )))
+    .unwrap();
+    let plan = scan.explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("FlatCombinedFields"),
+        "the appended fragment is unindexed, so the nested columns must be aliased \
+         for a flat child:\n{plan}"
+    );
+
+    let batch = scan.try_into_batch().await.unwrap();
+    let ids = batch["id"].as_primitive::<UInt64Type>();
+    let scores = batch["_score"].as_primitive::<Float32Type>();
+    let actual: Vec<(u64, f32)> = (0..batch.num_rows())
+        .map(|i| (ids.value(i), scores.value(i)))
+        .collect();
+    assert_eq!(
+        actual.len(),
+        expected_ids.len(),
+        "duplicate row: {actual:?}"
+    );
+    assert_eq!(
+        actual.iter().map(|(id, _)| *id).collect::<HashSet<_>>(),
+        expected_ids
+    );
+    for (id, score) in actual {
+        let want = expected[id as usize].expect("scan returned an unmatched doc");
+        assert!(
+            (score - want).abs() < 1e-3,
+            "id {id}: scan={score}, brute force={want}"
+        );
+    }
 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -62,7 +62,7 @@ use datafusion::common::{assert_contains, assert_not_contains};
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_arrow::json::ARROW_JSON_EXT_NAME;
-use lance_index::scalar::inverted::query::{FtsQuery, MultiMatchQuery};
+use lance_index::scalar::inverted::query::{CombinedFieldsQuery, FtsQuery, MultiMatchQuery};
 use lance_table::format::BasePath;
 use lance_testing::datagen::generate_random_array;
 use rand::Rng;
@@ -1285,8 +1285,69 @@ async fn create_fragmented_fts_index_with_groups(
     assert_eq!(segments.len(), expected_segments);
 }
 
+/// Three fragments over two indexed text columns, each column indexed as one
+/// segment per fragment.
+///
+/// Rows 3 and 4 carry the same text in both columns, so any query that scores
+/// them symmetrically produces an exact score tie and exposes tie ordering.
+async fn compound_fts_dataset() -> Dataset {
+    let batch = arrow_array::record_batch!(
+        (
+            "title",
+            Utf8,
+            [
+                "common",
+                "common filler filler filler filler filler filler filler",
+                "irrelevant",
+                "common tie",
+                "common tie",
+                "irrelevant"
+            ]
+        ),
+        (
+            "body",
+            Utf8,
+            [
+                "penalty",
+                "special",
+                "common",
+                "neutral",
+                "neutral",
+                "common filler filler filler penalty"
+            ]
+        )
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 3);
+    create_fragmented_fts_index(&mut dataset, "title", false).await;
+    create_fragmented_fts_index(&mut dataset, "body", false).await;
+    dataset
+}
+
 fn compound_multimatch_query() -> FtsQuery {
     MultiMatchQuery::try_new(
+        "common".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .try_with_boosts(vec![10.0, 1.0])
+    .unwrap()
+    .into()
+}
+
+fn compound_combined_fields_query() -> FtsQuery {
+    CombinedFieldsQuery::try_new(
         "common".to_owned(),
         vec!["title".to_owned(), "body".to_owned()],
     )
@@ -3213,47 +3274,7 @@ async fn test_boolean_must_scores_sum_across_execution_paths() {
 
 #[tokio::test]
 async fn test_nested_multimatch_limit_propagation() {
-    let batch = arrow_array::record_batch!(
-        (
-            "title",
-            Utf8,
-            [
-                "common",
-                "common filler filler filler filler filler filler filler",
-                "irrelevant",
-                "common tie",
-                "common tie",
-                "irrelevant"
-            ]
-        ),
-        (
-            "body",
-            Utf8,
-            [
-                "penalty",
-                "special",
-                "common",
-                "neutral",
-                "neutral",
-                "common filler filler filler penalty"
-            ]
-        )
-    )
-    .unwrap();
-    let schema = batch.schema();
-    let mut dataset = Dataset::write(
-        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
-        "memory://",
-        Some(WriteParams {
-            max_rows_per_file: 2,
-            ..Default::default()
-        }),
-    )
-    .await
-    .unwrap();
-    assert_eq!(dataset.get_fragments().len(), 3);
-    create_fragmented_fts_index(&mut dataset, "title", false).await;
-    create_fragmented_fts_index(&mut dataset, "body", false).await;
+    let dataset = compound_fts_dataset().await;
 
     let must_query: FtsQuery = BooleanQuery::new([
         (Occur::Must, compound_multimatch_query()),
@@ -3333,6 +3354,54 @@ async fn test_nested_multimatch_limit_propagation() {
         1,
     )
     .await;
+}
+
+/// `combined_fields` is planned recursively like every other FTS node, so it owes
+/// a compound parent the same contract a nested `MultiMatch` does (see
+/// `test_nested_multimatch_limit_propagation`): `FtsSearchParams::limit` decides
+/// completeness, and the ambient scanner limit must not reach the child. A child
+/// that applied the scanner limit itself would drop candidates before the parent
+/// finished composing scores.
+#[tokio::test]
+async fn test_nested_combined_fields_limit_propagation() {
+    let dataset = compound_fts_dataset().await;
+
+    let must_query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_combined_fields_query()),
+        (
+            Occur::Should,
+            compound_match_query("special", "body", 100.0),
+        ),
+    ])
+    .into();
+    let must_results = compound_fts_results(&dataset, must_query.clone(), None).await;
+    assert!(
+        must_results
+            .windows(2)
+            .any(|rows| rows[0].1 == rows[1].1 && rows[0].0 < rows[1].0),
+        "the exhaustive result should include a deterministic score tie"
+    );
+    assert_compound_fts_top_k(&dataset, must_query, 2).await;
+
+    let should_query: FtsQuery = BooleanQuery::new([
+        (Occur::Should, compound_combined_fields_query()),
+        (
+            Occur::Should,
+            compound_match_query("special", "body", 100.0),
+        ),
+    ])
+    .into();
+    assert_compound_fts_top_k(&dataset, should_query, 2).await;
+
+    let boost_query: FtsQuery = BoostQuery::new(
+        compound_combined_fields_query(),
+        compound_match_query("penalty", "body", 100.0),
+        Some(1.0),
+    )
+    .into();
+    assert_compound_fts_top_k(&dataset, boost_query, 2).await;
+
+    assert_compound_fts_top_k(&dataset, compound_combined_fields_query(), 1).await;
 }
 
 #[tokio::test]
@@ -3608,7 +3677,7 @@ async fn test_compound_tie_uses_resolved_row_id() {
     assert_eq!(exhaustive.len(), 384);
 }
 
-fn nested_fts_batch(
+pub(super) fn nested_fts_batch(
     ids: Vec<u64>,
     a_values: Vec<Option<&str>>,
     b_values: Vec<Option<&str>>,

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1453,6 +1453,12 @@ fn independent_compound_fts_oracle<'a>(
                 }
                 result
             }
+            // This oracle scores each leaf against its own column's statistics,
+            // which is exactly what BM25F does not do. combined_fields never
+            // reaches the cross-column compound path.
+            FtsQuery::CombinedFields(_) => {
+                unreachable!("combined_fields is not a cross-column compound leaf")
+            }
         }
     })
 }

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -797,14 +797,28 @@ async fn build_text_fts_index_with_positions(dataset: &mut Dataset) {
         .unwrap();
 }
 
-/// Collect sorted IDs of rows returned by an FTS query on `text`.
+/// Collect sorted IDs of rows returned by an FTS query.
 async fn fts_ids(dataset: &Dataset, query: FullTextSearchQuery) -> Vec<i32> {
-    let results = dataset
-        .scan()
+    fts_ids_opts(dataset, query, false).await
+}
+
+/// Like [`fts_ids`] but lets a test enable `fast_search()`, which restricts the
+/// answer to what the indexes can supply.
+async fn fts_ids_opts(
+    dataset: &Dataset,
+    query: FullTextSearchQuery,
+    fast_search: bool,
+) -> Vec<i32> {
+    let mut scanner = dataset.scan();
+    scanner
         .full_text_search(query)
         .unwrap()
         .project(&["id"])
-        .unwrap()
+        .unwrap();
+    if fast_search {
+        scanner.fast_search();
+    }
+    let results = scanner
         .try_into_stream()
         .await
         .unwrap()
@@ -1571,6 +1585,610 @@ async fn test_fts_overlay_unrelated_field_not_excluded() {
     // reflects the overlay even though the FTS index correctly returned that row.
     assert_eq!(fts_ids_matching(&dataset, "apple").await, vec![0, 999]);
     assert_eq!(fts_ids_matching(&dataset, "banana").await, vec![3, 999]);
+}
+
+fn combined_fields_query(terms: &str, columns: &[&str]) -> FullTextSearchQuery {
+    use lance_index::scalar::inverted::query::{CombinedFieldsQuery, FtsQuery};
+
+    FullTextSearchQuery::new_query(FtsQuery::CombinedFields(
+        CombinedFieldsQuery::try_new(
+            terms.to_owned(),
+            columns.iter().map(|column| column.to_string()).collect(),
+        )
+        .unwrap(),
+    ))
+}
+
+/// Sorted `id` values a cross-field (BM25F) `combined_fields` query returns.
+async fn fts_combined_ids(dataset: &Dataset, terms: &str, columns: &[&str]) -> Vec<i32> {
+    fts_ids(dataset, combined_fields_query(terms, columns)).await
+}
+
+/// Like [`fts_combined_ids`] but index-only (`fast_search`), so nothing re-reads
+/// the fragments the indexed scan had to skip.
+async fn fts_combined_ids_fast_search(
+    dataset: &Dataset,
+    terms: &str,
+    columns: &[&str],
+) -> Vec<i32> {
+    fts_ids_opts(dataset, combined_fields_query(terms, columns), true).await
+}
+
+/// Sorted `id` values a single-column `MatchQuery` returns. This is the reference
+/// answer `combined_fields` must agree with: an `Or` combined-fields query matches
+/// a document when a query term appears in at least one target column, so the
+/// combined result is the union of the per-column match results.
+async fn fts_match_ids(dataset: &Dataset, term: &str, column: &str) -> Vec<i32> {
+    use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery};
+
+    let query = FullTextSearchQuery::new_query(FtsQuery::Match(
+        MatchQuery::new(term.to_owned()).with_column(Some(column.to_owned())),
+    ));
+    fts_ids(dataset, query).await
+}
+
+/// Union of the per-column `MatchQuery` results for `term`, sorted.
+async fn fts_match_union_ids(dataset: &Dataset, term: &str, columns: &[&str]) -> Vec<i32> {
+    let mut ids = Vec::new();
+    for column in columns {
+        ids.extend(fts_match_ids(dataset, term, column).await);
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+/// Build an FTS index on `column` as one segment per fragment, the multi-segment
+/// counterpart of the whole-index single segment `build_text_fts_index` produces.
+/// An overlay-stale fragment is excluded from the indexed scan either way, so both
+/// layouts run the indexed and the flat side; only the number of segments the
+/// indexed side opens differs.
+async fn build_per_fragment_fts_index(dataset: &mut Dataset, column: &str) {
+    let params = InvertedIndexParams::default();
+    let name = format!("{column}_fts");
+    let fragment_ids = dataset
+        .get_fragments()
+        .into_iter()
+        .map(|fragment| fragment.id() as u32)
+        .collect::<Vec<_>>();
+    let mut segments = Vec::with_capacity(fragment_ids.len());
+    for fragment_id in fragment_ids {
+        segments.push(
+            CreateIndexBuilder::new(dataset, &[column], IndexType::Inverted, &params)
+                .name(name.clone())
+                .fragments(vec![fragment_id])
+                .execute_uncommitted()
+                .await
+                .unwrap(),
+        );
+    }
+    dataset
+        .commit_existing_index_segments(&name, column, segments)
+        .await
+        .unwrap();
+}
+
+/// `combined_fields` must honour the same data-overlay contract as `match`: a
+/// fragment holding an overlay-stale row is dropped from the indexed scan and
+/// re-evaluated on the flat path. Without that the indexed scan answers from the
+/// pre-overlay index, so it both returns stale hits and misses new matches.
+///
+/// `match` blocks the individual stale row addresses instead (see
+/// `plan_combined_fields_query` for why BM25F cannot), but the answer must be the
+/// same either way.
+///
+/// Parametrized over the segment layout: one segment for the whole index, and one
+/// segment per fragment.
+#[rstest]
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_agrees_with_match(
+    #[values(false, true)] per_fragment_segments: bool,
+) {
+    let mut dataset = create_text_dataset(false).await;
+    if per_fragment_segments {
+        build_per_fragment_fts_index(&mut dataset, "text").await;
+    } else {
+        build_text_fts_index(&mut dataset).await;
+    }
+
+    // fragment 0, row offset 1 (id=1): "apple banana" → "cherry mango".
+    // Field ID 1 is the `text` column.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_text_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
+    )
+    .await;
+
+    // Both directions: "apple"/"banana" must lose the stale id=1 hit, and
+    // "cherry"/"mango" must gain it.
+    for (term, expected) in [
+        ("apple", vec![0]),
+        ("banana", vec![3]),
+        ("cherry", vec![1, 2]),
+        ("mango", vec![1, 6]),
+    ] {
+        let combined = fts_combined_ids(&dataset, term, &["text"]).await;
+        assert_eq!(
+            combined,
+            fts_match_ids(&dataset, term, "text").await,
+            "combined_fields disagrees with match for '{term}'"
+        );
+        assert_eq!(combined, expected, "wrong rows for '{term}'");
+    }
+}
+
+/// The overlay term must be findable even when no indexed posting list holds it.
+///
+/// Taking the column's `docFreq_f` from the pre-overlay index alone leaves a term the
+/// overlay introduced at `docFreq' == 0`, so `query_weight` is `0.0`, the row scores
+/// zero and the flat scan drops it.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_new_term_absent_from_index_stats() {
+    let mut dataset = create_text_dataset(false).await;
+    build_text_fts_index(&mut dataset).await;
+
+    // fragment 0, row offset 1 (id=1): "apple banana" → "quasarunique", a term that
+    // occurs in no other row and so in no indexed posting list.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_unique_text_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("quasarunique")]))],
+    )
+    .await;
+
+    assert_eq!(
+        fts_match_ids(&dataset, "quasarunique", "text").await,
+        vec![1]
+    );
+    assert_eq!(
+        fts_combined_ids(&dataset, "quasarunique", &["text"]).await,
+        vec![1]
+    );
+}
+
+/// Text dataset with an `id` column holding the row offset plus one `Utf8` column per
+/// entry of `columns`, laid out `rows_per_file` rows to a fragment. `id` is field 0 and
+/// the text columns take the following field IDs in order.
+async fn create_text_dataset_with(columns: &[(&str, &[&str])], rows_per_file: usize) -> Dataset {
+    let num_rows = columns[0].1.len() as i32;
+    let mut fields = vec![ArrowField::new("id", DataType::Int32, true)];
+    let mut arrays: Vec<ArrayRef> = vec![Arc::new(Int32Array::from_iter_values(0..num_rows))];
+    for (name, values) in columns {
+        fields.push(ArrowField::new(*name, DataType::Utf8, true));
+        arrays.push(Arc::new(StringArray::from(values.to_vec())));
+    }
+    let schema = Arc::new(ArrowSchema::new(fields));
+    let batch = RecordBatch::try_new(schema.clone(), arrays).unwrap();
+    let write_params = WriteParams {
+        max_rows_per_file: rows_per_file,
+        ..Default::default()
+    };
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    Dataset::write(reader, "memory://", Some(write_params))
+        .await
+        .unwrap()
+}
+
+/// Top-`limit` ids of a prefiltered `combined_fields` query, in score order.
+async fn fts_combined_prefiltered_ids(
+    dataset: &Dataset,
+    terms: &str,
+    filter: &str,
+    limit: i64,
+) -> Vec<i32> {
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .filter(filter)
+        .unwrap()
+        .full_text_search(combined_fields_query(terms, &["text"]).limit(Some(limit)))
+        .unwrap()
+        .project(&["id"])
+        .unwrap();
+    ids_from_batches(&[scanner.try_into_batch().await.unwrap()])
+}
+
+/// A same-value overlay must not move top-k: it leaves every searchable value alone, so
+/// the corpus the ranking is measured against must not change either.
+///
+/// The prefilter prunes the flat scan, so statistics folded from that scan describe the
+/// filtered subset, while the indexed plan an overlay-free dataset takes uses the whole index.
+///
+/// `beta` is the rare term globally, so id 1 outranks id 0. Over the filtered pair the
+/// two terms have equal `docFreq` and the scores tie, which is enough to lose id 1.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_preserves_prefilter_corpus() {
+    let texts: &[&str] = &[
+        "alpha", "beta", "alpha", "alpha", "alpha", "alpha", "alpha", "alpha", "alpha", "alpha",
+        "alpha", "alpha",
+    ];
+    let mut dataset = create_text_dataset_with(&[("text", texts)], 12).await;
+    build_text_fts_index(&mut dataset).await;
+
+    assert_eq!(
+        fts_combined_prefiltered_ids(&dataset, "alpha beta", "id < 2", 1).await,
+        vec![1]
+    );
+
+    // Row offset 2 rewritten with the value it already holds, and the filter excludes it.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_prefilter_same_value_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([2])),
+        vec![Arc::new(StringArray::from(vec![Some("alpha")]))],
+    )
+    .await;
+    assert_eq!(
+        fts_combined_prefiltered_ids(&dataset, "alpha beta", "id < 2", 1).await,
+        vec![1]
+    );
+}
+
+/// [`test_fts_combined_fields_overlay_preserves_prefilter_corpus`] without the tie: the
+/// filtered subset inverts which term is rarer, so the ranking flips on a strict
+/// inequality rather than on tie order.
+///
+/// Globally `df(alpha) = 10` against `df(beta) = 2`, so id 1 wins. Over ids 0..2 it is
+/// `df(alpha) = 1` against `df(beta) = 2`, which puts id 0 ahead by roughly 2x. Id 2
+/// carries filler tokens purely to lengthen it, so it never ties with id 1.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_preserves_prefilter_corpus_strictly() {
+    let texts: &[&str] = &[
+        "alpha",
+        "beta",
+        "beta gamma delta",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+    ];
+    let mut dataset = create_text_dataset_with(&[("text", texts)], 12).await;
+    build_text_fts_index(&mut dataset).await;
+
+    assert_eq!(
+        fts_combined_prefiltered_ids(&dataset, "alpha beta", "id < 3", 1).await,
+        vec![1]
+    );
+
+    let dataset = commit_overlay(
+        dataset,
+        "combined_prefilter_strict_same_value_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([5])),
+        vec![Arc::new(StringArray::from(vec![Some("alpha")]))],
+    )
+    .await;
+    assert_eq!(
+        fts_combined_prefiltered_ids(&dataset, "alpha beta", "id < 3", 1).await,
+        vec![1]
+    );
+}
+
+/// Top-`limit` ids of a `combined_fields` query restricted to `fragment_ids`.
+async fn fts_combined_fragment_ids(
+    dataset: &Dataset,
+    terms: &str,
+    fragment_ids: &[u32],
+    limit: i64,
+) -> Vec<i32> {
+    let fragments = dataset
+        .fragments()
+        .iter()
+        .filter(|fragment| fragment_ids.contains(&(fragment.id as u32)))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut scanner = dataset.scan();
+    scanner
+        .with_fragments(fragments)
+        .full_text_search(combined_fields_query(terms, &["text"]).limit(Some(limit)))
+        .unwrap()
+        .project(&["id"])
+        .unwrap();
+    ids_from_batches(&[scanner.try_into_batch().await.unwrap()])
+}
+
+/// Fragment selection must restrict which rows are returned, not which corpus they
+/// are scored against. A same-value overlay inside the selection leaves every
+/// searchable value alone, so top-k must not move.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_preserves_fragment_corpus() {
+    // Fragment 0 holds the only `beta` rows; the nine `alpha` rows behind it are what
+    // make `beta` the rare term, and they are outside the selection.
+    let texts: &[&str] = &[
+        "alpha",
+        "beta",
+        "beta gamma delta",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+        "alpha",
+    ];
+    let mut dataset = create_text_dataset_with(&[("text", texts)], 3).await;
+    build_text_fts_index(&mut dataset).await;
+
+    assert_eq!(
+        fts_combined_fragment_ids(&dataset, "alpha beta", &[0], 1).await,
+        vec![1]
+    );
+
+    // Row offset 2 rewritten with the value it already holds.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_fragment_same_value_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([2])),
+        vec![Arc::new(StringArray::from(vec![Some("beta gamma delta")]))],
+    )
+    .await;
+    assert_eq!(
+        fts_combined_fragment_ids(&dataset, "alpha beta", &[0], 1).await,
+        vec![1]
+    );
+}
+
+/// An overlay must cost only the fragments it touched. Folding the stale rows on top
+/// of the index keeps the corpus global, so the untouched fragments stay on the
+/// indexed side instead of the whole table going through a full scan.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_keeps_clean_fragments_indexed() {
+    let mut dataset = create_text_dataset(false).await;
+    build_text_fts_index(&mut dataset).await;
+
+    // Fragment 0 only; fragment 1 (ids 6..11) is untouched.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_partial_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
+    )
+    .await;
+
+    let mut scan = dataset.scan();
+    scan.project(&["id"])
+        .unwrap()
+        .full_text_search(combined_fields_query("cherry", &["text"]))
+        .unwrap();
+    let plan = scan.explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("CombinedFieldsQuery"),
+        "fragment 1 has no stale entry, so it must stay on the indexed side:\n{plan}"
+    );
+    assert!(
+        plan.contains("FlatCombinedFields"),
+        "fragment 0 must be re-read on the flat side:\n{plan}"
+    );
+}
+
+/// An overlay must not cost the flat scan the rows only it can return.
+///
+/// Once a stale row folds, the flat scan is read unfiltered and its emitted rows
+/// are picked by a prefilter instead, so that a same-value overlay cannot move the
+/// corpus (see `test_fts_combined_fields_overlay_preserves_prefilter_corpus`).
+/// That prefilter has to span the fragments the flat scan reads. The indexed
+/// child's own prefilter does not: it is built over the fragments the target
+/// columns' indexes cover, so it names no row in an appended fragment, and an
+/// allow-list can only be narrowed afterwards, never widened.
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_keeps_unindexed_selected_match() {
+    let mut dataset = create_text_dataset(false).await;
+    build_text_fts_index(&mut dataset).await;
+
+    // `mango` now sits both in indexed fragment 1 (id 6) and in an appended
+    // fragment no index covers, so the two sides of the union are told apart.
+    let batch = arrow_array::record_batch!(("id", Int32, [12]), ("text", Utf8, ["mango"])).unwrap();
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let dataset = Dataset::write(
+        reader,
+        Arc::new(dataset),
+        Some(WriteParams {
+            mode: crate::dataset::write::WriteMode::Append,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    let appended_fragment_id = dataset.fragments().last().unwrap().id as u32;
+    // A fragment selection is what makes the prefilter fragment-scoped in the first
+    // place; with no filter and no selection it allows every row.
+    let selected_fragments = [0, appended_fragment_id];
+
+    assert_eq!(
+        fts_combined_fragment_ids(&dataset, "mango", &selected_fragments, 10).await,
+        vec![12],
+        "precondition: the appended match is returned before any overlay exists"
+    );
+
+    // Fragment 0 holds no `mango`, so this overlay changes no answer. All it does is
+    // route the scan onto the unfiltered-read path.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_unindexed_selected_match_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([0])),
+        vec![Arc::new(StringArray::from(vec![Some("apple pie")]))],
+    )
+    .await;
+
+    assert_eq!(
+        fts_combined_ids(&dataset, "mango", &["text"]).await,
+        vec![6, 12],
+        "unselected control: both matches are still reachable"
+    );
+    assert_eq!(
+        fts_combined_fragment_ids(&dataset, "mango", &selected_fragments, 10).await,
+        vec![12],
+        "the overlay dropped a match from a selected unindexed fragment"
+    );
+}
+
+/// Two-fragment dataset with two indexable text columns: `id`, `title`, `body`.
+/// Field IDs are 0 (`id`), 1 (`title`), 2 (`body`).
+async fn create_two_column_text_dataset() -> Dataset {
+    let titles: &[&str] = &[
+        "apple pie",
+        "apple banana", // row 1, fragment 0, overlaid in tests
+        "cherry cake",
+        "banana split",
+        "orange juice",
+        "grape vine",
+        "mango sorbet", // fragment 1 starts here
+        "pear tart",
+        "lemon curd",
+        "peach cobbler",
+        "plum pudding",
+        "fig newton",
+    ];
+    // `dessert` spans both fragments, and `fruit` sits on the overlaid row plus a
+    // row in the other fragment, so a body term exercises the flat and the indexed
+    // side of the union at once.
+    let bodies: &[&str] = &[
+        "sweet dessert",
+        "yellow fruit",
+        "red dessert",
+        "frozen treat",
+        "citrus drink",
+        "purple cluster",
+        "tropical ice",
+        "green fruit",
+        "sour spread",
+        "warm bake",
+        "dark dessert",
+        "dry biscuit",
+    ];
+    create_text_dataset_with(&[("title", titles), ("body", bodies)], 6).await
+}
+
+/// The multi-column shape of the contract above. An overlay on one target column
+/// makes the whole fragment unscorable from the indexes: a stale row poisons the
+/// blended `dl'`/`tf'` of every target column, not just the overlaid one, so the
+/// fragment has to be re-evaluated flat across all of them.
+///
+/// Only `title` is overlaid, so `body`'s index still covers the fragment. The
+/// indexed scan has to skip it for both columns anyway, the case where a missing
+/// fragment allow list emits the fragment twice, once per side of the union.
+#[rstest]
+#[tokio::test]
+async fn test_fts_combined_fields_multi_column_overlay_agrees_with_match(
+    #[values(false, true)] per_fragment_segments: bool,
+) {
+    let mut dataset = create_two_column_text_dataset().await;
+    for column in ["title", "body"] {
+        if per_fragment_segments {
+            build_per_fragment_fts_index(&mut dataset, column).await;
+        } else {
+            dataset
+                .create_index(
+                    &[column],
+                    IndexType::Inverted,
+                    None,
+                    &InvertedIndexParams::default(),
+                    true,
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    // Overlay `title` (field 1) of fragment 0, row offset 1 (id=1):
+    // "apple banana" → "cherry mango". `body` is untouched.
+    let dataset = commit_overlay(
+        dataset,
+        "combined_title_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
+    )
+    .await;
+
+    let columns = ["title", "body"];
+    for (term, expected) in [
+        // Stale title hits are dropped.
+        ("apple", vec![0]),
+        ("banana", vec![3]),
+        // New title matches are found.
+        ("cherry", vec![1, 2]),
+        ("mango", vec![1, 6]),
+        // A term of the untouched target column still resolves on both sides of the
+        // union: id=1 comes from the flat path, id=7 from the indexed path.
+        ("fruit", vec![1, 7]),
+        ("dessert", vec![0, 2, 10]),
+    ] {
+        let combined = fts_combined_ids(&dataset, term, &columns).await;
+        assert_eq!(
+            combined,
+            fts_match_union_ids(&dataset, term, &columns).await,
+            "combined_fields disagrees with match for '{term}'"
+        );
+        assert_eq!(combined, expected, "wrong rows for '{term}'");
+    }
+}
+
+/// `fast_search` is index-only, so the overlay-stale fragment is dropped instead of
+/// re-evaluated: the stale hit still must not come back, and the new value stays
+/// invisible until compaction folds the overlay into the base. Every other fragment
+/// keeps answering, whichever segment layout holds it.
+#[rstest]
+#[tokio::test]
+async fn test_fts_combined_fields_overlay_under_fast_search(
+    #[values(false, true)] per_fragment_segments: bool,
+) {
+    let mut dataset = create_text_dataset(false).await;
+    if per_fragment_segments {
+        build_per_fragment_fts_index(&mut dataset, "text").await;
+    } else {
+        build_text_fts_index(&mut dataset).await;
+    }
+    let dataset = commit_overlay(
+        dataset,
+        "combined_fast_search_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
+    )
+    .await;
+
+    // Fragment 0 is stale either way, so nothing it holds is answerable: no stale
+    // "apple"/"banana" hit and no new "cherry" hit.
+    for term in ["apple", "banana", "cherry"] {
+        assert_eq!(
+            fts_combined_ids_fast_search(&dataset, term, &["text"]).await,
+            Vec::<i32>::new(),
+            "fast_search returned a row from the stale fragment for '{term}'"
+        );
+    }
+    // Fragment 1 holds no stale row, so it stays on the indexed side and answers
+    // even though the whole-index segment layout also covers the stale fragment.
+    assert_eq!(
+        fts_combined_ids_fast_search(&dataset, "mango", &["text"]).await,
+        vec![6]
+    );
 }
 
 /// Benchmark: measure query latency for BTree, FTS, and vector ANN with 0/4/16 overlay layers.

--- a/rust/lance/src/dataset/tests/mod.rs
+++ b/rust/lance/src/dataset/tests/mod.rs
@@ -6,6 +6,7 @@ mod data_file_part;
 mod dataset_aggregate;
 mod dataset_common;
 mod dataset_concurrency_store;
+mod dataset_fts_combined_fields;
 #[cfg(feature = "geo")]
 mod dataset_geo;
 mod dataset_index;

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -106,6 +106,33 @@ impl DatasetPreFilter {
         }
     }
 
+    /// Like [`Self::new_with_filter_future`], but restricted to an explicit
+    /// fragment set instead of the union of the indices' fragment bitmaps.
+    ///
+    /// `combined_fields` needs the intersection of its target columns' coverage: a
+    /// cross-field BM25F score is only complete when every column's index holds the
+    /// row, so the union [`Self::new`] derives would admit rows that only some
+    /// columns cover. Routing through [`Self::create_restricted_deletion_mask`]
+    /// keeps the restriction in whichever id space the indices actually store,
+    /// stable row ids or row addresses, which a fragment-address block list cannot
+    /// do.
+    pub(crate) fn new_restricted_to_fragments(
+        dataset: Arc<Dataset>,
+        fragments: RoaringBitmap,
+        filter: Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>>,
+    ) -> Self {
+        let deleted_ids = Self::create_restricted_deletion_mask(dataset, fragments)
+            .map(SharedPrerequisite::spawn);
+        let filtered_ids = filter.map(SharedPrerequisite::spawn);
+        Self {
+            deleted_ids,
+            filtered_ids,
+            deleted_fragments: None,
+            overlay_block: None,
+            final_mask: Mutex::new(OnceCell::new()),
+        }
+    }
+
     #[instrument(level = "debug", skip_all)]
     async fn do_create_deletion_mask(
         dataset: Arc<Dataset>,

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -636,6 +636,45 @@ pub(crate) async fn resolve_query_document_granularity(
     Ok(resolved)
 }
 
+/// Check that one `combined_fields` target column can take part in a BM25F
+/// blend, and resolve its path.
+///
+/// Cross-field scoring joins the target columns on the row address and sums their
+/// per-row term frequencies and document lengths, so it needs row documents. A
+/// column indexed only at list-element granularity cannot supply them: that index
+/// stores several documents per row, identified by element coordinates a
+/// cross-column scan cannot pair up between columns and the combined result schema
+/// cannot report. A column carrying both granularities is fine; the row index is
+/// the one used.
+///
+/// Any field shape a row-document index accepts is allowed, list nesting included:
+/// the flat sibling scan reaches such a leaf through
+/// [`flatten_fts_document_column`], which uses the same traversal a single-column
+/// match drives through [`FtsDocument`].
+pub(crate) async fn validate_combined_fields_target_column(
+    dataset: &Dataset,
+    column: &str,
+) -> Result<()> {
+    let indices = indexed_fts_document_granularities(dataset, column).await?;
+    if !indices.is_empty()
+        && indices
+            .iter()
+            .all(|(_, granularity)| granularity.is_list_element())
+    {
+        let indexed = indices
+            .iter()
+            .map(|(name, granularity)| format!("'{name}' ({granularity:?})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(Error::not_supported(format!(
+            "combined_fields (BM25F) scores whole rows and needs a Row document granularity FTS \
+             index on every target column, but '{column}' only has: {indexed}"
+        )));
+    }
+    resolve_fts_field(dataset.schema(), column, DocumentGranularity::Row)?;
+    Ok(())
+}
+
 pub(crate) fn fts_document_schema(coordinate_rank: usize) -> Arc<ArrowSchema> {
     let mut fields = vec![
         ArrowField::new(VALUE_COLUMN_NAME, DataType::Utf8, false),

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -687,6 +687,71 @@ pub(crate) fn fts_document_schema(coordinate_rank: usize) -> Arc<ArrowSchema> {
     Arc::new(ArrowSchema::new(fields))
 }
 
+/// Add (or replace) a flat `Utf8` column holding each row's document text for a
+/// list-bearing FTS field path, leaving every other column and row untouched.
+///
+/// A Lance projection cannot address a field that continues past a `List`, so a
+/// scan that needs `docs.content` has to project the `docs` root instead. This
+/// walks the traversal down to the leaf per row, joining the elements exactly the
+/// way the index builder does at row granularity.
+///
+/// Row granularity yields one document per input row, in row order, keeping several
+/// such columns aligned for a cross-field blend. Not valid for list-element
+/// granularity, where a row expands to several documents.
+pub(crate) fn flatten_fts_document_column(
+    input: SendableRecordBatchStream,
+    resolved: ResolvedFtsField,
+) -> Result<SendableRecordBatchStream> {
+    if resolved.document_granularity.is_list_element() {
+        return Err(Error::internal(
+            "flatten_fts_document_column needs row documents to keep one output row per input row"
+                .to_string(),
+        ));
+    }
+    let input_schema = input.schema();
+    if input_schema
+        .column_with_name(&resolved.root_column)
+        .is_none()
+    {
+        return Err(Error::internal(format!(
+            "FTS document input must contain the root source column '{}'",
+            resolved.root_column
+        )));
+    }
+    let text_field = ArrowField::new(&resolved.canonical_path, DataType::Utf8, false);
+    let replaced = input_schema.column_with_name(&resolved.canonical_path);
+    let mut fields = input_schema.fields().to_vec();
+    match replaced {
+        Some((index, _)) => fields[index] = Arc::new(text_field),
+        None => fields.push(Arc::new(text_field)),
+    }
+    let replaced = replaced.map(|(index, _)| index);
+    let output_schema = Arc::new(ArrowSchema::new(fields));
+    let stream_schema = output_schema.clone();
+    let stream = input.map(move |batch| {
+        let batch = batch?;
+        let source = batch
+            .column_by_name(&resolved.root_column)
+            .expect("FTS document input schema was validated");
+        let documents = resolved
+            .documents_from_array(source, batch.num_rows())
+            .map_err(DataFusionError::from)?;
+        let texts = Arc::new(StringArray::from_iter_values(
+            documents.iter().map(|document| document.text.as_str()),
+        )) as ArrayRef;
+        let mut columns = batch.columns().to_vec();
+        match replaced {
+            Some(index) => columns[index] = texts,
+            None => columns.push(texts),
+        }
+        RecordBatch::try_new(stream_schema.clone(), columns).map_err(DataFusionError::from)
+    });
+    Ok(Box::pin(RecordBatchStreamAdapter::new(
+        output_schema,
+        stream,
+    )))
+}
+
 pub(crate) fn transform_fts_document_stream(
     input: SendableRecordBatchStream,
     resolved: ResolvedFtsField,

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -41,7 +41,9 @@ use lance_table::format::IndexMetadata;
 use rustc_hash::FxHashSet;
 
 use super::PreFilterSource;
-use super::utils::{IndexMetrics, PreFilterMasks, build_prefilter};
+use super::utils::{
+    IndexMetrics, PreFilterMasks, build_prefilter, build_prefilter_restricted_to_fragments,
+};
 use crate::dataset::mem_wal::index::{QueryLocalFtsIndex, QueryLocalFtsStats};
 use crate::index::scalar::inverted::{
     ResolvedFtsField, fts_document_schema, load_segment_details, load_segments,
@@ -53,17 +55,18 @@ use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
 use lance_index::scalar::inverted::document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer};
 use lance_index::scalar::inverted::query::{
-    BoostQuery, FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens,
-    collect_query_tokens, has_query_token, uses_fuzzy_expansion,
+    BoostQuery, CombinedFieldsQuery, FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, Operator,
+    PhraseQuery, Tokens, collect_query_tokens, has_query_token, uses_fuzzy_expansion,
 };
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
-    DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
-    MemBM25Scorer, PreparedBm25Query, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
+    CombinedFieldColumn, CombinedFieldsBM25Scorer, DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA,
+    FlatBm25SearchOptions, InvertedIndex, MemBM25Scorer, PreparedBm25Query, SCORE_COL, Scorer,
+    build_combined_bm25_scorer, build_global_bm25_scorer, combined_fields_search, compound_search,
     compound_search_prepared_match, compound_search_prepared_match_with_score_floor,
     compound_search_with_base_scorer, cross_column_compound_search, exclusive_scaled_score_floor,
     flat_bm25_search_stream_with_options_and_scorer, fts_schema, materialized_compound_top_k,
-    prepare_bm25_query,
+    prepare_bm25_query, validate_combined_tokenizers,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
@@ -581,6 +584,10 @@ fn count_fts_leaves(query: &FtsQuery) -> usize {
             count_fts_leaves(&query.positive) + count_fts_leaves(&query.negative)
         }
         FtsQuery::MultiMatch(query) => query.match_queries.len(),
+        // Unreachable while `supports_compound_scorer` rejects BM25F. Counted as
+        // the per-column posting scans anyway, so the arm stays honest if that
+        // changes.
+        FtsQuery::CombinedFields(query) => query.column_names().count(),
         FtsQuery::Boolean(query) => query
             .should
             .iter()
@@ -628,6 +635,14 @@ fn compound_leaf_columns(query: &FtsQuery) -> Result<Vec<&str>> {
                     visit(query, columns)?;
                 }
             }
+            // Unreachable while `supports_compound_scorer` rejects BM25F: a
+            // combined_fields leaf blends statistics across its columns, so it
+            // cannot name one column per leaf the way this list requires.
+            FtsQuery::CombinedFields(_) => {
+                return Err(Error::invalid_input(
+                    "cross-column compound FTS cannot take a combined_fields leaf".to_string(),
+                ));
+            }
         }
         Ok(())
     }
@@ -640,7 +655,8 @@ fn compound_leaf_columns(query: &FtsQuery) -> Result<Vec<&str>> {
 fn compound_query_uses_fuzzy_expansion(query: &FtsQuery) -> bool {
     match query {
         FtsQuery::Match(query) => uses_fuzzy_expansion(query.fuzziness),
-        FtsQuery::Phrase(_) => false,
+        // combined_fields matches terms exactly; it has no fuzziness setting.
+        FtsQuery::Phrase(_) | FtsQuery::CombinedFields(_) => false,
         FtsQuery::Boost(query) => {
             compound_query_uses_fuzzy_expansion(&query.positive)
                 || compound_query_uses_fuzzy_expansion(&query.negative)
@@ -2092,6 +2108,10 @@ fn tokenize_compound_query(query: &FtsQuery, index: &InvertedIndex) -> Tokenized
                     });
                 }
             }
+            // Unreachable: only `CompoundQueryExec` tokenizes this way, and
+            // `supports_compound_scorer` rejects BM25F at any depth. The
+            // combined_fields execs snapshot their own tokens.
+            FtsQuery::CombinedFields(_) => {}
             FtsQuery::Boolean(query) => {
                 for query in query
                     .should
@@ -2185,6 +2205,13 @@ fn tokenize_cross_column_compound_query(
                     visit(query, indices, leaves)?;
                 }
             }
+            // Unreachable while `supports_compound_scorer` rejects BM25F; see
+            // `compound_leaf_columns`.
+            FtsQuery::CombinedFields(_) => {
+                return Err(Error::invalid_input(
+                    "cross-column compound FTS cannot take a combined_fields leaf".to_string(),
+                ));
+            }
         }
         Ok(())
     }
@@ -2194,24 +2221,28 @@ fn tokenize_cross_column_compound_query(
     Ok(TokenizedCompoundQuery(leaves))
 }
 
-type SharedScorerResult = std::result::Result<Arc<MemBM25Scorer>, Arc<str>>;
+type SharedScorerResult<S> = std::result::Result<Arc<S>, Arc<str>>;
 
 /// Coordinates BM25 corpus statistics between the indexed and flat branches
 /// of a mixed search. The flat branch extends the indexed statistics with the
 /// unindexed documents, then publishes the resulting corpus-wide scorer.
+///
+/// Generic over the scorer so the single-column path can share a
+/// [`MemBM25Scorer`] and `combined_fields` a [`CombinedFieldsBM25Scorer`]; the
+/// coordination is the same either way.
 #[derive(Debug)]
-pub(crate) struct SharedFtsScorer {
-    sender: tokio::sync::watch::Sender<Option<SharedScorerResult>>,
+pub(crate) struct SharedFtsScorer<S = MemBM25Scorer> {
+    sender: tokio::sync::watch::Sender<Option<SharedScorerResult<S>>>,
 }
 
-impl SharedFtsScorer {
+impl<S: Send + Sync + 'static> SharedFtsScorer<S> {
     pub(crate) fn new() -> Self {
         let (sender, _) = tokio::sync::watch::channel(None);
         Self { sender }
     }
 
-    fn publish(&self, scorer: MemBM25Scorer) {
-        self.sender.send_replace(Some(Ok(Arc::new(scorer))));
+    fn publish(&self, scorer: Arc<S>) {
+        self.sender.send_replace(Some(Ok(scorer)));
     }
 
     fn publish_error(&self, error: &DataFusionError) {
@@ -2219,7 +2250,7 @@ impl SharedFtsScorer {
             .send_replace(Some(Err(Arc::from(error.to_string()))));
     }
 
-    async fn wait(&self) -> DataFusionResult<Arc<MemBM25Scorer>> {
+    async fn wait(&self) -> DataFusionResult<Arc<S>> {
         let mut receiver = self.sender.subscribe();
         loop {
             let result = receiver.borrow_and_update().clone();
@@ -2236,20 +2267,20 @@ impl SharedFtsScorer {
     }
 }
 
-struct SharedFtsScorerProducer {
-    scorer: Arc<SharedFtsScorer>,
+struct SharedFtsScorerProducer<S: Send + Sync + 'static = MemBM25Scorer> {
+    scorer: Arc<SharedFtsScorer<S>>,
     completed: bool,
 }
 
-impl SharedFtsScorerProducer {
-    fn new(scorer: Arc<SharedFtsScorer>) -> Self {
+impl<S: Send + Sync + 'static> SharedFtsScorerProducer<S> {
+    fn new(scorer: Arc<SharedFtsScorer<S>>) -> Self {
         Self {
             scorer,
             completed: false,
         }
     }
 
-    fn publish(mut self, scorer: MemBM25Scorer) {
+    fn publish(mut self, scorer: Arc<S>) {
         self.scorer.publish(scorer);
         self.completed = true;
     }
@@ -2260,7 +2291,7 @@ impl SharedFtsScorerProducer {
     }
 }
 
-impl Drop for SharedFtsScorerProducer {
+impl<S: Send + Sync + 'static> Drop for SharedFtsScorerProducer<S> {
     fn drop(&mut self) {
         if !self.completed {
             self.scorer.sender.send_replace(Some(Err(Arc::from(
@@ -2998,6 +3029,426 @@ impl ExecutionPlan for MatchQueryExec {
     }
 }
 
+/// Cross-field BM25F full-text search (`combined_fields`).
+///
+/// Unlike a `MultiMatch` plan (one [`MatchQueryExec`] per column fused by a
+/// `max` aggregate, i.e. `best_fields`), this is a single node: it opens every
+/// target column's segments, blends their corpus statistics, and runs one merged
+/// scan so term statistics are shared across fields. Per-column boosts are baked
+/// into the blended term frequency, so there is no post-scan boost multiplier or
+/// `AggregateExec(max)`. Emits `(ROW_ID, SCORE)` in [`FTS_SCHEMA`].
+#[derive(Debug)]
+pub struct CombinedFieldsQueryExec {
+    dataset: Arc<Dataset>,
+    query: CombinedFieldsQuery,
+    /// Tokens `execute()` actually produced, for `analyze_plan`. One snapshot
+    /// covers every target column because `validate_combined_tokenizers`
+    /// requires them to share a tokenizer, so the scan tokenizes once.
+    tokenized_query: Arc<OnceLock<TokenizedQuery>>,
+    params: FtsSearchParams,
+    prefilter_source: PreFilterSource,
+    /// When set, `execute()` skips `build_combined_bm25_scorer` and threads this
+    /// blended scorer down to the merged scan (distributed corpus-global stats).
+    base_scorer: Option<Arc<CombinedFieldsBM25Scorer>>,
+    /// Waits for the flat sibling's blended scorer; see
+    /// [`Self::with_shared_scorer`].
+    shared_scorer: Option<Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>>,
+    /// When set, restrict this scan to exactly these fragments: the ones every
+    /// target column's index covers. See [`Self::with_covered_fragments`].
+    covered_fragments: Option<roaring::RoaringBitmap>,
+    /// Optional external row-address mask ANDead into the prefilter so only
+    /// masked rows are scored (see [`MatchQueryExec::with_external_mask`]).
+    external_mask: Option<Arc<RowAddrMask>>,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl CombinedFieldsQueryExec {
+    pub fn new(
+        dataset: Arc<Dataset>,
+        query: CombinedFieldsQuery,
+        params: FtsSearchParams,
+        prefilter_source: PreFilterSource,
+    ) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(FTS_SCHEMA.clone()),
+            Partitioning::RoundRobinBatch(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        ));
+        Self {
+            dataset,
+            query,
+            tokenized_query: Arc::new(OnceLock::new()),
+            params,
+            prefilter_source,
+            base_scorer: None,
+            shared_scorer: None,
+            covered_fragments: None,
+            external_mask: None,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    /// See [`MatchQueryExec::with_external_mask`].
+    pub fn with_external_mask(mut self, mask: Option<Arc<RowAddrMask>>) -> Self {
+        self.external_mask = mask;
+        self
+    }
+
+    /// Restrict this scan to `fragments`, the ones every target column's index
+    /// covers.
+    ///
+    /// A BM25F score is only complete when every target column's index covers the
+    /// row's fragment: `dl'` sums each column's document length, and the per-column
+    /// lookup returns 0 for a row that column's index holds no document for, so a
+    /// fragment indexed for some target columns but not others would score with a
+    /// partial `tf'`/`dl'`. The planner routes those fragments to the flat scan and
+    /// passes the remainder here.
+    ///
+    /// This has to be an allow list rather than a fragment block list: the inverted
+    /// index trains with `_rowid`, which is a logical stable row id when the dataset
+    /// uses stable row ids, so a fragment-address block list would match nothing and
+    /// both sides of the union would emit the same row.
+    pub fn with_covered_fragments(mut self, fragments: roaring::RoaringBitmap) -> Self {
+        self.covered_fragments = Some(fragments);
+        self
+    }
+
+    /// Override the blended BM25F scorer used by `execute()`. When set, the
+    /// local `build_combined_bm25_scorer` call is skipped. Mirrors
+    /// [`MatchQueryExec::with_base_scorer`] for distributed queries that
+    /// aggregate cross-column corpus statistics out-of-band.
+    pub fn with_base_scorer(mut self, scorer: Arc<CombinedFieldsBM25Scorer>) -> Self {
+        self.base_scorer = Some(scorer);
+        self
+    }
+
+    /// Score against the blended scorer the flat sibling publishes instead of
+    /// building one from this side's index statistics alone.
+    ///
+    /// Only the flat scan sees the rows no index covers, so only it can produce
+    /// the statistics that describe the whole scanned corpus. Without this the two
+    /// children of a mixed plan score against different `docCount'`/`docFreq'`/
+    /// `avgdl'`, which makes their scores incomparable and the union's sort wrong.
+    pub(crate) fn with_shared_scorer(
+        mut self,
+        scorer: Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>,
+    ) -> Self {
+        self.shared_scorer = Some(scorer);
+        self
+    }
+
+    pub fn query(&self) -> &CombinedFieldsQuery {
+        &self.query
+    }
+
+    pub fn params(&self) -> &FtsSearchParams {
+        &self.params
+    }
+
+    pub fn prefilter_source(&self) -> &PreFilterSource {
+        &self.prefilter_source
+    }
+
+    fn clone_with_prefilter_source(&self, prefilter_source: PreFilterSource) -> Self {
+        Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params: self.params.clone(),
+            prefilter_source,
+            base_scorer: self.base_scorer.clone(),
+            shared_scorer: self.shared_scorer.clone(),
+            covered_fragments: self.covered_fragments.clone(),
+            external_mask: self.external_mask.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl DisplayAs for CombinedFieldsQueryExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt_combined_fields(
+            "CombinedFieldsQuery",
+            &self.query,
+            &self.tokenized_query,
+            t,
+            f,
+        )
+    }
+}
+
+/// The plan display every `combined_fields` exec uses: the label, the target
+/// columns and the query text, plus the tokens `execute()` produced once it has
+/// run.
+fn fmt_combined_fields(
+    label: &str,
+    query: &CombinedFieldsQuery,
+    tokenized_query: &OnceLock<TokenizedQuery>,
+    t: DisplayFormatType,
+    f: &mut std::fmt::Formatter,
+) -> std::fmt::Result {
+    let columns = query.column_names().collect::<Vec<_>>().join(", ");
+    // The one-line forms label with `: ` and separate fields with `, `; the tree
+    // render puts every field on its own line.
+    let (after_label, separator) = match t {
+        DisplayFormatType::TreeRender => ("\n", "\n"),
+        DisplayFormatType::Default | DisplayFormatType::Verbose => (": ", ", "),
+    };
+    write!(
+        f,
+        "{label}{after_label}columns=[{columns}]{separator}query={}",
+        query.terms()
+    )?;
+    fmt_tokenized_query(tokenized_query, separator, f)
+}
+
+/// What [`open_combined_fields_scan`] hands back to the `combined_fields` exec.
+struct CombinedFieldsScan {
+    columns: Vec<CombinedFieldColumn>,
+    /// Every segment opened across all target columns, for the indexed side's
+    /// prefilter.
+    segments: Vec<IndexMetadata>,
+    tokens: Tokens,
+}
+
+/// Open every target column's segments, pair each with its boost, and tokenize
+/// the query once.
+///
+/// Always every committed segment at row granularity: BM25F blends the target
+/// columns per row, and query planning rejects a column that only has a
+/// list-element index. The query stores each column together with its weight, so
+/// no column can be dropped here for want of one.
+///
+/// Both sides count the opened segments toward parts searched: the flat side needs
+/// them for the tokenizer and the blended corpus statistics, the indexed side for
+/// scoring.
+async fn open_combined_fields_scan(
+    dataset: &Dataset,
+    query: &CombinedFieldsQuery,
+    tokenized_query: &OnceLock<TokenizedQuery>,
+    metrics: &FtsIndexMetrics,
+) -> DataFusionResult<CombinedFieldsScan> {
+    let mut columns = Vec::with_capacity(query.column_names().len());
+    let mut all_segments = Vec::new();
+    for (column, weight) in query.weighted_columns() {
+        let segments = Some(
+            FtsSegmentSelection::AllCommitted
+                .resolve(
+                    dataset,
+                    column,
+                    DocumentGranularity::Row,
+                    &metrics.segment_bind_duration,
+                )
+                .await?,
+        );
+        let indices = match segments {
+            Some(segments) => {
+                let _details = load_segment_details(dataset, column, &segments).await?;
+                let indices =
+                    open_fts_segments(dataset, column, &segments, &metrics.index_metrics).await?;
+                all_segments.extend(segments.iter().cloned());
+                indices
+            }
+            None => Vec::new(),
+        };
+        columns.push(CombinedFieldColumn {
+            column: column.to_string(),
+            weight,
+            indices,
+        });
+    }
+    validate_combined_tokenizers(&columns)?;
+    metrics.record_parts_searched(
+        columns
+            .iter()
+            .flat_map(|column| &column.indices)
+            .map(|index| index.partition_count())
+            .sum(),
+    );
+
+    // Fields share a tokenizer (validated above), so tokenize once.
+    let first_index = columns
+        .iter()
+        .find_map(|column| column.indices.first())
+        .ok_or_else(|| {
+            // Not a user error: segment resolution already failed for any column
+            // without an index, and `CombinedFieldsQuery::try_new` rejects an empty
+            // column list, so reaching this means one of those two guarantees broke.
+            DataFusionError::Internal(
+                "combined_fields query reached execution with no target columns".to_string(),
+            )
+        })?;
+    let mut tokenizer = first_index.tokenizer();
+    let tokens = collect_query_tokens(query.terms(), &mut tokenizer);
+    record_tokenized_query(tokenized_query, &tokens);
+
+    Ok(CombinedFieldsScan {
+        columns,
+        segments: all_segments,
+        tokens,
+    })
+}
+
+impl ExecutionPlan for CombinedFieldsQueryExec {
+    fn name(&self) -> &str {
+        "CombinedFieldsQueryExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.prefilter_source.execution_plan().into_iter().collect()
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let expected = self.children().len();
+        if children.len() != expected {
+            return Err(DataFusionError::Internal(format!(
+                "CombinedFieldsQueryExec expected {expected} children, got {}",
+                children.len()
+            )));
+        }
+        let prefilter_source = match children.pop() {
+            Some(source) => self.prefilter_source.with_execution_plan(source)?,
+            None => PreFilterSource::None,
+        };
+        Ok(Arc::new(self.clone_with_prefilter_source(prefilter_source)))
+    }
+
+    #[instrument(name = "combined_fields_query_exec", level = "debug", skip_all)]
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let query = self.query.clone();
+        let tokenized_query = self.tokenized_query.clone();
+        let params = self.params.clone();
+        let ds = self.dataset.clone();
+        let prefilter_source = self.prefilter_source.clone();
+        let preset_base_scorer = self.base_scorer.clone();
+        let shared_scorer = self.shared_scorer.clone();
+        let covered_fragments = self.covered_fragments.clone();
+        let external_mask = self.external_mask.clone();
+        let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
+        let stream = stream::once(async move {
+            let _timer = metrics.baseline_metrics.elapsed_compute().timer();
+
+            let CombinedFieldsScan {
+                columns,
+                segments: all_segments,
+                tokens,
+                ..
+            } = open_combined_fields_scan(&ds, &query, &tokenized_query, metrics.as_ref()).await?;
+
+            // With mixed coverage the planner supplies the fragments every target
+            // column indexes, and the scan is restricted to exactly those: the
+            // rest go to the flat sibling. Otherwise the prefilter spans the union
+            // of the target columns' segments.
+            let mut pre_filter = match covered_fragments {
+                Some(covered) => build_prefilter_restricted_to_fragments(
+                    context.clone(),
+                    partition,
+                    &prefilter_source,
+                    ds,
+                    covered,
+                    external_mask,
+                )?,
+                None => build_prefilter(
+                    context.clone(),
+                    partition,
+                    &prefilter_source,
+                    ds,
+                    &all_segments,
+                    PreFilterMasks {
+                        overlay_block: None,
+                        external_mask,
+                    },
+                )?,
+            };
+            let deleted_fragments = columns.iter().flat_map(|column| &column.indices).fold(
+                roaring::RoaringBitmap::new(),
+                |mut deleted, index| {
+                    deleted |= index.deleted_fragments().clone();
+                    deleted
+                },
+            );
+            if !deleted_fragments.is_empty() {
+                Arc::get_mut(&mut pre_filter)
+                    .expect("prefilter just created")
+                    .set_deleted_fragments(deleted_fragments);
+            }
+            let scorer = match (preset_base_scorer, shared_scorer) {
+                (Some(scorer), _) => scorer,
+                // An injected scorer describes the corpus the whole plan scores
+                // against; wait for it rather than folding this side's statistics.
+                (None, Some(shared_scorer)) => shared_scorer.wait().await?,
+                (None, None) => {
+                    let scorer_start = std::time::Instant::now();
+                    let scorer = Arc::new(
+                        build_combined_bm25_scorer(&columns, &tokens, Some(metrics.as_ref()))
+                            .boxed()
+                            .await?,
+                    );
+                    metrics.record_scorer_build(scorer_start.elapsed());
+                    scorer
+                }
+            };
+
+            pre_filter.wait_for_ready().await?;
+            let (doc_ids, scores) = combined_fields_search(
+                &columns,
+                &tokens,
+                &params,
+                query.operator(),
+                scorer.as_ref(),
+                pre_filter,
+                metrics.as_ref(),
+            )
+            .await?;
+            metrics.baseline_metrics.record_output(doc_ids.len());
+
+            let batch = RecordBatch::try_new(
+                FTS_SCHEMA.clone(),
+                vec![
+                    Arc::new(UInt64Array::from(doc_ids)),
+                    Arc::new(Float32Array::from(scores)),
+                ],
+            )?;
+            Ok::<_, DataFusionError>(batch)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream.stream_in_current_span().boxed(),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+}
+
 /// Filters the input according to a match query's token operator.
 #[derive(Debug)]
 pub struct FlatMatchFilterExec {
@@ -3696,11 +4147,10 @@ impl ExecutionPlan for FlatMatchQueryExec {
         let document_column = self.document_column.clone();
         let phrase_slop = self.params.phrase_slop;
 
-        // CPU time accumulator passed into `flat_bm25_search_stream_with_metrics`
-        // so it can attribute the spawn_cpu tokenize work and synchronous
-        // scoring back onto this node's `elapsed_compute`. Sharing the same
-        // `Time` handle that's already inside the FtsIndexMetrics avoids
-        // registering a duplicate metric.
+        // Lets `flat_bm25_search_stream_with_metrics` attribute the spawn_cpu
+        // tokenize work and synchronous scoring back onto this node's
+        // `elapsed_compute`. Reusing the handle already inside `FtsIndexMetrics`
+        // avoids registering a duplicate metric.
         let elapsed_compute = metrics.baseline_metrics.elapsed_compute().clone();
 
         let column = query.column.ok_or(DataFusionError::Execution(format!(
@@ -3782,7 +4232,7 @@ impl ExecutionPlan for FlatMatchQueryExec {
             match result {
                 Ok((stream, scorer)) => {
                     if let Some(producer) = shared_scorer_producer {
-                        producer.publish(scorer);
+                        producer.publish(Arc::new(scorer));
                     }
                     Ok(stream)
                 }
@@ -3796,9 +4246,9 @@ impl ExecutionPlan for FlatMatchQueryExec {
         })
         .try_flatten()
         .map(move |batch| {
-            // record_poll records output_rows, output_bytes, and output_batches
-            // on the shared BaselineMetrics — same pattern DataFusion's own
-            // FilterExec uses inside its hand-written poll_next.
+            // Records output_rows, output_bytes, and output_batches on the shared
+            // BaselineMetrics, as DataFusion's own FilterExec does in its
+            // hand-written poll_next.
             let poll = metrics_clone
                 .baseline_metrics
                 .record_poll(std::task::Poll::Ready(Some(batch)));
@@ -4816,17 +5266,17 @@ mod tests {
     use lance_core::{ROW_ID, utils::address::RowAddress};
     use lance_datafusion::datagen::DatafusionDatagenExt;
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
-    use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
+    use lance_datafusion::utils::{INDEX_CACHE_HITS_METRIC, PARTITIONS_SEARCHED_METRIC};
     use lance_datagen::{BatchCount, ByteCount, RowCount};
     use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::scalar::inverted::builder::ScoredDoc;
     use lance_index::scalar::inverted::query::{
-        BooleanQuery, BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, Occur, Operator,
-        PhraseQuery, collect_query_tokens, has_query_token,
+        BooleanQuery, BoostQuery, CombinedFieldsQuery, FtsQuery, FtsSearchParams, MatchQuery,
+        Occur, Operator, PhraseQuery, collect_query_tokens, has_query_token,
     };
     use lance_index::scalar::inverted::{
-        DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, SCORE_COL,
-        build_global_bm25_scorer, prepare_bm25_query,
+        CombinedFieldColumn, DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, SCORE_COL,
+        build_combined_bm25_scorer, build_global_bm25_scorer, prepare_bm25_query,
     };
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{IndexCriteria, IndexType};
@@ -4843,11 +5293,12 @@ mod tests {
     };
 
     use super::{
-        BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
-        FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET, WandExactnessCertificate,
-        build_boolean_query_children, classify_wand_exactness_certificate, default_text_tokenizer,
-        open_fts_segments, tokenizer_for_match_query,
+        BoolSlot, BoostQueryExec, CombinedFieldsQueryExec, CompoundQueryExec,
+        CrossColumnCompoundQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec,
+        FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET,
+        WandExactnessCertificate, build_boolean_query_children,
+        classify_wand_exactness_certificate, default_text_tokenizer, open_fts_segments,
+        tokenizer_for_match_query,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -5020,33 +5471,47 @@ mod tests {
             .ascii_folding(false)
     }
 
-    async fn create_tokenized_query_fixture(with_unindexed_append: bool) -> Dataset {
-        let mut dataset = lance_datagen::gen_batch()
-            .col(
-                "text",
-                lance_datagen::array::cycle_utf8_literals(&["first and second"]),
-            )
+    /// Builds a dataset where every column in `columns` holds "first and second"
+    /// and carries its own inverted index. `combined_fields` needs an FTS index
+    /// per target column, so the columns are indexed one at a time rather than
+    /// as a single multi-column index.
+    ///
+    /// With `with_unindexed_append`, extra rows land outside the indices, which
+    /// forces the mixed plan where an indexed exec and its flat sibling both run.
+    async fn create_tokenized_query_fixture(
+        columns: &[&str],
+        with_unindexed_append: bool,
+    ) -> Dataset {
+        let corpus = || {
+            columns
+                .iter()
+                .fold(lance_datagen::gen_batch(), |batch, column| {
+                    batch.col(
+                        *column,
+                        lance_datagen::array::cycle_utf8_literals(&["first and second"]),
+                    )
+                })
+        };
+
+        let mut dataset = corpus()
             .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(2))
             .await
             .unwrap();
-        dataset
-            .create_index(
-                &["text"],
-                IndexType::Inverted,
-                None,
-                &tokenized_query_index_params(),
-                true,
-            )
-            .await
-            .unwrap();
+        for column in columns {
+            dataset
+                .create_index(
+                    &[*column],
+                    IndexType::Inverted,
+                    None,
+                    &tokenized_query_index_params(),
+                    true,
+                )
+                .await
+                .unwrap();
+        }
 
         if with_unindexed_append {
-            let appended = lance_datagen::gen_batch()
-                .col(
-                    "text",
-                    lance_datagen::array::cycle_utf8_literals(&["first and second"]),
-                )
-                .into_reader_rows(RowCount::from(2), BatchCount::from(1));
+            let appended = corpus().into_reader_rows(RowCount::from(2), BatchCount::from(1));
             dataset.append(appended, None).await.unwrap();
         }
         dataset
@@ -5168,7 +5633,7 @@ mod tests {
 
     #[tokio::test]
     async fn shared_fts_scorer_reports_cancelled_producer() {
-        let scorer = Arc::new(super::SharedFtsScorer::new());
+        let scorer = Arc::new(super::SharedFtsScorer::<super::MemBM25Scorer>::new());
         let producer = super::SharedFtsScorerProducer::new(scorer.clone());
         drop(producer);
 
@@ -5439,7 +5904,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_analyze_plan_shows_indexed_and_flat_match_tokens() {
-        let dataset = create_tokenized_query_fixture(true).await;
+        let dataset = create_tokenized_query_fixture(&["text"], true).await;
         let query = MatchQuery::new("FIRST and SECOND".to_string())
             .with_column(Some("text".to_string()))
             .with_operator(Operator::And);
@@ -5468,7 +5933,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_analyze_plan_shows_indexed_and_flat_phrase_tokens() {
-        let dataset = create_tokenized_query_fixture(true).await;
+        let dataset = create_tokenized_query_fixture(&["text"], true).await;
         let query =
             PhraseQuery::new("FIRST and SECOND".to_string()).with_column(Some("text".to_string()));
         let mut scanner = dataset.scan();
@@ -5490,7 +5955,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_analyze_plan_shows_compound_leaf_tokens() {
-        let dataset = create_tokenized_query_fixture(false).await;
+        let dataset = create_tokenized_query_fixture(&["text"], false).await;
         let query = BooleanQuery::new([
             (
                 Occur::Should,
@@ -5588,6 +6053,138 @@ mod tests {
         assert!(
             compound_line.contains(&format!("{PARTITIONS_SEARCHED_METRIC}={expected_total}")),
             "compound FTS scorer metrics missing partitions_searched: {compound_line}"
+        );
+    }
+
+    /// The cross-field scorer build reads one posting-metadata row per
+    /// (term, column, partition), and both `combined_fields` execs must report
+    /// those to their query's index-cache counters. Unreported, `EXPLAIN ANALYZE`
+    /// on a cold cross-field query undercounts `index_cache_misses`, so its
+    /// `index_cache_hit_ratio` is not comparable with `match`'s on the same data.
+    #[tokio::test]
+    async fn test_combined_fields_scorer_build_reports_index_cache_metrics() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col(
+                "title",
+                lance_datagen::array::cycle_utf8_literals(&[
+                    "hello world",
+                    "lance search",
+                    "hello lance",
+                ]),
+            )
+            .col(
+                "body",
+                lance_datagen::array::cycle_utf8_literals(&["lance", "hello", "search hello"]),
+            )
+            .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(9))
+            .await
+            .unwrap();
+        for column in ["title", "body"] {
+            dataset
+                .create_index(
+                    &[column],
+                    IndexType::Inverted,
+                    None,
+                    &InvertedIndexParams::default(),
+                    true,
+                )
+                .await
+                .unwrap();
+        }
+        let dataset = Arc::new(dataset);
+
+        let query = CombinedFieldsQuery::try_new(
+            "hello lance".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap();
+        let params = FtsSearchParams::default().with_limit(Some(10));
+
+        // Open the same segments the execs will, both to size the expected lookup
+        // count and to hand the preset runs a scorer identical to the one they
+        // would have built.
+        let mut columns = Vec::new();
+        for (column, weight) in query.weighted_columns() {
+            let segments = crate::index::scalar::inverted::load_segments(
+                &dataset,
+                column,
+                DocumentGranularity::Row,
+            )
+            .await
+            .unwrap()
+            .expect("FTS index just created");
+            let metrics_set = ExecutionPlanMetricsSet::new();
+            let indices = open_fts_segments(
+                &dataset,
+                column,
+                &segments,
+                &IndexMetrics::new(&metrics_set, 0),
+            )
+            .await
+            .unwrap();
+            columns.push(CombinedFieldColumn {
+                column: column.to_string(),
+                weight,
+                indices,
+            });
+        }
+        let mut tokenizer = columns[0].indices[0].tokenizer();
+        let tokens = collect_query_tokens(query.terms(), &mut tokenizer);
+        let mut terms = (0..tokens.len())
+            .map(|index| tokens.get_token(index).to_string())
+            .collect::<Vec<_>>();
+        terms.sort_unstable();
+        terms.dedup();
+        let partitions: usize = columns
+            .iter()
+            .flat_map(|column| &column.indices)
+            .map(|index| index.partition_count())
+            .sum();
+        // One posting-metadata row per (term, column, partition).
+        let expected_lookups = terms.len() * partitions;
+        assert!(expected_lookups > 0);
+        let scorer = Arc::new(
+            build_combined_bm25_scorer(&columns, &tokens, None)
+                .await
+                .unwrap(),
+        );
+
+        // Warm the index cache first: a cold run's counts depend on which entry
+        // each lookup happens to load, while on a warm cache every lookup is a
+        // hit and the two runs below differ only in the scorer build.
+        let warmup = CombinedFieldsQueryExec::new(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            PreFilterSource::None,
+        );
+        let expected = execute_results(&warmup).await.unwrap();
+        assert!(!expected.is_empty());
+
+        let built = CombinedFieldsQueryExec::new(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            PreFilterSource::None,
+        );
+        assert_eq!(execute_results(&built).await.unwrap(), expected);
+        let preset = CombinedFieldsQueryExec::new(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            PreFilterSource::None,
+        )
+        .with_base_scorer(scorer.clone());
+        assert_eq!(
+            execute_results(&preset).await.unwrap(),
+            expected,
+            "the preset scorer must match the one the exec builds",
+        );
+        assert_eq!(
+            metric_value(&built, INDEX_CACHE_HITS_METRIC)
+                - metric_value(&preset, INDEX_CACHE_HITS_METRIC),
+            expected_lookups,
+            "CombinedFieldsQueryExec must report the scorer build's cache lookups",
         );
     }
 
@@ -5787,6 +6384,24 @@ mod tests {
         assert_execution_error(
             execute_row_ids(&wrong_column).await.unwrap_err(),
             "no Inverted index found",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_combined_fields_exec_opens_all_committed_segments() {
+        let (dataset, _segments, fragment_ids) = create_segment_selection_fixture().await;
+        let query = CombinedFieldsQuery::try_new("quick".to_string(), vec!["text".to_string()])
+            .unwrap()
+            .try_with_boosts(vec![2.0])
+            .unwrap();
+        let params = FtsSearchParams::default().with_limit(Some(20));
+
+        // One segment per fragment, so a scan that opens every committed segment
+        // returns every fragment's matching row.
+        let exec = CombinedFieldsQueryExec::new(dataset, query, params, PreFilterSource::None);
+        assert_eq!(
+            execute_row_ids(&exec).await.unwrap(),
+            expected_row_ids(&fragment_ids)
         );
     }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -45,9 +45,10 @@ use super::utils::{
     IndexMetrics, PreFilterMasks, build_prefilter, build_prefilter_restricted_to_fragments,
 };
 use crate::dataset::mem_wal::index::{QueryLocalFtsIndex, QueryLocalFtsStats};
+use crate::index::prefilter::DatasetPreFilter;
 use crate::index::scalar::inverted::{
-    ResolvedFtsField, fts_document_schema, load_segment_details, load_segments,
-    transform_fts_document_stream,
+    ResolvedFtsField, flatten_fts_document_column, fts_document_schema, load_segment_details,
+    load_segments, transform_fts_document_stream,
 };
 use crate::{Dataset, index::DatasetIndexInternalExt};
 use lance_index::metrics::MetricsCollector;
@@ -60,15 +61,17 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
-    CombinedFieldColumn, CombinedFieldsBM25Scorer, DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA,
-    FlatBm25SearchOptions, InvertedIndex, MemBM25Scorer, PreparedBm25Query, SCORE_COL, Scorer,
-    build_combined_bm25_scorer, build_global_bm25_scorer, combined_fields_search, compound_search,
-    compound_search_prepared_match, compound_search_prepared_match_with_score_floor,
-    compound_search_with_base_scorer, cross_column_compound_search, exclusive_scaled_score_floor,
-    flat_bm25_search_stream_with_options_and_scorer, fts_schema, materialized_compound_top_k,
-    prepare_bm25_query, validate_combined_tokenizers,
+    CombinedCorpusStats, CombinedFieldColumn, CombinedFieldsBM25Scorer, DOC_INDEX_COL,
+    DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex, MemBM25Scorer,
+    PreparedBm25Query, SCORE_COL, Scorer, build_combined_bm25_scorer, build_global_bm25_scorer,
+    combined_fields_search, compound_search, compound_search_prepared_match,
+    compound_search_prepared_match_with_score_floor, compound_search_with_base_scorer,
+    cross_column_compound_search, exclusive_scaled_score_floor,
+    flat_bm25_search_stream_with_options_and_scorer, flat_combined_fields_search_stream,
+    fts_schema, materialized_compound_top_k, prepare_bm25_query, validate_combined_tokenizers,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
+use lance_select::{RowAddrTreeMap, RowSetOps};
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
 use tracing::instrument;
 use uuid::Uuid;
@@ -3206,13 +3209,26 @@ fn fmt_combined_fields(
     fmt_tokenized_query(tokenized_query, separator, f)
 }
 
-/// What [`open_combined_fields_scan`] hands back to the `combined_fields` exec.
+/// Which target columns of a `combined_fields` scan need an inverted index.
+#[derive(Debug, Clone, Copy)]
+enum CombinedFieldsIndexRequirement {
+    /// Every column, because the indexed side scores each of them from its
+    /// index.
+    EveryColumn,
+    /// At least one column, for the tokenizer. The flat side reads the document
+    /// text from the scan, so a column without an index only misses out on
+    /// contributing corpus statistics.
+    AtLeastOneColumn,
+}
+
+/// What [`open_combined_fields_scan`] hands back to either `combined_fields` exec.
 struct CombinedFieldsScan {
     columns: Vec<CombinedFieldColumn>,
     /// Every segment opened across all target columns, for the indexed side's
     /// prefilter.
     segments: Vec<IndexMetadata>,
     tokens: Tokens,
+    tokenizer: Box<dyn LanceTokenizer>,
 }
 
 /// Open every target column's segments, pair each with its boost, and tokenize
@@ -3229,22 +3245,30 @@ struct CombinedFieldsScan {
 async fn open_combined_fields_scan(
     dataset: &Dataset,
     query: &CombinedFieldsQuery,
+    index_requirement: CombinedFieldsIndexRequirement,
     tokenized_query: &OnceLock<TokenizedQuery>,
     metrics: &FtsIndexMetrics,
 ) -> DataFusionResult<CombinedFieldsScan> {
     let mut columns = Vec::with_capacity(query.column_names().len());
     let mut all_segments = Vec::new();
     for (column, weight) in query.weighted_columns() {
-        let segments = Some(
-            FtsSegmentSelection::AllCommitted
-                .resolve(
-                    dataset,
-                    column,
-                    DocumentGranularity::Row,
-                    &metrics.segment_bind_duration,
-                )
-                .await?,
-        );
+        let segments = match index_requirement {
+            CombinedFieldsIndexRequirement::EveryColumn => Some(
+                FtsSegmentSelection::AllCommitted
+                    .resolve(
+                        dataset,
+                        column,
+                        DocumentGranularity::Row,
+                        &metrics.segment_bind_duration,
+                    )
+                    .await?,
+            ),
+            CombinedFieldsIndexRequirement::AtLeastOneColumn => {
+                load_segments(dataset, column, DocumentGranularity::Row)
+                    .await?
+                    .map(Arc::from)
+            }
+        };
         let indices = match segments {
             Some(segments) => {
                 let _details = load_segment_details(dataset, column, &segments).await?;
@@ -3274,13 +3298,20 @@ async fn open_combined_fields_scan(
     let first_index = columns
         .iter()
         .find_map(|column| column.indices.first())
-        .ok_or_else(|| {
-            // Not a user error: segment resolution already failed for any column
-            // without an index, and `CombinedFieldsQuery::try_new` rejects an empty
-            // column list, so reaching this means one of those two guarantees broke.
-            DataFusionError::Internal(
+        .ok_or_else(|| match index_requirement {
+            // Not a user error: `EveryColumn` resolution already failed for any
+            // column without an index, and `CombinedFieldsQuery::try_new` rejects
+            // an empty column list, so reaching this means one of those two
+            // guarantees broke.
+            CombinedFieldsIndexRequirement::EveryColumn => DataFusionError::Internal(
                 "combined_fields query reached execution with no target columns".to_string(),
-            )
+            ),
+            CombinedFieldsIndexRequirement::AtLeastOneColumn => {
+                DataFusionError::Execution(format!(
+                    "combined_fields requires an inverted index on at least one of {:?}",
+                    query.column_names().collect::<Vec<_>>()
+                ))
+            }
         })?;
     let mut tokenizer = first_index.tokenizer();
     let tokens = collect_query_tokens(query.terms(), &mut tokenizer);
@@ -3290,6 +3321,7 @@ async fn open_combined_fields_scan(
         columns,
         segments: all_segments,
         tokens,
+        tokenizer,
     })
 }
 
@@ -3351,7 +3383,14 @@ impl ExecutionPlan for CombinedFieldsQueryExec {
                 segments: all_segments,
                 tokens,
                 ..
-            } = open_combined_fields_scan(&ds, &query, &tokenized_query, metrics.as_ref()).await?;
+            } = open_combined_fields_scan(
+                &ds,
+                &query,
+                CombinedFieldsIndexRequirement::EveryColumn,
+                &tokenized_query,
+                metrics.as_ref(),
+            )
+            .await?;
 
             // With mixed coverage the planner supplies the fragments every target
             // column indexes, and the scan is restricted to exactly those: the
@@ -3392,15 +3431,22 @@ impl ExecutionPlan for CombinedFieldsQueryExec {
             }
             let scorer = match (preset_base_scorer, shared_scorer) {
                 (Some(scorer), _) => scorer,
-                // An injected scorer describes the corpus the whole plan scores
-                // against; wait for it rather than folding this side's statistics.
+                // A mixed plan routes the rows no index covers to a flat sibling,
+                // so folding only this side's index statistics here would score the
+                // two children against different `docCount'`/`docFreq'`/`avgdl'`.
+                // Wait for the blend that describes the whole scanned corpus.
                 (None, Some(shared_scorer)) => shared_scorer.wait().await?,
                 (None, None) => {
                     let scorer_start = std::time::Instant::now();
                     let scorer = Arc::new(
-                        build_combined_bm25_scorer(&columns, &tokens, Some(metrics.as_ref()))
-                            .boxed()
-                            .await?,
+                        build_combined_bm25_scorer(
+                            &columns,
+                            &tokens,
+                            CombinedCorpusStats::IndexOnly,
+                            Some(metrics.as_ref()),
+                        )
+                        .boxed()
+                        .await?,
                     );
                     metrics.record_scorer_build(scorer_start.elapsed());
                     scorer
@@ -4257,6 +4303,435 @@ impl ExecutionPlan for FlatMatchQueryExec {
                 _ => unreachable!("record_poll preserves Ready(Some) input"),
             }
         });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream.stream_in_current_span().boxed(),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+}
+
+/// Cross-field (BM25F) scoring for rows no index covers.
+///
+/// One target column's share of the rows a flat `combined_fields` scan may fold
+/// into corpus statistics; see [`FlatCombinedFieldsExec::with_stats_coverage`].
+#[derive(Debug, Clone, Default)]
+pub struct FlatStatsCoverage {
+    /// Fragments this column's index does not cover at all.
+    pub fragments: roaring::RoaringBitmap,
+    /// Rows it does cover, but whose entries a newer overlay made stale, in the id
+    /// domain the scan's `_rowid` uses. The index still counts their pre-overlay
+    /// values, so folding these over-counts the column by at most their number.
+    pub stale_rows: RowAddrTreeMap,
+}
+
+impl FlatStatsCoverage {
+    /// Coverage by whole fragments, with no individually named stale rows.
+    pub fn for_fragments(fragments: roaring::RoaringBitmap) -> Self {
+        Self {
+            fragments,
+            stale_rows: RowAddrTreeMap::new(),
+        }
+    }
+}
+
+/// The sibling of [`CombinedFieldsQueryExec`] for the fragments that at least one
+/// target column's index is missing. Those rows cannot be scored from the indexes
+/// (`tf'`/`dl'` would omit the unindexed columns), so they are scored straight
+/// from their column values here. The two plans are unioned and re-sorted by the
+/// planner, exactly as the single-column match path does.
+///
+/// The input must carry `_rowid` plus every target column of the query.
+#[derive(Debug)]
+pub struct FlatCombinedFieldsExec {
+    dataset: Arc<Dataset>,
+    query: CombinedFieldsQuery,
+    /// Tokens `execute()` actually produced, for `analyze_plan`. Single snapshot
+    /// for the same reason as [`CombinedFieldsQueryExec::tokenized_query`].
+    tokenized_query: Arc<OnceLock<TokenizedQuery>>,
+    params: FtsSearchParams,
+    unindexed_input: Arc<dyn ExecutionPlan>,
+    /// Per target column (aligned with `query.columns`): the fragments that
+    /// column's index does not cover. Only rows in those fragments may be folded
+    /// into that column's corpus statistics; see
+    /// [`Self::with_stats_coverage`].
+    stats_coverage: Vec<FlatStatsCoverage>,
+    /// Set when the scan was read unfiltered: this then selects the rows to emit,
+    /// over `scanned_fragments`. See [`Self::with_emit_prefilter`].
+    emit_prefilter: Option<PreFilterSource>,
+    /// The fragments `unindexed_input` reads, so the emit mask spans exactly them.
+    scanned_fragments: roaring::RoaringBitmap,
+    /// Whether the target columns' index statistics are dropped in favour of this
+    /// scan's own. See [`Self::with_whole_corpus_stats`].
+    whole_corpus_stats: bool,
+    /// Per target column (aligned with `query.columns`): the schema-derived form
+    /// of its field path, which decides how `execute` turns the scanned column
+    /// into document text. See [`Self::with_resolved_fields`].
+    resolved_fields: Vec<ResolvedFtsField>,
+    /// Publishes the blended scorer to an indexed sibling; see
+    /// [`Self::with_shared_scorer`].
+    shared_scorer: Option<Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>>,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl DisplayAs for FlatCombinedFieldsExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt_combined_fields(
+            "FlatCombinedFields",
+            &self.query,
+            &self.tokenized_query,
+            t,
+            f,
+        )
+    }
+}
+
+impl FlatCombinedFieldsExec {
+    pub fn new(
+        dataset: Arc<Dataset>,
+        query: CombinedFieldsQuery,
+        params: FtsSearchParams,
+        unindexed_input: Arc<dyn ExecutionPlan>,
+    ) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(FTS_SCHEMA.clone()),
+            Partitioning::RoundRobinBatch(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        let stats_coverage = vec![FlatStatsCoverage::default(); query.column_names().len()];
+        Self {
+            dataset,
+            query,
+            tokenized_query: Arc::new(OnceLock::new()),
+            params,
+            unindexed_input,
+            stats_coverage,
+            emit_prefilter: None,
+            scanned_fragments: roaring::RoaringBitmap::new(),
+            whole_corpus_stats: false,
+            resolved_fields: Vec::new(),
+            shared_scorer: None,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    /// Supply the schema-derived form of each target column's field path, in
+    /// query order.
+    ///
+    /// The planner resolves these to decide what the scan projects, and `execute`
+    /// needs the same answers to read the projected batches back, so one entry
+    /// per target column is required.
+    pub(crate) fn with_resolved_fields(mut self, resolved_fields: Vec<ResolvedFtsField>) -> Self {
+        self.resolved_fields = resolved_fields;
+        self
+    }
+
+    /// Publish the blended scorer this scan builds to an indexed sibling.
+    ///
+    /// Only this side sees the unindexed rows, so only it can produce the corpus
+    /// statistics both sides must score against.
+    pub(crate) fn with_shared_scorer(
+        mut self,
+        scorer: Arc<SharedFtsScorer<CombinedFieldsBM25Scorer>>,
+    ) -> Self {
+        self.shared_scorer = Some(scorer);
+        self
+    }
+
+    /// Record, per target column, which scanned rows its index does not already
+    /// account for.
+    ///
+    /// The flat scan must read all of a row's target columns or `tf'`/`dl'` would be
+    /// partial, but a scanned fragment can still be indexed for some of those
+    /// columns. Without this, such a row would be folded into that column's corpus
+    /// statistics on top of the index statistics that already include it, inflating
+    /// `docCount_f`, `sumTotalTermFreq_f`, and `docFreq_f`.
+    pub fn with_stats_coverage(mut self, coverage: Vec<FlatStatsCoverage>) -> Self {
+        self.stats_coverage = coverage;
+        self
+    }
+
+    /// Select emitted rows with `prefilter` rather than with the scan.
+    ///
+    /// The caller reads the scan unfiltered so that a folded row's contribution to the
+    /// corpus statistics does not depend on the query's filter, and hands the filter
+    /// here instead, which is how [`CombinedFieldsQueryExec`] treats its own.
+    pub fn with_emit_prefilter(
+        mut self,
+        prefilter: PreFilterSource,
+        scanned_fragments: roaring::RoaringBitmap,
+    ) -> Self {
+        self.emit_prefilter = Some(prefilter);
+        self.scanned_fragments = scanned_fragments;
+        self
+    }
+
+    /// Drop the target columns' index statistics in favour of this scan's own; see
+    /// [`CombinedCorpusStats::FlatOnly`](lance_index::scalar::inverted::CombinedCorpusStats::FlatOnly).
+    ///
+    /// Every entry of [`Self::with_stats_coverage`] must then span every target
+    /// fragment, or the fold drops rows nothing else now accounts for.
+    pub fn with_whole_corpus_stats(mut self) -> Self {
+        self.whole_corpus_stats = true;
+        self
+    }
+
+    pub fn query(&self) -> &CombinedFieldsQuery {
+        &self.query
+    }
+
+    pub fn params(&self) -> &FtsSearchParams {
+        &self.params
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+}
+
+impl ExecutionPlan for FlatCombinedFieldsExec {
+    fn name(&self) -> &str {
+        "FlatCombinedFieldsExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        let mut children = vec![&self.unindexed_input];
+        children.extend(
+            self.emit_prefilter
+                .as_ref()
+                .and_then(PreFilterSource::execution_plan),
+        );
+        children
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        // `execute()` reads only `unindexed_input.execute(partition)` for the
+        // single output partition, so the input must be coalesced to one
+        // partition or fragments would be silently dropped. Same reasoning as
+        // `FlatMatchQueryExec`.
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != self.children().len() {
+            return Err(DataFusionError::Internal(
+                "Unexpected number of children".to_string(),
+            ));
+        }
+        // Reverse order: the optional prefilter child is last, so pop it first.
+        let emit_prefilter = match &self.emit_prefilter {
+            Some(source) if source.execution_plan().is_some() => Some(
+                source.with_execution_plan(children.pop().expect("child count checked above"))?,
+            ),
+            // A prefilter source with no child of its own leaves the input last.
+            source => source.clone(),
+        };
+        let Some(unindexed_input) = children.pop() else {
+            return Err(DataFusionError::Internal(
+                "combined_fields flat scan lost its input child".to_string(),
+            ));
+        };
+        Ok(Arc::new(Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params: self.params.clone(),
+            unindexed_input,
+            stats_coverage: self.stats_coverage.clone(),
+            emit_prefilter,
+            scanned_fragments: self.scanned_fragments.clone(),
+            whole_corpus_stats: self.whole_corpus_stats,
+            resolved_fields: self.resolved_fields.clone(),
+            shared_scorer: self.shared_scorer.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }))
+    }
+
+    #[instrument(name = "flat_combined_fields_exec", level = "debug", skip_all)]
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let query = self.query.clone();
+        let tokenized_query = self.tokenized_query.clone();
+        let ds = self.dataset.clone();
+        let stats_coverage = self.stats_coverage.clone();
+        let emit_prefilter = self.emit_prefilter.clone();
+        let scanned_fragments = self.scanned_fragments.clone();
+        let whole_corpus_stats = self.whole_corpus_stats;
+        let prefilter_context = context.clone();
+        let stats_mask_ds = self.dataset.clone();
+        let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
+        let metrics_clone = metrics.clone();
+        let target_batch_size = context.session_config().batch_size();
+        let elapsed_compute = metrics.baseline_metrics.elapsed_compute().clone();
+
+        let shared_scorer_producer = self.shared_scorer.clone().map(SharedFtsScorerProducer::new);
+
+        // One resolved field per target column. Without the check a short list
+        // would silently fall back to reading the raw column, which for a
+        // `List<Utf8>` target still tokenizes and so reverts to a per-element
+        // `dl_f` instead of erroring.
+        if self.resolved_fields.len() != query.column_names().len() {
+            return Err(DataFusionError::Internal(format!(
+                "combined_fields flat scan got {} resolved fields for {} target columns",
+                self.resolved_fields.len(),
+                query.column_names().len()
+            )));
+        }
+        let mut input = self.unindexed_input.execute(partition, context)?;
+        for (column, resolved) in query.column_names().zip(&self.resolved_fields) {
+            // A path that continues past a `List` cannot be projected, so the scan
+            // brought its list root instead and the leaf text is derived here.
+            input = if resolved.has_lists() {
+                flatten_fts_document_column(input, resolved.clone())?
+            } else {
+                document_input(input, column)?
+            };
+        }
+
+        let stream =
+            stream::once(async move {
+                let shared_scorer_producer = shared_scorer_producer;
+                let result = async {
+                let CombinedFieldsScan {
+                    columns,
+                    tokens,
+                    tokenizer,
+                    ..
+                } = open_combined_fields_scan(
+                    &ds,
+                    &query,
+                    CombinedFieldsIndexRequirement::AtLeastOneColumn,
+                    &tokenized_query,
+                    metrics.as_ref(),
+                )
+                .await?;
+
+                let input_schema = input.schema();
+                let doc_col_indices = query
+                    .column_names()
+                    .map(|column| input_schema.index_of(column))
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+
+                if stats_coverage.len() != columns.len() {
+                    return Err(DataFusionError::Internal(format!(
+                        "combined_fields flat scan got {} statistics coverage sets for {} columns",
+                        stats_coverage.len(),
+                        columns.len()
+                    )));
+                }
+                // One mask per target column, allowing the rows that column's index is
+                // missing. Built through `create_restricted_deletion_mask` so the
+                // fragment restriction lands in the same id space the flat scan's
+                // `_rowid` uses; a hand-rolled fragment-address allow list would match
+                // nothing under stable row ids. `None` means nothing needed filtering,
+                // i.e. every scanned row is missing from that index.
+                let mut stats_masks = Vec::with_capacity(stats_coverage.len());
+                for coverage in &stats_coverage {
+                    let mask = match DatasetPreFilter::create_restricted_deletion_mask(
+                        stats_mask_ds.clone(),
+                        coverage.fragments.clone(),
+                    ) {
+                        Some(fut) => fut.await?,
+                        None => Arc::new(RowAddrMask::all_rows()),
+                    };
+                    // The overlay-stale rows sit in fragments this column's index does
+                    // cover, so they are named individually rather than by fragment.
+                    let mask = if coverage.stale_rows.is_empty() {
+                        mask
+                    } else {
+                        Arc::new(mask.as_ref().clone().also_allow(coverage.stale_rows.clone()))
+                    };
+                    stats_masks.push(mask);
+                }
+
+                // Set when the scan was read unfiltered so a folded row's contribution
+                // does not move with the filter; the filter then picks what to emit.
+                let emit_mask = match emit_prefilter {
+                    Some(prefilter) => {
+                        let pre_filter = build_prefilter_restricted_to_fragments(
+                            prefilter_context,
+                            partition,
+                            &prefilter,
+                            stats_mask_ds.clone(),
+                            scanned_fragments,
+                            // The external row-address mask is applied by the
+                            // planner's `RowAddrMaskFilterExec` wrap around this
+                            // node, so it stays out of the corpus statistics.
+                            None,
+                        )?;
+                        pre_filter.wait_for_ready().await?;
+                        Some(pre_filter.mask())
+                    }
+                    None => None,
+                };
+
+                flat_combined_fields_search_stream(
+                    input,
+                    &columns,
+                    doc_col_indices,
+                    &stats_masks,
+                    emit_mask,
+                    whole_corpus_stats,
+                    &tokens,
+                    tokenizer,
+                    query.operator(),
+                    target_batch_size,
+                    Some(elapsed_compute),
+                    Some(metrics.as_ref()),
+                )
+                .await
+            }
+            .await;
+
+                match result {
+                    Ok((stream, scorer)) => {
+                        if let Some(producer) = shared_scorer_producer {
+                            producer.publish(scorer);
+                        }
+                        Ok(stream)
+                    }
+                    Err(error) => {
+                        if let Some(producer) = shared_scorer_producer {
+                            producer.publish_error(&error);
+                        }
+                        Err(error)
+                    }
+                }
+            })
+            .try_flatten()
+            .map(move |batch| {
+                let poll = metrics_clone
+                    .baseline_metrics
+                    .record_poll(std::task::Poll::Ready(Some(batch)));
+                match poll {
+                    std::task::Poll::Ready(Some(b)) => b,
+                    _ => unreachable!("record_poll preserves Ready(Some) input"),
+                }
+            });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
             stream.stream_in_current_span().boxed(),
@@ -5266,7 +5741,9 @@ mod tests {
     use lance_core::{ROW_ID, utils::address::RowAddress};
     use lance_datafusion::datagen::DatafusionDatagenExt;
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
-    use lance_datafusion::utils::{INDEX_CACHE_HITS_METRIC, PARTITIONS_SEARCHED_METRIC};
+    use lance_datafusion::utils::{
+        INDEX_CACHE_HITS_METRIC, INDEX_CACHE_MISSES_METRIC, PARTITIONS_SEARCHED_METRIC,
+    };
     use lance_datagen::{BatchCount, ByteCount, RowCount};
     use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::scalar::inverted::builder::ScoredDoc;
@@ -5275,8 +5752,9 @@ mod tests {
         Occur, Operator, PhraseQuery, collect_query_tokens, has_query_token,
     };
     use lance_index::scalar::inverted::{
-        CombinedFieldColumn, DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, SCORE_COL,
-        build_combined_bm25_scorer, build_global_bm25_scorer, prepare_bm25_query,
+        CombinedCorpusStats, CombinedFieldColumn, DocumentGranularity, FTS_SCHEMA, InvertedIndex,
+        Language, SCORE_COL, build_combined_bm25_scorer, build_global_bm25_scorer,
+        prepare_bm25_query,
     };
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{IndexCriteria, IndexType};
@@ -5294,9 +5772,9 @@ mod tests {
 
     use super::{
         BoolSlot, BoostQueryExec, CombinedFieldsQueryExec, CompoundQueryExec,
-        CrossColumnCompoundQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec,
-        FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET,
-        WandExactnessCertificate, build_boolean_query_children,
+        CrossColumnCompoundQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC, FlatCombinedFieldsExec,
+        FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
+        WAND_TIE_COMPLETION_BUDGET, WandExactnessCertificate, build_boolean_query_children,
         classify_wand_exactness_certificate, default_text_tokenizer, open_fts_segments,
         tokenizer_for_match_query,
     };
@@ -5988,6 +6466,41 @@ mod tests {
         );
     }
 
+    /// A `combined_fields` scan is a leaf FTS node, so `analyze_plan` must show
+    /// its tokens the way it does for `match` and `phrase`. Both children of a
+    /// mixed plan report, or a `Boolean{combined_fields, match}` plan would show
+    /// tokens on the `match` sibling only.
+    #[tokio::test]
+    async fn test_analyze_plan_shows_combined_fields_tokens() {
+        let dataset = create_tokenized_query_fixture(&["title", "body"], true).await;
+        let query = CombinedFieldsQuery::try_new(
+            "FIRST and SECOND".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap();
+        let mut scanner = dataset.scan();
+        scanner
+            .full_text_search(FullTextSearchQuery::new_query(query.into()))
+            .unwrap();
+
+        let explained = scanner.explain_plan(false).await.unwrap();
+        assert!(
+            !explained.contains("tokenized_query="),
+            "explain_plan should not claim runtime tokenization: {explained}"
+        );
+
+        let analysis = scanner.analyze_plan().await.unwrap();
+        let expected = r#"tokenized_query=[("first", 0), ("second", 2)]"#;
+        assert!(
+            find_plan_line(&analysis, "CombinedFieldsQuery:").contains(expected),
+            "indexed combined_fields is missing token positions:\n{analysis}"
+        );
+        assert!(
+            find_plan_line(&analysis, "FlatCombinedFields:").contains(expected),
+            "flat combined_fields is missing token positions:\n{analysis}"
+        );
+    }
+
     #[tokio::test]
     async fn test_boolean_query_parts_searched_metrics() {
         let mut dataset = lance_datagen::gen_batch()
@@ -6144,7 +6657,7 @@ mod tests {
         let expected_lookups = terms.len() * partitions;
         assert!(expected_lookups > 0);
         let scorer = Arc::new(
-            build_combined_bm25_scorer(&columns, &tokens, None)
+            build_combined_bm25_scorer(&columns, &tokens, CombinedCorpusStats::IndexOnly, None)
                 .await
                 .unwrap(),
         );
@@ -6185,6 +6698,40 @@ mod tests {
                 - metric_value(&preset, INDEX_CACHE_HITS_METRIC),
             expected_lookups,
             "CombinedFieldsQueryExec must report the scorer build's cache lookups",
+        );
+
+        // The flat sibling builds its own scorer from the same per-column index
+        // statistics. An empty input isolates those reads: the scanned rows
+        // contribute none, so the count is absolute rather than a delta.
+        let flat_schema = Arc::new(arrow_schema::Schema::new(vec![
+            lance_core::ROW_ID_FIELD.clone(),
+            arrow_schema::Field::new("title", DataType::Utf8, true),
+            arrow_schema::Field::new("body", DataType::Utf8, true),
+        ]));
+        let resolved_fields = query
+            .column_names()
+            .map(|column| {
+                crate::index::scalar::inverted::resolve_fts_field(
+                    dataset.schema(),
+                    column,
+                    DocumentGranularity::Row,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let flat = FlatCombinedFieldsExec::new(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            Arc::new(EmptyExec::new(flat_schema)),
+        )
+        .with_resolved_fields(resolved_fields);
+        assert!(execute_results(&flat).await.unwrap().is_empty());
+        assert_eq!(
+            metric_value(&flat, INDEX_CACHE_HITS_METRIC)
+                + metric_value(&flat, INDEX_CACHE_MISSES_METRIC),
+            expected_lookups,
+            "FlatCombinedFieldsExec must report the scorer build's cache lookups",
         );
     }
 

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -10,6 +10,7 @@ use lance_index::metrics::MetricsCollector;
 use lance_io::scheduler::{IoStats, ScanScheduler, ScanStats};
 use lance_table::format::IndexMetadata;
 use pin_project::pin_project;
+use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -365,14 +366,18 @@ fn shared_prefilter_future(
     .boxed()
 }
 
-pub(crate) fn build_prefilter(
+/// Resolve a prefilter source into the future that yields its mask, ANDing in
+/// the external row-address mask when the scan carries one.
+///
+/// The external mask restricts index-side scoring to the masked rows (mirroring
+/// the ANN path). It is independent of `overlay_block`, which the prefilter
+/// applies separately to drop index entries staled by a data overlay.
+fn prefilter_mask_future(
     context: Arc<datafusion::execution::TaskContext>,
     partition: usize,
     prefilter_source: &PreFilterSource,
-    ds: Arc<Dataset>,
-    index_meta: &[IndexMetadata],
-    masks: PreFilterMasks,
-) -> Result<Arc<DatasetPreFilter>> {
+    external_mask: Option<Arc<RowAddrMask>>,
+) -> Result<Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>>> {
     let mut shared_filter = None;
     let prefilter_loader = match &prefilter_source {
         PreFilterSource::FilteredRowIds(src_node) => {
@@ -407,12 +412,8 @@ pub(crate) fn build_prefilter(
         }
         PreFilterSource::None => None,
     };
-    // Combine the external row-address mask (logical AND) with whatever the
-    // filter produced, so an FTS prefilter restricts BM25 scoring to masked rows
-    // (mirrors the ANN path). Independent of `overlay_block`, which the prefilter
-    // applies separately to drop index entries staled by a data overlay.
-    let mut prefilter = if let Some(shared_filter) = shared_filter {
-        let shared_filter = match masks.external_mask {
+    if let Some(shared_filter) = shared_filter {
+        let shared_filter = match external_mask {
             Some(mask) => async move {
                 Ok(Arc::new(
                     mask.as_ref().clone() & shared_filter.await?.as_ref().clone(),
@@ -421,20 +422,52 @@ pub(crate) fn build_prefilter(
             .boxed(),
             None => shared_filter,
         };
-        DatasetPreFilter::new_with_filter_future(ds, index_meta, Some(shared_filter))
-    } else {
-        let prefilter_loader = match masks.external_mask {
-            Some(mask) => {
-                Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
-            }
-            None => prefilter_loader,
-        };
-        DatasetPreFilter::new(ds, index_meta, prefilter_loader)
+        return Ok(Some(shared_filter));
+    }
+    let prefilter_loader = match external_mask {
+        Some(mask) => {
+            Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
+        }
+        None => prefilter_loader,
     };
+    Ok(prefilter_loader.map(|loader| {
+        async move { loader.load().await.map(Arc::new) }
+            .in_current_span()
+            .boxed()
+    }))
+}
+
+pub(crate) fn build_prefilter(
+    context: Arc<datafusion::execution::TaskContext>,
+    partition: usize,
+    prefilter_source: &PreFilterSource,
+    ds: Arc<Dataset>,
+    index_meta: &[IndexMetadata],
+    masks: PreFilterMasks,
+) -> Result<Arc<DatasetPreFilter>> {
+    let filter = prefilter_mask_future(context, partition, prefilter_source, masks.external_mask)?;
+    let mut prefilter = DatasetPreFilter::new_with_filter_future(ds, index_meta, filter);
     if let Some(overlay_block) = masks.overlay_block {
         prefilter = prefilter.with_overlay_block(overlay_block);
     }
     Ok(Arc::new(prefilter))
+}
+
+/// Build a prefilter restricted to `fragments` rather than to the union of
+/// `index_meta`'s fragment bitmaps. See
+/// [`DatasetPreFilter::new_restricted_to_fragments`].
+pub(crate) fn build_prefilter_restricted_to_fragments(
+    context: Arc<datafusion::execution::TaskContext>,
+    partition: usize,
+    prefilter_source: &PreFilterSource,
+    ds: Arc<Dataset>,
+    fragments: RoaringBitmap,
+    external_mask: Option<Arc<RowAddrMask>>,
+) -> Result<Arc<DatasetPreFilter>> {
+    let filter = prefilter_mask_future(context, partition, prefilter_source, external_mask)?;
+    Ok(Arc::new(DatasetPreFilter::new_restricted_to_fragments(
+        ds, fragments, filter,
+    )))
 }
 
 // Utility to convert an input (containing row ids) into a prefilter

--- a/rust/lance/tests/query/inverted.rs
+++ b/rust/lance/tests/query/inverted.rs
@@ -22,8 +22,8 @@ use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::prefilter::NoFilter;
 use lance_index::scalar::inverted::query::{
-    BooleanQuery, BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, MultiMatchQuery, Occur,
-    Operator, PhraseQuery, collect_query_tokens,
+    BooleanQuery, BoostQuery, CombinedFieldsQuery, FtsQuery, FtsSearchParams, MatchQuery,
+    MultiMatchQuery, Occur, Operator, PhraseQuery, collect_query_tokens,
 };
 use lance_index::scalar::inverted::{DocumentGranularity, Language};
 use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
@@ -83,6 +83,16 @@ fn row_match_node(column: &str, terms: &str) -> MatchQuery {
 
 fn row_match(column: &str, terms: &str) -> FullTextSearchQuery {
     FullTextSearchQuery::new_query(FtsQuery::Match(row_match_node(column, terms)))
+}
+
+fn combined_fields(terms: &str, columns: &[&str]) -> FullTextSearchQuery {
+    FullTextSearchQuery::new_query(FtsQuery::CombinedFields(
+        CombinedFieldsQuery::try_new(
+            terms.to_string(),
+            columns.iter().map(|column| column.to_string()).collect(),
+        )
+        .unwrap(),
+    ))
 }
 
 fn row_phrase(column: &str, terms: &str) -> FullTextSearchQuery {
@@ -479,6 +489,20 @@ async fn test_element_document_fts_flat_indexed_and_mixed() {
         "{err}"
     );
 
+    // BM25F sums each target column's contribution for one row and reports no
+    // element coordinates, so a column that only has a list-element index has to
+    // be rejected rather than silently collapsed to a row score.
+    let mut element_only_combined = ds.scan();
+    element_only_combined
+        .full_text_search(combined_fields("alpha", &["tags"]))
+        .unwrap();
+    let err = element_only_combined.try_into_batch().await.unwrap_err();
+    assert!(
+        err.to_string().contains("combined_fields")
+            && err.to_string().contains("Row document granularity"),
+        "{err}"
+    );
+
     ds.create_index(
         &["tags"],
         IndexType::Inverted,
@@ -488,6 +512,17 @@ async fn test_element_document_fts_flat_indexed_and_mixed() {
     )
     .await
     .unwrap();
+
+    // With a row index alongside the list-element one, combined_fields picks the
+    // row index and scores whole rows, without a `_doc_index` column.
+    let combined = run_fts(&ds, combined_fields("alpha", &["tags"]), None).await;
+    assert_eq!(
+        combined["id"]
+            .as_primitive::<arrow_array::types::Int32Type>()
+            .values(),
+        &[0]
+    );
+    assert!(combined.column_by_name("_doc_index").is_none());
     let names = ds
         .load_indices()
         .await
@@ -969,6 +1004,40 @@ async fn test_element_document_nested_lists_use_deepest_boundary() {
     assert_eq!(row.fields, elements.fields);
     assert_eq!(row.fields, vec![content.id]);
     assert_ne!(row.fields, vec![docs.children[0].id]);
+
+    // A cross-field scan resolves the same path through the row index, and its
+    // flat sibling walks two list levels down to the leaf. Rows 2 and 3 repeat
+    // rows 0 and 1 in a fragment no index covers, so both sides contribute.
+    let combined_indexed = run_fts(&ds, combined_fields("alpha", &[path]), None).await;
+    assert_eq!(
+        combined_indexed["id"]
+            .as_primitive::<arrow_array::types::Int32Type>()
+            .values(),
+        &[0, 1]
+    );
+    assert!(combined_indexed.column_by_name("_doc_index").is_none());
+
+    let appended = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![2, 3])) as ArrayRef),
+        ("groups", batch.column_by_name("groups").unwrap().clone()),
+    ])
+    .unwrap();
+    let ds = InsertBuilder::new(Arc::new(ds))
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute(vec![appended])
+        .await
+        .unwrap();
+
+    let combined_mixed = run_fts(&ds, combined_fields("alpha", &[path]), None).await;
+    assert_eq!(
+        combined_mixed["id"]
+            .as_primitive::<arrow_array::types::Int32Type>()
+            .values(),
+        &[0, 1, 2, 3]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Exposes the Rust `combined_fields` (BM25F) query through the Java scanner API `FullTextQuery.combinedFields(queryText, columns)` plus an overload taking per-column boosts and an operator.

Unlike `multiMatch`, which scores each column separately and keeps the best field, this treats the target columns as one virtual field and blends term statistics across them, so a single query can match terms spread over several
columns.

Validation (unique columns, boost count matching column count, finite boosts >= 1) stays in the Rust core and surfaces as an exception when the query runs. The Java class only rejects null or empty text and columns, and defensively copies the column and boost lists.

Depends on the core combined_fields PR #7905