### PR TITLE
perf(fts): delay must-not probes until candidates survive

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -15,6 +15,7 @@ pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_ov
 pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
 pub const COMPOUND_POSITIVE_SURVIVORS_METRIC: &str = "compound_positive_survivors";
 pub const COMPOUND_MUST_NOT_PROBES_METRIC: &str = "compound_must_not_probes";
+pub const COMPOUND_MUST_NOT_POSTING_LOADS_METRIC: &str = "compound_must_not_posting_loads";
 pub const COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC: &str = "compound_should_skipped_windows";
 pub const COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC: &str =
     "compound_should_bound_recomputations";
@@ -121,6 +122,9 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record candidate-level probes of compound FTS MUST_NOT clauses.
     fn record_compound_must_not_probes(&self, _num_probes: usize) {}
+
+    /// Record deferred prohibited posting leaves that were actually loaded.
+    fn record_compound_must_not_posting_loads(&self, _num_loads: usize) {}
 
     /// Record pure-SHOULD compound FTS windows skipped using score bounds.
     fn record_compound_should_skipped_windows(&self, _num_windows: usize) {}

--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -13,6 +13,8 @@ pub const COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC: &str =
     "compound_peak_address_resolution_batch_size";
 pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_overflows";
 pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
+pub const COMPOUND_POSITIVE_SURVIVORS_METRIC: &str = "compound_positive_survivors";
+pub const COMPOUND_MUST_NOT_PROBES_METRIC: &str = "compound_must_not_probes";
 pub const COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC: &str = "compound_should_skipped_windows";
 pub const COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC: &str =
     "compound_should_bound_recomputations";
@@ -112,6 +114,13 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record a candidate-buffer high-water mark for compound FTS.
     fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}
+
+    /// Record compound FTS candidates whose exact positive score reached the
+    /// current competitive floor before prohibited clauses were evaluated.
+    fn record_compound_positive_survivors(&self, _num_candidates: usize) {}
+
+    /// Record candidate-level probes of compound FTS MUST_NOT clauses.
+    fn record_compound_must_not_probes(&self, _num_probes: usize) {}
 
     /// Record pure-SHOULD compound FTS windows skipped using score bounds.
     fn record_compound_should_skipped_windows(&self, _num_windows: usize) {}

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -2107,14 +2107,25 @@ impl<'a> BooleanScorer<'a> {
         // With no finite floor, every finite positive score is competitive.
         // Probe after positive confirmation and score only documents that are
         // not prohibited, avoiding wasted scoring when exclusions are dense.
-        self.set_current(Some(current));
-        self.positive_checked_doc = Some(current);
-        self.positive_survivor_doc = Some(current);
         self.work.positive_survivors += 1;
-        if !self.ensure_not_prohibited()? {
+        self.work.must_not_probes += 1;
+        let prohibited_matches = {
+            let prohibited = self
+                .prohibited
+                .as_mut()
+                .expect("unbounded MUST_NOT path requires a prohibited scorer");
+            prohibited.advance(current)? == Some(current) && prohibited.matches()?
+        };
+        if prohibited_matches {
             return Ok(false);
         }
 
+        // Only returned documents need repeat-call caches. Rejected documents
+        // remain internal to this loop and are never observable by a caller.
+        self.set_current(Some(current));
+        self.positive_checked_doc = Some(current);
+        self.positive_survivor_doc = Some(current);
+        self.prohibited_checked_doc = Some(current);
         self.optional_matches = if let Some(optional) = &mut self.optional {
             optional.advance(current)? == Some(current) && optional.matches()?
         } else {

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -873,6 +873,13 @@ impl<K: Copy + Ord> TopKCollector<K> {
                     }
                 }
             }
+            let next_min_score = self.competitive_score.get();
+            if next_min_score > min_score {
+                // A scorer may have an unbounded fast path until the heap first
+                // establishes a score floor. Publish that floor before asking
+                // it for another document so it can switch modes immediately.
+                scorer.set_min_competitive_score(next_min_score)?;
+            }
             doc = scorer.next()?;
         }
 
@@ -2087,6 +2094,59 @@ impl<'a> BooleanScorer<'a> {
         Ok(None)
     }
 
