### PR TITLE
feat(scanner): plan full-text search through the logical planner

### DIFF
--- a/rust/lance/src/dataset/scanner/logical/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/builder.rs
@@ -23,11 +23,13 @@ use lance_core::{
     ROW_ADDR, ROW_ID,
     datatypes::{OnMissing, Projection},
 };
+use lance_index::scalar::inverted::{DOC_INDEX_COL, SCORE_COL};
 use lance_index::vector::DIST_COL;
 
+use super::fts;
 use super::prepare::PreparedQueries;
 use super::source::{LanceScanSource, ScanSourceOptions};
-use super::{LanceTakeNode, TakeSettings, VectorRerankNode, VectorSearchNode};
+use super::{LanceTakeNode, TakeSettings, VectorAccessPath, VectorRerankNode, VectorSearchNode};
 use crate::dataset::scanner::{ColumnOrdering, MaterializationStyle};
 use crate::dataset::{Dataset, Scanner};
 use crate::io::exec::knn::QUERY_INDEX_COL;
@@ -44,9 +46,10 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
     // Prefilter and postfilter are the same predicate on opposite sides of the search: restrict
     // the candidates, or trim the results. They are genuinely different queries under
     // approximation, which is why this is operator ordering and not a flag on the search node.
-    let prefilter = scanner.prefilter && scanner.nearest.is_some();
+    let has_search = scanner.nearest.is_some() || prepared.full_text.is_some();
+    let prefilter = scanner.prefilter && has_search;
 
-    let mut source = scan;
+    let mut source = scan.clone();
     if prefilter && let Some(filter) = filter.clone() {
         source = LogicalPlanBuilder::new(source).filter(filter)?.build()?;
     }
@@ -101,14 +104,76 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
 
     // A `query_filter` obeys the same prefilter/postfilter switch as an expression filter: below
     // the search it produces the candidates, above it trims the results.
