### PR TITLE
feat(scanner): plan vector search through the logical planner

### DIFF
--- a/rust/lance/src/dataset/scanner/logical/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/builder.rs
@@ -19,7 +19,10 @@ use datafusion::logical_expr::{
 };
 
 use datafusion::prelude::col;
-use lance_core::{ROW_ADDR, ROW_ID, datatypes::OnMissing};
+use lance_core::{
+    ROW_ADDR, ROW_ID,
+    datatypes::{OnMissing, Projection},
+};
 use lance_index::vector::DIST_COL;
 
 use super::prepare::PreparedQueries;
@@ -47,6 +50,31 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
     if prefilter && let Some(filter) = filter.clone() {
         source = LogicalPlanBuilder::new(source).filter(filter)?.build()?;
     }
+
+    // An aggregate replaces the output projection, so late materialization above a search has
+    // nothing to materialize on its behalf — only whatever the aggregate itself reads. `COUNT(*)`
+    // reads nothing, and the take then drops out entirely rather than reading every column and
+    // projecting it away.
+    let take_projection = match &scanner.aggregate {
+        Some(aggregate) => {
+            let columns = aggregate
+                .group_by
+                .iter()
+                .chain(aggregate.aggregates.iter())
+                .flat_map(|expr| {
+                    expr.column_refs()
+                        .into_iter()
+                        .map(|column| column.name.clone())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            scanner
+                .dataset
+                .empty_projection()
+                .union_columns(&columns, OnMissing::Ignore)?
+        }
+        None => scanner.projection_plan.physical_projection.clone(),
+    };
 
     // A postfilter reads columns the user may not have projected, and above a search the only way
     // to get a column is to take it. So the take has to cover the filter's columns too, and the
@@ -85,6 +113,7 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
         let taken = with_take(
             LogicalPlanBuilder::new(searched),
             scanner,
+            &take_projection,
             &postfilter_columns,
         )?;
         // A vector search promises rows in distance order, and the take between the search and
@@ -190,11 +219,10 @@ fn scan_leaf(scanner: &Scanner) -> Result<LogicalPlan> {
 fn with_take(
     builder: LogicalPlanBuilder,
     scanner: &Scanner,
+    projection: &Projection,
     extra_columns: &[String],
 ) -> Result<LogicalPlanBuilder> {
-    let projection = scanner
-        .projection_plan
-        .physical_projection
+    let projection = projection
         .clone()
         .union_columns(extra_columns, OnMissing::Ignore)?;
     let input = builder.plan().clone();

--- a/rust/lance/src/dataset/scanner/logical/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/builder.rs
@@ -14,25 +14,109 @@ use std::sync::Arc;
 use datafusion::common::Column;
 use datafusion::datasource::provider_as_source;
 use datafusion::functions::core::expr_fn::get_field;
-use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder, SortExpr};
-use lance_core::{ROW_ADDR, ROW_ID};
+use datafusion::logical_expr::{
+    Expr, Extension, LogicalPlan, LogicalPlanBuilder, SortExpr, UserDefinedLogicalNodeCore,
+};
 
+use datafusion::prelude::col;
+use lance_core::{ROW_ADDR, ROW_ID, datatypes::OnMissing};
+use lance_index::vector::DIST_COL;
+
+use super::prepare::PreparedQueries;
 use super::source::{LanceScanSource, ScanSourceOptions};
-use crate::dataset::scanner::ColumnOrdering;
+use super::{LanceTakeNode, TakeSettings, VectorRerankNode, VectorSearchNode};
+use crate::dataset::scanner::{ColumnOrdering, MaterializationStyle};
 use crate::dataset::{Dataset, Scanner};
+use crate::io::exec::knn::QUERY_INDEX_COL;
 use crate::{Error, Result};
 
 /// Relation name for the scan leaf. Column references in filters and projections are
 /// unqualified, so this only ever shows up in `EXPLAIN` output.
 pub const TABLE_NAME: &str = "lance";
 
-pub fn build(scanner: &Scanner) -> Result<LogicalPlan> {
+pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPlan> {
     let scan = scan_leaf(scanner)?;
     let filter = scanner.get_expr_filter()?;
 
-    let mut builder = LogicalPlanBuilder::new(scan);
-    if let Some(filter) = filter {
-        builder = builder.filter(filter)?;
+    // Prefilter and postfilter are the same predicate on opposite sides of the search: restrict
+    // the candidates, or trim the results. They are genuinely different queries under
+    // approximation, which is why this is operator ordering and not a flag on the search node.
+    let prefilter = scanner.prefilter && scanner.nearest.is_some();
+
+    let mut source = scan;
+    if prefilter && let Some(filter) = filter.clone() {
+        source = LogicalPlanBuilder::new(source).filter(filter)?.build()?;
+    }
+
+    // A postfilter reads columns the user may not have projected, and above a search the only way
+    // to get a column is to take it. So the take has to cover the filter's columns too, and the
+    // final projection trims them back off. The imperative path splits this across two takes
+    // (`pre_filter_projection` then the output projection); one take plus a projection is the same
+    // set of reads.
+    // A sort sits above any search, so its columns have to survive late materialization too.
+    let mut postfilter_columns: Vec<String> = scanner
+        .ordering
+        .iter()
+        .flatten()
+        .map(|column| column.column_name.clone())
+        .collect();
+    if !prefilter {
+        if let Some(filter) = &filter {
+            postfilter_columns.extend(filter.column_refs().iter().map(|c| c.name.clone()));
+        }
+        // A vector `query_filter` above the search scores the rows it is given, so the vector
+        // column has to be in flight by then.
+        if let Some(query) = &prepared.vector_filter {
+            postfilter_columns.push(query.column.clone());
+        }
+    }
+
+    // A `query_filter` obeys the same prefilter/postfilter switch as an expression filter: below
+    // the search it produces the candidates, above it trims the results.
+    let mut builder = if let Some(query) = &scanner.nearest {
+        let searched = {
+            let search = VectorSearchNode::try_new(source, scanner.dataset.clone(), query.clone())?;
+            extension(if scanner.is_batch_nearest {
+                search.with_batch_queries(scanner.nearest_query_count)?
+            } else {
+                search
+            })
+        };
+        let taken = with_take(
+            LogicalPlanBuilder::new(searched),
+            scanner,
+            &postfilter_columns,
+        )?;
+        // A vector search promises rows in distance order, and the take between the search and
+        // here does not preserve it: `FilteredReadExec` reports no output ordering, so a
+        // multi-partition input gets a plain coalesce and the order is lost. Stating the ordering
+        // in the plan is the only way to hold the contract — inheriting it from whichever physical
+        // operator happened to sort is what made the imperative path's version of this fragile.
+        //
+        // A batch search interleaves every query's results, so they are grouped by query first.
+        let mut ordering = Vec::with_capacity(3);
+        if scanner.is_batch_nearest {
+            ordering.push(col(QUERY_INDEX_COL).sort(true, false));
+        }
+        ordering.push(col(DIST_COL).sort(true, false));
+        ordering.push(col(ROW_ID).sort(true, false));
+        taken.sort(ordering)?
+    } else {
+        LogicalPlanBuilder::new(source)
+    };
+
+    // Postfilters, innermost first, matching `FilterPlan::refine_filter`.
+    if !prefilter {
+        if let Some(query) = &prepared.vector_filter {
+            builder = LogicalPlanBuilder::new(extension(VectorRerankNode::try_new(
+                builder.plan().clone(),
+                &scanner.dataset,
+                query.clone(),
+            )?));
+        }
+        if let Some(filter) = filter {
+            builder = builder.filter(filter)?;
+        }
     }
 
     // An aggregate replaces the output projection rather than sitting above it, and `validate_options`
@@ -81,12 +165,49 @@ fn unqualified(expr: &Expr) -> Expr {
     expr.clone().alias(name)
 }
 
+/// Read settings a take must honor, lifted off the `Scanner`. `None` fragments means "all of
+/// them", which is a different plan from an explicit list of every fragment.
+fn take_settings(scanner: &Scanner) -> TakeSettings {
+    TakeSettings {
+        fragments: scanner.fragments.clone().map(Arc::new),
+        batch_size: scanner.batch_size.map(|size| size as u32),
+    }
+}
+
 fn scan_leaf(scanner: &Scanner) -> Result<LogicalPlan> {
     let source = LanceScanSource::new(scanner.dataset.clone(), source_options(scanner))?;
     Ok(
         LogicalPlanBuilder::scan(TABLE_NAME, provider_as_source(Arc::new(source)), None)?
             .build()?,
     )
+}
+
+/// Insert late materialization above a search, unless the search already produced everything.
+///
+/// A search emits only its scoring columns; the user's columns have to be fetched by row id
+/// afterwards. Plain scans need no equivalent — DataFusion's projection pushdown puts the column
+/// list into the leaf directly.
+fn with_take(
+    builder: LogicalPlanBuilder,
+    scanner: &Scanner,
+    extra_columns: &[String],
+) -> Result<LogicalPlanBuilder> {
+    let projection = scanner
+        .projection_plan
+        .physical_projection
+        .clone()
+        .union_columns(extra_columns, OnMissing::Ignore)?;
+    let input = builder.plan().clone();
+    if LanceTakeNode::is_noop(&input, &projection)? {
+        return Ok(builder);
+    }
+    let take = LanceTakeNode::try_new(
+        input,
+        scanner.dataset.clone(),
+        projection,
+        take_settings(scanner),
+    )?;
+    Ok(LogicalPlanBuilder::new(extension(take)))
 }
 
 /// The scanner's `order_by` as logical sort expressions.
@@ -115,6 +236,12 @@ fn ordering_exprs(ordering: &[ColumnOrdering], dataset: &Dataset) -> Result<Vec<
         .collect()
 }
 
+pub(super) fn extension(node: impl UserDefinedLogicalNodeCore) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
+        node: Arc::new(node),
+    })
+}
+
 /// The user's requested output columns, as logical expressions.
 ///
 /// `ProjectionPlan` has already parsed and coerced these against the full schema, so they can be
@@ -134,7 +261,31 @@ fn output_exprs(scanner: &Scanner) -> Result<Vec<Expr>> {
         })
         .collect::<Vec<_>>();
 
-    // `with_row_id`/`with_row_address` promise their column is *last*.
+    let named = |exprs: &[Expr], name: &str| {
+        exprs
+            .iter()
+            .any(|expr| expr.schema_name().to_string() == name)
+    };
+
+    // `_distance` is appended even when the user did not ask for it. That is legacy behavior the
+    // imperative path implements in `calculate_final_projection`; replicating it here is what lets
+    // the two paths be compared row for row.
+    if scanner.autoproject_scoring_columns && scanner.nearest.is_some() && !named(&exprs, DIST_COL)
+    {
+        exprs.push(col(DIST_COL));
+    }
+
+    // Batch nearest exposes the query discriminator as the *first* output column, which is what
+    // LanceDB's batch vector search reads it from.
+    if scanner.is_batch_nearest {
+        if !named(&exprs, QUERY_INDEX_COL) {
+            exprs.push(col(QUERY_INDEX_COL));
+        }
+        move_to_front(&mut exprs, QUERY_INDEX_COL);
+    }
+
+    // `with_row_id`/`with_row_address` promise their column is *last*, so the scoring columns that
+    // were just appended have to move ahead of it.
     if scanner.legacy_with_row_id {
         move_to_end(&mut exprs, ROW_ID);
     }
@@ -142,6 +293,16 @@ fn output_exprs(scanner: &Scanner) -> Result<Vec<Expr>> {
         move_to_end(&mut exprs, ROW_ADDR);
     }
     Ok(exprs)
+}
+
+fn move_to_front(exprs: &mut Vec<Expr>, name: &str) {
+    if let Some(position) = exprs
+        .iter()
+        .position(|expr| expr.schema_name().to_string() == name)
+    {
+        let expr = exprs.remove(position);
+        exprs.insert(0, expr);
+    }
 }
 
 fn move_to_end(exprs: &mut Vec<Expr>, name: &str) {
@@ -164,13 +325,20 @@ pub(super) fn source_options(scanner: &Scanner) -> ScanSourceOptions {
         fragments: scanner.fragments.clone().map(Arc::new),
         index_expr_result_format: scanner.index_expr_result_format(),
         use_scalar_index: scanner.use_scalar_index,
-        materialization_style: scanner.materialization_style.clone(),
+        // `MaterializationStyle` is documented as affecting plain scans only, and a search plan
+        // already takes its columns above the search. Splitting the read below it as well would
+        // add a take that fetches the same columns for strictly more rows.
+        materialization_style: match scanner.nearest.is_some() {
+            true => MaterializationStyle::AllEarly,
+            false => scanner.materialization_style.clone(),
+        },
         blob_handling: scanner.blob_handling.clone(),
         fast_search: scanner.fast_search,
         index_segments: scanner.index_segments.clone().map(Arc::new),
         include_deleted_rows: scanner.include_deleted_rows,
         rows: None,
         filter_plan: None,
+        overlay_block: None,
         legacy_scanner: super::source::v1::is_legacy(&scanner.dataset)
             .then(|| Arc::new(scanner.clone())),
     }

--- a/rust/lance/src/dataset/scanner/logical/context.rs
+++ b/rust/lance/src/dataset/scanner/logical/context.rs
@@ -10,33 +10,142 @@
 //! The prefetch set is deliberately small — **all index metadata, plus the manifest's fragment
 //! metadata**. The latter is already in memory (`Manifest::fragments`, carrying `physical_rows`,
 //! `deletion_file`, and `overlays`), which is what makes so many of the imperative path's `await`
-//! points collapse into synchronous derivations.
+//! points collapse into the synchronous derivations below.
 //!
 //! [`ScalarIndexInfo`](crate::index::ScalarIndexInfo) is the existing instance of this pattern —
-//! its doc comment describes the same contract for scalar indices. Later index types generalize it
-//! rather than inventing a second mechanism.
+//! its doc comment describes the same contract for scalar indices. This generalizes it to vector
+//! indices rather than inventing a second mechanism.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::logical_expr::LogicalPlan;
 use lance_core::utils::address::RowAddress;
+use lance_index::metrics::NoOpMetricsCollector;
+use lance_linalg::distance::DistanceType;
 use lance_select::mask::RowAddrTreeMap;
+use lance_table::format::{Fragment, IndexMetadata};
+use roaring::RoaringBitmap;
+
+use lance_index::scalar::expression::{IndexInformationProvider, ScalarIndexExpr};
 
 use super::scan_index::with_lance_source;
+use super::{TakeSettings, VectorSearchNode};
 use crate::Result;
-use crate::dataset::rowids::live_row_addrs_to_row_ids;
+use crate::dataset::overlay::{collect_overlay_stale_rows_for_segment, overlaid_fragments};
+use crate::dataset::rowids::{live_row_addrs_to_row_ids, translate_addr_treemap_to_row_ids};
 use crate::dataset::scanner::TakeOperation;
 use crate::dataset::{Dataset, row_offsets_to_row_addresses};
-use crate::index::{DatasetIndexInternalExt, ScalarIndexInfo};
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt, ScalarIndexInfo};
+
+/// What a data overlay did to an index's entries.
+///
+/// A data overlay committed after an index was built, touching a field that index covers, makes
+/// the index's entries for the overlaid rows describe values that no longer exist. This is the
+/// row-level half of index coverage, and it is prefetched for the same reason fragment coverage is:
+/// deciding it needs the index metadata and, under stable row ids, a row-id translation.
+#[derive(Debug, Clone, Default)]
+pub enum OverlayStaleness {
+    /// No overlay touches a field this index covers.
+    #[default]
+    None,
+    /// Exactly these rows' entries are stale; the rest of the index is current.
+    Rows(Arc<RowAddrTreeMap>),
+}
+
+/// The rows whose entries in `segments` an overlay has invalidated, in the domain index results
+/// use.
+///
+/// Index results are in the row-id domain, and a physical row address equals its row id only when
+/// the dataset does not use stable row ids — hence the translation, which is the one piece of this
+/// that needs I/O and the reason it lives in stage 2.
+pub async fn overlay_staleness(
+    dataset: &Dataset,
+    segments: &[IndexMetadata],
+    fragments: &[Fragment],
+) -> Result<OverlayStaleness> {
+    // Overlays are rare; this is the check that keeps the whole mechanism off the common path.
+    let overlaid = overlaid_fragments(fragments);
+    if overlaid.is_empty() {
+        return Ok(OverlayStaleness::None);
+    }
+
+    let mut stale: HashMap<u32, RoaringBitmap> = HashMap::new();
+    for segment in segments {
+        collect_overlay_stale_rows_for_segment(segment, &overlaid, &mut stale, dataset.schema())?;
+    }
+    if stale.is_empty() {
+        return Ok(OverlayStaleness::None);
+    }
+
+    let mut rows = RowAddrTreeMap::new();
+    for (fragment, offsets) in stale {
+        rows.insert_bitmap(fragment, offsets);
+    }
+    if dataset.manifest.uses_stable_row_ids() {
+        rows = translate_addr_treemap_to_row_ids(dataset, &rows).await?;
+    }
+    Ok(OverlayStaleness::Rows(Arc::new(rows)))
+}
+
+/// Everything known about the vector index covering one column.
+#[derive(Debug, Clone)]
+pub struct VectorIndexInfo {
+    /// The index's delta segments; a search fans out over all of them.
+    pub segments: Vec<IndexMetadata>,
+    /// The metric the index was built with. Resolving this is the one prefetch that may have to
+    /// open the index itself: indices written before `details` carried the metric have nowhere
+    /// else to record it, and "user asked for a different metric, so fall back to brute force"
+    /// is a planning decision that cannot wait until execution.
+    pub metric: DistanceType,
+    /// Row-level coverage: which of this index's entries a data overlay has invalidated.
+    pub staleness: OverlayStaleness,
+}
+
+impl VectorIndexInfo {
+    /// Fragments covered by at least one of this index's segments.
+    ///
+    /// A segment with no fragment bitmap predates the field, so nothing can be assumed about its
+    /// coverage; treating it as covering nothing would wrongly route indexed rows to a flat scan,
+    /// so callers get `None` and should fall back.
+    fn indexed_fragments(&self) -> Option<RoaringBitmap> {
+        let mut covered = RoaringBitmap::new();
+        for segment in &self.segments {
+            covered |= segment.fragment_bitmap.as_ref()?;
+        }
+        Some(covered)
+    }
+}
 
 /// Index and fragment state, captured once per planning invocation.
 #[derive(Debug)]
 pub struct ScanPlanningContext {
+    /// From the manifest, so this costs nothing — but holding it here is what lets the
+    /// derivations below be honest about doing no I/O.
+    fragments: Arc<Vec<Fragment>>,
+    vector: HashMap<String, VectorIndexInfo>,
+    /// Whether `Scanner::with_index_segments` pinned which segments a search may use.
+    ///
+    /// It makes the caller's chosen segments the whole answer: rows they do not cover are out of
+    /// scope rather than a coverage gap, so no brute-force branch fills it. Mirrors
+    /// `Scanner::knn_combined`.
+    segments_pinned: bool,
+    /// `Scanner::fast_search`: skip rows no index covers. A rule needs it to know whether to
+    /// build the flat branch at all, and it is not derivable from the plan.
+    fast_search: bool,
+    /// Read settings for any take a rule introduces, so a rewrite cannot lose the scanner's
+    /// fragment restriction.
+    take_settings: TakeSettings,
     /// What the filter parser needs to turn a predicate into a scalar index query. Already the
     /// canonical instance of this whole pattern — see the module docs.
     scalar_indices: Arc<ScalarIndexInfo>,
+    /// Row-level coverage for every index in the dataset, keyed by index name.
+    ///
+    /// Keyed by name rather than by column because that is how a scalar index query names what it
+    /// consulted. Empty unless some fragment carries an overlay, which is what keeps this off the
+    /// common path.
+    index_staleness: HashMap<String, OverlayStaleness>,
     /// Row selections for take-shaped predicates whose resolution needed I/O, keyed by the
     /// predicate's values rather than its expression: the rules see it after `PushDownFilter` has
     /// moved it, and the values are what survive that unchanged.
@@ -48,40 +157,363 @@ impl ScanPlanningContext {
     ///
     /// This is the only `async fn` in stages 2 through 4 that is allowed to do I/O.
     ///
-    /// Everything comes from the plan — the dataset and the scan-wide settings from its leaf.
-    /// Nothing reads the `Scanner`, so any plan built over a
-    /// [`LanceScanSource`](super::source::LanceScanSource) can be planned this way, not just one
-    /// the scanner's builder produced.
+    /// Everything comes from the plan — the dataset and the scan-wide settings from its leaf, the
+    /// searched columns from its extension nodes. Nothing reads the `Scanner`, so any plan built
+    /// over a [`LanceScanSource`](super::source::LanceScanSource) can be planned this way, not just
+    /// one the scanner's builder produced.
     pub async fn collect(plan: &LogicalPlan) -> Result<Self> {
         let mut leaf = None;
+        let mut searches: Vec<(String, Option<DistanceType>)> = Vec::new();
         let mut takes: Vec<TakeOperation> = Vec::new();
         plan.apply(|node| {
             takes.extend(take_operations(node));
+            if let LogicalPlan::Extension(extension) = node
+                && let Some(search) = extension.node.as_any().downcast_ref::<VectorSearchNode>()
+            {
+                let requested = search
+                    .distance_type_requested()
+                    .then(|| search.distance_type());
+                searches.push((search.query().column.clone(), requested));
+            }
             if leaf.is_none() {
-                leaf = with_lance_source(node, |source| source.dataset().clone());
+                leaf = with_lance_source(node, |source| {
+                    (source.dataset().clone(), source.options().clone())
+                });
             }
             Ok(TreeNodeRecursion::Continue)
         })?;
-        let Some(dataset) = leaf else {
+        let Some((dataset, options)) = leaf else {
             return Err(crate::Error::internal(
                 "a Lance scan plan reached stage 2 without a Lance scan leaf".to_string(),
             ));
         };
 
-        Ok(Self {
-            scalar_indices: Arc::new(dataset.scalar_index_info().await?),
-            take_rows: resolve_takes(&dataset, takes).await?,
-        })
-    }
+        let fragments = options
+            .fragments
+            .clone()
+            .unwrap_or_else(|| dataset.fragments().clone());
 
-    pub fn scalar_indices(&self) -> &ScalarIndexInfo {
-        &self.scalar_indices
+        let mut vector = HashMap::with_capacity(searches.len());
+        if !searches.is_empty() {
+            let indices = dataset.load_indices().await?;
+            for (column, requested_metric) in searches {
+                if vector.contains_key(&column) {
+                    continue;
+                }
+                if let Some(info) = load_vector_index(
+                    &dataset,
+                    options.index_segments.as_deref(),
+                    requested_metric,
+                    &indices,
+                    &column,
+                    &fragments,
+                )
+                .await?
+                {
+                    vector.insert(column, info);
+                }
+            }
+        }
+
+        let scalar_indices = Arc::new(dataset.scalar_index_info().await?);
+        let index_staleness = prefetch_index_staleness(&dataset, &fragments).await?;
+        let take_rows = resolve_takes(&dataset, takes).await?;
+
+        Ok(Self {
+            fragments,
+            vector,
+            fast_search: options.fast_search,
+            segments_pinned: options.index_segments.is_some(),
+            take_settings: TakeSettings {
+                fragments: options.fragments.clone(),
+                batch_size: options.batch_size.map(|size| size as u32),
+            },
+            scalar_indices,
+            index_staleness,
+            take_rows,
+        })
     }
 
     /// The rows a take-shaped predicate selects, if resolving it needed I/O and stage 2 did it.
     pub fn take_rows(&self, take: &TakeOperation) -> Option<&Arc<RowAddrTreeMap>> {
         self.take_rows.get(&take_key(take))
     }
+
+    pub fn scalar_indices(&self) -> &ScalarIndexInfo {
+        &self.scalar_indices
+    }
+
+    /// Whether any fragment this scan will read carries a data overlay.
+    ///
+    /// The one check that keeps overlay handling off the common path, and the reason
+    /// [`Self::index_query_staleness`] can answer `None` without consulting anything.
+    pub fn has_overlays(&self) -> bool {
+        !self.index_staleness.is_empty()
+    }
+
+    /// The rows a scalar index query's results cannot be trusted for.
+    ///
+    /// A query may consult several indices, so this is the union of what each one lost. One
+    /// untrustworthy index poisons the whole query, since the results are combined before anything
+    /// can tell them apart.
+    pub fn index_query_staleness(&self, query: &ScalarIndexExpr) -> OverlayStaleness {
+        let mut stale = RowAddrTreeMap::new();
+        let mut found = false;
+        let mut queue = vec![query];
+        while let Some(expr) = queue.pop() {
+            match expr {
+                ScalarIndexExpr::Not(inner) => queue.push(inner),
+                ScalarIndexExpr::And(lhs, rhs) | ScalarIndexExpr::Or(lhs, rhs) => {
+                    queue.push(lhs);
+                    queue.push(rhs);
+                }
+                ScalarIndexExpr::Query(search) => {
+                    match self.index_staleness.get(&search.index_name) {
+                        Some(OverlayStaleness::Rows(rows)) => {
+                            stale |= rows.as_ref().clone();
+                            found = true;
+                        }
+                        Some(OverlayStaleness::None) | None => {}
+                    }
+                }
+            }
+        }
+        match found {
+            true => OverlayStaleness::Rows(Arc::new(stale)),
+            false => OverlayStaleness::None,
+        }
+    }
+
+    /// The fragments these index segments can return a row from, limited to what this scan reads.
+    ///
+    /// A segment with no fragment bitmap could have indexed anything, so the answer widens to
+    /// every fragment. Mirrors `Scanner::get_indexed_frags`.
+    pub fn segment_coverage(&self, segments: &[IndexMetadata]) -> RoaringBitmap {
+        let scanned = RoaringBitmap::from_iter(self.fragments.iter().map(|f| f.id as u32));
+        let mut covered = RoaringBitmap::new();
+        for segment in segments {
+            let Some(bitmap) = segment.fragment_bitmap.as_ref() else {
+                return scanned;
+            };
+            covered |= bitmap;
+        }
+        covered & scanned
+    }
+
+    /// The fragments a scalar index query can answer for, or `None` if some index in it cannot
+    /// say which fragments it covers.
+    ///
+    /// Mirrors `Scanner::fragments_covered_by_index_query`, intersecting for `Or` as well as
+    /// `And`: an `Or` is only answerable where *both* sides are, since a fragment one side cannot
+    /// speak for could still contain a matching row.
+    pub fn index_query_coverage(&self, query: &ScalarIndexExpr) -> Option<RoaringBitmap> {
+        match query {
+            ScalarIndexExpr::Not(inner) => self.index_query_coverage(inner),
+            ScalarIndexExpr::And(lhs, rhs) | ScalarIndexExpr::Or(lhs, rhs) => {
+                Some(self.index_query_coverage(lhs)? & self.index_query_coverage(rhs)?)
+            }
+            ScalarIndexExpr::Query(search) => self
+                .scalar_indices
+                .fragment_bitmap(&search.column, &search.index_name),
+        }
+    }
+
+    pub fn vector_index(&self, column: &str) -> Option<&VectorIndexInfo> {
+        self.vector.get(column)
+    }
+
+    pub fn fast_search(&self) -> bool {
+        self.fast_search
+    }
+
+    /// Whether a vector index's coverage gap should be filled by a brute-force branch.
+    ///
+    /// Pinned segments are the whole answer, so rows they miss are out of scope — unless the
+    /// caller also named fragments, which asks for those fragments' rows however they have to be
+    /// found. Mirrors `Scanner::knn_combined`.
+    pub fn fills_vector_coverage_gaps(&self) -> bool {
+        !self.segments_pinned || self.take_settings.fragments.is_some()
+    }
+
+    pub fn take_settings(&self) -> &TakeSettings {
+        &self.take_settings
+    }
+
+    /// The subset of `segments` that could contribute a row this scan is allowed to return.
+    ///
+    /// A segment with no fragment bitmap predates the field, so its coverage is unknown and it has
+    /// to be kept.
+    pub fn reachable_segments(&self, segments: &[IndexMetadata]) -> Vec<IndexMetadata> {
+        let target = RoaringBitmap::from_iter(self.fragments.iter().map(|f| f.id as u32));
+        segments
+            .iter()
+            .filter(|segment| {
+                segment
+                    .fragment_bitmap
+                    .as_ref()
+                    .is_none_or(|covered| !covered.is_disjoint(&target))
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Fragments the given vector index does not cover — synchronous, because it is just the
+    /// index's fragment bitmap subtracted from the manifest's fragment list.
+    ///
+    /// This is the derivation that decides between a single-branch ANN plan and the two-branch
+    /// combined plan, and in the imperative path it is an `await`.
+    pub fn unindexed_fragments(&self, column: &str) -> Option<Vec<Fragment>> {
+        self.partition_fragments(column, false)
+    }
+
+    /// The complement of [`Self::unindexed_fragments`].
+    pub fn indexed_fragments(&self, column: &str) -> Option<Vec<Fragment>> {
+        self.partition_fragments(column, true)
+    }
+
+    fn partition_fragments(&self, column: &str, covered_side: bool) -> Option<Vec<Fragment>> {
+        let covered = self.vector_index(column)?.indexed_fragments()?;
+        Some(
+            self.fragments
+                .iter()
+                .filter(|fragment| covered.contains(fragment.id as u32) == covered_side)
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+/// Row-level coverage for every index in the dataset, keyed by index name.
+///
+/// Which indices a scan consults is not known until filter pushdown has settled, which is after
+/// every stage that is allowed to do I/O. Since the index list is short and this whole map is
+/// skipped unless an overlay exists, computing all of them up front is cheaper than an async hop
+/// later — and it is what lets the coverage split be one synchronous rule.
+async fn prefetch_index_staleness(
+    dataset: &Arc<Dataset>,
+    fragments: &[Fragment],
+) -> Result<HashMap<String, OverlayStaleness>> {
+    if overlaid_fragments(fragments).is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut segments: HashMap<String, Vec<IndexMetadata>> = HashMap::new();
+    for index in dataset.load_indices().await?.iter() {
+        segments
+            .entry(index.name.clone())
+            .or_default()
+            .push(index.clone());
+    }
+
+    let mut staleness = HashMap::with_capacity(segments.len());
+    for (name, segments) in segments {
+        staleness.insert(
+            name,
+            overlay_staleness(dataset, &segments, fragments).await?,
+        );
+    }
+    Ok(staleness)
+}
+
+async fn load_vector_index(
+    dataset: &Dataset,
+    index_segments: Option<&Vec<uuid::Uuid>>,
+    requested_metric: Option<DistanceType>,
+    indices: &[IndexMetadata],
+    column: &str,
+    fragments: &[Fragment],
+) -> Result<Option<VectorIndexInfo>> {
+    let Ok(field_id) = dataset.schema().field_id(column) else {
+        return Ok(None);
+    };
+
+    let segments = match index_segments {
+        Some(requested) => select_requested_segments(requested, indices, column, field_id)?,
+        None => {
+            let Some(index) = indices
+                .iter()
+                .find(|index| index.fields.contains(&field_id))
+            else {
+                return Ok(None);
+            };
+            dataset.load_indices_by_name(&index.name).await?.to_vec()
+        }
+    };
+
+    let metric = match crate::index::vector::details::metric_type_from_index_metadata(&segments[0])
+    {
+        Some(metric) => metric,
+        None => dataset
+            .open_vector_index(column, &segments[0].uuid, &NoOpMetricsCollector)
+            .await?
+            .metric_type(),
+    };
+    if let Some(requested) = requested_metric
+        && index_segments.is_some()
+        && requested != metric
+    {
+        // Without an explicit segment list a metric mismatch falls back to brute force. With one
+        // it cannot: the caller named these segments, so silently not using them would answer a
+        // different question than the one asked.
+        return Err(crate::Error::invalid_input(format!(
+            "with_index_segments requested metric {requested:?} but the selected index segments use {metric:?}",
+        )));
+    }
+
+    let staleness = overlay_staleness(dataset, &segments, fragments).await?;
+    Ok(Some(VectorIndexInfo {
+        segments,
+        metric,
+        staleness,
+    }))
+}
+
+/// The segments `with_index_segments` named, validated against the index metadata.
+///
+/// Mirrors `Scanner::vector_search`: every named segment must exist, cover the queried column, and
+/// belong to the same logical index as the others. Narrowing to the fragments this scan reads
+/// happens later, in `ScanPlanningContext::reachable_segments`, which every search goes through.
+fn select_requested_segments(
+    requested: &[uuid::Uuid],
+    indices: &[IndexMetadata],
+    column: &str,
+    field_id: i32,
+) -> Result<Vec<IndexMetadata>> {
+    let wanted = requested.iter().copied().collect::<HashSet<_>>();
+    let selected = indices
+        .iter()
+        .filter(|index| wanted.contains(&index.uuid))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if selected.len() != wanted.len() {
+        let found = selected
+            .iter()
+            .map(|index| index.uuid)
+            .collect::<HashSet<_>>();
+        let missing = wanted
+            .difference(&found)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        return Err(crate::Error::invalid_input(format!(
+            "with_index_segments referenced unknown index segments: {missing:?}",
+        )));
+    }
+    if selected
+        .iter()
+        .any(|index| !index.fields.contains(&field_id))
+    {
+        return Err(crate::Error::invalid_input(format!(
+            "with_index_segments contained a segment that does not belong to vector column '{column}'",
+        )));
+    }
+    let name = &selected[0].name;
+    if selected.iter().any(|index| &index.name != name) {
+        return Err(crate::Error::invalid_input(
+            "with_index_segments must reference segments from a single logical index".to_string(),
+        ));
+    }
+    Ok(selected)
 }
 
 /// The take-shaped predicates a plan node carries, if any.
@@ -101,7 +533,7 @@ fn take_operations(node: &LogicalPlan) -> Vec<TakeOperation> {
 }
 
 /// Identifies a take by what it selects, so the same take found at two points in planning agrees.
-fn take_key(take: &TakeOperation) -> String {
+pub fn take_key(take: &TakeOperation) -> String {
     format!("{take:?}")
 }
 

--- a/rust/lance/src/dataset/scanner/logical/coverage.rs
+++ b/rust/lance/src/dataset/scanner/logical/coverage.rs
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Splitting a search across the fragments an index covers and those it does not.
+//!
+//! Cross-index by design: the [`SplittableSearch`] trait is what lets one rule serve every
+//! search node type, and the scan leaf, without knowing what any of them are.
+
+use std::sync::Arc;
+
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::{DFSchemaRef, TableReference};
+use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{EmptyRelation, Extension, LogicalPlan, LogicalPlanBuilder};
+use datafusion::optimizer::{AnalyzerRule, ApplyOrder, OptimizerConfig, OptimizerRule};
+use datafusion::prelude::col;
+use lance_core::ROW_ID;
+use lance_core::datatypes::OnMissing;
+use lance_select::mask::RowAddrTreeMap;
+use lance_table::format::Fragment;
+
+use super::context::{OverlayStaleness, ScanPlanningContext};
+use super::source::ScanRestriction;
+use super::{LanceTakeNode, PrefilterSourceKind, VectorAccessPath, VectorSearchNode};
+use super::{analyze_bottom_up, map_lance_scan, restrict_scan, with_lance_source};
+
+/// What an index does not answer for, among the rows a scan will touch.
+///
+/// The whole point of this type is that fragment-level and row-level coverage are the same
+/// statement. `SplitPartiallyIndexedSearch` in the imperative path
+/// split on fragment coverage; the overlay stale-row handling threaded through
+/// `Scanner::new_filtered_read`, `knn_combined`, and `plan_flat_match_query` splits on row
+/// coverage. Both produce a brute-force branch reading exactly the rows in the hole, and the only
+/// difference is how that branch's scan is narrowed — which is what [`ScanRestriction`] carries.
+pub enum IndexCoverage {
+    /// The index answers for every row the scan will touch. Also the answer when coverage cannot
+    /// be determined: an index that will not say what it covers is used as-is, which is what the
+    /// imperative path does too.
+    Complete,
+    /// The index cannot be trusted for any row.
+    Unusable,
+    /// The indexed branch reads `indexed` and must not emit `block`; the brute-force branch reads
+    /// the rows described by `gaps`.
+    ///
+    /// `indexed: None` means the indexed branch reads everything the node already reads — the
+    /// scan-leaf case, where the hole is entirely at row level and there are no fragments to
+    /// exclude.
+    Partial {
+        indexed: Option<Vec<Fragment>>,
+        gaps: Vec<ScanRestriction>,
+        block: Option<Arc<RowAddrTreeMap>>,
+    },
+}
+
+impl IndexCoverage {
+    /// Drop the brute-force branch, keeping the block mask.
+    ///
+    /// This is `fast_search`: "answer from indices only" means a coverage gap is not filled, it is
+    /// simply not answered — and a stale entry is not an answer either, so the block stays.
+    fn indexed_only(self) -> Self {
+        match self {
+            Self::Partial {
+                indexed,
+                gaps: _,
+                block,
+            } => Self::Partial {
+                indexed,
+                gaps: Vec::new(),
+                block,
+            },
+            other => other,
+        }
+    }
+}
+
+/// A search node that answers from an index and can fall back to brute force for the rows its
+/// index does not cover.
+///
+/// The trait is the seam that lets [`SplitOnIndexCoverage`] be one rule: what counts as coverage,
+/// and how the branches merge back together, are per-index-kind decisions, while the split itself
+/// is not.
+pub trait SplittableSearch {
+    /// `false` when this node is already brute force, or is already the output of a split.
+    fn is_splittable(&self) -> bool;
+    fn coverage(&self, context: &ScanPlanningContext) -> IndexCoverage;
+    fn input(&self) -> &LogicalPlan;
+    /// Whether `fast_search` may drop this node's brute-force branch.
+    ///
+    /// True for a search, where `fast_search` is the user trading recall for latency. False for a
+    /// scan's predicate: there the brute-force branch re-reads rows whose index entry an overlay
+    /// invalidated, which repairs the index result rather than extending it past the index.
+    fn honors_fast_search(&self) -> bool {
+        true
+    }
+    /// This node reading only indexed rows, with `block` withheld from the index result.
+    fn indexed_branch(&self, input: LogicalPlan, block: Option<Arc<RowAddrTreeMap>>)
+    -> LogicalPlan;
+    /// This node as a brute-force search over `input`.
+    fn flat_branch(&self, input: LogicalPlan) -> LogicalPlan;
+    /// Combine the branches into one plan producing this node's schema.
+    fn merge(
+        &self,
+        indexed: LogicalPlan,
+        flat: LogicalPlan,
+        context: &ScanPlanningContext,
+    ) -> datafusion::common::Result<LogicalPlan>;
+}
+
+/// Recognize the node kinds that can be split.
+///
+/// This downcast list is the one place the shared rule has to know which index kinds exist, and it
+/// is exactly the registry a plugin system would own instead.
+pub fn splittable(plan: &LogicalPlan) -> Option<&dyn SplittableSearch> {
+    let LogicalPlan::Extension(extension) = plan else {
+        return None;
+    };
+    let node = extension.node.as_any();
+    if let Some(search) = node.downcast_ref::<VectorSearchNode>() {
+        return Some(search);
+    }
+    None
+}
+
+/// Split a search into an indexed branch and a brute-force branch over the rows the index does not
+/// answer for.
+///
+/// This is the design doc's Appendix A, generalized: a rewrite rather than fan-out inside the
+/// extension planner, and driven by [`IndexCoverage`] rather than by fragment lists alone. For a
+/// vector search it produces
+///
+/// ```text
+/// VectorSearch{Flat, k}              <- exact re-rank over the merged candidates
+///   Projection [_rowid, vec]         <- drop the branches' approximate _distance
+///     LanceTake [vec]                <- fetch vectors for the candidates
+///       Union
+///         VectorSearch{Index}  over the indexed fragments, minus the stale rows
+///         VectorSearch{Flat}   over the union of the coverage gaps
+/// ```
+///
+/// Three things fall out of writing it this way. The outer exact search *is* the re-rank — the
+/// same node type, no special-purpose operator. The single `Filter` child is duplicated onto both
+/// branches by ordinary plan surgery, so the "one predicate, two physical placements" problem is
+/// solved once here instead of inside the planner. And a data overlay's stale rows need no
+/// machinery of their own: they are one more coverage gap, and the same union absorbs them.
+#[derive(Debug)]
+pub struct SplitOnIndexCoverage {
+    context: Arc<ScanPlanningContext>,
+    scope: SplitScope,
+}
+
+/// Which node kind a [`SplitOnIndexCoverage`] instance is responsible for.
+///
+/// The rule is registered twice, in two different stages, because the two kinds of coverage become
+/// knowable at different times. A search node carries its index from the builder, so its coverage
+/// is settled before any optimization. A scan's index query does not exist until `PushDownFilter`
+/// has decided which predicates reach the leaf — so that half cannot run in the analyzer, however
+/// mandatory it is. Same rewrite, same trait, different stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitScope {
+    /// Vector and full-text search nodes. Runs in the analyzer.
+    Searches,
+    /// Scan leaves whose scalar index query has been resolved. Runs in the optimizer.
+    Scans,
+}
+
+impl SplitOnIndexCoverage {
+    pub fn searches(context: Arc<ScanPlanningContext>) -> Self {
+        Self {
+            context,
+            scope: SplitScope::Searches,
+        }
+    }
+
+    pub fn scans(context: Arc<ScanPlanningContext>) -> Self {
+        Self {
+            context,
+            scope: SplitScope::Scans,
+        }
+    }
+
+    fn rewrite_node(
+        &self,
+        plan: LogicalPlan,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let split = match self.scope {
+            SplitScope::Searches => match splittable(&plan) {
+                Some(node) => self.split(node, plan.schema())?,
+                None => None,
+            },
+            SplitScope::Scans => match ScanCoverage::of(&plan, &self.context) {
+                Some(node) => self.split(&node, plan.schema())?,
+                None => None,
+            },
+        };
+        Ok(match split {
+            Some(split) => Transformed::yes(split),
+            None => Transformed::no(plan),
+        })
+    }
+
+    /// The split itself, shared by every index kind. `None` means the node was left alone.
+    fn split(
+        &self,
+        node: &dyn SplittableSearch,
+        schema: &DFSchemaRef,
+    ) -> datafusion::common::Result<Option<LogicalPlan>> {
+        if !node.is_splittable() {
+            return Ok(None);
+        }
+
+        let fast_search = self.context.fast_search() && node.honors_fast_search();
+        let coverage = match fast_search {
+            true => node.coverage(&self.context).indexed_only(),
+            false => node.coverage(&self.context),
+        };
+        match coverage {
+            IndexCoverage::Complete => Ok(None),
+            IndexCoverage::Unusable if fast_search => {
+                Ok(Some(LogicalPlan::EmptyRelation(EmptyRelation {
+                    produce_one_row: false,
+                    schema: schema.clone(),
+                })))
+            }
+            IndexCoverage::Unusable => Ok(Some(node.flat_branch(node.input().clone()))),
+            IndexCoverage::Partial {
+                indexed,
+                gaps,
+                block,
+            } => {
+                let indexed_input = match indexed {
+                    Some(fragments) => restrict_scan(
+                        node.input(),
+                        &ScanRestriction::Fragments(Arc::new(fragments)),
+                    )?,
+                    None => node.input().clone(),
+                };
+                let indexed_branch = node.indexed_branch(indexed_input, block);
+                if gaps.is_empty() {
+                    return Ok(Some(indexed_branch));
+                }
+                let mut sources = Vec::with_capacity(gaps.len());
+                for gap in &gaps {
+                    sources.push(restrict_scan(node.input(), gap)?);
+                }
+                let mut builder = LogicalPlanBuilder::new(sources.remove(0));
+                for source in sources {
+                    builder = builder.union(source)?;
+                }
+                let flat_branch = node.flat_branch(builder.build()?);
+                Ok(Some(node.merge(
+                    indexed_branch,
+                    flat_branch,
+                    &self.context,
+                )?))
+            }
+        }
+    }
+}
+
+impl AnalyzerRule for SplitOnIndexCoverage {
+    fn name(&self) -> &str {
+        "split_on_index_coverage"
+    }
+
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        analyze_bottom_up(plan, |node| self.rewrite_node(node))
+    }
+}
+
+impl OptimizerRule for SplitOnIndexCoverage {
+    fn name(&self) -> &str {
+        "split_on_index_coverage"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        self.rewrite_node(plan)
+    }
+}
+
+impl SplittableSearch for VectorSearchNode {
+    fn is_splittable(&self) -> bool {
+        // Only an indexed search can have a coverage gap; a flat search already reads everything.
+        matches!(
+            self.access_path_resolution(),
+            Some(VectorAccessPath::Index { .. })
+        )
+    }
+
+    fn coverage(&self, context: &ScanPlanningContext) -> IndexCoverage {
+        let column = &self.query().column;
+        let staleness = context
+            .vector_index(column)
+            .map(|index| &index.staleness)
+            .unwrap_or(&OverlayStaleness::None);
+        // An ANN segment that cannot name its fragments still answers by row address, so blocking
+        // and re-scoring works regardless — the vector path never has to give up on the index.
+        let stale = match staleness {
+            OverlayStaleness::Rows(rows) => Some(rows.clone()),
+            OverlayStaleness::None => None,
+        };
+
+        let (Some(mut unindexed), Some(indexed)) = (
+            context.unindexed_fragments(column),
+            context.indexed_fragments(column),
+        ) else {
+            return IndexCoverage::Complete;
+        };
+        if !context.fills_vector_coverage_gaps() {
+            unindexed.clear();
+        }
+        if indexed.is_empty() {
+            return IndexCoverage::Unusable;
+        }
+        if unindexed.is_empty() && stale.is_none() {
+            return IndexCoverage::Complete;
+        }
+
+        let mut gaps = Vec::with_capacity(2);
+        if !unindexed.is_empty() {
+            gaps.push(ScanRestriction::Fragments(Arc::new(unindexed)));
+        }
+        if let Some(rows) = &stale {
+            gaps.push(ScanRestriction::Rows(rows.clone()));
+        }
+        IndexCoverage::Partial {
+            indexed: Some(indexed),
+            gaps,
+            block: stale,
+        }
+    }
+
+    fn input(&self) -> &LogicalPlan {
+        Self::input(self)
+    }
+
+    fn indexed_branch(
+        &self,
+        input: LogicalPlan,
+        block: Option<Arc<RowAddrTreeMap>>,
+    ) -> LogicalPlan {
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(self.clone().with_input(input).with_overlay_block(block)),
+        })
+    }
+
+    fn flat_branch(&self, input: LogicalPlan) -> LogicalPlan {
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                self.clone()
+                    .with_input(input)
+                    .with_resolution(VectorAccessPath::Flat),
+            ),
+        })
+    }
+
+    fn merge(
+        &self,
+        indexed: LogicalPlan,
+        flat: LogicalPlan,
+        context: &ScanPlanningContext,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        let column = &self.query().column;
+        let merged = LogicalPlanBuilder::new(indexed).union(flat)?.build()?;
+        let with_vectors = LogicalPlan::Extension(Extension {
+            node: Arc::new(LanceTakeNode::try_new(
+                merged,
+                self.dataset().clone(),
+                self.dataset()
+                    .empty_projection()
+                    .union_column(column, OnMissing::Error)?,
+                context.take_settings().clone(),
+            )?),
+        });
+        // The branches' `_distance` values are per-branch and, for the indexed one, approximate.
+        // Dropping the column here both discards them and keeps the re-rank from producing a
+        // duplicate `_distance`.
+        let candidates = LogicalPlanBuilder::new(with_vectors)
+            .project(vec![col(ROW_ID), col(column)])?
+            .build()?;
+        Ok(LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                self.clone()
+                    .with_input(candidates)
+                    .with_resolution(VectorAccessPath::Flat)
+                    .with_prefilter(PrefilterSourceKind::None)
+                    .with_overlay_block(None),
+            ),
+        }))
+    }
+}
+
+/// A Lance scan leaf whose scalar index query a data overlay has partly invalidated.
+///
+/// The third instance of the coverage split, and the one that needed a plan node to reach. Its
+/// coverage hole is purely at row level — the index covers every fragment, it just describes some
+/// rows as they were before an overlay changed them — which is why `indexed` is `None` and the
+/// only gap is a row set.
+struct ScanCoverage {
+    scan: LogicalPlan,
+    table_name: TableReference,
+    stale: Arc<RowAddrTreeMap>,
+}
+
+impl ScanCoverage {
+    /// Recognize a scan whose resolved index query has stale rows.
+    ///
+    /// Returns `None` for every scan on the common path: no index query, no overlays, or an index
+    /// query no overlay touched.
+    fn of(plan: &LogicalPlan, context: &ScanPlanningContext) -> Option<Self> {
+        if !context.has_overlays() {
+            return None;
+        }
+        let LogicalPlan::TableScan(scan) = plan else {
+            return None;
+        };
+        // Idempotence: this rule runs in the optimizer, which loops to a fixed point, and the
+        // indexed branch it produces is still a scan with an index query. The block it carries is
+        // what says the split already happened here.
+        let index_query = with_lance_source(plan, |source| match source.overlay_block() {
+            Some(_) => None,
+            None => source.filter_plan()?.index_query.clone(),
+        })??;
+        match context.index_query_staleness(&index_query) {
+            OverlayStaleness::Rows(stale) => Some(Self {
+                scan: plan.clone(),
+                table_name: scan.table_name.clone(),
+                stale,
+            }),
+            // A scalar index answers by row address whatever segment produced the entry, so there
+            // is no case where blocking cannot express the hole.
+            OverlayStaleness::None => None,
+        }
+    }
+}
+
+impl SplittableSearch for ScanCoverage {
+    fn is_splittable(&self) -> bool {
+        true
+    }
+
+    fn honors_fast_search(&self) -> bool {
+        false
+    }
+
+    fn coverage(&self, _context: &ScanPlanningContext) -> IndexCoverage {
+        IndexCoverage::Partial {
+            indexed: None,
+            gaps: vec![ScanRestriction::Rows(self.stale.clone())],
+            block: Some(self.stale.clone()),
+        }
+    }
+
+    fn input(&self) -> &LogicalPlan {
+        &self.scan
+    }
+
+    fn indexed_branch(
+        &self,
+        input: LogicalPlan,
+        block: Option<Arc<RowAddrTreeMap>>,
+    ) -> LogicalPlan {
+        let Some(block) = block else {
+            return input;
+        };
+        map_lance_scan(&input, |source| source.blocking(block.clone())).unwrap_or(input)
+    }
+
+    /// The gap branch is already a scan of exactly the stale rows with its index turned off, so
+    /// re-reading them from current values needs nothing further.
+    fn flat_branch(&self, input: LogicalPlan) -> LogicalPlan {
+        input
+    }
+
+    fn merge(
+        &self,
+        indexed: LogicalPlan,
+        flat: LogicalPlan,
+        _context: &ScanPlanningContext,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        // Aliased back to the table's own name: a union derives its output schema from its inputs
+        // and drops their relation qualifiers, which would strand every parent expression that
+        // still names the table. Both branches read the same table, so the name is still true.
+        LogicalPlanBuilder::new(indexed)
+            .union(flat)?
+            .alias(self.table_name.clone())?
+            .build()
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/mod.rs
@@ -29,6 +29,9 @@
 //!    ├─ validate_options + ensure_supported
 //!    │     exhaustive destructure of Scanner: an option is read, rejected, or explained
 //!    │
+//!    ├─ 0. PreparedQueries::resolve ....................................  prepare   [async]
+//!    │     resolve the FTS column and document granularity, which stage 1's schemas need
+//!    │
 //!    ├─ 1. builder::build .............................................   builder   [sync]
 //!    │     Scanner state -> the naive LogicalPlan, index-unaware
 //!    │
@@ -66,29 +69,51 @@
 //!    every equivalence test meaningless.
 //! 3. **Analyzer rules need no idempotence guard; optimizer rules do.** The optimizer runs to a
 //!    fixed point, so a structural rewrite there has to recognize its own output.
+//! 4. **Nothing may move a predicate or a limit across a search node.** Under approximation that
+//!    changes the answer. Enforced by the rule list being pinned, and pinned by tests.
+//! 5. **Output order is a plan-level contract**, stated by the builder rather than inherited from
+//!    whichever physical operator happened to sort.
 //!
 //! # Layout
 //!
-//! The framework is split by stage.
+//! The framework is split by stage; each index type keeps its own contribution together.
 //!
 //! ```text
 //! builder      stage 1: Scanner -> LogicalPlan
+//! prepare      stage 0: the async work that must precede the builder
 //! context      stage 2: the one prefetch every later stage reads from
 //! source       the scan leaf, as a TableProvider
-//! scan_index   recording on each scan how it finds its rows
+//! rules        rule plumbing shared by every index type
+//! coverage     splitting a search across indexed and unindexed fragments
+//! scan_index   recording on each scan how it finds its rows (index query, or a take)
 //! planner      stage 4: dispatch to each node's lowering
+//! take/        late materialization
+//! vector/      node, rerank, rules, planner
 //! ```
 //!
-//! Rule *ordering* stays here, in [`analyzer_rules`] and [`optimizer_rules`], because it is a
-//! whole-plan property that no single index type can decide.
+//! The design doc proposes that an index type could one day ship its own planning support, so
+//! `vector/` reaches the framework through a fixed set of entry points rather than reaching into
+//! it. Rule *ordering* stays here, in [`analyzer_rules`] and [`optimizer_rules`], because it is a
+//! whole-plan property that no single index can decide.
 
 pub(super) mod builder;
 pub(super) mod context;
+pub(super) mod coverage;
 pub(super) mod planner;
+pub(super) mod prepare;
+pub(super) mod rules;
 pub(super) mod scan_index;
 pub(super) mod source;
+pub(super) mod take;
 #[cfg(test)]
 mod tests;
+pub(super) mod vector;
+
+pub use coverage::*;
+pub use rules::*;
+pub use scan_index::*;
+pub use take::*;
+pub use vector::*;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -131,7 +156,8 @@ pub async fn create_plan(scanner: &Scanner) -> Result<Arc<dyn ExecutionPlan>> {
     scanner.validate_options()?;
     ensure_supported(scanner)?;
 
-    let logical_plan = builder::build(scanner)?;
+    let prepared = prepare::PreparedQueries::resolve(scanner).await?;
+    let logical_plan = builder::build(scanner, &prepared)?;
 
     if scanner.fragments.as_ref().is_some_and(Vec::is_empty) {
         // An explicit empty fragment list means the scan reads nothing, whatever the query on top
@@ -148,7 +174,8 @@ pub async fn create_plan(scanner: &Scanner) -> Result<Arc<dyn ExecutionPlan>> {
 /// Stages 2 through 4: prefetch, optimize, lower.
 ///
 /// Separate from [`create_plan`] because nothing here reads the `Scanner` — the plan is the only
-/// input. Any plan whose leaf is a [`LanceScanSource`](source::LanceScanSource) can go through it.
+/// input. Any plan whose leaf is a [`LanceScanSource`](source::LanceScanSource) can go through it,
+/// which is how [`dataframe`] plans a query DataFusion built.
 pub async fn lower(
     logical_plan: LogicalPlan,
     state: Arc<SessionState>,
@@ -267,8 +294,17 @@ fn planning_state(scanner: &Scanner) -> Arc<SessionState> {
 /// to pin it would be worse than inheriting it. The cost is that a DataFusion upgrade can change
 /// this stage's behavior without the change being visible here.
 fn analyzer_rules(context: &Arc<ScanPlanningContext>) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
-    let _ = context;
-    Analyzer::new().rules
+    let mut rules = Analyzer::new().rules;
+    rules.extend::<Vec<Arc<dyn AnalyzerRule + Send + Sync>>>(vec![
+        Arc::new(ResolveVectorAccessPath::new(context.clone())),
+        // Before the split and the refine, so both see plain single-query searches.
+        Arc::new(ExpandBatchSearch),
+        Arc::new(SplitOnIndexCoverage::searches(context.clone())),
+        // After the split, so the refine lands on the *indexed branch* of a partially-covered
+        // search rather than above the union — the nesting the imperative path produces.
+        Arc::new(ExpandVectorRefine::new(context.clone())),
+    ]);
+    rules
 }
 
 /// The curated logical rule set: a pinned subset of DataFusion's rules plus the Lance-owned ones
@@ -284,12 +320,20 @@ fn optimizer_rules(
     vec![
         Arc::new(SimplifyExpressions::new()),
         Arc::new(PushDownFilter::new()),
+        // The rest of this list is mandatory work that could not run in the analyzer, because each
+        // rule reads something `PushDownFilter` is what settles.
+        //
+        // Which predicates reached the leaf decides the scalar index query, and the index query
+        // decides the scan's coverage — so the split runs here for scans and in the analyzer for
+        // searches. Before `PushDownLimit`, so a limit is pushed into a union of branches rather
+        // than duplicated onto each of them.
+        Arc::new(ResolveTake::new(context.clone())),
+        Arc::new(ResolveScalarIndexQuery::new(context.clone())),
+        Arc::new(SplitOnIndexCoverage::scans(context.clone())),
         Arc::new(PushDownLimit::new()),
-        // Both run after `PushDownFilter`, so the predicate they read has reached the scan. A row
-        // restriction and a scalar index query compete for the same slot on the read, and the
-        // restriction wins.
-        Arc::new(scan_index::ResolveTake::new(context.clone())),
-        Arc::new(scan_index::ResolveScalarIndexQuery::new(context.clone())),
+        // Whether a predicate sits below the search is what makes it a prefilter, and pushdown is
+        // what moves it there.
+        Arc::new(ResolvePrefilterSource::new(context.clone())),
         Arc::new(OptimizeProjections::new()),
     ]
 }
@@ -304,17 +348,18 @@ fn optimizer_rules(
 /// * `JoinSelection` — `DefaultPhysicalPlanner` emits a `HashJoinExec` with `PartitionMode::Auto`,
 ///   which panics at `execute()` unless something resolves it. It runs first so the Lance rules see
 ///   a fully-resolved plan, the same way they do today.
-/// * `EnforceSorting` — a logical `Sort` is the only way to say "this order is the result's
-///   order", so the builder states it whether or not the plan below already produces it. Whether
-///   it does is a physical fact, so only a physical rule can drop the redundant sort. It runs
-///   last, after `EnforceDistribution` has settled partitioning, which is what decides whether an
-///   ordering survives a merge.
+/// * `EnforceSorting` — the builder restates a search's ordering above the take, because a logical
+///   `Sort` is the only way to say "this order is the result's order". Whether the take preserved
+///   it is a physical fact, so only a physical rule can drop the restatement. It runs last, after
+///   `EnforceDistribution` has settled partitioning, which is what decides whether an ordering
+///   survives a merge.
 fn physical_optimizer_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
     let mut rules: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> =
         vec![Arc::new(JoinSelection::new())];
     rules.extend(get_physical_optimizer().rules);
     rules.push(Arc::new(EnforceSorting::new()));
-    // Again, because dropping a sort can leave the projections it separated adjacent.
+    // Again, because dropping the restatement leaves the projections it separated adjacent: the
+    // search's own output-order fixup and the one the user's projection asked for.
     rules.push(Arc::new(SimplifyProjection));
     rules
 }
@@ -333,18 +378,24 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         // Read by the scan leaf, which decides there which columns it reads alongside the filter
         // and which it takes afterwards.
         materialization_style: _,
-        // Read by the scan leaf.
-        include_deleted_rows: _,
+        // Carried on the search node as its query count, and expanded by `ExpandBatchSearch`.
+        is_batch_nearest: _,
+        include_deleted_rows,
 
         // Applied by the builder as a stock `Aggregate` node, which also replaces the output
         // projection. `validate_options` has already rejected limit/offset/ordering alongside it.
         aggregate: _,
+
+        // Read by `ScanPlanningContext::collect`, which narrows the searched index to the
+        // segments it names.
+        index_segments: _,
 
         // Applied to the finished plan by `create_plan`, above every rule: it only reshapes
         // batches, so nothing in planning depends on it.
         strict_batch_size: _,
 
         // Read by the builder, the source, the context, or the session config.
+        prefilter: _,
         filter: _,
         batch_size: _,
         batch_readahead: _,
@@ -353,6 +404,8 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         limit: _,
         offset: _,
         ordering: _,
+        nearest,
+        full_text_query,
         use_scalar_index: _,
         fragments: _,
         fast_search: _,
@@ -360,6 +413,7 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         target_parallelism: _,
         legacy_with_row_id: _,
         legacy_with_row_addr: _,
+        autoproject_scoring_columns: _,
 
         // Read by the scan leaf, which types blob columns by it and reads them accordingly.
         blob_handling: _,
@@ -376,23 +430,16 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         ordered: _,
 
         // Not plan-affecting here. The callback is applied by `execute_plan` on the finished plan,
-        // and `explicit_projection` only gates a deprecation warning.
+        // `explicit_projection` only gates a deprecation warning, and `nearest_query_count` reaches
+        // the plan through the search node's query count.
         scan_stats_callback: _,
         explicit_projection: _,
-
-        // Search options. Every one of them is inert once the search itself is rejected below.
-        nearest,
-        full_text_query,
-        prefilter: _,
-        is_batch_nearest: _,
         nearest_query_count: _,
-        index_segments: _,
-        autoproject_scoring_columns: _,
     } = scanner;
 
-    if nearest.is_some() || full_text_query.is_some() {
+    if full_text_query.is_some() {
         return Err(Error::not_supported_source(
-            "The logical scan planner cannot plan a search yet".into(),
+            "The logical scan planner cannot plan a full-text search yet".into(),
         ));
     }
     if reads_row_offset(scanner)? {
@@ -402,11 +449,22 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
             "The logical scan planner cannot produce _rowoffset yet".into(),
         ));
     }
-    if projection_plan.has_output_cols() && projection_plan.physical_projection.is_empty() {
+    if *include_deleted_rows && nearest.is_some() {
+        // The imperative path rejects these in `vector_search_source`/`fts_search_source` for the
+        // same reason: a search returns row ids, and a deleted row does not have one.
+        return Err(Error::invalid_input_source(
+            "Cannot include deleted rows in a search".into(),
+        ));
+    }
+    if nearest.is_none()
+        && projection_plan.has_output_cols()
+        && projection_plan.physical_projection.is_empty()
+    {
         // `SELECT 1 AS foo` — output columns that read nothing. Not a gap: the imperative path
         // rejects this too (`scanner.rs:2846`), and for the same reason, so this states the same
         // refusal rather than deferring it. Without the guard, the leaf's "reading nothing is not a
-        // thing the reader can do" branch would quietly return row addresses instead.
+        // thing the reader can do" branch would quietly return row addresses instead. A search is
+        // exempt because it generates columns of its own, so `_distance` alone is a real query.
         //
         // Resolving the output against an empty schema first is what distinguishes the two ways to
         // land here: `SELECT 1` is unsupported, while `SELECT does_not_exist` is a missing column.

--- a/rust/lance/src/dataset/scanner/logical/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/mod.rs
@@ -260,14 +260,24 @@ fn planning_state(scanner: &Scanner) -> Arc<SessionState> {
         return state.clone();
     }
 
+    let mut config = session
+        .copied_config()
+        .with_target_partitions(target_partitions);
+    // DataFusion compares an aggregate's physical input schema against its logical one, schema
+    // metadata included. A search emits `[_rowid, _distance]`, and whether the dataset's schema
+    // metadata rides along depends on which physical shape the search lowered to: the brute-force
+    // chain inherits it from the read below, the index chain builds its own schema without it. One
+    // logical node declares the schema for both, so the comparison cannot be satisfied — and what it
+    // would reject is metadata no aggregate reads.
+    config
+        .options_mut()
+        .execution
+        .skip_physical_aggregate_schema_check = true;
+
     let state = Arc::new(
         SessionStateBuilder::new()
             .with_default_features()
-            .with_config(
-                session
-                    .copied_config()
-                    .with_target_partitions(target_partitions),
-            )
+            .with_config(config)
             .with_runtime_env(session.runtime_env())
             .with_physical_optimizer_rules(physical_optimizer_rules())
             .build(),

--- a/rust/lance/src/dataset/scanner/logical/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/planner.rs
@@ -5,18 +5,24 @@
 //!
 //! The dispatch itself is mechanical. Every decision was made by a rule already; by the time a
 //! node reaches here it names exactly one execution strategy.
-//!
-//! A plain scan has no Lance node above its leaf — the leaf is a `TableProvider`, which
-//! `DefaultPhysicalPlanner` lowers on its own — so there is nothing to dispatch yet. Each node
-//! type registers itself here as it arrives.
 
 use std::sync::Arc;
 
+use arrow_schema::SortOptions;
 use async_trait::async_trait;
 use datafusion::execution::session_state::SessionState;
 use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::expressions;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+use datafusion_physical_expr::PhysicalSortExpr;
+
+use super::{LanceTakeNode, PrefilterSourceKind, VectorRerankNode, VectorSearchNode};
+use super::{plan_flat_knn, plan_take, plan_vector_search};
+use crate::Result;
+use crate::dataset::Dataset;
+use crate::io::exec::PreFilterSource;
+use crate::io::exec::scalar_index::ScalarIndexExec;
 
 #[derive(Debug, Default)]
 pub struct LanceExtensionPlanner;
@@ -26,11 +32,66 @@ impl ExtensionPlanner for LanceExtensionPlanner {
     async fn plan_extension(
         &self,
         _planner: &dyn PhysicalPlanner,
-        _node: &dyn UserDefinedLogicalNode,
+        node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
-        _physical_inputs: &[Arc<dyn ExecutionPlan>],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
         _session_state: &SessionState,
     ) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
+        // FTS owns its own nodes, rules, and lowering; ask that module first.
+
+        let input = physical_inputs.first().cloned().ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(
+                "Lance logical nodes always have exactly one input".into(),
+            )
+        })?;
+
+        if let Some(search) = node.as_any().downcast_ref::<VectorSearchNode>() {
+            return Ok(Some(plan_vector_search(search, input)?));
+        }
+        if let Some(rerank) = node.as_any().downcast_ref::<VectorRerankNode>() {
+            return Ok(Some(plan_flat_knn(
+                rerank.query(),
+                rerank.distance_type(),
+                None,
+                input,
+            )?));
+        }
+        if let Some(take) = node.as_any().downcast_ref::<LanceTakeNode>() {
+            return Ok(Some(plan_take(take, input)?));
+        }
         Ok(None)
     }
+}
+
+/// Lower a search's candidate restriction.
+///
+/// `input` is the child plan. It is only read for [`PrefilterSourceKind::ChildRowIds`]; the other
+/// two answer without it, and the child is planned but never executed.
+pub fn plan_prefilter_source(
+    kind: &PrefilterSourceKind,
+    dataset: &Arc<Dataset>,
+    input: Arc<dyn ExecutionPlan>,
+) -> PreFilterSource {
+    match kind {
+        PrefilterSourceKind::None => PreFilterSource::None,
+        PrefilterSourceKind::ChildRowIds => PreFilterSource::FilteredRowIds(input),
+        PrefilterSourceKind::ScalarIndexQuery {
+            query,
+            result_format,
+        } => PreFilterSource::ScalarIndexQuery(Arc::new(ScalarIndexExec::new(
+            dataset.clone(),
+            query.as_ref().clone(),
+            *result_format,
+        ))),
+    }
+}
+
+pub fn sort_asc(column: &str, plan: &dyn ExecutionPlan) -> Result<PhysicalSortExpr> {
+    Ok(PhysicalSortExpr {
+        expr: expressions::col(column, plan.schema().as_ref())?,
+        options: SortOptions {
+            descending: false,
+            nulls_first: false,
+        },
+    })
 }

--- a/rust/lance/src/dataset/scanner/logical/prepare.rs
+++ b/rust/lance/src/dataset/scanner/logical/prepare.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 0: normalize the scanner's queries before the plan is built.
+//!
+//! Stage 1 is synchronous, and a search query may carry fields that take I/O to fill in, so
+//! whatever resolving they need happens here.
+
+use lance_index::vector::Query;
+
+use super::super::QueryFilter;
+use crate::Result;
+use crate::dataset::Scanner;
+
+/// The scanner's search queries, with every implicit field resolved.
+#[derive(Debug, Default)]
+pub struct PreparedQueries {
+    pub vector_filter: Option<Query>,
+}
+
+impl PreparedQueries {
+    pub async fn resolve(scanner: &Scanner) -> Result<Self> {
+        let vector_filter = match &scanner.filter.query_filter {
+            Some(QueryFilter::Vector(query)) => Some(query.clone()),
+            _ => None,
+        };
+        Ok(Self { vector_filter })
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/rules.rs
+++ b/rust/lance/src/dataset/scanner/logical/rules.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Rule plumbing shared by every index type.
+
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::logical_expr::LogicalPlan;
+
+/// Apply a node rewrite bottom-up over the whole plan.
+///
+/// An [`AnalyzerRule`] receives the entire plan, so the traversal that
+/// [`OptimizerRule::apply_order`] used to supply is written out here instead. Bottom-up matters for
+/// the same reason it did there: a rule that replaces a node with a subtree must not then descend
+/// into the subtree it just built.
+pub fn analyze_bottom_up(
+    plan: LogicalPlan,
+    rewrite: impl FnMut(LogicalPlan) -> datafusion::common::Result<Transformed<LogicalPlan>>,
+) -> datafusion::common::Result<LogicalPlan> {
+    Ok(plan.transform_up(rewrite)?.data)
+}

--- a/rust/lance/src/dataset/scanner/logical/scan_index.rs
+++ b/rust/lance/src/dataset/scanner/logical/scan_index.rs
@@ -7,16 +7,17 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion::datasource::{provider_as_source, source_as_provider};
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
 use datafusion::logical_expr::utils::conjunction;
 use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
-
 use lance_select::mask::RowAddrTreeMap;
+use roaring::RoaringBitmap;
 
-use super::context::ScanPlanningContext;
+use super::PrefilterSourceKind;
+use super::context::{OverlayStaleness, ScanPlanningContext};
 use super::source::{LanceScanSource, ScanRestriction};
 use crate::dataset::scanner::TakeOperation;
 
@@ -26,7 +27,8 @@ use crate::dataset::scanner::TakeOperation;
 /// only inside `TableProvider::scan`, where no rule can see it — which is why the scan leaf was the
 /// one coverage split that had to be written out by hand.
 ///
-/// It runs after `PushDownFilter`, so the predicate has reached its final position first.
+/// It runs after `PushDownFilter` for the same reason
+/// [`ResolvePrefilterSource`] does: the predicate has to have reached its final position first.
 #[derive(Debug)]
 pub struct ResolveScalarIndexQuery {
     context: Arc<ScanPlanningContext>,
@@ -111,14 +113,117 @@ pub fn map_lance_scan(
         .data)
 }
 
+/// Rebuild `plan`, pointing every scan leaf at the same source narrowed by `restriction`.
+///
+/// The recursion exists because the predicate may not have reached the leaf: before
+/// `PushDownFilter` runs there is a `Filter` in between, and that `Filter` has to be duplicated
+/// onto every branch along with the scan.
+pub fn restrict_scan(
+    plan: &LogicalPlan,
+    restriction: &ScanRestriction,
+) -> datafusion::common::Result<LogicalPlan> {
+    Ok(plan
+        .clone()
+        .transform_down(|node| {
+            let LogicalPlan::TableScan(scan) = &node else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(provider) = source_as_provider(&scan.source).ok() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(source) = (provider.as_ref() as &dyn Any).downcast_ref::<LanceScanSource>()
+            else {
+                return Ok(Transformed::no(node));
+            };
+            let mut scan = scan.clone();
+            scan.source = provider_as_source(Arc::new(source.restricted_to(restriction)));
+            Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
+        })?
+        .data)
+}
+
+/// The index lookup that can stand in for a search's whole prefilter subtree, if this one can.
+///
+/// A prefilter is normally a read that materializes the row ids the predicate selects. When the
+/// predicate is answered exactly by a scalar index, the lookup already *is* that row set, so the
+/// search can consume it directly and the read never happens. Mirrors the `ScalarIndexExec`
+/// branch of `Scanner::prefilter_source`.
+///
+/// `required_fragments` are the fragments the search itself can return a row from: a candidate
+/// set that cannot speak for one of them would silently drop rows the search would have found.
+pub fn scalar_index_prefilter(
+    input: &LogicalPlan,
+    required_fragments: &RoaringBitmap,
+    context: &ScanPlanningContext,
+) -> Option<PrefilterSourceKind> {
+    with_lance_source(input, |source| {
+        let options = source.options();
+        // The lookup reads the whole dataset, so a narrowing of the scan it replaces is lost with
+        // the scan. Which narrowings matter differs:
+        //
+        // * A caller's `with_fragments` is enforced by this read and nothing else, so dropping it
+        //   would let rows from other fragments through.
+        // * A row restriction singles out rows whose index entries are not to be trusted, which is
+        //   the opposite of what a lookup would answer.
+        // * A restriction a coverage split added is neither: it narrows the read to what this
+        //   branch is responsible for, and the branch's index can only emit rows from there
+        //   anyway, so a wider allow list adds nothing.
+        if context.take_settings().fragments.is_some()
+            || options.rows.is_some()
+            || options.overlay_block.is_some()
+        {
+            return None;
+        }
+        let filter_plan = source.filter_plan()?;
+        if !filter_plan.is_exact_index_search() {
+            return None;
+        }
+        let query = filter_plan.index_query.clone()?;
+        // Stale entries would reach the search as candidates whose indexed values no longer hold.
+        // The read this replaces is what masks them out, so keep it.
+        if !matches!(
+            context.index_query_staleness(&query),
+            OverlayStaleness::None
+        ) {
+            return None;
+        }
+        let covered = context.index_query_coverage(&query)?;
+        if !context.fast_search() && !required_fragments.is_subset(&covered) {
+            return None;
+        }
+        Some(PrefilterSourceKind::ScalarIndexQuery {
+            query: Arc::new(query),
+            result_format: options.index_expr_result_format,
+        })
+    })?
+}
+
+pub fn restricts_candidates(plan: &LogicalPlan) -> bool {
+    let mut restricts = false;
+    let _ = plan.apply(|node| {
+        match node {
+            LogicalPlan::Filter(_) => restricts = true,
+            LogicalPlan::TableScan(scan) if !scan.filters.is_empty() => restricts = true,
+            _ => {}
+        }
+        if restricts {
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    });
+    restricts
+}
+
 /// Turn a predicate that names its rows into a direct take.
 ///
 /// `_rowid IN (10, 20)` leaves nothing to search for: the ids *are* the selection. Recording them
 /// on the scan's source is the logical-layer version of `Scanner::take_source`, which assembles the
 /// same read by hand.
 ///
-/// Row ids are resolved here; `_rowaddr` names a physical position, and turning those into row ids
-/// reads row-id sequences and deletion vectors, so stage 2 does it and this looks the answer up.
+/// Row ids are resolved here; `_rowaddr` and `_rowoffset` name physical positions, and turning
+/// those into row ids reads row-id sequences and deletion vectors, so stage 2 does it and this
+/// looks the answer up.
 ///
 /// Runs after `PushDownFilter`, so the predicate has reached the scan, and before
 /// [`ResolveScalarIndexQuery`] — a row restriction and a scalar index query compete for the same
@@ -131,19 +236,6 @@ pub struct ResolveTake {
 impl ResolveTake {
     pub fn new(context: Arc<ScanPlanningContext>) -> Self {
         Self { context }
-    }
-
-    /// The row ids a take selects, or `None` when the plan cannot be rewritten.
-    ///
-    /// A stage-2 miss means it walked a different plan than this one, so the predicate is left
-    /// alone rather than guessed at: reading every row and filtering is slower, not wrong.
-    fn rows_for(&self, take: &TakeOperation) -> Option<Arc<RowAddrTreeMap>> {
-        match take {
-            TakeOperation::RowIds(ids) => {
-                Some(Arc::new(RowAddrTreeMap::from_iter(ids.iter().copied())))
-            }
-            _ => self.context.take_rows(take).cloned(),
-        }
     }
 }
 
@@ -160,6 +252,34 @@ impl OptimizerRule for ResolveTake {
         &self,
         plan: LogicalPlan,
         _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        match &plan {
+            LogicalPlan::TableScan(_) => self.restrict_scan(plan),
+            _ => Ok(Transformed::no(plan)),
+        }
+    }
+}
+
+impl ResolveTake {
+    /// The row ids a take selects, or `None` when the plan cannot be rewritten.
+    ///
+    /// Only row ids are resolved here. `_rowaddr` and `_rowoffset` name physical positions, and
+    /// translating those reads row-id sequences and deletion vectors, so stage 2 did it and this
+    /// looks the answer up. A miss means stage 2 walked a different plan than this one, so the
+    /// predicate is left alone rather than guessed at: reading every row and filtering is slower,
+    /// not wrong.
+    fn rows_for(&self, take: &TakeOperation) -> Option<Arc<RowAddrTreeMap>> {
+        match take {
+            TakeOperation::RowIds(ids) => {
+                Some(Arc::new(RowAddrTreeMap::from_iter(ids.iter().copied())))
+            }
+            _ => self.context.take_rows(take).cloned(),
+        }
+    }
+
+    fn restrict_scan(
+        &self,
+        plan: LogicalPlan,
     ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
         let LogicalPlan::TableScan(scan) = &plan else {
             return Ok(Transformed::no(plan));

--- a/rust/lance/src/dataset/scanner/logical/source/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/source/mod.rs
@@ -45,9 +45,16 @@ use crate::io::exec::scalar_index::ScalarIndexExec;
 use crate::io::exec::{FilterPlan as ExprFilterPlan, Planner};
 use crate::{Error, Result};
 
-/// How a scan is narrowed to the rows one part of the plan is responsible for.
+/// How a branch's scan is narrowed to the rows that branch is responsible for.
+///
+/// The two variants are the same statement at two granularities, which is the point: index
+/// coverage has holes at fragment level (the index never saw those rows) and at row level (the
+/// index saw the row before a data overlay changed it), and both holes are filled by a
+/// brute-force branch reading exactly the rows in the hole.
 #[derive(Debug, Clone)]
 pub enum ScanRestriction {
+    /// Read only these fragments.
+    Fragments(Arc<Vec<Fragment>>),
     /// Read only these rows, identified by row id.
     Rows(Arc<RowAddrTreeMap>),
 }
@@ -88,7 +95,9 @@ pub struct ScanSourceOptions {
     /// Read only these rows, from [`ScanRestriction::Rows`].
     ///
     /// The row set arrives through the same leaf slot a scalar-index result would, so a scan
-    /// restricted this way cannot also consult a scalar index.
+    /// restricted this way cannot also consult a scalar index — which is exactly right for the
+    /// case that produces one: these rows were singled out *because* their index entries are no
+    /// longer trustworthy.
     pub rows: Option<Arc<RowAddrTreeMap>>,
     /// How this scan's predicate splits into a scalar index query and a refine filter.
     ///
@@ -96,6 +105,10 @@ pub struct ScanSourceOptions {
     /// what makes the index decision part of the plan rather than a private detail of
     /// [`TableProvider::scan`] — see [`ResolveScalarIndexQuery`](ResolveScalarIndexQuery).
     pub filter_plan: Option<ExprFilterPlan>,
+    /// Rows the scalar index result must not emit, because a data overlay invalidated its entries
+    /// for them. The same rows are re-read on a sibling branch, restricted by
+    /// [`ScanRestriction::Rows`].
+    pub overlay_block: Option<Arc<RowAddrTreeMap>>,
     /// The scanner this plan came from, captured only for legacy (v1) datasets.
     ///
     /// The legacy scan builder reads its options straight off `&Scanner` and is frozen, so the v1
@@ -127,6 +140,7 @@ impl std::fmt::Debug for ScanSourceOptions {
             .field("include_deleted_rows", &self.include_deleted_rows)
             .field("rows", &self.rows)
             .field("filter_plan", &self.filter_plan)
+            .field("overlay_block", &self.overlay_block)
             .field("legacy", &self.legacy_scanner.is_some())
             .finish()
     }
@@ -192,21 +206,30 @@ impl LanceScanSource {
 
     /// The scan-wide settings this leaf was built with.
     ///
-    /// Read from here rather than from the `Scanner`, which is what lets stages 2 through 4 run
-    /// against any plan whose leaf is a Lance scan.
+    /// Stage 2 reads them from here rather than from the `Scanner`, which is what lets stages 2
+    /// through 4 run against any plan whose leaf is a Lance scan.
     pub fn options(&self) -> &ScanSourceOptions {
         &self.options
     }
 
-    /// The same source, reading only the rows `restriction` names.
+    /// The same source narrowed to part of the dataset.
     ///
-    /// The schema is unchanged, so a `TableScan`'s `projected_schema` stays valid across the swap.
+    /// Used by [`SplitOnIndexCoverage`](SplitOnIndexCoverage) to give the indexed
+    /// and brute-force branches disjoint row sets. The schema is unchanged, so a `TableScan`'s
+    /// `projected_schema` stays valid across the swap.
     pub fn restricted_to(&self, restriction: &ScanRestriction) -> Self {
         let options = match restriction {
+            ScanRestriction::Fragments(fragments) => ScanSourceOptions {
+                fragments: Some(fragments.clone()),
+                ..self.options.clone()
+            },
+            // The resolved filter plan goes with it: it was resolved *using* the index whose
+            // entries for these rows are the reason this branch exists.
             ScanRestriction::Rows(rows) => ScanSourceOptions {
                 rows: Some(rows.clone()),
                 use_scalar_index: false,
                 filter_plan: None,
+                overlay_block: None,
                 ..self.options.clone()
             },
         };
@@ -225,6 +248,19 @@ impl LanceScanSource {
     pub fn with_filter_plan(&self, filter_plan: ExprFilterPlan) -> Self {
         self.with_options(ScanSourceOptions {
             filter_plan: Some(filter_plan),
+            ..self.options.clone()
+        })
+    }
+
+    /// The rows withheld from this source's index result, if a split has already happened here.
+    pub fn overlay_block(&self) -> Option<&Arc<RowAddrTreeMap>> {
+        self.options.overlay_block.as_ref()
+    }
+
+    /// The same source, with `rows` withheld from whatever its index query returns.
+    pub fn blocking(&self, rows: Arc<RowAddrTreeMap>) -> Self {
+        self.with_options(ScanSourceOptions {
+            overlay_block: Some(rows),
             ..self.options.clone()
         })
     }
@@ -448,7 +484,6 @@ impl LanceScanSource {
     /// mask. That does not by itself make the scan re-executable — `FilteredReadExec` drains one
     /// shared task stream per instance, so every Lance scan plan is single-execution — but it keeps
     /// the reason for that in one place instead of two.
-    /// A row restriction, shaped as the scalar-index result the leaf reads its rows from.
     fn rows_as_index_input(&self, rows: &RowAddrTreeMap) -> Result<Arc<dyn ExecutionPlan>> {
         let result = IndexExprResult::exact(RowAddrMask::from_allowed(rows.clone()));
         let batch = result.serialize(
@@ -539,6 +574,15 @@ impl LanceScanSource {
                     "a legacy (v1) scan reached the leaf without the scanner it needs".to_string(),
                 ));
             };
+            // Both of these come from a data overlay, and no writer can put one on a v1 dataset:
+            // `lance_file::versions::create_writer` refuses `V1`. Reaching here means a split rule
+            // produced a branch for a dataset that cannot have the coverage gap it is filling.
+            if self.options.rows.is_some() || self.options.overlay_block.is_some() {
+                return Err(Error::internal(
+                    "a legacy (v1) scan was restricted by a data overlay, which v1 cannot have"
+                        .to_string(),
+                ));
+            }
             let plan = v1::scan(
                 scanner,
                 &filter_plan,
@@ -585,6 +629,11 @@ impl LanceScanSource {
         }
         if let Some(scan_range) = scan_range {
             read_options = read_options.with_scan_range_before_filter(scan_range)?;
+        }
+
+        if let Some(rows) = &self.options.overlay_block {
+            read_options =
+                read_options.with_overlay_block(RowAddrMask::from_block(rows.as_ref().clone()));
         }
 
         // A row restriction and a scalar-index query compete for the same slot, and

--- a/rust/lance/src/dataset/scanner/logical/take/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/take/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Late materialization: fetching the columns a search did not produce.
+
+mod node;
+mod planner;
+
+pub use node::*;
+pub use planner::*;

--- a/rust/lance/src/dataset/scanner/logical/take/node.rs
+++ b/rust/lance/src/dataset/scanner/logical/take/node.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Late materialization as a logical node: fetch the columns a search did not
+//! produce, keyed by row id.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_schema::Schema as ArrowSchema;
+use datafusion::common::{DFSchema, DFSchemaRef};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_core::ROW_ID;
+use lance_core::datatypes::Projection;
+use lance_table::format::Fragment;
+
+use crate::Result;
+use crate::dataset::Dataset;
+use crate::io::exec::TakeExec;
+
+/// The read settings every take in a plan has to honor, carried down from the `Scanner`.
+///
+/// A take is a read, so a fragment restriction applies to it: rows the search found outside the
+/// target fragments are dropped here. That is how `with_fragments` reaches a search whose index
+/// covers more fragments than the scan asked for.
+#[derive(Debug, Clone, Default)]
+pub struct TakeSettings {
+    pub fragments: Option<Arc<Vec<Fragment>>>,
+    pub batch_size: Option<u32>,
+}
+
+/// Late materialization: fetch `projection`'s columns for rows the input has already identified,
+/// keyed by `_rowid`.
+///
+/// The physical form is a row-stream `FilteredReadExec`, whose output is the input's columns
+/// followed by the newly fetched ones. That ordering is reproduced here with the same helper the
+/// physical node uses, so the logical and physical schemas cannot drift.
+#[derive(Debug, Clone)]
+pub struct LanceTakeNode {
+    input: LogicalPlan,
+    dataset: Arc<Dataset>,
+    projection: Projection,
+    settings: TakeSettings,
+    schema: DFSchemaRef,
+}
+
+impl LanceTakeNode {
+    pub fn try_new(
+        input: LogicalPlan,
+        dataset: Arc<Dataset>,
+        projection: Projection,
+        settings: TakeSettings,
+    ) -> Result<Self> {
+        let schema = Self::output_schema(&input, &dataset, &projection)?;
+        Ok(Self {
+            input,
+            dataset,
+            projection,
+            settings,
+            schema,
+        })
+    }
+
+    /// Whether a take is needed at all: if the input already carries every projected column,
+    /// the node is a no-op and the builder should skip it.
+    pub fn is_noop(input: &LogicalPlan, projection: &Projection) -> Result<bool> {
+        let input_schema = input.schema().as_arrow().clone();
+        let missing = projection
+            .clone()
+            .subtract_arrow_schema(&input_schema, lance_core::datatypes::OnMissing::Ignore)?;
+        Ok(!missing.has_data_fields() && !missing.with_row_id && !missing.with_row_addr)
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    pub fn projection(&self) -> &Projection {
+        &self.projection
+    }
+
+    pub fn settings(&self) -> &TakeSettings {
+        &self.settings
+    }
+
+    fn output_schema(
+        input: &LogicalPlan,
+        dataset: &Dataset,
+        projection: &Projection,
+    ) -> Result<DFSchemaRef> {
+        let input_schema = input.schema().as_arrow().clone();
+        let fields_to_read = projection
+            .clone()
+            .subtract_arrow_schema(&input_schema, lance_core::datatypes::OnMissing::Ignore)?;
+        let output =
+            TakeExec::calculate_output_schema(dataset.schema(), &input_schema, &fields_to_read);
+        Ok(Arc::new(DFSchema::try_from(ArrowSchema::from(&output))?))
+    }
+}
+
+impl PartialEq for LanceTakeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input
+            && self.dataset.base == other.dataset.base
+            && self.projection.field_ids == other.projection.field_ids
+    }
+}
+
+impl Eq for LanceTakeNode {}
+
+impl Hash for LanceTakeNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.dataset.base.hash(state);
+        let mut ids = self
+            .projection
+            .field_ids
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids.hash(state);
+    }
+}
+
+impl PartialOrd for LanceTakeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.input.partial_cmp(&other.input)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for LanceTakeNode {
+    fn name(&self) -> &str {
+        "LanceTake"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut columns = self
+            .projection
+            .to_bare_schema()
+            .fields
+            .iter()
+            .map(|field| field.name.clone())
+            .collect::<Vec<_>>();
+        columns.sort();
+        write!(
+            f,
+            "LanceTake: columns=[{}] by={}",
+            columns.join(", "),
+            ROW_ID
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() {
+            return Err(datafusion::common::DataFusionError::Internal(
+                "LanceTake takes no expressions".into(),
+            ));
+        }
+        if inputs.len() != 1 {
+            return Err(datafusion::common::DataFusionError::Internal(format!(
+                "LanceTake takes exactly one input, got {}",
+                inputs.len()
+            )));
+        }
+        Self::try_new(
+            inputs.remove(0),
+            self.dataset.clone(),
+            self.projection.clone(),
+            self.settings.clone(),
+        )
+        .map_err(|e| datafusion::common::DataFusionError::External(Box::new(e)))
+    }
+
+    /// Every input column carries through to the output, so nothing below can be dropped.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/take/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/take/planner.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 4: lowering the take node to a read keyed by the rows the input found.
+
+use std::sync::Arc;
+
+use datafusion::physical_plan::ExecutionPlan;
+use lance_core::ROW_ID;
+
+use super::super::LanceTakeNode;
+use super::super::source::v1;
+use crate::Result;
+use crate::io::exec::filtered_read::{FilteredReadExec, FilteredReadOptions};
+
+pub fn plan_take(
+    node: &LanceTakeNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    // Both forms emit the input's columns followed by the fetched ones, which is why the node's
+    // schema holds either way. See [`v1::take`] for why v1 needs its own.
+    if v1::is_legacy(node.dataset()) {
+        return v1::take(
+            node.dataset(),
+            input,
+            node.projection().clone(),
+            node.settings().batch_size,
+        );
+    }
+    let options = take_options(node, input.schema().as_ref());
+    Ok(Arc::new(FilteredReadExec::try_new(
+        node.dataset().clone(),
+        options,
+        Some(input),
+    )?))
+}
+
+/// Carry through whichever identity columns the input already has, so the take does not drop
+/// them. Mirrors `Scanner::take_current`.
+pub fn take_options(
+    node: &LanceTakeNode,
+    input_schema: &arrow_schema::Schema,
+) -> FilteredReadOptions {
+    let mut projection = node.projection().clone();
+    projection.with_row_id |= input_schema.column_with_name(ROW_ID).is_some();
+    projection.with_row_addr |= input_schema
+        .column_with_name(lance_core::ROW_ADDR)
+        .is_some();
+    let mut options = FilteredReadOptions::new(projection);
+    if let Some(batch_size) = node.settings().batch_size {
+        options = options.with_batch_size(batch_size);
+    }
+    if let Some(fragments) = &node.settings().fragments {
+        options = options.with_fragments(fragments.clone());
+    }
+    options
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/harness.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/harness.rs
@@ -10,7 +10,7 @@ use arrow_array::RecordBatch;
 use datafusion::physical_plan::ExecutionPlan;
 use futures::TryStreamExt;
 use lance_datafusion::exec::{LanceExecutionOptions, execute_plan};
-use lance_datagen::{BatchCount, ByteCount, RowCount, array, gen_batch};
+use lance_datagen::{BatchCount, ByteCount, Dimension, RowCount, array, gen_batch};
 use lance_file::version::LanceFileVersion;
 
 use crate::Result;
@@ -244,6 +244,8 @@ pub(super) fn assert_columns_match(actual: &RecordBatch, fixture: &Fixture, row_
     }
 }
 
+pub(super) const DIM: u32 = 32;
+
 /// Tag a reader's schema with dataset-level metadata.
 ///
 /// The imperative suite's own fixtures do this deliberately — `scanner.rs:6489` says "so it tests
@@ -297,4 +299,161 @@ pub(super) async fn test_dataset_versioned(version: LanceFileVersion) -> Dataset
     )
     .await
     .unwrap()
+}
+
+/// Written through a real (in-memory) object store rather than `into_ram_dataset`, so index
+/// creation and `io_stats_incremental` both work.
+pub(super) async fn vector_dataset() -> Dataset {
+    use crate::dataset::WriteParams;
+    use arrow::datatypes::{Float32Type, Int32Type};
+
+    // 1024 rows so PQ has enough to train on, split into two fragments so plans exercise the
+    // multi-fragment path.
+    let data = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .col("s", array::rand_utf8(ByteCount::from(8), false))
+        .col("vec", array::rand_vec::<Float32Type>(Dimension::from(DIM)))
+        .into_reader_rows(RowCount::from(256), BatchCount::from(4));
+    Dataset::write(
+        tagged(data),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 512,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap()
+}
+
+/// A query inside the fixture's value range.
+///
+/// `rand_vec` draws each coordinate from [0, 1), so a query built from raw indices would sit far
+/// outside the cloud, at nearly the same distance from every row. "The five nearest" is then a
+/// coin flip no approximate index can be expected to win, and the recall assertions below would
+/// measure the query rather than the plan.
+pub(super) fn query_vector() -> arrow_array::Float32Array {
+    arrow_array::Float32Array::from((0..DIM).map(|v| v as f32 / DIM as f32).collect::<Vec<_>>())
+}
+
+/// A vector dataset with an IVF_PQ index covering every fragment.
+pub(super) async fn indexed_vector_dataset() -> Dataset {
+    indexed_vector_dataset_with_metric(lance_linalg::distance::DistanceType::L2).await
+}
+
+/// As [`indexed_vector_dataset`], but with the index built for a chosen metric.
+pub(super) async fn indexed_vector_dataset_with_metric(
+    metric: lance_linalg::distance::DistanceType,
+) -> Dataset {
+    use crate::index::DatasetIndexExt;
+    use crate::index::vector::VectorIndexParams;
+    use lance_index::IndexType;
+
+    let mut dataset = vector_dataset().await;
+    // Two partitions, so the plan exercises the multi-partition path, and no quantizer. The
+    // fixture's coordinates are uniform random, so in 32 dimensions its rows sit at nearly equal
+    // distances from any query: a quantizer's error then exceeds the gaps it has to preserve, and
+    // which rows come back varies with how k-means happened to land. That noise measures the
+    // quantizer, not the plan, which is what these assertions are about.
+    let params = VectorIndexParams::ivf_flat(2, metric);
+    dataset
+        .create_index(&["vec"], IndexType::Vector, None, &params, true)
+        .await
+        .unwrap();
+    dataset
+}
+
+// ---------------------------------------------------------------------------------------------
+// Search oracles
+// ---------------------------------------------------------------------------------------------
+
+/// The `i` values of the `k` vectors closest to `query`, computed by brute force over the whole
+/// dataset. Ties broken by `i`, so the answer is a sequence rather than a set.
+pub(super) async fn exact_neighbors(
+    dataset: &Dataset,
+    query: &arrow_array::Float32Array,
+    metric: lance_linalg::distance::DistanceType,
+    k: usize,
+) -> Result<Vec<i32>> {
+    use arrow_array::cast::AsArray;
+
+    let fixture = Fixture::read(dataset).await?;
+    let vectors = fixture.rows["vec"].as_fixed_size_list();
+    let distances = metric.arrow_batch_func()(query, vectors)?;
+
+    let mut ranked = fixture
+        .ids()
+        .iter()
+        .copied()
+        .zip(distances.values().iter().copied())
+        .filter(|(_, distance)| !distance.is_nan())
+        .collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        left.1
+            .total_cmp(&right.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    ranked.truncate(k);
+    Ok(ranked.into_iter().map(|(id, _)| id).collect())
+}
+
+/// Assert a vector search found at least `min_recall` of the true nearest neighbours, and returned
+/// them in nondecreasing distance order.
+///
+/// Recall rather than equality because an IVF_PQ index is approximate by construction: it quantizes
+/// the vectors and probes a subset of partitions, so an exact match would be a coincidence of the
+/// fixture's size rather than a contract. Pass `1.0` where the search is brute force and the exact
+/// answer *is* the contract.
+pub(super) async fn assert_search_recall(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    query: &arrow_array::Float32Array,
+    metric: lance_linalg::distance::DistanceType,
+    k: usize,
+    min_recall: f64,
+) -> Result<()> {
+    let fixture = Fixture::read(dataset).await?;
+    let expected = exact_neighbors(dataset, query, metric, k).await?;
+
+    let actual = scan_rows(dataset, probe_every_partition(config)).await?;
+    let row_ids = row_ids_of(&actual);
+    assert_eq!(row_ids.len(), k, "search returned the wrong number of rows");
+    assert_distances_ascending(&actual);
+    assert_columns_match(&actual, &fixture, &row_ids);
+
+    let found = fixture.ids_of(&row_ids);
+    let hits = found.iter().filter(|id| expected.contains(id)).count();
+    let recall = hits as f64 / expected.len() as f64;
+    assert!(
+        recall >= min_recall,
+        "recall {recall} below {min_recall}: expected {expected:?}, got {found:?}"
+    );
+    Ok(())
+}
+
+/// Probe both of the fixture index's partitions.
+///
+/// The default probes one of the two, so recall then depends mostly on which partition k-means put
+/// the neighbours in — it varies run to run and says nothing about the plan. Probing both leaves
+/// quantization error, which is the approximation these assertions are about. Plan-shape tests do
+/// not go through here, so they still pin the default `minimum_nprobes=1`.
+pub(super) fn probe_every_partition(config: impl ScanConfig) -> impl ScanConfig {
+    move |scan: &mut Scanner| {
+        config(scan)?;
+        Ok(scan.minimum_nprobes(2))
+    }
+}
+
+/// Assert `_distance` never decreases down the result, which is the ordering a search promises.
+pub(super) fn assert_distances_ascending(batch: &RecordBatch) {
+    use arrow::datatypes::Float32Type;
+    use arrow_array::cast::AsArray;
+
+    let distances = batch[lance_index::vector::DIST_COL]
+        .as_primitive::<Float32Type>()
+        .values();
+    assert!(
+        distances.windows(2).all(|pair| pair[0] <= pair[1]),
+        "distances are not ascending: {distances:?}"
+    );
 }

--- a/rust/lance/src/dataset/scanner/logical/tests/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/mod.rs
@@ -7,4 +7,6 @@
 //! the logical path and compare the rows. See [`harness`] for that oracle.
 
 mod harness;
+mod planner;
 mod scan;
+mod vector;

--- a/rust/lance/src/dataset/scanner/logical/tests/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/planner.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Whole-planner properties: guards, ordering, overlays, and output schema.
+
+use futures::TryStreamExt;
+use lance_datafusion::exec::{LanceExecutionOptions, execute_plan};
+use lance_datagen::{Dimension, array, gen_batch};
+
+use crate::Result;
+use crate::dataset::scanner::ColumnOrdering;
+
+use super::harness::*;
+
+#[tokio::test]
+async fn test_ordering() {
+    let dataset = test_dataset().await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    assert_scan_returns(
+        &dataset,
+        |scan| {
+            scan.project(&["s", "i"])?
+                .order_by(Some(vec![ColumnOrdering::desc_nulls_last("i".into())]))
+        },
+        &fixture,
+        (0..200).rev().collect(),
+    )
+    .await
+    .unwrap();
+}
+
+/// A limit must take the first rows *of the ordering*, which is only true if the sort is below
+/// the limit. It also blocks the scan-range pushdown a bare limit would get.
+#[tokio::test]
+async fn test_ordering_with_limit() {
+    let dataset = test_dataset().await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    // Descending from 199, skip 3, keep 7: rows 196 down to 190. Taking the limit before the sort
+    // would return the first rows of *storage* order instead.
+    assert_scan_returns(
+        &dataset,
+        |scan| {
+            scan.project(&["s", "i"])?
+                .limit(Some(7), Some(3))?
+                .order_by(Some(vec![ColumnOrdering::desc_nulls_last("i".into())]))
+        },
+        &fixture,
+        (190..197).rev().collect(),
+    )
+    .await
+    .unwrap();
+}
+
+/// The ordering column is not projected, so it has to be read and then dropped again.
+#[tokio::test]
+async fn test_ordering_by_an_unprojected_column() {
+    let dataset = test_dataset().await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    assert_scan_returns(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .filter("i > 20")?
+                .order_by(Some(vec![ColumnOrdering::asc_nulls_first("i".into())]))
+        },
+        &fixture,
+        (21..200).collect(),
+    )
+    .await
+    .unwrap();
+}
+
+/// A top-k whose result spans more than one output batch, at real parallelism. Regression test for
+/// the take losing the search's distance ordering: `FilteredReadExec` advertises no output
+/// ordering, so without an explicit sort above it `execute_plan` merges partitions with a plain
+/// coalesce and the global order is scrambled.
+#[tokio::test]
+async fn test_flat_knn_large_limit_stays_globally_ordered() {
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+    use arrow::datatypes::Float32Type;
+    use arrow_array::cast::AsArray;
+    use lance_index::vector::DIST_COL;
+
+    let dataset = gen_batch()
+        .col("vec", array::rand_vec::<Float32Type>(Dimension::from(16)))
+        .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(5_000))
+        .await
+        .unwrap();
+    let query = arrow_array::Float32Array::from(vec![0.0_f32; 16]);
+
+    // BATCH_SIZE_FALLBACK is 8192, so 12k results span batches. The scrambling is a scheduling
+    // race, hence the repeats.
+    for _ in 0..5 {
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &query, 12_000).unwrap();
+        scan.target_parallelism(8);
+        let batch = run(super::super::create_plan(&scan).await.unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(batch.num_rows(), 12_000);
+        let distances = batch[DIST_COL].as_primitive::<Float32Type>();
+        for pair in distances.values().windows(2) {
+            assert!(
+                pair[0] <= pair[1],
+                "results must be globally sorted by distance, found {} before {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+}
+
+/// A plan rebuilds its output schema several times on the way down, and the dataset's own schema
+/// metadata has to survive every one of them.
+#[tokio::test]
+async fn test_output_schema_keeps_dataset_metadata() -> Result<()> {
+    let dataset = test_dataset().await;
+    let expected = dataset.schema().metadata.clone();
+    assert!(
+        !expected.is_empty(),
+        "fixture must carry schema metadata for this test to mean anything"
+    );
+
+    let plan = logical_plan_for(&dataset, |scan| scan.filter("i > 50")?.project(&["s"])).await?;
+    assert_eq!(
+        plan.schema().metadata(),
+        &expected,
+        "the plan's schema dropped the dataset's schema metadata"
+    );
+    // Checked separately from the plan schema because they can disagree, and it is the batch the
+    // caller actually receives.
+    let batches = execute_plan(plan, LanceExecutionOptions::default())?
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(
+        batches[0].schema().metadata(),
+        &expected,
+        "the output batches dropped the dataset's schema metadata"
+    );
+    Ok(())
+}
+
+/// The check that replaced the deleted idempotence markers: a search whose access path was never
+/// resolved is rejected as non-executable rather than lowered to a silent brute-force fallback.
+///
+/// DataFusion runs this check at the end of the analyzer, which is the stage the resolving rules
+/// live in, so a rule that fails to fire surfaces as a planning error.
+#[tokio::test]
+async fn test_an_unresolved_search_is_not_executable() {
+    use datafusion::logical_expr::InvariantLevel;
+
+    let dataset = vector_dataset().await;
+    let mut scan = dataset.scan();
+    scan.nearest("vec", &query_vector(), 5).unwrap();
+
+    let prepared = super::super::prepare::PreparedQueries::resolve(&scan)
+        .await
+        .unwrap();
+    let plan = super::super::builder::build(&scan, &prepared).unwrap();
+
+    let err = plan
+        .check_invariants(InvariantLevel::Executable)
+        .expect_err("an unresolved search must not pass the executable check");
+    assert!(
+        err.to_string().contains("no access path resolved"),
+        "unexpected error: {err}"
+    );
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/scan.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/scan.rs
@@ -220,6 +220,21 @@ async fn test_include_deleted_rows_surfaces_them_with_a_null_row_id(
     }
 }
 
+/// Deleted rows carry a null row id, and a search answers in row ids, so the two cannot be
+/// combined.
+#[tokio::test]
+async fn test_include_deleted_rows_is_rejected_for_a_search() {
+    let dataset = vector_dataset().await;
+    let mut scan = dataset.scan();
+    scan.with_row_id().include_deleted_rows();
+    scan.nearest("vec", &query_vector(), 5).unwrap();
+
+    let err = super::super::create_plan(&scan)
+        .await
+        .expect_err("a search cannot include deleted rows");
+    assert!(err.to_string().contains("deleted rows"), "{err}");
+}
+
 /// Every batch but the last carries exactly the requested number of rows.
 #[tokio::test]
 async fn test_strict_batch_size() {

--- a/rust/lance/src/dataset/scanner/logical/tests/vector.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/vector.rs
@@ -673,3 +673,46 @@ async fn test_batch_search_groups_results_by_query() {
         .to_vec();
     assert_eq!(indices, vec![0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]);
 }
+
+/// An aggregate replaces the output projection, so the take above a search has nothing to fetch for
+/// it. `COUNT(*)` reads no columns at all, and then the take goes away rather than reading every
+/// column so the aggregate can throw them out.
+#[tokio::test]
+async fn test_a_count_over_a_search_reads_no_columns() {
+    use crate::dataset::scanner::AggregateExpr;
+
+    let dataset = vector_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.nearest("vec", &query_vector(), 5)?;
+        scan.aggregate(AggregateExpr::builder().count_star().build())
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+
+    assert!(
+        !text.contains("projection=[i, s, vec]"),
+        "the take is still fetching the output columns:\n{text}"
+    );
+    let batch = run(plan).await.unwrap();
+    assert_eq!(batch.num_rows(), 1);
+}
+
+/// The aggregate's own columns still have to be taken, or there is nothing to sum.
+#[tokio::test]
+async fn test_a_sum_over_a_search_takes_its_column() {
+    use crate::dataset::scanner::AggregateExpr;
+
+    let dataset = vector_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.nearest("vec", &query_vector(), 5)?;
+        scan.aggregate(AggregateExpr::builder().sum("i").build())
+    })
+    .await
+    .unwrap();
+    let batch = run(plan).await.unwrap();
+    assert_eq!(batch.num_rows(), 1);
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/vector.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/vector.rs
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Vector search: flat, ANN, prefilter/postfilter, and partial index coverage.
+
+use lance_datagen::{BatchCount, ByteCount, Dimension, RowCount, array, gen_batch};
+use lance_linalg::distance::DistanceType;
+
+use crate::dataset::Dataset;
+use crate::dataset::scanner::Scanner;
+
+use super::harness::*;
+
+/// The recall floor these searches assert.
+///
+/// The fixtures are deliberately tiny — two partitions over a few hundred rows, so index
+/// construction stays fast — and unquantized, so a plan that reaches every partition recalls
+/// everything. The floor is the repo's convention for vector index tests rather than a measured
+/// expectation: what it catches is a plan that drops or misorders candidates.
+const MIN_ANN_RECALL: f64 = 0.5;
+
+#[tokio::test]
+pub(super) async fn test_flat_knn_plan() {
+    let dataset = vector_dataset().await;
+
+    // The projection below the search is narrowed to `[vec, _rowid]` by DataFusion's
+    // `optimize_projections` reaching through the extension node via `necessary_children_exprs`;
+    // `i` and `s` are fetched afterwards by the take.
+    //
+    // There is exactly one sort, and it is the top-k. The builder also restates the distance
+    // ordering above the take — a logical `Sort` is the only way to say "this is the result's
+    // order" — and `EnforceSorting` drops it, because the take advertises that it preserved the
+    // ordering it was given.
+    assert_logical_plan(
+        &dataset,
+        |scan| scan.nearest("vec", &query_vector(), 5),
+        "ProjectionExec: expr=[i@2 as i, s@3 as s, vec@4 as vec, _distance@1 as _distance]
+  LanceRead: uri=..., projection=[i, s, vec], source=stream(_rowid)
+    ProjectionExec: expr=[_rowid@1 as _rowid, _distance@2 as _distance]
+      FilterExec: _distance@2 IS NOT NULL
+        SortExec: TopK(fetch=5), expr=[_distance@2 ASC NULLS LAST, _rowid@1 ASC NULLS LAST], preserve_partitioning=[false]
+          KNNVectorDistance: metric=l2
+            LanceRead: uri=..., projection=[vec], num_fragments=2, range_before=None, range_after=None, \
+            row_id=true, row_addr=false, full_filter=--, refine_filter=--",
+    )
+    .await
+    .unwrap();
+}
+
+/// Brute force has no approximation to forgive, so it must return the exact neighbours.
+#[tokio::test]
+pub(super) async fn test_flat_knn_finds_the_exact_neighbors() {
+    let dataset = vector_dataset().await;
+    assert_search_recall(
+        &dataset,
+        |scan| scan.nearest("vec", &query_vector(), 5),
+        &query_vector(),
+        DistanceType::L2,
+        5,
+        1.0,
+    )
+    .await
+    .unwrap();
+}
+
+/// Narrowing the projection changes what the take fetches, not which rows the search found.
+#[tokio::test]
+pub(super) async fn test_flat_knn_with_projection() {
+    let dataset = vector_dataset().await;
+    assert_search_recall(
+        &dataset,
+        |scan| scan.project(&["i"])?.nearest("vec", &query_vector(), 7),
+        &query_vector(),
+        DistanceType::L2,
+        7,
+        1.0,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_ann_plan_uses_the_index() {
+    let dataset = indexed_vector_dataset().await;
+
+    // Same logical node as the flat case; the only difference is what `ResolveVectorAccessPath`
+    // found in the planning context.
+    assert_logical_plan(
+        &dataset,
+        |scan| scan.nearest("vec", &query_vector(), 5),
+        "ProjectionExec: ...
+  LanceRead: ...
+    ProjectionExec: expr=[_rowid@1 as _rowid, _distance@0 as _distance]
+      SortExec: TopK(fetch=5), expr=[_distance@0 ASC NULLS LAST, _rowid@1 ASC NULLS LAST], ...
+        ANNSubIndex: name=..., k=5, deltas=1, metric=L2
+          ANNIvfPartition: uuid=..., minimum_nprobes=1, maximum_nprobes=None, deltas=1",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_ann_recalls_the_exact_neighbors() {
+    let dataset = indexed_vector_dataset().await;
+    assert_search_recall(
+        &dataset,
+        |scan| scan.nearest("vec", &query_vector(), 5),
+        &query_vector(),
+        DistanceType::L2,
+        5,
+        MIN_ANN_RECALL,
+    )
+    .await
+    .unwrap();
+}
+
+/// `use_index(false)` is a semantic downgrade to exact search, so the rule must not pick the
+/// index even though one exists.
+#[tokio::test]
+pub(super) async fn test_exact_accuracy_forces_flat() {
+    let dataset = indexed_vector_dataset().await;
+    let mut scan = dataset.scan();
+    scan.target_parallelism(1);
+    scan.nearest("vec", &query_vector(), 5).unwrap();
+    scan.use_index(false);
+
+    let plan = super::super::create_plan(&scan).await.unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+    assert!(text.contains("KNNVectorDistance"), "{text}");
+    assert!(!text.contains("ANNSubIndex"), "{text}");
+}
+
+/// Context collection is the only stage that reads storage, and what it reads is cached. So
+/// planning the same query twice must issue no reads the second time — the same invariant
+/// `test_scan_planning_io` pins for the imperative path.
+#[tokio::test]
+pub(super) async fn test_planning_is_io_free_once_warm() {
+    use lance_io::assert_io_eq;
+
+    let dataset = indexed_vector_dataset().await;
+    logical_plan_for(&dataset, |scan| scan.nearest("vec", &query_vector(), 5))
+        .await
+        .unwrap();
+    dataset.object_store.as_ref().io_stats_incremental();
+
+    logical_plan_for(&dataset, |scan| scan.nearest("vec", &query_vector(), 5))
+        .await
+        .unwrap();
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(io_stats, read_iops, 0);
+}
+
+/// Doc case (d): the predicate sits below the search, so it restricts the candidate set. It
+/// reaches the index as a `PreFilterSource` — visible here as the second child of `ANNSubIndex`.
+#[tokio::test]
+pub(super) async fn test_ann_prefilter_feeds_the_index() {
+    let dataset = indexed_vector_dataset().await;
+
+    assert_logical_plan(
+        &dataset,
+        |scan| {
+            scan.prefilter(true)
+                .filter("i > 10")?
+                .nearest("vec", &query_vector(), 5)
+        },
+        "ProjectionExec: ...
+        ANNSubIndex: name=..., k=5, deltas=1, metric=L2
+          ANNIvfPartition: uuid=..., minimum_nprobes=1, maximum_nprobes=None, deltas=1
+          LanceRead: uri=..., projection=[], num_fragments=2, range_before=None, range_after=None, \
+          row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=i > Int32(10)",
+    )
+    .await
+    .unwrap();
+}
+
+/// Doc case (e): the same predicate above the search trims the results instead. The index sees
+/// no prefilter, and a `FilterExec` survives above the take.
+#[tokio::test]
+pub(super) async fn test_ann_postfilter_stays_above_the_search() {
+    let dataset = indexed_vector_dataset().await;
+
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.prefilter(false)
+            .filter("i > 10")?
+            .nearest("vec", &query_vector(), 5)
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+
+    let filter_line = text
+        .lines()
+        .position(|line| line.contains("FilterExec: i@"))
+        .unwrap_or_else(|| panic!("no postfilter in plan:\n{text}"));
+    let search_line = text
+        .lines()
+        .position(|line| line.contains("ANNSubIndex"))
+        .unwrap_or_else(|| panic!("no ANN search in plan:\n{text}"));
+
+    // The load-bearing invariant: `PushDownFilter` must treat the search node as opaque. If it
+    // ever learns to push through, a postfilter silently becomes a prefilter and the query
+    // quietly changes meaning.
+    assert!(
+        filter_line < search_line,
+        "postfilter sank below the search:\n{text}"
+    );
+}
+
+#[tokio::test]
+pub(super) async fn test_ann_prefilter_restricts_the_candidates() {
+    let dataset = indexed_vector_dataset().await;
+    assert_prefiltered_search(&dataset, MIN_ANN_RECALL).await;
+}
+
+#[tokio::test]
+pub(super) async fn test_flat_knn_prefilter_restricts_the_candidates() {
+    let dataset = vector_dataset().await;
+    assert_prefiltered_search(&dataset, 1.0).await;
+}
+
+/// A prefiltered search answers from the rows the predicate kept, so the exact answer is the
+/// nearest neighbours *of that subset* — not the global ones with the rejects dropped.
+async fn assert_prefiltered_search(dataset: &Dataset, min_recall: f64) {
+    let fixture = Fixture::read(dataset).await.unwrap();
+    let candidates = exact_neighbors(dataset, &query_vector(), DistanceType::L2, usize::MAX)
+        .await
+        .unwrap();
+    let expected = candidates
+        .into_iter()
+        .filter(|i| *i > 10)
+        .take(5)
+        .collect::<Vec<_>>();
+
+    let actual = scan_rows(
+        dataset,
+        probe_every_partition(|scan: &mut Scanner| {
+            scan.prefilter(true)
+                .filter("i > 10")?
+                .nearest("vec", &query_vector(), 5)
+        }),
+    )
+    .await
+    .unwrap();
+    let found = fixture.ids_of(&row_ids_of(&actual));
+
+    assert!(found.iter().all(|i| *i > 10), "prefilter leaked: {found:?}");
+    assert_distances_ascending(&actual);
+    let hits = found.iter().filter(|i| expected.contains(i)).count();
+    assert!(
+        hits as f64 / expected.len() as f64 >= min_recall,
+        "expected {expected:?}, got {found:?}"
+    );
+}
+
+/// Appendix A: an index that covers only some fragments.
+pub(super) async fn partially_indexed_dataset() -> Dataset {
+    use crate::dataset::WriteParams;
+    use arrow::datatypes::{Float32Type, Int32Type};
+
+    let mut dataset = indexed_vector_dataset().await;
+    let more = gen_batch()
+        .col("i", array::step_custom::<Int32Type>(10_000, 1))
+        .col("s", array::rand_utf8(ByteCount::from(8), false))
+        .col("vec", array::rand_vec::<Float32Type>(Dimension::from(DIM)))
+        .into_reader_rows(RowCount::from(64), BatchCount::from(1));
+    dataset
+        .append(
+            more,
+            Some(WriteParams {
+                mode: crate::dataset::WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    dataset
+}
+
+#[tokio::test]
+pub(super) async fn test_combined_knn_ann_splits_into_two_branches() {
+    let dataset = partially_indexed_dataset().await;
+
+    let plan = logical_plan_for(&dataset, |scan| scan.nearest("vec", &query_vector(), 5))
+        .await
+        .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+
+    assert!(text.contains("UnionExec"), "no union in plan:\n{text}");
+    assert!(text.contains("ANNSubIndex"), "no indexed branch:\n{text}");
+    // Two brute-force nodes: the unindexed branch, and the exact re-rank above the union.
+    assert_eq!(
+        text.matches("KNNVectorDistance").count(),
+        2,
+        "expected a flat branch and a re-rank:\n{text}"
+    );
+}
+
+/// The union's whole point: rows the index never saw still turn up in the answer.
+#[tokio::test]
+pub(super) async fn test_combined_knn_ann_searches_both_halves() {
+    let dataset = partially_indexed_dataset().await;
+    assert_search_recall(
+        &dataset,
+        |scan| scan.nearest("vec", &query_vector(), 5),
+        &query_vector(),
+        DistanceType::L2,
+        5,
+        MIN_ANN_RECALL,
+    )
+    .await
+    .unwrap();
+}
+
+/// The stress case from Appendix A: one logical `Filter` has to reach both branches — as a
+/// prefilter source on the indexed side and as an ordinary predicate on the flat side.
+#[tokio::test]
+pub(super) async fn test_combined_knn_ann_prefilter() {
+    let dataset = partially_indexed_dataset().await;
+    assert_prefiltered_search(&dataset, MIN_ANN_RECALL).await;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Index segment selection and metric resolution
+// ---------------------------------------------------------------------------------------------
+
+async fn index_segment_uuids(dataset: &Dataset) -> Vec<uuid::Uuid> {
+    use crate::index::DatasetIndexExt;
+
+    dataset
+        .load_indices()
+        .await
+        .unwrap()
+        .iter()
+        .map(|index| index.uuid)
+        .collect()
+}
+
+#[tokio::test]
+async fn test_an_explicit_index_segment() {
+    let dataset = indexed_vector_dataset().await;
+    let segments = index_segment_uuids(&dataset).await;
+    let query = query_vector();
+
+    // Naming every segment the index has is the same search as naming none.
+    assert_search_recall(
+        &dataset,
+        |scan| {
+            scan.nearest("vec", &query, 10)?
+                .minimum_nprobes(2)
+                .with_index_segments(segments.clone())
+        },
+        &query,
+        DistanceType::L2,
+        10,
+        MIN_ANN_RECALL,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_unknown_index_segment_is_rejected() {
+    let dataset = indexed_vector_dataset().await;
+    let mut scan = dataset.scan();
+    scan.nearest("vec", &query_vector(), 10)
+        .unwrap()
+        .with_index_segments(vec![uuid::Uuid::nil()])
+        .unwrap();
+
+    let err = super::super::create_plan(&scan)
+        .await
+        .expect_err("an unknown segment must be rejected");
+    assert!(err.to_string().contains("unknown index segments"), "{err}");
+}
+
+/// Without an explicit segment list a metric mismatch falls back to brute force; with one it is an
+/// error, because the caller named segments that cannot answer the question they asked.
+#[tokio::test]
+async fn test_index_segment_with_a_conflicting_metric_is_rejected() {
+    use lance_linalg::distance::DistanceType;
+
+    let dataset = indexed_vector_dataset_with_metric(DistanceType::Cosine).await;
+    let segments = index_segment_uuids(&dataset).await;
+    let mut scan = dataset.scan();
+    scan.nearest("vec", &query_vector(), 10)
+        .unwrap()
+        .distance_metric(DistanceType::L2)
+        .with_index_segments(segments)
+        .unwrap();
+
+    let err = super::super::create_plan(&scan)
+        .await
+        .expect_err("a conflicting metric must be rejected");
+    assert!(err.to_string().contains("requested metric"), "{err}");
+}
+
+/// A search that names no metric adopts the index's rather than falling back to brute force on a
+/// mismatch with the element type's default.
+#[tokio::test]
+async fn test_search_without_a_metric_adopts_the_index_metric() {
+    use lance_linalg::distance::DistanceType;
+
+    let dataset = indexed_vector_dataset_with_metric(DistanceType::Cosine).await;
+    let query = query_vector();
+    let plan = logical_plan_for(&dataset, |scan| {
+        Ok(scan.nearest("vec", &query, 10)?.minimum_nprobes(2))
+    })
+    .await
+    .unwrap();
+
+    let display = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+    assert!(
+        display.contains("ANNSubIndex"),
+        "search fell back to flat:\n{display}"
+    );
+    assert!(display.contains("metric=Cosine"), "{display}");
+
+    assert_search_recall(
+        &dataset,
+        |scan| Ok(scan.nearest("vec", &query, 10)?.minimum_nprobes(2)),
+        &query,
+        DistanceType::Cosine,
+        10,
+        MIN_ANN_RECALL,
+    )
+    .await
+    .unwrap();
+}
+
+/// Without an index, a multivector row is scored the same way any other row is.
+///
+/// The assertion is structural rather than an exact answer: a multivector score aggregates over a
+/// row's vectors, so restating it here would restate the scorer rather than check it.
+#[tokio::test]
+async fn test_a_flat_multivector_search() {
+    let dataset = multivector_dataset().await;
+    let query = batch_query_vectors(2);
+    assert_search_shape(&dataset, |scan| scan.nearest("vec", &query, 5), 5).await;
+}
+
+/// With an index, each query vector gets its own fanout and the row is scored across all of them.
+#[tokio::test]
+async fn test_an_indexed_multivector_search() {
+    use crate::index::DatasetIndexExt;
+    use crate::index::vector::VectorIndexParams;
+    use lance_index::IndexType;
+    use lance_linalg::distance::DistanceType;
+
+    let mut dataset = multivector_dataset().await;
+    let params = VectorIndexParams::ivf_pq(2, 8, 2, DistanceType::Cosine, 2);
+    dataset
+        .create_index(&["vec"], IndexType::Vector, None, &params, true)
+        .await
+        .unwrap();
+
+    let query = batch_query_vectors(2);
+    assert_search_shape(&dataset, |scan| scan.nearest("vec", &query, 5), 5).await;
+}
+
+/// Assert a search returned `k` distinct rows in distance order.
+///
+/// The bar for a shape whose scoring the tests do not independently reproduce: whatever the scores
+/// are, the result is still a ranked list of distinct rows of the requested length.
+async fn assert_search_shape(dataset: &Dataset, config: impl ScanConfig, k: usize) {
+    let batch = scan_rows(dataset, config).await.unwrap();
+    let mut row_ids = row_ids_of(&batch);
+    assert_eq!(row_ids.len(), k, "search returned the wrong number of rows");
+    assert_distances_ascending(&batch);
+    row_ids.sort_unstable();
+    row_ids.dedup();
+    assert_eq!(row_ids.len(), k, "search returned a row twice");
+}
+
+/// `vec` is `List<FixedSizeList<Float32, DIM>>` — two vectors per row.
+async fn multivector_dataset() -> crate::dataset::Dataset {
+    use arrow::buffer::OffsetBuffer;
+    use arrow_array::{
+        FixedSizeListArray, Float32Array, Int32Array, ListArray, RecordBatch, RecordBatchIterator,
+    };
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    // 256 rows of two vectors each: PQ needs 256 training vectors.
+    const ROWS: usize = 256;
+    const VECTORS_PER_ROW: usize = 2;
+
+    let item = Arc::new(Field::new("item", DataType::Float32, true));
+    let vectors = FixedSizeListArray::try_new(
+        item.clone(),
+        DIM as i32,
+        Arc::new(Float32Array::from(
+            (0..ROWS * VECTORS_PER_ROW * DIM as usize)
+                .map(|value| value as f32 % 13.0)
+                .collect::<Vec<_>>(),
+        )),
+        None,
+    )
+    .unwrap();
+    let element = Arc::new(Field::new(
+        "item",
+        DataType::FixedSizeList(item, DIM as i32),
+        true,
+    ));
+    let multivectors = ListArray::try_new(
+        element.clone(),
+        OffsetBuffer::from_lengths(std::iter::repeat_n(VECTORS_PER_ROW, ROWS)),
+        Arc::new(vectors),
+        None,
+    )
+    .unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("i", DataType::Int32, false),
+        Field::new("vec", DataType::List(element), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from((0..ROWS as i32).collect::<Vec<_>>())),
+            Arc::new(multivectors),
+        ],
+    )
+    .unwrap();
+    crate::dataset::Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap()
+}
+
+/// A batch of query vectors, built the way the scanner's own batch tests build one.
+fn batch_query_vectors(count: usize) -> arrow_array::FixedSizeListArray {
+    use arrow_array::FixedSizeListArray;
+    use lance_arrow::FixedSizeListArrayExt;
+
+    // Inside the fixture's value range, for the reason `query_vector` gives.
+    let values = arrow_array::Float32Array::from(
+        (0..count)
+            .flat_map(|query| (0..DIM).map(move |v| (v + query as u32) as f32 / DIM as f32))
+            .collect::<Vec<_>>(),
+    );
+    FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap()
+}
+
+/// Brute force answers every query in one pass, so the batch stays a single node.
+#[tokio::test]
+async fn test_a_flat_batch_search() {
+    let dataset = vector_dataset().await;
+    assert_batch_search(&dataset, 3, None, 1.0).await;
+}
+
+/// The index fanout is single-query, so a batch becomes a union of one search per query.
+#[tokio::test]
+async fn test_an_indexed_batch_search() {
+    let dataset = indexed_vector_dataset().await;
+    assert_batch_search(&dataset, 3, None, MIN_ANN_RECALL).await;
+}
+
+/// A prefilter applies to every query in the batch.
+#[tokio::test]
+async fn test_a_prefiltered_batch_search() {
+    let dataset = indexed_vector_dataset().await;
+    assert_batch_search(&dataset, 2, Some(("i < 500", &|i| i < 500)), MIN_ANN_RECALL).await;
+}
+
+/// Assert each query in a batch got its own answer: `k` rows, grouped under its `query_index`, that
+/// recall the neighbours of *that* query vector.
+async fn assert_batch_search(
+    dataset: &Dataset,
+    query_count: usize,
+    filter: Option<(&str, &dyn Fn(i32) -> bool)>,
+    min_recall: f64,
+) {
+    use arrow::datatypes::Int32Type;
+    use arrow_array::cast::AsArray;
+
+    const K: usize = 4;
+
+    let fixture = Fixture::read(dataset).await.unwrap();
+    let queries = batch_query_vectors(query_count);
+    let predicate = filter.map(|(expression, _)| expression.to_string());
+    let batch = scan_rows(dataset, move |scan| {
+        // Probe both of the fixture's partitions. A prefilter this selective would otherwise leave
+        // the single default probe with too few surviving candidates to answer from, which says
+        // nothing about the batch path this is here to check.
+        scan.nearest("vec", &queries, K)?.minimum_nprobes(2);
+        if let Some(predicate) = &predicate {
+            scan.filter(predicate)?.prefilter(true);
+        }
+        Ok(scan)
+    })
+    .await
+    .unwrap();
+
+    let found = fixture.ids_of(&row_ids_of(&batch));
+    let group = batch["query_index"].as_primitive::<Int32Type>().values();
+    assert_eq!(
+        group,
+        &(0..query_count as i32)
+            .flat_map(|query| std::iter::repeat_n(query, K))
+            .collect::<Vec<_>>(),
+        "results are not grouped by query"
+    );
+
+    let queries = batch_query_vectors(query_count);
+    for query in 0..query_count {
+        // A prefilter restricts the search space, so the exact answer is the nearest neighbours
+        // among the rows that survive it.
+        let expected = exact_neighbors(
+            dataset,
+            &query_column(&queries, query),
+            DistanceType::L2,
+            usize::MAX,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|id| filter.is_none_or(|(_, keep)| keep(*id)))
+        .take(K)
+        .collect::<Vec<_>>();
+        let answer = &found[query * K..(query + 1) * K];
+        let hits = answer.iter().filter(|id| expected.contains(id)).count();
+        assert!(
+            hits as f64 / K as f64 >= min_recall,
+            "query {query}: expected {expected:?}, got {answer:?}"
+        );
+    }
+}
+
+/// One query vector out of a batch.
+fn query_column(
+    queries: &arrow_array::FixedSizeListArray,
+    query: usize,
+) -> arrow_array::Float32Array {
+    use arrow_array::cast::AsArray;
+    queries
+        .value(query)
+        .as_primitive::<arrow::datatypes::Float32Type>()
+        .clone()
+}
+
+/// `query_index` leads the output, which is where LanceDB's batch search reads it from.
+#[tokio::test]
+async fn test_batch_search_groups_results_by_query() {
+    use arrow::datatypes::Int32Type;
+    use arrow_array::cast::AsArray;
+
+    let dataset = indexed_vector_dataset().await;
+    let queries = batch_query_vectors(3);
+    let plan = logical_plan_for(&dataset, |scan| scan.nearest("vec", &queries, 4))
+        .await
+        .unwrap();
+    let batch = run(plan).await.unwrap();
+
+    assert_eq!(batch.schema().field(0).name(), "query_index");
+    let indices = batch["query_index"]
+        .as_primitive::<Int32Type>()
+        .values()
+        .to_vec();
+    assert_eq!(indices, vec![0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]);
+}

--- a/rust/lance/src/dataset/scanner/logical/vector/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Vector search, as logical nodes, rules, and lowering.
+//!
+//! Arranged deliberately like [`fts`](super::fts): the same five entry points, so that the
+//! plugin boundary the design doc proposes is tested by two index types rather than asserted
+//! by one.
+
+mod node;
+mod planner;
+mod rerank;
+mod rules;
+
+pub use node::*;
+pub use planner::*;
+pub use rerank::*;
+pub use rules::*;

--- a/rust/lance/src/dataset/scanner/logical/vector/node.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/node.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The vector search node: what the caller asked for, and how it will be answered.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use datafusion::common::plan_err;
+use datafusion::common::{DFSchema, DFSchemaRef};
+use datafusion::logical_expr::{Expr, InvariantLevel, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_core::datatypes::parse_field_path;
+use lance_core::{ROW_ID, ROW_ID_FIELD};
+use lance_index::scalar::expression::ScalarIndexExpr;
+use lance_index::vector::{ApproxMode, DIST_COL, Query};
+use lance_linalg::distance::DistanceType;
+use lance_select::mask::RowAddrTreeMap;
+use lance_select::result::IndexExprResultWireFormat;
+use lance_table::format::IndexMetadata;
+use uuid::Uuid;
+
+use crate::Result;
+use crate::dataset::Dataset;
+use crate::index::vector::utils::{default_distance_type_for, get_vector_type};
+use crate::io::exec::knn::query_index_field;
+
+/// What answer the caller will accept.
+///
+/// This is the *semantic* half of a vector search and the only thing that authorizes an
+/// approximate access path. No rule may strengthen [`Exact`](Self::Exact) into
+/// [`Approximate`](Self::Approximate).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum SearchAccuracy {
+    /// Only brute force, or an index that provably returns exact results.
+    Exact,
+    /// An ANN index may be used. The knobs that only mean something under approximation live
+    /// here rather than beside the semantic contract.
+    Approximate {
+        minimum_nprobes: usize,
+        maximum_nprobes: Option<usize>,
+        ef: Option<usize>,
+        /// Over-fetch `k * refine_factor` candidates, then re-rank them exactly.
+        refine_factor: Option<u32>,
+    },
+}
+
+impl SearchAccuracy {
+    /// Derive the semantic contract from today's [`Query`].
+    ///
+    /// `Query` mixes the semantic contract (`use_index`, `approx_mode`) with the approximation
+    /// knobs and with pure execution hints. Doing the split in exactly one place keeps the
+    /// mapping auditable while both representations coexist.
+    pub fn from_query(query: &Query) -> Self {
+        if !query.use_index || query.approx_mode == ApproxMode::Accurate {
+            return Self::Exact;
+        }
+        Self::Approximate {
+            minimum_nprobes: query.minimum_nprobes,
+            maximum_nprobes: query.maximum_nprobes,
+            ef: query.ef,
+            refine_factor: query.refine_factor,
+        }
+    }
+
+    pub fn is_exact(&self) -> bool {
+        matches!(self, Self::Exact)
+    }
+}
+
+/// How a search will actually be computed. Filled in by
+/// [`ResolveVectorAccessPath`](ResolveVectorAccessPath); `None` until then.
+///
+/// Keeping this on the node — rather than deciding it during lowering — is what lets the
+/// combined indexed/unindexed case be expressed as a rewrite over two ordinary search nodes
+/// instead of a special case inside the planner.
+#[derive(Debug, Clone)]
+pub enum VectorAccessPath {
+    /// Brute force over the input.
+    Flat,
+    /// Fan out over the index's segments.
+    Index { segments: Vec<IndexMetadata> },
+}
+
+impl VectorAccessPath {
+    /// Segment uuids identify the access path; `IndexMetadata` is neither `Eq` nor `Hash`, and
+    /// the rest of it is descriptive.
+    fn identity(&self) -> Option<Vec<Uuid>> {
+        match self {
+            Self::Flat => None,
+            Self::Index { segments } => Some(segments.iter().map(|s| s.uuid).collect()),
+        }
+    }
+}
+
+impl PartialEq for VectorAccessPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity() == other.identity()
+    }
+}
+
+impl Eq for VectorAccessPath {}
+
+impl Hash for VectorAccessPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.identity().hash(state);
+    }
+}
+
+impl PartialOrd for VectorAccessPath {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.identity().partial_cmp(&other.identity())
+    }
+}
+
+/// Where the candidate restriction for an indexed search comes from. Decided by
+/// [`ResolvePrefilterSource`](ResolvePrefilterSource).
+///
+/// This is the lowering artifact of a *prefilter*: a predicate positioned below the search.
+/// Nothing about it is visible in the logical result — a postfilter puts the same predicate
+/// above the search instead, and never produces one of these.
+#[derive(Debug, Clone, Default)]
+pub enum PrefilterSourceKind {
+    /// Nothing below the search restricts the candidates.
+    #[default]
+    None,
+    /// The child's row ids are the candidate set.
+    ChildRowIds,
+    /// A scalar index answers the predicate outright, so the candidates come from the index
+    /// lookup and the child plan is never read.
+    ///
+    /// Only correct when the lookup is exact and covers every fragment the search can return a
+    /// row from; [`ResolvePrefilterSource`](ResolvePrefilterSource) is where those conditions are
+    /// checked.
+    ScalarIndexQuery {
+        query: Arc<ScalarIndexExpr>,
+        result_format: IndexExprResultWireFormat,
+    },
+}
+
+impl PrefilterSourceKind {
+    /// Which of the three it is. `ScalarIndexExpr` is neither `Eq` nor `Hash`, and it is derived
+    /// from the child plan, so two otherwise-equal nodes cannot disagree about it.
+    fn identity(&self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::ChildRowIds => 1,
+            Self::ScalarIndexQuery { .. } => 2,
+        }
+    }
+}
+
+impl PartialEq for PrefilterSourceKind {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity() == other.identity()
+    }
+}
+
+impl Eq for PrefilterSourceKind {}
+
+impl Hash for PrefilterSourceKind {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.identity().hash(state);
+    }
+}
+
+impl PartialOrd for PrefilterSourceKind {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.identity().partial_cmp(&other.identity())
+    }
+}
+
+impl fmt::Display for PrefilterSourceKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::ChildRowIds => write!(f, "ChildRowIds"),
+            Self::ScalarIndexQuery { .. } => write!(f, "ScalarIndexQuery"),
+        }
+    }
+}
+
+/// Nearest-neighbor search over the input's rows.
+///
+/// Output is `[_rowid, _distance]` regardless of how it is lowered: an index scan and a
+/// brute-force scan are two implementations of the same logical operator, and downstream nodes
+/// must not be able to tell them apart.
+#[derive(Debug, Clone)]
+pub struct VectorSearchNode {
+    input: LogicalPlan,
+    /// Held directly, as `MergeInsertWriteNode` does. The design doc proposed recovering it by
+    /// downcasting the child `TableScan`'s `TableSource`; that turned out to buy nothing, since
+    /// `LanceTakeNode` needs a handle regardless.
+    dataset: Arc<Dataset>,
+    /// Retained whole rather than decomposed: the physical nodes still take a `Query`, so
+    /// rebuilding one during lowering would just be a lossy round trip.
+    query: Query,
+    accuracy: SearchAccuracy,
+    /// Resolved up front from the column's element type when the caller did not name one.
+    /// Leaving it unresolved would force lowering to reach for the dataset schema again.
+    distance_type: DistanceType,
+    /// How many query vectors `query.key` holds end to end, when the caller sent a batch.
+    ///
+    /// `None` is an ordinary single-vector search. `Some(n)` is a batch search: every query is
+    /// answered against the same rows, and the output gains a `query_index` discriminator saying
+    /// which query a row answers. `Some(1)` is a batch of one — still batch-shaped, because that
+    /// is the output the caller asked for.
+    batch_queries: Option<usize>,
+    /// Whether `distance_type` is what the caller asked for, or a default stood in for them.
+    ///
+    /// The difference decides what a metric mismatch means. A caller who named a metric and got an
+    /// index built with another one is asking a question that index cannot answer, so the search
+    /// falls back to brute force. A caller who named none is not asking for any particular metric,
+    /// so the index's own is adopted — which is what the imperative path does.
+    distance_type_requested: bool,
+    resolution: Option<VectorAccessPath>,
+    prefilter: PrefilterSourceKind,
+    /// Rows the index must not emit, because a data overlay committed after the index was built
+    /// changed a value the index covers. Set by
+    /// [`SplitOnIndexCoverage`](SplitOnIndexCoverage), which puts the same rows on a
+    /// brute-force branch so they are answered from their current values.
+    overlay_block: Option<Arc<RowAddrTreeMap>>,
+    schema: DFSchemaRef,
+}
+
+impl VectorSearchNode {
+    pub fn try_new(input: LogicalPlan, dataset: Arc<Dataset>, mut query: Query) -> Result<Self> {
+        let accuracy = SearchAccuracy::from_query(&query);
+        let distance_type_requested = query.metric_type.is_some();
+        let distance_type = match query.metric_type {
+            Some(metric) => metric,
+            None => {
+                let (_, element_type) = get_vector_type(dataset.schema(), &query.column)?;
+                default_distance_type_for(&element_type)
+            }
+        };
+        // Write the resolution back so the `Query` handed to the physical nodes is complete.
+        // Leaving it `None` there makes them report `metric=default` in `EXPLAIN`.
+        query.metric_type = Some(distance_type);
+        let schema = Self::output_schema(None)?;
+        Ok(Self {
+            input,
+            dataset,
+            query,
+            accuracy,
+            distance_type,
+            batch_queries: None,
+            distance_type_requested,
+            resolution: None,
+            prefilter: PrefilterSourceKind::default(),
+            overlay_block: None,
+            schema,
+        })
+    }
+
+    /// The `[_rowid, _distance]` contract, plus the batch discriminator when there is one.
+    fn output_schema(batch_queries: Option<usize>) -> Result<DFSchemaRef> {
+        let mut fields = Vec::with_capacity(3);
+        if batch_queries.is_some() {
+            fields.push(query_index_field());
+        }
+        fields.push(ROW_ID_FIELD.clone());
+        fields.push(ArrowField::new(DIST_COL, DataType::Float32, true));
+        Ok(Arc::new(DFSchema::try_from(ArrowSchema::new(fields))?))
+    }
+
+    /// Answer `count` query vectors at once, reading them end to end out of `query.key`, and emit
+    /// batch-shaped output.
+    pub fn with_batch_queries(mut self, count: usize) -> Result<Self> {
+        self.schema = Self::output_schema(Some(count))?;
+        self.batch_queries = Some(count);
+        Ok(self)
+    }
+
+    /// `Some(n)` when this is a batch of `n` query vectors, `None` for a single-vector search.
+    pub fn batch_queries(&self) -> Option<usize> {
+        self.batch_queries
+    }
+
+    /// How many query vectors `query.key` holds — one, unless this is a batch.
+    pub fn query_count(&self) -> usize {
+        self.batch_queries.unwrap_or(1)
+    }
+
+    /// The `i`th query vector's own single-query search, for a rewrite that answers them one at a
+    /// time. The input is shared: every query searches the same rows.
+    pub fn single_query(&self, index: usize) -> Result<Self> {
+        let dim = self.query.key.len() / self.query_count();
+        let mut query = self.query.clone();
+        query.key = self.query.key.slice(index * dim, dim);
+        Ok(Self {
+            query,
+            batch_queries: None,
+            schema: Self::output_schema(None)?,
+            ..self.clone()
+        })
+    }
+
+    pub fn with_resolution(mut self, resolution: VectorAccessPath) -> Self {
+        self.resolution = Some(resolution);
+        self
+    }
+
+    /// Adopt an index's metric, for a search that did not name one.
+    ///
+    /// Written into the carried `Query` as well, because that is what the physical nodes read.
+    pub fn with_distance_type(mut self, distance_type: DistanceType) -> Self {
+        self.distance_type = distance_type;
+        self.query.metric_type = Some(distance_type);
+        self
+    }
+
+    pub fn distance_type_requested(&self) -> bool {
+        self.distance_type_requested
+    }
+
+    pub fn with_prefilter(mut self, prefilter: PrefilterSourceKind) -> Self {
+        self.prefilter = prefilter;
+        self
+    }
+
+    pub fn prefilter(&self) -> &PrefilterSourceKind {
+        &self.prefilter
+    }
+
+    pub fn with_overlay_block(mut self, block: Option<Arc<RowAddrTreeMap>>) -> Self {
+        self.overlay_block = block;
+        self
+    }
+
+    pub fn overlay_block(&self) -> Option<&Arc<RowAddrTreeMap>> {
+        self.overlay_block.as_ref()
+    }
+
+    pub fn input(&self) -> &LogicalPlan {
+        &self.input
+    }
+
+    /// Re-parent the node. The output schema is fixed at `[_rowid, _distance]` and does not
+    /// depend on the input, so no revalidation is needed.
+    pub fn with_input(mut self, input: LogicalPlan) -> Self {
+        self.input = input;
+        self
+    }
+
+    pub fn access_path_resolution(&self) -> Option<&VectorAccessPath> {
+        self.resolution.as_ref()
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    pub fn query(&self) -> &Query {
+        &self.query
+    }
+
+    pub fn distance_type(&self) -> DistanceType {
+        self.distance_type
+    }
+
+    pub fn accuracy(&self) -> &SearchAccuracy {
+        &self.accuracy
+    }
+}
+
+impl PartialEq for VectorSearchNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input
+            && self.query.column == other.query.column
+            && self.query.k == other.query.k
+            && self.accuracy == other.accuracy
+            && self.batch_queries == other.batch_queries
+            && self.resolution == other.resolution
+            && self.prefilter == other.prefilter
+            && self.overlay_block == other.overlay_block
+    }
+}
+
+impl Eq for VectorSearchNode {}
+
+impl Hash for VectorSearchNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.query.column.hash(state);
+        self.query.k.hash(state);
+        self.accuracy.hash(state);
+        self.batch_queries.hash(state);
+        self.resolution.hash(state);
+        self.prefilter.hash(state);
+        // `RowAddrTreeMap` is not `Hash`, and the flag is the part that distinguishes plans: two
+        // nodes with different block lists cannot share an input anyway.
+        self.overlay_block.is_some().hash(state);
+    }
+}
+
+impl PartialOrd for VectorSearchNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.query.column.partial_cmp(&other.query.column) {
+            Some(Ordering::Equal) => self.input.partial_cmp(&other.input),
+            other => other,
+        }
+    }
+}
+
+impl UserDefinedLogicalNodeCore for VectorSearchNode {
+    fn name(&self) -> &str {
+        "VectorSearch"
+    }
+
+    /// An unresolved search is not executable.
+    ///
+    /// The rules that resolve it are mandatory, and a missed one used to mean silently wrong rows
+    /// — a brute-force fallback where an index was expected, or an index consulted for rows it no
+    /// longer describes. DataFusion checks this at the end of the analyzer, which is the stage
+    /// those rules run in, so a rule that fails to fire becomes a planning error instead.
+    fn check_invariants(&self, check: InvariantLevel) -> datafusion::common::Result<()> {
+        if matches!(check, InvariantLevel::Executable) && self.resolution.is_none() {
+            return plan_err!(
+                "vector search on column '{}' reached execution with no access path resolved",
+                self.query.column
+            );
+        }
+        Ok(())
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    /// The query vector is data, not an expression, so there is nothing here for DataFusion's
+    /// expression rewriting to visit.
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "VectorSearch: column={}, k={}, metric={}, accuracy={:?}",
+            self.query.column, self.query.k, self.distance_type, self.accuracy
+        )?;
+        if let Some(count) = self.batch_queries {
+            write!(f, ", queries={}", count)?;
+        }
+        match &self.resolution {
+            Some(VectorAccessPath::Flat) => write!(f, ", via=flat")?,
+            Some(VectorAccessPath::Index { segments }) => {
+                write!(f, ", via=index(deltas={})", segments.len())?
+            }
+            None => {}
+        }
+        if self.prefilter != PrefilterSourceKind::None {
+            write!(f, ", prefilter={}", self.prefilter)?;
+        }
+        if self.overlay_block.is_some() {
+            write!(f, ", overlay_block")?;
+        }
+        Ok(())
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() {
+            return Err(datafusion::common::DataFusionError::Internal(
+                "VectorSearch takes no expressions".into(),
+            ));
+        }
+        if inputs.len() != 1 {
+            return Err(datafusion::common::DataFusionError::Internal(format!(
+                "VectorSearch takes exactly one input, got {}",
+                inputs.len()
+            )));
+        }
+        Ok(Self {
+            input: inputs.remove(0),
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            accuracy: self.accuracy.clone(),
+            distance_type: self.distance_type,
+            batch_queries: self.batch_queries,
+            distance_type_requested: self.distance_type_requested,
+            resolution: self.resolution.clone(),
+            prefilter: self.prefilter.clone(),
+            overlay_block: self.overlay_block.clone(),
+            schema: self.schema.clone(),
+        })
+    }
+
+    /// What the child has to produce depends on the access path, which is why this is only
+    /// accurate after [`ResolveVectorAccessPath`](ResolveVectorAccessPath) has run:
+    /// an indexed search reads vectors from the index and wants nothing but row ids from the
+    /// child, while a brute-force search has to read the vectors itself.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        let reads_vectors = !matches!(self.resolution, Some(VectorAccessPath::Index { .. }));
+        // The child's schema holds top-level columns, so a nested vector column like
+        // `payload.vec` has to be asked for by its root or the child reads nothing.
+        let vector_root = parse_field_path(&self.query.column)
+            .ok()
+            .and_then(|parts| parts.first().cloned())
+            .unwrap_or_else(|| self.query.column.clone());
+        let needed = self
+            .input
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, field)| {
+                field.name() == ROW_ID || (reads_vectors && field.name() == &vector_root)
+            })
+            .map(|(idx, _)| idx)
+            .collect();
+        Some(vec![needed])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/vector/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/planner.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 4: lowering vector search nodes to execution plans.
+
+use std::sync::Arc;
+
+use arrow_schema::DataType;
+use datafusion::logical_expr::utils::conjunction;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::expressions;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::prelude::{col, lit};
+use lance_core::ROW_ID;
+use lance_index::vector::DIST_COL;
+use lance_linalg::distance::DistanceType;
+use lance_select::mask::RowAddrMask;
+
+use lance_table::format::IndexMetadata;
+
+use super::super::{VectorAccessPath, VectorSearchNode};
+use crate::Result;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+
+use crate::dataset::scanner::DEFAULT_XTR_OVERFETCH;
+use crate::index::vector::utils::{get_vector_dim, get_vector_type};
+use crate::io::exec::knn::{KnnBatchParams, MultivectorScoringExec, QUERY_INDEX_COL, new_knn_exec};
+use crate::io::exec::{KNNVectorDistanceExec, LanceFilterExec, PreFilterSource};
+
+use super::super::planner::{plan_prefilter_source, sort_asc};
+
+/// Lower a vector search along whichever access path the rules chose.
+///
+/// Both branches end in the same normalizing projection. That is what makes the node's
+/// `[_rowid, _distance]` output contract hold: the two exec trees carry different extra columns
+/// (`KNNVectorDistanceExec` appends `_distance` to its input; `ANNSubIndex` emits
+/// `[_distance, _rowid]`), and without the projection they would not be interchangeable.
+pub fn plan_vector_search(
+    node: &VectorSearchNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let searched = match node.access_path_resolution() {
+        Some(VectorAccessPath::Index { segments }) => {
+            // The child is already a `_rowid`-only read carrying the predicate — see
+            // `VectorSearchNode::necessary_children_exprs`.
+            let prefilter = plan_prefilter_source(node.prefilter(), node.dataset(), input);
+            plan_indexed_search(node, segments, prefilter)?
+        }
+        // An unresolved node means the rule did not run; brute force is the answer that is
+        // always correct, so it is the safe default rather than an error.
+        Some(VectorAccessPath::Flat) | None => plan_flat_knn(
+            node.query(),
+            node.distance_type(),
+            node.batch_queries(),
+            input,
+        )?,
+    };
+    normalize_search_output(searched)
+}
+
+pub fn plan_indexed_search(
+    node: &VectorSearchNode,
+    segments: &[IndexMetadata],
+    prefilter: PreFilterSource,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let query = node.query();
+    let block = node
+        .overlay_block()
+        .map(|rows| RowAddrMask::from_block(rows.as_ref().clone()));
+    let (vector_type, _) = get_vector_type(node.dataset().schema(), &query.column)?;
+    let fanout = match vector_type {
+        // A multivector row holds many vectors, so one row is scored from several fanouts at once
+        // rather than one. Mirrors `Scanner::multivec_ann`.
+        DataType::List(_) => plan_multivector_fanout(node, segments, prefilter, block)?,
+        _ => new_knn_exec(node.dataset().clone(), segments, query, prefilter, block)?,
+    };
+
+    // Over-fetch when refining: the extra candidates are what the exact re-rank chooses from.
+    let fetch = query.k * query.refine_factor.unwrap_or(1) as usize;
+    Ok(Arc::new(
+        SortExec::new(
+            [
+                sort_asc(DIST_COL, fanout.as_ref())?,
+                sort_asc(ROW_ID, fanout.as_ref())?,
+            ]
+            .into(),
+            fanout,
+        )
+        .with_fetch(Some(fetch)),
+    ))
+}
+
+/// Search each of a multivector query's vectors separately, then score rows across the results.
+///
+/// The per-vector searches deliberately over-fetch: XTR scores a row from whichever of its vectors
+/// were retrieved, so recall depends on each search reaching deep enough to find them.
+fn plan_multivector_fanout(
+    node: &VectorSearchNode,
+    segments: &[IndexMetadata],
+    prefilter: PreFilterSource,
+    block: Option<RowAddrMask>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let query = node.query();
+    let dim = get_vector_dim(node.dataset().schema(), &query.column)?;
+    let over_fetch = *DEFAULT_XTR_OVERFETCH;
+
+    let mut searches = Vec::with_capacity(query.key.len() / dim);
+    for offset in (0..query.key.len()).step_by(dim) {
+        let mut single = query.clone();
+        single.key = query.key.slice(offset, dim);
+        // XTR scores from the retrieved vectors themselves, so there is nothing to refine against
+        // — the factor is purely how deep each search goes.
+        single.refine_factor = Some(over_fetch);
+        let fanout = new_knn_exec(
+            node.dataset().clone(),
+            segments,
+            &single,
+            prefilter.clone(),
+            block.clone(),
+        )?;
+        searches.push(Arc::new(
+            SortExec::new(
+                [
+                    sort_asc(DIST_COL, fanout.as_ref())?,
+                    sort_asc(ROW_ID, fanout.as_ref())?,
+                ]
+                .into(),
+                fanout,
+            )
+            .with_fetch(Some(query.k * over_fetch as usize)),
+        ) as Arc<dyn ExecutionPlan>);
+    }
+
+    Ok(Arc::new(MultivectorScoringExec::try_new(
+        searches,
+        query.clone(),
+    )?))
+}
+
+/// Brute-force top-`k` by distance over the input. Mirrors `Scanner::flat_knn`, and is shared by
+/// the flat access path and by [`VectorRerankNode`] — they are the same computation, differing only
+/// in what the caller does with the output schema.
+pub fn plan_flat_knn(
+    query: &lance_index::vector::Query,
+    distance_type: DistanceType,
+    batch_queries: Option<usize>,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    // A batch scores every query vector in one pass over the rows, so it has to see all of them:
+    // its top-`k` per query cannot be assembled from independent per-partition top-`k`s.
+    let is_batch = batch_queries.is_some();
+    let input = match is_batch {
+        true => Arc::new(CoalescePartitionsExec::new(input)) as Arc<dyn ExecutionPlan>,
+        false => input,
+    };
+    let distances = Arc::new(KNNVectorDistanceExec::try_new_batch(
+        input,
+        &query.column,
+        query.key.clone(),
+        KnnBatchParams {
+            is_batch,
+            query_count: batch_queries.unwrap_or(1),
+            k: query.k,
+            lower_bound: query.lower_bound,
+            upper_bound: query.upper_bound,
+            distance_type,
+            // The take above the search refetches whatever the user projected, so keeping the
+            // vector here would only widen the batches this node emits.
+            retain_vector: false,
+        },
+    )?);
+
+    // The batch node applies the distance bounds and the per-query top-`k` itself, and drops rows
+    // with no vector on the way. There is nothing left for the tail below to do.
+    if is_batch {
+        return Ok(distances);
+    }
+
+    let lower = query
+        .lower_bound
+        .map(|bound| col(DIST_COL).gt_eq(lit(bound)));
+    let upper = query.upper_bound.map(|bound| col(DIST_COL).lt(lit(bound)));
+    let bounded = match conjunction([lower, upper].into_iter().flatten()) {
+        None => distances as Arc<dyn ExecutionPlan>,
+        Some(predicate) => Arc::new(LanceFilterExec::try_new(predicate, distances)?),
+    };
+
+    let sorted = Arc::new(
+        SortExec::new(
+            [
+                sort_asc(DIST_COL, bounded.as_ref())?,
+                sort_asc(ROW_ID, bounded.as_ref())?,
+            ]
+            .into(),
+            bounded,
+        )
+        .with_fetch(Some(query.k)),
+    );
+
+    // A null distance means the row had no vector; it is not a neighbor at any rank.
+    Ok(Arc::new(LanceFilterExec::try_new(
+        col(DIST_COL).is_not_null(),
+        sorted,
+    )?))
+}
+
+/// Trim whatever the access path carried down to the node's declared output columns.
+pub fn normalize_search_output(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = plan.schema();
+    let mut columns = Vec::with_capacity(3);
+    // Only a batch search has this, and only the brute-force path produces it here — the indexed
+    // path gets it from the projection `ExpandBatchSearch` puts above each expanded search.
+    if schema.column_with_name(QUERY_INDEX_COL).is_some() {
+        columns.push(QUERY_INDEX_COL);
+    }
+    columns.extend([ROW_ID, DIST_COL]);
+    Ok(Arc::new(ProjectionExec::try_new(
+        columns
+            .into_iter()
+            .map(|name| Ok((expressions::col(name, schema.as_ref())?, name.to_string())))
+            .collect::<Result<Vec<_>>>()?,
+        plan,
+    )?))
+}

--- a/rust/lance/src/dataset/scanner/logical/vector/rerank.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/rerank.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The rerank node, which merges the branches of a coverage split back into one
+//! top-k answer.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field as ArrowField};
+use datafusion::common::{DFSchema, DFSchemaRef};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_arrow::SchemaExt;
+use lance_index::vector::{DIST_COL, Query};
+use lance_linalg::distance::DistanceType;
+
+use crate::Result;
+use crate::dataset::Dataset;
+use crate::index::vector::utils::{default_distance_type_for, get_vector_type};
+
+/// Score the input's rows by distance to the query vector and keep the nearest `k`.
+///
+/// The difference from [`VectorSearchNode`] is what it does to the schema, and that follows from
+/// where it sits: a search *is* the source, so it may narrow its output to `[_rowid, _distance]`,
+/// while this sits above one and has to carry the columns already in flight. It also has no
+/// access path — a filter over rows someone else chose is brute force by definition.
+#[derive(Debug, Clone)]
+pub struct VectorRerankNode {
+    input: LogicalPlan,
+    query: Query,
+    distance_type: DistanceType,
+    schema: DFSchemaRef,
+}
+
+impl VectorRerankNode {
+    pub fn try_new(input: LogicalPlan, dataset: &Dataset, mut query: Query) -> Result<Self> {
+        let distance_type = match query.metric_type {
+            Some(metric) => metric,
+            None => {
+                let (_, element_type) = get_vector_type(dataset.schema(), &query.column)?;
+                default_distance_type_for(&element_type)
+            }
+        };
+        query.metric_type = Some(distance_type);
+
+        // Mirrors `KNNVectorDistanceExec::try_new_batch`: an existing `_distance` is dropped so the
+        // new one lands last.
+        let mut arrow = input.schema().as_arrow().clone();
+        if arrow.column_with_name(DIST_COL).is_some() {
+            arrow = arrow.without_column(DIST_COL);
+        }
+        let arrow = arrow.try_with_column(ArrowField::new(DIST_COL, DataType::Float32, true))?;
+        Ok(Self {
+            input,
+            query,
+            distance_type,
+            schema: Arc::new(DFSchema::try_from(arrow)?),
+        })
+    }
+
+    pub fn query(&self) -> &Query {
+        &self.query
+    }
+
+    pub fn distance_type(&self) -> DistanceType {
+        self.distance_type
+    }
+}
+
+impl PartialEq for VectorRerankNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input
+            && self.query.column == other.query.column
+            && self.query.k == other.query.k
+    }
+}
+
+impl Eq for VectorRerankNode {}
+
+impl Hash for VectorRerankNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.query.column.hash(state);
+        self.query.k.hash(state);
+    }
+}
+
+impl PartialOrd for VectorRerankNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.input.partial_cmp(&other.input)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for VectorRerankNode {
+    fn name(&self) -> &str {
+        "VectorRerank"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "VectorRerank: column={}, k={}, metric={}",
+            self.query.column, self.query.k, self.distance_type
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() {
+            return Err(datafusion::common::DataFusionError::Internal(
+                "VectorRerank takes no expressions".into(),
+            ));
+        }
+        if inputs.len() != 1 {
+            return Err(datafusion::common::DataFusionError::Internal(format!(
+                "VectorRerank takes exactly one input, got {}",
+                inputs.len()
+            )));
+        }
+        Ok(Self {
+            input: inputs.remove(0),
+            query: self.query.clone(),
+            distance_type: self.distance_type,
+            schema: self.schema.clone(),
+        })
+    }
+
+    /// The vector column has to survive down to here, and every other input column is part of the
+    /// output, so nothing below may be pruned.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/vector/rules.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/rules.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Analyzer and optimizer rules owned by the vector index.
+
+use std::sync::Arc;
+
+use datafusion::common::DataFusionError;
+use datafusion::common::tree_node::Transformed;
+use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{
+    EmptyRelation, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
+};
+use datafusion::optimizer::{AnalyzerRule, ApplyOrder, OptimizerConfig, OptimizerRule};
+use datafusion::prelude::{col, lit};
+use lance_core::ROW_ID;
+use lance_core::datatypes::OnMissing;
+use lance_index::vector::DIST_COL;
+use lance_linalg::distance::DistanceType;
+use lance_table::format::IndexMetadata;
+
+use super::super::context::ScanPlanningContext;
+use super::super::{LanceTakeNode, PrefilterSourceKind, VectorAccessPath, VectorSearchNode};
+use super::super::{analyze_bottom_up, restricts_candidates, scalar_index_prefilter};
+use crate::io::exec::knn::QUERY_INDEX_COL;
+
+/// Decide whether each vector search uses its index or brute force.
+///
+/// Three things can rule the index out, and all of them are decisions rather than mechanics,
+/// which is why they belong in a rule and not in the planner:
+///
+/// * the caller demanded exact results;
+/// * there is no vector index on the column;
+/// * the index was built with a different metric than the one being queried — using it would
+///   answer a different question, so the imperative path falls back to brute force here too.
+#[derive(Debug)]
+pub struct ResolveVectorAccessPath {
+    context: Arc<ScanPlanningContext>,
+}
+
+impl ResolveVectorAccessPath {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+
+    /// Returns the access path, plus the metric to search with if the index's differs from the
+    /// search's current one.
+    fn resolve(&self, search: &VectorSearchNode) -> (VectorAccessPath, Option<DistanceType>) {
+        if !search.accuracy().is_exact()
+            && let Some(index) = self.context.vector_index(&search.query().column)
+        {
+            if !search.distance_type_requested() || index.metric == search.distance_type() {
+                // A delta segment covering none of the fragments this scan will touch has nothing
+                // to contribute, so it is dropped from the fan-out rather than searched and
+                // discarded. If that leaves nothing, there is no index to search here at all.
+                let segments = self.context.reachable_segments(&index.segments);
+                if !segments.is_empty() {
+                    let adopted = (index.metric != search.distance_type()).then_some(index.metric);
+                    return (VectorAccessPath::Index { segments }, adopted);
+                }
+                return (VectorAccessPath::Flat, None);
+            }
+            log::warn!(
+                "Requested metric {:?} is incompatible with index metric {:?}, falling back to brute-force search",
+                search.distance_type(),
+                index.metric,
+            );
+        }
+        (VectorAccessPath::Flat, None)
+    }
+}
+
+impl ResolveVectorAccessPath {
+    fn rewrite_node(
+        &self,
+        plan: LogicalPlan,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(search) = extension.node.as_any().downcast_ref::<VectorSearchNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Not an idempotence guard: the builder resolves a search to `Flat` when its candidates
+        // are the search space (a vector search over FTS results), and that is a decision, not a
+        // default. See `builder::build`.
+        if search.access_path_resolution().is_some() {
+            return Ok(Transformed::no(plan));
+        }
+
+        // `fast_search` means "answer from indices only". With no usable index there is nothing to
+        // answer from, so the result is empty rather than a brute-force scan. The partially-indexed
+        // case is the same rule applied to one branch, and lives in `SplitPartiallyIndexedSearch`.
+        let (resolved, adopted_metric) = self.resolve(search);
+        if self.context.fast_search()
+            && matches!(resolved, VectorAccessPath::Flat)
+            && self.context.vector_index(&search.query().column).is_none()
+        {
+            return Ok(Transformed::yes(LogicalPlan::EmptyRelation(
+                EmptyRelation {
+                    produce_one_row: false,
+                    schema: search.schema().clone(),
+                },
+            )));
+        }
+
+        let mut resolved = search.clone().with_resolution(resolved);
+        if let Some(metric) = adopted_metric {
+            resolved = resolved.with_distance_type(metric);
+        }
+        Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+            node: Arc::new(resolved),
+        })))
+    }
+}
+
+impl AnalyzerRule for ResolveVectorAccessPath {
+    fn name(&self) -> &str {
+        "resolve_vector_access_path"
+    }
+
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        analyze_bottom_up(plan, |node| self.rewrite_node(node))
+    }
+}
+
+/// Record whether an indexed search has a prefilter, and therefore whether its child plan is a
+/// candidate restriction rather than dead weight.
+///
+/// This is the rule that reads the doc's structural claim off the plan: *a predicate below the
+/// search is a prefilter*. Once DataFusion has pushed the predicate into the leaf, "below the
+/// search" means "on the child `TableScan`", so both forms are checked.
+///
+/// It must run after `PushDownFilter`, so that the predicate has reached its final position, and
+/// after `ResolveVectorAccessPath`, since only an indexed search has a prefilter source at all —
+/// a brute-force search just scans the already-filtered child.
+#[derive(Debug)]
+pub struct ResolvePrefilterSource {
+    context: Arc<ScanPlanningContext>,
+}
+
+impl ResolvePrefilterSource {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+
+    /// The candidate source for a search whose index covers `segments`.
+    fn kind_for(&self, input: &LogicalPlan, segments: &[IndexMetadata]) -> PrefilterSourceKind {
+        let required = self.context.segment_coverage(segments);
+        scalar_index_prefilter(input, &required, &self.context)
+            .unwrap_or_else(|| prefilter_kind(input))
+    }
+}
+
+impl OptimizerRule for ResolvePrefilterSource {
+    fn name(&self) -> &str {
+        "resolve_prefilter_source"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        if let Some(search) = extension.node.as_any().downcast_ref::<VectorSearchNode>() {
+            let Some(VectorAccessPath::Index { segments }) = search.access_path_resolution() else {
+                return Ok(Transformed::no(plan));
+            };
+            let kind = self.kind_for(search.input(), segments);
+            if &kind == search.prefilter() {
+                return Ok(Transformed::no(plan));
+            }
+            return Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+                node: Arc::new(search.clone().with_prefilter(kind)),
+            })));
+        }
+        Ok(Transformed::no(plan))
+    }
+}
+
+pub fn prefilter_kind(input: &LogicalPlan) -> PrefilterSourceKind {
+    if restricts_candidates(input) {
+        PrefilterSourceKind::ChildRowIds
+    } else {
+        PrefilterSourceKind::None
+    }
+}
+
+/// Put the exact re-rank above an indexed search that asked to refine.
+///
+/// `refine_factor` means "over-fetch `k * factor` approximate candidates, then re-score them
+/// exactly and keep the best `k`". The over-fetch is already a lowering detail of the indexed
+/// search; the re-scoring is structure, so it belongs here:
+///
+/// ```text
+/// VectorSearch{Flat, k}                       <- exact re-rank
+///   Projection [_rowid, vec]
+///     LanceTake [vec]
+///       VectorSearch{Index, k, refine_factor} <- over-fetches k * factor
+/// ```
+///
+/// That is the same subtree [`SplitPartiallyIndexedSearch`] builds, which is the point: "re-rank
+/// approximate candidates exactly" is one operation in the logical layer, and both the refine knob
+/// and partial index coverage are reasons to reach for it.
+#[derive(Debug)]
+pub struct ExpandVectorRefine {
+    context: Arc<ScanPlanningContext>,
+}
+
+impl ExpandVectorRefine {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+}
+
+impl AnalyzerRule for ExpandVectorRefine {
+    fn name(&self) -> &str {
+        "expand_vector_refine"
+    }
+
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        analyze_bottom_up(plan, |node| self.rewrite_node(node))
+    }
+}
+
+impl ExpandVectorRefine {
+    fn rewrite_node(
+        &self,
+        plan: LogicalPlan,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(search) = extension.node.as_any().downcast_ref::<VectorSearchNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Only an indexed search produces approximate distances worth refining.
+        if search.query().refine_factor.is_none()
+            || !matches!(
+                search.access_path_resolution(),
+                Some(VectorAccessPath::Index { .. })
+            )
+        {
+            return Ok(Transformed::no(plan));
+        }
+
+        let column = &search.query().column;
+        let approximate = LogicalPlan::Extension(Extension {
+            node: Arc::new(search.clone()),
+        });
+        let candidates = LogicalPlanBuilder::new(LogicalPlan::Extension(Extension {
+            node: Arc::new(LanceTakeNode::try_new(
+                approximate,
+                search.dataset().clone(),
+                search
+                    .dataset()
+                    .empty_projection()
+                    .union_column(column, OnMissing::Error)?,
+                self.context.take_settings().clone(),
+            )?),
+        }))
+        // Drop the approximate `_distance` so the re-rank does not produce a second one.
+        .project(vec![col(ROW_ID), col(column)])?
+        .build()?;
+
+        Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                search
+                    .clone()
+                    .with_input(candidates)
+                    .with_resolution(VectorAccessPath::Flat)
+                    .with_prefilter(PrefilterSourceKind::None),
+            ),
+        })))
+    }
+}
+
+/// Answer a batch of query vectors against an index by asking each one separately.
+///
+/// The index fanout searches one query vector at a time, so a batch of `n` becomes a union of `n`
+/// searches over the same input, each tagged with the `query_index` that identifies which query it
+/// answers:
+///
+/// ```text
+/// Union
+///   Projection [0 AS query_index, _rowid, _distance]
+///     VectorSearch{Index, key=queries[0]}
+///   Projection [1 AS query_index, _rowid, _distance]
+///     VectorSearch{Index, key=queries[1]}
+///   ...
+/// ```
+///
+/// Expanding here rather than in the planner means every later rule — partial index coverage,
+/// refine — sees ordinary single-query searches and needs to know nothing about batching. That is
+/// also what the imperative path does, by re-entering `vector_search` once per query vector.
+///
+/// A brute-force batch search is not expanded: `KNNVectorDistanceExec` scores all `n` queries in
+/// one pass over the rows, which is the whole reason to send them as a batch.
+#[derive(Debug, Default)]
+pub struct ExpandBatchSearch;
+
+impl AnalyzerRule for ExpandBatchSearch {
+    fn name(&self) -> &str {
+        "expand_batch_search"
+    }
+
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        analyze_bottom_up(plan, Self::rewrite_node)
+    }
+}
+
+impl ExpandBatchSearch {
+    fn rewrite_node(plan: LogicalPlan) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(search) = extension.node.as_any().downcast_ref::<VectorSearchNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        if search.batch_queries().is_none()
+            || !matches!(
+                search.access_path_resolution(),
+                Some(VectorAccessPath::Index { .. })
+            )
+        {
+            return Ok(Transformed::no(plan));
+        }
+
+        let mut branches = Vec::with_capacity(search.query_count());
+        for query_index in 0..search.query_count() {
+            let single = LogicalPlan::Extension(Extension {
+                node: Arc::new(search.single_query(query_index)?),
+            });
+            branches.push(
+                LogicalPlanBuilder::new(single)
+                    .project(vec![
+                        lit(query_index as i32).alias(QUERY_INDEX_COL),
+                        col(ROW_ID),
+                        col(DIST_COL),
+                    ])?
+                    .build()?,
+            );
+        }
+
+        let mut branches = branches.into_iter();
+        let mut unioned = LogicalPlanBuilder::new(branches.next().ok_or_else(|| {
+            DataFusionError::Internal("a batch search has at least one query".into())
+        })?);
+        for branch in branches {
+            unioned = unioned.union(branch)?;
+        }
+        Ok(Transformed::yes(unioned.build()?))
+    }
+}


