### PR TITLE
fix: carry input ordering through FilteredReadExec take mode

### DIFF
--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -24,7 +24,10 @@ use datafusion::physical_plan::{
     execution_plan::{Boundedness, EmissionType},
 };
 use datafusion_expr::Expr;
-use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
+use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::{
+    EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr,
+};
 use datafusion_physical_plan::Statistics;
 use datafusion_physical_plan::filter::FilterExec;
 use datafusion_physical_plan::metrics::{BaselineMetrics, Count, MetricsSet, Time};
@@ -1976,13 +1979,39 @@ impl FilteredReadExec {
             ),
         ));
 
+        // Take mode emits one output row per input row, in input order, so the
+        // input's ordering survives. It has to be re-expressed against the output
+        // schema, whose column positions differ; the ordering prefix stops at the
+        // first expression the output schema cannot name.
+        let mut eq_properties = EquivalenceProperties::new(output_schema.clone());
+        if let Some(input_ordering) = input.properties().eq_properties.output_ordering() {
+            let mut carried = Vec::with_capacity(input_ordering.len());
+            for sort_expr in input_ordering.iter() {
+                let expr = sort_expr.expr.as_ref() as &dyn std::any::Any;
+                let Some(column) = expr.downcast_ref::<Column>() else {
+                    break;
+                };
+                let Ok(remapped) = Column::new_with_schema(column.name(), output_schema.as_ref())
+                else {
+                    break;
+                };
+                carried.push(PhysicalSortExpr::new(
+                    Arc::new(remapped) as Arc<dyn PhysicalExpr>,
+                    sort_expr.options,
+                ));
+            }
+            if !carried.is_empty() {
+                eq_properties.add_ordering(carried);
+            }
+        }
+
         // Partitioning and emission behavior follow the input
         let properties = Arc::new(
             input
                 .properties()
                 .as_ref()
                 .clone()
-                .with_eq_properties(EquivalenceProperties::new(output_schema)),
+                .with_eq_properties(eq_properties),
         );
 
         let bare_schema = arrow_schema::Schema::from(&fields_to_read.to_bare_schema());
@@ -3158,6 +3187,8 @@ mod tests {
     use arrow_array::{
         Array, ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, UInt32Array, cast::AsArray,
     };
+    use arrow_schema::SortOptions;
+    use datafusion_physical_plan::sorts::sort::SortExec;
     use itertools::Itertools;
     use lance_core::datatypes::OnMissing;
     use lance_core::utils::address::RowAddress;
@@ -3832,6 +3863,66 @@ mod tests {
             }
         }
         assert!(num_batches > 0, "expected at least one non-empty batch");
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_take_carries_input_ordering() {
+        let fixture = TestFixture::new().await;
+
+        // A vector search feeds the take a stream ordered by distance. The take emits one
+        // output row per input row, in input order, so that ordering survives — but the
+        // output schema puts the columns in different positions, so it has to be
+        // re-expressed rather than copied.
+        let input_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new(ROW_ID, arrow_schema::DataType::UInt64, false),
+            arrow_schema::Field::new("_distance", arrow_schema::DataType::Float32, false),
+        ]));
+        let sort_options = SortOptions {
+            descending: false,
+            nulls_first: false,
+        };
+        let sorted = Arc::new(SortExec::new(
+            [PhysicalSortExpr::new(
+                Arc::new(Column::new_with_schema("_distance", input_schema.as_ref()).unwrap()),
+                sort_options,
+            )]
+            .into(),
+            Arc::new(OneShotExec::from_batch(RecordBatch::new_empty(
+                input_schema,
+            ))),
+        ));
+
+        let projection = fixture
+            .dataset
+            .empty_projection()
+            .union_column("not_indexed", OnMissing::Error)
+            .unwrap()
+            .with_row_id();
+        let take = FilteredReadExec::try_new(
+            fixture.dataset,
+            FilteredReadOptions::new(projection),
+            Some(sorted),
+        )
+        .unwrap();
+
+        let output_ordering = take
+            .properties()
+            .eq_properties
+            .output_ordering()
+            .expect("take mode should advertise its input's ordering");
+        assert_eq!(output_ordering.len(), 1);
+        let sort_expr = &output_ordering[0];
+        assert_eq!(sort_expr.options, sort_options);
+        let column = (sort_expr.expr.as_ref() as &dyn std::any::Any)
+            .downcast_ref::<Column>()
+            .expect("the carried ordering should still be a column reference");
+        assert_eq!(column.name(), "_distance");
+        // The index is the one the *output* schema uses, not the input's.
+        assert_eq!(
+            take.schema().field(column.index()).name(),
+            "_distance",
+            "ordering column index must be resolved against the output schema"
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -75,6 +75,19 @@ fn public_blob_v2_binary_projection_schema(projection: &Projection) -> SchemaRef
     Arc::new(schema)
 }
 
+/// Restamp a batch with the schema-level metadata this node declares it emits.
+///
+/// A fragment reader builds its batches from the projected field list alone, so they arrive
+/// without the dataset's schema metadata even though `output_schema` carries it. A caller that
+/// ends in a projection re-stamps the metadata on the way out and never sees the difference; a
+/// caller that hands this node's output straight to the user does.
+fn align_output_metadata(batch: RecordBatch, output_schema: &SchemaRef) -> Result<RecordBatch> {
+    if batch.schema_ref().metadata() == output_schema.metadata() {
+        return Ok(batch);
+    }
+    Ok(batch.with_metadata(output_schema.metadata().clone())?)
+}
+
 #[derive(Debug)]
 pub struct EvaluatedIndex {
     index_result: IndexExprResult,
@@ -1172,15 +1185,16 @@ impl FilteredReadStream {
                     }
                 });
                 let partition_metrics_clone = partition_metrics.clone();