+    fn accept_driver_doc_without_score_floor(&mut self) -> Result<bool> {
+        debug_assert!(self.prohibited.is_some());
+        debug_assert_eq!(self.min_competitive_score, f32::NEG_INFINITY);
+        let Some(current) = self.driver.doc() else {
+            return Ok(false);
+        };
+        if !self.driver.matches()? {
+            return Ok(false);
+        }
+
+        // With no finite floor, every finite positive score is competitive.
+        // Probe after positive confirmation and score only documents that are
+        // not prohibited, avoiding wasted scoring when exclusions are dense.
+        self.set_current(Some(current));
+        self.positive_checked_doc = Some(current);
+        self.positive_survivor_doc = Some(current);
+        self.work.positive_survivors += 1;
+        if !self.ensure_not_prohibited()? {
+            return Ok(false);
+        }
+
+        self.optional_matches = if let Some(optional) = &mut self.optional {
+            optional.advance(current)? == Some(current) && optional.matches()?
+        } else {
+            false
+        };
+        let mut score = self.driver.score()?;
+        if self.optional_matches
+            && let Some(optional) = &mut self.optional
+        {
+            score += optional.score()?;
+        }
+        self.positive_score = Some(checked_score(score, "BooleanQuery scorer")?);
+        Ok(true)
+    }
+
+    fn next_accepted_without_score_floor(&mut self, target: Option<u64>) -> Result<Option<u64>> {
+        debug_assert!(self.prohibited.is_some());
+        debug_assert_eq!(self.min_competitive_score, f32::NEG_INFINITY);
+        let mut doc = match target {
+            Some(target) => self.driver.advance(target)?,
+            None => self.driver.next()?,
+        };
+        while doc.is_some() {
+            if self.accept_driver_doc_without_score_floor()? {
+                return Ok(self.current);
+            }
+            doc = self.driver.next()?;
+        }
+        self.set_current(None);
+        Ok(None)
+    }
+
     fn set_current(&mut self, current: Option<u64>) {
         if self.current != current {
             self.optional_matches = false;
@@ -2176,6 +2236,8 @@ impl ComposableScorer for BooleanScorer<'_> {
     fn next(&mut self) -> Result<Option<u64>> {
         if self.prohibited.is_none() {
             self.next_accepted_without_prohibited(None)
+        } else if self.min_competitive_score == f32::NEG_INFINITY {
+            self.next_accepted_without_score_floor(None)
         } else {
             self.position(None)
         }
@@ -2187,6 +2249,8 @@ impl ComposableScorer for BooleanScorer<'_> {
         }
         if self.prohibited.is_none() {
             self.next_accepted_without_prohibited(Some(target))
+        } else if self.min_competitive_score == f32::NEG_INFINITY {
+            self.next_accepted_without_score_floor(Some(target))
         } else {
             self.position(Some(target))
         }
@@ -3732,6 +3796,62 @@ mod tests {
         assert_eq!(scorer.score().unwrap(), 1.0);
         assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 1);
         assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn boolean_with_unbounded_floor_rejects_prohibited_candidates_before_scoring() {
+        let positive_rows = (0..100).map(|doc| (doc, 1.0)).collect::<Vec<_>>();
+        let (positive, positive_work) = instrumented(materialized(&positive_rows));
+        let prohibited_rows = (0..100).map(|doc| (doc, 0.0)).collect::<Vec<_>>();
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&prohibited_rows, (0..100).collect(), Some(1.0));
+        let mut scorer =
+            BooleanScorer::try_new(Vec::new(), vec![positive], vec![prohibited]).unwrap();
+
+        assert!(
+            TopKCollector::new(1)
+                .collect(&mut scorer)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(positive_work.scores.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 100);
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 100);
+    }
+
+    #[test]
+    fn boolean_switches_to_delayed_probes_after_raising_the_score_floor() {
+        let positive_rows = (0..100)
+            .map(|doc| {
+                let score = match doc {
+                    0 => 50.0,
+                    99 => 50.5,
+                    _ => 0.5,
+                };
+                (doc, score)
+            })
+            .collect::<Vec<_>>();
+        let positive = || materialized(&positive_rows);
+        let prohibited_rows = (0..100).map(|doc| (doc, 0.0)).collect::<Vec<_>>();
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&prohibited_rows, (1..100).collect(), Some(1.0));
+        let metrics = BooleanMetrics::default();
+        let results = {
+            let mut scorer = BooleanScorer::try_new_with_metrics(
+                Vec::new(),
+                vec![positive(), positive()],
+                vec![prohibited],
+                Some(&metrics),
+            )
+            .unwrap();
+            TopKCollector::new(1).collect(&mut scorer).unwrap()
+        };
+
+        assert_eq!(results, rows(&[(0, 100.0)]));
+        assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(metrics.positive_survivors.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(metrics.must_not_probes.load(AtomicOrdering::Relaxed), 2);
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -2035,6 +2035,7 @@ impl<'a> BooleanScorer<'a> {
                     as BoxScorer<'a>,
             )
         };
+        let metrics = if prohibited.is_some() { metrics } else { None };
         Ok(Self {
             driver,
             optional,
@@ -2050,6 +2051,40 @@ impl<'a> BooleanScorer<'a> {
             metrics,
             work: BooleanWork::default(),
         })
+    }
+
+    fn accept_driver_doc_without_prohibited(&mut self) -> Result<bool> {
+        debug_assert!(self.prohibited.is_none());
+        let Some(current) = self.driver.doc() else {
+            return Ok(false);
+        };
+        if !self.driver.matches()? {
+            return Ok(false);
+        }
+        self.optional_matches = if let Some(optional) = &mut self.optional {
+            optional.advance(current)? == Some(current) && optional.matches()?
+        } else {
+            false
+        };
+        self.current = Some(current);
+        Ok(true)
+    }
+
+    fn next_accepted_without_prohibited(&mut self, target: Option<u64>) -> Result<Option<u64>> {
+        debug_assert!(self.prohibited.is_none());
+        let mut doc = match target {
+            Some(target) => self.driver.advance(target)?,
+            None => self.driver.next()?,
+        };
+        while doc.is_some() {
+            if self.accept_driver_doc_without_prohibited()? {
+                return Ok(self.current);
+            }
+            doc = self.driver.next()?;
+        }
+        self.current = None;
+        self.optional_matches = false;
+        Ok(None)
     }
 
     fn set_current(&mut self, current: Option<u64>) {
@@ -2139,14 +2174,22 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn next(&mut self) -> Result<Option<u64>> {
-        self.position(None)
+        if self.prohibited.is_none() {
+            self.next_accepted_without_prohibited(None)
+        } else {
+            self.position(None)
+        }
     }
 
     fn advance(&mut self, target: u64) -> Result<Option<u64>> {
         if self.current.is_some_and(|current| current >= target) {
             return Ok(self.current);
         }
-        self.position(Some(target))
+        if self.prohibited.is_none() {
+            self.next_accepted_without_prohibited(Some(target))
+        } else {
+            self.position(Some(target))
+        }
     }
 
     fn cost(&self) -> usize {
@@ -2154,6 +2197,20 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn score(&mut self) -> Result<f32> {
+        if self.prohibited.is_none() {
+            if self.current.is_none() {
+                return Err(Error::internal(
+                    "Boolean FTS scorer is not positioned on a document",
+                ));
+            }
+            let mut score = self.driver.score()?;
+            if self.optional_matches
+                && let Some(optional) = &mut self.optional
+            {
+                score += optional.score()?;
+            }
+            return checked_score(score, "BooleanQuery scorer");
+        }
         let current = self
             .current
             .ok_or_else(|| Error::internal("Boolean FTS scorer is not positioned on a document"))?;
@@ -2210,13 +2267,15 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
-        if min_score.is_nan() {
-            return Err(Error::invalid_input(
-                "minimum competitive FTS score cannot be NaN",
-            ));
-        }
-        if min_score > self.min_competitive_score {
-            self.min_competitive_score = min_score;
+        if self.prohibited.is_some() {
+            if min_score.is_nan() {
+                return Err(Error::invalid_input(
+                    "minimum competitive FTS score cannot be NaN",
+                ));
+            }
+            if min_score > self.min_competitive_score {
+                self.min_competitive_score = min_score;
+            }
         }
         // When SHOULD is also present, a global sibling bound is required to
         // translate the parent threshold safely. The combined block bound still
@@ -2228,6 +2287,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn matches(&mut self) -> Result<bool> {
+        if self.prohibited.is_none() {
+            return Ok(self.current.is_some());
+        }
         let Some(score) = self.ensure_positive_score()? else {
             return Ok(false);
         };
@@ -2255,8 +2317,12 @@ impl Drop for BooleanScorer<'_> {
         let Some(metrics) = self.metrics else {
             return;
         };
-        metrics.record_compound_positive_survivors(self.work.positive_survivors);
-        metrics.record_compound_must_not_probes(self.work.must_not_probes);
+        if self.work.positive_survivors > 0 {
+            metrics.record_compound_positive_survivors(self.work.positive_survivors);
+        }
+        if self.work.must_not_probes > 0 {
+            metrics.record_compound_must_not_probes(self.work.must_not_probes);
+        }
     }
 }
 
@@ -2986,6 +3052,7 @@ mod tests {
 
     #[derive(Default)]
     struct BooleanMetrics {
+        reports: AtomicUsize,
         positive_survivors: AtomicUsize,
         must_not_probes: AtomicUsize,
     }
@@ -2998,11 +3065,13 @@ mod tests {
         fn record_comparisons(&self, _num_comparisons: usize) {}
 
         fn record_compound_positive_survivors(&self, num_candidates: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
             self.positive_survivors
                 .fetch_add(num_candidates, AtomicOrdering::Relaxed);
         }
 
         fn record_compound_must_not_probes(&self, num_probes: usize) {
+            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
             self.must_not_probes
                 .fetch_add(num_probes, AtomicOrdering::Relaxed);
         }
@@ -3207,6 +3276,7 @@ mod tests {
     struct ScorerWork {
         advances: AtomicUsize,
         confirmations: AtomicUsize,
+        scores: AtomicUsize,
         shallow_advances: AtomicUsize,
         bounds: AtomicUsize,
     }
@@ -3246,6 +3316,7 @@ mod tests {
         }
 
         fn score(&mut self) -> Result<f32> {
+            self.work.scores.fetch_add(1, AtomicOrdering::Relaxed);
             self.inner.score()
         }
 
@@ -3634,6 +3705,7 @@ mod tests {
         assert_eq!(results, rows(&[(99, 100.0)]));
         assert_eq!(probes, 1);
         assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 2);
         assert_eq!(metrics.positive_survivors.load(AtomicOrdering::Relaxed), 1);
         assert_eq!(metrics.must_not_probes.load(AtomicOrdering::Relaxed), 1);
         assert!(
@@ -3677,6 +3749,94 @@ mod tests {
         );
         assert_eq!(positive_confirmations.load(AtomicOrdering::Relaxed), 2);
         assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn boolean_without_must_not_keeps_confirmed_iteration_and_skips_metrics() {
+        let metrics = BooleanMetrics::default();
+        let (positive, positive_approximations, positive_confirmations) =
+            two_phase(&[(0, 1.0), (1, 2.0)], vec![1], Some(1.0));
+        let (positive, positive_work) = instrumented(positive);
+        {
+            let mut scorer = BooleanScorer::try_new_with_metrics(
+                Vec::new(),
+                vec![positive],
+                Vec::new(),
+                Some(&metrics),
+            )
+            .unwrap();
+
+            assert_eq!(scorer.next().unwrap(), Some(1));
+            assert_eq!(positive_work.scores.load(AtomicOrdering::Relaxed), 0);
+            assert!(scorer.matches().unwrap());
+            assert_eq!(positive_work.scores.load(AtomicOrdering::Relaxed), 0);
+            assert_eq!(scorer.score().unwrap(), 2.0);
+            assert_eq!(positive_work.scores.load(AtomicOrdering::Relaxed), 1);
+            assert_eq!(scorer.next().unwrap(), None);
+        }
+
+        assert_eq!(positive_approximations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(positive_confirmations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn boolean_without_must_not_positions_signed_optional_after_confirmation() {
+        let (required, _, required_confirmations) =
+            two_phase(&[(0, 1.0), (1, 2.0)], vec![1], Some(1.0));
+        let signed_optional = Box::new(
+            BoostScorer::try_new(
+                materialized(&[(0, 4.0), (1, 4.0)]),
+                materialized(&[(0, 1.0), (1, 1.0)]),
+                0.5,
+            )
+            .unwrap(),
+        );
+        let (signed_optional, optional_work) = instrumented(signed_optional);
+        let mut scorer =
+            BooleanScorer::try_new(vec![signed_optional], vec![required], Vec::new()).unwrap();
+
+        assert_eq!(
+            TopKCollector::new(1).collect(&mut scorer).unwrap(),
+            rows(&[(1, 5.5)])
+        );
+        assert_eq!(required_confirmations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(optional_work.advances.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn outer_boolean_without_must_not_preserves_inner_delayed_probes() {
+        let metrics = BooleanMetrics::default();
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&[(0, 0.0), (1, 0.0)], Vec::new(), Some(1.0));
+        let inner = BooleanScorer::try_new_with_metrics(
+            Vec::new(),
+            vec![materialized(&[(0, 1.0), (1, 50.0)])],
+            vec![prohibited],
+            Some(&metrics),
+        )
+        .unwrap();
+        let results = {
+            let mut outer = BooleanScorer::try_new_with_metrics(
+                Vec::new(),
+                vec![Box::new(inner)],
+                Vec::new(),
+                Some(&metrics),
+            )
+            .unwrap();
+            let competitive_score = Arc::new(CompetitiveScore::default());
+            competitive_score.raise(50.0);
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut outer)
+                .unwrap()
+        };
+
+        assert_eq!(results, rows(&[(1, 50.0)]));
+        assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(metrics.positive_survivors.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(metrics.must_not_probes.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -1949,6 +1949,12 @@ impl ComposableScorer for ReqOptScorer<'_> {
     }
 }
 
+#[derive(Default)]
+struct BooleanWork {
+    positive_survivors: usize,
+    must_not_probes: usize,
+}
+
 /// Boolean scorer preserving the current membership and score semantics.
 pub(super) struct BooleanScorer<'a> {
     driver: BoxScorer<'a>,
@@ -1956,6 +1962,14 @@ pub(super) struct BooleanScorer<'a> {
     prohibited: Option<BoxScorer<'a>>,
     current: Option<u64>,
     optional_matches: bool,
+    min_competitive_score: f32,
+    positive_checked_doc: Option<u64>,
+    positive_score: Option<f32>,
+    positive_survivor_doc: Option<u64>,
+    prohibited_checked_doc: Option<u64>,
+    prohibited_matches: bool,
+    metrics: Option<&'a dyn MetricsCollector>,
+    work: BooleanWork,
 }
 
 impl<'a> BooleanScorer<'a> {
@@ -2027,45 +2041,91 @@ impl<'a> BooleanScorer<'a> {
             prohibited,
             current: None,
             optional_matches: false,
+            min_competitive_score: f32::NEG_INFINITY,
+            positive_checked_doc: None,
+            positive_score: None,
+            positive_survivor_doc: None,
+            prohibited_checked_doc: None,
+            prohibited_matches: false,
+            metrics,
+            work: BooleanWork::default(),
         })
     }
 
-    fn accept_driver_doc(&mut self) -> Result<bool> {
-        let Some(current) = self.driver.doc() else {
-            return Ok(false);
-        };
-        if !self.driver.matches()? {
-            return Ok(false);
+    fn set_current(&mut self, current: Option<u64>) {
+        if self.current != current {
+            self.optional_matches = false;
+            self.positive_checked_doc = None;
+            self.positive_score = None;
+            self.positive_survivor_doc = None;
+            self.prohibited_checked_doc = None;
+            self.prohibited_matches = false;
         }
-        if let Some(prohibited) = &mut self.prohibited
-            && prohibited.advance(current)? == Some(current)
-            && prohibited.matches()?
-        {
-            return Ok(false);
-        }
-        self.optional_matches = if let Some(optional) = &mut self.optional {
-            optional.advance(current)? == Some(current) && optional.matches()?
-        } else {
-            false
-        };
-        self.current = Some(current);
-        Ok(true)
+        self.current = current;
     }
 
-    fn next_accepted(&mut self, target: Option<u64>) -> Result<Option<u64>> {
-        let mut doc = match target {
+    fn position(&mut self, target: Option<u64>) -> Result<Option<u64>> {
+        let current = match target {
             Some(target) => self.driver.advance(target)?,
             None => self.driver.next()?,
         };
-        while doc.is_some() {
-            if self.accept_driver_doc()? {
-                return Ok(self.current);
-            }
-            doc = self.driver.next()?;
+        // The separate optional scorer is the exact fallback for shapes that
+        // cannot use ReqOpt. Keep its approximation positioned so parent
+        // shallow bounds include a possible optional contribution.
+        if let Some(current) = current
+            && let Some(optional) = &mut self.optional
+        {
+            optional.advance(current)?;
         }
-        self.current = None;
-        self.optional_matches = false;
-        Ok(None)
+        self.set_current(current);
+        Ok(current)
+    }
+
+    fn ensure_positive_score(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        if self.positive_checked_doc == Some(current) {
+            return Ok(self.positive_score);
+        }
+        if !self.driver.matches()? {
+            self.positive_checked_doc = Some(current);
+            self.positive_score = None;
+            return Ok(None);
+        }
+        self.optional_matches = if let Some(optional) = &mut self.optional {
+            debug_assert!(optional.doc().is_none_or(|doc| doc >= current));
+            optional.doc() == Some(current) && optional.matches()?
+        } else {
+            false
+        };
+        let mut score = self.driver.score()?;
+        if self.optional_matches
+            && let Some(optional) = &mut self.optional
+        {
+            score += optional.score()?;
+        }
+        let score = checked_score(score, "BooleanQuery scorer")?;
+        self.positive_checked_doc = Some(current);
+        self.positive_score = Some(score);
+        Ok(Some(score))
+    }
+
+    fn ensure_not_prohibited(&mut self) -> Result<bool> {
+        let Some(current) = self.current else {
+            return Ok(false);
+        };
+        if self.prohibited_checked_doc == Some(current) {
+            return Ok(!self.prohibited_matches);
+        }
+        self.prohibited_matches = if let Some(prohibited) = &mut self.prohibited {
+            self.work.must_not_probes += 1;
+            prohibited.advance(current)? == Some(current) && prohibited.matches()?
+        } else {
+            false
+        };
+        self.prohibited_checked_doc = Some(current);
+        Ok(!self.prohibited_matches)
     }
 }
 
@@ -2079,14 +2139,14 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn next(&mut self) -> Result<Option<u64>> {
-        self.next_accepted(None)
+        self.position(None)
     }
 
     fn advance(&mut self, target: u64) -> Result<Option<u64>> {
         if self.current.is_some_and(|current| current >= target) {
             return Ok(self.current);
         }
-        self.next_accepted(Some(target))
+        self.position(Some(target))
     }
 
     fn cost(&self) -> usize {
@@ -2094,18 +2154,17 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn score(&mut self) -> Result<f32> {
-        if self.current.is_none() {
+        let current = self
+            .current
+            .ok_or_else(|| Error::internal("Boolean FTS scorer is not positioned on a document"))?;
+        if self.positive_checked_doc != Some(current) {
             return Err(Error::internal(
-                "Boolean FTS scorer is not positioned on a document",
+                "Boolean FTS score requested before confirming the positive scorer",
             ));
         }
-        let mut score = self.driver.score()?;
-        if self.optional_matches
-            && let Some(optional) = &mut self.optional
-        {
-            score += optional.score()?;
-        }
-        checked_score(score, "BooleanQuery scorer")
+        self.positive_score.ok_or_else(|| {
+            Error::internal("Boolean FTS score requested for a rejected positive candidate")
+        })
     }
 
     fn advance_shallow(&mut self, target: u64) -> Result<u64> {
@@ -2151,6 +2210,14 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        if min_score > self.min_competitive_score {
+            self.min_competitive_score = min_score;
+        }
         // When SHOULD is also present, a global sibling bound is required to
         // translate the parent threshold safely. The combined block bound still
         // prunes at this node. Without SHOULD, driver score is the full score.
@@ -2161,7 +2228,17 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn matches(&mut self) -> Result<bool> {
-        Ok(self.current.is_some())
+        let Some(score) = self.ensure_positive_score()? else {
+            return Ok(false);
+        };
+        if score < self.min_competitive_score {
+            return Ok(false);
+        }
+        if self.prohibited.is_some() && self.positive_survivor_doc != self.current {
+            self.positive_survivor_doc = self.current;
+            self.work.positive_survivors += 1;
+        }
+        self.ensure_not_prohibited()
     }
 
     fn scores_non_negative(&self) -> bool {
@@ -2170,6 +2247,16 @@ impl ComposableScorer for BooleanScorer<'_> {
                 .optional
                 .as_ref()
                 .is_none_or(|optional| optional.scores_non_negative())
+    }
+}
+
+impl Drop for BooleanScorer<'_> {
+    fn drop(&mut self) {
+        let Some(metrics) = self.metrics else {
+            return;
+        };
+        metrics.record_compound_positive_survivors(self.work.positive_survivors);
+        metrics.record_compound_must_not_probes(self.work.must_not_probes);
     }
 }
 
@@ -2897,6 +2984,30 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct BooleanMetrics {
+        positive_survivors: AtomicUsize,
+        must_not_probes: AtomicUsize,
+    }
+
+    impl MetricsCollector for BooleanMetrics {
+        fn record_parts_loaded(&self, _num_parts: usize) {}
+
+        fn record_index_loads(&self, _num_loads: usize) {}
+
+        fn record_comparisons(&self, _num_comparisons: usize) {}
+
+        fn record_compound_positive_survivors(&self, num_candidates: usize) {
+            self.positive_survivors
+                .fetch_add(num_candidates, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_must_not_probes(&self, num_probes: usize) {
+            self.must_not_probes
+                .fetch_add(num_probes, AtomicOrdering::Relaxed);
+        }
+    }
+
     #[test]
     fn score_bounds_are_conservative_under_nested_sum_and_boost() {
         let should = DisjunctionScorer::try_new(
@@ -3461,6 +3572,114 @@ mod tests {
     }
 
     #[test]
+    fn boolean_delays_must_not_until_exact_positive_score_is_competitive() {
+        let positive_rows = [(0, 0.5), (1, 50.0)];
+        let positive = || {
+            Box::new(MaterializedScorer::try_new(rows(&positive_rows)).unwrap()) as BoxScorer<'_>
+        };
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&[(0, 0.0), (1, 0.0)], Vec::new(), Some(1.0));
+        let mut scorer =
+            BooleanScorer::try_new(Vec::new(), vec![positive(), positive()], vec![prohibited])
+                .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(50.0);
+
+        let results = TopKCollector::with_competitive_score(1, competitive_score)
+            .collect(&mut scorer)
+            .unwrap();
+
+        assert_eq!(results, rows(&[(1, 100.0)]));
+        assert_eq!(
+            prohibited_approximations.load(AtomicOrdering::Relaxed),
+            1,
+            "the low-scoring document shares a high block bound but must not probe MUST_NOT"
+        );
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn boolean_delays_selective_must_not_probes() {
+        let positive_rows = (0..100)
+            .map(|doc| (doc, if doc == 99 { 50.0 } else { 0.5 }))
+            .collect::<Vec<_>>();
+        let prohibited_rows = (0..100).map(|doc| (doc, 0.0)).collect::<Vec<_>>();
+        let eager_probes = positive_rows.len();
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&prohibited_rows, Vec::new(), Some(1.0));
+        let metrics = BooleanMetrics::default();
+        let results = {
+            let positive = || {
+                Box::new(
+                    MaterializedScorer::try_new(rows(&positive_rows))
+                        .unwrap()
+                        .with_block_size(1),
+                ) as BoxScorer<'_>
+            };
+            let mut scorer = BooleanScorer::try_new_with_metrics(
+                Vec::new(),
+                vec![positive(), positive()],
+                vec![prohibited],
+                Some(&metrics),
+            )
+            .unwrap();
+            let competitive_score = Arc::new(CompetitiveScore::default());
+            competitive_score.raise(50.0);
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut scorer)
+                .unwrap()
+        };
+        let probes = prohibited_approximations.load(AtomicOrdering::Relaxed);
+
+        assert_eq!(results, rows(&[(99, 100.0)]));
+        assert_eq!(probes, 1);
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(metrics.positive_survivors.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(metrics.must_not_probes.load(AtomicOrdering::Relaxed), 1);
+        assert!(
+            probes * 5 <= eager_probes * 4,
+            "delayed MUST_NOT should reduce probes by at least 20%: {probes}/{eager_probes}"
+        );
+    }
+
+    #[test]
+    fn boolean_caches_must_not_decision_for_current_document() {
+        let (prohibited, prohibited_approximations, prohibited_confirmations) =
+            two_phase(&[(0, 0.0)], Vec::new(), Some(10.0));
+        let mut scorer = BooleanScorer::try_new(
+            Vec::new(),
+            vec![materialized(&[(0, 1.0)])],
+            vec![prohibited],
+        )
+        .unwrap();
+
+        assert_eq!(scorer.next().unwrap(), Some(0));
+        assert!(scorer.matches().unwrap());
+        assert_eq!(scorer.score().unwrap(), 1.0);
+        assert!(scorer.matches().unwrap());
+        assert_eq!(scorer.score().unwrap(), 1.0);
+        assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(prohibited_confirmations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn boolean_skips_must_not_for_positive_confirmation_rejects() {
+        let (positive, _, positive_confirmations) =
+            two_phase(&[(0, 1.0), (1, 2.0)], vec![1], Some(1.0));
+        let (prohibited, prohibited_approximations, _) =
+            two_phase(&[(0, 0.0), (1, 0.0)], Vec::new(), Some(10.0));
+        let mut scorer =
+            BooleanScorer::try_new(Vec::new(), vec![positive], vec![prohibited]).unwrap();
+
+        assert_eq!(
+            TopKCollector::new(2).collect(&mut scorer).unwrap(),
+            rows(&[(1, 2.0)])
+        );
+        assert_eq!(positive_confirmations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(prohibited_approximations.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
     fn reqopt_delays_sparse_optional_probes() {
         let values = (0..100).map(|doc| (doc, 1.0)).collect::<Vec<_>>();
         let build = || {
@@ -3485,6 +3704,14 @@ mod tests {
             prohibited: None,
             current: None,
             optional_matches: false,
+            min_competitive_score: f32::NEG_INFINITY,
+            positive_checked_doc: None,
+            positive_score: None,
+            positive_survivor_doc: None,
+            prohibited_checked_doc: None,
+            prohibited_matches: false,
+            metrics: None,
+            work: BooleanWork::default(),
         };
         let eager_results = TopKCollector::new(1).collect(&mut eager).unwrap();
 

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -4,7 +4,7 @@
 mod should_maxscore;
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::{BinaryHeap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
@@ -35,6 +35,9 @@ use self::should_maxscore::ShouldMaxScoreScorer;
 
 const DEFAULT_BLOCK_SIZE: usize = 128;
 const SCORE_FLOOR_RESOLUTION_BATCH_SIZE: usize = DEFAULT_BLOCK_SIZE;
+/// Bound deferred exclusion I/O concurrency while letting each completed
+/// batch raise the global score floor before more partitions are admitted.
+const DEFERRED_MUST_NOT_LOAD_BATCH_SIZE: usize = 8;
 
 /// One exact FTS result in a compound collector's candidate domain.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -240,6 +243,12 @@ fn sum_global_score_upper_bounds(children: &[BoxScorer<'_>]) -> Option<f32> {
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompoundScoreMode {
+    Scoring,
+    CompleteNoScores,
+}
+
 #[derive(Debug, Clone)]
 enum CompoundScorerPlan {
     Leaf {
@@ -256,11 +265,16 @@ enum CompoundScorerPlan {
         should: Vec<Self>,
         must: Vec<Self>,
         must_not: Vec<Self>,
+        score_mode: CompoundScoreMode,
     },
 }
 
 impl CompoundScorerPlan {
-    fn from_query(query: &FtsQuery, num_leaves: &mut usize) -> Result<Self> {
+    fn from_query(
+        query: &FtsQuery,
+        num_leaves: &mut usize,
+        score_mode: CompoundScoreMode,
+    ) -> Result<Self> {
         match query {
             FtsQuery::Match(query) => {
                 let index = *num_leaves;
@@ -275,35 +289,61 @@ impl CompoundScorerPlan {
                 *num_leaves += 1;
                 Ok(Self::Leaf { index, boost: 1.0 })
             }
-            FtsQuery::Boost(query) => Ok(Self::Boost {
-                positive: Box::new(Self::from_query(&query.positive, num_leaves)?),
-                negative: Box::new(Self::from_query(&query.negative, num_leaves)?),
-                negative_boost: query.negative_boost,
-            }),
+            FtsQuery::Boost(query) => {
+                if !query.negative_boost.is_finite() || query.negative_boost < 0.0 {
+                    return Err(Error::invalid_input(format!(
+                        "BoostQuery negative_boost must be finite and non-negative, got {}",
+                        query.negative_boost
+                    )));
+                }
+                let positive = Self::from_query(&query.positive, num_leaves, score_mode)?;
+                if score_mode == CompoundScoreMode::CompleteNoScores {
+                    return Ok(positive);
+                }
+                Ok(Self::Boost {
+                    positive: Box::new(positive),
+                    negative: Box::new(Self::from_query(&query.negative, num_leaves, score_mode)?),
+                    negative_boost: query.negative_boost,
+                })
+            }
             FtsQuery::MultiMatch(query) => Ok(Self::MultiMatch(
                 query
                     .match_queries
                     .iter()
-                    .map(|query| Self::from_query(&FtsQuery::Match(query.clone()), num_leaves))
+                    .map(|query| {
+                        Self::from_query(&FtsQuery::Match(query.clone()), num_leaves, score_mode)
+                    })
                     .collect::<Result<Vec<_>>>()?,
             )),
-            FtsQuery::Boolean(query) => Ok(Self::Boolean {
-                should: query
-                    .should
-                    .iter()
-                    .map(|query| Self::from_query(query, num_leaves))
-                    .collect::<Result<Vec<_>>>()?,
-                must: query
-                    .must
-                    .iter()
-                    .map(|query| Self::from_query(query, num_leaves))
-                    .collect::<Result<Vec<_>>>()?,
-                must_not: query
-                    .must_not
-                    .iter()
-                    .map(|query| Self::from_query(query, num_leaves))
-                    .collect::<Result<Vec<_>>>()?,
-            }),
+            FtsQuery::Boolean(query) => {
+                let should = if score_mode == CompoundScoreMode::CompleteNoScores
+                    && !query.must.is_empty()
+                {
+                    Vec::new()
+                } else {
+                    query
+                        .should
+                        .iter()
+                        .map(|query| Self::from_query(query, num_leaves, score_mode))
+                        .collect::<Result<Vec<_>>>()?
+                };
+                Ok(Self::Boolean {
+                    should,
+                    must: query
+                        .must
+                        .iter()
+                        .map(|query| Self::from_query(query, num_leaves, score_mode))
+                        .collect::<Result<Vec<_>>>()?,
+                    must_not: query
+                        .must_not
+                        .iter()
+                        .map(|query| {
+                            Self::from_query(query, num_leaves, CompoundScoreMode::CompleteNoScores)
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                    score_mode,
+                })
+            }
         }
     }
 
@@ -344,20 +384,110 @@ impl CompoundScorerPlan {
                 should,
                 must,
                 must_not,
-            } => Ok(Box::new(BooleanScorer::try_new_with_metrics(
-                should
+                score_mode,
+            } => Ok(Box::new(
+                BooleanScorer::try_new_with_metrics_and_score_mode(
+                    should
+                        .iter()
+                        .map(|child| child.build(leaves, metrics))
+                        .collect::<Result<Vec<_>>>()?,
+                    must.iter()
+                        .map(|child| child.build(leaves, metrics))
+                        .collect::<Result<Vec<_>>>()?,
+                    must_not
+                        .iter()
+                        .map(|child| child.build(leaves, metrics))
+                        .collect::<Result<Vec<_>>>()?,
+                    Some(metrics),
+                    *score_mode,
+                )?,
+            )),
+        }
+    }
+
+    /// Build a scorer whose score is an upper envelope of the complete query
+    /// score while ignoring every prohibited subtree.
+    ///
+    /// The gate runs before prohibited postings are loaded. Boolean
+    /// exclusions can only remove matches. A BoostQuery's negative side can be
+    /// dropped when [`Self::positive_gate_is_safe`] proves it cannot itself
+    /// score below zero. Under that precondition, false positives only load
+    /// deferred postings earlier than necessary.
+    fn build_gate<'a>(
+        &self,
+        leaves: &mut [Option<BoxScorer<'a>>],
+        metrics: &'a dyn MetricsCollector,
+    ) -> Result<BoxScorer<'a>> {
+        match self {
+            Self::Leaf { index, boost } => {
+                let leaf = leaves
+                    .get_mut(*index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "compound FTS positive gate references missing leaf index {index}"
+                        ))
+                    })?;
+                Ok(Box::new(ScaleScorer::try_new(leaf, *boost)?))
+            }
+            Self::Boost { positive, .. } => positive.build_gate(leaves, metrics),
+            Self::MultiMatch(children) => Ok(Box::new(DisjunctionScorer::try_new(
+                children
                     .iter()
-                    .map(|child| child.build(leaves, metrics))
+                    .map(|child| child.build_gate(leaves, metrics))
                     .collect::<Result<Vec<_>>>()?,
-                must.iter()
-                    .map(|child| child.build(leaves, metrics))
-                    .collect::<Result<Vec<_>>>()?,
-                must_not
-                    .iter()
-                    .map(|child| child.build(leaves, metrics))
-                    .collect::<Result<Vec<_>>>()?,
-                Some(metrics),
+                DisjunctionScore::Max,
             )?)),
+            Self::Boolean { should, must, .. } => {
+                Ok(Box::new(BooleanScorer::try_new_with_metrics(
+                    should
+                        .iter()
+                        .map(|child| child.build_gate(leaves, metrics))
+                        .collect::<Result<Vec<_>>>()?,
+                    must.iter()
+                        .map(|child| child.build_gate(leaves, metrics))
+                        .collect::<Result<Vec<_>>>()?,
+                    Vec::new(),
+                    Some(metrics),
+                )?))
+            }
+        }
+    }
+
+    /// Whether [`Self::build_gate`] is guaranteed not to underestimate any
+    /// final score. A BoostQuery may only drop its negative side when that
+    /// subtree cannot itself produce a negative score.
+    fn positive_gate_is_safe(&self) -> bool {
+        match self {
+            Self::Leaf { boost, .. } => boost.is_finite() && *boost >= 0.0,
+            Self::Boost {
+                positive,
+                negative,
+                negative_boost,
+            } => {
+                positive.positive_gate_is_safe()
+                    && (*negative_boost == 0.0 || negative.scores_provably_non_negative())
+            }
+            Self::MultiMatch(children) => children.iter().all(Self::positive_gate_is_safe),
+            Self::Boolean { should, must, .. } => {
+                should.iter().chain(must).all(Self::positive_gate_is_safe)
+            }
+        }
+    }
+
+    fn scores_provably_non_negative(&self) -> bool {
+        match self {
+            Self::Leaf { boost, .. } => boost.is_finite() && *boost >= 0.0,
+            Self::Boost {
+                positive,
+                negative_boost,
+                ..
+            } => *negative_boost == 0.0 && positive.scores_provably_non_negative(),
+            Self::MultiMatch(children) => children.iter().all(Self::scores_provably_non_negative),
+            Self::Boolean { should, must, .. } => should
+                .iter()
+                .chain(must)
+                .all(Self::scores_provably_non_negative),
         }
     }
 }
@@ -815,9 +945,19 @@ impl<K: Copy + Ord> TopKCollector<K> {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn collect_mapped(
         &mut self,
         scorer: &mut dyn ComposableScorer,
+        map_document: impl FnMut(u64) -> Result<K>,
+    ) -> Result<CollectionStatus> {
+        self.collect_mapped_from(scorer, None, map_document)
+    }
+
+    fn collect_mapped_from(
+        &mut self,
+        scorer: &mut dyn ComposableScorer,
+        start_doc: Option<u64>,
         mut map_document: impl FnMut(u64) -> Result<K>,
     ) -> Result<CollectionStatus> {
         if self.limit == 0 {
@@ -832,7 +972,10 @@ impl<K: Copy + Ord> TopKCollector<K> {
             .reserve(expected.saturating_sub(self.heap.capacity()));
 
         scorer.set_min_competitive_score(self.competitive_score.get())?;
-        let mut doc = scorer.next()?;
+        let mut doc = match start_doc {
+            Some(start_doc) => scorer.advance(start_doc)?,
+            None => scorer.next()?,
+        };
         while let Some(doc_id) = doc {
             let min_score = self.competitive_score.get();
             scorer.set_min_competitive_score(min_score)?;
@@ -906,6 +1049,49 @@ impl TopKCollector<u64> {
         self.collect_mapped(scorer, Ok)?;
         Ok(self.into_rows())
     }
+}
+
+/// Return the first exact match at or above a fixed score floor without
+/// mutating the authoritative top-k collector.
+fn first_competitive_match(
+    scorer: &mut dyn ComposableScorer,
+    min_score: f32,
+) -> Result<Option<u64>> {
+    if min_score.is_nan() {
+        return Err(Error::invalid_input(
+            "minimum competitive FTS score cannot be NaN",
+        ));
+    }
+    scorer.set_min_competitive_score(min_score)?;
+    let mut doc = scorer.next()?;
+    while let Some(doc_id) = doc {
+        if min_score != f32::NEG_INFINITY {
+            let up_to = scorer.advance_shallow(doc_id)?;
+            if scorer.score_bounds(up_to)?.upper < min_score {
+                doc = if up_to == u64::MAX {
+                    None
+                } else {
+                    scorer.advance(up_to + 1)?
+                };
+                continue;
+            }
+        }
+        if let Some(match_cost) = scorer.match_cost()
+            && (!match_cost.is_finite() || match_cost < 0.0)
+        {
+            return Err(Error::internal(format!(
+                "FTS scorer reported invalid two-phase match cost: {match_cost}"
+            )));
+        }
+        if scorer.matches()?
+            && (min_score == f32::NEG_INFINITY
+                || checked_score(scorer.score()?, "compound positive gate")? >= min_score)
+        {
+            return Ok(Some(doc_id));
+        }
+        doc = scorer.next()?;
+    }
+    Ok(None)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1967,6 +2153,7 @@ pub(super) struct BooleanScorer<'a> {
     driver: BoxScorer<'a>,
     optional: Option<BoxScorer<'a>>,
     prohibited: Option<BoxScorer<'a>>,
+    score_mode: CompoundScoreMode,
     current: Option<u64>,
     optional_matches: bool,
     min_competitive_score: f32,
@@ -1995,13 +2182,31 @@ impl<'a> BooleanScorer<'a> {
         must_not: Vec<BoxScorer<'a>>,
         metrics: Option<&'a dyn MetricsCollector>,
     ) -> Result<Self> {
+        Self::try_new_with_metrics_and_score_mode(
+            should,
+            must,
+            must_not,
+            metrics,
+            CompoundScoreMode::Scoring,
+        )
+    }
+
+    fn try_new_with_metrics_and_score_mode(
+        should: Vec<BoxScorer<'a>>,
+        must: Vec<BoxScorer<'a>>,
+        must_not: Vec<BoxScorer<'a>>,
+        metrics: Option<&'a dyn MetricsCollector>,
+        score_mode: CompoundScoreMode,
+    ) -> Result<Self> {
         let (driver, optional) = if must.is_empty() {
             if should.is_empty() {
                 return Err(Error::invalid_input(
                     "boolean query must have at least one should/must query",
                 ));
             }
-            let driver = if let Some(global_bounds) = ShouldMaxScoreScorer::global_bounds(&should) {
+            let driver = if score_mode == CompoundScoreMode::Scoring
+                && let Some(global_bounds) = ShouldMaxScoreScorer::global_bounds(&should)
+            {
                 Box::new(ShouldMaxScoreScorer::new(should, global_bounds, metrics)) as BoxScorer<'a>
             } else {
                 Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
@@ -2009,16 +2214,18 @@ impl<'a> BooleanScorer<'a> {
             };
             (driver, None)
         } else {
-            let mut optional = if should.is_empty() {
-                None
-            } else {
-                Some(
-                    Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
-                        as BoxScorer<'a>,
-                )
-            };
+            let mut optional =
+                if should.is_empty() || score_mode == CompoundScoreMode::CompleteNoScores {
+                    None
+                } else {
+                    Some(
+                        Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
+                            as BoxScorer<'a>,
+                    )
+                };
             let required = Box::new(RequiredConjunctionScorer::try_new(must)?) as BoxScorer<'a>;
-            let driver = if required.scores_non_negative()
+            let driver = if score_mode == CompoundScoreMode::Scoring
+                && required.scores_non_negative()
                 && optional
                     .as_ref()
                     .is_some_and(|optional| optional.scores_non_negative())
@@ -2047,6 +2254,7 @@ impl<'a> BooleanScorer<'a> {
             driver,
             optional,
             prohibited,
+            score_mode,
             current: None,
             optional_matches: false,
             min_competitive_score: f32::NEG_INFINITY,
@@ -2104,9 +2312,8 @@ impl<'a> BooleanScorer<'a> {
             return Ok(false);
         }
 
-        // With no finite floor, every finite positive score is competitive.
-        // Probe after positive confirmation and score only documents that are
-        // not prohibited, avoiding wasted scoring when exclusions are dense.
+        // Probe after positive confirmation. Scoring mode scores only accepted
+        // documents, while COMPLETE_NO_SCORES stops after exact membership.
         self.work.positive_survivors += 1;
         self.work.must_not_probes += 1;
         let prohibited_matches = {
@@ -2126,6 +2333,9 @@ impl<'a> BooleanScorer<'a> {
         self.positive_checked_doc = Some(current);
         self.positive_survivor_doc = Some(current);
         self.prohibited_checked_doc = Some(current);
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return Ok(true);
+        }
         self.optional_matches = if let Some(optional) = &mut self.optional {
             optional.advance(current)? == Some(current) && optional.matches()?
         } else {
@@ -2247,7 +2457,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     fn next(&mut self) -> Result<Option<u64>> {
         if self.prohibited.is_none() {
             self.next_accepted_without_prohibited(None)
-        } else if self.min_competitive_score == f32::NEG_INFINITY {
+        } else if self.score_mode == CompoundScoreMode::CompleteNoScores
+            || self.min_competitive_score == f32::NEG_INFINITY
+        {
             self.next_accepted_without_score_floor(None)
         } else {
             self.position(None)
@@ -2260,7 +2472,9 @@ impl ComposableScorer for BooleanScorer<'_> {
         }
         if self.prohibited.is_none() {
             self.next_accepted_without_prohibited(Some(target))
-        } else if self.min_competitive_score == f32::NEG_INFINITY {
+        } else if self.score_mode == CompoundScoreMode::CompleteNoScores
+            || self.min_competitive_score == f32::NEG_INFINITY
+        {
             self.next_accepted_without_score_floor(Some(target))
         } else {
             self.position(Some(target))
@@ -2272,6 +2486,11 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn score(&mut self) -> Result<f32> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return Err(Error::internal(
+                "score requested from a COMPLETE_NO_SCORES Boolean FTS scorer",
+            ));
+        }
         if self.prohibited.is_none() {
             if self.current.is_none() {
                 return Err(Error::internal(
@@ -2300,6 +2519,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return Ok(u64::MAX);
+        }
         let mut up_to = self.driver.advance_shallow(target)?;
         if let Some(optional) = &mut self.optional
             && let Some(doc) = optional.doc()
@@ -2310,6 +2532,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return Ok(ScoreBounds::UNBOUNDED);
+        }
         let mut bounds = self.driver.score_bounds(up_to)?;
         if let Some(optional) = &mut self.optional
             && optional.doc().is_some_and(|doc| doc <= up_to)
@@ -2320,6 +2545,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn global_score_upper_bound(&self) -> Option<f32> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return None;
+        }
         if !self.scores_non_negative() {
             return None;
         }
@@ -2342,6 +2570,14 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            if min_score.is_nan() {
+                return Err(Error::invalid_input(
+                    "minimum competitive FTS score cannot be NaN",
+                ));
+            }
+            return Ok(());
+        }
         if self.prohibited.is_some() {
             if min_score.is_nan() {
                 return Err(Error::invalid_input(
@@ -2362,6 +2598,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn matches(&mut self) -> Result<bool> {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return Ok(self.current.is_some());
+        }
         if self.prohibited.is_none() {
             return Ok(self.current.is_some());
         }
@@ -2379,6 +2618,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn scores_non_negative(&self) -> bool {
+        if self.score_mode == CompoundScoreMode::CompleteNoScores {
+            return false;
+        }
         self.driver.scores_non_negative()
             && self
                 .optional
@@ -2405,12 +2647,6 @@ impl Drop for BooleanScorer<'_> {
 enum LeafQuery {
     Match(MatchQuery),
     Phrase(PhraseQuery),
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum LeafScoreMode {
-    Scoring,
-    Membership,
 }
 
 impl LeafQuery {
@@ -2447,15 +2683,17 @@ impl LeafQuery {
 
 fn collect_leaf_queries(
     query: &FtsQuery,
-    score_mode: LeafScoreMode,
-    leaves: &mut Vec<(LeafQuery, LeafScoreMode)>,
+    score_mode: CompoundScoreMode,
+    leaves: &mut Vec<(LeafQuery, CompoundScoreMode)>,
 ) -> Result<()> {
     match query {
         FtsQuery::Match(query) => leaves.push((LeafQuery::Match(query.clone()), score_mode)),
         FtsQuery::Phrase(query) => leaves.push((LeafQuery::Phrase(query.clone()), score_mode)),
         FtsQuery::Boost(query) => {
             collect_leaf_queries(&query.positive, score_mode, leaves)?;
-            collect_leaf_queries(&query.negative, score_mode, leaves)?;
+            if score_mode == CompoundScoreMode::Scoring {
+                collect_leaf_queries(&query.negative, score_mode, leaves)?;
+            }
         }
         FtsQuery::MultiMatch(query) => {
             leaves.extend(
@@ -2467,20 +2705,16 @@ fn collect_leaf_queries(
             );
         }
         FtsQuery::Boolean(query) => {
-            for child in query.should.iter().chain(&query.must) {
+            if score_mode == CompoundScoreMode::Scoring || query.must.is_empty() {
+                for child in &query.should {
+                    collect_leaf_queries(child, score_mode, leaves)?;
+                }
+            }
+            for child in &query.must {
                 collect_leaf_queries(child, score_mode, leaves)?;
             }
             for child in &query.must_not {
-                // Prohibited leaves never contribute a score. Start with the
-                // direct shapes covered by the current compound execution
-                // plan; complex nested exclusions retain the scoring cursor
-                // until the whole subtree can carry this mode explicitly.
-                let child_mode = if matches!(child, FtsQuery::Match(_) | FtsQuery::Phrase(_)) {
-                    LeafScoreMode::Membership
-                } else {
-                    LeafScoreMode::Scoring
-                };
-                collect_leaf_queries(child, child_mode, leaves)?;
+                collect_leaf_queries(child, CompoundScoreMode::CompleteNoScores, leaves)?;
             }
         }
     }
@@ -2492,7 +2726,7 @@ struct PreparedLeaf {
     params: Arc<FtsSearchParams>,
     operator: Operator,
     scorer: Arc<MemBM25Scorer>,
-    score_mode: LeafScoreMode,
+    score_mode: CompoundScoreMode,
 }
 
 fn tokenize_leaf(index: &InvertedIndex, leaf: &LeafQuery, params: &FtsSearchParams) -> Tokens {
@@ -2546,6 +2780,55 @@ fn validate_injected_scorer_tokens(scorer: &MemBM25Scorer, tokens: &Tokens) -> R
     Ok(())
 }
 
+fn validate_compound_query(query: &FtsQuery) -> Result<()> {
+    fn validate_multiplier(name: &str, value: f32) -> Result<()> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(())
+        } else {
+            Err(Error::invalid_input(format!(
+                "{name} must be finite and non-negative, got {value}"
+            )))
+        }
+    }
+
+    match query {
+        FtsQuery::Match(query) => validate_multiplier("MatchQuery boost", query.boost),
+        FtsQuery::Phrase(_) => Ok(()),
+        FtsQuery::Boost(query) => {
+            validate_multiplier("BoostQuery negative_boost", query.negative_boost)?;
+            validate_compound_query(&query.positive)?;
+            validate_compound_query(&query.negative)
+        }
+        FtsQuery::MultiMatch(query) => {
+            if query.match_queries.is_empty() {
+                return Err(Error::invalid_input(
+                    "MultiMatchQuery must have at least one match query",
+                ));
+            }
+            for match_query in &query.match_queries {
+                validate_multiplier("MultiMatchQuery boost", match_query.boost)?;
+            }
+            Ok(())
+        }
+        FtsQuery::Boolean(query) => {
+            if query.should.is_empty() && query.must.is_empty() {
+                return Err(Error::invalid_input(
+                    "boolean query must have at least one should/must query",
+                ));
+            }
+            for child in query
+                .should
+                .iter()
+                .chain(&query.must)
+                .chain(&query.must_not)
+            {
+                validate_compound_query(child)?;
+            }
+            Ok(())
+        }
+    }
+}
+
 async fn prepare_compound_query(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
@@ -2556,10 +2839,14 @@ async fn prepare_compound_query(
     let first_index = indices
         .first()
         .ok_or_else(|| Error::invalid_input("compound FTS requires at least one index segment"))?;
+    // CompleteNoScores prunes score-only branches. Validate the original AST
+    // first so pruning cannot make malformed nested queries silently valid.
+    validate_compound_query(query)?;
     let mut leaf_queries = Vec::new();
-    collect_leaf_queries(query, LeafScoreMode::Scoring, &mut leaf_queries)?;
+    collect_leaf_queries(query, CompoundScoreMode::Scoring, &mut leaf_queries)?;
     let mut num_plan_leaves = 0;
-    let plan = CompoundScorerPlan::from_query(query, &mut num_plan_leaves)?;
+    let plan =
+        CompoundScorerPlan::from_query(query, &mut num_plan_leaves, CompoundScoreMode::Scoring)?;
     if num_plan_leaves != leaf_queries.len() {
         return Err(Error::internal(format!(
             "compound FTS planned {num_plan_leaves} leaves but prepared {}",
@@ -2573,14 +2860,14 @@ async fn prepare_compound_query(
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
         let scorer = match score_mode {
-            LeafScoreMode::Membership => membership_scorer
+            CompoundScoreMode::CompleteNoScores => membership_scorer
                 .get_or_insert_with(|| {
                     // Posting loading still carries a scorer, but membership
                     // cursors never observe its weights or score bounds.
                     Arc::new(MemBM25Scorer::new(1, 1, Default::default()))
                 })
                 .clone(),
-            LeafScoreMode::Scoring => match &base_scorer {
+            CompoundScoreMode::Scoring => match &base_scorer {
                 Some(scorer) => scorer.clone(),
                 None => Arc::new(
                     build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics))
@@ -2592,7 +2879,7 @@ async fn prepare_compound_query(
         for index in indices {
             let expanded_tokens =
                 expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())?;
-            if score_mode == LeafScoreMode::Scoring && base_scorer.is_some() {
+            if score_mode == CompoundScoreMode::Scoring && base_scorer.is_some() {
                 validate_injected_scorer_tokens(&scorer, &expanded_tokens)?;
             }
             tokens_by_segment.push(Arc::new(expanded_tokens));
@@ -2609,11 +2896,17 @@ async fn prepare_compound_query(
 }
 
 struct LoadedLeaf {
-    postings: Vec<PostingIterator>,
+    postings: Option<Vec<PostingIterator>>,
     params: Arc<FtsSearchParams>,
     operator: Operator,
     scorer: Arc<MemBM25Scorer>,
-    score_mode: LeafScoreMode,
+    score_mode: CompoundScoreMode,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PartitionLoadMode {
+    ScoringOnly,
+    All,
 }
 
 enum LoadedDocuments {
@@ -2632,6 +2925,9 @@ struct LoadedPartition {
     partition: Arc<InvertedPartition>,
     documents: LoadedDocuments,
     leaves: Vec<LoadedLeaf>,
+    /// First positive document that can still meet the score floor used by
+    /// the preflight gate. Documents before it cannot enter the final top-k.
+    collection_start_doc: Option<u64>,
 }
 
 async fn load_compound_partition(
@@ -2641,6 +2937,7 @@ async fn load_compound_partition(
     leaves: &[PreparedLeaf],
     mask: Arc<RowAddrMask>,
     metrics: Arc<dyn MetricsCollector>,
+    load_mode: PartitionLoadMode,
 ) -> Result<Option<LoadedPartition>> {
     let leaf_loads = leaves.iter().map(|leaf| {
         let partition = partition.clone();
@@ -2652,19 +2949,36 @@ async fn load_compound_partition(
         let operator = leaf.operator;
         async move {
             let postings = if tokens.is_empty() {
-                Vec::new()
+                Some(Vec::new())
+            } else if load_mode == PartitionLoadMode::ScoringOnly
+                && score_mode == CompoundScoreMode::CompleteNoScores
+            {
+                None
+            } else if score_mode == CompoundScoreMode::CompleteNoScores {
+                Some(
+                    partition
+                        .load_membership_posting_lists(
+                            tokens.as_ref(),
+                            params.as_ref(),
+                            operator,
+                            metrics.as_ref(),
+                        )
+                        .await?,
+                )
             } else {
-                partition
-                    .load_posting_lists(
-                        tokens.as_ref(),
-                        params.as_ref(),
-                        operator,
-                        scorer.as_ref(),
-                        metrics.as_ref(),
-                        score_mode == LeafScoreMode::Scoring,
-                    )
-                    .await?
-                    .postings
+                Some(
+                    partition
+                        .load_posting_lists(
+                            tokens.as_ref(),
+                            params.as_ref(),
+                            operator,
+                            scorer.as_ref(),
+                            metrics.as_ref(),
+                            true,
+                        )
+                        .await?
+                        .postings,
+                )
             };
             Result::Ok(LoadedLeaf {
                 postings,
@@ -2718,7 +3032,72 @@ async fn load_compound_partition(
         partition,
         documents,
         leaves,
+        collection_start_doc: None,
     }))
+}
+
+async fn load_deferred_prohibited_postings(
+    mut loaded: LoadedPartition,
+    leaves: &[PreparedLeaf],
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<LoadedPartition> {
+    if loaded.leaves.len() != leaves.len() {
+        return Err(Error::internal(format!(
+            "compound FTS loaded {} leaves for a {}-leaf plan",
+            loaded.leaves.len(),
+            leaves.len()
+        )));
+    }
+    let segment_ordinal = loaded.segment_ordinal;
+    let loads = loaded
+        .leaves
+        .iter()
+        .enumerate()
+        .filter(|(_, leaf)| leaf.postings.is_none())
+        .map(|(index, loaded_leaf)| {
+            let partition = loaded.partition.clone();
+            let prepared = &leaves[index];
+            let tokens = prepared.tokens_by_segment[segment_ordinal].clone();
+            let params = prepared.params.clone();
+            let metrics = metrics.clone();
+            let operator = prepared.operator;
+            let score_mode = prepared.score_mode;
+            debug_assert_eq!(loaded_leaf.score_mode, CompoundScoreMode::CompleteNoScores);
+            async move {
+                if score_mode != CompoundScoreMode::CompleteNoScores {
+                    return Err(Error::internal(format!(
+                        "compound FTS deferred scoring leaf index {index}"
+                    )));
+                }
+                let postings = if tokens.is_empty() {
+                    Vec::new()
+                } else {
+                    partition
+                        .load_membership_posting_lists(
+                            tokens.as_ref(),
+                            params.as_ref(),
+                            operator,
+                            metrics.as_ref(),
+                        )
+                        .await?
+                };
+                Result::Ok((index, postings))
+            }
+        });
+    let postings = futures::future::try_join_all(loads).await?;
+    let num_loads = postings.len();
+    for (index, postings) in postings {
+        let leaf = loaded.leaves.get_mut(index).ok_or_else(|| {
+            Error::internal(format!(
+                "compound FTS deferred leaf index {index} disappeared while loading"
+            ))
+        })?;
+        leaf.postings = Some(postings);
+    }
+    if num_loads > 0 {
+        metrics.record_compound_must_not_posting_loads(num_loads);
+    }
+    Ok(loaded)
 }
 
 struct DeferredCompoundRows {
@@ -2731,17 +3110,69 @@ struct OverflowedCompoundPartition {
     partition_ordinal: usize,
     partition: Arc<InvertedPartition>,
     documents: Arc<PartitionDocuments>,
+    collection_start_doc: Option<u64>,
 }
 
 enum PartitionCollectionBoundary {
+    NeedsProhibited(Vec<LoadedPartition>),
     Deferred(DeferredCompoundRows),
     Overflow(OverflowedCompoundPartition),
 }
 
 struct CollectedPartitions {
     collector: TopKCollector<u64>,
-    remaining: Vec<LoadedPartition>,
+    remaining: VecDeque<LoadedPartition>,
     boundary: Option<PartitionCollectionBoundary>,
+}
+
+fn first_partition_competitive_doc<'a, D: WandDocuments + Sync>(
+    documents: &'a D,
+    leaves: &'a [LoadedLeaf],
+    plan: &CompoundScorerPlan,
+    metrics: &'a dyn MetricsCollector,
+    min_score: f32,
+) -> Result<Option<u64>> {
+    let is_membership_gate = min_score == f32::NEG_INFINITY;
+    let mut leaf_scorers = leaves
+        .iter()
+        .map(|leaf| -> Result<Option<BoxScorer<'a>>> {
+            if leaf.score_mode == CompoundScoreMode::CompleteNoScores {
+                return Ok(None);
+            }
+            let postings = leaf
+                .postings
+                .as_ref()
+                .ok_or_else(|| Error::internal("compound FTS positive posting was not loaded"))?;
+            let postings = postings
+                .iter()
+                .map(PostingIterator::fork_from_start)
+                .collect::<Vec<_>>();
+            let scorer: BoxScorer<'a> = if postings.is_empty() {
+                Box::new(EmptyScorer)
+            } else if is_membership_gate {
+                Box::new(WandCursor::new_membership(
+                    leaf.operator,
+                    postings,
+                    documents,
+                    leaf.scorer.clone(),
+                    leaf.params.as_ref(),
+                    metrics,
+                ))
+            } else {
+                Box::new(WandCursor::new(
+                    leaf.operator,
+                    postings,
+                    documents,
+                    leaf.scorer.clone(),
+                    leaf.params.as_ref(),
+                    metrics,
+                ))
+            };
+            Ok(Some(scorer))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut scorer = plan.build_gate(&mut leaf_scorers, metrics)?;
+    first_competitive_match(scorer.as_mut(), min_score)
 }
 
 fn collect_partition_with_documents<D, K>(
@@ -2750,6 +3181,7 @@ fn collect_partition_with_documents<D, K>(
     plan: &CompoundScorerPlan,
     metrics: &dyn MetricsCollector,
     collector: &mut TopKCollector<K>,
+    collection_start_doc: Option<u64>,
     mut map_document: impl FnMut(u64) -> Result<K>,
 ) -> Result<CollectionStatus>
 where
@@ -2758,13 +3190,16 @@ where
 {
     let mut leaf_scorers = leaves
         .into_iter()
-        .map(|leaf| {
-            let scorer: BoxScorer<'_> = if leaf.postings.is_empty() {
+        .map(|leaf| -> Result<Option<BoxScorer<'_>>> {
+            let postings = leaf.postings.ok_or_else(|| {
+                Error::internal("compound FTS prohibited posting was not loaded before collection")
+            })?;
+            let scorer: BoxScorer<'_> = if postings.is_empty() {
                 Box::new(EmptyScorer)
-            } else if leaf.score_mode == LeafScoreMode::Membership {
+            } else if leaf.score_mode == CompoundScoreMode::CompleteNoScores {
                 Box::new(WandCursor::new_membership(
                     leaf.operator,
-                    leaf.postings,
+                    postings,
                     documents,
                     leaf.scorer,
                     leaf.params.as_ref(),
@@ -2773,40 +3208,108 @@ where
             } else {
                 Box::new(WandCursor::new(
                     leaf.operator,
-                    leaf.postings,
+                    postings,
                     documents,
                     leaf.scorer,
                     leaf.params.as_ref(),
                     metrics,
                 ))
             };
-            Some(scorer)
+            Ok(Some(scorer))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
     let mut scorer = plan.build(&mut leaf_scorers, metrics)?;
     if leaf_scorers.iter().any(Option::is_some) {
         return Err(Error::internal(
             "compound FTS scorer did not consume every prepared leaf",
         ));
     }
-    collector.collect_mapped(scorer.as_mut(), &mut map_document)
+    collector.collect_mapped_from(scorer.as_mut(), collection_start_doc, &mut map_document)
 }
 
 fn collect_loaded_partitions(
-    partitions: Vec<LoadedPartition>,
+    mut partitions: VecDeque<LoadedPartition>,
     plan: &CompoundScorerPlan,
+    may_have_deferred_prohibited: bool,
     mask: &RowAddrMask,
     metrics: &dyn MetricsCollector,
     mut collector: TopKCollector<u64>,
 ) -> Result<CollectedPartitions> {
-    let mut partitions = partitions.into_iter();
-    while let Some(partition) = partitions.next() {
+    let mut needs_prohibited = Vec::with_capacity(DEFERRED_MUST_NOT_LOAD_BATCH_SIZE);
+    let mut has_safe_score_gate = None;
+    while let Some(mut partition) = partitions.pop_front() {
+        if may_have_deferred_prohibited
+            && partition.leaves.iter().any(|leaf| leaf.postings.is_none())
+        {
+            // Signed nested Boosts can make a positive-only score gate
+            // underestimate the final score. The positive match set remains
+            // exact, so use a membership-only gate for those plans instead of
+            // eagerly loading every prohibited posting.
+            let has_safe_score_gate =
+                *has_safe_score_gate.get_or_insert_with(|| plan.positive_gate_is_safe());
+            let min_score = if has_safe_score_gate {
+                collector.competitive_score.get()
+            } else {
+                f32::NEG_INFINITY
+            };
+            let collection_start_doc = match &partition.documents {
+                LoadedDocuments::Legacy(docs) => {
+                    let documents = LegacyWandDocuments::new(docs.as_ref(), mask);
+                    first_partition_competitive_doc(
+                        &documents,
+                        &partition.leaves,
+                        plan,
+                        metrics,
+                        min_score,
+                    )?
+                }
+                LoadedDocuments::Modern {
+                    lengths,
+                    visibility,
+                    ..
+                } => {
+                    let documents = ModernWandDocuments::filtered(lengths.as_ref(), visibility);
+                    first_partition_competitive_doc(
+                        &documents,
+                        &partition.leaves,
+                        plan,
+                        metrics,
+                        min_score,
+                    )?
+                }
+            };
+            if let Some(collection_start_doc) = collection_start_doc {
+                partition.collection_start_doc = Some(collection_start_doc);
+                needs_prohibited.push(partition);
+                if needs_prohibited.len() == DEFERRED_MUST_NOT_LOAD_BATCH_SIZE {
+                    return Ok(CollectedPartitions {
+                        collector,
+                        remaining: partitions,
+                        boundary: Some(PartitionCollectionBoundary::NeedsProhibited(
+                            needs_prohibited,
+                        )),
+                    });
+                }
+            }
+            continue;
+        }
+        if !needs_prohibited.is_empty() {
+            partitions.push_front(partition);
+            return Ok(CollectedPartitions {
+                collector,
+                remaining: partitions,
+                boundary: Some(PartitionCollectionBoundary::NeedsProhibited(
+                    needs_prohibited,
+                )),
+            });
+        }
         let LoadedPartition {
             segment_ordinal,
             partition_ordinal,
             partition: source,
             documents,
             leaves,
+            collection_start_doc,
         } = partition;
         match documents {
             LoadedDocuments::Legacy(docs) => {
@@ -2817,6 +3320,7 @@ fn collect_loaded_partitions(
                     plan,
                     metrics,
                     &mut collector,
+                    collection_start_doc,
                     Ok,
                 )?;
                 debug_assert_eq!(status, CollectionStatus::Complete);
@@ -2836,6 +3340,7 @@ fn collect_loaded_partitions(
                         plan,
                         metrics,
                         &mut collector,
+                        collection_start_doc,
                         |doc_id| {
                             let doc_id = DocId::new(u32::try_from(doc_id).map_err(|_| {
                                 Error::index(format!(
@@ -2869,6 +3374,7 @@ fn collect_loaded_partitions(
                         plan,
                         metrics,
                         &mut local_collector,
+                        collection_start_doc,
                         |doc_id| {
                             Ok(DocId::new(u32::try_from(doc_id).map_err(|_| {
                                 Error::index(format!(
@@ -2892,13 +3398,14 @@ fn collect_loaded_partitions(
                                 partition_ordinal,
                                 partition: source,
                                 documents: partition_documents,
+                                collection_start_doc,
                             })
                         }
                     };
                     metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
                     return Ok(CollectedPartitions {
                         collector,
-                        remaining: partitions.collect(),
+                        remaining: partitions,
                         boundary: Some(boundary),
                     });
                 }
@@ -2906,10 +3413,13 @@ fn collect_loaded_partitions(
         }
     }
     metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
+    let boundary = (!needs_prohibited.is_empty()).then_some(
+        PartitionCollectionBoundary::NeedsProhibited(needs_prohibited),
+    );
     Ok(CollectedPartitions {
         collector,
-        remaining: Vec::new(),
-        boundary: None,
+        remaining: partitions,
+        boundary,
     })
 }
 
@@ -2957,6 +3467,7 @@ async fn reload_compound_partition_with_projection(
         leaves,
         mask,
         metrics,
+        PartitionLoadMode::All,
     )
     .await?
     .ok_or_else(|| {
@@ -2977,6 +3488,7 @@ async fn reload_compound_partition_with_projection(
             )));
         }
     }
+    loaded.collection_start_doc = overflow.collection_start_doc;
     Ok(loaded)
 }
 
@@ -3035,6 +3547,9 @@ async fn compound_search_impl(
     }
     let (plan, leaves) =
         prepare_compound_query(indices, query, params, metrics.as_ref(), base_scorer).await?;
+    let has_prohibited_leaves = leaves
+        .iter()
+        .any(|leaf| leaf.score_mode == CompoundScoreMode::CompleteNoScores);
     prefilter.wait_for_ready().await?;
     let mask = prefilter.mask();
     let mut collector = TopKCollector::new(limit);
@@ -3054,15 +3569,20 @@ async fn compound_search_impl(
                         &leaves,
                         mask.clone(),
                         metrics.clone(),
+                        PartitionLoadMode::ScoringOnly,
                     )
                 });
-        let mut partitions = stream::iter(loads)
+        let mut loaded_partitions = stream::iter(loads)
             .buffer_unordered(get_num_compute_intensive_cpus().clamp(1, 32))
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
+        if has_prohibited_leaves {
+            loaded_partitions.sort_unstable_by_key(|partition| partition.partition_ordinal);
+        }
+        let mut partitions = VecDeque::from(loaded_partitions);
         while !partitions.is_empty() {
             let cpu_plan = plan.clone();
             let cpu_mask = mask.clone();
@@ -3071,6 +3591,7 @@ async fn compound_search_impl(
                 collect_loaded_partitions(
                     partitions,
                     &cpu_plan,
+                    has_prohibited_leaves,
                     cpu_mask.as_ref(),
                     cpu_metrics.as_ref(),
                     collector,
@@ -3080,6 +3601,15 @@ async fn compound_search_impl(
             collector = collected.collector;
             partitions = collected.remaining;
             match collected.boundary {
+                Some(PartitionCollectionBoundary::NeedsProhibited(pending)) => {
+                    let loads = pending.into_iter().map(|partition| {
+                        load_deferred_prohibited_postings(partition, &leaves, metrics.clone())
+                    });
+                    let loaded = futures::future::try_join_all(loads).await?;
+                    let mut resumed = VecDeque::from(loaded);
+                    resumed.append(&mut partitions);
+                    partitions = resumed;
+                }
                 Some(PartitionCollectionBoundary::Deferred(deferred)) => {
                     merge_resolved_compound_rows(&mut collector, deferred, metrics.as_ref())
                         .await?;
@@ -3092,7 +3622,7 @@ async fn compound_search_impl(
                         metrics.clone(),
                     )
                     .await?;
-                    partitions.insert(0, retry);
+                    partitions.push_front(retry);
                 }
                 None => debug_assert!(partitions.is_empty()),
             }
@@ -3111,7 +3641,7 @@ mod tests {
     use rand::{Rng, SeedableRng, rngs::SmallRng};
 
     use super::*;
-    use crate::scalar::inverted::query::{BooleanQuery, Occur};
+    use crate::scalar::inverted::query::{BooleanQuery, BoostQuery, MultiMatchQuery, Occur};
 
     fn rows(values: &[(u64, f32)]) -> Vec<ScoredRow> {
         values
@@ -3142,20 +3672,316 @@ mod tests {
         ]));
         let mut leaves = Vec::new();
 
-        collect_leaf_queries(&query, LeafScoreMode::Scoring, &mut leaves).unwrap();
+        collect_leaf_queries(&query, CompoundScoreMode::Scoring, &mut leaves).unwrap();
 
         assert!(matches!(
             &leaves[0],
-            (LeafQuery::Match(_), LeafScoreMode::Scoring)
+            (LeafQuery::Match(_), CompoundScoreMode::Scoring)
         ));
         assert!(matches!(
             &leaves[1],
-            (LeafQuery::Match(_), LeafScoreMode::Membership)
+            (LeafQuery::Match(_), CompoundScoreMode::CompleteNoScores)
         ));
         assert!(matches!(
             &leaves[2],
-            (LeafQuery::Phrase(_), LeafScoreMode::Membership)
+            (LeafQuery::Phrase(_), CompoundScoreMode::CompleteNoScores)
         ));
+    }
+
+    #[test]
+    fn prohibited_subtrees_recursively_use_membership_mode() {
+        let nested = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Should,
+                FtsQuery::Phrase(PhraseQuery::new(String::from("optional phrase"))),
+            ),
+            (
+                Occur::Must,
+                FtsQuery::MultiMatch(MultiMatchQuery {
+                    match_queries: vec![
+                        MatchQuery::new(String::from("multi a")),
+                        MatchQuery::new(String::from("multi b")),
+                    ],
+                }),
+            ),
+            (
+                Occur::Must,
+                FtsQuery::Boost(BoostQuery::new(
+                    FtsQuery::Match(MatchQuery::new(String::from("boost positive"))),
+                    FtsQuery::Match(MatchQuery::new(String::from("boost negative"))),
+                    Some(0.25),
+                )),
+            ),
+            (
+                Occur::MustNot,
+                FtsQuery::Boolean(BooleanQuery::new([(
+                    Occur::Should,
+                    FtsQuery::Phrase(PhraseQuery::new(String::from("nested exclusion"))),
+                )])),
+            ),
+        ]));
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("required"))),
+            ),
+            (Occur::MustNot, nested),
+        ]));
+        let mut leaves = Vec::new();
+
+        collect_leaf_queries(&query, CompoundScoreMode::Scoring, &mut leaves).unwrap();
+
+        assert_eq!(
+            leaves
+                .iter()
+                .map(|(leaf, _)| leaf.terms())
+                .collect::<Vec<_>>(),
+            vec![
+                "required",
+                "multi a",
+                "multi b",
+                "boost positive",
+                "nested exclusion"
+            ]
+        );
+        assert_eq!(leaves[0].1, CompoundScoreMode::Scoring);
+        assert!(
+            leaves[1..]
+                .iter()
+                .all(|(_, mode)| *mode == CompoundScoreMode::CompleteNoScores)
+        );
+    }
+
+    #[test]
+    fn prohibited_subtree_pruning_preserves_query_validation() {
+        let invalid_optional =
+            FtsQuery::Match(MatchQuery::new(String::from("invalid optional")).with_boost(f32::NAN));
+        let prohibited = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("required"))),
+            ),
+            (Occur::Should, invalid_optional),
+        ]));
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("positive"))),
+            ),
+            (Occur::MustNot, prohibited),
+        ]));
+
+        let error = validate_compound_query(&query).unwrap_err();
+        assert!(matches!(&error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("MatchQuery boost must be finite and non-negative, got NaN")
+        );
+
+        let empty_multi_match = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("positive"))),
+            ),
+            (
+                Occur::MustNot,
+                FtsQuery::Boost(BoostQuery::new(
+                    FtsQuery::Match(MatchQuery::new(String::from("required"))),
+                    FtsQuery::MultiMatch(MultiMatchQuery {
+                        match_queries: Vec::new(),
+                    }),
+                    Some(0.5),
+                )),
+            ),
+        ]));
+        let error = validate_compound_query(&empty_multi_match).unwrap_err();
+        assert!(matches!(&error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("MultiMatchQuery must have at least one match query")
+        );
+    }
+
+    #[test]
+    fn prohibited_subtrees_never_score_nested_compound_leaves() {
+        let nested = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Should,
+                FtsQuery::Match(MatchQuery::new(String::from("optional"))),
+            ),
+            (
+                Occur::Must,
+                FtsQuery::MultiMatch(MultiMatchQuery {
+                    match_queries: vec![
+                        MatchQuery::new(String::from("multi a")),
+                        MatchQuery::new(String::from("multi b")),
+                    ],
+                }),
+            ),
+            (
+                Occur::Must,
+                FtsQuery::Boost(BoostQuery::new(
+                    FtsQuery::Match(
+                        MatchQuery::new(String::from("boost positive")).with_boost(2.0),
+                    ),
+                    FtsQuery::Match(MatchQuery::new(String::from("boost negative"))),
+                    Some(0.5),
+                )),
+            ),
+            (
+                Occur::MustNot,
+                FtsQuery::Boolean(BooleanQuery::new([(
+                    Occur::Should,
+                    FtsQuery::Match(MatchQuery::new(String::from("inner exclusion"))),
+                )])),
+            ),
+        ]));
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("required"))),
+            ),
+            (Occur::MustNot, nested),
+        ]));
+        let mut num_leaves = 0;
+        let plan =
+            CompoundScorerPlan::from_query(&query, &mut num_leaves, CompoundScoreMode::Scoring)
+                .unwrap();
+        assert_eq!(num_leaves, 5);
+
+        let (positive, _) = instrumented(materialized(&[
+            (0, 10.0),
+            (1, 9.0),
+            (2, 8.0),
+            (3, 7.0),
+            (4, 6.0),
+        ]));
+        let prohibited_rows = [
+            &[(1, 1.0), (2, 1.0), (3, 1.0)][..],
+            &[(2, 1.0), (4, 1.0)][..],
+            &[(1, 3.0), (2, 3.0), (4, 3.0)][..],
+        ];
+        let metrics = BooleanMetrics::default();
+        let mut prohibited_work = Vec::new();
+        let mut leaves = vec![Some(positive)];
+        for values in prohibited_rows {
+            let (scorer, work) = instrumented(materialized(values));
+            leaves.push(Some(scorer));
+            prohibited_work.push(work);
+        }
+        let (inner_exclusion, _, inner_exclusion_confirmations) =
+            two_phase(&[(2, 1.0), (4, 1.0)], vec![2, 4], Some(1.0));
+        let (inner_exclusion, work) = instrumented(inner_exclusion);
+        leaves.push(Some(inner_exclusion));
+        prohibited_work.push(work);
+        let mut scorer = plan.build(&mut leaves, &metrics).unwrap();
+
+        assert_eq!(
+            TopKCollector::new(10).collect(scorer.as_mut()).unwrap(),
+            rows(&[(0, 10.0), (2, 8.0), (3, 7.0), (4, 6.0)])
+        );
+        assert!(leaves.iter().all(Option::is_none));
+        assert_eq!(
+            inner_exclusion_confirmations.load(AtomicOrdering::Relaxed),
+            2
+        );
+        for work in prohibited_work {
+            assert_eq!(work.scores.load(AtomicOrdering::Relaxed), 0);
+            assert_eq!(work.shallow_advances.load(AtomicOrdering::Relaxed), 0);
+            assert_eq!(work.bounds.load(AtomicOrdering::Relaxed), 0);
+        }
+    }
+
+    #[test]
+    fn positive_gate_keeps_floor_ties() {
+        let mut tied = MaterializedScorer::try_new(rows(&[(0, 4.0), (1, 5.0)])).unwrap();
+        assert_eq!(first_competitive_match(&mut tied, 5.0).unwrap(), Some(1));
+
+        let mut below = MaterializedScorer::try_new(rows(&[(0, 4.0), (1, 5.0)])).unwrap();
+        assert_eq!(first_competitive_match(&mut below, 6.0).unwrap(), None);
+
+        let (mut unbounded, work) = instrumented(materialized(&[(0, 1.0)]));
+        assert_eq!(
+            first_competitive_match(unbounded.as_mut(), f32::NEG_INFINITY).unwrap(),
+            Some(0)
+        );
+        assert_eq!(work.scores.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(work.shallow_advances.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(work.bounds.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn collection_resumes_at_first_competitive_positive() {
+        let values = [(0, 1.0), (1, 10.0), (2, 11.0)];
+        let mut gate = MaterializedScorer::try_new(rows(&values)).unwrap();
+        let start_doc = first_competitive_match(&mut gate, 10.0).unwrap();
+        assert_eq!(start_doc, Some(1));
+
+        let mut scorer = BooleanScorer::try_new(
+            Vec::new(),
+            vec![materialized(&values)],
+            vec![materialized(&[(1, 1.0)])],
+        )
+        .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(10.0);
+        let mut collector = TopKCollector::with_competitive_score(1, competitive_score);
+
+        collector
+            .collect_mapped_from(&mut scorer, start_doc, Ok)
+            .unwrap();
+
+        assert_eq!(collector.into_rows(), rows(&[(2, 11.0)]));
+    }
+
+    #[test]
+    fn positive_gate_falls_back_for_signed_negative_subtrees() {
+        let match_query = |terms: &str| FtsQuery::Match(MatchQuery::new(String::from(terms)));
+        let signed_negative = FtsQuery::Boost(BoostQuery::new(
+            match_query("inner positive"),
+            match_query("inner negative"),
+            Some(1.0),
+        ));
+        let unsafe_query = FtsQuery::Boost(BoostQuery::new(
+            match_query("outer positive"),
+            signed_negative.clone(),
+            Some(0.5),
+        ));
+        let mut num_leaves = 0;
+        let unsafe_plan = CompoundScorerPlan::from_query(
+            &unsafe_query,
+            &mut num_leaves,
+            CompoundScoreMode::Scoring,
+        )
+        .unwrap();
+        assert!(!unsafe_plan.positive_gate_is_safe());
+        let metrics = BooleanMetrics::default();
+        let mut leaves = vec![
+            Some(materialized(&[(0, 1.0)])),
+            Some(materialized(&[(0, 1.0)])),
+            Some(materialized(&[(0, 11.0)])),
+        ];
+        let mut scorer = unsafe_plan.build(&mut leaves, &metrics).unwrap();
+        assert_eq!(
+            TopKCollector::new(1).collect(scorer.as_mut()).unwrap(),
+            rows(&[(0, 6.0)])
+        );
+
+        let safe_query = FtsQuery::Boost(BoostQuery::new(
+            match_query("outer positive"),
+            signed_negative,
+            Some(0.0),
+        ));
+        let mut num_leaves = 0;
+        let safe_plan = CompoundScorerPlan::from_query(
+            &safe_query,
+            &mut num_leaves,
+            CompoundScoreMode::Scoring,
+        )
+        .unwrap();
+        assert!(safe_plan.positive_gate_is_safe());
     }
 
     fn should_maxscore<'a>(
@@ -4075,6 +4901,7 @@ mod tests {
             driver: required,
             optional: Some(optional),
             prohibited: None,
+            score_mode: CompoundScoreMode::Scoring,
             current: None,
             optional_matches: false,
             min_competitive_score: f32::NEG_INFINITY,

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -2407,6 +2407,12 @@ enum LeafQuery {
     Phrase(PhraseQuery),
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LeafScoreMode {
+    Scoring,
+    Membership,
+}
+
 impl LeafQuery {
     fn terms(&self) -> &str {
         match self {
@@ -2439,25 +2445,42 @@ impl LeafQuery {
     }
 }
 
-fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>) -> Result<()> {
+fn collect_leaf_queries(
+    query: &FtsQuery,
+    score_mode: LeafScoreMode,
+    leaves: &mut Vec<(LeafQuery, LeafScoreMode)>,
+) -> Result<()> {
     match query {
-        FtsQuery::Match(query) => leaves.push(LeafQuery::Match(query.clone())),
-        FtsQuery::Phrase(query) => leaves.push(LeafQuery::Phrase(query.clone())),
+        FtsQuery::Match(query) => leaves.push((LeafQuery::Match(query.clone()), score_mode)),
+        FtsQuery::Phrase(query) => leaves.push((LeafQuery::Phrase(query.clone()), score_mode)),
         FtsQuery::Boost(query) => {
-            collect_leaf_queries(&query.positive, leaves)?;
-            collect_leaf_queries(&query.negative, leaves)?;
+            collect_leaf_queries(&query.positive, score_mode, leaves)?;
+            collect_leaf_queries(&query.negative, score_mode, leaves)?;
         }
         FtsQuery::MultiMatch(query) => {
-            leaves.extend(query.match_queries.iter().cloned().map(LeafQuery::Match));
+            leaves.extend(
+                query
+                    .match_queries
+                    .iter()
+                    .cloned()
+                    .map(|query| (LeafQuery::Match(query), score_mode)),
+            );
         }
         FtsQuery::Boolean(query) => {
-            for child in query
-                .should
-                .iter()
-                .chain(&query.must)
-                .chain(&query.must_not)
-            {
-                collect_leaf_queries(child, leaves)?;
+            for child in query.should.iter().chain(&query.must) {
+                collect_leaf_queries(child, score_mode, leaves)?;
+            }
+            for child in &query.must_not {
+                // Prohibited leaves never contribute a score. Start with the
+                // direct shapes covered by the current compound execution
+                // plan; complex nested exclusions retain the scoring cursor
+                // until the whole subtree can carry this mode explicitly.
+                let child_mode = if matches!(child, FtsQuery::Match(_) | FtsQuery::Phrase(_)) {
+                    LeafScoreMode::Membership
+                } else {
+                    LeafScoreMode::Scoring
+                };
+                collect_leaf_queries(child, child_mode, leaves)?;
             }
         }
     }
@@ -2469,6 +2492,7 @@ struct PreparedLeaf {
     params: Arc<FtsSearchParams>,
     operator: Operator,
     scorer: Arc<MemBM25Scorer>,
+    score_mode: LeafScoreMode,
 }
 
 fn tokenize_leaf(index: &InvertedIndex, leaf: &LeafQuery, params: &FtsSearchParams) -> Tokens {
@@ -2533,7 +2557,7 @@ async fn prepare_compound_query(
         .first()
         .ok_or_else(|| Error::invalid_input("compound FTS requires at least one index segment"))?;
     let mut leaf_queries = Vec::new();
-    collect_leaf_queries(query, &mut leaf_queries)?;
+    collect_leaf_queries(query, LeafScoreMode::Scoring, &mut leaf_queries)?;
     let mut num_plan_leaves = 0;
     let plan = CompoundScorerPlan::from_query(query, &mut num_plan_leaves)?;
     if num_plan_leaves != leaf_queries.len() {
@@ -2544,21 +2568,31 @@ async fn prepare_compound_query(
     }
 
     let mut leaves = Vec::with_capacity(leaf_queries.len());
-    for leaf in leaf_queries {
+    let mut membership_scorer = None;
+    for (leaf, score_mode) in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
-        let scorer = match &base_scorer {
-            Some(scorer) => scorer.clone(),
-            None => Arc::new(
-                build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics))
-                    .await?,
-            ),
+        let scorer = match score_mode {
+            LeafScoreMode::Membership => membership_scorer
+                .get_or_insert_with(|| {
+                    // Posting loading still carries a scorer, but membership
+                    // cursors never observe its weights or score bounds.
+                    Arc::new(MemBM25Scorer::new(1, 1, Default::default()))
+                })
+                .clone(),
+            LeafScoreMode::Scoring => match &base_scorer {
+                Some(scorer) => scorer.clone(),
+                None => Arc::new(
+                    build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics))
+                        .await?,
+                ),
+            },
         };
         let mut tokens_by_segment = Vec::with_capacity(indices.len());
         for index in indices {
             let expanded_tokens =
                 expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())?;
-            if base_scorer.is_some() {
+            if score_mode == LeafScoreMode::Scoring && base_scorer.is_some() {
                 validate_injected_scorer_tokens(&scorer, &expanded_tokens)?;
             }
             tokens_by_segment.push(Arc::new(expanded_tokens));
@@ -2568,6 +2602,7 @@ async fn prepare_compound_query(
             params: Arc::new(effective_params),
             operator: leaf.operator(),
             scorer,
+            score_mode,
         });
     }
     Ok((plan, leaves))
@@ -2578,6 +2613,7 @@ struct LoadedLeaf {
     params: Arc<FtsSearchParams>,
     operator: Operator,
     scorer: Arc<MemBM25Scorer>,
+    score_mode: LeafScoreMode,
 }
 
 enum LoadedDocuments {
@@ -2611,6 +2647,7 @@ async fn load_compound_partition(
         let tokens = leaf.tokens_by_segment[segment_ordinal].clone();
         let params = leaf.params.clone();
         let scorer = leaf.scorer.clone();
+        let score_mode = leaf.score_mode;
         let metrics = metrics.clone();
         let operator = leaf.operator;
         async move {
@@ -2624,7 +2661,7 @@ async fn load_compound_partition(
                         operator,
                         scorer.as_ref(),
                         metrics.as_ref(),
-                        true,
+                        score_mode == LeafScoreMode::Scoring,
                     )
                     .await?
                     .postings
@@ -2634,6 +2671,7 @@ async fn load_compound_partition(
                 params,
                 operator,
                 scorer,
+                score_mode,
             })
         }
     });
@@ -2723,6 +2761,15 @@ where
         .map(|leaf| {
             let scorer: BoxScorer<'_> = if leaf.postings.is_empty() {
                 Box::new(EmptyScorer)
+            } else if leaf.score_mode == LeafScoreMode::Membership {
+                Box::new(WandCursor::new_membership(
+                    leaf.operator,
+                    leaf.postings,
+                    documents,
+                    leaf.scorer,
+                    leaf.params.as_ref(),
+                    metrics,
+                ))
             } else {
                 Box::new(WandCursor::new(
                     leaf.operator,
@@ -3064,6 +3111,7 @@ mod tests {
     use rand::{Rng, SeedableRng, rngs::SmallRng};
 
     use super::*;
+    use crate::scalar::inverted::query::{BooleanQuery, Occur};
 
     fn rows(values: &[(u64, f32)]) -> Vec<ScoredRow> {
         values
@@ -3074,6 +3122,40 @@ mod tests {
 
     fn materialized(values: &[(u64, f32)]) -> Box<dyn ComposableScorer> {
         Box::new(MaterializedScorer::try_new(rows(values)).unwrap())
+    }
+
+    #[test]
+    fn direct_prohibited_leaves_use_membership_mode() {
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                FtsQuery::Match(MatchQuery::new(String::from("required"))),
+            ),
+            (
+                Occur::MustNot,
+                FtsQuery::Match(MatchQuery::new(String::from("excluded"))),
+            ),
+            (
+                Occur::MustNot,
+                FtsQuery::Phrase(PhraseQuery::new(String::from("excluded phrase"))),
+            ),
+        ]));
+        let mut leaves = Vec::new();
+
+        collect_leaf_queries(&query, LeafScoreMode::Scoring, &mut leaves).unwrap();
+
+        assert!(matches!(
+            &leaves[0],
+            (LeafQuery::Match(_), LeafScoreMode::Scoring)
+        ));
+        assert!(matches!(
+            &leaves[1],
+            (LeafQuery::Match(_), LeafScoreMode::Membership)
+        ));
+        assert!(matches!(
+            &leaves[2],
+            (LeafQuery::Phrase(_), LeafScoreMode::Membership)
+        ));
     }
 
     fn should_maxscore<'a>(

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -2953,7 +2953,14 @@ async fn load_compound_partition(
             } else if load_mode == PartitionLoadMode::ScoringOnly
                 && score_mode == CompoundScoreMode::CompleteNoScores
             {
-                None
+                partition
+                    .load_cached_membership_posting_lists(
+                        tokens.as_ref(),
+                        params.as_ref(),
+                        operator,
+                        metrics.as_ref(),
+                    )
+                    .await?
             } else if score_mode == CompoundScoreMode::CompleteNoScores {
                 Some(
                     partition

--- a/rust/lance-index/src/scalar/inverted/encoding.rs
+++ b/rust/lance-index/src/scalar/inverted/encoding.rs
@@ -1033,6 +1033,49 @@ pub fn decompress_posting_block(
     );
 }
 
+/// Decode only document ids from a full posting block, leaving the following
+/// frequency payload untouched. Membership-only queries do not need term
+/// frequencies, so avoiding that second bitpacking pass saves work without
+/// changing the on-disk block layout.
+pub fn decompress_posting_block_doc_ids(
+    block: &[u8],
+    buffer: &mut [u32],
+    doc_ids: &mut Vec<u32>,
+    block_size: usize,
+) {
+    debug_assert!(validate_block_size(block_size).is_ok());
+    debug_assert!(buffer.len() >= block_size);
+    let block = &block[posting_block_score_prefix_len(block_size)..];
+    match block_size {
+        BitPacker4x::BLOCK_LEN => {
+            decompress_sorted_block_with::<BitPacker4x>(block, buffer, doc_ids);
+        }
+        BitPacker8x::BLOCK_LEN => {
+            decompress_sorted_block_with::<BitPacker8x>(block, buffer, doc_ids);
+        }
+        _ => unreachable!("validated posting block size should be supported"),
+    }
+}
+
+fn decompress_varint_tail_doc_ids(block: &[u8], n: usize, doc_ids: &mut Vec<u32>) -> usize {
+    let mut offset = 0usize;
+    let mut previous = 0u32;
+    for index in 0..n {
+        let delta = decode_varint_u32(block, &mut offset)
+            .expect("posting tail doc ids should contain valid varints");
+        let doc_id = if index == 0 {
+            delta
+        } else {
+            previous
+                .checked_add(delta)
+                .expect("posting tail doc id delta should not overflow")
+        };
+        doc_ids.push(doc_id);
+        previous = doc_id;
+    }
+    offset
+}
+
 pub fn decompress_posting_remainder(
     block: &[u8],
     n: usize,
@@ -1048,21 +1091,7 @@ pub fn decompress_posting_remainder(
             decompress_raw_remainder(&block[n * 4..], n, frequencies);
         }
         PostingTailCodec::VarintDelta => {
-            let mut offset = 0usize;
-            let mut previous = 0u32;
-            for index in 0..n {
-                let delta = decode_varint_u32(block, &mut offset)
-                    .expect("posting tail doc ids should contain valid varints");
-                let doc_id = if index == 0 {
-                    delta
-                } else {
-                    previous
-                        .checked_add(delta)
-                        .expect("posting tail doc id delta should not overflow")
-                };
-                doc_ids.push(doc_id);
-                previous = doc_id;
-            }
+            let mut offset = decompress_varint_tail_doc_ids(block, n, doc_ids);
             for _ in 0..n {
                 let frequency = decode_varint_u32(block, &mut offset)
                     .expect("posting tail frequencies should contain valid varints");
@@ -1074,6 +1103,27 @@ pub fn decompress_posting_remainder(
                 "posting tail block has {} trailing bytes after decoding",
                 block.len() - offset
             );
+        }
+    }
+}
+
+/// Decode only document ids from a posting tail, leaving its frequency payload
+/// untouched. This supports both historical fixed-width tails and the current
+/// delta-varint tails without introducing another persistent format.
+pub fn decompress_posting_remainder_doc_ids(
+    block: &[u8],
+    n: usize,
+    codec: PostingTailCodec,
+    block_size: usize,
+    doc_ids: &mut Vec<u32>,
+) {
+    let block = &block[posting_block_score_prefix_len(block_size)..];
+    match codec {
+        PostingTailCodec::Fixed32 => {
+            decompress_raw_remainder(block, n, doc_ids);
+        }
+        PostingTailCodec::VarintDelta => {
+            decompress_varint_tail_doc_ids(block, n, doc_ids);
         }
     }
 }
@@ -1224,6 +1274,84 @@ mod tests {
                 )?;
             assert_eq!(decoded_doc_ids, doc_ids);
             assert_eq!(decoded_frequencies, frequencies);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_doc_id_only_decoder_does_not_read_full_block_frequencies() -> Result<()> {
+        for block_size in [BitPacker4x::BLOCK_LEN, BitPacker8x::BLOCK_LEN] {
+            let doc_ids = (0..block_size as u32)
+                .map(|doc_id| doc_id * 3 + 7)
+                .collect::<Vec<_>>();
+            let frequencies = (0..block_size as u32)
+                .map(|value| value % 11 + 1)
+                .collect::<Vec<_>>();
+            let posting_list = compress_posting_list_with_tail_codec_and_block_size(
+                doc_ids.len(),
+                doc_ids.iter(),
+                frequencies.iter(),
+                std::iter::once(1.0),
+                PostingTailCodec::VarintDelta,
+                block_size,
+            )?;
+
+            let block = posting_list.value(0);
+            let prefix = posting_block_score_prefix_len(block_size);
+            let doc_num_bits = block[prefix + 4];
+            let doc_payload_len = match block_size {
+                BitPacker4x::BLOCK_LEN => BitPacker4x::compressed_block_size(doc_num_bits),
+                BitPacker8x::BLOCK_LEN => BitPacker8x::compressed_block_size(doc_num_bits),
+                _ => unreachable!(),
+            };
+            // Deliberately omit the frequency header and payload. A decoder
+            // that touches either would fail on this truncated slice.
+            let doc_only_block = &block[..prefix + 5 + doc_payload_len];
+            let mut decoded = Vec::new();
+            let mut buffer = [0u32; MAX_POSTING_BLOCK_SIZE];
+            decompress_posting_block_doc_ids(doc_only_block, &mut buffer, &mut decoded, block_size);
+            assert_eq!(decoded, doc_ids);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_doc_id_only_decoder_does_not_read_tail_frequencies() -> Result<()> {
+        let doc_ids = vec![3_u32, 10_u32, 24_u32];
+        let frequencies = [1_u32, 7_u32, 2_u32];
+        for block_size in [BitPacker4x::BLOCK_LEN, BitPacker8x::BLOCK_LEN] {
+            for codec in [PostingTailCodec::Fixed32, PostingTailCodec::VarintDelta] {
+                let posting_list = compress_posting_list_with_tail_codec_and_block_size(
+                    doc_ids.len(),
+                    doc_ids.iter(),
+                    frequencies.iter(),
+                    std::iter::once(1.0),
+                    codec,
+                    block_size,
+                )?;
+                let block = posting_list.value(0);
+                let prefix = posting_block_score_prefix_len(block_size);
+                let doc_payload_end = match codec {
+                    PostingTailCodec::Fixed32 => prefix + doc_ids.len() * 4,
+                    PostingTailCodec::VarintDelta => {
+                        let mut offset = prefix;
+                        for _ in &doc_ids {
+                            decode_varint_u32(block, &mut offset)?;
+                        }
+                        offset
+                    }
+                };
+                // Deliberately omit every encoded frequency.
+                let mut decoded = Vec::new();
+                decompress_posting_remainder_doc_ids(
+                    &block[..doc_payload_end],
+                    doc_ids.len(),
+                    codec,
+                    block_size,
+                    &mut decoded,
+                );
+                assert_eq!(decoded, doc_ids);
+            }
         }
         Ok(())
     }

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -455,6 +455,350 @@ impl InvertedPartition {
         }
     }
 
+    fn union_plain_membership_posting_lists(
+        postings: Vec<PostingList>,
+        with_positions: bool,
+    ) -> Result<PostingList> {
+        if with_positions {
+            let mut positions_by_row_id = BTreeMap::<u64, Vec<u32>>::new();
+            for posting in postings {
+                let PostingList::Plain(posting) = posting else {
+                    return Err(Error::index(
+                        "cannot union mixed plain and compressed posting lists".to_owned(),
+                    ));
+                };
+                let positions = posting.positions.as_ref().ok_or_else(|| {
+                    Error::index("cannot union grouped phrase terms without positions".to_string())
+                })?;
+                let position_values = positions.values().as_primitive::<Int32Type>().values();
+                for (index, row_id) in posting.row_ids.iter().copied().enumerate() {
+                    let start = positions.value_offsets()[index] as usize;
+                    let end = positions.value_offsets()[index + 1] as usize;
+                    positions_by_row_id.entry(row_id).or_default().extend(
+                        position_values[start..end]
+                            .iter()
+                            .map(|value| *value as u32),
+                    );
+                }
+            }
+
+            let mut row_ids = Vec::with_capacity(positions_by_row_id.len());
+            let mut frequencies = Vec::with_capacity(positions_by_row_id.len());
+            let mut positions_builder = ListBuilder::new(Int32Builder::new());
+            for (row_id, mut positions) in positions_by_row_id {
+                positions.sort_unstable();
+                row_ids.push(row_id);
+                frequencies.push(positions.len() as f32);
+                for position in positions {
+                    positions_builder.values().append_value(position as i32);
+                }
+                positions_builder.append(true);
+            }
+            return Ok(PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from(row_ids),
+                ScalarBuffer::from(frequencies),
+                None,
+                Some(positions_builder.finish()),
+            )));
+        }
+
+        let mut row_ids = BTreeSet::new();
+        for posting in postings {
+            let PostingList::Plain(posting) = posting else {
+                return Err(Error::index(
+                    "cannot union mixed plain and compressed posting lists".to_owned(),
+                ));
+            };
+            row_ids.extend(posting.row_ids.iter().copied());
+        }
+        let row_ids = row_ids.into_iter().collect::<Vec<_>>();
+        let frequencies = vec![1.0; row_ids.len()];
+        Ok(PostingList::Plain(PlainPostingList::new(
+            ScalarBuffer::from(row_ids),
+            ScalarBuffer::from(frequencies),
+            None,
+            None,
+        )))
+    }
+
+    fn union_compressed_membership_posting_lists(
+        postings: Vec<PostingList>,
+        with_positions: bool,
+    ) -> Result<PostingList> {
+        let block_size = postings.iter().find_map(|posting| match posting {
+            PostingList::Compressed(posting) => Some(posting.block_size),
+            PostingList::Plain(_) => None,
+        });
+        let Some(block_size) = block_size else {
+            return Err(Error::internal(
+                "compressed membership union received no compressed postings",
+            ));
+        };
+        let mut builder = PostingListBuilder::new_with_block_size(with_positions, block_size);
+
+        if with_positions {
+            // Compressed position streams use frequency prefix sums as document
+            // boundaries. Exact phrase membership must decode those frequencies,
+            // but it still avoids BM25 weights, score bounds, and document lengths.
+            let mut positions_by_doc_id = BTreeMap::<u32, Vec<u32>>::new();
+            for posting in postings {
+                for (doc_id, _, positions) in posting.iter() {
+                    let doc_id = u32::try_from(doc_id).map_err(|_| {
+                        Error::index(format!(
+                            "compressed posting doc id {} exceeds u32::MAX",
+                            doc_id
+                        ))
+                    })?;
+                    let positions = positions.ok_or_else(|| {
+                        Error::index(
+                            "cannot union grouped phrase terms without positions".to_string(),
+                        )
+                    })?;
+                    positions_by_doc_id
+                        .entry(doc_id)
+                        .or_default()
+                        .extend(positions);
+                }
+            }
+            for (doc_id, mut positions) in positions_by_doc_id {
+                positions.sort_unstable();
+                builder.add(doc_id, PositionRecorder::Position(positions.into()));
+            }
+        } else {
+            let mut doc_ids = RoaringBitmap::new();
+            let mut decoded_doc_ids = Vec::with_capacity(block_size);
+            let mut decode_buffer = Box::new([0_u32; MAX_POSTING_BLOCK_SIZE]);
+            for posting in postings {
+                let PostingList::Compressed(posting) = posting else {
+                    return Err(Error::index(
+                        "cannot union mixed plain and compressed posting lists".to_owned(),
+                    ));
+                };
+                let remainder = posting.length as usize % posting.block_size;
+                for block_idx in 0..posting.blocks.len() {
+                    decoded_doc_ids.clear();
+                    let block = posting.blocks.value(block_idx);
+                    if block_idx + 1 == posting.blocks.len() && remainder != 0 {
+                        super::super::encoding::decompress_posting_remainder_doc_ids(
+                            block,
+                            remainder,
+                            posting.posting_tail_codec,
+                            posting.block_size,
+                            &mut decoded_doc_ids,
+                        );
+                    } else {
+                        super::super::encoding::decompress_posting_block_doc_ids(
+                            block,
+                            decode_buffer.as_mut_slice(),
+                            &mut decoded_doc_ids,
+                            posting.block_size,
+                        );
+                    }
+                    doc_ids.extend(decoded_doc_ids.iter().copied());
+                }
+            }
+            for doc_id in doc_ids {
+                builder.add(doc_id, PositionRecorder::Count(1));
+            }
+        }
+
+        if builder.is_empty() {
+            return Ok(PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from(Vec::<u64>::new()),
+                ScalarBuffer::from(Vec::<f32>::new()),
+                None,
+                None,
+            )));
+        }
+        let num_blocks = builder.len().div_ceil(block_size);
+        let batch = builder.to_batch(vec![0.0; num_blocks])?;
+        let max_score = batch[MAX_SCORE_COL].as_primitive::<Float32Type>().value(0);
+        let length = batch[LENGTH_COL].as_primitive::<UInt32Type>().value(0);
+        PostingList::from_batch(&batch, Some(max_score), Some(length))
+    }
+
+    fn union_membership_posting_lists(
+        postings: Vec<PostingList>,
+        with_positions: bool,
+    ) -> Result<PostingList> {
+        let has_plain = postings
+            .iter()
+            .any(|posting| matches!(posting, PostingList::Plain(_)));
+        let has_compressed = postings
+            .iter()
+            .any(|posting| matches!(posting, PostingList::Compressed(_)));
+        match (has_plain, has_compressed) {
+            (true, true) => Err(Error::index(
+                "cannot union mixed plain and compressed posting lists".to_owned(),
+            )),
+            (true, false) => Self::union_plain_membership_posting_lists(postings, with_positions),
+            (false, true) => {
+                Self::union_compressed_membership_posting_lists(postings, with_positions)
+            }
+            (false, false) => Ok(PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from(Vec::<u64>::new()),
+                ScalarBuffer::from(Vec::<f32>::new()),
+                None,
+                None,
+            ))),
+        }
+    }
+
+    fn membership_posting_iterator(
+        token: String,
+        token_id: u32,
+        position: u32,
+        mut posting: PostingList,
+        num_docs: usize,
+    ) -> PostingIterator {
+        if let PostingList::Plain(posting) = &mut posting {
+            // The generic iterator derives an IDF fallback when a plain list
+            // has no stored bound. Membership never reads score bounds, so a
+            // zero sentinel avoids doing score preparation on this path.
+            posting.max_score = Some(0.0);
+        }
+        PostingIterator::with_query_weight_deferred(
+            token, token_id, position, 0.0, posting, num_docs,
+        )
+    }
+
+    fn membership_requires_group_union(
+        operator: Operator,
+        is_phrase_query: bool,
+        positions: impl IntoIterator<Item = u32>,
+    ) -> bool {
+        if operator != Operator::And && !is_phrase_query {
+            return false;
+        }
+        let mut previous = None;
+        positions.into_iter().any(|position| {
+            let is_grouped = previous == Some(position);
+            previous = Some(position);
+            is_grouped
+        })
+    }
+
+    /// Load postings for membership-only execution without preparing any
+    /// BM25 weights or score bounds. Same-position alternatives are unioned
+    /// when required so AND and phrase semantics remain identical to scoring.
+    #[instrument(level = "debug", skip_all)]
+    pub(in super::super) async fn load_membership_posting_lists(
+        &self,
+        tokens: &Tokens,
+        params: &FtsSearchParams,
+        operator: Operator,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Vec<PostingIterator>> {
+        let is_phrase_query = params.phrase_slop.is_some();
+        let is_and_query = operator == Operator::And;
+        let required_positions = (is_and_query || is_phrase_query).then(|| {
+            (0..tokens.len())
+                .map(|index| tokens.position(index))
+                .collect::<HashSet<_>>()
+        });
+        let tokens = tokens.clone();
+        let token_positions = (0..tokens.len())
+            .map(|index| tokens.position(index))
+            .collect::<Vec<_>>();
+        let mut token_ids = Vec::with_capacity(tokens.len());
+        let mut matched_positions = required_positions.as_ref().map(|_| HashSet::new());
+        for (index, token) in tokens.into_iter().enumerate() {
+            if let Some(token_id) = self.map(&token) {
+                let position = token_positions[index];
+                if let Some(matched_positions) = matched_positions.as_mut() {
+                    matched_positions.insert(position);
+                }
+                token_ids.push((token_id, token, position));
+            }
+        }
+        if token_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        if let Some(required_positions) = required_positions.as_ref()
+            && let Some(matched_positions) = matched_positions.as_ref()
+            && !required_positions.is_subset(matched_positions)
+        {
+            return Ok(Vec::new());
+        }
+
+        token_ids.sort_unstable_by_key(|(token_id, _, position)| (*position, *token_id));
+        token_ids.dedup_by(|lhs, rhs| lhs.0 == rhs.0 && lhs.2 == rhs.2);
+        let loaded_postings = stream::iter(token_ids)
+            .map(|(token_id, token, position)| async move {
+                let posting = self
+                    .inverted_list
+                    .posting_list(token_id, is_phrase_query, metrics)
+                    .await?;
+                Result::Ok((token_id, token, position, posting))
+            })
+            .buffered(self.store.io_parallelism())
+            .try_collect::<Vec<_>>()
+            .await?;
+        // A non-phrase OR already has exact union semantics in WAND, so keep
+        // fuzzy alternatives as independent doc-only iterators. Materializing
+        // a union is required only when one query position must act as a
+        // single required/positional clause.
+        let needs_union = Self::membership_requires_group_union(
+            operator,
+            is_phrase_query,
+            loaded_postings.iter().map(|(_, _, position, _)| *position),
+        );
+        if (is_and_query || is_phrase_query)
+            && !needs_union
+            && loaded_postings
+                .iter()
+                .any(|(_, _, _, posting)| posting.is_empty())
+        {
+            return Ok(Vec::new());
+        }
+
+        let num_docs = self.docs.len();
+        if !needs_union {
+            return Ok(loaded_postings
+                .into_iter()
+                .filter(|(_, _, _, posting)| !posting.is_empty())
+                .map(|(token_id, token, position, posting)| {
+                    Self::membership_posting_iterator(token, token_id, position, posting, num_docs)
+                })
+                .collect());
+        }
+
+        let mut membership_postings = Vec::new();
+        let mut iter = loaded_postings.into_iter().peekable();
+        while let Some((token_id, token, position, posting)) = iter.next() {
+            let mut group = vec![posting];
+            while matches!(iter.peek(), Some((_, _, next_position, _)) if *next_position == position)
+            {
+                let Some((_, _, _, posting)) = iter.next() else {
+                    return Err(Error::internal(
+                        "grouped membership posting disappeared after peek",
+                    ));
+                };
+                group.push(posting);
+            }
+            let posting = if group.len() == 1 {
+                let Some(posting) = group.pop() else {
+                    return Err(Error::internal(
+                        "single-item membership posting group was empty",
+                    ));
+                };
+                posting
+            } else {
+                Self::union_membership_posting_lists(group, is_phrase_query)?
+            };
+            if posting.is_empty() {
+                if is_and_query || is_phrase_query {
+                    return Ok(Vec::new());
+                }
+                continue;
+            }
+            membership_postings.push(Self::membership_posting_iterator(
+                token, token_id, position, posting, num_docs,
+            ));
+        }
+        Ok(membership_postings)
+    }
+
     // search the documents that contain the query
     // return the doc info and the doc length
     // ref: https://en.wikipedia.org/wiki/Okapi_BM25
@@ -799,5 +1143,242 @@ impl InvertedPartition {
                 .push(posting_list.into_builder(&builder.docs));
         }
         Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scalar::inverted::encoding::{
+        compress_posting_list_with_tail_codec_and_block_size, decode_varint_u32,
+        posting_block_score_prefix_len,
+    };
+
+    fn posting_with_positions(
+        doc_ids: &[u32],
+        positions_by_doc: &[Vec<u32>],
+        is_compressed: bool,
+    ) -> PostingList {
+        if is_compressed {
+            let mut builder = PostingListBuilder::new(true);
+            for (doc_id, positions) in doc_ids.iter().copied().zip(positions_by_doc) {
+                builder.add(doc_id, PositionRecorder::Position(positions.clone().into()));
+            }
+            let batch = builder
+                .to_batch(vec![0.0; doc_ids.len().div_ceil(LEGACY_BLOCK_SIZE)])
+                .unwrap();
+            PostingList::from_batch(&batch, Some(0.0), Some(doc_ids.len() as u32)).unwrap()
+        } else {
+            let mut positions_builder = ListBuilder::new(Int32Builder::new());
+            for positions in positions_by_doc {
+                for position in positions {
+                    positions_builder.values().append_value(*position as i32);
+                }
+                positions_builder.append(true);
+            }
+            PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from_iter(doc_ids.iter().map(|doc_id| u64::from(*doc_id))),
+                // Deliberately omit frequencies: membership preparation must
+                // read only row ids and positions from a plain phrase posting.
+                ScalarBuffer::from(Vec::<f32>::new()),
+                None,
+                Some(positions_builder.finish()),
+            ))
+        }
+    }
+
+    fn posting_with_truncated_frequencies(
+        doc_ids: &[u32],
+        block_size: usize,
+    ) -> Result<PostingList> {
+        let frequencies = vec![7_u32; doc_ids.len()];
+        let blocks = compress_posting_list_with_tail_codec_and_block_size(
+            doc_ids.len(),
+            doc_ids.iter(),
+            frequencies.iter(),
+            std::iter::once(1.0),
+            PostingTailCodec::VarintDelta,
+            block_size,
+        )?;
+        let block = blocks.value(0);
+        let prefix_len = posting_block_score_prefix_len(block_size);
+        let doc_bits = usize::from(block[prefix_len + 4]);
+        let doc_payload_len = doc_bits * block_size / 8;
+        let doc_only_end = prefix_len + 5 + doc_payload_len;
+        let doc_only_blocks = LargeBinaryArray::from_iter_values([&block[..doc_only_end]]);
+        Ok(PostingList::Compressed(CompressedPostingList::new(
+            doc_only_blocks,
+            1.0,
+            doc_ids.len() as u32,
+            PostingTailCodec::VarintDelta,
+            block_size,
+            None,
+            None,
+        )))
+    }
+
+    fn posting_with_truncated_tail_frequencies(
+        doc_ids: &[u32],
+        block_size: usize,
+        tail_codec: PostingTailCodec,
+    ) -> Result<PostingList> {
+        let frequencies = vec![7_u32; doc_ids.len()];
+        let blocks = compress_posting_list_with_tail_codec_and_block_size(
+            doc_ids.len(),
+            doc_ids.iter(),
+            frequencies.iter(),
+            std::iter::once(1.0),
+            tail_codec,
+            block_size,
+        )?;
+        let block = blocks.value(0);
+        let prefix_len = posting_block_score_prefix_len(block_size);
+        let doc_only_end = match tail_codec {
+            PostingTailCodec::Fixed32 => prefix_len + doc_ids.len() * 4,
+            PostingTailCodec::VarintDelta => {
+                let mut offset = prefix_len;
+                for _ in doc_ids {
+                    decode_varint_u32(block, &mut offset)?;
+                }
+                offset
+            }
+        };
+        let doc_only_blocks = LargeBinaryArray::from_iter_values([&block[..doc_only_end]]);
+        Ok(PostingList::Compressed(CompressedPostingList::new(
+            doc_only_blocks,
+            1.0,
+            doc_ids.len() as u32,
+            tail_codec,
+            block_size,
+            None,
+            None,
+        )))
+    }
+
+    #[test]
+    fn membership_group_union_decodes_only_compressed_doc_ids() -> Result<()> {
+        for block_size in [LEGACY_BLOCK_SIZE, MAX_POSTING_BLOCK_SIZE] {
+            let even = (0..block_size as u32)
+                .map(|doc_id| doc_id * 2)
+                .collect::<Vec<_>>();
+            let odd = (0..block_size as u32)
+                .map(|doc_id| doc_id * 2 + 1)
+                .collect::<Vec<_>>();
+            let posting = InvertedPartition::union_membership_posting_lists(
+                vec![
+                    posting_with_truncated_frequencies(&even, block_size)?,
+                    posting_with_truncated_frequencies(&odd, block_size)?,
+                ],
+                false,
+            )?;
+            let actual = posting
+                .iter()
+                .map(|(doc_id, _, _)| doc_id)
+                .collect::<Vec<_>>();
+            assert_eq!(actual, (0..(block_size * 2) as u64).collect::<Vec<_>>());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn membership_group_union_is_skipped_for_non_phrase_or() {
+        let grouped_positions = [0, 0, 1];
+        assert!(!InvertedPartition::membership_requires_group_union(
+            Operator::Or,
+            false,
+            grouped_positions,
+        ));
+        assert!(InvertedPartition::membership_requires_group_union(
+            Operator::And,
+            false,
+            grouped_positions,
+        ));
+        assert!(InvertedPartition::membership_requires_group_union(
+            Operator::Or,
+            true,
+            grouped_positions,
+        ));
+        assert!(!InvertedPartition::membership_requires_group_union(
+            Operator::And,
+            false,
+            [0, 1, 2],
+        ));
+    }
+
+    #[test]
+    fn membership_group_union_decodes_only_compressed_tail_doc_ids() -> Result<()> {
+        for block_size in [LEGACY_BLOCK_SIZE, MAX_POSTING_BLOCK_SIZE] {
+            for tail_codec in [PostingTailCodec::Fixed32, PostingTailCodec::VarintDelta] {
+                let posting = InvertedPartition::union_membership_posting_lists(
+                    vec![
+                        posting_with_truncated_tail_frequencies(
+                            &[2, 10, 30],
+                            block_size,
+                            tail_codec,
+                        )?,
+                        posting_with_truncated_tail_frequencies(
+                            &[3, 10, 40],
+                            block_size,
+                            tail_codec,
+                        )?,
+                    ],
+                    false,
+                )?;
+                let actual = posting
+                    .iter()
+                    .map(|(doc_id, _, _)| doc_id)
+                    .collect::<Vec<_>>();
+                assert_eq!(actual, vec![2, 3, 10, 30, 40]);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn membership_group_union_preserves_phrase_positions() -> Result<()> {
+        for is_compressed in [false, true] {
+            let posting = InvertedPartition::union_membership_posting_lists(
+                vec![
+                    posting_with_positions(&[0, 2], &[vec![0, 4], vec![2]], is_compressed),
+                    posting_with_positions(&[0, 1], &[vec![1], vec![3]], is_compressed),
+                ],
+                true,
+            )?;
+            let actual = posting
+                .iter()
+                .map(|(doc_id, _, positions)| {
+                    (
+                        doc_id,
+                        positions
+                            .map(Iterator::collect::<Vec<_>>)
+                            .unwrap_or_default(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(actual, vec![(0, vec![0, 1, 4]), (1, vec![3]), (2, vec![2])]);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn membership_phrase_union_rejects_missing_positions() {
+        let posting = || {
+            PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from(vec![1_u64]),
+                ScalarBuffer::from(vec![1.0_f32]),
+                None,
+                None,
+            ))
+        };
+        let error =
+            InvertedPartition::union_membership_posting_lists(vec![posting(), posting()], true)
+                .unwrap_err();
+        assert!(matches!(&error, Error::Index { .. }), "{error:?}");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot union grouped phrase terms without positions"),
+            "{error}"
+        );
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -678,17 +678,12 @@ impl InvertedPartition {
         })
     }
 
-    /// Load postings for membership-only execution without preparing any
-    /// BM25 weights or score bounds. Same-position alternatives are unioned
-    /// when required so AND and phrase semantics remain identical to scoring.
-    #[instrument(level = "debug", skip_all)]
-    pub(in super::super) async fn load_membership_posting_lists(
+    fn membership_token_ids(
         &self,
         tokens: &Tokens,
         params: &FtsSearchParams,
         operator: Operator,
-        metrics: &dyn MetricsCollector,
-    ) -> Result<Vec<PostingIterator>> {
+    ) -> Vec<(u32, String, u32)> {
         let is_phrase_query = params.phrase_slop.is_some();
         let is_and_query = operator == Operator::And;
         let required_positions = (is_and_query || is_phrase_query).then(|| {
@@ -711,29 +706,26 @@ impl InvertedPartition {
                 token_ids.push((token_id, token, position));
             }
         }
-        if token_ids.is_empty() {
-            return Ok(Vec::new());
-        }
         if let Some(required_positions) = required_positions.as_ref()
             && let Some(matched_positions) = matched_positions.as_ref()
             && !required_positions.is_subset(matched_positions)
         {
-            return Ok(Vec::new());
+            return Vec::new();
         }
 
         token_ids.sort_unstable_by_key(|(token_id, _, position)| (*position, *token_id));
         token_ids.dedup_by(|lhs, rhs| lhs.0 == rhs.0 && lhs.2 == rhs.2);
-        let loaded_postings = stream::iter(token_ids)
-            .map(|(token_id, token, position)| async move {
-                let posting = self
-                    .inverted_list
-                    .posting_list(token_id, is_phrase_query, metrics)
-                    .await?;
-                Result::Ok((token_id, token, position, posting))
-            })
-            .buffered(self.store.io_parallelism())
-            .try_collect::<Vec<_>>()
-            .await?;
+        token_ids
+    }
+
+    fn membership_posting_iterators(
+        &self,
+        loaded_postings: Vec<(u32, String, u32, PostingList)>,
+        params: &FtsSearchParams,
+        operator: Operator,
+    ) -> Result<Vec<PostingIterator>> {
+        let is_phrase_query = params.phrase_slop.is_some();
+        let is_and_query = operator == Operator::And;
         // A non-phrase OR already has exact union semantics in WAND, so keep
         // fuzzy alternatives as independent doc-only iterators. Materializing
         // a union is required only when one query position must act as a
@@ -797,6 +789,69 @@ impl InvertedPartition {
             ));
         }
         Ok(membership_postings)
+    }
+
+    /// Reuse membership postings only when every backing cache entry is
+    /// already present. A miss returns `None` without invoking any loader.
+    #[instrument(level = "debug", skip_all)]
+    pub(in super::super) async fn load_cached_membership_posting_lists(
+        &self,
+        tokens: &Tokens,
+        params: &FtsSearchParams,
+        operator: Operator,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Option<Vec<PostingIterator>>> {
+        let is_phrase_query = params.phrase_slop.is_some();
+        let token_ids = self.membership_token_ids(tokens, params, operator);
+        if token_ids.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        let cached_postings = stream::iter(token_ids)
+            .map(|(token_id, token, position)| async move {
+                let posting = self
+                    .inverted_list
+                    .cached_posting_list(token_id, is_phrase_query, metrics)
+                    .await?;
+                Result::Ok(posting.map(|posting| (token_id, token, position, posting)))
+            })
+            .buffered(self.store.io_parallelism())
+            .try_collect::<Vec<_>>()
+            .await?;
+        let Some(loaded_postings) = cached_postings.into_iter().collect::<Option<Vec<_>>>() else {
+            return Ok(None);
+        };
+        self.membership_posting_iterators(loaded_postings, params, operator)
+            .map(Some)
+    }
+
+    /// Load postings for membership-only execution without preparing any
+    /// BM25 weights or score bounds. Same-position alternatives are unioned
+    /// when required so AND and phrase semantics remain identical to scoring.
+    #[instrument(level = "debug", skip_all)]
+    pub(in super::super) async fn load_membership_posting_lists(
+        &self,
+        tokens: &Tokens,
+        params: &FtsSearchParams,
+        operator: Operator,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Vec<PostingIterator>> {
+        let is_phrase_query = params.phrase_slop.is_some();
+        let token_ids = self.membership_token_ids(tokens, params, operator);
+        if token_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let loaded_postings = stream::iter(token_ids)
+            .map(|(token_id, token, position)| async move {
+                let posting = self
+                    .inverted_list
+                    .posting_list(token_id, is_phrase_query, metrics)
+                    .await?;
+                Result::Ok((token_id, token, position, posting))
+            })
+            .buffered(self.store.io_parallelism())
+            .try_collect::<Vec<_>>()
+            .await?;
+        self.membership_posting_iterators(loaded_postings, params, operator)
     }
 
     // search the documents that contain the query

--- a/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
@@ -310,6 +310,41 @@ impl PostingListReader {
         }
     }
 
+    async fn cached_posting_metadata_for_token(
+        &self,
+        token_id: u32,
+        metrics: &dyn MetricsCollector,
+    ) -> Option<(Option<f32>, Option<u32>)> {
+        match &self.metadata {
+            PostingMetadata::LegacyV1 { max_scores, .. } => Some((
+                max_scores.as_ref().map(|scores| scores[token_id as usize]),
+                None,
+            )),
+            PostingMetadata::V2 { metadata } => {
+                if let Some(loaded) = metadata.get() {
+                    return Some((
+                        Some(loaded.max_scores[token_id as usize]),
+                        Some(loaded.lengths[token_id as usize]),
+                    ));
+                }
+                let cached = self
+                    .index_cache
+                    .get_with_key(&PostingMetadataKey { token_id })
+                    .await;
+                match cached {
+                    Some(cached) => {
+                        metrics.record_index_cache_hit();
+                        Some((Some(cached.max_score), Some(cached.length)))
+                    }
+                    None => {
+                        metrics.record_index_cache_miss();
+                        None
+                    }
+                }
+            }
+        }
+    }
+
     /// Force the v2 bulk metadata (`max_scores`, `lengths`) into
     /// memory. Cheap to call repeatedly; no-op for legacy v1 indexes whose
     /// metadata is already populated from schema metadata at `try_new` time.
@@ -485,6 +520,83 @@ impl PostingListReader {
         }
 
         Ok(posting)
+    }
+
+    /// Return a posting only when every required cache entry is already present.
+    ///
+    /// This never invokes a posting, metadata, or position loader. Compound
+    /// exclusion uses it to avoid an async preflight/replay cycle when a prior
+    /// query or prewarm has already paid the physical load cost.
+    pub(crate) async fn cached_posting_list(
+        &self,
+        token_id: u32,
+        is_phrase_query: bool,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Option<PostingList>> {
+        let mut posting = match self.group_range_for_token(token_id) {
+            Some((start, end)) => {
+                let cached = self
+                    .index_cache
+                    .get_with_key(&posting_list_group_cache_key(start, end, self.has_impacts))
+                    .await;
+                let Some(group) = cached else {
+                    metrics.record_index_cache_miss();
+                    return Ok(None);
+                };
+                metrics.record_index_cache_hit();
+                let (max_score, length) = if group.needs_external_metadata() {
+                    let Some(metadata) = self
+                        .cached_posting_metadata_for_token(token_id, metrics)
+                        .await
+                    else {
+                        return Ok(None);
+                    };
+                    metadata
+                } else {
+                    (None, None)
+                };
+                let slot = (token_id - start) as usize;
+                group
+                    .posting_list(slot, max_score, length)?
+                    .ok_or_else(|| {
+                        Error::index(format!(
+                            "token {token_id} maps to slot {slot} outside posting group [{start}, {end})"
+                        ))
+                    })?
+            }
+            None => {
+                let cached = self
+                    .index_cache
+                    .get_with_key(&posting_list_cache_key(token_id, self.has_impacts))
+                    .await;
+                let Some(posting) = cached else {
+                    metrics.record_index_cache_miss();
+                    return Ok(None);
+                };
+                metrics.record_index_cache_hit();
+                posting.as_ref().clone()
+            }
+        };
+
+        if !self.modern_posting_is_validated(token_id)? {
+            self.ensure_modern_posting_validated(token_id, &posting)
+                .await?;
+        }
+
+        if is_phrase_query && !posting.has_position() {
+            let cached = self
+                .index_cache
+                .get_with_key(&PositionKey { token_id })
+                .await;
+            let Some(positions) = cached else {
+                metrics.record_index_cache_miss();
+                return Ok(None);
+            };
+            metrics.record_index_cache_hit();
+            posting.set_positions(positions.0.clone());
+        }
+
+        Ok(Some(posting))
     }
 
     pub(super) async fn ensure_modern_posting_validated(

--- a/rust/lance-index/src/scalar/inverted/index/tests/grouping.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/grouping.rs
@@ -339,6 +339,46 @@ async fn test_prewarm_synthetic_grouping_populates_group_entries() {
     }
 }
 
+#[tokio::test]
+async fn test_cached_posting_list_never_loads_a_cold_entry() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let mut builder = InnerBuilder::new(0, false, TokenSetFormat::default());
+    builder.tokens.add("term".to_owned());
+    let mut posting = PostingListBuilder::new(false);
+    posting.add(0, PositionRecorder::Count(3));
+    builder.posting_lists.push(posting);
+    builder.docs.append(1000, 3);
+    builder.write(store.as_ref()).await.unwrap();
+
+    let reader = store.open_index_file(&posting_file_path(0)).await.unwrap();
+    let cache = LanceCache::with_capacity(1 << 20);
+    let posting_reader = PostingListReader::try_new(reader, &cache).await.unwrap();
+    let metrics = NoOpMetricsCollector;
+    assert!(
+        posting_reader
+            .cached_posting_list(0, false, &metrics)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let loaded = posting_reader
+        .posting_list(0, false, &metrics)
+        .await
+        .unwrap();
+    let cached = posting_reader
+        .cached_posting_list(0, false, &metrics)
+        .await
+        .unwrap()
+        .expect("a normal load should populate the posting cache");
+    assert_eq!(posting_entries(&cached), posting_entries(&loaded));
+}
+
 /// End-to-end BM25 search over a grouped multi-group index must return the
 /// correct documents, and a warm-cache query must match the cold-cache
 /// result exactly (issue #7040).

--- a/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
@@ -184,6 +184,12 @@ async fn test_prewarm_with_positions_populates_separate_position_cache() {
         ),
         "positions should be stored in the dedicated position cache"
     );
+    let cached_phrase = inverted_list
+        .cached_posting_list(0, true, &NoOpMetricsCollector)
+        .await
+        .unwrap()
+        .expect("with-position prewarm should satisfy a cache-only phrase lookup");
+    assert!(cached_phrase.has_position());
 
     drop(positions);
     drop(group);
@@ -194,6 +200,14 @@ async fn test_prewarm_with_positions_populates_separate_position_cache() {
             .get_with_key(&PositionKey { token_id: 0 })
             .await
             .is_none()
+    );
+    assert!(
+        inverted_list
+            .cached_posting_list(0, true, &NoOpMetricsCollector)
+            .await
+            .unwrap()
+            .is_none(),
+        "a cache-only phrase lookup must not reload evicted positions"
     );
 
     index

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -32,7 +32,8 @@ use super::{
     builder::ScoredDoc,
     encoding::{
         MAX_POSTING_BLOCK_SIZE, decode_position_stream_block, decompress_positions,
-        decompress_posting_block, decompress_posting_remainder, seek_packed_doc_positions,
+        decompress_posting_block, decompress_posting_block_doc_ids, decompress_posting_remainder,
+        decompress_posting_remainder_doc_ids, seek_packed_doc_positions,
     },
     query::FtsSearchParams,
     scorer::Scorer,
@@ -387,6 +388,8 @@ pub struct PostingIterator {
     // the index of current block, this can be changed by `next() and shallow_next()`
     block_idx: usize,
     current_doc: Option<DocInfo>,
+    decode_mode: PostingDecodeMode,
+    is_initialized: bool,
     approximate_upper_bound: f32,
     // Stored block maxima may use partition-local statistics. Queries scored
     // with corpus-wide statistics must use a scorer-provided bound instead.
@@ -403,9 +406,23 @@ pub struct PostingIterator {
     compressed: Option<UnsafeCell<CompressedState>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PostingDecodeMode {
+    Full,
+    DocIdsOnly,
+}
+
+impl PostingDecodeMode {
+    #[inline]
+    fn needs_frequencies(self) -> bool {
+        self == Self::Full
+    }
+}
+
 #[derive(Clone)]
 struct CompressedState {
     block_idx: usize,
+    decode_mode: PostingDecodeMode,
     doc_ids: Vec<u32>,
     freqs: Vec<u32>,
     buffer: Box<[u32; MAX_POSTING_BLOCK_SIZE]>,
@@ -434,6 +451,7 @@ impl CompressedState {
     fn new(block_size: usize) -> Self {
         Self {
             block_idx: 0,
+            decode_mode: PostingDecodeMode::Full,
             doc_ids: Vec::with_capacity(block_size),
             freqs: Vec::with_capacity(block_size),
             buffer: Box::new([0; MAX_POSTING_BLOCK_SIZE]),
@@ -466,15 +484,25 @@ impl CompressedState {
 
         let remainder = length as usize % block_size;
         if block_idx + 1 == num_blocks && remainder != 0 {
-            decompress_posting_remainder(
-                block,
-                remainder,
-                tail_codec,
-                block_size,
-                &mut self.doc_ids,
-                &mut self.freqs,
-            );
-        } else {
+            if self.decode_mode.needs_frequencies() {
+                decompress_posting_remainder(
+                    block,
+                    remainder,
+                    tail_codec,
+                    block_size,
+                    &mut self.doc_ids,
+                    &mut self.freqs,
+                );
+            } else {
+                decompress_posting_remainder_doc_ids(
+                    block,
+                    remainder,
+                    tail_codec,
+                    block_size,
+                    &mut self.doc_ids,
+                );
+            }
+        } else if self.decode_mode.needs_frequencies() {
             decompress_posting_block(
                 block,
                 &mut self.buffer[..],
@@ -482,6 +510,18 @@ impl CompressedState {
                 &mut self.freqs,
                 block_size,
             );
+        } else {
+            decompress_posting_block_doc_ids(
+                block,
+                &mut self.buffer[..],
+                &mut self.doc_ids,
+                block_size,
+            );
+        }
+        if !self.decode_mode.needs_frequencies() {
+            // Keep the hot cursor path identical for scoring and membership:
+            // one mode branch per decoded block, not one branch per document.
+            self.freqs.resize(self.doc_ids.len(), 0);
         }
         self.block_idx = block_idx;
         self.position_block_idx = None;
@@ -606,10 +646,11 @@ impl Debug for PostingIterator {
             .field(
                 "doc",
                 &self
-                    .doc()
+                    .current_doc
                     .map(|doc| doc.doc_id())
                     .unwrap_or(TERMINATED_DOC_ID),
             )
+            .field("is_initialized", &self.is_initialized)
             .field("approximate_upper_bound", &self.approximate_upper_bound)
             .field("token_id", &self.token_id)
             .finish()
@@ -799,6 +840,30 @@ impl PostingIterator {
         list: PostingList,
         num_doc: usize,
     ) -> Self {
+        let mut posting = Self::with_query_weight_deferred(
+            token,
+            token_id,
+            position,
+            query_weight,
+            list,
+            num_doc,
+        );
+        posting.initialize(PostingDecodeMode::Full);
+        posting
+    }
+
+    /// Build an iterator without decoding its first block. The owning WAND
+    /// selects full or document-only decoding before it initializes the
+    /// iterator, avoiding an otherwise wasted frequency decode for prohibited
+    /// membership leaves.
+    pub(crate) fn with_query_weight_deferred(
+        token: String,
+        token_id: u32,
+        position: u32,
+        query_weight: f32,
+        list: PostingList,
+        num_doc: usize,
+    ) -> Self {
         // BM25's doc weight is bounded by K1 + 1 for any freq and doc length,
         // so query_weight * (K1 + 1) is a valid global bound even when index
         // stats drift after appends. Keeping it finite matters: an INFINITY
@@ -821,7 +886,7 @@ impl PostingIterator {
             PostingList::Plain(_) => None,
         };
 
-        let mut posting = Self {
+        Self {
             token,
             token_id,
             position,
@@ -830,14 +895,62 @@ impl PostingIterator {
             index: 0,
             block_idx: 0,
             current_doc: None,
+            decode_mode: PostingDecodeMode::Full,
+            is_initialized: false,
             approximate_upper_bound,
             use_scorer_upper_bound: false,
             grouped_terms: None,
             position_scratch: RefCell::new(Some(Vec::new())),
             compressed,
+        }
+    }
+
+    fn initialize(&mut self, decode_mode: PostingDecodeMode) {
+        if self.is_initialized && self.decode_mode == decode_mode {
+            return;
+        }
+        self.decode_mode = decode_mode;
+        self.is_initialized = true;
+        self.current_doc = None;
+        if let Some(compressed) = self.compressed.as_ref() {
+            let compressed = unsafe { &mut *compressed.get() };
+            compressed.decode_mode = decode_mode;
+            compressed.doc_ids.clear();
+            compressed.freqs.clear();
+            compressed.position_block_idx = None;
+            compressed.position_values.clear();
+            compressed.position_offsets.clear();
+        }
+        self.refresh_current_doc();
+    }
+
+    /// Create a fresh deferred cursor over the same immutable posting data.
+    /// The caller's WAND chooses the decode mode when it initializes the fork.
+    pub(super) fn fork_from_start(&self) -> Self {
+        let list = self.list.clone();
+        let compressed = match &list {
+            PostingList::Compressed(list) => {
+                Some(UnsafeCell::new(CompressedState::new(list.block_size)))
+            }
+            PostingList::Plain(_) => None,
         };
-        posting.refresh_current_doc();
-        posting
+        Self {
+            token: self.token.clone(),
+            token_id: self.token_id,
+            position: self.position,
+            query_weight: self.query_weight,
+            list,
+            index: 0,
+            block_idx: 0,
+            current_doc: None,
+            decode_mode: PostingDecodeMode::Full,
+            is_initialized: false,
+            approximate_upper_bound: self.approximate_upper_bound,
+            use_scorer_upper_bound: self.use_scorer_upper_bound,
+            grouped_terms: self.grouped_terms.clone(),
+            position_scratch: RefCell::new(Some(Vec::new())),
+            compressed,
+        }
     }
 
     pub(super) fn with_scorer_upper_bound(mut self) -> Self {
@@ -898,6 +1011,11 @@ impl PostingIterator {
 
     #[inline]
     fn score<S: Scorer + ?Sized>(&self, scorer: &S, freq: u32, doc_length: u32) -> f32 {
+        debug_assert_eq!(
+            self.decode_mode,
+            PostingDecodeMode::Full,
+            "membership-only posting iterator must not score documents"
+        );
         if let (Some(grouped_terms), Some(doc)) = (&self.grouped_terms, self.current_doc) {
             return grouped_terms
                 .iter()
@@ -924,6 +1042,10 @@ impl PostingIterator {
 
     #[inline]
     fn doc(&self) -> Option<DocInfo> {
+        debug_assert!(
+            self.is_initialized,
+            "posting iterator must be initialized by its owning WAND"
+        );
         self.current_doc
     }
 
@@ -951,6 +1073,11 @@ impl PostingIterator {
     }
 
     fn position_cursor(&self) -> Result<PositionCursor<'_>> {
+        if !self.decode_mode.needs_frequencies() {
+            return Err(Error::internal(
+                "positions requested from a document-id-only posting iterator",
+            ));
+        }
         match self.list {
             PostingList::Plain(ref list) => {
                 let positions = list.positions.as_ref().ok_or_else(|| {
@@ -1099,6 +1226,10 @@ impl PostingIterator {
 
     // move to the next doc id that is greater than or equal to least_id
     fn next(&mut self, least_id: u64) {
+        debug_assert!(
+            self.is_initialized,
+            "posting iterator must be initialized before advancing"
+        );
         match self.list {
             PostingList::Compressed(ref list) => {
                 debug_assert!(least_id <= u32::MAX as u64);
@@ -1444,6 +1575,7 @@ pub(super) fn validate_modern_posting_doc_ids(
         ))
     })?;
     let mut state = CompressedState::new(list.block_size);
+    state.decode_mode = PostingDecodeMode::DocIdsOnly;
     state.decompress(
         list.blocks.value(last_block_idx),
         last_block_idx,
@@ -1997,9 +2129,41 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         documents: &'a D,
         scorer: S,
     ) -> Self {
+        Self::new_with_posting_decode_mode(
+            operator,
+            postings,
+            documents,
+            scorer,
+            PostingDecodeMode::Full,
+        )
+    }
+
+    fn new_membership(
+        operator: Operator,
+        postings: impl Iterator<Item = PostingIterator>,
+        documents: &'a D,
+        scorer: S,
+        needs_positions: bool,
+    ) -> Self {
+        let decode_mode = if needs_positions {
+            PostingDecodeMode::Full
+        } else {
+            PostingDecodeMode::DocIdsOnly
+        };
+        Self::new_with_posting_decode_mode(operator, postings, documents, scorer, decode_mode)
+    }
+
+    fn new_with_posting_decode_mode(
+        operator: Operator,
+        postings: impl Iterator<Item = PostingIterator>,
+        documents: &'a D,
+        scorer: S,
+        decode_mode: PostingDecodeMode,
+    ) -> Self {
         let mut head = BinaryHeap::new();
         let mut lead = Vec::new();
-        for posting in postings {
+        for mut posting in postings {
+            posting.initialize(decode_mode);
             if posting.doc().is_none() {
                 continue;
             }
@@ -4505,8 +4669,18 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             ),
         }
         .unwrap_or_default();
+        let wand = match mode {
+            WandCursorMode::Scoring => Wand::new(operator, postings.into_iter(), documents, scorer),
+            WandCursorMode::Membership => Wand::new_membership(
+                operator,
+                postings.into_iter(),
+                documents,
+                scorer,
+                params.phrase_slop.is_some(),
+            ),
+        };
         Self {
-            wand: Wand::new(operator, postings.into_iter(), documents, scorer),
+            wand,
             mode,
             phrase_slop: params.phrase_slop,
             wand_factor: params.wand_factor,
@@ -5129,7 +5303,7 @@ mod tests {
             docs.append(row_id, 8);
         }
         let postings = vec![
-            PostingIterator::with_query_weight(
+            PostingIterator::with_query_weight_deferred(
                 String::from("alpha"),
                 0,
                 0,
@@ -5137,7 +5311,7 @@ mod tests {
                 generate_posting_list(vec![0, 2, 4], 1.0, None, is_compressed),
                 docs.len(),
             ),
-            PostingIterator::with_query_weight(
+            PostingIterator::with_query_weight_deferred(
                 String::from("beta"),
                 1,
                 1,
@@ -5147,13 +5321,14 @@ mod tests {
             ),
         ];
         let scored = Arc::new(AtomicUsize::new(0));
-        let mut wand = Wand::new(
+        let mut wand = Wand::new_membership(
             Operator::Or,
             postings.into_iter(),
             &docs,
             CountingScorer {
                 scored: scored.clone(),
             },
+            false,
         );
 
         let mut actual = Vec::new();
@@ -5167,6 +5342,174 @@ mod tests {
     }
 
     #[rstest]
+    fn membership_conjunction_intersects_docs_without_scoring(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        for row_id in 0..5 {
+            docs.append(row_id, 8);
+        }
+        let postings = vec![
+            PostingIterator::with_query_weight_deferred(
+                String::from("alpha"),
+                0,
+                0,
+                1.0,
+                generate_posting_list(vec![0, 2, 4], 1.0, None, is_compressed),
+                docs.len(),
+            ),
+            PostingIterator::with_query_weight_deferred(
+                String::from("beta"),
+                1,
+                1,
+                1.0,
+                generate_posting_list(vec![1, 2, 4], 1.0, None, is_compressed),
+                docs.len(),
+            ),
+        ];
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new_membership(
+            Operator::And,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+            false,
+        );
+
+        let mut actual = Vec::new();
+        while let Some(doc) = wand.next_membership() {
+            actual.push(doc.doc_id());
+        }
+
+        assert_eq!(actual, vec![2, 4]);
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn membership_posting_synthesizes_zero_frequencies_across_blocks() {
+        let total = BLOCK_SIZE + 7;
+        let mut posting = PostingIterator::with_query_weight_deferred(
+            String::from("term"),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(
+                (0..total as u32).collect(),
+                (0..total as u32).map(|value| value % 9 + 1).collect(),
+                1.0,
+                None,
+                true,
+            ),
+            total,
+        );
+
+        posting.initialize(PostingDecodeMode::DocIdsOnly);
+        assert_eq!(posting.doc().unwrap().doc_id(), 0);
+        let compressed = unsafe { &*posting.compressed_state_ptr() };
+        assert_eq!(compressed.doc_ids.len(), BLOCK_SIZE);
+        assert_eq!(compressed.freqs, vec![0; BLOCK_SIZE]);
+
+        posting.next((BLOCK_SIZE + 3) as u64);
+        assert_eq!(posting.doc().unwrap().doc_id(), (BLOCK_SIZE + 3) as u64);
+        let compressed = unsafe { &*posting.compressed_state_ptr() };
+        assert_eq!(compressed.doc_ids.len(), 7);
+        assert_eq!(compressed.freqs, vec![0; 7]);
+    }
+
+    #[test]
+    fn deferred_scoring_posting_still_decodes_frequencies() {
+        let total = BLOCK_SIZE + 7;
+        let frequencies = (0..total as u32)
+            .map(|value| value % 9 + 1)
+            .collect::<Vec<_>>();
+        let mut posting = PostingIterator::with_query_weight_deferred(
+            String::from("term"),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(
+                (0..total as u32).collect(),
+                frequencies.clone(),
+                1.0,
+                None,
+                true,
+            ),
+            total,
+        );
+
+        posting.initialize(PostingDecodeMode::Full);
+        assert_eq!(posting.doc().unwrap().frequency(), frequencies[0]);
+        let compressed = unsafe { &*posting.compressed_state_ptr() };
+        assert_eq!(compressed.freqs, frequencies[..BLOCK_SIZE]);
+
+        posting.next((BLOCK_SIZE + 3) as u64);
+        assert_eq!(
+            posting.doc().unwrap().frequency(),
+            frequencies[BLOCK_SIZE + 3]
+        );
+        let compressed = unsafe { &*posting.compressed_state_ptr() };
+        assert_eq!(compressed.freqs, frequencies[BLOCK_SIZE..]);
+    }
+
+    #[test]
+    fn posting_fork_restarts_with_shared_backing_and_fresh_decode_state() {
+        let total = BLOCK_SIZE + 7;
+        let frequencies = (0..total as u32)
+            .map(|value| value % 9 + 1)
+            .collect::<Vec<_>>();
+        let list = generate_posting_list_with_freqs(
+            (0..total as u32).collect(),
+            frequencies.clone(),
+            1.0,
+            None,
+            true,
+        );
+        let grouped_terms = Arc::<[GroupedTermScorer]>::from([GroupedTermScorer::new(2.0, &list)]);
+        let mut original =
+            PostingIterator::with_query_weight(String::from("term"), 7, 3, 2.5, list, total)
+                .with_scorer_upper_bound()
+                .with_grouped_terms(grouped_terms);
+        original.next((BLOCK_SIZE + 3) as u64);
+
+        let mut fork = original.fork_from_start();
+        assert!(!fork.is_initialized);
+        assert_eq!(fork.index, 0);
+        assert_eq!(fork.current_doc, None);
+        assert_eq!(fork.token, original.token);
+        assert_eq!(fork.token_id, original.token_id);
+        assert_eq!(fork.position, original.position);
+        assert_eq!(fork.query_weight, original.query_weight);
+        assert_eq!(
+            fork.approximate_upper_bound,
+            original.approximate_upper_bound
+        );
+        assert!(fork.use_scorer_upper_bound);
+        assert!(Arc::ptr_eq(
+            fork.grouped_terms.as_ref().unwrap(),
+            original.grouped_terms.as_ref().unwrap()
+        ));
+        let (PostingList::Compressed(original_list), PostingList::Compressed(fork_list)) =
+            (&original.list, &fork.list)
+        else {
+            panic!("expected compressed posting lists");
+        };
+        assert_eq!(
+            original_list.blocks.values().as_ptr(),
+            fork_list.blocks.values().as_ptr()
+        );
+        let compressed = unsafe { &*fork.compressed_state_ptr() };
+        assert!(compressed.doc_ids.is_empty());
+        assert!(compressed.freqs.is_empty());
+
+        fork.initialize(PostingDecodeMode::Full);
+        assert_eq!(fork.doc().unwrap().doc_id(), 0);
+        assert_eq!(fork.doc().unwrap().frequency(), frequencies[0]);
+        assert_eq!(original.doc().unwrap().doc_id(), (BLOCK_SIZE + 3) as u64);
+    }
+
+    #[rstest]
     fn membership_phrase_confirms_positions_without_scoring(
         #[values(false, true)] is_compressed: bool,
     ) {
@@ -5174,7 +5517,7 @@ mod tests {
         docs.append(0, 8);
         docs.append(1, 8);
         let postings = vec![
-            PostingIterator::with_query_weight(
+            PostingIterator::with_query_weight_deferred(
                 String::from("alpha"),
                 0,
                 0,
@@ -5187,7 +5530,7 @@ mod tests {
                 ),
                 docs.len(),
             ),
-            PostingIterator::with_query_weight(
+            PostingIterator::with_query_weight_deferred(
                 String::from("beta"),
                 1,
                 1,
@@ -5202,13 +5545,14 @@ mod tests {
             ),
         ];
         let scored = Arc::new(AtomicUsize::new(0));
-        let mut wand = Wand::new(
+        let mut wand = Wand::new_membership(
             Operator::And,
             postings.into_iter(),
             &docs,
             CountingScorer {
                 scored: scored.clone(),
             },
+            true,
         );
 
         let first = wand.next_membership().unwrap();

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -2943,6 +2943,26 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
         }
     }
+
+    /// Return the next matching document without evaluating scores or score
+    /// bounds. Prohibited clauses only need membership; phrase positions stay
+    /// as a separate two-phase confirmation on the cursor.
+    fn next_membership(&mut self) -> Option<DocInfo> {
+        if self.operator == Operator::And {
+            return self.next_and_membership_candidate();
+        }
+
+        debug_assert_eq!(self.threshold, 0.0);
+        debug_assert!(self.tail.is_empty());
+        loop {
+            let target = self.head_doc()?;
+            self.move_head_doc_to_lead(target);
+            if let Some(doc) = self.lead.first().and_then(|posting| posting.doc()) {
+                return Some(doc);
+            }
+        }
+    }
+
     fn next_and_candidate(&mut self) -> Option<DocInfo> {
         if self.lead.len() < self.num_terms {
             return None;
@@ -3006,6 +3026,44 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 continue;
             }
 
+            self.and_last_doc = Some(doc);
+            return Some(lead_doc);
+        }
+    }
+
+    fn next_and_membership_candidate(&mut self) -> Option<DocInfo> {
+        if self.lead.len() < self.num_terms {
+            return None;
+        }
+        if let Some(last_doc) = self.and_last_doc
+            && self
+                .lead
+                .first()
+                .and_then(|posting| posting.doc())
+                .map(|doc| doc.doc_id())
+                == Some(last_doc)
+        {
+            self.lead[0].next(last_doc.saturating_add(1));
+        }
+
+        'advance_head: loop {
+            let doc = self
+                .lead
+                .first()
+                .and_then(|posting| posting.doc())?
+                .doc_id();
+            for posting in self.lead.iter_mut().skip(1) {
+                if posting.doc()?.doc_id() < doc {
+                    posting.next(doc);
+                }
+                let next = posting.doc()?.doc_id();
+                if next > doc {
+                    self.lead[0].next(next);
+                    continue 'advance_head;
+                }
+            }
+
+            let lead_doc = self.lead.first().and_then(|posting| posting.doc())?;
             self.and_last_doc = Some(doc);
             return Some(lead_doc);
         }
@@ -4368,6 +4426,7 @@ impl<'a> PositionCursor<'a> {
 /// which owns the only competitive score for the whole scorer tree.
 pub(super) struct WandCursor<'a, D: WandDocuments> {
     wand: Wand<'a, Arc<MemBM25Scorer>, D>,
+    mode: WandCursorMode,
     phrase_slop: Option<u32>,
     wand_factor: f32,
     cost: usize,
@@ -4382,6 +4441,12 @@ pub(super) struct WandCursor<'a, D: WandDocuments> {
     metrics: &'a dyn MetricsCollector,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WandCursorMode {
+    Scoring,
+    Membership,
+}
+
 impl<'a, D: WandDocuments> WandCursor<'a, D> {
     pub(super) fn new(
         operator: Operator,
@@ -4390,6 +4455,45 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         scorer: Arc<MemBM25Scorer>,
         params: &FtsSearchParams,
         metrics: &'a dyn MetricsCollector,
+    ) -> Self {
+        Self::new_with_mode(
+            operator,
+            postings,
+            documents,
+            scorer,
+            params,
+            metrics,
+            WandCursorMode::Scoring,
+        )
+    }
+
+    pub(super) fn new_membership(
+        operator: Operator,
+        postings: Vec<PostingIterator>,
+        documents: &'a D,
+        scorer: Arc<MemBM25Scorer>,
+        params: &FtsSearchParams,
+        metrics: &'a dyn MetricsCollector,
+    ) -> Self {
+        Self::new_with_mode(
+            operator,
+            postings,
+            documents,
+            scorer,
+            params,
+            metrics,
+            WandCursorMode::Membership,
+        )
+    }
+
+    fn new_with_mode(
+        operator: Operator,
+        postings: Vec<PostingIterator>,
+        documents: &'a D,
+        scorer: Arc<MemBM25Scorer>,
+        params: &FtsSearchParams,
+        metrics: &'a dyn MetricsCollector,
+        mode: WandCursorMode,
     ) -> Self {
         let cost = match operator {
             Operator::And => postings.iter().map(PostingIterator::cost).min(),
@@ -4403,6 +4507,7 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         .unwrap_or_default();
         Self {
             wand: Wand::new(operator, postings.into_iter(), documents, scorer),
+            mode,
             phrase_slop: params.phrase_slop,
             wand_factor: params.wand_factor,
             cost,
@@ -4442,6 +4547,13 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
     }
 
     fn position_next(&mut self) -> Result<Option<u64>> {
+        match self.mode {
+            WandCursorMode::Scoring => self.position_next_scoring(),
+            WandCursorMode::Membership => self.position_next_membership(),
+        }
+    }
+
+    fn position_next_scoring(&mut self) -> Result<Option<u64>> {
         loop {
             let Some((doc, mut score)) = self.wand.next()? else {
                 self.clear_current();
@@ -4473,6 +4585,29 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         }
     }
 
+    fn position_next_membership(&mut self) -> Result<Option<u64>> {
+        loop {
+            let Some(doc) = self.wand.next_membership() else {
+                self.clear_current();
+                self.record_metrics();
+                return Ok(None);
+            };
+            self.comparisons += 1;
+            let doc_id = doc.doc_id();
+            let Some(document_key) = self.wand.documents.document_key(&doc) else {
+                if self.wand.operator == Operator::Or {
+                    self.wand.push_back_leads(doc_id.saturating_add(1));
+                }
+                continue;
+            };
+            self.current_doc = Some(doc);
+            self.current_document_key = Some(document_key);
+            self.confirmation = self.phrase_slop.is_none().then_some(true);
+            self.shallow = None;
+            return Ok(Some(doc_id));
+        }
+    }
+
     pub(super) fn next(&mut self) -> Result<Option<u64>> {
         if let Some(doc) = self.current_doc
             && self.wand.operator == Operator::Or
@@ -4497,12 +4632,20 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
     }
 
     pub(super) fn global_score_upper_bound(&self) -> Option<f32> {
+        if self.mode == WandCursorMode::Membership {
+            return None;
+        }
         *self
             .global_score_upper_bound
             .get_or_init(|| self.wand.compound_global_score_upper_bound())
     }
 
     pub(super) fn current_score(&self) -> Result<f32> {
+        if self.mode == WandCursorMode::Membership {
+            return Err(Error::internal(
+                "score requested from a membership-only posting FTS scorer",
+            ));
+        }
         self.current_doc
             .map(|_| self.current_score)
             .ok_or_else(|| Error::internal("posting FTS scorer is not positioned on a document"))
@@ -4528,12 +4671,20 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
     }
 
     pub(super) fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        if self.mode == WandCursorMode::Membership {
+            return Ok(TERMINATED_DOC_ID);
+        }
         let (up_to, upper) = self.wand.compound_shallow_bound(target);
         self.shallow = Some((target, up_to, upper));
         Ok(up_to)
     }
 
     pub(super) fn score_upper_bound(&self, up_to: u64) -> Result<f32> {
+        if self.mode == WandCursorMode::Membership {
+            return Err(Error::internal(
+                "score bound requested from a membership-only posting FTS scorer",
+            ));
+        }
         let (target, shallow_up_to, upper) = self.shallow.ok_or_else(|| {
             Error::internal("score bound requires advance_shallow on the posting FTS scorer")
         })?;
@@ -4550,6 +4701,9 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             return Err(Error::invalid_input(
                 "minimum competitive FTS score cannot be NaN",
             ));
+        }
+        if self.mode == WandCursorMode::Membership {
+            return Ok(());
         }
         let threshold = next_down_f32(min_score) * self.wand_factor;
         if threshold > self.wand.threshold {
@@ -4964,6 +5118,107 @@ mod tests {
             self.scored.fetch_add(1, Ordering::Relaxed);
             freq as f32 / doc_tokens as f32
         }
+    }
+
+    #[rstest]
+    fn membership_disjunction_merges_docs_without_scoring(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        for row_id in 0..6 {
+            docs.append(row_id, 8);
+        }
+        let postings = vec![
+            PostingIterator::with_query_weight(
+                String::from("alpha"),
+                0,
+                0,
+                1.0,
+                generate_posting_list(vec![0, 2, 4], 1.0, None, is_compressed),
+                docs.len(),
+            ),
+            PostingIterator::with_query_weight(
+                String::from("beta"),
+                1,
+                1,
+                1.0,
+                generate_posting_list(vec![1, 2, 5], 1.0, None, is_compressed),
+                docs.len(),
+            ),
+        ];
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        );
+
+        let mut actual = Vec::new();
+        while let Some(doc) = wand.next_membership() {
+            actual.push(doc.doc_id());
+            wand.push_back_leads(doc.doc_id().saturating_add(1));
+        }
+
+        assert_eq!(actual, vec![0, 1, 2, 4, 5]);
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
+    }
+
+    #[rstest]
+    fn membership_phrase_confirms_positions_without_scoring(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 8);
+        docs.append(1, 8);
+        let postings = vec![
+            PostingIterator::with_query_weight(
+                String::from("alpha"),
+                0,
+                0,
+                1.0,
+                generate_posting_list_with_positions(
+                    vec![0, 1],
+                    vec![vec![3], vec![10]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::with_query_weight(
+                String::from("beta"),
+                1,
+                1,
+                1.0,
+                generate_posting_list_with_positions(
+                    vec![0, 1],
+                    vec![vec![1], vec![11]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::And,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        );
+
+        let first = wand.next_membership().unwrap();
+        assert_eq!(first.doc_id(), 0);
+        assert!(!wand.check_positions(0).unwrap());
+        let second = wand.next_membership().unwrap();
+        assert_eq!(second.doc_id(), 1);
+        assert!(wand.check_positions(0).unwrap());
+        assert!(wand.next_membership().is_none());
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
     }
 
     #[derive(Default)]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -35,6 +35,7 @@ use lance_arrow::ARROW_EXT_NAME_KEY;
 use lance_core::cache::{
     CacheBackend, CacheCodec, CacheEntry, InternalCacheKey, LanceCache, QuickCacheBackend,
 };
+use lance_core::utils::address::RowAddress;
 use lance_core::utils::tempfile::TempStrDir;
 use lance_datafusion::exec::ExecutionSummaryCounts;
 use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
@@ -43,11 +44,11 @@ use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
 use lance_index::metrics::{
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_MUST_NOT_PROBES_METRIC, COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
-    COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, COMPOUND_POSITIVE_SURVIVORS_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
-    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
+    COMPOUND_MUST_NOT_POSTING_LOADS_METRIC, COMPOUND_MUST_NOT_PROBES_METRIC,
+    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_POSITIVE_SURVIVORS_METRIC, COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
+    COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
+    COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
@@ -960,6 +961,39 @@ async fn compound_fts_results(
         .collect()
 }
 
+async fn compound_fts_results_with_stats(
+    dataset: &Dataset,
+    query: FtsQuery,
+    limit: Option<i64>,
+    filter: Option<&str>,
+) -> (Vec<(u64, f32)>, ExecutionSummaryCounts) {
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scan = dataset.scan();
+    scan.scan_stats_callback(Arc::new(move |stats| {
+        *stats_setter.lock().unwrap() = Some(stats.clone());
+    }))
+    .with_row_id()
+    .full_text_search(FullTextSearchQuery::new_query(query))
+    .unwrap();
+    if let Some(filter) = filter {
+        scan.prefilter(true).filter(filter).unwrap();
+    }
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    let rows = row_ids
+        .iter()
+        .copied()
+        .zip(scores.iter().copied())
+        .collect();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    (rows, stats)
+}
+
 async fn assert_compound_fts_top_k(dataset: &Dataset, query: FtsQuery, limit: usize) {
     let exhaustive = compound_fts_results(dataset, query.clone(), None).await;
     assert!(
@@ -1395,12 +1429,24 @@ async fn test_compound_must_not_phrase_is_exact_across_shapes() {
         (Occur::Should, match_query("beta")),
     ])
     .into();
+    let nested_prohibited: FtsQuery = BooleanQuery::new([
+        (Occur::Must, prohibited_phrase()),
+        (Occur::Must, match_query("beta")),
+        (Occur::Should, match_query("rare")),
+    ])
+    .into();
+    let nested_prohibited_boolean: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("alpha")),
+        (Occur::MustNot, nested_prohibited),
+    ])
+    .into();
 
     for (shape, query) in [
         ("conjunction", conjunction.clone()),
         ("ReqOpt", reqopt),
         ("pure SHOULD", pure_should),
         ("nested Boolean", nested),
+        ("nested prohibited Boolean", nested_prohibited_boolean),
     ] {
         let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
         assert!(
@@ -1434,6 +1480,195 @@ async fn test_compound_must_not_phrase_is_exact_across_shapes() {
     assert!(
         plan.contains("CompoundFtsScorer"),
         "same-column Phrase prohibition should use the compound scorer:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn test_compound_must_not_posting_loads_follow_positive_candidates() {
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        [
+            "positive blocked",
+            "positive clear",
+            "positive blocked filler filler filler filler",
+            "neutral"
+        ]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    create_fragmented_fts_index(&mut dataset, "text", false).await;
+
+    let match_query = |term: &str| compound_match_query(term, "text", 1.0);
+    let no_positive: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("missing")),
+        (Occur::MustNot, match_query("blocked")),
+    ])
+    .into();
+    let (rows, stats) = compound_fts_results_with_stats(&dataset, no_positive, Some(1), None).await;
+    assert!(rows.is_empty());
+    assert_eq!(
+        stats.all_counts[COMPOUND_MUST_NOT_POSTING_LOADS_METRIC], 0,
+        "prohibited postings must remain deferred when there are no positive candidates"
+    );
+
+    let has_positive: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("positive")),
+        (Occur::MustNot, match_query("blocked")),
+    ])
+    .into();
+    let (rows, stats) =
+        compound_fts_results_with_stats(&dataset, has_positive, Some(1), None).await;
+    assert_eq!(
+        rows.iter().map(|(row_id, _)| *row_id).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        stats.all_counts[COMPOUND_MUST_NOT_POSTING_LOADS_METRIC], 1,
+        "only the first fragment should load the one prohibited posting leaf; the lower-scoring \
+         positive candidate in the second fragment must be pruned by the established score floor"
+    );
+}
+
+#[tokio::test]
+async fn test_compound_must_not_deferred_load_respects_modern_visibility() {
+    let batch = arrow_array::record_batch!(
+        (
+            "text",
+            Utf8,
+            [
+                "positive blocked",
+                "positive clear",
+                "blocked neutral",
+                "neutral"
+            ]
+        ),
+        ("scope", Int32, [1, 2, 0, 0])
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 1);
+    create_fragmented_fts_index(&mut dataset, "text", false).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("positive", "text", 1.0)),
+        (Occur::MustNot, compound_match_query("blocked", "text", 1.0)),
+    ])
+    .into();
+    for (filter, expected_row_ids, expected_loads) in [
+        ("scope = 0", Vec::new(), 0),
+        ("scope = 1", Vec::new(), 1),
+        ("scope = 2", vec![1], 1),
+    ] {
+        let (rows, stats) =
+            compound_fts_results_with_stats(&dataset, query.clone(), Some(1), Some(filter)).await;
+        assert_eq!(
+            rows.iter().map(|(row_id, _)| *row_id).collect::<Vec<_>>(),
+            expected_row_ids,
+            "unexpected MUST_NOT result for prefilter {filter}"
+        );
+        assert_eq!(
+            stats.all_counts[COMPOUND_MUST_NOT_POSTING_LOADS_METRIC], expected_loads,
+            "unexpected prohibited posting loads for prefilter {filter}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_compound_phrase_confirmation_rejects_before_must_not_load() {
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        ["alpha filler beta blocked", "beta filler alpha blocked"]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "text", true).await;
+
+    let approximation: FtsQuery = MatchQuery::new("alpha beta".to_owned())
+        .with_column(Some("text".to_owned()))
+        .with_operator(Operator::And)
+        .into();
+    let mut approximation_row_ids = compound_fts_results(&dataset, approximation, None)
+        .await
+        .into_iter()
+        .map(|(row_id, _)| row_id)
+        .collect::<Vec<_>>();
+    approximation_row_ids.sort_unstable();
+    assert_eq!(approximation_row_ids, vec![0, 1]);
+
+    let positive_phrase: FtsQuery = PhraseQuery::new("alpha beta".to_owned())
+        .with_column(Some("text".to_owned()))
+        .into();
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, positive_phrase),
+        (Occur::MustNot, compound_match_query("blocked", "text", 1.0)),
+    ])
+    .into();
+    let (rows, stats) = compound_fts_results_with_stats(&dataset, query, Some(1), None).await;
+    assert!(rows.is_empty());
+    assert_eq!(
+        stats.all_counts[COMPOUND_MUST_NOT_POSTING_LOADS_METRIC], 0,
+        "phrase approximations rejected by positions must not load prohibited postings"
+    );
+}
+
+#[tokio::test]
+async fn test_compound_must_not_absent_from_positive_segment_keeps_match() {
+    let batch =
+        arrow_array::record_batch!(("text", Utf8, ["blocked only", "positive clear"])).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    let positive_fragment_id = dataset.get_fragments()[1].id() as u32;
+    create_fragmented_fts_index(&mut dataset, "text", false).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("positive", "text", 1.0)),
+        (Occur::MustNot, compound_match_query("blocked", "text", 1.0)),
+    ])
+    .into();
+    let rows = compound_fts_results(&dataset, query, Some(1)).await;
+    assert_eq!(
+        rows.iter().map(|(row_id, _)| *row_id).collect::<Vec<_>>(),
+        vec![u64::from(RowAddress::new_from_parts(
+            positive_fragment_id,
+            0
+        ))]
     );
 }
 
@@ -1691,6 +1926,141 @@ async fn test_compound_tie_uses_resolved_row_id() {
             "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
         )),
         "compound FTS metrics missing the bounded resolution batch: {compound_line}"
+    );
+}
+
+#[tokio::test]
+async fn test_compound_must_not_projection_retry_preserves_exact_ties() {
+    // Every document has the same length and the same positive term, so all
+    // surviving scores tie. More than k + SCORE_FLOOR_RESOLUTION_BATCH_SIZE
+    // survivors in one segment force the no-resident-projection retry path.
+    let values = (0..384)
+        .map(|index| {
+            if index % 3 == 0 {
+                "common blocked"
+            } else {
+                "common clear"
+            }
+        })
+        .collect::<Vec<_>>();
+    let batch = arrow_array::record_batch!(("text", Utf8, values)).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 256,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index_with_order(&mut dataset, "text", false, true).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("common", "text", 1.0)),
+        (Occur::MustNot, compound_match_query("blocked", "text", 1.0)),
+    ])
+    .into();
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    scanner.limit(Some(1), None).unwrap();
+    let limited = scanner.try_into_batch().await.unwrap();
+    let limited_row = (
+        limited[ROW_ID].as_primitive::<UInt64Type>().value(0),
+        limited[SCORE_COL].as_primitive::<Float32Type>().value(0),
+    );
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+
+    let exhaustive = compound_fts_results(&dataset, query, None).await;
+    assert_eq!(exhaustive.len(), 256);
+    assert_eq!(limited_row, exhaustive[0]);
+    assert_eq!(
+        limited_row.0, 1,
+        "row 0 is prohibited, so row 1 wins the tie"
+    );
+    assert_eq!(
+        stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
+        Some(&1),
+        "MUST_NOT collection must exercise the score-floor overflow retry"
+    );
+    assert_eq!(
+        stats.all_counts.get(COMPOUND_MUST_NOT_POSTING_LOADS_METRIC),
+        Some(&2),
+        "both positive-bearing segments must load their prohibited posting"
+    );
+}
+
+#[tokio::test]
+async fn test_compound_must_not_equal_floor_loads_later_segment() {
+    // Reverse the segments so row 2 fills k=1 first. Row 0 has the same score
+    // and a smaller row id, so the later segment must pass an equal score floor,
+    // load its prohibited posting, and replace row 2.
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        [
+            "common clear",
+            "common blocked",
+            "common clear",
+            "neutral blocked"
+        ]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    create_fragmented_fts_index_with_order(&mut dataset, "text", false, true).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("common", "text", 1.0)),
+        (Occur::MustNot, compound_match_query("blocked", "text", 1.0)),
+    ])
+    .into();
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    scanner.limit(Some(1), None).unwrap();
+    let limited = scanner.try_into_batch().await.unwrap();
+    let limited_row = (
+        limited[ROW_ID].as_primitive::<UInt64Type>().value(0),
+        limited[SCORE_COL].as_primitive::<Float32Type>().value(0),
+    );
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+
+    let exhaustive = compound_fts_results(&dataset, query, None).await;
+    assert_eq!(exhaustive.len(), 2);
+    assert_eq!(exhaustive[0].1, exhaustive[1].1);
+    assert_eq!(limited_row, exhaustive[0]);
+    assert_eq!(limited_row.0, 0);
+    assert_eq!(
+        stats.all_counts.get(COMPOUND_MUST_NOT_POSTING_LOADS_METRIC),
+        Some(&2),
+        "the later equal-floor segment must not be skipped before exclusion loads"
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1575,8 +1575,12 @@ async fn test_compound_must_not_deferred_load_respects_modern_visibility() {
     .into();
     for (filter, expected_row_ids, expected_loads) in [
         ("scope = 0", Vec::new(), 0),
-        ("scope = 1", Vec::new(), 1),
-        ("scope = 2", vec![1], 1),
+        // The positive and prohibited terms share a runtime posting group.
+        // Loading the positive leaf above makes the prohibited member of that
+        // immutable group cache-resident, so neither visible-positive case
+        // needs a deferred load or positive preflight cycle.
+        ("scope = 1", Vec::new(), 0),
+        ("scope = 2", vec![1], 0),
     ] {
         let (rows, stats) =
             compound_fts_results_with_stats(&dataset, query.clone(), Some(1), Some(filter)).await;

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -43,7 +43,8 @@ use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
 use lance_index::metrics::{
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_MUST_NOT_PROBES_METRIC, COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
+    COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, COMPOUND_POSITIVE_SURVIVORS_METRIC,
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
@@ -1325,6 +1326,118 @@ async fn test_same_column_compound_scorer_is_exact_and_bounded() {
 }
 
 #[tokio::test]
+async fn test_compound_must_not_phrase_is_exact_across_shapes() {
+    let batch = arrow_array::record_batch!((
+        "text",
+        Utf8,
+        [
+            "alpha beta rare red flag",
+            "alpha beta rare",
+            "alpha beta rare",
+            "alpha beta rare",
+            "alpha beta",
+            "alpha beta red flag",
+            "alpha gamma rare",
+            "beta gamma rare",
+            "alpha beta rare",
+            "alpha beta",
+            "alpha beta rare",
+            "alpha"
+        ]
+    ))
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 3,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 4);
+    create_fragmented_fts_index_with_order(&mut dataset, "text", true, true).await;
+
+    let match_query = |term: &str| compound_match_query(term, "text", 1.0);
+    let prohibited_phrase = || -> FtsQuery {
+        PhraseQuery::new("red flag".to_owned())
+            .with_column(Some("text".to_owned()))
+            .into()
+    };
+    let conjunction: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("alpha")),
+        (Occur::Must, match_query("beta")),
+        (Occur::MustNot, prohibited_phrase()),
+    ])
+    .into();
+    let reqopt: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("alpha")),
+        (Occur::Should, match_query("rare")),
+        (Occur::MustNot, prohibited_phrase()),
+    ])
+    .into();
+    let pure_should: FtsQuery = BooleanQuery::new([
+        (Occur::Should, match_query("alpha")),
+        (Occur::Should, match_query("beta")),
+        (Occur::Should, match_query("rare")),
+        (Occur::MustNot, prohibited_phrase()),
+    ])
+    .into();
+    let nested_positive: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("alpha")),
+        (Occur::MustNot, prohibited_phrase()),
+    ])
+    .into();
+    let nested: FtsQuery = BooleanQuery::new([
+        (Occur::Must, nested_positive),
+        (Occur::Should, match_query("beta")),
+    ])
+    .into();
+
+    for (shape, query) in [
+        ("conjunction", conjunction.clone()),
+        ("ReqOpt", reqopt),
+        ("pure SHOULD", pure_should),
+        ("nested Boolean", nested),
+    ] {
+        let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+        assert!(
+            exhaustive.len() > 2,
+            "{shape} must have candidates beyond top-k"
+        );
+        assert!(
+            exhaustive
+                .iter()
+                .all(|(row_id, _)| *row_id != 0 && *row_id != 5),
+            "{shape} must exclude every matching prohibited phrase"
+        );
+        let limited = compound_fts_results(&dataset, query, Some(2)).await;
+        assert_eq!(limited, exhaustive[..2], "{shape} top-k must remain exact");
+    }
+
+    let exhaustive = compound_fts_results(&dataset, conjunction.clone(), None).await;
+    assert!(
+        exhaustive
+            .windows(2)
+            .any(|rows| rows[0].1 == rows[1].1 && rows[0].0 < rows[1].0),
+        "conjunction results should retain an ascending row-id score tie"
+    );
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(conjunction))
+        .unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("CompoundFtsScorer"),
+        "same-column Phrase prohibition should use the compound scorer:\n{plan}"
+    );
+}
+
+#[tokio::test]
 async fn test_pure_should_maxscore_is_exact_across_fragments() {
     let batch = arrow_array::record_batch!((
         "text",
@@ -1406,6 +1519,8 @@ async fn test_pure_should_maxscore_is_exact_across_fragments() {
     scanner.try_into_batch().await.unwrap();
     let stats = collected_stats.lock().unwrap().take().unwrap();
     for metric in [
+        COMPOUND_POSITIVE_SURVIVORS_METRIC,
+        COMPOUND_MUST_NOT_PROBES_METRIC,
         COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
         COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
         COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
@@ -1423,6 +1538,15 @@ async fn test_pure_should_maxscore_is_exact_across_fragments() {
     assert!(
         stats.all_counts[COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC] > 0,
         "pure-SHOULD execution should evaluate essential clauses"
+    );
+    assert!(
+        stats.all_counts[COMPOUND_POSITIVE_SURVIVORS_METRIC] > 0,
+        "pure-SHOULD execution should produce candidates for MUST_NOT"
+    );
+    assert_eq!(
+        stats.all_counts[COMPOUND_MUST_NOT_PROBES_METRIC],
+        stats.all_counts[COMPOUND_POSITIVE_SURVIVORS_METRIC],
+        "each positive survivor should probe MUST_NOT exactly once"
     );
     assert_eq!(
         stats.all_counts.get(PARTITIONS_SEARCHED_METRIC),

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -45,7 +45,8 @@ use crate::{Dataset, index::DatasetIndexInternalExt};
 use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_MUST_NOT_PROBES_METRIC, COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
+    COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, COMPOUND_POSITIVE_SURVIVORS_METRIC,
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
@@ -1060,6 +1061,8 @@ pub struct FtsIndexMetrics {
     compound_peak_address_resolution_batch_size: Gauge,
     compound_score_floor_overflows: Count,
     compound_peak_buffered_candidates: Gauge,
+    compound_positive_survivors: Count,
+    compound_must_not_probes: Count,
     compound_should_skipped_windows: Count,
     compound_should_bound_recomputations: Count,
     compound_should_essential_evaluations: Count,
@@ -1093,6 +1096,9 @@ impl FtsIndexMetrics {
                 .new_count(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
             compound_peak_buffered_candidates: metrics
                 .new_gauge(COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
+            compound_positive_survivors: metrics
+                .new_count(COMPOUND_POSITIVE_SURVIVORS_METRIC, partition),
+            compound_must_not_probes: metrics.new_count(COMPOUND_MUST_NOT_PROBES_METRIC, partition),
             compound_should_skipped_windows: metrics
                 .new_count(COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, partition),
             compound_should_bound_recomputations: metrics
@@ -1173,6 +1179,14 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_compound_peak_buffered_candidates(&self, num_candidates: usize) {
         self.compound_peak_buffered_candidates
             .set_max(num_candidates);
+    }
+
+    fn record_compound_positive_survivors(&self, num_candidates: usize) {
+        self.compound_positive_survivors.add(num_candidates);
+    }
+
+    fn record_compound_must_not_probes(&self, num_probes: usize) {
+        self.compound_must_not_probes.add(num_probes);
     }
 
     fn record_compound_should_skipped_windows(&self, num_windows: usize) {
@@ -3547,15 +3561,19 @@ mod tests {
     }
 
     #[test]
-    fn test_compound_should_metrics_are_counted_independently() {
+    fn test_compound_metrics_are_counted_independently() {
         let metrics_set = ExecutionPlanMetricsSet::new();
         let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
 
+        metrics.record_compound_positive_survivors(11);
+        metrics.record_compound_must_not_probes(13);
         metrics.record_compound_should_skipped_windows(2);
         metrics.record_compound_should_bound_recomputations(3);
         metrics.record_compound_should_essential_evaluations(5);
         metrics.record_compound_should_non_essential_evaluations(7);
 
+        assert_eq!(metrics.compound_positive_survivors.value(), 11);
+        assert_eq!(metrics.compound_must_not_probes.value(), 13);
         assert_eq!(metrics.compound_should_skipped_windows.value(), 2);
         assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
         assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -45,11 +45,12 @@ use crate::{Dataset, index::DatasetIndexInternalExt};
 use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_MUST_NOT_PROBES_METRIC, COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
-    COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, COMPOUND_POSITIVE_SURVIVORS_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
-    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
+    COMPOUND_MUST_NOT_POSTING_LOADS_METRIC, COMPOUND_MUST_NOT_PROBES_METRIC,
+    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
+    COMPOUND_POSITIVE_SURVIVORS_METRIC, COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
+    COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
+    COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
+    FREQS_COLLECTED_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -1063,6 +1064,7 @@ pub struct FtsIndexMetrics {
     compound_peak_buffered_candidates: Gauge,
     compound_positive_survivors: Count,
     compound_must_not_probes: Count,
+    compound_must_not_posting_loads: Count,
     compound_should_skipped_windows: Count,
     compound_should_bound_recomputations: Count,
     compound_should_essential_evaluations: Count,
@@ -1099,6 +1101,8 @@ impl FtsIndexMetrics {
             compound_positive_survivors: metrics
                 .new_count(COMPOUND_POSITIVE_SURVIVORS_METRIC, partition),
             compound_must_not_probes: metrics.new_count(COMPOUND_MUST_NOT_PROBES_METRIC, partition),
+            compound_must_not_posting_loads: metrics
+                .new_count(COMPOUND_MUST_NOT_POSTING_LOADS_METRIC, partition),
             compound_should_skipped_windows: metrics
                 .new_count(COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, partition),
             compound_should_bound_recomputations: metrics
@@ -1187,6 +1191,10 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_compound_must_not_probes(&self, num_probes: usize) {
         self.compound_must_not_probes.add(num_probes);
+    }
+
+    fn record_compound_must_not_posting_loads(&self, num_loads: usize) {
+        self.compound_must_not_posting_loads.add(num_loads);
     }
 
     fn record_compound_should_skipped_windows(&self, num_windows: usize) {
@@ -3567,6 +3575,7 @@ mod tests {
 
         metrics.record_compound_positive_survivors(11);
         metrics.record_compound_must_not_probes(13);
+        metrics.record_compound_must_not_posting_loads(17);
         metrics.record_compound_should_skipped_windows(2);
         metrics.record_compound_should_bound_recomputations(3);
         metrics.record_compound_should_essential_evaluations(5);
@@ -3574,6 +3583,7 @@ mod tests {
 
         assert_eq!(metrics.compound_positive_survivors.value(), 11);
         assert_eq!(metrics.compound_must_not_probes.value(), 13);
+        assert_eq!(metrics.compound_must_not_posting_loads.value(), 17);
         assert_eq!(metrics.compound_should_skipped_windows.value(), 2);
         assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
         assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);


### PR DESCRIPTION
## What is the performance issue?

Same-column compound FTS evaluated Boolean `MUST_NOT` clauses while advancing the positive driver. Candidates rejected by positive two-phase confirmation, block bounds, or the exact competitive score could still pay for prohibited posting advances and phrase confirmation. Prohibited clauses also used scoring cursors even though exclusion only needs exact membership, and their postings were loaded before the query knew whether a partition contained a competitive positive candidate.

Closes [OSS-1705](https://linear.app/lancedb/issue/OSS-1705/delay-same-column-fts-must-not-probes-until-positive-candidates).

## How does this PR improve performance?

This follows the same separation used by Lucene's [`ReqExclScorer`](https://github.com/apache/lucene/blob/9cda46563a4bb30f26fd120ab9bc1397106bf945/lucene/core/src/java/org/apache/lucene/search/ReqExclScorer.java) and `COMPLETE_NO_SCORES` handling in [`BooleanScorerSupplier`](https://github.com/apache/lucene/blob/9cda46563a4bb30f26fd120ab9bc1397106bf945/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java):

- Delay `MUST_NOT` confirmation until the exact positive side survives two-phase matching and the current competitive score floor. The current-document positive score and prohibited decision are cached.
- Propagate `CompleteNoScores` through the complete prohibited subtree, including nested Boolean, MultiMatch, and Boost queries. Membership-irrelevant scoring branches are removed while query validation remains unchanged.
- Use dedicated membership posting cursors. Non-Phrase membership decodes document IDs without frequencies, document lengths, BM25, or impact scoring. Phrase membership retains frequencies only because they delimit the shared position stream and still performs exact position confirmation.
- Load scoring leaves first. When prohibited postings are not already cached, an exact positive gate determines whether a partition can compete before loading its prohibited leaves. Deferred loads are batched concurrently, and full collection resumes at the first competitive document instead of replaying the rejected prefix.
- Use a conservative membership-only gate when signed Boost subtrees cannot prove a safe score upper envelope. Score-floor ties remain eligible, so ordered top-k semantics are unchanged.
- Reuse cached prohibited postings directly. Fully prewarmed workloads avoid the gate/replay scheduling path while still using delayed probes and no-score cursors.
- Preserve the original fast path for Boolean queries without `MUST_NOT`.

The query API and persisted index format do not change.

## Measurement

### 10M-row end-to-end benchmark

Every value below is the geometric mean of four isolated process samples per build and case. Throughput is higher-is-better; latency is lower-is-better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Reversed Phrase `MUST_NOT`, k=10 throughput | 1,753.43 queries/s | 1,799.34 queries/s | 1.026x throughput |
| Reversed Phrase `MUST_NOT`, k=10 p99 latency | 8.19 ms | 7.37 ms | 1.112x speedup |
| Reversed Phrase `MUST_NOT`, k=100 throughput | 1,594.99 queries/s | 1,603.53 queries/s | 1.005x throughput |
| Reversed Phrase `MUST_NOT`, k=100 p99 latency | 9.78 ms | 9.16 ms | 1.067x speedup |
| Nested doc-only `MUST_NOT`, k=10 throughput | 1,700.42 queries/s | 1,739.82 queries/s | 1.023x throughput |
| Nested doc-only `MUST_NOT`, k=10 p99 latency | 8.54 ms | 7.85 ms | 1.089x speedup |
| Nested doc-only `MUST_NOT`, k=100 throughput | 1,541.75 queries/s | 1,555.20 queries/s | 1.009x throughput |
| Nested doc-only `MUST_NOT`, k=100 p99 latency | 9.87 ms | 9.73 ms | 1.014x speedup |
| Paired no-`MUST_NOT` control, k=10 throughput | 2,081.67 queries/s | 2,072.02 queries/s | 1.005x slower |
| Paired no-`MUST_NOT` control, k=10 p99 latency | 6.32 ms | 6.31 ms | 1.002x speedup |
| Paired no-`MUST_NOT` control, k=100 throughput | 1,785.00 queries/s | 1,779.28 queries/s | 1.003x slower |
| Paired no-`MUST_NOT` control, k=100 p99 latency | 7.60 ms | 7.61 ms | 1.001x slower |
| Dense all-match `MUST_NOT`, k=10 throughput | 2,019.56 queries/s | 2,021.31 queries/s | 1.001x throughput |
| Dense all-match `MUST_NOT`, k=10 p99 latency | 6.68 ms | 6.56 ms | 1.018x speedup |
| Dense all-match `MUST_NOT`, k=100 throughput | 2,035.74 queries/s | 2,009.28 queries/s | 1.013x slower |
| Dense all-match `MUST_NOT`, k=100 p99 latency | 6.61 ms | 6.63 ms | 1.002x slower |

The intended tight-top-k workloads improve most: k=10 gains 1.023-1.026x throughput and 1.089-1.112x p99 latency. At k=100, fewer candidates can be eliminated before exclusion, so throughput is close to flat. The dense all-match k=100 case is the expected adverse control: it never establishes a useful accepted-result floor and regresses throughput by 1.013x. The no-`MUST_NOT` control is within 0.5% of baseline.

Methodology: GCP `c4-highmem-16` in `us-central1-c` (16 vCPU, 121 GiB OS-visible RAM), frozen 10,000,000-row MMLB code dataset spanning 42 languages and 10 fragments, 37.8 GiB FTS index, 64 GiB Lance index cache, 8 workers, and `release-with-debug`. Each case ran 1,000 deterministic queries repeated 20 times (20,000 timed executions). Two A-B-B-A blocks compared baseline `706b941b6` with target source tree `0c4bad883`, reversed case order, and prewarmed positions in every process. The suite completed 1,280,000 timed executions. All 56,000 cross-process result signatures matched exactly, and the input index tree was unchanged before and after the run.

This hot-cache benchmark primarily measures delayed confirmation and no-score CPU work. The doc-only decoder reduces decoding CPU, not persisted bytes for a posting that is loaded. True cold-I/O avoidance is covered deterministically by the deferred-posting-load integration tests rather than claimed from this prewarmed latency run.

## Validation

- `cargo test -p lance-index --lib` (1,050 passed, 2 ignored)
- Dataset compound FTS integration suite (11 passed), including deferred posting loads, visibility, Phrase false-positive rejection, and multi-fragment exactness
- Baseline and target bounded-vs-unbounded exact oracles: 24/24 cases per build, zero mismatches
- Baseline-vs-target oracle comparison: zero mismatches
- Full timed ABBA validation: 64 raw result files, 56,000 cross-process signatures, zero mismatches
- `cargo check -p lance-index --tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`

Regression coverage includes required conjunction, required-plus-optional, pure `SHOULD`, nested Boolean/MultiMatch/Boost, Phrase prohibitions, multiple fragments and partitions, score-floor ties, signed negative subtrees, visibility masks, projection overflow retry, cached and uncached prohibited postings, and doc-only plain/compressed OR and AND cursors.