-    let mut builder = if let Some(query) = &scanner.nearest {
-        let searched = {
-            let search = VectorSearchNode::try_new(source, scanner.dataset.clone(), query.clone())?;
-            extension(if scanner.is_batch_nearest {
-                search.with_batch_queries(scanner.nearest_query_count)?
-            } else {
-                search
-            })
+    let mut builder = if let Some(query) = &prepared.full_text {
+        let searched = match prepared.vector_filter.as_ref().filter(|_| prefilter) {
+            // Vector search first, then re-rank the survivors by BM25.
+            Some(vector_query) => {
+                let vector = extension(VectorSearchNode::try_new(
+                    source,
+                    scanner.dataset.clone(),
+                    vector_query.clone(),
+                )?);
+                fts::build_rerank(
+                    vector,
+                    scan,
+                    &scanner.dataset,
+                    query,
+                    search_limit(scanner),
+                    &take_settings(scanner),
+                )?
+            }
+            None => fts::build_source(source, &scanner.dataset, query, search_limit(scanner))?,
+        };
+        // Relevance order is the result's order, and it has to be restated above the take for the
+        // same reason a vector search's distance order does — see the comment below. Without it,
+        // `EnforceSorting` is entitled to drop whichever sort the FTS operators happened to
+        // produce, because nothing above them asks for an ordering.
+        //
+        // Row id breaks ties, so that two queries differing only in their limit agree on which of
+        // two equally relevant rows comes first.
+        with_take(
+            LogicalPlanBuilder::new(searched),
+            scanner,
+            &take_projection,
+            &postfilter_columns,
+        )?
+        .sort(vec![
+            col(SCORE_COL).sort(false, false),
+            col(ROW_ID).sort(true, false),
+        ])?
+    } else if let Some(query) = &scanner.nearest {
+        let searched = match prepared.fts_filter.as_ref().filter(|_| prefilter) {
+            // An FTS query used as a filter produces the candidate rows, whose vectors are then
+            // fetched and scored exactly. `with_resolution(Flat)` is what says "these candidates
+            // are the search space", so no rule may swap in the index.
+            Some(fts_query) => {
+                let mut candidates = fts::build_source(source, &scanner.dataset, fts_query, None)?;
+                if candidates
+                    .schema()
+                    .has_column_with_unqualified_name(DOC_INDEX_COL)
+                {
+                    candidates = fts::dedupe_rows(candidates)?;
+                }
+                let candidates = fts::take_column(
+                    candidates,
+                    &scanner.dataset,
+                    &query.column,
+                    &take_settings(scanner),
+                )?;
+                extension(
+                    VectorSearchNode::try_new(candidates, scanner.dataset.clone(), query.clone())?
+                        .with_resolution(VectorAccessPath::Flat),
+                )
+            }
+            None => {
+                let search =
+                    VectorSearchNode::try_new(source, scanner.dataset.clone(), query.clone())?;
+                extension(if scanner.is_batch_nearest {
+                    search.with_batch_queries(scanner.nearest_query_count)?
+                } else {
+                    search
+                })
+            }
         };
         let taken = with_take(
             LogicalPlanBuilder::new(searched),
@@ -134,8 +199,17 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
         LogicalPlanBuilder::new(source)
     };
 
-    // Postfilters, innermost first, matching `FilterPlan::refine_filter`.
+    // Postfilters, innermost first: an FTS `query_filter` runs before the expression filter,
+    // matching `FilterPlan::refine_filter`.
     if !prefilter {
+        if let Some(query) = &prepared.fts_filter {
+            builder = LogicalPlanBuilder::new(fts::build_match_filter(
+                builder.plan().clone(),
+                &scanner.dataset,
+                query,
+                &take_settings(scanner),
+            )?);
+        }
         if let Some(query) = &prepared.vector_filter {
             builder = LogicalPlanBuilder::new(extension(VectorRerankNode::try_new(
                 builder.plan().clone(),
@@ -180,7 +254,7 @@ pub fn build(scanner: &Scanner, prepared: &PreparedQueries) -> Result<LogicalPla
         )?;
     }
 
-    builder = builder.project(output_exprs(scanner)?)?;
+    builder = builder.project(output_exprs(scanner, prepared)?)?;
     Ok(builder.build()?)
 }
 
@@ -209,6 +283,18 @@ fn scan_leaf(scanner: &Scanner) -> Result<LogicalPlan> {
         LogicalPlanBuilder::scan(TABLE_NAME, provider_as_source(Arc::new(source)), None)?
             .build()?,
     )
+}
+
+/// The number of results the search itself should produce, before any post-filtering.
+///
+/// An offset means the search has to return `limit + offset` so the limit node has something to
+/// skip past; an offset with no limit means it cannot be bounded at all.
+fn search_limit(scanner: &Scanner) -> Option<usize> {
+    match (scanner.limit, scanner.offset) {
+        (Some(limit), Some(offset)) => Some((limit + offset) as usize),
+        (Some(limit), None) => Some(limit as usize),
+        (None, _) => None,
+    }
 }
 
 /// Insert late materialization above a search, unless the search already produced everything.
@@ -275,7 +361,7 @@ pub(super) fn extension(node: impl UserDefinedLogicalNodeCore) -> LogicalPlan {
 /// `ProjectionPlan` has already parsed and coerced these against the full schema, so they can be
 /// used as-is. An alias is only added when the output name differs from what the expression
 /// would be named anyway — a redundant `s AS s` survives optimization and shows up in `EXPLAIN`.
-fn output_exprs(scanner: &Scanner) -> Result<Vec<Expr>> {
+fn output_exprs(scanner: &Scanner, prepared: &PreparedQueries) -> Result<Vec<Expr>> {
     let mut exprs = scanner
         .projection_plan
         .requested_output_expr
@@ -295,12 +381,20 @@ fn output_exprs(scanner: &Scanner) -> Result<Vec<Expr>> {
             .any(|expr| expr.schema_name().to_string() == name)
     };
 
-    // `_distance` is appended even when the user did not ask for it. That is legacy behavior the
-    // imperative path implements in `calculate_final_projection`; replicating it here is what lets
-    // the two paths be compared row for row.
-    if scanner.autoproject_scoring_columns && scanner.nearest.is_some() && !named(&exprs, DIST_COL)
+    // The scoring columns are appended even when the user did not ask for them. That is legacy
+    // behavior the imperative path implements in `calculate_final_projection`; replicating it
+    // here is what lets the two paths be compared row for row.
+    if prepared.full_text.is_some() && prepared.element_granularity && !named(&exprs, DOC_INDEX_COL)
     {
-        exprs.push(col(DIST_COL));
+        exprs.push(col(DOC_INDEX_COL));
+    }
+    if scanner.autoproject_scoring_columns {
+        if scanner.nearest.is_some() && !named(&exprs, DIST_COL) {
+            exprs.push(col(DIST_COL));
+        }
+        if prepared.full_text.is_some() && !named(&exprs, SCORE_COL) {
+            exprs.push(col(SCORE_COL));
+        }
     }
 
     // Batch nearest exposes the query discriminator as the *first* output column, which is what
@@ -356,7 +450,8 @@ pub(super) fn source_options(scanner: &Scanner) -> ScanSourceOptions {
         // `MaterializationStyle` is documented as affecting plain scans only, and a search plan
         // already takes its columns above the search. Splitting the read below it as well would
         // add a take that fetches the same columns for strictly more rows.
-        materialization_style: match scanner.nearest.is_some() {
+        materialization_style: match scanner.nearest.is_some() || scanner.full_text_query.is_some()
+        {
             true => MaterializationStyle::AllEarly,
             false => scanner.materialization_style.clone(),
         },

--- a/rust/lance/src/dataset/scanner/logical/context.rs
+++ b/rust/lance/src/dataset/scanner/logical/context.rs
@@ -29,7 +29,9 @@ use lance_table::format::{Fragment, IndexMetadata};
 use roaring::RoaringBitmap;
 
 use lance_index::scalar::expression::{IndexInformationProvider, ScalarIndexExpr};
+use lance_index::scalar::inverted::DocumentGranularity;
 
+use super::fts::{self, FtsIndexInfo};
 use super::scan_index::with_lance_source;
 use super::{TakeSettings, VectorSearchNode};
 use crate::Result;
@@ -52,6 +54,22 @@ pub enum OverlayStaleness {
     None,
     /// Exactly these rows' entries are stale; the rest of the index is current.
     Rows(Arc<RowAddrTreeMap>),
+    /// An overlay touched an indexed field of a segment that cannot say which rows it indexed, so
+    /// no entry can be trusted.
+    Unknown,
+}
+
+/// How to treat a segment that does not record which fragments it indexed.
+///
+/// Legacy segments predate `fragment_bitmap`, and the two index kinds make different calls here —
+/// which is why it is a parameter rather than a policy baked into the helper.
+pub enum OpaqueSegments {
+    /// Assume the segment indexed every fragment, so its stale rows are the overlaid ones. Safe
+    /// for a vector index: blocking a row address works no matter which segment produced it.
+    Covering,
+    /// Refuse to trust the index at all. An inverted segment's scores depend on the whole indexed
+    /// document set, so "which rows did you index" is not a question the FTS path can leave open.
+    Opaque,
 }
 
 /// The rows whose entries in `segments` an overlay has invalidated, in the domain index results
@@ -64,6 +82,7 @@ pub async fn overlay_staleness(
     dataset: &Dataset,
     segments: &[IndexMetadata],
     fragments: &[Fragment],
+    opaque: OpaqueSegments,
 ) -> Result<OverlayStaleness> {
     // Overlays are rare; this is the check that keeps the whole mechanism off the common path.
     let overlaid = overlaid_fragments(fragments);
@@ -73,6 +92,19 @@ pub async fn overlay_staleness(
 
     let mut stale: HashMap<u32, RoaringBitmap> = HashMap::new();
     for segment in segments {
+        if segment.fragment_bitmap.is_none() && matches!(opaque, OpaqueSegments::Opaque) {
+            let mut opaque_stale = HashMap::new();
+            collect_overlay_stale_rows_for_segment(
+                segment,
+                &overlaid,
+                &mut opaque_stale,
+                dataset.schema(),
+            )?;
+            if !opaque_stale.is_empty() {
+                return Ok(OverlayStaleness::Unknown);
+            }
+            continue;
+        }
         collect_overlay_stale_rows_for_segment(segment, &overlaid, &mut stale, dataset.schema())?;
     }
     if stale.is_empty() {
@@ -125,6 +157,7 @@ pub struct ScanPlanningContext {
     /// derivations below be honest about doing no I/O.
     fragments: Arc<Vec<Fragment>>,
     vector: HashMap<String, VectorIndexInfo>,
+    fts: HashMap<(String, DocumentGranularity), FtsIndexInfo>,
     /// Whether `Scanner::with_index_segments` pinned which segments a search may use.
     ///
     /// It makes the caller's chosen segments the whole answer: rows they do not cover are out of
@@ -215,6 +248,16 @@ impl ScanPlanningContext {
             }
         }
 
+        let target_fragments =
+            RoaringBitmap::from_iter(fragments.iter().map(|fragment| fragment.id as u32));
+        let fts = fts::prefetch(
+            &dataset,
+            &fts::collect_requests(plan),
+            &target_fragments,
+            &fragments,
+        )
+        .await?;
+
         let scalar_indices = Arc::new(dataset.scalar_index_info().await?);
         let index_staleness = prefetch_index_staleness(&dataset, &fragments).await?;
         let take_rows = resolve_takes(&dataset, takes).await?;
@@ -222,6 +265,7 @@ impl ScanPlanningContext {
         Ok(Self {
             fragments,
             vector,
+            fts,
             fast_search: options.fast_search,
             segments_pinned: options.index_segments.is_some(),
             take_settings: TakeSettings {
@@ -273,6 +317,7 @@ impl ScanPlanningContext {
                             stale |= rows.as_ref().clone();
                             found = true;
                         }
+                        Some(OverlayStaleness::Unknown) => return OverlayStaleness::Unknown,
                         Some(OverlayStaleness::None) | None => {}
                     }
                 }
@@ -357,6 +402,32 @@ impl ScanPlanningContext {
             .collect()
     }
 
+    pub fn fts_index(
+        &self,
+        column: &str,
+        granularity: DocumentGranularity,
+    ) -> Option<&FtsIndexInfo> {
+        self.fts.get(&(column.to_string(), granularity))
+    }
+
+    /// Fragments the FTS index on `column` does not cover — the same synchronous bitmap
+    /// arithmetic the vector path uses, over the same manifest fragment list.
+    pub fn fts_unindexed_fragments(
+        &self,
+        column: &str,
+        granularity: DocumentGranularity,
+    ) -> Option<Vec<Fragment>> {
+        fts::partition_fragments(self.fts_index(column, granularity)?, &self.fragments, false)
+    }
+
+    pub fn fts_indexed_fragments(
+        &self,
+        column: &str,
+        granularity: DocumentGranularity,
+    ) -> Option<Vec<Fragment>> {
+        fts::partition_fragments(self.fts_index(column, granularity)?, &self.fragments, true)
+    }
+
     /// Fragments the given vector index does not cover — synchronous, because it is just the
     /// index's fragment bitmap subtracted from the manifest's fragment list.
     ///
@@ -409,7 +480,7 @@ async fn prefetch_index_staleness(
     for (name, segments) in segments {
         staleness.insert(
             name,
-            overlay_staleness(dataset, &segments, fragments).await?,
+            overlay_staleness(dataset, &segments, fragments, OpaqueSegments::Covering).await?,
         );
     }
     Ok(staleness)
@@ -460,7 +531,8 @@ async fn load_vector_index(
         )));
     }
 
-    let staleness = overlay_staleness(dataset, &segments, fragments).await?;
+    let staleness =
+        overlay_staleness(dataset, &segments, fragments, OpaqueSegments::Covering).await?;
     Ok(Some(VectorIndexInfo {
         segments,
         metric,

--- a/rust/lance/src/dataset/scanner/logical/coverage.rs
+++ b/rust/lance/src/dataset/scanner/logical/coverage.rs
@@ -20,6 +20,7 @@ use lance_select::mask::RowAddrTreeMap;
 use lance_table::format::Fragment;
 
 use super::context::{OverlayStaleness, ScanPlanningContext};
+use super::fts::FtsLeafNode;
 use super::source::ScanRestriction;
 use super::{LanceTakeNode, PrefilterSourceKind, VectorAccessPath, VectorSearchNode};
 use super::{analyze_bottom_up, map_lance_scan, restrict_scan, with_lance_source};
@@ -27,7 +28,7 @@ use super::{analyze_bottom_up, map_lance_scan, restrict_scan, with_lance_source}
 /// What an index does not answer for, among the rows a scan will touch.
 ///
 /// The whole point of this type is that fragment-level and row-level coverage are the same
-/// statement. `SplitPartiallyIndexedSearch` in the imperative path
+/// statement. `SplitPartiallyIndexedSearch` and `SplitPartiallyIndexedFts` in the imperative path
 /// split on fragment coverage; the overlay stale-row handling threaded through
 /// `Scanner::new_filtered_read`, `knn_combined`, and `plan_flat_match_query` splits on row
 /// coverage. Both produce a brute-force branch reading exactly the rows in the hole, and the only
@@ -117,6 +118,9 @@ pub fn splittable(plan: &LogicalPlan) -> Option<&dyn SplittableSearch> {
     let node = extension.node.as_any();
     if let Some(search) = node.downcast_ref::<VectorSearchNode>() {
         return Some(search);
+    }
+    if let Some(leaf) = node.downcast_ref::<FtsLeafNode>() {
+        return Some(leaf);
     }
     None
 }
@@ -308,7 +312,7 @@ impl SplittableSearch for VectorSearchNode {
         // and re-scoring works regardless — the vector path never has to give up on the index.
         let stale = match staleness {
             OverlayStaleness::Rows(rows) => Some(rows.clone()),
-            OverlayStaleness::None => None,
+            OverlayStaleness::None | OverlayStaleness::Unknown => None,
         };
 
         let (Some(mut unindexed), Some(indexed)) = (
@@ -440,7 +444,7 @@ impl ScanCoverage {
             }),
             // A scalar index answers by row address whatever segment produced the entry, so there
             // is no case where blocking cannot express the hole.
-            OverlayStaleness::None => None,
+            OverlayStaleness::None | OverlayStaleness::Unknown => None,
         }
     }
 }

--- a/rust/lance/src/dataset/scanner/logical/fts/builder.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/builder.rs
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 1: building the FTS subtree of the logical plan.
+
+use std::sync::Arc;
+
+use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
+use lance_core::ROW_ID;
+use lance_core::datatypes::OnMissing;
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::inverted::DocumentGranularity;
+use lance_index::scalar::inverted::query::{FtsQuery, FtsSearchParams};
+
+use super::super::{LanceTakeNode, TakeSettings};
+use super::*;
+use crate::dataset::Dataset;
+use crate::index::scalar::inverted::resolve_fts_field;
+use crate::{Error, Result};
+
+/// Build the subtree for a full-text search source over `input`.
+///
+/// `limit` is the scanner's limit, which the imperative path folds into the root node's params;
+/// compound children get `None` so intermediate results stay complete.
+pub fn build_source(
+    input: LogicalPlan,
+    dataset: &Arc<Dataset>,
+    query: &FullTextSearchQuery,
+    limit: Option<usize>,
+) -> Result<LogicalPlan> {
+    validate_query_contract(&query.query)?;
+    let mut params = query.params();
+    if params.limit.is_none() {
+        params = params.with_limit(limit);
+    }
+    build_query(input, dataset, &query.query, &params)
+}
+
+fn build_query(
+    input: LogicalPlan,
+    dataset: &Arc<Dataset>,
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+) -> Result<LogicalPlan> {
+    let granularity = granularity_of(query)?;
+    match query {
+        FtsQuery::Match(_) | FtsQuery::Phrase(_) => Ok(extension(FtsLeafNode::try_new(
+            input,
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+        )?)),
+        // Compound parents require complete child results, so the limit stops here. This is the
+        // "recursive planning contract" `FtsSearchParams::limit` documents.
+        FtsQuery::Boost(boost) => {
+            let unlimited = params.clone().with_limit(None);
+            let children = vec![
+                build_query(input.clone(), dataset, &boost.positive, &unlimited)?,
+                build_query(input, dataset, &boost.negative, &unlimited)?,
+            ];
+            Ok(extension(FtsCompoundNode::try_new(
+                children,
+                query.clone(),
+                params.clone(),
+                FtsCompoundKind::Boost,
+                granularity,
+            )?))
+        }
+        FtsQuery::MultiMatch(multi) => {
+            let children = multi
+                .match_queries
+                .iter()
+                .map(|child| {
+                    build_query(
+                        input.clone(),
+                        dataset,
+                        &FtsQuery::Match(child.clone()),
+                        params,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(extension(FtsCompoundNode::try_new(
+                children,
+                query.clone(),
+                params.clone(),
+                FtsCompoundKind::MultiMatch,
+                granularity,
+            )?))
+        }
+        FtsQuery::Boolean(boolean) => {
+            let unlimited = params.clone().with_limit(None);
+            let mut children = Vec::with_capacity(
+                boolean.should.len() + boolean.must.len() + boolean.must_not.len(),
+            );
+            for child in boolean
+                .should
+                .iter()
+                .chain(&boolean.must)
+                .chain(&boolean.must_not)
+            {
+                children.push(build_query(input.clone(), dataset, child, &unlimited)?);
+            }
+            Ok(extension(FtsCompoundNode::try_new(
+                children,
+                query.clone(),
+                params.clone(),
+                FtsCompoundKind::Boolean {
+                    should: boolean.should.len(),
+                    must: boolean.must.len(),
+                    must_not: boolean.must_not.len(),
+                },
+                granularity,
+            )?))
+        }
+    }
+}
+
+/// Reject queries whose scoring parameters have no meaning, before anything plans them.
+///
+/// A boost is a multiplier on a BM25 score, so a negative or non-finite one produces a ranking that
+/// no downstream node can make sense of. Checking here rather than at execution keeps the error at
+/// the API boundary, where the caller can still see which query it came from.
+fn validate_query_contract(query: &FtsQuery) -> Result<()> {
+    fn validate_multiplier(name: &str, value: f32) -> Result<()> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(())
+        } else {
+            Err(Error::invalid_input(format!(
+                "{name} must be finite and non-negative, got {value}"
+            )))
+        }
+    }
+
+    match query {
+        FtsQuery::Match(query) => validate_multiplier("MatchQuery boost", query.boost),
+        FtsQuery::Phrase(_) => Ok(()),
+        FtsQuery::Boost(query) => {
+            validate_multiplier("BoostQuery negative_boost", query.negative_boost)?;
+            validate_query_contract(&query.positive)?;
+            validate_query_contract(&query.negative)
+        }
+        FtsQuery::MultiMatch(query) => {
+            for match_query in &query.match_queries {
+                validate_multiplier("MultiMatchQuery boost", match_query.boost)?;
+            }
+            Ok(())
+        }
+        FtsQuery::Boolean(query) => {
+            if query.should.is_empty() && query.must.is_empty() {
+                return Err(Error::invalid_input(
+                    "boolean query must have at least one should/must query",
+                ));
+            }
+            for child in query
+                .should
+                .iter()
+                .chain(&query.must)
+                .chain(&query.must_not)
+            {
+                validate_query_contract(child)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn granularity_of(query: &FtsQuery) -> Result<DocumentGranularity> {
+    let missing = || Error::internal("FTS query document granularity was not resolved".to_string());
+    match query {
+        FtsQuery::Match(q) => q.document_granularity.ok_or_else(missing),
+        FtsQuery::Phrase(q) => q.document_granularity.ok_or_else(missing),
+        FtsQuery::Boost(q) => granularity_of(&q.positive),
+        FtsQuery::MultiMatch(q) => q
+            .match_queries
+            .first()
+            .and_then(|child| child.document_granularity)
+            .ok_or_else(missing),
+        FtsQuery::Boolean(q) => q
+            .should
+            .iter()
+            .chain(&q.must)
+            .chain(&q.must_not)
+            .next()
+            .ok_or_else(|| {
+                Error::invalid_input(
+                    "boolean query must have at least one should/must query".to_string(),
+                )
+            })
+            .and_then(granularity_of),
+    }
+}
+
+/// Re-rank an already-scored input by BM25, for `full_text_search` combined with a vector
+/// `query_filter`.
+///
+/// A `Match` re-rank is just a flat leaf over the input, which is why it needs no node of its
+/// own. Anything else is a join against an independently planned FTS tree — and that join is a
+/// stock DataFusion node, not a Lance one.
+pub fn build_rerank(
+    input: LogicalPlan,
+    scan: LogicalPlan,
+    dataset: &Arc<Dataset>,
+    query: &FullTextSearchQuery,
+    limit: Option<usize>,
+    settings: &TakeSettings,
+) -> Result<LogicalPlan> {
+    match &query.query {
+        // The imperative `fts_rerank` uses the query's own params here, without folding in the
+        // scanner limit: the input is already bounded by the upstream search.
+        FtsQuery::Match(match_query) => {
+            let params = query.params();
+            let column = match_query.column.clone().ok_or_else(|| {
+                Error::invalid_input("the column must be specified in the query".to_string())
+            })?;
+            let granularity = match_query.document_granularity.ok_or_else(|| {
+                Error::internal("FTS Match query granularity was not resolved".to_string())
+            })?;
+            let field = resolve_fts_field(dataset.schema(), &column, granularity)?;
+            let input = take_column(input, dataset, &field.root_column, settings)?;
+            Ok(extension(
+                FtsLeafNode::try_new(
+                    input,
+                    dataset.clone(),
+                    FtsQuery::Match(match_query.clone()),
+                    params,
+                )?
+                .with_resolution(FtsAccessPath::Flat)
+                .retaining_input_order(),
+            ))
+        }
+        other => {
+            let mut params = query.params();
+            if params.limit.is_none() {
+                params = params.with_limit(limit);
+            }
+            let fts = build_query(scan, dataset, other, &params)?;
+            join_on_row_id(input, fts)
+        }
+    }
+}
+
+/// Insert a [`LanceTakeNode`] for `column` unless the input already carries it.
+pub fn take_column(
+    input: LogicalPlan,
+    dataset: &Arc<Dataset>,
+    column: &str,
+    settings: &TakeSettings,
+) -> Result<LogicalPlan> {
+    let projection = dataset
+        .empty_projection()
+        .union_column(column, OnMissing::Error)?;
+    if LanceTakeNode::is_noop(&input, &projection)? {
+        return Ok(input);
+    }
+    Ok(extension(LanceTakeNode::try_new(
+        input,
+        dataset.clone(),
+        projection,
+        settings.clone(),
+    )?))
+}
+
+/// Inner-join two scored plans on `_rowid`, keeping one copy of each column.
+fn join_on_row_id(left: LogicalPlan, right: LogicalPlan) -> Result<LogicalPlan> {
+    // Both sides carry an unqualified `_rowid`, so the join key would be ambiguous without
+    // relation aliases.
+    let left = LogicalPlanBuilder::new(left).alias("search")?;
+    let right = LogicalPlanBuilder::new(right).alias("fts")?.build()?;
+    let key = |relation: &str| {
+        datafusion::common::Column::new(
+            Some(datafusion::common::TableReference::bare(relation)),
+            ROW_ID,
+        )
+    };
+    // `join_on` with an equality predicate lowers to a `NestedLoopJoinExec`; naming the keys is
+    // what makes it a hash join, and a hash join also emits in probe-side (FTS score) order,
+    // which is the ordering the imperative path's `HashJoinExec` produces.
+    let joined = left.join(
+        right,
+        datafusion::logical_expr::JoinType::Inner,
+        (vec![key("search")], vec![key("fts")]),
+        None,
+    )?;
+
+    // Drop the right side's duplicate `_rowid`, matching the projection the imperative path
+    // builds by hand over its `HashJoinExec`.
+    let mut exprs = Vec::new();
+    let mut seen_row_id = false;
+    for (qualifier, field) in joined.schema().iter() {
+        if field.name() == ROW_ID {
+            if seen_row_id {
+                continue;
+            }
+            seen_row_id = true;
+        }
+        exprs.push(Expr::Column(datafusion::common::Column::from((
+            qualifier,
+            field.as_ref(),
+        ))));
+    }
+    Ok(joined.project(exprs)?.build()?)
+}
+
+/// Apply an FTS `query_filter` above `input`, as a postfilter.
+pub fn build_match_filter(
+    input: LogicalPlan,
+    dataset: &Arc<Dataset>,
+    query: &FullTextSearchQuery,
+    settings: &TakeSettings,
+) -> Result<LogicalPlan> {
+    let FtsQuery::Match(match_query) = &query.query else {
+        return Err(Error::not_supported(
+            "Only Match queries are supported currently when using FTS as a post-filter",
+        ));
+    };
+    let granularity = match_query.document_granularity.ok_or_else(|| {
+        Error::internal("FTS Match query granularity was not resolved".to_string())
+    })?;
+    let column = match_query.column.clone().ok_or_else(|| {
+        Error::invalid_input("the column must be specified in the query".to_string())
+    })?;
+    let field = resolve_fts_field(dataset.schema(), &column, granularity)?;
+    let input = take_column(input, dataset, &field.root_column, settings)?;
+    Ok(extension(FtsMatchFilterNode::try_new(
+        input,
+        dataset.clone(),
+        match_query.clone(),
+        query.params(),
+    )?))
+}
+
+/// Deduplicate an FTS filter's element-level hits down to one row per `_rowid`.
+///
+/// Stock `Aggregate` with no aggregate expressions — the imperative path builds the same thing
+/// out of `RepartitionExec` + `AggregateExec` by hand.
+pub fn dedupe_rows(input: LogicalPlan) -> Result<LogicalPlan> {
+    Ok(LogicalPlanBuilder::new(input)
+        .aggregate(vec![datafusion::prelude::col(ROW_ID)], Vec::<Expr>::new())?
+        .build()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use lance_index::scalar::inverted::query::{BooleanQuery, BoostQuery, MatchQuery, Occur};
+
+    use super::*;
+
+    #[test]
+    fn test_fts_query_contract_rejects_invalid_values() {
+        let negative_match = FtsQuery::Match(MatchQuery::new("hello".to_string()).with_boost(-1.0));
+        let error = validate_query_contract(&negative_match).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("finite and non-negative"));
+
+        let empty_boolean = FtsQuery::Boolean(BooleanQuery::new(Vec::<(Occur, FtsQuery)>::new()));
+        let error = validate_query_contract(&empty_boolean).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("at least one should/must query"));
+
+        let infinite_boost = FtsQuery::Boost(BoostQuery::new(
+            MatchQuery::new("hello".to_string()).into(),
+            MatchQuery::new("world".to_string()).into(),
+            Some(f32::INFINITY),
+        ));
+        let error = validate_query_contract(&infinite_boost).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("BoostQuery negative_boost"));
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/compound.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/compound.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Compound FTS nodes: `Boost`, `Boolean`, and `MultiMatch` over child leaves.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::common::{DFSchema, DFSchemaRef, DataFusionError};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_index::scalar::inverted::query::{FtsQuery, FtsSearchParams};
+use lance_index::scalar::inverted::{DocumentGranularity, fts_schema};
+
+use crate::Result;
+
+/// How a compound FTS node combines its children.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum FtsCompoundKind {
+    /// Two children: positive, then negative.
+    Boost,
+    /// N children, one per sub-match.
+    MultiMatch,
+    /// Children laid out as `should ++ must ++ must_not`.
+    Boolean {
+        should: usize,
+        must: usize,
+        must_not: usize,
+    },
+}
+
+/// `Boost`, `MultiMatch`, or `Boolean` over N already-scored children.
+///
+/// The children are ordinary logical inputs, which is what lets the leaf-level rules run
+/// uniformly no matter how deeply a leaf is nested.
+#[derive(Debug, Clone)]
+pub struct FtsCompoundNode {
+    pub(super) inputs: Vec<LogicalPlan>,
+    pub(super) query: FtsQuery,
+    pub(super) params: FtsSearchParams,
+    pub(super) kind: FtsCompoundKind,
+    pub(super) granularity: DocumentGranularity,
+    pub(super) schema: DFSchemaRef,
+}
+
+impl FtsCompoundNode {
+    pub fn try_new(
+        inputs: Vec<LogicalPlan>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+        kind: FtsCompoundKind,
+        granularity: DocumentGranularity,
+    ) -> Result<Self> {
+        let schema = Arc::new(DFSchema::try_from(
+            fts_schema(granularity).as_ref().clone(),
+        )?);
+        Ok(Self {
+            inputs,
+            query,
+            params,
+            kind,
+            granularity,
+            schema,
+        })
+    }
+}
+
+impl PartialEq for FtsCompoundNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.inputs == other.inputs && self.kind == other.kind && self.query == other.query
+    }
+}
+
+impl Eq for FtsCompoundNode {}
+
+impl Hash for FtsCompoundNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inputs.hash(state);
+        self.kind.hash(state);
+        self.query.to_string().hash(state);
+    }
+}
+
+impl PartialOrd for FtsCompoundNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.inputs.partial_cmp(&other.inputs)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for FtsCompoundNode {
+    fn name(&self) -> &str {
+        "FtsCompound"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        self.inputs.iter().collect()
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FtsCompound: kind={:?}, limit={:?}",
+            self.kind, self.params.limit
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() || inputs.len() != self.inputs.len() {
+            return Err(DataFusionError::Internal(
+                "FtsCompound input arity changed".into(),
+            ));
+        }
+        let mut node = self.clone();
+        node.inputs = inputs;
+        Ok(node)
+    }
+
+    /// Children are scored FTS results; every column of each is consumed.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(
+            self.inputs
+                .iter()
+                .map(|input| (0..input.schema().fields().len()).collect())
+                .collect(),
+        )
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/leaf.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/leaf.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The FTS leaf node: one `Match` or `Phrase` against one column, and the access
+//! path that resolves it to an index or a flat scan.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::common::plan_err;
+use datafusion::common::{DFSchema, DFSchemaRef, DataFusionError};
+use datafusion::logical_expr::{Expr, InvariantLevel, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_core::ROW_ID;
+use lance_index::scalar::inverted::query::{FtsQuery, FtsSearchParams};
+use lance_index::scalar::inverted::{DocumentGranularity, fts_schema};
+use lance_select::mask::RowAddrTreeMap;
+use lance_table::format::IndexMetadata;
+use uuid::Uuid;
+
+use super::super::PrefilterSourceKind;
+use crate::dataset::Dataset;
+use crate::index::scalar::inverted::{ResolvedFtsField, resolve_fts_field};
+use crate::io::exec::fts::SharedFtsScorer;
+use crate::{Error, Result};
+
+// ---------------------------------------------------------------------------------------------
+// Logical nodes
+// ---------------------------------------------------------------------------------------------
+
+/// How an FTS leaf will actually be computed. Filled in by [`ResolveFtsAccessPath`].
+#[derive(Debug, Clone)]
+pub enum FtsAccessPath {
+    /// Tokenize and score the input's text directly.
+    Flat,
+    /// Search the index's posting lists.
+    Index { segments: Vec<IndexMetadata> },
+}
+
+impl FtsAccessPath {
+    fn identity(&self) -> Option<Vec<Uuid>> {
+        match self {
+            Self::Flat => None,
+            Self::Index { segments } => Some(segments.iter().map(|s| s.uuid).collect()),
+        }
+    }
+}
+
+impl PartialEq for FtsAccessPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity() == other.identity()
+    }
+}
+
+impl Eq for FtsAccessPath {}
+
+impl Hash for FtsAccessPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.identity().hash(state);
+    }
+}
+
+impl PartialOrd for FtsAccessPath {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.identity().partial_cmp(&other.identity())
+    }
+}
+
+/// A single `Match` or `Phrase` query over the input's rows.
+///
+/// Output is `fts_schema(granularity)` — `[_rowid, _score]`, plus `_doc_index` for list-element
+/// granularity — no matter which access path it lowers to, so the two are interchangeable in
+/// exactly the way [`VectorSearchNode`](super::super::VectorSearchNode)'s two paths are.
+#[derive(Debug, Clone)]
+pub struct FtsLeafNode {
+    pub(super) input: LogicalPlan,
+    pub(super) dataset: Arc<Dataset>,
+    /// Always `FtsQuery::Match` or `FtsQuery::Phrase`; the compound variants get their own node.
+    pub(super) query: FtsQuery,
+    pub(super) params: FtsSearchParams,
+    pub(super) granularity: DocumentGranularity,
+    /// The schema-resolved field path. Computed once because both `necessary_children_exprs` and
+    /// lowering need it, and `resolve_fts_field` is not free.
+    pub(super) field: ResolvedFtsField,
+    pub(super) resolution: Option<FtsAccessPath>,
+    pub(super) prefilter: PrefilterSourceKind,
+    /// Whether the input's row order is the answer's row order.
+    ///
+    /// A bounded flat leaf normally has to sort by score to produce the global top-k. When the
+    /// leaf is re-ranking someone else's already-bounded result (`full_text_search` with a vector
+    /// `query_filter`), the ordering contract belongs to that upstream search, and sorting here
+    /// would reshuffle it.
+    pub(super) retains_input_order: bool,
+    /// Rows the index must not emit, because a data overlay changed a value the index covers. Set
+    /// by [`SplitOnIndexCoverage`](SplitOnIndexCoverage), which puts the same rows on
+    /// a flat branch so they are scored from their current text.
+    pub(super) overlay_block: Option<Arc<RowAddrTreeMap>>,
+    /// The rendezvous through which the two branches of a split leaf agree on corpus statistics.
+    ///
+    /// A BM25 score is only meaningful relative to a corpus, so scores from an index that saw part
+    /// of the data and a flat scan that saw the rest are not comparable — and the merge above them
+    /// ranks the two together. The flat branch, which can see both halves, computes the combined
+    /// statistics and publishes them here; the indexed branch waits for them instead of using its
+    /// own. It is an execution-time object living in a logical node because only the rule that
+    /// created both branches knows they are two halves of one search.
+    ///
+    /// Only list-element granularity needs it: whole-document scores already share the index's
+    /// corpus-wide statistics.
+    pub(super) shared_scorer: Option<Arc<SharedFtsScorer>>,
+    pub(super) schema: DFSchemaRef,
+}
+
+impl FtsLeafNode {
+    pub fn try_new(
+        input: LogicalPlan,
+        dataset: Arc<Dataset>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+    ) -> Result<Self> {
+        let (column, granularity) = match &query {
+            FtsQuery::Match(q) => (q.column.clone(), q.document_granularity),
+            FtsQuery::Phrase(q) => (q.column.clone(), q.document_granularity),
+            other => {
+                return Err(Error::internal(format!(
+                    "FtsLeafNode only accepts Match and Phrase queries, got {other}"
+                )));
+            }
+        };
+        let column = column.ok_or_else(|| {
+            Error::invalid_input("the column must be specified in the query".to_string())
+        })?;
+        let granularity = granularity.ok_or_else(|| {
+            Error::internal("FTS query document granularity was not resolved".to_string())
+        })?;
+        let field = resolve_fts_field(dataset.schema(), &column, granularity)?;
+        let schema = Arc::new(DFSchema::try_from(
+            fts_schema(granularity).as_ref().clone(),
+        )?);
+        Ok(Self {
+            input,
+            dataset,
+            query,
+            params,
+            granularity,
+            field,
+            resolution: None,
+            prefilter: PrefilterSourceKind::default(),
+            retains_input_order: false,
+            overlay_block: None,
+            shared_scorer: None,
+            schema,
+        })
+    }
+
+    pub fn column(&self) -> &str {
+        &self.field.canonical_path
+    }
+
+    pub fn granularity(&self) -> DocumentGranularity {
+        self.granularity
+    }
+
+    pub fn is_phrase(&self) -> bool {
+        matches!(self.query, FtsQuery::Phrase(_))
+    }
+
+    pub fn input(&self) -> &LogicalPlan {
+        &self.input
+    }
+
+    pub fn resolution(&self) -> Option<&FtsAccessPath> {
+        self.resolution.as_ref()
+    }
+
+    pub fn prefilter(&self) -> &PrefilterSourceKind {
+        &self.prefilter
+    }
+
+    pub fn with_input(mut self, input: LogicalPlan) -> Self {
+        self.input = input;
+        self
+    }
+
+    pub fn with_resolution(mut self, resolution: FtsAccessPath) -> Self {
+        self.resolution = Some(resolution);
+        self
+    }
+
+    pub fn with_prefilter(mut self, prefilter: PrefilterSourceKind) -> Self {
+        self.prefilter = prefilter;
+        self
+    }
+
+    pub fn retaining_input_order(mut self) -> Self {
+        self.retains_input_order = true;
+        self
+    }
+
+    pub fn with_overlay_block(mut self, block: Option<Arc<RowAddrTreeMap>>) -> Self {
+        self.overlay_block = block;
+        self
+    }
+
+    pub fn with_shared_scorer(mut self, scorer: Option<Arc<SharedFtsScorer>>) -> Self {
+        self.shared_scorer = scorer;
+        self
+    }
+
+    fn reads_text(&self) -> bool {
+        !matches!(self.resolution, Some(FtsAccessPath::Index { .. }))
+    }
+}
+
+impl PartialEq for FtsLeafNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input
+            && self.query == other.query
+            && self.params.limit == other.params.limit
+            && self.granularity == other.granularity
+            && self.resolution == other.resolution
+            && self.prefilter == other.prefilter
+            && self.overlay_block == other.overlay_block
+    }
+}
+
+impl Eq for FtsLeafNode {}
+
+impl Hash for FtsLeafNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.query.to_string().hash(state);
+        self.granularity.hash(state);
+        self.resolution.hash(state);
+        self.prefilter.hash(state);
+        // `RowAddrTreeMap` is not `Hash`; see the note on `VectorSearchNode`'s impl.
+        self.overlay_block.is_some().hash(state);
+    }
+}
+
+impl PartialOrd for FtsLeafNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self
+            .field
+            .canonical_path
+            .partial_cmp(&other.field.canonical_path)
+        {
+            Some(Ordering::Equal) => self.input.partial_cmp(&other.input),
+            other => other,
+        }
+    }
+}
+
+impl UserDefinedLogicalNodeCore for FtsLeafNode {
+    fn name(&self) -> &str {
+        "FtsLeaf"
+    }
+
+    /// An unresolved leaf is not executable. See [`VectorSearchNode::check_invariants`].
+    ///
+    /// [`VectorSearchNode::check_invariants`]: super::super::VectorSearchNode
+    fn check_invariants(&self, check: InvariantLevel) -> datafusion::common::Result<()> {
+        if matches!(check, InvariantLevel::Executable) && self.resolution.is_none() {
+            return plan_err!(
+                "full-text search on column '{}' reached execution with no access path resolved",
+                self.column()
+            );
+        }
+        Ok(())
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FtsLeaf: column={}, query={}, limit={:?}",
+            self.field.canonical_path, self.query, self.params.limit
+        )?;
+        match &self.resolution {
+            Some(FtsAccessPath::Flat) => write!(f, ", via=flat")?,
+            Some(FtsAccessPath::Index { segments }) => {
+                write!(f, ", via=index(segments={})", segments.len())?
+            }
+            None => {}
+        }
+        if self.prefilter != PrefilterSourceKind::None {
+            write!(f, ", prefilter={}", self.prefilter)?;
+        }
+        if self.overlay_block.is_some() {
+            write!(f, ", overlay_block")?;
+        }
+        Ok(())
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() || inputs.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "FtsLeaf takes exactly one input and no expressions".into(),
+            ));
+        }
+        let mut node = self.clone();
+        node.input = inputs.remove(0);
+        Ok(node)
+    }
+
+    /// The same pivot the vector path turns on: an indexed leaf wants only row ids from its child
+    /// — which is precisely a prefilter — while a flat leaf has to read the text itself.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        let reads_text = self.reads_text();
+        let root = &self.field.root_column;
+        let needed = self
+            .input
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, field)| field.name() == ROW_ID || (reads_text && field.name() == root))
+            .map(|(idx, _)| idx)
+            .collect();
+        Some(vec![needed])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/match_filter.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/match_filter.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The match-filter node: applies an FTS predicate to rows a search already produced.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_schema::Schema as ArrowSchema;
+use datafusion::common::{DFSchema, DFSchemaRef, DataFusionError};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_index::scalar::inverted::query::{FtsSearchParams, MatchQuery};
+
+use crate::dataset::Dataset;
+use crate::index::scalar::inverted::{ResolvedFtsField, resolve_fts_field};
+use crate::{Error, Result};
+
+/// FTS used as a *filter* rather than as a source: keep the input's rows that match, and append
+/// their `_score`.
+///
+/// Unlike [`FtsLeafNode`] this preserves its input's columns, so it cannot be the same node —
+/// which is also true of the exec nodes (`FlatMatchFilterExec` vs `FlatMatchQueryExec`).
+#[derive(Debug, Clone)]
+pub struct FtsMatchFilterNode {
+    pub(super) input: LogicalPlan,
+    pub(super) dataset: Arc<Dataset>,
+    pub(super) query: MatchQuery,
+    pub(super) params: FtsSearchParams,
+    pub(super) field: ResolvedFtsField,
+    pub(super) schema: DFSchemaRef,
+}
+
+impl FtsMatchFilterNode {
+    pub fn try_new(
+        input: LogicalPlan,
+        dataset: Arc<Dataset>,
+        query: MatchQuery,
+        params: FtsSearchParams,
+    ) -> Result<Self> {
+        let column = query.column.clone().ok_or_else(|| {
+            Error::invalid_input("the column must be specified in the query".to_string())
+        })?;
+        let granularity = query.document_granularity.ok_or_else(|| {
+            Error::internal("FTS Match query granularity was not resolved".to_string())
+        })?;
+        let field = resolve_fts_field(dataset.schema(), &column, granularity)?;
+        let mut fields = input.schema().as_arrow().fields().to_vec();
+        fields.push(Arc::new(lance_index::scalar::inverted::SCORE_FIELD.clone()));
+        let schema = Arc::new(DFSchema::try_from(ArrowSchema::new(fields))?);
+        Ok(Self {
+            input,
+            dataset,
+            query,
+            params,
+            field,
+            schema,
+        })
+    }
+}
+
+impl PartialEq for FtsMatchFilterNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input && self.query == other.query
+    }
+}
+
+impl Eq for FtsMatchFilterNode {}
+
+impl Hash for FtsMatchFilterNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.query.terms.hash(state);
+    }
+}
+
+impl PartialOrd for FtsMatchFilterNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.input.partial_cmp(&other.input)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for FtsMatchFilterNode {
+    fn name(&self) -> &str {
+        "FtsMatchFilter"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FtsMatchFilter: column={}, query=[{}]",
+            self.field.canonical_path, self.query.terms
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() || inputs.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "FtsMatchFilter takes exactly one input and no expressions".into(),
+            ));
+        }
+        Self::try_new(
+            inputs.remove(0),
+            self.dataset.clone(),
+            self.query.clone(),
+            self.params.clone(),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))
+    }
+
+    /// The filter reads the text and passes everything else through, so nothing can be dropped.
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/mod.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Full-text search, as logical nodes, rules, and lowering.
+//!
+//! Everything FTS-specific lives under this directory rather than being spread across the
+//! framework's `builder` / `rules` / `planner` modules. That is deliberate: the design doc asks
+//! whether an index type could one day ship its own planning support, and keeping one index's
+//! nodes, rules, prefetch, and lowering together is the closest thing to an answer we have. The
+//! rest of the module reaches in through five entry points — [`build_source`], [`prefetch`],
+//! [`analyzer_rules`] / [`optimizer_rules`], [`plan_extension`], and [`collect_requests`].
+//!
+//! [`vector`](super::vector) is deliberately arranged the same way. Two index types sharing one
+//! shape is what makes the boundary a claim rather than an artifact of a single file.
+//!
+//! # Shape
+//!
+//! An [`FtsQuery`](lance_index::scalar::inverted::query::FtsQuery) is a recursive IR, so it maps
+//! onto a subtree rather than a single node:
+//!
+//! ```text
+//! FtsCompound{Boolean}                 <- Boost / MultiMatch / Boolean
+//!   FtsLeaf{Match, via=index}          <- one per Match / Phrase
+//!     Filter / TableScan               <- prefilter source, or the text to scan
+//!   FtsLeaf{Match, via=flat}
+//!     Filter / TableScan
+//! ```
+//!
+//! Each leaf resolves independently, which is what lets a partially-indexed column be handled by
+//! the same split-into-two-branches rewrite the vector path uses.
+
+mod builder;
+mod compound;
+mod leaf;
+mod match_filter;
+mod planner;
+mod prefetch;
+mod rules;
+mod scorer;
+
+pub use builder::*;
+pub use compound::*;
+pub use leaf::*;
+pub use match_filter::*;
+pub use planner::*;
+pub use prefetch::*;
+pub use rules::*;
+pub use scorer::*;
+
+use datafusion::logical_expr::{Extension, LogicalPlan, UserDefinedLogicalNodeCore};
+use std::sync::Arc;
+
+/// Wrap a node as a [`LogicalPlan::Extension`].
+fn extension(node: impl UserDefinedLogicalNodeCore) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
+        node: Arc::new(node),
+    })
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/planner.rs
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 4: lowering FTS logical nodes to execution plans.
+
+use std::sync::Arc;
+
+use arrow_schema::SortOptions;
+use datafusion::functions_aggregate;
+use datafusion::logical_expr::UserDefinedLogicalNode;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, expressions};
+use datafusion_physical_expr::{PhysicalExpr, PhysicalSortExpr};
+use lance_core::ROW_ID;
+use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, Operator};
+use lance_index::scalar::inverted::{SCORE_COL, fts_schema};
+use lance_index::scalar::registry::VALUE_COLUMN_NAME;
+use lance_select::mask::RowAddrMask;
+use lance_table::format::Fragment;
+
+use super::super::planner::plan_prefilter_source;
+use super::*;
+use crate::dataset::{Dataset, Scanner};
+use crate::io::exec::fts::{
+    BoolSlot, BooleanQueryExec, BoostQueryExec, CompoundQueryExec, FlatMatchFilterExec,
+    FlatMatchQueryExec, FtsDocumentExec, MatchQueryExec, PhraseQueryExec,
+    build_boolean_query_children_with_schema,
+};
+use crate::{Error, Result};
+
+// ---------------------------------------------------------------------------------------------
+// Stage 4: lowering
+// ---------------------------------------------------------------------------------------------
+
+/// Lower any FTS node. Returns `None` for nodes this module does not own.
+pub fn plan_extension(
+    node: &dyn UserDefinedLogicalNode,
+    inputs: &[Arc<dyn ExecutionPlan>],
+) -> Option<Result<Arc<dyn ExecutionPlan>>> {
+    if let Some(leaf) = node.as_any().downcast_ref::<FtsLeafNode>() {
+        return Some(plan_leaf(leaf, inputs.first().cloned()?));
+    }
+    if let Some(compound) = node.as_any().downcast_ref::<FtsCompoundNode>() {
+        return Some(plan_compound(compound, inputs));
+    }
+    if let Some(scorer) = node.as_any().downcast_ref::<FtsCompoundScorerNode>() {
+        return Some(plan_compound_scorer(scorer, inputs.first().cloned()?));
+    }
+    if let Some(filter) = node.as_any().downcast_ref::<FtsMatchFilterNode>() {
+        return Some(plan_match_filter(filter, inputs.first().cloned()?));
+    }
+    None
+}
+
+fn plan_leaf(node: &FtsLeafNode, input: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    match &node.resolution {
+        Some(FtsAccessPath::Index { segments }) => {
+            let prefilter = plan_prefilter_source(&node.prefilter, &node.dataset, input);
+            let block = node
+                .overlay_block
+                .as_ref()
+                .map(|rows| RowAddrMask::from_block(rows.as_ref().clone()));
+            let plan: Arc<dyn ExecutionPlan> = match &node.query {
+                FtsQuery::Match(query) => {
+                    let mut exec = MatchQueryExec::new_with_segments_and_document_granularity(
+                        node.dataset.clone(),
+                        query.clone(),
+                        node.params.clone(),
+                        prefilter,
+                        segments.clone(),
+                        node.granularity,
+                    );
+                    if let Some(block) = block {
+                        exec = exec.with_overlay_block(block);
+                    }
+                    if let Some(scorer) = &node.shared_scorer {
+                        exec = exec.with_shared_scorer(scorer.clone());
+                    }
+                    Arc::new(exec)
+                }
+                FtsQuery::Phrase(query) => {
+                    let mut exec = PhraseQueryExec::new_with_segments_and_document_granularity(
+                        node.dataset.clone(),
+                        query.clone(),
+                        node.params.clone(),
+                        prefilter,
+                        segments.clone(),
+                        node.granularity,
+                    );
+                    if let Some(block) = block {
+                        exec = exec.with_overlay_block(block);
+                    }
+                    if let Some(scorer) = &node.shared_scorer {
+                        exec = exec.with_shared_scorer(scorer.clone());
+                    }
+                    Arc::new(exec)
+                }
+                other => {
+                    return Err(Error::internal(format!(
+                        "FtsLeaf holds a compound query: {other}"
+                    )));
+                }
+            };
+            Ok(plan)
+        }
+        // An unresolved leaf means the rule did not run; a flat scan is always correct.
+        Some(FtsAccessPath::Flat) | None => plan_flat_leaf(node, input),
+    }
+}
+
+/// The brute-force path: feed the input's text to `FlatMatchQueryExec`.
+///
+/// A phrase query becomes an `And` match with a slop parameter, which is how the imperative path
+/// scores phrases over unindexed rows too.
+fn plan_flat_leaf(
+    node: &FtsLeafNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let (query, params) = match &node.query {
+        FtsQuery::Match(query) => (query.clone(), node.params.clone()),
+        FtsQuery::Phrase(phrase) => (
+            MatchQuery::new(phrase.terms.clone())
+                .with_column(phrase.column.clone())
+                .with_operator(Operator::And)
+                .with_document_granularity(node.granularity),
+            node.params.clone().with_phrase_slop(Some(phrase.slop)),
+        ),
+        other => {
+            return Err(Error::internal(format!(
+                "FtsLeaf holds a compound query: {other}"
+            )));
+        }
+    };
+
+    let document_column = if node.field.has_lists() {
+        VALUE_COLUMN_NAME.to_string()
+    } else {
+        node.field.canonical_path.clone()
+    };
+    let input = if node.field.has_lists() {
+        Arc::new(FtsDocumentExec::new(input, node.field.clone())) as Arc<dyn ExecutionPlan>
+    } else {
+        ensure_column_alias(input, &node.dataset, &document_column)?
+    };
+
+    let mut flat = FlatMatchQueryExec::new_with_document_granularity(
+        node.dataset.clone(),
+        query,
+        params,
+        input,
+        node.granularity,
+        document_column,
+    );
+    // The flat branch is the producer: it is the one that can see both halves of the corpus.
+    if let Some(scorer) = &node.shared_scorer {
+        flat = flat.with_shared_scorer(scorer.clone());
+    }
+    let scored = Arc::new(flat) as Arc<dyn ExecutionPlan>;
+
+    // `combine_fts_leaf_plans` sorts a flat-only leaf when the search is bounded; the index path
+    // gets its top-k from the posting lists instead.
+    match node.params.limit {
+        Some(limit) if !node.retains_input_order => Ok(sort_by_score(scored, Some(limit))?),
+        _ => Ok(scored),
+    }
+}
+
+fn plan_compound(
+    node: &FtsCompoundNode,
+    inputs: &[Arc<dyn ExecutionPlan>],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    match &node.kind {
+        FtsCompoundKind::Boost => {
+            let FtsQuery::Boost(query) = &node.query else {
+                return Err(Error::internal(
+                    "FtsCompound{Boost} holds a non-boost query",
+                ));
+            };
+            let [positive, negative] = inputs else {
+                return Err(Error::internal("boost query requires exactly two children"));
+            };
+            Ok(Arc::new(BoostQueryExec::new(
+                query.clone(),
+                node.params.clone(),
+                positive.clone(),
+                negative.clone(),
+            )))
+        }
+        FtsCompoundKind::MultiMatch => plan_multi_match(node, inputs),
+        FtsCompoundKind::Boolean {
+            should,
+            must,
+            must_not,
+        } => {
+            let FtsQuery::Boolean(query) = &node.query else {
+                return Err(Error::internal(
+                    "FtsCompound{Boolean} holds a non-boolean query",
+                ));
+            };
+            if inputs.len() != should + must + must_not {
+                return Err(Error::internal("boolean query child arity changed"));
+            }
+            let schema = fts_schema(node.granularity);
+            let (should_children, rest) = inputs.split_at(*should);
+            let (must_children, must_not_children) = rest.split_at(*must);
+
+            let should_plan = build_boolean_query_children_with_schema(
+                BoolSlot::Should,
+                should_children.to_vec(),
+                schema.clone(),
+            )?
+            .ok_or_else(|| {
+                Error::internal("boolean should planning returned no execution plan".to_string())
+            })?;
+            let must_plan = build_boolean_query_children_with_schema(
+                BoolSlot::Must,
+                must_children.to_vec(),
+                schema.clone(),
+            )?;
+            let must_not_plan = build_boolean_query_children_with_schema(
+                BoolSlot::MustNot,
+                must_not_children.to_vec(),
+                schema,
+            )?
+            .ok_or_else(|| {
+                Error::internal("boolean must-not planning returned no execution plan".to_string())
+            })?;
+
+            if *should == 0 && must_plan.is_none() {
+                return Err(Error::invalid_input(
+                    "boolean query must have at least one should/must query".to_string(),
+                ));
+            }
+            Ok(Arc::new(BooleanQueryExec::new(
+                query.clone(),
+                node.params.clone(),
+                should_plan,
+                must_plan,
+                must_not_plan,
+            )))
+        }
+    }
+}
+
+/// Union the sub-matches, keep the best score per row, and take the top k.
+///
+/// Everything here is stock relational algebra — union, group-by-max, sort-with-fetch — which is
+/// a finding in itself: `MultiMatch` needs no Lance-specific execution at all.
+fn plan_multi_match(
+    node: &FtsCompoundNode,
+    inputs: &[Arc<dyn ExecutionPlan>],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let unioned = UnionExec::try_new(inputs.to_vec())?;
+    let schema = unioned.schema();
+    let single = Arc::new(RepartitionExec::try_new(
+        unioned,
+        Partitioning::RoundRobinBatch(1),
+    )?);
+    let deduped = Arc::new(AggregateExec::try_new(
+        AggregateMode::Single,
+        PhysicalGroupBy::new_single(vec![(
+            expressions::col(ROW_ID, schema.as_ref())?,
+            ROW_ID.to_string(),
+        )]),
+        vec![Arc::new(
+            datafusion_physical_expr::aggregate::AggregateExprBuilder::new(
+                functions_aggregate::min_max::max_udaf(),
+                vec![expressions::col(SCORE_COL, &schema)?],
+            )
+            .schema(schema.clone())
+            .alias(SCORE_COL)
+            .build()?,
+        )],
+        vec![None],
+        single,
+        schema,
+    )?);
+    sort_by_score_and_row_id(deduped, node.params.limit)
+}
+
+fn plan_compound_scorer(
+    node: &FtsCompoundScorerNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(Arc::new(CompoundQueryExec::new_with_segments(
+        node.dataset.clone(),
+        node.query.clone(),
+        node.params.clone(),
+        plan_prefilter_source(&node.prefilter, &node.dataset, input),
+        node.segments.clone(),
+    )))
+}
+
+fn plan_match_filter(
+    node: &FtsMatchFilterNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let input = if node.field.has_lists() {
+        input
+    } else {
+        ensure_column_alias(input, &node.dataset, &node.field.canonical_path)?
+    };
+    Ok(Arc::new(FlatMatchFilterExec::new_with_resolved_field(
+        input,
+        node.dataset.clone(),
+        node.query.clone(),
+        node.params.clone(),
+        node.field.clone(),
+    )))
+}
+
+fn sort_by_score(
+    plan: Arc<dyn ExecutionPlan>,
+    fetch: Option<usize>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let expr = PhysicalSortExpr {
+        expr: expressions::col(SCORE_COL, plan.schema().as_ref())?,
+        options: SortOptions {
+            descending: true,
+            nulls_first: false,
+        },
+    };
+    Ok(Arc::new(
+        SortExec::new([expr].into(), plan).with_fetch(fetch),
+    ))
+}
+
+fn sort_by_score_and_row_id(
+    plan: Arc<dyn ExecutionPlan>,
+    fetch: Option<usize>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = plan.schema();
+    let exprs = [
+        PhysicalSortExpr {
+            expr: expressions::col(SCORE_COL, schema.as_ref())?,
+            options: SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+        },
+        PhysicalSortExpr {
+            expr: expressions::col(ROW_ID, schema.as_ref())?,
+            options: SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+        },
+    ];
+    Ok(Arc::new(
+        SortExec::new(exprs.into(), plan).with_fetch(fetch),
+    ))
+}
+
+/// Expose a (possibly nested) field path as a top-level column, as `Scanner::ensure_column_alias`
+/// does: the reader produces the containing struct, but the FTS executor wants one named column.
+fn ensure_column_alias(
+    input: Arc<dyn ExecutionPlan>,
+    dataset: &Arc<Dataset>,
+    column: &str,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = input.schema();
+    if schema.column_with_name(column).is_some() {
+        return Ok(input);
+    }
+    let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            expressions::col(field.name(), schema.as_ref()).map(|expr| (expr, field.name().clone()))
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    exprs.push((
+        Scanner::create_column_expr(column, dataset.as_ref(), schema.as_ref())?,
+        column.to_string(),
+    ));
+    Ok(Arc::new(ProjectionExec::try_new(exprs, input)?))
+}
+
+/// Fragments an FTS index does or does not cover, for the split rule's two branches.
+pub fn partition_fragments(
+    info: &FtsIndexInfo,
+    fragments: &[Fragment],
+    covered_side: bool,
+) -> Option<Vec<Fragment>> {
+    let covered = info.covered_fragments()?;
+    Some(
+        fragments
+            .iter()
+            .filter(|fragment| covered.contains(fragment.id as u32) == covered_side)
+            .cloned()
+            .collect(),
+    )
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/prefetch.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/prefetch.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stage 2 prefetch for full-text search: what one FTS index contributes to the
+//! planning context.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::logical_expr::LogicalPlan;
+use lance_index::scalar::inverted::DocumentGranularity;
+use lance_index::scalar::inverted::query::FtsQuery;
+use lance_table::format::{Fragment, IndexMetadata};
+use roaring::RoaringBitmap;
+
+use super::super::context::{OpaqueSegments, OverlayStaleness};
+use super::*;
+use crate::dataset::Dataset;
+use crate::index::scalar::inverted::load_segment_details;
+use crate::{Error, Result};
+
+// ---------------------------------------------------------------------------------------------
+// Stage 2: prefetch
+// ---------------------------------------------------------------------------------------------
+
+/// Everything known about one FTS index, captured once per planning invocation.
+#[derive(Debug, Clone)]
+pub struct FtsIndexInfo {
+    /// Every committed segment of the index; a search fans out over all of them.
+    pub segments: Vec<IndexMetadata>,
+    /// Whether the index stores token positions. Only phrase queries need it, and finding out
+    /// requires reading the index details, so it is resolved here rather than at lowering time.
+    pub with_position: bool,
+    /// Row-level coverage: which of this index's entries a data overlay has invalidated.
+    pub staleness: OverlayStaleness,
+}
+
+impl FtsIndexInfo {
+    pub(super) fn covered_fragments(&self) -> Option<RoaringBitmap> {
+        let mut covered = RoaringBitmap::new();
+        for segment in &self.segments {
+            covered |= segment.fragment_bitmap.as_ref()?;
+        }
+        Some(covered)
+    }
+}
+
+/// Which FTS index a plan needs metadata for. One per (column, granularity) pair, since a column
+/// may carry both a row-level and a list-element index.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FtsIndexRequest {
+    pub column: String,
+    pub granularity: DocumentGranularity,
+    /// Whether any leaf on this column is a phrase query, which is what makes `with_position`
+    /// worth the extra read.
+    pub needs_position: bool,
+}
+
+/// Walk the unoptimized plan for the FTS indices it will need.
+pub fn collect_requests(plan: &LogicalPlan) -> Vec<FtsIndexRequest> {
+    let mut requests: Vec<FtsIndexRequest> = Vec::new();
+    let _ = plan.apply(|node| {
+        if let LogicalPlan::Extension(extension) = node
+            && let Some(leaf) = extension.node.as_any().downcast_ref::<FtsLeafNode>()
+        {
+            let needs_position = matches!(leaf.query, FtsQuery::Phrase(_));
+            match requests.iter_mut().find(|r| {
+                r.column == leaf.field.canonical_path && r.granularity == leaf.granularity
+            }) {
+                Some(existing) => existing.needs_position |= needs_position,
+                None => requests.push(FtsIndexRequest {
+                    column: leaf.field.canonical_path.clone(),
+                    granularity: leaf.granularity,
+                    needs_position,
+                }),
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    });
+    requests
+}
+
+/// Load the index metadata for each request. The one stage that is allowed to do I/O.
+///
+/// Input validation that depends on this metadata happens here too, not in the rules: an error
+/// raised inside an `OptimizerRule` comes back wrapped as a DataFusion `External` error, which
+/// loses the [`Error`] variant callers match on.
+pub async fn prefetch(
+    dataset: &Arc<Dataset>,
+    requests: &[FtsIndexRequest],
+    target_fragments: &RoaringBitmap,
+    fragments: &[Fragment],
+) -> Result<HashMap<(String, DocumentGranularity), FtsIndexInfo>> {
+    let mut loaded = HashMap::with_capacity(requests.len());
+    for request in requests {
+        let Some(segments) = crate::index::scalar::inverted::load_segments(
+            dataset,
+            &request.column,
+            request.granularity,
+        )
+        .await?
+        else {
+            continue;
+        };
+        let with_position = if request.needs_position {
+            load_segment_details(dataset, &request.column, &segments)
+                .await?
+                .with_position
+        } else {
+            false
+        };
+        // `Opaque`, not `Covering`: a legacy segment cannot say which rows it indexed, and a BM25
+        // score depends on the whole indexed document set, so a relevant overlay invalidates it
+        // wholesale rather than row by row.
+        let staleness = super::super::context::overlay_staleness(
+            dataset,
+            &segments,
+            fragments,
+            OpaqueSegments::Opaque,
+        )
+        .await?;
+        let info = FtsIndexInfo {
+            segments,
+            with_position,
+            staleness,
+        };
+        // A phrase query only needs positions from an index it will actually read. When the index
+        // covers none of the target fragments the query is answered by a flat scan, which computes
+        // positions from the text itself.
+        let index_is_reachable = info
+            .covered_fragments()
+            .is_none_or(|covered| !(&covered & target_fragments).is_empty());
+        if request.needs_position && !with_position && index_is_reachable {
+            return Err(Error::invalid_input(
+                "position is not found but required for phrase queries, try recreating the index with position"
+                    .to_string(),
+            ));
+        }
+        loaded.insert((request.column.clone(), request.granularity), info);
+    }
+    Ok(loaded)
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/rules.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/rules.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Analyzer and optimizer rules that resolve FTS access paths and rewrite compound
+//! subtrees.
+
+use std::sync::Arc;
+
+use datafusion::common::plan_err;
+use datafusion::common::tree_node::Transformed;
+use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder};
+use datafusion::optimizer::{AnalyzerRule, ApplyOrder, OptimizerConfig, OptimizerRule};
+use lance_index::scalar::inverted::SCORE_COL;
+use lance_index::scalar::inverted::query::FtsQuery;
+use lance_select::mask::RowAddrTreeMap;
+
+use super::super::PrefilterSourceKind;
+use super::super::context::{OverlayStaleness, ScanPlanningContext};
+use super::super::source::ScanRestriction;
+use super::super::{IndexCoverage, SplittableSearch};
+use super::*;
+use crate::io::exec::fts::SharedFtsScorer;
+
+// ---------------------------------------------------------------------------------------------
+// Stage 3: rules
+// ---------------------------------------------------------------------------------------------
+
+/// The FTS-owned mandatory rewrites. Deciding whether a leaf can use its index is not an
+/// optimization — an unresolved leaf cannot be lowered at all.
+pub fn analyzer_rules(
+    context: &Arc<ScanPlanningContext>,
+) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
+    vec![Arc::new(ResolveFtsAccessPath::new(context.clone()))]
+}
+
+/// The FTS-owned optimizations. `UseFtsCompoundScorer` is the only rule in the spike that fits
+/// `OptimizerRule`'s documented contract: drop it and the plan still returns the same rows, just
+/// by scoring each leaf separately and combining afterwards.
+pub fn optimizer_rules(
+    context: &Arc<ScanPlanningContext>,
+) -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
+    vec![Arc::new(UseFtsCompoundScorer::new(context.clone()))]
+}
+
+/// Decide whether each leaf uses its inverted index or scans text.
+///
+/// The index is ruled out when there is none, when it covers no fragment the scan will touch, or
+/// — for a phrase query — when it was built without positions, which is the one case that is an
+/// error rather than a fallback.
+#[derive(Debug)]
+pub struct ResolveFtsAccessPath {
+    pub(super) context: Arc<ScanPlanningContext>,
+}
+
+impl ResolveFtsAccessPath {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+}
+
+impl AnalyzerRule for ResolveFtsAccessPath {
+    fn name(&self) -> &str {
+        "resolve_fts_access_path"
+    }
+
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        super::super::analyze_bottom_up(plan, |node| self.rewrite_node(node))
+    }
+}
+
+impl ResolveFtsAccessPath {
+    fn rewrite_node(
+        &self,
+        plan: LogicalPlan,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(leaf) = extension.node.as_any().downcast_ref::<FtsLeafNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Not an idempotence guard: the builder resolves a leaf to `Flat` when its input already
+        // *is* the candidate set — an FTS query scoring the output of a vector filter — and that
+        // is a decision, not a default.
+        if leaf.resolution.is_some() {
+            return Ok(Transformed::no(plan));
+        }
+
+        // A phrase query over an index without positions was already rejected during prefetch, so
+        // an index in the context is always usable by the time this runs.
+        let resolved = match self.context.fts_index(leaf.column(), leaf.granularity()) {
+            Some(index) if !(leaf.is_phrase() && !index.with_position) => FtsAccessPath::Index {
+                segments: index.segments.clone(),
+            },
+            _ => FtsAccessPath::Flat,
+        };
+
+        Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+            node: Arc::new(leaf.clone().with_resolution(resolved)),
+        })))
+    }
+}
+
+/// Collapse a single-column compound query into one posting-list scorer.
+///
+/// The whole subtree — compound node, leaves, and each leaf's copy of the prefilter — becomes a
+/// single [`FtsCompoundScorerNode`]. It is a nice demonstration of the shape the design doc is
+/// after: a fast path that the imperative planner expresses as an early `return` from
+/// `plan_fts` is, here, a rule that pattern-matches a subtree.
+#[derive(Debug)]
+pub struct UseFtsCompoundScorer {
+    pub(super) context: Arc<ScanPlanningContext>,
+}
+
+impl UseFtsCompoundScorer {
+    pub fn new(context: Arc<ScanPlanningContext>) -> Self {
+        Self { context }
+    }
+
+    /// Every leaf under `node`, or `None` if the subtree holds anything else.
+    fn leaves<'a>(&self, node: &'a FtsCompoundNode) -> Option<Vec<&'a FtsLeafNode>> {
+        fn walk<'a>(plan: &'a LogicalPlan, out: &mut Vec<&'a FtsLeafNode>) -> bool {
+            let LogicalPlan::Extension(extension) = plan else {
+                return false;
+            };
+            if let Some(leaf) = extension.node.as_any().downcast_ref::<FtsLeafNode>() {
+                out.push(leaf);
+                return true;
+            }
+            if let Some(compound) = extension.node.as_any().downcast_ref::<FtsCompoundNode>() {
+                return compound.inputs.iter().all(|input| walk(input, out));
+            }
+            false
+        }
+        let mut leaves = Vec::new();
+        node.inputs
+            .iter()
+            .all(|input| walk(input, &mut leaves))
+            .then_some(leaves)
+    }
+}
+
+impl OptimizerRule for UseFtsCompoundScorer {
+    fn name(&self) -> &str {
+        "use_fts_compound_scorer"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        // Top-down so the outermost compound node is collapsed whole, rather than an inner one
+        // first leaving the parent unable to match.
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Extension(extension) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(compound) = extension.node.as_any().downcast_ref::<FtsCompoundNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        if compound.granularity.is_list_element() || !supports_compound_scorer(&compound.query) {
+            return Ok(Transformed::no(plan));
+        }
+        let Some(leaves) = self.leaves(compound) else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(first) = leaves.first() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Flat and posting-backed leaves do not share a document domain, so a mixed subtree has
+        // to keep the general plan.
+        if !leaves.iter().all(|leaf| {
+            leaf.column() == first.column()
+                && matches!(leaf.resolution, Some(FtsAccessPath::Index { .. }))
+                && self
+                    .context
+                    .fts_unindexed_fragments(leaf.column(), leaf.granularity())
+                    .is_none_or(|unindexed| unindexed.is_empty())
+        }) {
+            return Ok(Transformed::no(plan));
+        }
+        let Some(index) = self.context.fts_index(first.column(), first.granularity()) else {
+            return Ok(Transformed::no(plan));
+        };
+        if contains_phrase_query(&compound.query) && !index.with_position {
+            return Ok(Transformed::no(plan));
+        }
+
+        Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+            node: Arc::new(FtsCompoundScorerNode {
+                input: first.input.clone(),
+                dataset: first.dataset.clone(),
+                query: compound.query.clone(),
+                params: compound.params.clone(),
+                segments: index.segments.clone(),
+                // Computed here rather than read off the leaf: this rule may collapse the
+                // subtree before `ResolvePrefilterSource` has visited it.
+                prefilter: super::super::prefilter_kind(&first.input),
+                schema: compound.schema.clone(),
+            }),
+        })))
+    }
+}
+
+/// The FTS half of [`SplitOnIndexCoverage`](SplitOnIndexCoverage).
+///
+/// Structurally simpler than the vector half: there is no re-rank, because BM25 scores from the
+/// two branches are directly comparable. The merge is a stock `Union` + `Sort` + `Limit`, which is
+/// exactly what `Scanner::combine_fts_leaf_plans` builds by hand.
+impl SplittableSearch for FtsLeafNode {
+    fn is_splittable(&self) -> bool {
+        matches!(self.resolution, Some(FtsAccessPath::Index { .. }))
+    }
+
+    fn coverage(&self, context: &ScanPlanningContext) -> IndexCoverage {
+        let staleness = context
+            .fts_index(self.column(), self.granularity())
+            .map(|index| &index.staleness)
+            .unwrap_or(&OverlayStaleness::None);
+        let stale = match staleness {
+            OverlayStaleness::Rows(rows) => Some(rows.clone()),
+            OverlayStaleness::None => None,
+            // A BM25 score depends on the whole indexed document set, so a segment that cannot say
+            // which rows it indexed has nothing salvageable once an overlay touches it.
+            OverlayStaleness::Unknown => return IndexCoverage::Unusable,
+        };
+
+        let (Some(unindexed), Some(indexed)) = (
+            context.fts_unindexed_fragments(self.column(), self.granularity()),
+            context.fts_indexed_fragments(self.column(), self.granularity()),
+        ) else {
+            return IndexCoverage::Complete;
+        };
+        // Nothing is indexed among the fragments we will touch: this is a flat search that happens
+        // to have an index sitting next to it.
+        if indexed.is_empty() {
+            return IndexCoverage::Unusable;
+        }
+        if unindexed.is_empty() && stale.is_none() {
+            return IndexCoverage::Complete;
+        }
+
+        let mut gaps = Vec::with_capacity(2);
+        if !unindexed.is_empty() {
+            gaps.push(ScanRestriction::Fragments(Arc::new(unindexed)));
+        }
+        if let Some(rows) = &stale {
+            gaps.push(ScanRestriction::Rows(rows.clone()));
+        }
+        IndexCoverage::Partial {
+            indexed: Some(indexed),
+            gaps,
+            block: stale,
+        }
+    }
+
+    fn input(&self) -> &LogicalPlan {
+        &self.input
+    }
+
+    fn indexed_branch(
+        &self,
+        input: LogicalPlan,
+        block: Option<Arc<RowAddrTreeMap>>,
+    ) -> LogicalPlan {
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(self.clone().with_input(input).with_overlay_block(block)),
+        })
+    }
+
+    fn flat_branch(&self, input: LogicalPlan) -> LogicalPlan {
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                self.clone()
+                    .with_input(input)
+                    .with_resolution(FtsAccessPath::Flat)
+                    .with_prefilter(PrefilterSourceKind::None)
+                    .with_overlay_block(None),
+            ),
+        })
+    }
+
+    fn merge(
+        &self,
+        indexed: LogicalPlan,
+        flat: LogicalPlan,
+        _context: &ScanPlanningContext,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        // This merge ranks the two branches' scores against each other, which is only meaningful
+        // once they agree on the corpus they scored against — see `FtsLeafNode::shared_scorer`.
+        // Linking them here rather than in the branch constructors is not incidental: this is the
+        // only point at which one caller holds both halves.
+        let (indexed, flat) = match self.granularity.is_list_element() {
+            true => share_corpus_statistics(indexed, flat)?,
+            false => (indexed, flat),
+        };
+        let mut merged = LogicalPlanBuilder::new(indexed)
+            .union(flat)?
+            .sort(vec![datafusion::prelude::col(SCORE_COL).sort(false, false)])?;
+        if let Some(limit) = self.params.limit {
+            merged = merged.limit(0, Some(limit))?;
+        }
+        merged.build()
+    }
+}
+
+/// Point both branches of a split leaf at one rendezvous for corpus statistics.
+fn share_corpus_statistics(
+    indexed: LogicalPlan,
+    flat: LogicalPlan,
+) -> datafusion::common::Result<(LogicalPlan, LogicalPlan)> {
+    let leaf = |plan: &LogicalPlan| match plan {
+        LogicalPlan::Extension(extension) => extension
+            .node
+            .as_any()
+            .downcast_ref::<FtsLeafNode>()
+            .cloned(),
+        _ => None,
+    };
+    let (Some(indexed_leaf), Some(flat_leaf)) = (leaf(&indexed), leaf(&flat)) else {
+        return plan_err!("a split FTS leaf's branches must both be FTS leaves");
+    };
+    let scorer = Arc::new(SharedFtsScorer::new());
+    Ok((
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(indexed_leaf.with_shared_scorer(Some(scorer.clone()))),
+        }),
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(flat_leaf.with_shared_scorer(Some(scorer))),
+        }),
+    ))
+}
+
+fn supports_compound_scorer(query: &FtsQuery) -> bool {
+    fn supports_shape(query: &FtsQuery) -> bool {
+        match query {
+            FtsQuery::Match(_) | FtsQuery::Phrase(_) | FtsQuery::MultiMatch(_) => true,
+            FtsQuery::Boolean(query) => {
+                (!query.should.is_empty() || !query.must.is_empty())
+                    && query
+                        .should
+                        .iter()
+                        .chain(&query.must)
+                        .chain(&query.must_not)
+                        .all(supports_shape)
+            }
+            FtsQuery::Boost(query) => {
+                supports_shape(&query.positive) && supports_shape(&query.negative)
+            }
+        }
+    }
+    !matches!(query, FtsQuery::Match(_) | FtsQuery::Phrase(_)) && supports_shape(query)
+}
+
+fn contains_phrase_query(query: &FtsQuery) -> bool {
+    match query {
+        FtsQuery::Phrase(_) => true,
+        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) => false,
+        FtsQuery::Boost(query) => {
+            contains_phrase_query(&query.positive) || contains_phrase_query(&query.negative)
+        }
+        FtsQuery::Boolean(query) => query
+            .should
+            .iter()
+            .chain(&query.must)
+            .chain(&query.must_not)
+            .any(contains_phrase_query),
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/fts/scorer.rs
+++ b/rust/lance/src/dataset/scanner/logical/fts/scorer.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The compound scorer node, which scores a whole compound subtree in one pass
+//! instead of scoring each leaf and combining the results afterwards.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::common::{DFSchemaRef, DataFusionError};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use lance_core::ROW_ID;
+use lance_index::scalar::inverted::query::{FtsQuery, FtsSearchParams};
+use lance_table::format::IndexMetadata;
+
+use super::super::PrefilterSourceKind;
+use crate::dataset::Dataset;
+
+/// A whole compound query answered by one posting-list scorer.
+///
+/// Produced by [`UseFtsCompoundScorer`], which collapses a qualifying `FtsCompound` subtree — and
+/// with it every leaf and every leaf's copy of the prefilter — into this single node.
+#[derive(Debug, Clone)]
+pub struct FtsCompoundScorerNode {
+    /// The prefilter subtree, kept even when unused so the node has an input to plan.
+    pub(super) input: LogicalPlan,
+    pub(super) dataset: Arc<Dataset>,
+    pub(super) query: FtsQuery,
+    pub(super) params: FtsSearchParams,
+    pub(super) segments: Vec<IndexMetadata>,
+    pub(super) prefilter: PrefilterSourceKind,
+    pub(super) schema: DFSchemaRef,
+}
+
+impl PartialEq for FtsCompoundScorerNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input && self.query == other.query && self.prefilter == other.prefilter
+    }
+}
+
+impl Eq for FtsCompoundScorerNode {}
+
+impl Hash for FtsCompoundScorerNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+        self.query.to_string().hash(state);
+        self.prefilter.hash(state);
+    }
+}
+
+impl PartialOrd for FtsCompoundScorerNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.input.partial_cmp(&other.input)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for FtsCompoundScorerNode {
+    fn name(&self) -> &str {
+        "FtsCompoundScorer"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FtsCompoundScorer: query={}, segments={}, limit={:?}",
+            self.query,
+            self.segments.len(),
+            self.params.limit
+        )?;
+        if self.prefilter != PrefilterSourceKind::None {
+            write!(f, ", prefilter={}", self.prefilter)?;
+        }
+        Ok(())
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
+        if !exprs.is_empty() || inputs.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "FtsCompoundScorer takes exactly one input and no expressions".into(),
+            ));
+        }
+        let mut node = self.clone();
+        node.input = inputs.remove(0);
+        Ok(node)
+    }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        let needed = self
+            .input
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, field)| field.name() == ROW_ID)
+            .map(|(idx, _)| idx)
+            .collect();
+        Some(vec![needed])
+    }
+}