+                let emitted_schema = output_schema.clone();
                 let base_batch_stream =
                     futures_stream
                         .try_buffered(num_threads)
                         .try_filter_map(move |batch| {
-                            std::future::ready(Ok(if batch.num_rows() == 0 {
-                                None
+                            std::future::ready(if batch.num_rows() == 0 {
+                                Ok(None)
                             } else {
-                                Some(batch)
-                            }))
+                                align_output_metadata(batch, &emitted_schema).map(Some)
+                            })
                         });
 
                 let batch_stream = if let Some(ref range) = self.scan_range_after_filter {
@@ -1253,12 +1267,15 @@ impl FilteredReadStream {
                         .instrument(tracing::debug_span!("filtered_read_task"))
                     }
                 })
-                .try_filter_map(move |batch| {
-                    std::future::ready(Ok(if batch.num_rows() == 0 {
-                        None
-                    } else {
-                        Some(batch)
-                    }))
+                .try_filter_map({
+                    let emitted_schema = output_schema.clone();
+                    move |batch| {
+                        std::future::ready(if batch.num_rows() == 0 {
+                            Ok(None)
+                        } else {
+                            align_output_metadata(batch, &emitted_schema).map(Some)
+                        })
+                    }
                 })
                 .map_err(|e: lance_core::Error| DataFusionError::External(e.into()));
                 Box::pin(RecordBatchStreamAdapter::new(output_schema, batch_stream))
@@ -3762,6 +3779,59 @@ mod tests {
             panic!("Expected an InvalidInput error when given an empty projection");
         };
         assert!(source.to_string().contains("no columns were selected"));
+    }
+
+    #[rstest::rstest]
+    #[case::one_partition(FilteredReadThreadingMode::OnePartitionMultipleThreads(2))]
+    #[case::multiple_partitions(FilteredReadThreadingMode::MultiplePartitions(2))]
+    #[test_log::test(tokio::test)]
+    async fn test_emitted_batches_carry_schema_metadata(
+        #[case] threading_mode: FilteredReadThreadingMode,
+    ) {
+        // Fragment readers build batches from the projected field list, which carries no
+        // schema-level metadata, so this node has to restamp what `output_schema` declares.
+        // Callers ending in a projection never notice; callers reading this node's output
+        // directly do.
+        let metadata =
+            std::collections::HashMap::from([("owner".to_string(), "lance".to_string())]);
+        let schema = Arc::new(arrow_schema::Schema::new_with_metadata(
+            vec![arrow_schema::Field::new(
+                "id",
+                arrow_schema::DataType::Int32,
+                false,
+            )],
+            metadata.clone(),
+        ));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from((0..100).collect::<Vec<_>>()))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let dataset = Arc::new(Dataset::write(reader, "memory://", None).await.unwrap());
+        assert_eq!(dataset.schema().metadata, metadata);
+
+        // Both `get_stream` branches build their batches independently.
+        let options =
+            FilteredReadOptions::basic_full_read(&dataset).with_threading_mode(threading_mode);
+        let plan = FilteredReadExec::try_new(dataset.clone(), options, None).unwrap();
+        assert_eq!(plan.schema().metadata(), &metadata);
+
+        let num_partitions = match threading_mode {
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(_) => 1,
+            FilteredReadThreadingMode::MultiplePartitions(n) => n,
+        };
+        let mut num_batches = 0;
+        for partition in 0..num_partitions {
+            let stream = plan
+                .execute(partition, Arc::new(TaskContext::default()))
+                .unwrap();
+            for batch in stream.try_collect::<Vec<_>>().await.unwrap() {
+                assert_eq!(batch.schema_ref().metadata(), &metadata);
+                num_batches += 1;
+            }
+        }
+        assert!(num_batches > 0, "expected at least one non-empty batch");
     }
 
     #[test_log::test(tokio::test)]


### PR DESCRIPTION
`FilteredReadExec` has two modes. In scan mode it reads a dataset from scratch. In take mode it sits above another operator — typically a vector or full-text search — and fetches the columns that operator did not produce, one output row per input row, in the order the input delivered them.

That means the input's sort order still holds on the output, but the node did not say so. It inherited the input's plan properties, which describe partitioning and how rows are emitted, and then replaced the ordering information wholesale with an empty set. So a search that carefully produced rows sorted by distance handed them to a take that reported no ordering at all, and every operator above had to assume the data was unsorted.

This PR carries the ordering through. The output schema puts columns in different positions than the input, so the ordering is re-expressed against the output schema rather than copied, and it stops at the first term the output schema cannot name. Scan mode is unchanged — it is a leaf with no input ordering to carry, and claiming an order there is a separate and larger question.

No query plans change as a result. Of the physical optimizer rules in use, only `EnforceDistribution` consults ordering, and it does not repartition below a take.

## Not included

Nothing yet consumes the newly advertised ordering. The rule that would use it to drop a redundant sort (`EnforceSorting`) is not in the physical rule set; adding it is follow-up work.

---

Stacked on #8555 — review the second commit only.
