### PR TITLE
feat(scanner): plan a take-shaped predicate as a row restriction

### DIFF
--- a/rust/lance/src/dataset/scanner/logical/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/builder.rs
@@ -169,6 +169,7 @@ pub(super) fn source_options(scanner: &Scanner) -> ScanSourceOptions {
         fast_search: scanner.fast_search,
         index_segments: scanner.index_segments.clone().map(Arc::new),
         include_deleted_rows: scanner.include_deleted_rows,
+        rows: None,
         filter_plan: None,
         legacy_scanner: super::source::v1::is_legacy(&scanner.dataset)
             .then(|| Arc::new(scanner.clone())),

--- a/rust/lance/src/dataset/scanner/logical/context.rs
+++ b/rust/lance/src/dataset/scanner/logical/context.rs
@@ -16,13 +16,19 @@
 //! its doc comment describes the same contract for scalar indices. Later index types generalize it
 //! rather than inventing a second mechanism.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::logical_expr::LogicalPlan;
+use lance_core::utils::address::RowAddress;
+use lance_select::mask::RowAddrTreeMap;
 
 use super::scan_index::with_lance_source;
 use crate::Result;
+use crate::dataset::rowids::live_row_addrs_to_row_ids;
+use crate::dataset::scanner::TakeOperation;
+use crate::dataset::{Dataset, row_offsets_to_row_addresses};
 use crate::index::{DatasetIndexInternalExt, ScalarIndexInfo};
 
 /// Index and fragment state, captured once per planning invocation.
@@ -31,6 +37,10 @@ pub struct ScanPlanningContext {
     /// What the filter parser needs to turn a predicate into a scalar index query. Already the
     /// canonical instance of this whole pattern — see the module docs.
     scalar_indices: Arc<ScalarIndexInfo>,
+    /// Row selections for take-shaped predicates whose resolution needed I/O, keyed by the
+    /// predicate's values rather than its expression: the rules see it after `PushDownFilter` has
+    /// moved it, and the values are what survive that unchanged.
+    take_rows: HashMap<String, Arc<RowAddrTreeMap>>,
 }
 
 impl ScanPlanningContext {
@@ -44,7 +54,9 @@ impl ScanPlanningContext {
     /// the scanner's builder produced.
     pub async fn collect(plan: &LogicalPlan) -> Result<Self> {
         let mut leaf = None;
+        let mut takes: Vec<TakeOperation> = Vec::new();
         plan.apply(|node| {
+            takes.extend(take_operations(node));
             if leaf.is_none() {
                 leaf = with_lance_source(node, |source| source.dataset().clone());
             }
@@ -58,10 +70,71 @@ impl ScanPlanningContext {
 
         Ok(Self {
             scalar_indices: Arc::new(dataset.scalar_index_info().await?),
+            take_rows: resolve_takes(&dataset, takes).await?,
         })
     }
 
     pub fn scalar_indices(&self) -> &ScalarIndexInfo {
         &self.scalar_indices
     }
+
+    /// The rows a take-shaped predicate selects, if resolving it needed I/O and stage 2 did it.
+    pub fn take_rows(&self, take: &TakeOperation) -> Option<&Arc<RowAddrTreeMap>> {
+        self.take_rows.get(&take_key(take))
+    }
+}
+
+/// The take-shaped predicates a plan node carries, if any.
+///
+/// Both positions are checked because stage 2 runs before `PushDownFilter`: a predicate written by
+/// the builder is a `Filter`, while one the DataFrame API pushed is already on the scan.
+fn take_operations(node: &LogicalPlan) -> Vec<TakeOperation> {
+    let predicates: Vec<_> = match node {
+        LogicalPlan::Filter(filter) => vec![filter.predicate.clone()],
+        LogicalPlan::TableScan(scan) => scan.filters.clone(),
+        _ => vec![],
+    };
+    predicates
+        .iter()
+        .filter_map(|predicate| Some(TakeOperation::try_from_expr(predicate)?.0))
+        .collect()
+}
+
+/// Identifies a take by what it selects, so the same take found at two points in planning agrees.
+fn take_key(take: &TakeOperation) -> String {
+    format!("{take:?}")
+}
+
+/// Turn `_rowaddr` and `_rowoffset` takes into the row ids a read can be restricted to.
+///
+/// `TakeOperation::RowIds` is absent because it needs no translation — the rule handles it inline.
+async fn resolve_takes(
+    dataset: &Arc<Dataset>,
+    takes: Vec<TakeOperation>,
+) -> Result<HashMap<String, Arc<RowAddrTreeMap>>> {
+    let mut resolved = HashMap::new();
+    for take in takes {
+        let key = take_key(&take);
+        if resolved.contains_key(&key) {
+            continue;
+        }
+        let addrs = match &take {
+            TakeOperation::RowIds(_) => continue,
+            TakeOperation::RowAddrs(addrs) => addrs.clone(),
+            TakeOperation::RowOffsets(offsets) => {
+                let mut addrs =
+                    row_offsets_to_row_addresses(&dataset.get_fragments(), offsets).await?;
+                // An offset can only name a live row, so a tombstone means the offset ran past
+                // the end of the dataset. Mirrors `Scanner::take_source`.
+                addrs.retain(|addr| *addr != RowAddress::TOMBSTONE_ROW);
+                addrs
+            }
+        };
+        let row_ids = live_row_addrs_to_row_ids(dataset, addrs.into_iter().map(Some)).await?;
+        resolved.insert(
+            key,
+            Arc::new(RowAddrTreeMap::from_iter(row_ids.into_iter().flatten())),
+        );
+    }
+    Ok(resolved)
 }

--- a/rust/lance/src/dataset/scanner/logical/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/mod.rs
@@ -285,7 +285,10 @@ fn optimizer_rules(
         Arc::new(SimplifyExpressions::new()),
         Arc::new(PushDownFilter::new()),
         Arc::new(PushDownLimit::new()),
-        // After `PushDownFilter`, so the predicate it reads has reached the scan.
+        // Both run after `PushDownFilter`, so the predicate they read has reached the scan. A row
+        // restriction and a scalar index query compete for the same slot on the read, and the
+        // restriction wins.
+        Arc::new(scan_index::ResolveTake::new(context.clone())),
         Arc::new(scan_index::ResolveScalarIndexQuery::new(context.clone())),
         Arc::new(OptimizeProjections::new()),
     ]

--- a/rust/lance/src/dataset/scanner/logical/scan_index.rs
+++ b/rust/lance/src/dataset/scanner/logical/scan_index.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Recording on a Lance scan's source how it will find its rows.
+//! Recording on a Lance scan's source how it will find its rows: a scalar index query, or a row
+//! restriction that makes the read a take.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -10,10 +11,14 @@ use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::datasource::{provider_as_source, source_as_provider};
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
+use datafusion::logical_expr::utils::conjunction;
 use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
 
+use lance_select::mask::RowAddrTreeMap;
+
 use super::context::ScanPlanningContext;
-use super::source::LanceScanSource;
+use super::source::{LanceScanSource, ScanRestriction};
+use crate::dataset::scanner::TakeOperation;
 
 /// Derive each Lance scan's scalar index query and record it on the scan's source.
 ///
@@ -104,4 +109,79 @@ pub fn map_lance_scan(
             Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
         })?
         .data)
+}
+
+/// Turn a predicate that names its rows into a direct take.
+///
+/// `_rowid IN (10, 20)` leaves nothing to search for: the ids *are* the selection. Recording them
+/// on the scan's source is the logical-layer version of `Scanner::take_source`, which assembles the
+/// same read by hand.
+///
+/// Row ids are resolved here; `_rowaddr` names a physical position, and turning those into row ids
+/// reads row-id sequences and deletion vectors, so stage 2 does it and this looks the answer up.
+///
+/// Runs after `PushDownFilter`, so the predicate has reached the scan, and before
+/// [`ResolveScalarIndexQuery`] — a row restriction and a scalar index query compete for the same
+/// slot on the read, and this one wins.
+#[derive(Debug)]
+pub struct ResolveTake {
+    context: Arc<ScanPlanningContext>,
+}
+
+impl ResolveTake {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+
+    /// The row ids a take selects, or `None` when the plan cannot be rewritten.
+    ///
+    /// A stage-2 miss means it walked a different plan than this one, so the predicate is left
+    /// alone rather than guessed at: reading every row and filtering is slower, not wrong.
+    fn rows_for(&self, take: &TakeOperation) -> Option<Arc<RowAddrTreeMap>> {
+        match take {
+            TakeOperation::RowIds(ids) => {
+                Some(Arc::new(RowAddrTreeMap::from_iter(ids.iter().copied())))
+            }
+            _ => self.context.take_rows(take).cloned(),
+        }
+    }
+}
+
+impl OptimizerRule for ResolveTake {
+    fn name(&self) -> &str {
+        "resolve_take"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::TableScan(scan) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let restrictable = with_lance_source(&plan, |source| source.options().rows.is_none());
+        if restrictable != Some(true) || scan.filters.is_empty() {
+            return Ok(Transformed::no(plan));
+        }
+        let Some(predicate) = conjunction(unnormalize_cols(scan.filters.iter().cloned())) else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some((take, remainder)) = TakeOperation::try_from_expr(&predicate) else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(rows) = self.rows_for(&take) else {
+            return Ok(Transformed::no(plan));
+        };
+        let mut scan = scan.clone();
+        scan.filters = remainder.into_iter().collect();
+        let restricted = LogicalPlan::TableScan(scan);
+        Ok(Transformed::yes(map_lance_scan(&restricted, |source| {
+            source.restricted_to(&ScanRestriction::Rows(rows.clone()))
+        })?))
+    }
 }

--- a/rust/lance/src/dataset/scanner/logical/source/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/source/mod.rs
@@ -19,6 +19,7 @@ use arrow_schema::{Schema as ArrowSchema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::DataFusionError;
+use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::projection::ProjectionExec;
@@ -30,7 +31,8 @@ use lance_core::{
 };
 use lance_file::reader::FileReaderOptions;
 use lance_index::scalar::expression::PlannerIndexExt;
-use lance_select::result::IndexExprResultWireFormat;
+use lance_select::mask::{RowAddrMask, RowAddrTreeMap};
+use lance_select::result::{IndexExprResult, IndexExprResultWireFormat};
 use lance_table::format::Fragment;
 
 use crate::dataset::scanner::MaterializationStyle;
@@ -42,6 +44,13 @@ use crate::io::exec::filtered_read::{
 use crate::io::exec::scalar_index::ScalarIndexExec;
 use crate::io::exec::{FilterPlan as ExprFilterPlan, Planner};
 use crate::{Error, Result};
+
+/// How a scan is narrowed to the rows one part of the plan is responsible for.
+#[derive(Debug, Clone)]
+pub enum ScanRestriction {
+    /// Read only these rows, identified by row id.
+    Rows(Arc<RowAddrTreeMap>),
+}
 
 /// The subset of [`Scanner`](crate::dataset::Scanner) state that reaches the scan leaf.
 ///
@@ -76,6 +85,11 @@ pub struct ScanSourceOptions {
     /// A branch of a coverage split keeps this, and should: the branches read disjoint fragment
     /// sets, so between them they still emit every deleted row exactly once.
     pub include_deleted_rows: bool,
+    /// Read only these rows, from [`ScanRestriction::Rows`].
+    ///
+    /// The row set arrives through the same leaf slot a scalar-index result would, so a scan
+    /// restricted this way cannot also consult a scalar index.
+    pub rows: Option<Arc<RowAddrTreeMap>>,
     /// How this scan's predicate splits into a scalar index query and a refine filter.
     ///
     /// `None` means nothing has resolved it yet and the leaf will do so itself. Filling this in is
@@ -111,6 +125,7 @@ impl std::fmt::Debug for ScanSourceOptions {
             .field("fast_search", &self.fast_search)
             .field("index_segments", &self.index_segments)
             .field("include_deleted_rows", &self.include_deleted_rows)
+            .field("rows", &self.rows)
             .field("filter_plan", &self.filter_plan)
             .field("legacy", &self.legacy_scanner.is_some())
             .finish()
@@ -173,6 +188,29 @@ impl LanceScanSource {
 
     pub fn dataset(&self) -> &Arc<Dataset> {
         &self.dataset
+    }
+
+    /// The scan-wide settings this leaf was built with.
+    ///
+    /// Read from here rather than from the `Scanner`, which is what lets stages 2 through 4 run
+    /// against any plan whose leaf is a Lance scan.
+    pub fn options(&self) -> &ScanSourceOptions {
+        &self.options
+    }
+
+    /// The same source, reading only the rows `restriction` names.
+    ///
+    /// The schema is unchanged, so a `TableScan`'s `projected_schema` stays valid across the swap.
+    pub fn restricted_to(&self, restriction: &ScanRestriction) -> Self {
+        let options = match restriction {
+            ScanRestriction::Rows(rows) => ScanSourceOptions {
+                rows: Some(rows.clone()),
+                use_scalar_index: false,
+                filter_plan: None,
+                ..self.options.clone()
+            },
+        };
+        self.with_options(options)
     }
 
     /// How this scan's predicate splits into a scalar index query and a refine filter, once a rule
@@ -410,6 +448,21 @@ impl LanceScanSource {
     /// mask. That does not by itself make the scan re-executable — `FilteredReadExec` drains one
     /// shared task stream per instance, so every Lance scan plan is single-execution — but it keeps
     /// the reason for that in one place instead of two.
+    /// A row restriction, shaped as the scalar-index result the leaf reads its rows from.
+    fn rows_as_index_input(&self, rows: &RowAddrTreeMap) -> Result<Arc<dyn ExecutionPlan>> {
+        let result = IndexExprResult::exact(RowAddrMask::from_allowed(rows.clone()));
+        let batch = result.serialize(
+            self.dataset.fragment_bitmap.as_ref(),
+            self.options.index_expr_result_format,
+        )?;
+        let schema = batch.schema();
+        Ok(MemorySourceConfig::try_new_exec(
+            &[vec![batch]],
+            schema,
+            None,
+        )?)
+    }
+
     fn fragments(&self) -> &Arc<Vec<Fragment>> {
         self.options
             .fragments
@@ -534,13 +587,18 @@ impl LanceScanSource {
             read_options = read_options.with_scan_range_before_filter(scan_range)?;
         }
 
-        let index_input = filter_plan.index_query.map(|index_query| {
-            Arc::new(ScalarIndexExec::new(
-                self.dataset.clone(),
-                index_query,
-                self.options.index_expr_result_format,
-            )) as Arc<dyn ExecutionPlan>
-        });
+        // A row restriction and a scalar-index query compete for the same slot, and
+        // `restricted_to` has already turned the index off in that case.
+        let index_input = match &self.options.rows {
+            Some(rows) => Some(self.rows_as_index_input(rows)?),
+            None => filter_plan.index_query.map(|index_query| {
+                Arc::new(ScalarIndexExec::new(
+                    self.dataset.clone(),
+                    index_query,
+                    self.options.index_expr_result_format,
+                )) as Arc<dyn ExecutionPlan>
+            }),
+        };
 
         let plan = Arc::new(FilteredReadExec::try_new(
             self.dataset.clone(),

--- a/rust/lance/src/dataset/scanner/logical/tests/scan.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/scan.rs
@@ -429,3 +429,60 @@ async fn test_a_projection_that_reads_nothing_is_rejected() {
     );
     assert!(error.to_string().contains("at least one column"), "{error}");
 }
+
+/// A `_rowid` predicate names its rows, so the scan reads only those.
+#[tokio::test]
+async fn test_a_row_id_take() {
+    fn config(scan: &mut crate::dataset::Scanner) -> crate::Result<&mut crate::dataset::Scanner> {
+        scan.filter("_rowid IN (5, 10, 20)")?.with_row_id();
+        Ok(scan)
+    }
+
+    let dataset = test_dataset().await;
+    // Without stable row ids a row id is its address, so these name rows 5, 10 and 20 of the first
+    // fragment — whose `i` values are the same numbers.
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    assert_scan_returns(&dataset, config, &fixture, vec![5, 10, 20])
+        .await
+        .unwrap();
+
+    let plan = logical_plan_for(&dataset, config).await.unwrap();
+    let display = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(true)
+        .to_string();
+    assert!(
+        !display.contains("full_filter=_rowid"),
+        "the take should have replaced the predicate: {display}"
+    );
+}
+
+/// The rest of a conjunction survives the rewrite as an ordinary filter.
+#[tokio::test]
+async fn test_a_row_id_take_with_a_remainder() {
+    fn config(scan: &mut crate::dataset::Scanner) -> crate::Result<&mut crate::dataset::Scanner> {
+        scan.filter("_rowid IN (5, 10, 20) AND i > 7")?
+            .with_row_id();
+        Ok(scan)
+    }
+
+    let dataset = test_dataset().await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    assert_scan_returns(&dataset, config, &fixture, vec![10, 20])
+        .await
+        .unwrap();
+}
+
+/// A `_rowaddr` predicate is a take too, once stage 2 has translated the addresses.
+#[tokio::test]
+async fn test_a_row_address_take() {
+    fn config(scan: &mut crate::dataset::Scanner) -> crate::Result<&mut crate::dataset::Scanner> {
+        scan.filter("_rowaddr IN (5, 10, 20)")?.with_row_address();
+        Ok(scan)
+    }
+
+    let dataset = test_dataset().await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    assert_scan_returns(&dataset, config, &fixture, vec![5, 10, 20])
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
`_rowid IN (10, 20)` leaves nothing to search for: the ids are the selection. The imperative path recognizes this in `Scanner::take_source` and assembles the read by hand.

This adds the logical-path equivalent — a rule that recognizes the predicate after `PushDownFilter` has settled it onto the scan, and records the rows on the scan's source, so the read is restricted rather than filtered. The rest of a conjunction survives as an ordinary filter.

`_rowaddr` names a physical position, and translating one into a row id reads row-id sequences and deletion vectors, so stage 2 resolves those and the rule looks the answer up. A stage-2 miss leaves the predicate alone: reading every row and filtering is slower, not wrong.

The rule runs before `ResolveScalarIndexQuery` — a row restriction and a scalar index query compete for the same slot on the read, and the restriction wins.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