--- a/rust/lance/src/dataset/scanner/logical/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/mod.rs
@@ -88,17 +88,20 @@
 //! scan_index   recording on each scan how it finds its rows (index query, or a take)
 //! planner      stage 4: dispatch to each node's lowering
 //! take/        late materialization
-//! vector/      node, rerank, rules, planner
+//! vector/      node, rerank, rules, planner   <- five entry points
+//! fts/         node, rules, planner, prefetch <- the same five
 //! ```
 //!
-//! The design doc proposes that an index type could one day ship its own planning support, so
-//! `vector/` reaches the framework through a fixed set of entry points rather than reaching into
-//! it. Rule *ordering* stays here, in [`analyzer_rules`] and [`optimizer_rules`], because it is a
-//! whole-plan property that no single index can decide.
+//! `vector/` and `fts/` are deliberately symmetrical. The design doc proposes that an index type
+//! could one day ship its own planning support; two index types reaching the framework through the
+//! same five entry points is what makes that a claim rather than a guess. Rule *ordering* stays
+//! here, in [`analyzer_rules`] and [`optimizer_rules`], because it is a whole-plan property that no
+//! single index can decide.
 
 pub(super) mod builder;
 pub(super) mod context;
 pub(super) mod coverage;
+pub(super) mod fts;
 pub(super) mod planner;
 pub(super) mod prepare;
 pub(super) mod rules;
