### PR TITLE
feat(scanner): a logical-plan read path for plain scans

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -129,6 +129,8 @@ use crate::{
     io::exec::fts::{BoolSlot, BooleanQueryExec, build_boolean_query_children_with_schema},
 };
 
+pub(crate) mod logical;
+
 pub use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
 #[cfg(feature = "substrait")]
 use lance_datafusion::substrait::parse_substrait;
@@ -399,7 +401,7 @@ impl ColumnOrdering {
 ///
 /// This parameter only affects scans.  Vector search and full text search
 /// always use late materialization.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum MaterializationStyle {
     /// Heuristic-based materialization style
     ///
@@ -2794,6 +2796,9 @@ impl Scanner {
     #[instrument(level = "debug", skip_all)]
     pub async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
         log::trace!("creating scanner plan");
+        if logical::is_enabled() {
+            return logical::create_plan(self).await;
+        }
         self.validate_options()?;
 
         let full_text_query = match &self.full_text_query {

--- a/rust/lance/src/dataset/scanner/logical/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/builder.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 1: `Scanner` state -> an unoptimized [`LogicalPlan`].
+//!
+//! This stage is deliberately synchronous and does no I/O. It emits the *naive* plan — the shape
+//! the user's query literally describes — with no index awareness and no late-materialization
+//! split. Every Lance-specific decision is left to the rules in
+//! [`super::rules`], which run after [`super::context::ScanPlanningContext`] has done the
+//! prefetching they need.
+
+use std::sync::Arc;
+
+use datafusion::common::Column;
+use datafusion::datasource::provider_as_source;
+use datafusion::functions::core::expr_fn::get_field;
+use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder, SortExpr};
+use lance_core::{ROW_ADDR, ROW_ID};
+
+use super::source::{LanceScanSource, ScanSourceOptions};
+use crate::dataset::scanner::ColumnOrdering;
+use crate::dataset::{Dataset, Scanner};
+use crate::{Error, Result};
+
+/// Relation name for the scan leaf. Column references in filters and projections are
+/// unqualified, so this only ever shows up in `EXPLAIN` output.
+pub const TABLE_NAME: &str = "lance";
+
+pub fn build(scanner: &Scanner) -> Result<LogicalPlan> {
+    let scan = scan_leaf(scanner)?;
+    let filter = scanner.get_expr_filter()?;
+
+    let mut builder = LogicalPlanBuilder::new(scan);
+    if let Some(filter) = filter {
+        builder = builder.filter(filter)?;
+    }
+
+    // An aggregate replaces the output projection rather than sitting above it, and `validate_options`
+    // has already rejected a limit, offset or ordering alongside one. The columns it reads are found
+    // by projection pushdown, which is what the imperative path's `agg_projection` does by hand.
+    if let Some(aggregate) = &scanner.aggregate {
+        let aggregate = builder.aggregate(
+            aggregate
+                .group_by
+                .iter()
+                .map(unqualified)
+                .collect::<Vec<_>>(),
+            aggregate
+                .aggregates
+                .iter()
+                .map(unqualified)
+                .collect::<Vec<_>>(),
+        )?;
+        return Ok(aggregate.build()?);
+    }
+
+    // Sort below limit/offset, matching the imperative path: the limit takes the first rows of the
+    // ordering, not an arbitrary subset that is then ordered.
+    if let Some(ordering) = &scanner.ordering {
+        builder = builder.sort(ordering_exprs(ordering, &scanner.dataset)?)?;
+    }
+
+    if scanner.limit.unwrap_or(0) > 0 || scanner.offset.is_some() {
+        builder = builder.limit(
+            scanner.offset.unwrap_or(0) as usize,
+            scanner.limit.map(|l| l as usize),
+        )?;
+    }
+
+    builder = builder.project(output_exprs(scanner)?)?;
+    Ok(builder.build()?)
+}
+
+/// Pin an aggregate expression's output name to the unqualified one.
+///
+/// Resolving `sum(i)` against the scan relation would otherwise name the result `sum(lance.i)`,
+/// leaking this module's relation name into the user's output schema. The imperative path names
+/// these from the expression as written, so this keeps the two agreeing.
+fn unqualified(expr: &Expr) -> Expr {
+    let name = expr.schema_name().to_string();
+    expr.clone().alias(name)
+}
+
+fn scan_leaf(scanner: &Scanner) -> Result<LogicalPlan> {
+    let source = LanceScanSource::new(scanner.dataset.clone(), source_options(scanner))?;
+    Ok(
+        LogicalPlanBuilder::scan(TABLE_NAME, provider_as_source(Arc::new(source)), None)?
+            .build()?,
+    )
+}
+
+/// The scanner's `order_by` as logical sort expressions.
+///
+/// A nested ordering column ("outer.inner") becomes a chain of `get_field` calls rather than a
+/// column reference, which is also what makes projection pushdown keep the outer struct.
+fn ordering_exprs(ordering: &[ColumnOrdering], dataset: &Dataset) -> Result<Vec<SortExpr>> {
+    ordering
+        .iter()
+        .map(|column| {
+            let path = dataset
+                .schema()
+                .resolve_case_insensitive(&column.column_name)
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Field '{}' not found in schema",
+                        column.column_name
+                    ))
+                })?;
+            let mut expr = Expr::Column(Column::new_unqualified(&path[0].name));
+            for nested in &path[1..] {
+                expr = get_field(expr, nested.name.clone());
+            }
+            Ok(expr.sort(column.ascending, column.nulls_first))
+        })
+        .collect()
+}
+
+/// The user's requested output columns, as logical expressions.
+///
+/// `ProjectionPlan` has already parsed and coerced these against the full schema, so they can be
+/// used as-is. An alias is only added when the output name differs from what the expression
+/// would be named anyway — a redundant `s AS s` survives optimization and shows up in `EXPLAIN`.
+fn output_exprs(scanner: &Scanner) -> Result<Vec<Expr>> {
+    let mut exprs = scanner
+        .projection_plan
+        .requested_output_expr
+        .iter()
+        .map(|output| {
+            if output.expr.schema_name().to_string() == output.name {
+                output.expr.clone()
+            } else {
+                output.expr.clone().alias(&output.name)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // `with_row_id`/`with_row_address` promise their column is *last*.
+    if scanner.legacy_with_row_id {
+        move_to_end(&mut exprs, ROW_ID);
+    }
+    if scanner.legacy_with_row_addr {
+        move_to_end(&mut exprs, ROW_ADDR);
+    }
+    Ok(exprs)
+}
+
+fn move_to_end(exprs: &mut Vec<Expr>, name: &str) {
+    if let Some(position) = exprs
+        .iter()
+        .position(|expr| expr.schema_name().to_string() == name)
+    {
+        let expr = exprs.remove(position);
+        exprs.push(expr);
+    }
+}
+
+pub(super) fn source_options(scanner: &Scanner) -> ScanSourceOptions {
+    ScanSourceOptions {
+        batch_size: scanner.batch_size,
+        batch_readahead: scanner.batch_readahead,
+        fragment_readahead: scanner.fragment_readahead,
+        io_buffer_size: scanner.io_buffer_size,
+        file_reader_options: scanner.resolved_file_reader_options(),
+        fragments: scanner.fragments.clone().map(Arc::new),
+        index_expr_result_format: scanner.index_expr_result_format(),
+        use_scalar_index: scanner.use_scalar_index,
+        materialization_style: scanner.materialization_style.clone(),
+        blob_handling: scanner.blob_handling.clone(),
+        fast_search: scanner.fast_search,
+        index_segments: scanner.index_segments.clone().map(Arc::new),
+        include_deleted_rows: scanner.include_deleted_rows,
+        filter_plan: None,
+        legacy_scanner: super::source::v1::is_legacy(&scanner.dataset)
+            .then(|| Arc::new(scanner.clone())),
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/context.rs
+++ b/rust/lance/src/dataset/scanner/logical/context.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 2: the bridge between async planning and synchronous rules.
+//!
+//! An `OptimizerRule` is synchronous, so a rule cannot load index metadata. This struct is how a
+//! rule gets it anyway: everything is fetched once, up front, while we are still in an async
+//! context, and the rules hold an `Arc` to the result.
+//!
+//! The prefetch set is deliberately small — **all index metadata, plus the manifest's fragment
+//! metadata**. The latter is already in memory (`Manifest::fragments`, carrying `physical_rows`,
+//! `deletion_file`, and `overlays`), which is what makes so many of the imperative path's `await`
+//! points collapse into synchronous derivations.
+//!
+//! [`ScalarIndexInfo`](crate::index::ScalarIndexInfo) is the existing instance of this pattern —
+//! its doc comment describes the same contract for scalar indices. Later index types generalize it
+//! rather than inventing a second mechanism.
+
+use std::sync::Arc;
+
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::logical_expr::LogicalPlan;
+
+use super::scan_index::with_lance_source;
+use crate::Result;
+use crate::index::{DatasetIndexInternalExt, ScalarIndexInfo};
+
+/// Index and fragment state, captured once per planning invocation.
+#[derive(Debug)]
+pub struct ScanPlanningContext {
+    /// What the filter parser needs to turn a predicate into a scalar index query. Already the
+    /// canonical instance of this whole pattern — see the module docs.
+    scalar_indices: Arc<ScalarIndexInfo>,
+}
+
+impl ScanPlanningContext {
+    /// Walk the unoptimized plan for what it will need, then fetch all of it.
+    ///
+    /// This is the only `async fn` in stages 2 through 4 that is allowed to do I/O.
+    ///
+    /// Everything comes from the plan — the dataset and the scan-wide settings from its leaf.
+    /// Nothing reads the `Scanner`, so any plan built over a
+    /// [`LanceScanSource`](super::source::LanceScanSource) can be planned this way, not just one
+    /// the scanner's builder produced.
+    pub async fn collect(plan: &LogicalPlan) -> Result<Self> {
+        let mut leaf = None;
+        plan.apply(|node| {
+            if leaf.is_none() {
+                leaf = with_lance_source(node, |source| source.dataset().clone());
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+        let Some(dataset) = leaf else {
+            return Err(crate::Error::internal(
+                "a Lance scan plan reached stage 2 without a Lance scan leaf".to_string(),
+            ));
+        };
+
+        Ok(Self {
+            scalar_indices: Arc::new(dataset.scalar_index_info().await?),
+        })
+    }
+
+    pub fn scalar_indices(&self) -> &ScalarIndexInfo {
+        &self.scalar_indices
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/mod.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! A logical-plan read path for the scanner.
+//!
+//! [`Scanner::create_plan`](crate::dataset::Scanner::create_plan) builds physical plans directly.
+//! This module is the alternative: assemble the query as a DataFusion [`LogicalPlan`], run a
+//! curated rule set over it, and lower it with an `ExtensionPlanner`.
+//!
+//! Planning is staged so that the parts which must be synchronous can be:
+//!
+//! 1. **Build** the naive logical plan from `Scanner` state. Sync, no I/O.
+//! 2. **Collect** a [`ScanPlanningContext`](context::ScanPlanningContext) by walking that plan and
+//!    prefetching everything the later stages need — index metadata, plus the manifest's fragment
+//!    metadata, which is already in memory. This is the only stage that does I/O.
+//! 3. **Derive** the Lance-owned rules from the context. Each rule holds an
+//!    `Arc<ScanPlanningContext>`, which is how a synchronous rule gets at information that took
+//!    I/O to obtain. Rewrites that must happen for the plan to be *correct* are `AnalyzerRule`s;
+//!    only rewrites that are optional are `OptimizerRule`s.
+//! 4. **Optimize and lower**, analyzer then logical rules then physical.
+//!
+//! This path is off by default. See [`is_enabled`].
+//!
+//! # The pipeline
+//!
+//! ```text
+//! Scanner (the user's query, as builder state)
+//!    │
+//!    ├─ validate_options + ensure_supported
+//!    │     exhaustive destructure of Scanner: an option is read, rejected, or explained
+//!    │
+//!    ├─ 1. builder::build .............................................   builder   [sync]
+//!    │     Scanner state -> the naive LogicalPlan, index-unaware
+//!    │
+//!    ├─ 2. ScanPlanningContext::collect ...............................   context   [async]
+//!    │     walk the plan, prefetch every fact the rules will need
+//!    │     *** the only stage that does I/O ***
+//!    │
+//!    ├─ 3a. Analyzer::with_rules(analyzer_rules(&context)) ............             [sync]
+//!    │      the rewrites a correct plan requires; each runs exactly once
+//!    │
+//!    ├─ 3b. Optimizer::with_rules(optimizer_rules(&context)) ..........             [sync]
+//!    │      stock DataFusion rules, plus the mandatory rewrites that need to see
+//!    │      where PushDownFilter left the predicates; runs to a fixed point
+//!    │
+//!    └─ 4. DefaultPhysicalPlanner + LanceExtensionPlanner .............   planner   [async]
+//!          Lance nodes -> exec nodes, TableScan -> LanceScanSource::scan,
+//!          then the physical rules
+//!    ▼
+//! Arc<dyn ExecutionPlan>
+//! ```
+//!
+//! The staging answers one question: an `OptimizerRule` is synchronous, so how does it get at index
+//! metadata? It does not fetch it — stage 2 fetches everything up front and every rule holds an
+//! `Arc<ScanPlanningContext>`.
+//!
+//! Stage 4 *is* async — DataFusion's `ExtensionPlanner` and `TableProvider::scan` both are — so
+//! keeping I/O out of it is a choice rather than a language constraint. It is what lets the same
+//! decisions be made by synchronous rules in stage 3, where they are visible in the plan instead of
+//! buried in a constructor.
+//!
+//! # Invariants
+//!
+//! 1. **Stages 3 and 4 do no I/O.** Everything they need came from stage 2.
+//! 2. **An unplannable query fails loudly.** A silent fallback to the imperative path would make
+//!    every equivalence test meaningless.
+//! 3. **Analyzer rules need no idempotence guard; optimizer rules do.** The optimizer runs to a
+//!    fixed point, so a structural rewrite there has to recognize its own output.
+//!
+//! # Layout
+//!
+//! The framework is split by stage.
+//!
+//! ```text
+//! builder      stage 1: Scanner -> LogicalPlan
+//! context      stage 2: the one prefetch every later stage reads from
+//! source       the scan leaf, as a TableProvider
+//! scan_index   recording on each scan how it finds its rows
+//! planner      stage 4: dispatch to each node's lowering
+//! ```
+//!
+//! Rule *ordering* stays here, in [`analyzer_rules`] and [`optimizer_rules`], because it is a
+//! whole-plan property that no single index type can decide.
+
+pub(super) mod builder;
+pub(super) mod context;
+pub(super) mod planner;
+pub(super) mod scan_index;
+pub(super) mod source;
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use datafusion::execution::session_state::{SessionState, SessionStateBuilder};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::optimizer::optimize_projections::OptimizeProjections;
+use datafusion::optimizer::push_down_filter::PushDownFilter;
+use datafusion::optimizer::push_down_limit::PushDownLimit;
+use datafusion::optimizer::simplify_expressions::SimplifyExpressions;
+use datafusion::optimizer::{Analyzer, AnalyzerRule, Optimizer, OptimizerRule};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_optimizer::enforce_sorting::EnforceSorting;
+use datafusion::physical_optimizer::join_selection::JoinSelection;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+use lance_core::ROW_OFFSET;
+use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_datafusion::exec::{StrictBatchSizeExec, get_session_context};
+
+use self::context::ScanPlanningContext;
+use crate::dataset::Scanner;
+use crate::io::exec::{SimplifyProjection, get_physical_optimizer};
+use crate::{Error, Result};
+
+/// Environment switch for the new path. Off unless explicitly set to `1`.
+///
+/// An env var (rather than a `Scanner` field) keeps this from touching the public builder API
+/// while both paths coexist; the flag and the imperative path go away together.
+pub fn is_enabled() -> bool {
+    std::env::var("LANCE_LOGICAL_SCAN_PLANNER").is_ok_and(|value| value == "1")
+}
+
+/// Plan a scan through the logical path.
+///
+/// Rejects a query shape it cannot plan rather than silently falling back to the imperative path —
+/// a quiet fallback would make the equivalence tests meaningless.
+pub async fn create_plan(scanner: &Scanner) -> Result<Arc<dyn ExecutionPlan>> {
+    scanner.validate_options()?;
+    ensure_supported(scanner)?;
+
+    let logical_plan = builder::build(scanner)?;
+
+    if scanner.fragments.as_ref().is_some_and(Vec::is_empty) {
+        // An explicit empty fragment list means the scan reads nothing, whatever the query on top
+        // of it is. Stating that once here rather than per query kind also skips stage 2: there is
+        // no point loading index metadata to plan a scan over no data.
+        let schema = Arc::new(logical_plan.schema().as_arrow().clone());
+        return Ok(Arc::new(EmptyExec::new(schema)));
+    }
+
+    let plan = lower(logical_plan, planning_state(scanner)).await?;
+    Ok(apply_strict_batch_size(scanner, plan))
+}
+
+/// Stages 2 through 4: prefetch, optimize, lower.
+///
+/// Separate from [`create_plan`] because nothing here reads the `Scanner` — the plan is the only
+/// input. Any plan whose leaf is a [`LanceScanSource`](source::LanceScanSource) can go through it.
+pub async fn lower(
+    logical_plan: LogicalPlan,
+    state: Arc<SessionState>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let context = Arc::new(ScanPlanningContext::collect(&logical_plan).await?);
+
+    // Run the two logical stages directly rather than through `SessionState::optimize`, because the
+    // rule lists are the one part of planning that genuinely varies per query — each Lance rule
+    // holds the `ScanPlanningContext` above — and registering them on a `SessionState` would drag
+    // the rest of the state into varying with them. See [`planning_state`].
+    let analyzed = Analyzer::with_rules(analyzer_rules(&context)).execute_and_check(
+        logical_plan,
+        state.config_options(),
+        |_, _| {},
+    )?;
+    let optimized = Optimizer::with_rules(optimizer_rules(&context)).optimize(
+        analyzed,
+        state.as_ref(),
+        |_, _| {},
+    )?;
+
+    Ok(
+        DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
+            planner::LanceExtensionPlanner,
+        )])
+        .create_physical_plan(&optimized, state.as_ref())
+        .await?,
+    )
+}
+
+/// Rechunk the finished plan's output to an exact batch size, if the caller asked for one.
+///
+/// Above every rule rather than inside the plan, because it is not a planning decision: the node
+/// delegates its `PlanProperties` to its input and only reshapes batches, so no rule has anything
+/// to say about it.
+fn apply_strict_batch_size(
+    scanner: &Scanner,
+    plan: Arc<dyn ExecutionPlan>,
+) -> Arc<dyn ExecutionPlan> {
+    if !scanner.strict_batch_size {
+        return plan;
+    }
+    Arc::new(StrictBatchSizeExec::new(plan, scanner.get_batch_size()))
+}
+
+/// The query-independent half of planning state, built once and shared.
+///
+/// Built from the same session `execute_plan` will run this plan on, so that lowering sees the
+/// runtime it will actually execute against. `DefaultPhysicalPlanner` consults the config when it
+/// builds sorts and joins — `sort_spill_reservation_bytes` in particular — and a bare
+/// `SessionConfig::new()` here made the resulting plans hold more concurrently in the shared
+/// `FairSpillPool` than the imperative path's, which showed up as intermittent
+/// `ResourcesExhausted` under parallel test load.
+///
+/// Cached because building it is not cheap and nothing in it depends on the query:
+/// `with_default_features()` re-populates DataFusion's entire catalog of scalar, aggregate, window,
+/// and table functions, plus file formats and expression planners, none of which a scan consults.
+/// Measured at roughly 37 µs — against an imperative plan-build of 27 µs for the same query, so
+/// paying it per query doubled the cost of planning a trivial scan.
+///
+/// Only the *rule lists* vary per query, and they are a handful of `Arc`s; [`create_plan`] applies
+/// them with a standalone [`Analyzer`] and [`Optimizer`] instead of registering them here.
+fn planning_state(scanner: &Scanner) -> Arc<SessionState> {
+    /// Keyed by the session this state derives from and the parallelism it was built for.
+    type StateCache = Mutex<HashMap<(String, usize), Arc<SessionState>>>;
+
+    let session = get_session_context(&scanner.execution_options());
+    let target_partitions = scanner
+        .target_parallelism
+        .unwrap_or_else(get_num_compute_intensive_cpus);
+    // The session id identifies the cached `SessionContext` this state derives from, so it stands in
+    // for every execution option without this module having to know what they are.
+    let key = (session.session_id(), target_partitions);
+
+    static CACHE: OnceLock<StateCache> = OnceLock::new();
+    let mut cache = CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if let Some(state) = cache.get(&key) {
+        return state.clone();
+    }
+
+    let state = Arc::new(
+        SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(
+                session
+                    .copied_config()
+                    .with_target_partitions(target_partitions),
+            )
+            .with_runtime_env(session.runtime_env())
+            .with_physical_optimizer_rules(physical_optimizer_rules())
+            .build(),
+    );
+
+    // The key space is (execution options) × (requested parallelism), both of which take a handful
+    // of distinct values in practice — `get_session_context` caps its own side at 4. Clearing on
+    // overflow rather than evicting an entry keeps this to one line; a workload that actually
+    // thrashed it would be better served by a real LRU.
+    const MAX_ENTRIES: usize = 8;
+    if cache.len() >= MAX_ENTRIES {
+        cache.clear();
+    }
+    cache.insert(key, state.clone());
+    state
+}
+
+/// The rewrites that must happen for the plan to be *correct*, in the stage that guarantees each
+/// runs exactly once and then checks `InvariantLevel::Executable`.
+///
+/// Unlike [`optimizer_rules`], this list is *not* pinned: it starts from whatever
+/// `Analyzer::new()` provides, because `TypeCoercion` in particular has to run over the predicates
+/// the builder produced before anything duplicates them onto two branches, and reimplementing that
+/// to pin it would be worse than inheriting it. The cost is that a DataFusion upgrade can change
+/// this stage's behavior without the change being visible here.
+fn analyzer_rules(context: &Arc<ScanPlanningContext>) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
+    let _ = context;
+    Analyzer::new().rules
+}
+
+/// The curated logical rule set: a pinned subset of DataFusion's rules plus the Lance-owned ones
+/// derived from the planning context.
+///
+/// Pinned rather than inherited from `with_default_features()` so that a DataFusion upgrade cannot
+/// silently change what runs — the same discipline `get_physical_optimizer` already applies on the
+/// physical side. Anything that could move a predicate or limit *across* a search node is
+/// deliberately absent.
+fn optimizer_rules(
+    context: &Arc<ScanPlanningContext>,
+) -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
+    vec![
+        Arc::new(SimplifyExpressions::new()),
+        Arc::new(PushDownFilter::new()),
+        Arc::new(PushDownLimit::new()),
+        // After `PushDownFilter`, so the predicate it reads has reached the scan.
+        Arc::new(scan_index::ResolveScalarIndexQuery::new(context.clone())),
+        Arc::new(OptimizeProjections::new()),
+    ]
+}
+
+/// The physical rule set: Lance's own rules, plus the stock DataFusion rules that hand-built
+/// physical plans never needed.
+///
+/// `get_physical_optimizer` is tuned for the imperative path, where every node is constructed with
+/// its final configuration already chosen. A plan lowered from stock logical nodes is not like
+/// that, and two stock rules earn their place because of it:
+///
+/// * `JoinSelection` — `DefaultPhysicalPlanner` emits a `HashJoinExec` with `PartitionMode::Auto`,
+///   which panics at `execute()` unless something resolves it. It runs first so the Lance rules see
+///   a fully-resolved plan, the same way they do today.
+/// * `EnforceSorting` — a logical `Sort` is the only way to say "this order is the result's
+///   order", so the builder states it whether or not the plan below already produces it. Whether
+///   it does is a physical fact, so only a physical rule can drop the redundant sort. It runs
+///   last, after `EnforceDistribution` has settled partitioning, which is what decides whether an
+///   ordering survives a merge.
+fn physical_optimizer_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
+    let mut rules: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> =
+        vec![Arc::new(JoinSelection::new())];
+    rules.extend(get_physical_optimizer().rules);
+    rules.push(Arc::new(EnforceSorting::new()));
+    // Again, because dropping a sort can leave the projections it separated adjacent.
+    rules.push(Arc::new(SimplifyProjection));
+    rules
+}
+
+/// Account for every `Scanner` option, rejecting the query shapes this path cannot plan.
+///
+/// `Scanner` is destructured **exhaustively** — no `..` — so that adding a field to it fails to
+/// compile until someone decides what this path does with it. That is the point of the function:
+/// an option this path silently ignores is worse than one it rejects, because it returns different
+/// rows with no signal that anything was dropped. Every binding below is either read somewhere in
+/// this module, rejected here, or carries a comment saying why it cannot affect the plan.
+fn ensure_supported(scanner: &Scanner) -> Result<()> {
+    let Scanner {
+        dataset: _,
+        projection_plan,
+        // Read by the scan leaf, which decides there which columns it reads alongside the filter
+        // and which it takes afterwards.
+        materialization_style: _,
+        // Read by the scan leaf.
+        include_deleted_rows: _,
+
+        // Applied by the builder as a stock `Aggregate` node, which also replaces the output
+        // projection. `validate_options` has already rejected limit/offset/ordering alongside it.
+        aggregate: _,
+
+        // Applied to the finished plan by `create_plan`, above every rule: it only reshapes
+        // batches, so nothing in planning depends on it.
+        strict_batch_size: _,
+
+        // Read by the builder, the source, the context, or the session config.
+        filter: _,
+        batch_size: _,
+        batch_readahead: _,
+        fragment_readahead: _,
+        io_buffer_size: _,
+        limit: _,
+        offset: _,
+        ordering: _,
+        use_scalar_index: _,
+        fragments: _,
+        fast_search: _,
+        file_reader_options: _,
+        target_parallelism: _,
+        legacy_with_row_id: _,
+        legacy_with_row_addr: _,
+
+        // Read by the scan leaf, which types blob columns by it and reads them accordingly.
+        blob_handling: _,
+
+        // Folded into something this path does read, at the moment the caller sets it:
+        // `batch_size_bytes` into `resolved_file_reader_options`, and
+        // `relational_algebra_version` into `index_expr_result_format`.
+        batch_size_bytes: _,
+        relational_algebra_version: _,
+
+        // Read only by `legacy_filtered_read` and `scan_fragments`, which the v1 leaf hands the
+        // whole scanner to.
+        use_stats: _,
+        ordered: _,
+
+        // Not plan-affecting here. The callback is applied by `execute_plan` on the finished plan,
+        // and `explicit_projection` only gates a deprecation warning.
+        scan_stats_callback: _,
+        explicit_projection: _,
+
+        // Search options. Every one of them is inert once the search itself is rejected below.
+        nearest,
+        full_text_query,
+        prefilter: _,
+        is_batch_nearest: _,
+        nearest_query_count: _,
+        index_segments: _,
+        autoproject_scoring_columns: _,
+    } = scanner;
+
+    if nearest.is_some() || full_text_query.is_some() {
+        return Err(Error::not_supported_source(
+            "The logical scan planner cannot plan a search yet".into(),
+        ));
+    }
+    if reads_row_offset(scanner)? {
+        // `_rowoffset` is computed above the scan rather than read from it, so producing it needs a
+        // node this path does not have yet.
+        return Err(Error::not_supported_source(
+            "The logical scan planner cannot produce _rowoffset yet".into(),
+        ));
+    }
+    if projection_plan.has_output_cols() && projection_plan.physical_projection.is_empty() {
+        // `SELECT 1 AS foo` — output columns that read nothing. Not a gap: the imperative path
+        // rejects this too (`scanner.rs:2846`), and for the same reason, so this states the same
+        // refusal rather than deferring it. Without the guard, the leaf's "reading nothing is not a
+        // thing the reader can do" branch would quietly return row addresses instead.
+        //
+        // Resolving the output against an empty schema first is what distinguishes the two ways to
+        // land here: `SELECT 1` is unsupported, while `SELECT does_not_exist` is a missing column.
+        let output_expr = scanner.calculate_final_projection(&arrow_schema::Schema::empty())?;
+        return Err(Error::not_supported_source(
+            format!(
+                "Scans must request at least one column.  Received only dynamic expressions: {output_expr:?}"
+            )
+            .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn reads_row_offset(scanner: &Scanner) -> Result<bool> {
+    let names_it = |expr: &datafusion::logical_expr::Expr| {
+        expr.column_refs().iter().any(|col| col.name == ROW_OFFSET)
+    };
+    Ok(scanner
+        .projection_plan
+        .requested_output_expr
+        .iter()
+        .any(|output| names_it(&output.expr))
+        || scanner.get_expr_filter()?.as_ref().is_some_and(names_it))
+}

--- a/rust/lance/src/dataset/scanner/logical/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/planner.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 4: dispatching each Lance logical node to its lowering.
+//!
+//! The dispatch itself is mechanical. Every decision was made by a rule already; by the time a
+//! node reaches here it names exactly one execution strategy.
+//!
+//! A plain scan has no Lance node above its leaf — the leaf is a `TableProvider`, which
+//! `DefaultPhysicalPlanner` lowers on its own — so there is nothing to dispatch yet. Each node
+//! type registers itself here as it arrives.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::execution::session_state::SessionState;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+
+#[derive(Debug, Default)]
+pub struct LanceExtensionPlanner;
+
+#[async_trait]
+impl ExtensionPlanner for LanceExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        _node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        _physical_inputs: &[Arc<dyn ExecutionPlan>],
+        _session_state: &SessionState,
+    ) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/scan_index.rs
+++ b/rust/lance/src/dataset/scanner/logical/scan_index.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Recording on a Lance scan's source how it will find its rows.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::datasource::{provider_as_source, source_as_provider};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
+use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+
+use super::context::ScanPlanningContext;
+use super::source::LanceScanSource;
+
+/// Derive each Lance scan's scalar index query and record it on the scan's source.
+///
+/// This is what gives the index decision a place in the plan. Until it runs, the decision exists
+/// only inside `TableProvider::scan`, where no rule can see it — which is why the scan leaf was the
+/// one coverage split that had to be written out by hand.
+///
+/// It runs after `PushDownFilter`, so the predicate has reached its final position first.
+#[derive(Debug)]
+pub struct ResolveScalarIndexQuery {
+    context: Arc<ScanPlanningContext>,
+}
+
+impl ResolveScalarIndexQuery {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+}
+
+impl OptimizerRule for ResolveScalarIndexQuery {
+    fn name(&self) -> &str {
+        "resolve_scalar_index_query"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::TableScan(scan) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        // The physical planner unqualifies a `TableScan`'s filters before handing them to
+        // `TableProvider::scan`, and the Lance expression planner expects the same bare columns.
+        let filters = unnormalize_cols(scan.filters.iter().cloned());
+        let resolved = with_lance_source(&plan, |source| {
+            match source.filter_plan().is_some() || filters.is_empty() {
+                true => None,
+                false => Some(source.resolve_filter_plan(&filters, self.context.scalar_indices())),
+            }
+        });
+        let Some(Some(filter_plan)) = resolved else {
+            return Ok(Transformed::no(plan));
+        };
+        let filter_plan = filter_plan.map_err(datafusion::common::DataFusionError::from)?;
+        Ok(Transformed::yes(map_lance_scan(&plan, |source| {
+            source.with_filter_plan(filter_plan.clone())
+        })?))
+    }
+}
+
+/// Run `f` against the [`LanceScanSource`] behind a `TableScan`, if that is what this node is.
+///
+/// Closure-shaped rather than returning a reference because `source_as_provider` hands back an
+/// owned `Arc`, so the borrow cannot outlive this call.
+pub fn with_lance_source<R>(
+    plan: &LogicalPlan,
+    f: impl FnOnce(&LanceScanSource) -> R,
+) -> Option<R> {
+    let LogicalPlan::TableScan(scan) = plan else {
+        return None;
+    };
+    let provider = source_as_provider(&scan.source).ok()?;
+    let source = (provider.as_ref() as &dyn Any).downcast_ref::<LanceScanSource>()?;
+    Some(f(source))
+}
+
+/// Rebuild `plan`, replacing every Lance scan leaf's source with `f` applied to it.
+pub fn map_lance_scan(
+    plan: &LogicalPlan,
+    f: impl Fn(&LanceScanSource) -> LanceScanSource,
+) -> datafusion::common::Result<LogicalPlan> {
+    Ok(plan
+        .clone()
+        .transform_down(|node| {
+            let Some(source) = with_lance_source(&node, &f) else {
+                return Ok(Transformed::no(node));
+            };
+            let LogicalPlan::TableScan(scan) = &node else {
+                return Ok(Transformed::no(node));
+            };
+            let mut scan = scan.clone();
+            scan.source = provider_as_source(Arc::new(source));
+            Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
+        })?
+        .data)
+}

--- a/rust/lance/src/dataset/scanner/logical/source/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/source/mod.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The scan leaf for the logical read path.
+//!
+//! [`LanceScanSource`] is the [`TableProvider`] that a `TableScan` in a Lance logical plan is
+//! backed by. It exists instead of reusing [`LanceTableProvider`] because that provider's
+//! `scan()` recurses into `Dataset::scan().create_plan()` — the imperative builder this path is
+//! meant to replace. This one lowers straight to a [`FilteredReadExec`].
+//!
+//! [`LanceTableProvider`]: crate::datafusion::LanceTableProvider
+
+pub mod v1;
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_schema::{Schema as ArrowSchema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::DataFusionError;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{ExecutionPlan, expressions};
+use lance_arrow::{DataTypeExt, SchemaExt as ArrowSchemaExt};
+use lance_core::datatypes::{BlobHandling, Field as LanceField, OnMissing, Projection};
+use lance_core::{
+    ROW_ADDR_FIELD, ROW_CREATED_AT_VERSION_FIELD, ROW_ID_FIELD, ROW_LAST_UPDATED_AT_VERSION_FIELD,
+};
+use lance_file::reader::FileReaderOptions;
+use lance_index::scalar::expression::PlannerIndexExt;
+use lance_select::result::IndexExprResultWireFormat;
+use lance_table::format::Fragment;
+
+use crate::dataset::scanner::MaterializationStyle;
+use crate::dataset::{Dataset, Scanner};
+use crate::index::{DatasetIndexInternalExt, ScalarIndexInfo};
+use crate::io::exec::filtered_read::{
+    FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
+};
+use crate::io::exec::scalar_index::ScalarIndexExec;
+use crate::io::exec::{FilterPlan as ExprFilterPlan, Planner};
+use crate::{Error, Result};
+
+/// The subset of [`Scanner`](crate::dataset::Scanner) state that reaches the scan leaf.
+///
+/// Captured up front so the provider does not hold a `Scanner` reference: DataFusion owns the
+/// provider for the life of the plan, well past the borrow the builder runs under.
+#[derive(Clone)]
+pub struct ScanSourceOptions {
+    pub batch_size: Option<usize>,
+    pub batch_readahead: usize,
+    pub fragment_readahead: Option<usize>,
+    pub io_buffer_size: Option<u64>,
+    pub file_reader_options: Option<FileReaderOptions>,
+    pub fragments: Option<Arc<Vec<Fragment>>>,
+    pub index_expr_result_format: IndexExprResultWireFormat,
+    pub use_scalar_index: bool,
+    /// Which columns are cheap enough to read alongside the filter, rather than take after it.
+    pub materialization_style: MaterializationStyle,
+    /// Whether blob columns come back as their full binary value or as a description of where it
+    /// lives. It changes both what the leaf reads and how wide the column is, so the
+    /// materialization decision reads it too.
+    pub blob_handling: BlobHandling,
+    /// Answer from indices only: fragments a scalar index does not cover are skipped rather than
+    /// scanned. Only meaningful alongside an index query.
+    pub fast_search: bool,
+    /// The exact vector index segments a search may use, from `Scanner::with_index_segments`.
+    ///
+    /// The leaf itself never reads this — it is here because the leaf is where stage 2 recovers
+    /// the scan-wide settings that are not otherwise expressed in the plan.
+    pub index_segments: Option<Arc<Vec<uuid::Uuid>>>,
+    /// Emit deleted rows too, carrying a null row id.
+    ///
+    /// A branch of a coverage split keeps this, and should: the branches read disjoint fragment
+    /// sets, so between them they still emit every deleted row exactly once.
+    pub include_deleted_rows: bool,
+    /// How this scan's predicate splits into a scalar index query and a refine filter.
+    ///
+    /// `None` means nothing has resolved it yet and the leaf will do so itself. Filling this in is
+    /// what makes the index decision part of the plan rather than a private detail of
+    /// [`TableProvider::scan`] — see [`ResolveScalarIndexQuery`](ResolveScalarIndexQuery).
+    pub filter_plan: Option<ExprFilterPlan>,
+    /// The scanner this plan came from, captured only for legacy (v1) datasets.
+    ///
+    /// The legacy scan builder reads its options straight off `&Scanner` and is frozen, so the v1
+    /// leaf hands it one rather than changing its signature. `None` on current storage, where
+    /// nothing needs it. See [`v1`].
+    ///
+    /// Omitted from `Debug`: `Scanner` does not implement it, and the leaf's debug output is about
+    /// what the leaf will read, not how the query got here.
+    pub legacy_scanner: Option<Arc<Scanner>>,
+}
+
+impl std::fmt::Debug for ScanSourceOptions {
+    /// `Scanner` has no `Debug`, and what the leaf will read is what matters here, so the captured
+    /// legacy scanner is reported only as present or absent.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScanSourceOptions")
+            .field("batch_size", &self.batch_size)
+            .field("batch_readahead", &self.batch_readahead)
+            .field("fragment_readahead", &self.fragment_readahead)
+            .field("io_buffer_size", &self.io_buffer_size)
+            .field("file_reader_options", &self.file_reader_options)
+            .field("fragments", &self.fragments)
+            .field("index_expr_result_format", &self.index_expr_result_format)
+            .field("use_scalar_index", &self.use_scalar_index)
+            .field("materialization_style", &self.materialization_style)
+            .field("blob_handling", &self.blob_handling)
+            .field("fast_search", &self.fast_search)
+            .field("index_segments", &self.index_segments)
+            .field("include_deleted_rows", &self.include_deleted_rows)
+            .field("filter_plan", &self.filter_plan)
+            .field("legacy", &self.legacy_scanner.is_some())
+            .finish()
+    }
+}
+
+pub struct LanceScanSource {
+    dataset: Arc<Dataset>,
+    options: ScanSourceOptions,
+    /// Dataset schema plus the system columns the leaf can produce. DataFusion's projection
+    /// indices index into this, so it must stay stable for the life of the provider.
+    full_schema: SchemaRef,
+    row_id_idx: usize,
+    row_addr_idx: usize,
+    created_version_idx: usize,
+    updated_version_idx: usize,
+}
+
+impl std::fmt::Debug for LanceScanSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LanceScanSource")
+            .field("uri", &self.dataset.base)
+            .field("options", &self.options)
+            .finish()
+    }
+}
+
+impl LanceScanSource {
+    pub fn new(dataset: Arc<Dataset>, options: ScanSourceOptions) -> Result<Self> {
+        // Blob handling changes a blob column's type — full binary value or a description of where
+        // it lives — so it belongs to the schema the plan is built against, not just to the read.
+        let base = ArrowSchema::from(
+            &dataset
+                .full_projection()
+                .with_blob_handling(options.blob_handling.clone())
+                .to_bare_schema(),
+        );
+        // System columns go in the order `Projection::to_schema` appends them, because that is the
+        // order the read emits. A provider that advertises a different one hands DataFusion
+        // projection indices that name the wrong column.
+        let full_schema = base
+            .try_with_column(ROW_ID_FIELD.clone())?
+            .try_with_column(ROW_ADDR_FIELD.clone())?
+            .try_with_column(ROW_LAST_UPDATED_AT_VERSION_FIELD.clone())?
+            .try_with_column(ROW_CREATED_AT_VERSION_FIELD.clone())?;
+        let created_version_idx = full_schema.fields.len() - 1;
+        let updated_version_idx = created_version_idx - 1;
+        let row_addr_idx = updated_version_idx - 1;
+        let row_id_idx = row_addr_idx - 1;
+        Ok(Self {
+            dataset,
+            options,
+            full_schema: Arc::new(full_schema),
+            row_id_idx,
+            row_addr_idx,
+            created_version_idx,
+            updated_version_idx,
+        })
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    /// How this scan's predicate splits into a scalar index query and a refine filter, once a rule
+    /// has resolved it.
+    ///
+    /// This is the accessor that makes the index decision inspectable from the plan. Without it the
+    /// decision exists only inside [`TableProvider::scan`], where no rule can reach it.
+    pub fn filter_plan(&self) -> Option<&ExprFilterPlan> {
+        self.options.filter_plan.as_ref()
+    }
+
+    pub fn with_filter_plan(&self, filter_plan: ExprFilterPlan) -> Self {
+        self.with_options(ScanSourceOptions {
+            filter_plan: Some(filter_plan),
+            ..self.options.clone()
+        })
+    }
+
+    fn with_options(&self, options: ScanSourceOptions) -> Self {
+        Self {
+            dataset: self.dataset.clone(),
+            options,
+            full_schema: self.full_schema.clone(),
+            row_id_idx: self.row_id_idx,
+            row_addr_idx: self.row_addr_idx,
+            created_version_idx: self.created_version_idx,
+            updated_version_idx: self.updated_version_idx,
+        }
+    }
+
+    /// Translate DataFusion's positional projection into a Lance [`Projection`].
+    ///
+    /// `None` means "every column", matching DataFusion's convention.
+    fn to_lance_projection(&self, projection: Option<&Vec<usize>>) -> Result<Projection> {
+        let blob_handling = self.options.blob_handling.clone();
+        let Some(projection) = projection else {
+            return Ok(self
+                .dataset
+                .full_projection()
+                .with_blob_handling(blob_handling));
+        };
+        let mut columns = Vec::with_capacity(projection.len());
+        let mut result = self
+            .dataset
+            .empty_projection()
+            .with_blob_handling(blob_handling);
+        for idx in projection {
+            if *idx == self.row_id_idx {
+                result = result.with_row_id();
+            } else if *idx == self.row_addr_idx {
+                result = result.with_row_addr();
+            } else if *idx == self.created_version_idx {
+                result.with_row_created_at_version = true;
+            } else if *idx == self.updated_version_idx {
+                result.with_row_last_updated_at_version = true;
+            } else {
+                columns.push(self.full_schema.field(*idx).name());
+            }
+        }
+        result.union_columns(columns, OnMissing::Error)
+    }
+
+    /// Whether `field` is cheap enough to read alongside the filter rather than take after it.
+    ///
+    /// Mirrors `Scanner::is_early_field`, including the reasoning behind the heuristic's byte-width
+    /// thresholds, which is written out there.
+    fn is_early_field(&self, field: &LanceField) -> bool {
+        match &self.options.materialization_style {
+            MaterializationStyle::AllEarly => true,
+            MaterializationStyle::AllLate => false,
+            MaterializationStyle::AllEarlyExcept(cols) => !cols.contains(&(field.id as u32)),
+            MaterializationStyle::Heuristic => {
+                if field.is_blob() && self.options.blob_handling.returns_description(field) {
+                    // A description is an offset and a size, so it is cheap however wide the blob
+                    // it points at is.
+                    return true;
+                }
+                let byte_width = field.data_type().byte_width_opt();
+                match self.dataset.object_store.as_ref().is_cloud() {
+                    true => byte_width.is_some_and(|width| width < 1000),
+                    false => byte_width.is_some_and(|width| width < 10),
+                }
+            }
+        }
+    }
+
+    /// The columns to read alongside the filter, when taking the rest afterwards is cheaper than
+    /// reading everything in one pass.
+    ///
+    /// `None` means read everything in one pass, which is the answer whenever the split would buy
+    /// nothing: there is no refine filter for a take to skip rows against, or every requested
+    /// column is cheap enough to read anyway. Mirrors `Scanner::calc_eager_projection` and the part
+    /// of `Scanner::filtered_read_source` that decides whether to call it.
+    fn eager_projection(
+        &self,
+        filter_plan: &ExprFilterPlan,
+        requested: &Projection,
+    ) -> Result<Option<Projection>> {
+        if !filter_plan.has_refine() {
+            return Ok(None);
+        }
+        // The one legacy branch that ignores the projection it is handed cannot be narrowed; see
+        // `v1::uses_statistics_pushdown`. The imperative path hits the same wall from the other
+        // side — it computes an eager projection for v1 too, and the take it plans afterwards
+        // finds every column already there.
+        if let Some(scanner) = self.options.legacy_scanner.as_ref()
+            && v1::uses_statistics_pushdown(
+                scanner,
+                filter_plan,
+                requested,
+                self.options.fragments.as_ref(),
+            )?
+        {
+            return Ok(None);
+        }
+        // A column the filter reads is loaded by the read whether or not it is projected, so
+        // deferring it would cost a take and save nothing. This is why the emptiness check below
+        // has to come after the union rather than before it: a wide column the filter also reads
+        // would otherwise look deferrable and leave the take with nothing to fetch.
+        let filter_schema = self
+            .dataset
+            .empty_projection()
+            .union_columns(filter_plan.all_columns(), OnMissing::Error)?
+            .into_schema();
+        let eager = requested
+            .clone()
+            .subtract_predicate(|field| !self.is_early_field(field))
+            .union_schema(&filter_schema);
+        // Compare what the two reads would emit, not which field ids they carry. A blob column
+        // read as a description emits one column no matter how many storage fields sit under it,
+        // so an id-level difference can name columns that never reach the output and leave the
+        // take with nothing to fetch. This is the same comparison the take itself makes.
+        let eager_schema = ArrowSchema::from(&eager.to_schema());
+        if !requested
+            .clone()
+            .subtract_arrow_schema(&eager_schema, OnMissing::Ignore)?
+            .has_data_fields()
+        {
+            return Ok(None);
+        }
+        Ok(Some(eager.with_row_id()))
+    }
+
+    /// Fetch the columns the eager read left behind, for the rows that survived the filter.
+    fn take_late(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        requested: &Projection,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let taken = match v1::is_legacy(&self.dataset) {
+            true => v1::take(
+                &self.dataset,
+                input,
+                requested.clone(),
+                self.options.batch_size.map(|size| size as u32),
+            )?,
+            false => {
+                let mut options = FilteredReadOptions::new(requested.clone().with_row_id());
+                if self.options.include_deleted_rows {
+                    // Forwarded so the row-stream read rejects it: a deleted row carries a null
+                    // row id, which the take would silently drop. `Scanner::take_current` does
+                    // the same.
+                    options = options.with_deleted_rows()?;
+                }
+                if let Some(batch_size) = self.options.batch_size {
+                    options = options.with_batch_size(batch_size as u32);
+                }
+                if let Some(fragments) = &self.options.fragments {
+                    options = options.with_fragments(fragments.clone());
+                }
+                Arc::new(FilteredReadExec::try_new(
+                    self.dataset.clone(),
+                    options,
+                    Some(input),
+                )?) as Arc<dyn ExecutionPlan>
+            }
+        };
+
+        // The take appends its columns to the ones the eager read carried, so its output is in
+        // neither the requested order nor the requested set. Restating both here is what keeps the
+        // leaf's promise to return exactly the projection it was asked for.
+        let schema = taken.schema();
+        let columns = requested
+            .to_schema()
+            .fields
+            .iter()
+            .map(|field| {
+                Ok((
+                    expressions::col(&field.name, schema.as_ref())?,
+                    field.name.clone(),
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Arc::new(ProjectionExec::try_new(columns, taken)?))
+    }
+
+    /// Split the pushed-down predicates into a scalar-index query plus a refine expression.
+    ///
+    /// This mirrors [`Scanner::create_filter_plan`](crate::dataset::Scanner), including its
+    /// guard that scalar indices are unusable when any fragment is missing a row count. It is
+    /// synchronous because [`ScanPlanningContext`](super::context::ScanPlanningContext) already
+    /// holds the `ScalarIndexInfo`, which is what lets a rule call it.
+    pub fn resolve_filter_plan(
+        &self,
+        filters: &[Expr],
+        index_info: &ScalarIndexInfo,
+    ) -> Result<ExprFilterPlan> {
+        let Some(expr) = conjunction(filters) else {
+            return Ok(ExprFilterPlan::default());
+        };
+
+        let planner = Planner::new(self.full_schema.clone());
+        let plan =
+            planner.create_filter_plan(expr.clone(), index_info, self.options.use_scalar_index)?;
+
+        if plan.index_query.is_some() && self.fragments().iter().any(|f| f.physical_rows.is_none())
+        {
+            // Scalar index results are expressed in row addresses, which need fragment row
+            // counts to interpret. Without them, fall back to a pure refine filter.
+            return planner.create_filter_plan(expr, index_info, false);
+        }
+        Ok(plan)
+    }
+
+    /// [`Self::resolve_filter_plan`] for the case where no rule got there first.
+    async fn build_filter_plan(&self, filters: &[Expr]) -> Result<ExprFilterPlan> {
+        let index_info = self.dataset.scalar_index_info().await?;
+        self.resolve_filter_plan(filters, &index_info)
+    }
+
+    /// Present a row allow list in the shape the leaf's index-result slot expects.
+    ///
+    /// `Scanner::row_ids_as_take_input` wraps the same batch in a `OneShotExec`. A memory source
+    /// says the same thing without the one-shot restriction, since the allow list is a materialized
+    /// mask. That does not by itself make the scan re-executable — `FilteredReadExec` drains one
+    /// shared task stream per instance, so every Lance scan plan is single-execution — but it keeps
+    /// the reason for that in one place instead of two.
+    fn fragments(&self) -> &Arc<Vec<Fragment>> {
+        self.options
+            .fragments
+            .as_ref()
+            .unwrap_or_else(|| self.dataset.fragments())
+    }
+
+    /// How much of the fragment sequence a pushed-down limit lets the read stop after.
+    ///
+    /// `limit` is what DataFusion pushed into the scan, so it already carries any offset above it.
+    /// Mirrors `Scanner::get_scan_range`, including both of its refusals: a range is a count of
+    /// physical positions, so it cannot describe a limit that applies after a filter, and on a
+    /// stable-row-id dataset those positions can be tombstones whose live replacements sit in later
+    /// fragments — spending the range on them would skip rows the limit should have returned.
+    fn scan_range(&self, limit: Option<usize>, filter_plan: &ExprFilterPlan) -> Option<Range<u64>> {
+        let limit = limit?;
+        if filter_plan.has_any_filter() || self.dataset.manifest.uses_stable_row_ids() {
+            return None;
+        }
+        // Clamping keeps the range honest about the read it describes; an over-long one reads the
+        // same rows but claims otherwise in every plan that prints it.
+        let rows = self
+            .fragments()
+            .iter()
+            .map(|fragment| fragment.num_rows())
+            .sum::<Option<usize>>();
+        Some(0..rows.map_or(limit, |rows| limit.min(rows)) as u64)
+    }
+
+    async fn scan_impl(
+        &self,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let requested = self.to_lance_projection(projection)?;
+        // A read of no fragments is a read of no rows. Saying so here rather than building one
+        // keeps a branch a coverage split could not avoid producing — and a scan of a dataset that
+        // has no data yet — from costing an operator. Mirrors the `EmptyExec` short-circuits in
+        // `Scanner::plan_fts`.
+        if self.fragments().is_empty() {
+            let schema = ArrowSchema::from(&requested.to_schema());
+            return Ok(Arc::new(EmptyExec::new(Arc::new(schema))));
+        }
+        let filter_plan = match self.options.filter_plan.clone() {
+            Some(filter_plan) => filter_plan,
+            None => self.build_filter_plan(filters).await?,
+        };
+
+        // Reading the wide columns for every row only to filter most of them away is the case late
+        // materialization exists for; when it applies, the read below is narrower than what the
+        // caller asked for and a take makes up the difference.
+        let late = self.eager_projection(&filter_plan, &requested)?;
+        let mut projection = late.clone().unwrap_or_else(|| requested.clone());
+
+        // DataFusion asks for no columns when only the row count matters — `COUNT(*)`. Reading
+        // nothing is not a thing the reader can do, so an identity column stands in and is
+        // projected away again below. Matches `Scanner::filtered_read_source`, except on v1: the
+        // legacy scan reads `with_row_addr` off the `Scanner` rather than the projection it is
+        // handed, so the row id is the column that actually gets through there.
+        let counting_rows = projection.is_empty();
+        if counting_rows {
+            match v1::is_legacy(&self.dataset) {
+                true => projection.with_row_id = true,
+                false => projection.with_row_addr = true,
+            }
+        }
+
+        let scan_range = self.scan_range(limit, &filter_plan);
+
+        if v1::is_legacy(&self.dataset) {
+            let Some(scanner) = self.options.legacy_scanner.as_ref() else {
+                return Err(Error::internal(
+                    "a legacy (v1) scan reached the leaf without the scanner it needs".to_string(),
+                ));
+            };
+            let plan = v1::scan(
+                scanner,
+                &filter_plan,
+                projection,
+                self.options.include_deleted_rows,
+                self.options.fragments.clone(),
+                scan_range,
+            )
+            .await?;
+            return match (counting_rows, &late) {
+                (true, _) => drop_all_columns(plan),
+                (false, Some(_)) => self.take_late(plan, &requested),
+                (false, None) => Ok(plan),
+            };
+        }
+
+        let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
+            .with_filter_plan(filter_plan.clone())
+            .with_projection(projection)
+            .with_threading_mode(FilteredReadThreadingMode::OnePartitionMultipleThreads(
+                self.options.batch_readahead,
+            ));
+
+        if let Some(fragments) = self.options.fragments.clone() {
+            read_options = read_options.with_fragments(fragments);
+        }
+        if let Some(batch_size) = self.options.batch_size {
+            read_options = read_options.with_batch_size(batch_size as u32);
+        }
+        if let Some(file_reader_options) = self.options.file_reader_options.clone() {
+            read_options = read_options.with_file_reader_options(file_reader_options);
+        }
+        if let Some(fragment_readahead) = self.options.fragment_readahead {
+            read_options = read_options.with_fragment_readahead(fragment_readahead);
+        }
+        if let Some(io_buffer_size) = self.options.io_buffer_size {
+            read_options = read_options.with_io_buffer_size(io_buffer_size);
+        }
+        if self.options.fast_search && filter_plan.has_index_query() {
+            read_options = read_options.with_only_indexed_fragments();
+        }
+        if self.options.include_deleted_rows {
+            read_options = read_options.with_deleted_rows()?;
+        }
+        if let Some(scan_range) = scan_range {
+            read_options = read_options.with_scan_range_before_filter(scan_range)?;
+        }
+
+        let index_input = filter_plan.index_query.map(|index_query| {
+            Arc::new(ScalarIndexExec::new(
+                self.dataset.clone(),
+                index_query,
+                self.options.index_expr_result_format,
+            )) as Arc<dyn ExecutionPlan>
+        });
+
+        let plan = Arc::new(FilteredReadExec::try_new(
+            self.dataset.clone(),
+            read_options,
+            index_input,
+        )?) as Arc<dyn ExecutionPlan>;
+        match (counting_rows, &late) {
+            (true, _) => drop_all_columns(plan),
+            (false, Some(_)) => self.take_late(plan, &requested),
+            (false, None) => Ok(plan),
+        }
+    }
+}
+
+/// A plan with the same rows and no columns.
+fn drop_all_columns(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let no_columns: Vec<(Arc<dyn datafusion::physical_expr::PhysicalExpr>, String)> = vec![];
+    Ok(Arc::new(ProjectionExec::try_new(no_columns, plan)?))
+}
+
+#[async_trait]
+impl TableProvider for LanceScanSource {
+    fn schema(&self) -> SchemaRef {
+        self.full_schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        self.scan_impl(projection, filters, limit)
+            .await
+            .map_err(DataFusionError::from)
+    }
+
+    /// The leaf applies the predicate itself, so DataFusion never needs to re-check it.
+    ///
+    /// True on both storage versions, though for different reasons: `FilteredReadExec` always
+    /// applies it, while on v1 [`v1::scan`] tops the legacy plan with a filter in the one case
+    /// where the legacy builder would not have applied it.
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+}
+
+fn conjunction(filters: &[Expr]) -> Option<Expr> {
+    filters
+        .iter()
+        .cloned()
+        .reduce(datafusion::logical_expr::Expr::and)
+}

--- a/rust/lance/src/dataset/scanner/logical/source/v1.rs
+++ b/rust/lance/src/dataset/scanner/logical/source/v1.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The scan leaf on legacy (v1) storage.
+//!
+//! V1 is the only place the read path branches on file version, and it branches in exactly one
+//! spot: a full scan with a predicate. Everything else the planner builds — takes, scalar index
+//! lookups, every search node — is version-agnostic, because `FilteredReadExec` implements
+//! `take_all_tasks` for v1 fragments and only refuses `read_ranges_tasks`
+//! (`dataset/fragment.rs`). So this module covers the scan-mode case and nothing else.
+//!
+//! It does not reimplement the legacy scan; it calls it.
+//! [`legacy_filtered_read`](crate::dataset::Scanner::legacy_filtered_read) is a frozen
+//! compatibility surface, and the way to honor that is to keep using it verbatim. What that costs
+//! is a captured `Scanner`: the legacy builder reads a dozen fields straight off `&Scanner`, and
+//! changing its signature to take them individually would be a legacy refactor for no read-path
+//! benefit.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_schema::Schema as ArrowSchema;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_plan::ExecutionPlan;
+#[allow(deprecated)]
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use lance_arrow::SchemaExt as ArrowSchemaExt;
+use lance_core::datatypes::{OnMissing, Projection};
+use lance_file::version::ConcreteFileVersion;
+use lance_table::format::Fragment;
+
+use crate::dataset::Scanner;
+use crate::dataset::scanner::{BATCH_SIZE_FALLBACK, get_default_batch_size};
+use crate::dataset::versions;
+use crate::io::exec::{FilterPlan as ExprFilterPlan, LanceFilterExec, Planner, TakeExec};
+use crate::{Error, Result};
+
+/// Whether the scan leaf must go through the legacy builder for this dataset.
+pub fn is_legacy(dataset: &crate::Dataset) -> bool {
+    dataset.manifest().data_storage_format.lance_file_format() == ConcreteFileVersion::V1
+}
+
+/// Whether the legacy builder's statistics-pushdown branch is the one it will take.
+///
+/// Mirrors the branch condition in
+/// [`legacy_filtered_read`](crate::dataset::Scanner::legacy_filtered_read), with `is_prefilter`
+/// pinned to `false` the way [`scan`] calls it. Says nothing about whether that branch answers the
+/// right question — see [`pushdown_covers`].
+fn takes_statistics_pushdown(scanner: &Scanner, filter_plan: &ExprFilterPlan) -> bool {
+    !filter_plan.has_index_query()
+        && filter_plan.has_refine()
+        && scanner.batch_size.is_none()
+        && scanner.use_stats
+        && !scanner.filter_references_version_columns(filter_plan)
+}
+
+/// Whether `pushdown_scan` would read what this scan asked for.
+///
+/// It is the one legacy branch that ignores both arguments the leaf cares about: it takes its
+/// columns and its fragment list straight off the `Scanner`. So it only answers the right question
+/// where the two agree — the plan's root scan, reading what the caller configured. Every narrowing
+/// the rules introduce afterwards is invisible to it: a coverage split's fragment subset, an
+/// identity column a search node needs, a late-materialized projection. Where they disagree,
+/// [`scan`] turns the branch off rather than let it answer for a different read.
+fn pushdown_covers(
+    scanner: &Scanner,
+    projection: &Projection,
+    fragments: Option<&Arc<Vec<Fragment>>>,
+) -> Result<bool> {
+    if let Some(fragments) = fragments {
+        let configured = scanner
+            .fragments
+            .as_deref()
+            .unwrap_or_else(|| scanner.dataset.fragments());
+        if !fragments
+            .iter()
+            .map(|f| f.id)
+            .eq(configured.iter().map(|f| f.id))
+        {
+            return Ok(false);
+        }
+    }
+    // `ScanConfig` carries no version-column flags, so the branch cannot emit those however the
+    // scanner is projected.
+    let mut emitted = scanner.projection_plan.physical_projection.clone();
+    emitted.with_row_last_updated_at_version = false;
+    emitted.with_row_created_at_version = false;
+
+    let missing = projection
+        .clone()
+        .subtract_arrow_schema(&ArrowSchema::from(&emitted.to_schema()), OnMissing::Ignore)?;
+    Ok(!missing.has_data_fields()
+        && !missing.with_row_id
+        && !missing.with_row_addr
+        && !missing.with_row_last_updated_at_version
+        && !missing.with_row_created_at_version)
+}
+
+/// Whether a read of `projection` will go through the legacy statistics-pushdown branch.
+///
+/// Late materialization has to ask, because that branch reads the `Scanner`'s columns whatever it
+/// is handed: narrowing the projection under it would save nothing and cost a take that finds every
+/// column already there.
+pub fn uses_statistics_pushdown(
+    scanner: &Scanner,
+    filter_plan: &ExprFilterPlan,
+    projection: &Projection,
+    fragments: Option<&Arc<Vec<Fragment>>>,
+) -> Result<bool> {
+    Ok(takes_statistics_pushdown(scanner, filter_plan)
+        && pushdown_covers(scanner, projection, fragments)?)
+}
+
+/// Fetch `projection`'s columns for the rows `input` has already identified.
+///
+/// `FilteredReadExec` refuses a row-stream read on legacy files, so every take on v1 comes here
+/// instead — the scan leaf's late materialization as well as the plan's own take nodes. Mirrors
+/// `Scanner::take_legacy`, including the coalesce: `TakeExec` issues one read per batch, so small
+/// batches out of a search would each become their own round trip.
+#[allow(deprecated)]
+pub fn take(
+    dataset: &Arc<crate::Dataset>,
+    input: Arc<dyn ExecutionPlan>,
+    projection: Projection,
+    batch_size: Option<u32>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let batch_size = get_default_batch_size().unwrap_or_else(|| {
+        batch_size.map(|size| size as usize).unwrap_or_else(|| {
+            std::cmp::max(
+                dataset.object_store.as_ref().block_size() / 4,
+                BATCH_SIZE_FALLBACK,
+            )
+        })
+    });
+    let coalesced = Arc::new(CoalesceBatchesExec::new(input.clone(), batch_size));
+    match TakeExec::try_new(dataset.clone(), coalesced, projection)? {
+        Some(take) => Ok(Arc::new(take)),
+        None => Ok(input),
+    }
+}
+
+/// Build a v1 scan through the frozen legacy path.
+///
+/// The plan this returns satisfies the same contract as the v2 leaf: it applies the whole
+/// predicate, and its schema is exactly `projection`. Neither is free here — the legacy builder
+/// picks one of three branches and only two of them apply the predicate, and none of them promise
+/// an exact output schema — so both are re-established on the way out.
+///
+/// `scan_range` is only ever `Some` when there is no filter, matching what the imperative path
+/// asks of the legacy builder.
+pub async fn scan(
+    scanner: &Scanner,
+    filter_plan: &ExprFilterPlan,
+    projection: Projection,
+    include_deleted_rows: bool,
+    fragments: Option<Arc<Vec<Fragment>>>,
+    scan_range: Option<Range<u64>>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let output_schema: ArrowSchema = (&projection.to_schema()).into();
+
+    // Nothing in the legacy builder's signature turns the pushdown branch off, so when it would
+    // answer for a different read than the one asked for, take away the field its condition reads.
+    // The fragment scan it falls back to honors both arguments. Asked before the union below,
+    // because that union is for the branch this one is not.
+    let restated;
+    let scanner = if takes_statistics_pushdown(scanner, filter_plan)
+        && !pushdown_covers(scanner, &projection, fragments.as_ref())?
+    {
+        let mut without_stats = scanner.clone();
+        without_stats.use_stats = false;
+        restated = without_stats;
+        &restated
+    } else {
+        scanner
+    };
+
+    // The branch that does not apply the refine predicate also does not read its columns, so ask
+    // for them up front. Where a branch was going to read them anyway this is a no-op, and where
+    // it was not they are trimmed off again by `align_to_projection`.
+    let read_projection = match filter_plan.refine_expr.as_ref() {
+        Some(refine_expr) => projection.union_columns(
+            Planner::column_names_in_expr(refine_expr),
+            OnMissing::Ignore,
+        )?,
+        None => projection,
+    };
+
+    let planned = versions::filtered_read(
+        ConcreteFileVersion::V1,
+        scanner,
+        filter_plan,
+        read_projection,
+        include_deleted_rows,
+        fragments,
+        scan_range,
+        // Prefilter-ness is operator ordering in this path, so the leaf has nothing to say about
+        // it. `false` is the value that leaves the legacy builder's statistics-pushdown branch
+        // reachable, which is worth keeping: it is the only page pruning v1 has.
+        false,
+    )
+    .await?;
+
+    let mut plan = planned.plan;
+    // Two of the three legacy branches apply the predicate themselves: the statistics pushdown
+    // says so with `filter_pushed_down`, and the scalar-indexed scan applies it as a post-take
+    // filter without saying so. The third — the plain fragment scan — leaves it to the caller.
+    let already_filtered = planned.filter_pushed_down || filter_plan.has_index_query();
+    if let Some(refine_expr) = filter_plan.refine_expr.as_ref()
+        && !already_filtered
+    {
+        plan = Arc::new(LanceFilterExec::try_new(refine_expr.clone(), plan)?);
+    }
+
+    align_to_projection(plan, &output_schema)
+}
+
+/// Trim the legacy plan's output down to exactly the columns the projection asked for.
+///
+/// The legacy builder reads whatever its own branches need — the filter's columns as well as the
+/// projected ones — and orders system columns to suit itself. `TableProvider::scan` promises a
+/// plan whose schema *is* the requested projection, so anything extra or out of order has to be
+/// corrected here. On a full scan the schemas already match and no node is added.
+fn align_to_projection(
+    plan: Arc<dyn ExecutionPlan>,
+    output_schema: &ArrowSchema,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let input_schema = plan.schema();
+    if input_schema.fields() == output_schema.fields() {
+        return Ok(plan);
+    }
+    let mut exprs = Vec::with_capacity(output_schema.fields().len());
+    for field in output_schema.fields() {
+        let column =
+            Column::new_with_schema(field.name(), input_schema.as_ref()).map_err(|_| {
+                Error::internal(format!(
+                    "the legacy scan did not produce the projected column {}; it produced {:?}",
+                    field.name(),
+                    input_schema.field_names(),
+                ))
+            })?;
+        exprs.push((
+            Arc::new(column) as Arc<dyn PhysicalExpr>,
+            field.name().clone(),
+        ));
+    }
+    Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/harness.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/harness.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Shared harness: the result oracles and the datasets the tests run against.
+
+use std::sync::Arc;
+
+use arrow::compute::concat_batches;
+use arrow_array::RecordBatch;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::TryStreamExt;
+use lance_datafusion::exec::{LanceExecutionOptions, execute_plan};
+use lance_datagen::{BatchCount, ByteCount, RowCount, array, gen_batch};
+use lance_file::version::LanceFileVersion;
+
+use crate::Result;
+use crate::dataset::{Dataset, Scanner};
+use crate::utils::test::assert_plan_node_equals;
+
+/// A scanner-configuring closure. Generic rather than a `fn` pointer so a case can close over its
+/// query vector or filter string.
+pub(super) trait ScanConfig: Fn(&mut Scanner) -> Result<&mut Scanner> {}
+impl<F: Fn(&mut Scanner) -> Result<&mut Scanner>> ScanConfig for F {}
+
+/// Pin a closure's lifetime to the `ScanConfig` bound.
+///
+/// Rust infers a single fixed lifetime for a closure argument unless something forces the
+/// higher-ranked form, and `impl ScanConfig` is not enough on its own. Wrapping the closure here is
+/// what makes it one; a plain `fn` item needs no wrapper.
+pub(super) fn config<F>(f: F) -> F
+where
+    F: for<'a> Fn(&'a mut Scanner) -> Result<&'a mut Scanner>,
+{
+    f
+}
+
+/// Build a scanner, apply `config`, and plan it through the logical path.
+///
+/// `target_parallelism(1)` pins `EnforceDistribution`'s output so plan strings do not depend on
+/// the machine's CPU count, matching the convention in the scanner's own plan tests.
+pub(super) async fn logical_plan_for(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let mut scan = dataset.scan();
+    scan.target_parallelism(1);
+    config(&mut scan)?;
+    super::super::create_plan(&scan).await
+}
+
+/// As [`logical_plan_for`], but through the imperative path this module replaces.
+///
+/// Only the equivalence check below uses it. It goes away with the imperative path.
+pub(super) async fn imperative_plan_for(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let mut scan = dataset.scan();
+    scan.target_parallelism(1);
+    config(&mut scan)?;
+    scan.create_plan().await
+}
+
+pub(super) async fn assert_logical_plan(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    expected: &str,
+) -> Result<()> {
+    let plan = logical_plan_for(dataset, config).await?;
+    assert_plan_node_equals(plan, expected).await
+}
+
+pub(super) async fn run(plan: Arc<dyn ExecutionPlan>) -> Result<RecordBatch> {
+    let schema = plan.schema();
+    let batches = execute_plan(plan, LanceExecutionOptions::default())?
+        .try_collect::<Vec<_>>()
+        .await?;
+    Ok(concat_batches(&schema, &batches)?)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Result oracles
+// ---------------------------------------------------------------------------------------------
+//
+// Every fixture in this module derives its data from the row's `i` value, so the answer to a query
+// can be stated in terms of `i` and computed in Rust. That is what these helpers compare against:
+// a claim about the data, not another planner's output. Results are identified by `_rowid`, which
+// [`Fixture`] maps back to `i`, so a case can say which rows it expects without having to project
+// the column it is filtering on.
+
+/// The whole dataset, read once, as the reference the assertions are stated against.
+pub(super) struct Fixture {
+    rows: RecordBatch,
+}
+
+impl Fixture {
+    /// A plain unfiltered scan, which is the one shape whose answer is not in question.
+    pub(super) async fn read(dataset: &Dataset) -> Result<Self> {
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        Ok(Self {
+            rows: scan.try_into_batch().await?,
+        })
+    }
+
+    pub(super) fn row_ids(&self) -> &[u64] {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::UInt64Type;
+        self.rows[lance_core::ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+    }
+
+    pub(super) fn ids(&self) -> &[i32] {
+        use arrow::datatypes::Int32Type;
+        use arrow_array::cast::AsArray;
+        self.rows["i"].as_primitive::<Int32Type>().values()
+    }
+
+    /// The `i` values of `row_ids`, in the order given.
+    pub(super) fn ids_of(&self, row_ids: &[u64]) -> Vec<i32> {
+        let index: std::collections::HashMap<u64, i32> = self
+            .row_ids()
+            .iter()
+            .copied()
+            .zip(self.ids().iter().copied())
+            .collect();
+        row_ids
+            .iter()
+            .map(|row_id| index[row_id])
+            .collect::<Vec<_>>()
+    }
+
+    /// A string column's values, in storage order.
+    pub(super) fn strings(&self, column: &str) -> Vec<String> {
+        use arrow_array::cast::AsArray;
+        self.rows[column]
+            .as_string::<i32>()
+            .iter()
+            .map(|value| value.unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// The `i` values of every row satisfying `keep`, in storage order.
+    pub(super) fn ids_where(&self, keep: impl Fn(i32) -> bool) -> Vec<i32> {
+        self.ids().iter().copied().filter(|i| keep(*i)).collect()
+    }
+
+    /// The value of `column` for the row identified by `row_id`.
+    fn cell(&self, column: &str, row_id: u64) -> arrow_array::ArrayRef {
+        let position = self
+            .row_ids()
+            .iter()
+            .position(|candidate| *candidate == row_id)
+            .expect("result row is not in the dataset");
+        self.rows[column].slice(position, 1)
+    }
+}
+
+/// The `_rowid` column of a result, which every oracle here uses to identify rows.
+pub(super) fn row_ids_of(batch: &RecordBatch) -> Vec<u64> {
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::UInt64Type;
+    batch[lance_core::ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .to_vec()
+}
+
+/// Run `config`'s scan with `_rowid` appended, so its rows can be named.
+///
+/// Every result oracle below funnels through here, so this is also where the path being replaced is
+/// held to the same answer: the imperative path plans the same query, and the two must return the
+/// same rows in the same order. The oracles state what the answer *is*; this states that nothing
+/// changed on the way to it. Both halves go away together — the oracles stay, the comparison
+/// leaves with the imperative path.
+///
+/// Row order is compared because it is observable: a path that returns the right rows in a
+/// different order has still changed what a caller sees.
+pub(super) async fn scan_rows(dataset: &Dataset, config: impl ScanConfig) -> Result<RecordBatch> {
+    let config = config_with_row_id(config);
+    let actual = run(logical_plan_for(dataset, &config).await?).await?;
+    let expected = run(imperative_plan_for(dataset, &config).await?).await?;
+
+    assert_eq!(
+        expected.schema(),
+        actual.schema(),
+        "logical path produced a different output schema"
+    );
+    assert_eq!(expected, actual, "logical path produced different rows");
+    Ok(actual)
+}
+
+fn config_with_row_id(config: impl ScanConfig) -> impl ScanConfig {
+    move |scan: &mut Scanner| {
+        config(scan)?;
+        Ok(scan.with_row_id())
+    }
+}
+
+/// Assert `config`'s scan returned exactly the rows whose `i` satisfies `keep`, in storage order,
+/// and that every column it returned carries that row's value.
+pub(super) async fn assert_scan_keeps(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    keep: impl Fn(i32) -> bool,
+) -> Result<()> {
+    let fixture = Fixture::read(dataset).await?;
+    assert_scan_returns(dataset, config, &fixture, fixture.ids_where(keep)).await
+}
+
+/// Assert `config`'s scan returned exactly the rows named by `expected`, in that order.
+pub(super) async fn assert_scan_returns(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    fixture: &Fixture,
+    expected: Vec<i32>,
+) -> Result<()> {
+    let actual = scan_rows(dataset, config).await?;
+    let row_ids = row_ids_of(&actual);
+    assert_eq!(fixture.ids_of(&row_ids), expected, "wrong rows");
+    assert_columns_match(&actual, fixture, &row_ids);
+    Ok(())
+}
+
+/// Check every projected column against the dataset's own copy of that row.
+///
+/// Row identity alone would not catch a take that fetched the right rows and then misaligned their
+/// values, which is the failure mode late materialization is most exposed to.
+pub(super) fn assert_columns_match(actual: &RecordBatch, fixture: &Fixture, row_ids: &[u64]) {
+    for field in actual.schema().fields() {
+        // Only columns the dataset stores; scores and distances are the search's own output.
+        if !fixture.rows.schema().fields().iter().any(|f| f == field) {
+            continue;
+        }
+        for (position, row_id) in row_ids.iter().enumerate() {
+            assert_eq!(
+                &actual[field.name()].slice(position, 1),
+                &fixture.cell(field.name(), *row_id),
+                "column {} disagrees with the dataset at row {position}",
+                field.name()
+            );
+        }
+    }
+}
+
+/// Tag a reader's schema with dataset-level metadata.
+///
+/// The imperative suite's own fixtures do this deliberately — `scanner.rs:6489` says "so it tests
+/// all paths that re-construct the schema along the way". The oracle needs it for the same reason:
+/// a lowering step that rebuilds an output schema and drops its metadata is invisible against a
+/// fixture that has none.
+pub(super) fn tagged(
+    reader: impl arrow_array::RecordBatchReader,
+) -> impl arrow_array::RecordBatchReader {
+    use arrow::datatypes::Schema as ArrowSchema;
+    use arrow_array::{RecordBatch, RecordBatchIterator};
+
+    let schema = Arc::new(ArrowSchema::new_with_metadata(
+        reader.schema().fields().clone(),
+        [("dataset".to_string(), "logical".to_string())].into(),
+    ));
+    let batches = reader
+        .map(|batch| {
+            let batch = batch?;
+            RecordBatch::try_new(schema.clone(), batch.columns().to_vec())
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+    RecordBatchIterator::new(batches.into_iter().map(Ok), schema)
+}
+
+pub(super) async fn test_dataset() -> Dataset {
+    test_dataset_versioned(LanceFileVersion::Stable).await
+}
+
+/// The `i`/`s` fixture, written at a chosen storage version.
+///
+/// Legacy (v1) storage is the one thing that changes the shape of the scan leaf, so the plain-scan
+/// equivalence cases run against both versions rather than only the default.
+pub(super) async fn test_dataset_versioned(version: LanceFileVersion) -> Dataset {
+    use crate::dataset::WriteParams;
+    use arrow::datatypes::Int32Type;
+
+    let data = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .col("s", array::rand_utf8(ByteCount::from(8), false))
+        .into_reader_rows(RowCount::from(100), BatchCount::from(2));
+    Dataset::write(
+        tagged(data),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 100,
+            data_storage_version: Some(version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap()
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Tests for the logical scan planner.
+//!
+//! Most of these are equivalence tests: they build the same query through both the imperative and
+//! the logical path and compare the rows. See [`harness`] for that oracle.
+
+mod harness;
+mod scan;

--- a/rust/lance/src/dataset/scanner/logical/tests/scan.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/scan.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Plain scans: filter, projection, limit.
+//!
+//! These run against both storage versions. Legacy (v1) storage is the one case where the scan
+//! leaf lowers to something else entirely — the frozen legacy builder rather than
+//! `FilteredReadExec` — so it needs its own coverage of the same shapes, not just the default.
+
+use lance_file::version::LanceFileVersion;
+
+use crate::dataset::scanner::{AggregateExpr, MaterializationStyle};
+use rstest::rstest;
+
+use super::harness::*;
+
+#[tokio::test]
+async fn test_filtered_scan_plan() {
+    let dataset = test_dataset().await;
+
+    // DataFusion pushed both the projection and the predicate into the scan leaf, and the leaf
+    // claims exact filter pushdown, so no FilterExec survives above it. What the leaf lowers to is
+    // two reads rather than one: `s` is a string, so its width is unknown and the heuristic reads
+    // it late — only for the rows the filter kept.
+    assert_logical_plan(
+        &dataset,
+        |scan| scan.project(&["s"])?.filter("i > 10 and i < 20"),
+        "ProjectionExec: expr=[s@2 as s]
+  LanceRead: uri=..., projection=[s], source=stream(_rowid)
+    LanceRead: uri=..., projection=[i], num_fragments=2, range_before=None, range_after=None, \
+     row_id=true, row_addr=false, full_filter=i > Int32(10) AND i < Int32(20), \
+     refine_filter=i > Int32(10) AND i < Int32(20)",
+    )
+    .await
+    .unwrap();
+}
+
+/// Reading everything in one pass is what an explicitly early materialization asks for.
+#[tokio::test]
+async fn test_filtered_scan_plan_all_early() {
+    let dataset = test_dataset().await;
+
+    assert_logical_plan(
+        &dataset,
+        config(|scan| {
+            scan.project(&["s"])?
+                .filter("i > 10 and i < 20")?
+                .materialization_style(MaterializationStyle::AllEarly);
+            Ok(scan)
+        }),
+        "LanceRead: uri=..., projection=[s], num_fragments=2, range_before=None, range_after=None, \
+         row_id=false, row_addr=false, full_filter=i > Int32(10) AND i < Int32(20), \
+         refine_filter=i > Int32(10) AND i < Int32(20)",
+    )
+    .await
+    .unwrap();
+}
+
+/// The v1 counterpart of [`test_filtered_scan_plan`].
+///
+/// Also a single node, but the legacy one: the leaf routed to the statistics-pushdown scan, which
+/// applies the predicate itself and emits the projection, so nothing survives above it. That the
+/// plan is not `LanceScan + FilterExec` is the point — the leaf reports exact pushdown on v1 and
+/// keeps the only page pruning legacy storage has.
+#[tokio::test]
+async fn test_filtered_scan_plan_v1() {
+    let dataset = test_dataset_versioned(LanceFileVersion::Legacy).await;
+
+    assert_logical_plan(
+        &dataset,
+        |scan| scan.project(&["s"])?.filter("i > 10 and i < 20"),
+        "LancePushdownScan: uri=..., projection=[s], predicate=i > Int32(10) AND i < Int32(20), \
+         row_id=false, row_addr=false, ordered=true",
+    )
+    .await
+    .unwrap();
+}
+
+#[rstest]
+#[case::v1(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_filtered_scan_returns_the_matching_rows(#[case] version: LanceFileVersion) {
+    let dataset = test_dataset_versioned(version).await;
+    assert_scan_keeps(
+        &dataset,
+        |scan| scan.project(&["s"])?.filter("i > 10 and i < 20"),
+        |i| i > 10 && i < 20,
+    )
+    .await
+    .unwrap();
+}
+
+#[rstest]
+#[case::v1(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_full_scan_returns_every_row(#[case] version: LanceFileVersion) {
+    let dataset = test_dataset_versioned(version).await;
+    assert_scan_keeps(&dataset, |scan| Ok(scan), |_| true)
+        .await
+        .unwrap();
+}
+
+#[rstest]
+#[case::v1(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_limit_skips_then_truncates(#[case] version: LanceFileVersion) {
+    let dataset = test_dataset_versioned(version).await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    // Offset 5, limit 10: the rows are in storage order, so this is `i` 5 through 14.
+    assert_scan_returns(
+        &dataset,
+        |scan| scan.limit(Some(10), Some(5)),
+        &fixture,
+        (5..15).collect(),
+    )
+    .await
+    .unwrap();
+}
+
+/// The legacy branch that does *not* apply the predicate.
+///
+/// Setting a batch size disqualifies the statistics-pushdown scan, so the leaf falls through to
+/// the plain fragment scan and has to apply the predicate itself. Without that, this query would
+/// return every row.
+#[tokio::test]
+async fn test_a_v1_scan_that_cannot_push_down_still_filters() {
+    let dataset = test_dataset_versioned(LanceFileVersion::Legacy).await;
+    assert_scan_keeps(
+        &dataset,
+        |scan| {
+            scan.batch_size(16);
+            scan.project(&["s"])?.filter("i > 10 and i < 20")
+        },
+        |i| i > 10 && i < 20,
+    )
+    .await
+    .unwrap();
+}
+
+/// The legacy branch that reaches the predicate through a scalar index.
+#[tokio::test]
+async fn test_a_v1_scalar_indexed_scan_returns_the_matching_rows() {
+    use crate::index::DatasetIndexExt;
+    use lance_index::IndexType;
+    use lance_index::scalar::ScalarIndexParams;
+
+    let mut dataset = test_dataset_versioned(LanceFileVersion::Legacy).await;
+    dataset
+        .create_index(
+            &["i"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    assert_scan_keeps(
+        &dataset,
+        |scan| scan.project(&["s"])?.filter("i > 10 and i < 20"),
+        |i| i > 10 && i < 20,
+    )
+    .await
+    .unwrap();
+}
+
+#[rstest]
+#[case::v1(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_row_id_projection(#[case] version: LanceFileVersion) {
+    let dataset = test_dataset_versioned(version).await;
+    assert_scan_keeps(
+        &dataset,
+        |scan| scan.project(&["i"])?.with_row_id().filter("i % 3 = 0"),
+        |i| i % 3 == 0,
+    )
+    .await
+    .unwrap();
+}
+
+/// A dataset with deletions, so `include_deleted_rows` has something to surface.
+async fn deleted_rows_dataset(version: LanceFileVersion) -> crate::dataset::Dataset {
+    let mut dataset = test_dataset_versioned(version).await;
+    dataset.delete("i % 7 = 0").await.unwrap();
+    dataset
+}
+
+#[rstest]
+#[case::v1(LanceFileVersion::Legacy)]
+#[case::stable(LanceFileVersion::Stable)]
+#[tokio::test]
+async fn test_include_deleted_rows_surfaces_them_with_a_null_row_id(
+    #[case] version: LanceFileVersion,
+) {
+    use arrow::datatypes::Int32Type;
+    use arrow_array::cast::AsArray;
+
+    let dataset = deleted_rows_dataset(version).await;
+    let batch = scan_rows(&dataset, |scan| {
+        scan.include_deleted_rows();
+        Ok(scan.project(&["i"])?.with_row_id())
+    })
+    .await
+    .unwrap();
+
+    // Every row is back, deleted ones included, and a null row id is what marks them: a deleted
+    // row has no stable identity to hand out.
+    let ids = batch["i"].as_primitive::<Int32Type>().values();
+    assert_eq!(ids, &(0..200).collect::<Vec<i32>>());
+    let deleted = batch[lance_core::ROW_ID]
+        .nulls()
+        .expect("deleted rows must have a null row id");
+    for (id, live) in ids.iter().zip(deleted.iter()) {
+        assert_eq!(live, id % 7 != 0, "row {id} has the wrong liveness");
+    }
+}
+
+/// Every batch but the last carries exactly the requested number of rows.
+#[tokio::test]
+async fn test_strict_batch_size() {
+    use futures::TryStreamExt;
+    use lance_datafusion::exec::{LanceExecutionOptions, execute_plan};
+
+    let dataset = test_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.batch_size(32).strict_batch_size(true);
+        scan.project(&["i"])
+    })
+    .await
+    .unwrap();
+
+    let batches = execute_plan(plan, LanceExecutionOptions::default())
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    let sizes = batches.iter().map(|b| b.num_rows()).collect::<Vec<_>>();
+    assert_eq!(sizes.iter().sum::<usize>(), 200);
+    let (last, rest) = sizes.split_last().expect("plan produced no batches");
+    assert!(rest.iter().all(|size| *size == 32), "{sizes:?}");
+    assert!(*last <= 32, "{sizes:?}");
+}
+
+/// Aggregates are stock DataFusion nodes, so the whole of `COUNT(*)` and `SUM` comes from the
+/// builder emitting an `Aggregate` and letting projection pushdown find its columns.
+#[rstest]
+// `i` is 0..199, so `i > 10` keeps 189 rows summing to 11 + 12 + ... + 199.
+#[case::count_star(AggregateExpr::builder().count_star().build(), 189)]
+#[case::sum(AggregateExpr::builder().sum("i").build(), (11..200i64).sum())]
+#[tokio::test]
+async fn test_aggregates(#[case] aggregate: AggregateExpr, #[case] expected: i64) {
+    use arrow::datatypes::Int64Type;
+    use arrow_array::cast::AsArray;
+
+    let dataset = test_dataset().await;
+    let plan = logical_plan_for(&dataset, move |scan| {
+        scan.aggregate(aggregate.clone())?.filter("i > 10")
+    })
+    .await
+    .unwrap();
+    let batch = run(plan).await.unwrap();
+
+    assert_eq!(batch.num_rows(), 1);
+    assert_eq!(
+        batch.column(0).as_primitive::<Int64Type>().value(0),
+        expected
+    );
+}
+
+/// A grouped aggregate. Hash aggregation promises no order, so this asserts the groups as a set.
+#[tokio::test]
+async fn test_a_grouped_aggregate() {
+    use arrow::datatypes::Int64Type;
+    use arrow_array::cast::AsArray;
+    use std::collections::HashMap;
+
+    let dataset = test_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.aggregate(AggregateExpr::builder().group_by("s").count_star().build())?
+            .filter("i > 10")
+    })
+    .await
+    .unwrap();
+    let batch = run(plan).await.unwrap();
+
+    let mut counted: HashMap<String, i64> = HashMap::new();
+    let groups = batch.column(0).as_string::<i32>();
+    let counts = batch.column(1).as_primitive::<Int64Type>();
+    for row in 0..batch.num_rows() {
+        counted.insert(groups.value(row).to_string(), counts.value(row));
+    }
+
+    // The fixture's `s` values are random, so how many groups there are is a property of the data
+    // rather than of the query: count them the same way the aggregate should have.
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    let mut expected: HashMap<String, i64> = HashMap::new();
+    for (id, text) in fixture.ids().iter().zip(fixture.strings("s")) {
+        if *id > 10 {
+            *expected.entry(text).or_default() += 1;
+        }
+    }
+    assert_eq!(counted, expected);
+}
+
+/// Which columns the scan reads alongside the filter and which it takes afterwards is a cost
+/// decision: every style has to return the same rows.
+#[rstest]
+#[case::heuristic(MaterializationStyle::Heuristic)]
+#[case::all_early(MaterializationStyle::AllEarly)]
+#[case::all_late(MaterializationStyle::AllLate)]
+#[tokio::test]
+async fn test_materialization_style(
+    #[case] style: MaterializationStyle,
+    #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)] version: LanceFileVersion,
+) {
+    let dataset = test_dataset_versioned(version).await;
+    let scan_config = config(move |scan: &mut crate::dataset::Scanner| {
+        scan.project(&["i", "s"])?
+            .filter("i > 10 and i < 20")?
+            .materialization_style(style.clone());
+        Ok(scan)
+    });
+    assert_scan_keeps(&dataset, scan_config, |i| i > 10 && i < 20)
+        .await
+        .unwrap();
+}
+
+/// A wide column the filter also reads is not deferrable: the filtered pass has to load it either
+/// way, so the read stays a single pass and there is no take.
+#[tokio::test]
+async fn test_a_filtered_column_is_never_late() {
+    let dataset = test_dataset().await;
+    let scan_config = config(|scan: &mut crate::dataset::Scanner| {
+        scan.project(&["s"])?
+            .filter("s IS NOT NULL")?
+            .materialization_style(MaterializationStyle::AllLate);
+        Ok(scan)
+    });
+    assert_scan_keeps(&dataset, &scan_config, |_| true)
+        .await
+        .unwrap();
+
+    let plan = logical_plan_for(&dataset, &scan_config).await.unwrap();
+    let display = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(true)
+        .to_string();
+    assert_eq!(
+        display.matches("LanceRead").count(),
+        1,
+        "expected a single read: {display}"
+    );
+}
+
+/// `AllEarlyExcept` names the late columns by field id, so it also covers the case where only
+/// part of the projection is deferred.
+#[tokio::test]
+async fn test_all_early_except() {
+    let dataset = test_dataset().await;
+    let style = MaterializationStyle::all_early_except(&["s"], dataset.schema()).unwrap();
+    let scan_config = config(move |scan: &mut crate::dataset::Scanner| {
+        scan.project(&["i", "s"])?
+            .filter("i > 10 and i < 20")?
+            .materialization_style(style.clone());
+        Ok(scan)
+    });
+    assert_scan_keeps(&dataset, scan_config, |i| i > 10 && i < 20)
+        .await
+        .unwrap();
+}
+
+/// Late materialization is a cost decision, and equivalence cannot see cost. Assert the point of
+/// it directly: a selective filter over a wide column reads less when the column is taken
+/// afterwards than when it is read for every row.
+#[tokio::test]
+async fn test_late_materialization_reads_less() {
+    use crate::dataset::{Dataset, WriteParams};
+    use arrow::datatypes::Int32Type;
+    use lance_datagen::{BatchCount, ByteCount, RowCount, array, gen_batch};
+
+    let data = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .col("wide", array::rand_fixedbin(ByteCount::from(4096), false))
+        .into_reader_rows(RowCount::from(100), BatchCount::from(4));
+    let dataset = Dataset::write(data, "memory://", Some(WriteParams::default()))
+        .await
+        .unwrap();
+
+    async fn read_bytes(dataset: &Dataset, style: MaterializationStyle) -> u64 {
+        let scan_config = config(move |scan: &mut crate::dataset::Scanner| {
+            scan.project(&["wide"])?
+                .filter("i = 7")?
+                .materialization_style(style.clone());
+            Ok(scan)
+        });
+        let plan = logical_plan_for(dataset, scan_config).await.unwrap();
+        let _ = dataset.object_store.as_ref().io_stats_incremental();
+        run(plan).await.unwrap();
+        dataset
+            .object_store
+            .as_ref()
+            .io_stats_incremental()
+            .read_bytes
+    }
+
+    let early = read_bytes(&dataset, MaterializationStyle::AllEarly).await;
+    let late = read_bytes(&dataset, MaterializationStyle::AllLate).await;
+    assert!(late < early, "late read {late} bytes, early read {early}");
+}
+
+/// `SELECT 1 AS foo` reads nothing, and is refused rather than answered with an invented column.
+#[tokio::test]
+async fn test_a_projection_that_reads_nothing_is_rejected() {
+    let dataset = test_dataset().await;
+    let error = logical_plan_for(&dataset, |scan| {
+        scan.project_with_transform(&[("foo", "1")])
+    })
+    .await
+    .expect_err("nothing to read");
+
+    assert!(
+        matches!(error, crate::Error::NotSupported { .. }),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("at least one column"), "{error}");
+}


### PR DESCRIPTION
`Scanner::create_plan` builds DataFusion physical plans directly, by hand. This adds an alternative path that assembles the query as a `LogicalPlan`, runs a curated rule set over it, and lowers it with an `ExtensionPlanner`. It is off unless `LANCE_LOGICAL_SCAN_PLANNER=1`.

This first layer covers plain scans: filter, projection, sort, limit, aggregate. Searches and `_rowoffset` are rejected rather than silently mis-planned; later PRs add them.

The pieces are:

* `source` — the scan leaf as a `TableProvider`, including the branch to the frozen legacy (v1) scan builder.
* `builder` — `Scanner` state to an unoptimized `LogicalPlan`. Synchronous, no I/O.
* `context` — the bridge. An `OptimizerRule` is synchronous and so cannot load index metadata; this fetches everything up front, and each rule holds an `Arc` to it.
* `scan_index` — the one rule this layer has, recording on each scan leaf how it finds its rows, so the index decision is visible in the plan rather than private to `TableProvider::scan`.
* `planner` — stage 4 dispatch, empty until a later layer adds a node.

`ensure_supported` destructures `Scanner` exhaustively, so a new field fails to compile until someone decides what this path does with it.

Every test in `tests/` also plans the same query through the imperative path and asserts the two return the same rows in the same order. That comparison goes away with the imperative path; the assertions about the answer stay.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