### PR DESCRIPTION
Adds the vector search node and everything that lowers it, so the logical path can plan a KNN or ANN query.

Prefilter and postfilter become operator ordering rather than a flag: a prefilter is a `Filter` below the search, a postfilter one above it. They are genuinely different queries under approximation, which is why the plan states which one it is.

Three rules turn the naive plan into one the extension planner can lower mechanically:

* `ResolveVectorAccessPath` picks the index or brute force, encoding the metric-mismatch fallback that `Scanner::vector_search` buries in a constructor.
* `SplitOnIndexCoverage` is the design doc's Appendix A as a logical rewrite: a search over a partially-indexed column becomes a re-rank over the union of an indexed branch and a brute-force branch. Coverage has holes at fragment level and, where a data overlay changed an indexed value, at row level; both are filled the same way.
* `ResolvePrefilterSource` decides whether a scalar index lookup can stand in for the prefilter's whole subtree.

Late materialization above the search is a `LanceTakeNode`, and the search's output ordering is restated above it. `FilteredReadExec` reports no output ordering, so a multi-partition input would otherwise be coalesced and the order lost. `EnforceSorting` drops the restatement when the take turns out to have preserved it.

An aggregate replaces the output projection, so above a search it is the aggregate's own columns that get taken, not the projection's. `COUNT(*)` reads none and the take drops out entirely.

Full-text search and `_rowoffset` are still rejected; later PRs add them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