@@ -305,8 +308,11 @@ fn planning_state(scanner: &Scanner) -> Arc<SessionState> {
 /// this stage's behavior without the change being visible here.
 fn analyzer_rules(context: &Arc<ScanPlanningContext>) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     let mut rules = Analyzer::new().rules;
+    rules.push(Arc::new(ResolveVectorAccessPath::new(context.clone())));
+    // The FTS rules are contributed as a block by the module that owns the FTS nodes, which is
+    // the closest the spike gets to the doc's "each index plugin provides its own rules".
+    rules.extend(fts::analyzer_rules(context));
     rules.extend::<Vec<Arc<dyn AnalyzerRule + Send + Sync>>>(vec![
-        Arc::new(ResolveVectorAccessPath::new(context.clone())),
         // Before the split and the refine, so both see plain single-query searches.
         Arc::new(ExpandBatchSearch),
         Arc::new(SplitOnIndexCoverage::searches(context.clone())),
@@ -327,7 +333,8 @@ fn analyzer_rules(context: &Arc<ScanPlanningContext>) -> Vec<Arc<dyn AnalyzerRul
 fn optimizer_rules(
     context: &Arc<ScanPlanningContext>,
 ) -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
-    vec![
+    let mut rules = fts::optimizer_rules(context);
+    rules.extend::<Vec<Arc<dyn OptimizerRule + Send + Sync>>>(vec![
         Arc::new(SimplifyExpressions::new()),
         Arc::new(PushDownFilter::new()),
         // The rest of this list is mandatory work that could not run in the analyzer, because each
@@ -345,7 +352,8 @@ fn optimizer_rules(
         // what moves it there.
         Arc::new(ResolvePrefilterSource::new(context.clone())),
         Arc::new(OptimizeProjections::new()),
-    ]
+    ]);
+    rules
 }
 
 /// The physical rule set: Lance's own rules, plus the stock DataFusion rules that hand-built
@@ -407,6 +415,7 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         // Read by the builder, the source, the context, or the session config.
         prefilter: _,
         filter: _,
+        full_text_query,
         batch_size: _,
         batch_readahead: _,
         fragment_readahead: _,
@@ -415,7 +424,6 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         offset: _,
         ordering: _,
         nearest,
-        full_text_query,
         use_scalar_index: _,
         fragments: _,
         fast_search: _,
@@ -447,11 +455,6 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         nearest_query_count: _,
     } = scanner;
 
-    if full_text_query.is_some() {
-        return Err(Error::not_supported_source(
-            "The logical scan planner cannot plan a full-text search yet".into(),
-        ));
-    }
     if reads_row_offset(scanner)? {
         // `_rowoffset` is computed above the scan rather than read from it, so producing it needs a
         // node this path does not have yet.
@@ -459,7 +462,7 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
             "The logical scan planner cannot produce _rowoffset yet".into(),
         ));
     }
-    if *include_deleted_rows && nearest.is_some() {
+    if *include_deleted_rows && (nearest.is_some() || full_text_query.is_some()) {
         // The imperative path rejects these in `vector_search_source`/`fts_search_source` for the
         // same reason: a search returns row ids, and a deleted row does not have one.
         return Err(Error::invalid_input_source(
@@ -467,6 +470,7 @@ fn ensure_supported(scanner: &Scanner) -> Result<()> {
         ));
     }
     if nearest.is_none()
+        && full_text_query.is_none()
         && projection_plan.has_output_cols()
         && projection_plan.physical_projection.is_empty()
     {

--- a/rust/lance/src/dataset/scanner/logical/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/planner.rs
@@ -38,6 +38,9 @@ impl ExtensionPlanner for LanceExtensionPlanner {
         _session_state: &SessionState,
     ) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
         // FTS owns its own nodes, rules, and lowering; ask that module first.
+        if let Some(plan) = super::fts::plan_extension(node, physical_inputs) {
+            return Ok(Some(plan?));
+        }
 
         let input = physical_inputs.first().cloned().ok_or_else(|| {
             datafusion::common::DataFusionError::Internal(

--- a/rust/lance/src/dataset/scanner/logical/prepare.rs
+++ b/rust/lance/src/dataset/scanner/logical/prepare.rs
@@ -3,9 +3,16 @@
 
 //! Stage 0: normalize the scanner's queries before the plan is built.
 //!
-//! Stage 1 is synchronous, and a search query may carry fields that take I/O to fill in, so
-//! whatever resolving they need happens here.
+//! This stage exists only because of full-text search, and it is the one place the design doc's
+//! four-stage model needed extending. An [`FtsQuery`](lance_index::scalar::inverted::query::FtsQuery)
+//! may omit both the column it searches and its document granularity, and filling them in means
+//! asking which columns carry an inverted index — I/O. Stage 1 is synchronous, and a node's
+//! output schema depends on the granularity, so the question cannot be deferred into a rule
+//! either.
+//!
+//! The vector path needs nothing here: a `Query` always names its column.
 
+use lance_index::scalar::FullTextSearchQuery;
 use lance_index::vector::Query;
 
 use super::super::QueryFilter;
@@ -15,15 +22,41 @@ use crate::dataset::Scanner;
 /// The scanner's search queries, with every implicit field resolved.
 #[derive(Debug, Default)]
 pub struct PreparedQueries {
+    pub full_text: Option<FullTextSearchQuery>,
+    pub fts_filter: Option<FullTextSearchQuery>,
     pub vector_filter: Option<Query>,
+    /// Whether the full-text query scores list elements rather than whole rows. Decides whether
+    /// `_doc_index` is part of the output.
+    pub element_granularity: bool,
 }
 
 impl PreparedQueries {
     pub async fn resolve(scanner: &Scanner) -> Result<Self> {
-        let vector_filter = match &scanner.filter.query_filter {
-            Some(QueryFilter::Vector(query)) => Some(query.clone()),
-            _ => None,
+        let full_text = match &scanner.full_text_query {
+            Some(query) => Some(scanner.resolve_full_text_search_query(query).await?),
+            None => None,
         };
-        Ok(Self { vector_filter })
+        let (fts_filter, vector_filter) = match &scanner.filter.query_filter {
+            Some(QueryFilter::Fts(query)) => (
+                Some(scanner.resolve_full_text_search_query(query).await?),
+                None,
+            ),
+            Some(QueryFilter::Vector(query)) => (None, Some(query.clone())),
+            None => (None, None),
+        };
+
+        let element_granularity = match &full_text {
+            Some(query) => scanner
+                .fts_document_granularity(&query.query)?
+                .is_list_element(),
+            None => false,
+        };
+
+        Ok(Self {
+            full_text,
+            fts_filter,
+            vector_filter,
+            element_granularity,
+        })
     }
 }

--- a/rust/lance/src/dataset/scanner/logical/tests/fts.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/fts.rs
@@ -1,0 +1,882 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Full-text search, including hybrid queries that combine it with vector search.
+
+use arrow_array::RecordBatch;
+use std::sync::Arc;
+
+use crate::dataset::{Dataset, Scanner};
+
+use super::harness::*;
+
+// ---------------------------------------------------------------------------------------------
+// Full-text search
+// ---------------------------------------------------------------------------------------------
+
+/// Text with enough shared vocabulary that boolean and boost queries actually select subsets.
+pub(super) fn fts_text(row: i32) -> String {
+    const WORDS: [&str; 4] = ["hello", "world", "lance", "search"];
+    let mut terms = vec![format!("doc{row}")];
+    for (index, word) in WORDS.iter().enumerate() {
+        if (row as usize).is_multiple_of(index + 2) {
+            terms.push((*word).to_string());
+        }
+    }
+    terms.join(" ")
+}
+
+/// Whether the fixture's document for `row` contains `term`.
+///
+/// Stated from [`fts_text`] rather than from a modulus, so the expectations stay true if the
+/// fixture's vocabulary changes.
+pub(super) fn contains(term: &'static str) -> impl Fn(i32) -> bool + Copy {
+    move |row| fts_text(row).split(' ').any(|word| word == term)
+}
+
+/// Whether the fixture's document for `row` contains `phrase` as consecutive words.
+pub(super) fn contains_phrase(phrase: &'static str) -> impl Fn(i32) -> bool + Copy {
+    move |row| fts_text(row).contains(phrase)
+}
+
+/// The tags the list-element fixture gives `row`: its own document and its successors', one more
+/// of them every third row, so a row can match on an element that is not its own.
+pub(super) fn list_element_tags(row: i32) -> Vec<String> {
+    (0..(row % 3) + 1)
+        .map(|element| fts_text(row + element))
+        .collect()
+}
+
+/// Whether any of `row`'s tags contains `term`.
+pub(super) fn any_tag_contains(term: &'static str) -> impl Fn(i32) -> bool + Copy {
+    move |row| {
+        list_element_tags(row)
+            .iter()
+            .any(|tag| tag.split(' ').any(|word| word == term))
+    }
+}
+
+/// Whether any of `row`'s tags contains `phrase` as consecutive words.
+pub(super) fn any_tag_contains_phrase(phrase: &'static str) -> impl Fn(i32) -> bool + Copy {
+    move |row| {
+        list_element_tags(row)
+            .iter()
+            .any(|tag| tag.contains(phrase))
+    }
+}
+
+/// `[i, s, vec]` — the vector column is here so the FTS/vector `query_filter` combinations can be
+/// tested on the same fixture. Values are a deterministic function of the row so both planning
+/// paths see identical data.
+pub(super) fn fts_data(start: i32, count: i32) -> Box<dyn arrow_array::RecordBatchReader + Send> {
+    use arrow_array::{
+        FixedSizeListArray, Float32Array, Int32Array, RecordBatchIterator, StringArray,
+    };
+    use arrow_schema::{DataType, Field, Schema};
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("i", DataType::Int32, false),
+        Field::new("s", DataType::Utf8, false),
+        Field::new(
+            "vec",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            true,
+        ),
+    ]));
+    let rows = start..start + count;
+    let vectors = Float32Array::from(
+        rows.clone()
+            .flat_map(|row| (0..DIM).map(move |dim| (row + dim as i32) as f32 % 17.0))
+            .collect::<Vec<_>>(),
+    );
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(rows.clone().collect::<Vec<_>>())),
+            Arc::new(StringArray::from(rows.map(fts_text).collect::<Vec<_>>())),
+            Arc::new(
+                FixedSizeListArray::try_new(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIM as i32,
+                    Arc::new(vectors),
+                    None,
+                )
+                .unwrap(),
+            ),
+        ],
+    )
+    .unwrap();
+    Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema))
+}
+
+/// A two-fragment dataset with an inverted index covering everything.
+pub(super) async fn fts_dataset() -> Dataset {
+    use crate::dataset::WriteParams;
+    use crate::index::DatasetIndexExt;
+    use lance_index::IndexType;
+    use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+    let mut dataset = Dataset::write(
+        fts_data(0, 200),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 100,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    // Positions are required for phrase queries; stop words are kept so short tokens stay
+    // searchable, matching the scanner's own FTS fixtures.
+    let params = InvertedIndexParams::default()
+        .with_position(true)
+        .remove_stop_words(false);
+    dataset
+        .create_index(&["s"], IndexType::Inverted, None, &params, true)
+        .await
+        .unwrap();
+    dataset
+}
+
+/// The same dataset with rows appended after the index was built.
+pub(super) async fn partially_indexed_fts_dataset() -> Dataset {
+    use crate::dataset::{WriteMode, WriteParams};
+
+    let mut dataset = fts_dataset().await;
+    dataset
+        .append(
+            fts_data(1000, 60),
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    dataset
+}
+
+/// `with_fragments` narrower than the index's coverage. The index still scores every fragment it
+/// covers, so the restriction is enforced by the take above the search.
+#[tokio::test]
+pub(super) async fn test_fts_with_a_fragment_restriction() {
+    let dataset = fts_dataset().await;
+    // The first fragment holds the first 100 rows, so the restriction is what keeps the index's
+    // hits from the second fragment out of the answer.
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            let first = vec![dataset_fragments(scan)[0].clone()];
+            scan.project(&["s"])?
+                .with_row_id()
+                .with_fragments(first)
+                .full_text_search(match_query("hello"))
+        },
+        |row| contains("hello")(row) && row < 100,
+    )
+    .await
+    .unwrap();
+}
+
+/// `Scanner::fragments` is private to the scanner module, and a `ScanConfig` closure has no other
+/// handle on the dataset, so read the list off the scanner itself.
+pub(super) fn dataset_fragments(scan: &Scanner) -> &[lance_table::format::Fragment] {
+    scan.dataset.fragments()
+}
+
+/// A `list<utf8>` text column with a list-element-granularity inverted index.
+///
+/// The distinct thing about this shape is the schema: hits are `(row, element)` pairs, so the FTS
+/// nodes carry a `_doc_index` column and the same row can appear more than once.
+pub(super) async fn list_element_fts_dataset() -> Dataset {
+    use crate::dataset::WriteParams;
+    use crate::index::DatasetIndexExt;
+    use arrow_array::builder::{ListBuilder, StringBuilder};
+    use arrow_array::{Int32Array, RecordBatchIterator};
+    use lance_index::IndexType;
+    use lance_index::scalar::inverted::DocumentGranularity;
+    use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+    let mut tags = ListBuilder::new(StringBuilder::new());
+    for row in 0..200 {
+        for tag in list_element_tags(row) {
+            tags.values().append_value(tag);
+        }
+        tags.append(true);
+    }
+    let batch = RecordBatch::try_from_iter(vec![
+        (
+            "i",
+            Arc::new(Int32Array::from((0..200).collect::<Vec<_>>())) as arrow_array::ArrayRef,
+        ),
+        ("tags", Arc::new(tags.finish()) as arrow_array::ArrayRef),
+    ])
+    .unwrap();
+    let schema = batch.schema();
+
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 100,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    dataset
+        .create_index(
+            &["tags"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default()
+                .with_position(true)
+                .remove_stop_words(false)
+                .document_granularity(DocumentGranularity::ListElement),
+            true,
+        )
+        .await
+        .unwrap();
+    dataset
+}
+
+pub(super) fn list_element_match_query(terms: &str) -> lance_index::scalar::FullTextSearchQuery {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::DocumentGranularity;
+    use lance_index::scalar::inverted::query::MatchQuery;
+
+    FullTextSearchQuery::new_query(
+        MatchQuery::new(terms.to_owned())
+            .with_column(Some("tags".to_owned()))
+            .with_document_granularity(DocumentGranularity::ListElement)
+            .into(),
+    )
+}
+
+/// A row matches if *any* of its tags does, so the same row can come back more than once — once
+/// per matching element.
+#[tokio::test]
+pub(super) async fn test_list_element_fts() {
+    let dataset = list_element_fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["i"])?
+                .with_row_id()
+                .full_text_search(list_element_match_query("hello"))
+        },
+        any_tag_contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_list_element_fts_prefilter() {
+    let dataset = list_element_fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["i"])?
+                .with_row_id()
+                .prefilter(true)
+                .filter("i > 10")?
+                .full_text_search(list_element_match_query("hello"))
+        },
+        |row| any_tag_contains("hello")(row) && row > 10,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_list_element_fts_phrase() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::DocumentGranularity;
+    use lance_index::scalar::inverted::query::PhraseQuery;
+
+    let dataset = list_element_fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["i"])?
+                .with_row_id()
+                .full_text_search(FullTextSearchQuery::new_query(
+                    PhraseQuery::new("hello world".to_owned())
+                        .with_column(Some("tags".to_owned()))
+                        .with_document_granularity(DocumentGranularity::ListElement)
+                        .into(),
+                ))
+        },
+        any_tag_contains_phrase("hello world"),
+    )
+    .await
+    .unwrap();
+}
+
+/// A vector query for use as a `QueryFilter::Vector`. `Query` has no builder, so every field is
+/// spelled out; `use_index` is false because there is no vector index on the FTS fixture.
+pub(super) fn vector_filter_query() -> lance_index::vector::Query {
+    use lance_index::vector::Query;
+    use lance_linalg::distance::DistanceType;
+
+    Query {
+        column: "vec".to_string(),
+        key: Arc::new(query_vector()),
+        k: 20,
+        lower_bound: None,
+        upper_bound: None,
+        minimum_nprobes: 1,
+        maximum_nprobes: None,
+        ef: None,
+        refine_factor: None,
+        metric_type: Some(DistanceType::L2),
+        use_index: false,
+        query_parallelism: 0,
+        dist_q_c: 0.0,
+        approx_mode: Default::default(),
+    }
+}
+
+pub(super) fn match_query(terms: &str) -> lance_index::scalar::FullTextSearchQuery {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::MatchQuery;
+    FullTextSearchQuery::new_query(
+        MatchQuery::new(terms.to_owned())
+            .with_column(Some("s".to_owned()))
+            .into(),
+    )
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_match_uses_the_index() {
+    let dataset = fts_dataset().await;
+
+    // The leaf lowered straight to a `MatchQuery` exec with no prefilter child, and the take
+    // above it is the ordinary late materialization every search gets.
+    //
+    // The `SortExec` is the relevance order the builder states above the take. Unlike the vector
+    // case it survives lowering, because no FTS operator advertises `_score DESC` as its output
+    // ordering — and several genuinely do not produce it, since a compound query's merge unions
+    // its branches.
+    assert_logical_plan(
+        &dataset,
+        |scan| scan.project(&["s"])?.full_text_search(match_query("hello")),
+        "ProjectionExec: expr=[s@2 as s, _score@1 as _score]
+  SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
+    LanceRead: uri=..., projection=[s], source=stream(_rowid)
+      MatchQuery: column=s, query=[hello]",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_match() {
+    let dataset = fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(match_query("hello"))
+        },
+        contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_phrase() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::PhraseQuery;
+
+    let dataset = fts_dataset().await;
+    // A phrase is stricter than its terms: a document with both words but not adjacent does not
+    // match, which is what separates this expectation from the boolean one below.
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(FullTextSearchQuery::new_query(
+                    PhraseQuery::new("hello world".to_owned())
+                        .with_column(Some("s".to_owned()))
+                        .into(),
+                ))
+        },
+        contains_phrase("hello world"),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_boost() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::{BoostQuery, MatchQuery};
+
+    let dataset = fts_dataset().await;
+    // A boost reweights the positive query's results; it does not add to or remove from them, so
+    // the matching set is the positive query's alone.
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            let positive = MatchQuery::new("hello".to_owned()).with_column(Some("s".to_owned()));
+            let negative = MatchQuery::new("world".to_owned()).with_column(Some("s".to_owned()));
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(FullTextSearchQuery::new_query(
+                    BoostQuery::new(positive.into(), negative.into(), Some(1.0)).into(),
+                ))
+        },
+        contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_boolean() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::{BooleanQuery, MatchQuery, Occur};
+
+    let dataset = fts_dataset().await;
+    // `should` only reweights: the set is decided by `must` and `must_not`.
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            let must = MatchQuery::new("hello".to_owned()).with_column(Some("s".to_owned()));
+            let should = MatchQuery::new("lance".to_owned()).with_column(Some("s".to_owned()));
+            let excluded = MatchQuery::new("search".to_owned()).with_column(Some("s".to_owned()));
+            let query = BooleanQuery::new(vec![
+                (Occur::Must, must.into()),
+                (Occur::Should, should.into()),
+                (Occur::MustNot, excluded.into()),
+            ]);
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(FullTextSearchQuery::new_query(query.into()))
+        },
+        |row| contains("hello")(row) && !contains("search")(row),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_multi_match() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::MultiMatchQuery;
+
+    let dataset = fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(FullTextSearchQuery::new_query(
+                    MultiMatchQuery::try_new("hello".to_owned(), vec!["s".to_owned()])
+                        .unwrap()
+                        .into(),
+                ))
+        },
+        contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+/// The compound-scorer fast path is a rule that collapses a whole subtree — leaves, and each
+/// leaf's copy of the prefilter — into one posting-list scorer.
+#[tokio::test]
+pub(super) async fn test_fts_boost_collapses_to_a_compound_scorer() {
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::{BoostQuery, MatchQuery};
+
+    let dataset = fts_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        let positive = MatchQuery::new("hello".to_owned()).with_column(Some("s".to_owned()));
+        let negative = MatchQuery::new("world".to_owned()).with_column(Some("s".to_owned()));
+        scan.project(&["s"])?
+            .full_text_search(FullTextSearchQuery::new_query(
+                BoostQuery::new(positive.into(), negative.into(), Some(1.0)).into(),
+            ))
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+    assert!(text.contains("CompoundFtsScorer"), "{text}");
+    assert!(!text.contains("BoostQuery"), "{text}");
+}
+
+/// The same structural claim the vector path makes: a predicate below the search becomes the
+/// prefilter source, visible here as the `MatchQuery`'s child.
+#[tokio::test]
+pub(super) async fn test_fts_prefilter_feeds_the_index() {
+    let dataset = fts_dataset().await;
+
+    assert_logical_plan(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .prefilter(true)
+                .filter("i > 10")?
+                .full_text_search(match_query("hello"))
+        },
+        "ProjectionExec: expr=[s@2 as s, _score@1 as _score]
+  SortExec: expr=[_score@1 DESC NULLS LAST, _rowid@0 ASC NULLS LAST], preserve_partitioning=[false]
+    LanceRead: uri=..., projection=[s], source=stream(_rowid)
+      MatchQuery: column=s, query=[hello]
+        LanceRead: uri=..., projection=[], num_fragments=2, range_before=None, range_after=None, \
+        row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=i > Int32(10)",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_prefilter() {
+    let dataset = fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(true)
+                .filter("i > 10")?
+                .full_text_search(match_query("hello"))
+        },
+        |row| contains("hello")(row) && row > 10,
+    )
+    .await
+    .unwrap();
+}
+
+/// An unbounded search reaches the same set either way; the difference between the two is which
+/// operator applies the predicate, not what survives it.
+#[tokio::test]
+pub(super) async fn test_fts_postfilter() {
+    let dataset = fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(false)
+                .filter("i > 10")?
+                .full_text_search(match_query("hello"))
+        },
+        |row| contains("hello")(row) && row > 10,
+    )
+    .await
+    .unwrap();
+}
+
+/// `doc7` appears in exactly one document, so the limit has nothing to truncate.
+#[tokio::test]
+pub(super) async fn test_fts_limit() {
+    let dataset = fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(match_query("doc7"))?
+                .limit(Some(3), None)
+        },
+        |row| row == 7,
+    )
+    .await
+    .unwrap();
+}
+
+/// An index that covers only some fragments splits into an indexed branch and a flat branch,
+/// merged by a stock `Union` + `Sort` + `Limit`.
+#[tokio::test]
+pub(super) async fn test_partially_indexed_fts_splits() {
+    let dataset = partially_indexed_fts_dataset().await;
+
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.project(&["s"])?.full_text_search(match_query("hello"))
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+    assert!(text.contains("UnionExec"), "no union in plan:\n{text}");
+    assert!(text.contains("MatchQuery:"), "no indexed branch:\n{text}");
+    assert!(text.contains("FlatMatchQuery:"), "no flat branch:\n{text}");
+}
+
+#[tokio::test]
+pub(super) async fn test_partially_indexed_fts_finds_both_halves() {
+    let dataset = partially_indexed_fts_dataset().await;
+    // The appended rows are 1000..1060 and were never indexed, so a result set that stops at 199
+    // means the flat branch went missing.
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(match_query("hello"))
+        },
+        contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+pub(super) async fn test_partially_indexed_fts_prefilter() {
+    let dataset = partially_indexed_fts_dataset().await;
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(true)
+                .filter("i > 10")?
+                .full_text_search(match_query("hello"))
+        },
+        |row| contains("hello")(row) && row > 10,
+    )
+    .await
+    .unwrap();
+}
+
+/// `fast_search` drops the flat branch entirely rather than merging it.
+#[tokio::test]
+pub(super) async fn test_fast_search_skips_the_flat_branch() {
+    let dataset = partially_indexed_fts_dataset().await;
+
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.project(&["s"])?
+            .fast_search()
+            .full_text_search(match_query("hello"))
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+    assert!(text.contains("MatchQuery:"), "{text}");
+    assert!(!text.contains("FlatMatchQuery:"), "{text}");
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_without_an_index() {
+    use crate::dataset::WriteParams;
+
+    let dataset = Dataset::write(
+        fts_data(0, 200),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 100,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_fts_matches(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .full_text_search(match_query("hello"))
+        },
+        contains("hello"),
+    )
+    .await
+    .unwrap();
+}
+
+/// The `i` values a hybrid query should return, from the two halves computed separately.
+///
+/// The whole content of the prefilter/postfilter switch is the order the two are applied in, so
+/// stating both orders here is stating the thing under test:
+///
+/// * prefiltered — the filter picks the candidates, and the search ranks what is left, so the `k`
+///   is spent entirely on rows that match.
+/// * postfiltered — the search picks its `k` first and the filter trims them, so fewer than `k`
+///   rows come back.
+pub(super) async fn hybrid_expectation(
+    dataset: &Dataset,
+    matches: impl Fn(i32) -> bool,
+    k: usize,
+    prefilter: bool,
+) -> Vec<i32> {
+    use lance_linalg::distance::DistanceType;
+
+    let ranked = exact_neighbors(dataset, &query_vector(), DistanceType::L2, usize::MAX)
+        .await
+        .unwrap();
+    let mut expected = match prefilter {
+        true => ranked.into_iter().filter(|i| matches(*i)).take(k).collect(),
+        false => ranked
+            .into_iter()
+            .take(k)
+            .filter(|i| matches(*i))
+            .collect::<Vec<_>>(),
+    };
+    expected.sort_unstable();
+    expected
+}
+
+/// Assert a hybrid query returned exactly `expected`, whatever order the two searches leave it in.
+/// Which of a hybrid query's two searches decides the order of its results.
+///
+/// Only the equivalence check reads this: relevance ties are broken by row id here and not at all
+/// on the imperative path, so a relevance-ordered result is compared as a set. Distance-ordered
+/// results are compared in order.
+enum ResultOrder {
+    Distance,
+    Relevance,
+}
+
+async fn assert_hybrid(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    order: ResultOrder,
+    expected: Vec<i32>,
+) {
+    let fixture = Fixture::read(dataset).await.unwrap();
+    let batch = match order {
+        ResultOrder::Distance => scan_rows(dataset, config).await.unwrap(),
+        ResultOrder::Relevance => scan_rows_unordered(dataset, config).await.unwrap(),
+    };
+    let mut found = fixture.ids_of(&row_ids_of(&batch));
+    found.sort_unstable();
+    found.dedup();
+    assert!(!expected.is_empty(), "the fixture must produce some hits");
+    assert_eq!(found, expected);
+}
+
+/// A `query_filter` is only legal alongside the *other* kind of search, and it obeys the same
+/// prefilter/postfilter switch: below the search it supplies the candidates, above it trims the
+/// results. All four combinations are here because each lowers to a different node.
+#[tokio::test]
+pub(super) async fn test_fts_filter_postfiltering_a_vector_search() {
+    use crate::dataset::scanner::QueryFilter;
+
+    let dataset = fts_dataset().await;
+    let expected = hybrid_expectation(&dataset, contains("hello"), 20, false).await;
+    assert_hybrid(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(false)
+                .nearest("vec", &query_vector(), 20)?
+                .filter_query(QueryFilter::Fts(match_query("hello")))
+        },
+        ResultOrder::Distance,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+pub(super) async fn test_fts_filter_prefiltering_a_vector_search() {
+    use crate::dataset::scanner::QueryFilter;
+
+    let dataset = fts_dataset().await;
+    let expected = hybrid_expectation(&dataset, contains("hello"), 20, true).await;
+    assert_hybrid(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(true)
+                .nearest("vec", &query_vector(), 20)?
+                .filter_query(QueryFilter::Fts(match_query("hello")))
+        },
+        ResultOrder::Distance,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+pub(super) async fn test_vector_filter_postfiltering_an_fts_search() {
+    use crate::dataset::scanner::QueryFilter;
+
+    let dataset = fts_dataset().await;
+    // The vector query re-ranks the FTS hits and keeps its own `k` of them, so the roles are
+    // reversed: the text query supplies the candidates.
+    let expected = hybrid_expectation(&dataset, contains("hello"), 20, true).await;
+    assert_hybrid(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(false)
+                .full_text_search(match_query("hello"))?
+                .filter_query(QueryFilter::Vector(vector_filter_query()))
+        },
+        ResultOrder::Relevance,
+        expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+pub(super) async fn test_vector_filter_prefiltering_an_fts_search() {
+    use crate::dataset::scanner::QueryFilter;
+
+    let dataset = fts_dataset().await;
+    // Prefiltering runs the vector search first, so its `k` is spent before the text query sees
+    // anything: only the hits among those 20 rows survive.
+    let expected = hybrid_expectation(&dataset, contains("hello"), 20, false).await;
+    assert_hybrid(
+        &dataset,
+        |scan| {
+            scan.project(&["s"])?
+                .with_row_id()
+                .prefilter(true)
+                .full_text_search(match_query("hello"))?
+                .filter_query(QueryFilter::Vector(vector_filter_query()))
+        },
+        ResultOrder::Relevance,
+        expected,
+    )
+    .await;
+}
+
+/// The same take-nothing rule a vector search gets: `COUNT(*)` over a text search reads no columns,
+/// so the late materialization above the search drops out instead of fetching the projection the
+/// aggregate is about to discard.
+#[tokio::test]
+pub(super) async fn test_a_count_over_an_fts_search_reads_no_columns() {
+    use crate::dataset::scanner::AggregateExpr;
+
+    let dataset = fts_dataset().await;
+    let plan = logical_plan_for(&dataset, |scan| {
+        scan.full_text_search(match_query("hello"))?
+            .aggregate(AggregateExpr::builder().count_star().build())
+    })
+    .await
+    .unwrap();
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+    );
+
+    assert!(
+        !text.contains("LanceRead"),
+        "the take is still fetching columns the aggregate discards:\n{text}"
+    );
+    let batch = run(plan).await.unwrap();
+    assert_eq!(batch.num_rows(), 1);
+}

--- a/rust/lance/src/dataset/scanner/logical/tests/harness.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/harness.rs
@@ -70,6 +70,35 @@ pub(super) async fn assert_logical_plan(
     assert_plan_node_equals(plan, expected).await
 }
 
+/// A result's rows as a sorted multiset, for comparing two plans that need not agree on order.
+///
+/// Rendered rather than sorted in place because no sort key over the columns is guaranteed to be
+/// total: a list-element full-text search returns one row per matching element, so the same row id
+/// can appear twice with the same score and differ only in a `List` column, which Arrow's lexsort
+/// cannot order. Rendering every column and sorting the strings compares the rows a caller would
+/// actually see, whatever their types.
+pub(super) fn row_multiset(batch: &RecordBatch) -> Result<Vec<String>> {
+    use arrow::util::display::{ArrayFormatter, FormatOptions};
+
+    let formatters = batch
+        .columns()
+        .iter()
+        .map(|column| ArrayFormatter::try_new(column.as_ref(), &FormatOptions::default()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let mut rows = (0..batch.num_rows())
+        .map(|row| {
+            formatters
+                .iter()
+                .map(|formatter| formatter.value(row).to_string())
+                .collect::<Vec<_>>()
+                .join(" | ")
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    Ok(rows)
+}
+
 pub(super) async fn run(plan: Arc<dyn ExecutionPlan>) -> Result<RecordBatch> {
     let schema = plan.schema();
     let batches = execute_plan(plan, LanceExecutionOptions::default())?
@@ -176,8 +205,29 @@ pub(super) fn row_ids_of(batch: &RecordBatch) -> Vec<u64> {
 /// leaves with the imperative path.
 ///
 /// Row order is compared because it is observable: a path that returns the right rows in a
-/// different order has still changed what a caller sees.
+/// different order has still changed what a caller sees. Reach for [`scan_rows_unordered`] only
+/// where the two paths genuinely have no shared order to agree on.
 pub(super) async fn scan_rows(dataset: &Dataset, config: impl ScanConfig) -> Result<RecordBatch> {
+    scan_rows_compared(dataset, config, false).await
+}
+
+/// As [`scan_rows`], but comparing the two paths' rows as a set.
+///
+/// Only relevance ties need this: the logical path breaks them by row id and the imperative path
+/// does not break them at all, so there is no order for the two to agree on. What that order should
+/// be is asserted directly against the data instead.
+pub(super) async fn scan_rows_unordered(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+) -> Result<RecordBatch> {
+    scan_rows_compared(dataset, config, true).await
+}
+
+async fn scan_rows_compared(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    as_set: bool,
+) -> Result<RecordBatch> {
     let config = config_with_row_id(config);
     let actual = run(logical_plan_for(dataset, &config).await?).await?;
     let expected = run(imperative_plan_for(dataset, &config).await?).await?;
@@ -187,7 +237,15 @@ pub(super) async fn scan_rows(dataset: &Dataset, config: impl ScanConfig) -> Res
         actual.schema(),
         "logical path produced a different output schema"
     );
-    assert_eq!(expected, actual, "logical path produced different rows");
+    if as_set {
+        assert_eq!(
+            row_multiset(&expected)?,
+            row_multiset(&actual)?,
+            "logical path produced different rows"
+        );
+    } else {
+        assert_eq!(expected, actual, "logical path produced different rows");
+    }
     Ok(actual)
 }
 
@@ -456,4 +514,45 @@ pub(super) fn assert_distances_ascending(batch: &RecordBatch) {
         distances.windows(2).all(|pair| pair[0] <= pair[1]),
         "distances are not ascending: {distances:?}"
     );
+}
+
+/// Assert `_score` never increases down the result: relevance order, most relevant first.
+pub(super) fn assert_scores_descending(batch: &RecordBatch) {
+    use arrow::datatypes::Float32Type;
+    use arrow_array::cast::AsArray;
+
+    let scores = batch[lance_index::scalar::inverted::SCORE_COL]
+        .as_primitive::<Float32Type>()
+        .values();
+    assert!(
+        scores.windows(2).all(|pair| pair[0] >= pair[1]),
+        "scores are not descending: {scores:?}"
+    );
+}
+
+/// Assert a full-text search returned exactly the documents `matches` names, scored in descending
+/// order.
+///
+/// The row *set* is the part BM25 does not get a say in — a document either contains the terms or
+/// it does not — so it can be stated from the fixture's text. Within that set the ranking is the
+/// scorer's business, and only its direction is asserted here.
+pub(super) async fn assert_fts_matches(
+    dataset: &Dataset,
+    config: impl ScanConfig,
+    matches: impl Fn(i32) -> bool,
+) -> Result<()> {
+    let fixture = Fixture::read(dataset).await?;
+    // Unordered: relevance ties are exactly what the two paths order differently, and
+    // `assert_scores_descending` below is what pins the order that matters.
+    let actual = scan_rows_unordered(dataset, config).await?;
+    let row_ids = row_ids_of(&actual);
+
+    assert_scores_descending(&actual);
+    assert_columns_match(&actual, &fixture, &row_ids);
+
+    let mut found = fixture.ids_of(&row_ids);
+    found.sort_unstable();
+    found.dedup();
+    assert_eq!(found, fixture.ids_where(matches), "wrong documents matched");
+    Ok(())
 }

--- a/rust/lance/src/dataset/scanner/logical/tests/mod.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/mod.rs
@@ -6,6 +6,7 @@
 //! Most of these are equivalence tests: they build the same query through both the imperative and
 //! the logical path and compare the rows. See [`harness`] for that oracle.
 
+mod fts;
 mod harness;
 mod planner;
 mod scan;

--- a/rust/lance/src/dataset/scanner/logical/tests/planner.rs
+++ b/rust/lance/src/dataset/scanner/logical/tests/planner.rs
@@ -10,6 +10,7 @@ use lance_datagen::{Dimension, array, gen_batch};
 use crate::Result;
 use crate::dataset::scanner::ColumnOrdering;
 
+use super::fts::*;
 use super::harness::*;
 
 #[tokio::test]
@@ -68,6 +69,55 @@ async fn test_ordering_by_an_unprojected_column() {
     )
     .await
     .unwrap();
+}
+
+/// A vector `query_filter` under a *compound* FTS query takes the other rerank branch: the FTS
+/// query is planned independently and joined to the vector results on `_rowid`. That join is the
+/// only stock DataFusion join in the whole plan, and its physical form decides the output order —
+/// so this asserts ordering, not just row membership.
+#[tokio::test]
+async fn test_vector_filter_prefiltering_a_compound_fts_search() {
+    use crate::dataset::scanner::QueryFilter;
+    use lance_index::scalar::FullTextSearchQuery;
+    use lance_index::scalar::inverted::query::PhraseQuery;
+
+    let dataset = fts_dataset().await;
+    // Prefiltered, so the vector search spends its 20 first and the phrase trims what is left.
+    let expected = hybrid_expectation(&dataset, contains_phrase("hello world"), 20, false).await;
+    let fixture = Fixture::read(&dataset).await.unwrap();
+    let batch = scan_rows(&dataset, |scan| {
+        scan.project(&["s"])?
+            .with_row_id()
+            .prefilter(true)
+            .full_text_search(FullTextSearchQuery::new_query(
+                PhraseQuery::new("hello world".to_owned())
+                    .with_column(Some("s".to_owned()))
+                    .into(),
+            ))?
+            .filter_query(QueryFilter::Vector(vector_filter_query()))
+    })
+    .await
+    .unwrap();
+
+    let mut found = fixture.ids_of(&row_ids_of(&batch));
+    found.sort_unstable();
+    assert_eq!(found, expected);
+}
+
+/// An empty fragment selection is planned like any other: the search runs and the take, restricted
+/// to no fragments, returns nothing.
+#[tokio::test]
+async fn test_an_empty_fragment_selection_returns_nothing() {
+    let dataset = fts_dataset().await;
+    let batch = scan_rows(&dataset, |scan| {
+        scan.with_fragments(Vec::new());
+        scan.project(&["s"])?
+            .with_row_id()
+            .full_text_search(match_query("hello"))
+    })
+    .await
+    .unwrap();
+    assert_eq!(batch.num_rows(), 0);
 }
 
 /// A top-k whose result spans more than one output batch, at real parallelism. Regression test for

--- a/rust/lance/src/dataset/scanner/logical/vector/rules.rs
+++ b/rust/lance/src/dataset/scanner/logical/vector/rules.rs
@@ -20,6 +20,7 @@ use lance_linalg::distance::DistanceType;
 use lance_table::format::IndexMetadata;
 
 use super::super::context::ScanPlanningContext;
+use super::super::fts::{FtsAccessPath, FtsLeafNode};
 use super::super::{LanceTakeNode, PrefilterSourceKind, VectorAccessPath, VectorSearchNode};
 use super::super::{analyze_bottom_up, restricts_candidates, scalar_index_prefilter};
 use crate::io::exec::knn::QUERY_INDEX_COL;
@@ -183,6 +184,18 @@ impl OptimizerRule for ResolvePrefilterSource {
             }
             return Ok(Transformed::yes(LogicalPlan::Extension(Extension {
                 node: Arc::new(search.clone().with_prefilter(kind)),
+            })));
+        }
+        if let Some(leaf) = extension.node.as_any().downcast_ref::<FtsLeafNode>() {
+            let Some(FtsAccessPath::Index { segments }) = leaf.resolution() else {
+                return Ok(Transformed::no(plan));
+            };
+            let kind = self.kind_for(leaf.input(), segments);
+            if &kind == leaf.prefilter() {
+                return Ok(Transformed::no(plan));
+            }
+            return Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+                node: Arc::new(leaf.clone().with_prefilter(kind)),
             })));
         }
         Ok(Transformed::no(plan))


### PR DESCRIPTION
Adds the FTS half of the logical scan planner, so a full-text query plans through the same pipeline as a vector one.

An `FtsQuery` is a recursive IR, so it maps onto a subtree rather than a single node: an `FtsCompound` over one `FtsLeaf` per match or phrase, each with its own prefilter source below it. Each leaf resolves independently, which is what lets a partially-indexed text column reuse the same split-into-two-branches rewrite `SplitOnIndexCoverage` already does for vectors — the rule is shared, not duplicated.

`fts/` is arranged the same way `vector/` is, reaching the framework through a fixed set of entry points rather than spreading itself across `builder` / `rules` / `planner`. Two index types independently landing on that shape is what makes the plugin boundary the design doc asks about a claim rather than an artifact of one file.

Three things the framework gains here, all driven by FTS needing them:

* `prepare` — a stage that runs before the builder, resolving the searched column and its document granularity. The builder's schemas depend on the answer and the builder is synchronous, so this is where the lookup goes.
* `analyze_bottom_up` — analyzer-rule plumbing for rewrites that must happen exactly once for the plan to be correct, as opposed to optimizer rules, which run to a fixed point.
* `OverlayStaleness::Unknown` — a third state for a segment whose coverage cannot be determined. Vector coverage is known or absent; an inverted index can also be opaque, and a plan must not prune on a guess.

Results are ordered by `_score` descending with `_rowid` as the tie-break, stated in the plan. The imperative path leaves ties unbroken, so where a query's relevance ties are observable the equivalence check compares the two paths' rows as a set and asserts the ordering directly against the data instead.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
