### PR TITLE
perf(index): skip unnecessary null tracking for BTree and Bitmap indexes

### DIFF
--- a/rust/lance-index-core/src/scalar.rs
+++ b/rust/lance-index-core/src/scalar.rs
@@ -507,12 +507,26 @@ pub struct SearchOptions {
     ///
     /// Callers may disable this only when NULL rows cannot affect the final
     /// result, such as a top-level filter whose NULL results will be discarded.
-    pub track_nulls: bool,
+    track_nulls: bool,
 }
 
 impl Default for SearchOptions {
     fn default() -> Self {
         Self { track_nulls: true }
+    }
+}
+
+impl SearchOptions {
+    /// Configure whether searches preserve rows where the query evaluates to
+    /// NULL. When disabled, implementations return only TRUE rows.
+    pub fn with_track_nulls(mut self, track_nulls: bool) -> Self {
+        self.track_nulls = track_nulls;
+        self
+    }
+
+    /// Whether searches preserve rows where the query evaluates to NULL.
+    pub fn track_nulls(&self) -> bool {
+        self.track_nulls
     }
 }
 

--- a/rust/lance-index-core/src/scalar.rs
+++ b/rust/lance-index-core/src/scalar.rs
@@ -500,6 +500,22 @@ impl UpdateCriteria {
     }
 }
 
+/// Execution-time options for scalar index searches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchOptions {
+    /// Preserve rows where the query evaluates to NULL.
+    ///
+    /// Callers may disable this only when NULL rows cannot affect the final
+    /// result, such as a top-level filter whose NULL results will be discarded.
+    pub track_nulls: bool,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        Self { track_nulls: true }
+    }
+}
+
 /// A trait for a scalar index, a structure that can determine row ids that satisfy scalar queries
 #[async_trait]
 pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
@@ -511,6 +527,20 @@ pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult>;
+
+    /// Search the scalar index with execution-time options.
+    ///
+    /// Index implementations that do not need the options can rely on this
+    /// default implementation. The default preserves the behavior of
+    /// [`Self::search`].
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        _options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        self.search(query, metrics).await
+    }
 
     /// Returns true if this index reports matches as physical row addresses
     /// (`fragment_id << 32 | offset`) rather than row ids

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -27,7 +27,7 @@ pub use crate::metrics::MetricsCollector;
 pub use lance_index_core::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexFile, IndexReader, IndexStore, IndexWriter,
     LANCE_SCALAR_INDEX, OldIndexDataFilter, RowIdRemapper, ScalarIndex, ScalarIndexParams,
-    SearchResult, TrainingCriteria, TrainingOrdering, UpdateCriteria,
+    SearchOptions, SearchResult, TrainingCriteria, TrainingOrdering, UpdateCriteria,
 };
 
 pub mod bitmap;

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -36,7 +36,7 @@ use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, warn};
 
-use super::{AnyQuery, IndexFile, IndexStore, ScalarIndex};
+use super::{AnyQuery, IndexFile, IndexStore, ScalarIndex, SearchOptions};
 use super::{
     BuiltinIndexType, SargableQuery, ScalarIndexParams, SearchResult, btree::OrderableScalarValue,
 };
@@ -681,7 +681,25 @@ impl ScalarIndex for BitmapIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
+
+        let tracked_null_rows = || {
+            if options.track_nulls && !self.null_map.is_empty() {
+                Some((*self.null_map).clone())
+            } else {
+                None
+            }
+        };
 
         let (row_ids, null_row_ids) = match query {
             SargableQuery::Equals(val) => {
@@ -692,12 +710,7 @@ impl ScalarIndex for BitmapIndex {
                 } else {
                     let key = OrderableScalarValue(val.clone());
                     let bitmap = self.load_bitmap(&key, Some(metrics)).await?;
-                    let null_rows = if !self.null_map.is_empty() {
-                        Some((*self.null_map).clone())
-                    } else {
-                        None
-                    };
-                    ((*bitmap).clone(), null_rows)
+                    ((*bitmap).clone(), tracked_null_rows())
                 }
             }
             SargableQuery::Range(start, end) => {
@@ -748,12 +761,7 @@ impl ScalarIndex for BitmapIndex {
                     RowAddrTreeMap::union_all(&bitmap_refs)
                 };
 
-                let null_rows = if !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
-                (result, null_rows)
+                (result, tracked_null_rows())
             }
             SargableQuery::IsIn(values) => {
                 metrics.record_comparisons(values.len());
@@ -801,11 +809,7 @@ impl ScalarIndex for BitmapIndex {
 
                 // If the query explicitly includes null, then nulls are TRUE (not NULL)
                 // Otherwise, nulls remain NULL (unknown)
-                let null_rows = if !has_null && !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
+                let null_rows = if has_null { None } else { tracked_null_rows() };
                 (result, null_rows)
             }
             SargableQuery::IsNull() => {
@@ -2813,8 +2817,32 @@ mod tests {
             .await
             .unwrap();
 
-        // Test 1: Search for value 5 - should return allow=[1], null=[2]
+        // Test 1: A caller that does not need NULL bookkeeping should receive
+        // the same true rows without cloning the null bitmap.
         let query = SargableQuery::Equals(ScalarValue::Int64(Some(5)));
+        let result = index
+            .search_with_options(
+                &query,
+                SearchOptions { track_nulls: false },
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match result {
+            SearchResult::Exact(row_ids) => {
+                let actual_rows: Vec<u64> = row_ids
+                    .true_rows()
+                    .row_addrs()
+                    .unwrap()
+                    .map(u64::from)
+                    .collect();
+                assert_eq!(actual_rows, vec![1]);
+                assert!(row_ids.null_rows().is_empty());
+            }
+            _ => panic!("Expected Exact search result"),
+        }
+
+        // The existing API keeps NULL rows for three-valued logic.
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
 
         match result {

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -694,7 +694,7 @@ impl ScalarIndex for BitmapIndex {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
 
         let tracked_null_rows = || {
-            if options.track_nulls && !self.null_map.is_empty() {
+            if options.track_nulls() && !self.null_map.is_empty() {
                 Some((*self.null_map).clone())
             } else {
                 None
@@ -2823,7 +2823,7 @@ mod tests {
         let result = index
             .search_with_options(
                 &query,
-                SearchOptions { track_nulls: false },
+                SearchOptions::default().with_track_nulls(false),
                 &NoOpMetricsCollector,
             )
             .await

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -13,7 +13,7 @@ use std::{
 
 use super::{
     AnyQuery, BuiltinIndexType, IndexFile, IndexReader, IndexStore, IndexWriter, MetricsCollector,
-    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchResult,
+    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchOptions, SearchResult,
     compute_next_prefix,
 };
 use crate::cache_pb::{BTreeIndexHeader, RangeToFile};
@@ -2127,6 +2127,16 @@ impl ScalarIndex for BTreeIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
         let mut pages = match query {
             SargableQuery::Equals(val) => self
@@ -2193,7 +2203,7 @@ impl ScalarIndex for BTreeIndex {
         // page with zero nulls is a true Matches::All, while one with nulls needs
         // Matches::Some only to track the null rows; surfacing `null_count` here
         // could refine that classification (see #6802).
-        if !matches!(query, SargableQuery::IsNull()) {
+        if options.track_nulls && !matches!(query, SargableQuery::IsNull()) {
             let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
             for &page_id in self
                 .page_lookup
@@ -3410,7 +3420,8 @@ mod tests {
     use crate::{
         metrics::NoOpMetricsCollector,
         scalar::{
-            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchResult,
+            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchOptions,
+            SearchResult,
             btree::{BTREE_PAGES_NAME, BTreeIndex},
             lance_format::LanceIndexStore,
         },
@@ -5469,13 +5480,10 @@ mod tests {
         }
     }
 
-    /// Regression test: BTree search must track null row IDs for non-IsNull
-    /// queries, even when no pages match the queried value.
-    ///
-    /// Without this, `NOT(x = val)` when `val` is absent from the data would
-    /// produce an empty null set, causing NULL rows to incorrectly pass.
+    /// Regression test: BTree search skips null pages only when the caller
+    /// explicitly opts out of NULL tracking.
     #[tokio::test]
-    async fn test_search_tracks_nulls_for_absent_value() {
+    async fn test_search_null_tracking_options_for_absent_value() {
         use arrow_array::{Int32Array, UInt64Array};
 
         let tmpdir = TempObjDir::default();
@@ -5526,16 +5534,22 @@ mod tests {
             index.page_lookup.all_null_pages.len(),
         );
 
-        let metrics = NoOpMetricsCollector;
+        let query = SargableQuery::Equals(ScalarValue::Int32(Some(0)));
 
-        // Search for Equals(0) — value 0 doesn't exist in any page
+        // A top-level positive filter can discard NULL results. No BTree page
+        // should be read when the searched value is absent.
+        let metrics = LocalMetricsCollector::default();
         let result = index
-            .search(
-                &SargableQuery::Equals(ScalarValue::Int32(Some(0))),
-                &metrics,
-            )
+            .search_with_options(&query, SearchOptions { track_nulls: false }, &metrics)
             .await
             .unwrap();
+        assert_eq!(result, SearchResult::exact(RowAddrTreeMap::default()));
+        assert_eq!(metrics.parts_loaded.load(Ordering::Relaxed), 0);
+        assert_eq!(metrics.comparisons.load(Ordering::Relaxed), 0);
+
+        // The existing search API keeps its NULL-preserving behavior for
+        // callers that need three-valued logic.
+        let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
 
         match result {
             SearchResult::Exact(set) => {
@@ -5557,7 +5571,7 @@ mod tests {
                     std::ops::Bound::Unbounded,
                     std::ops::Bound::Excluded(ScalarValue::Int32(Some(50))),
                 ),
-                &metrics,
+                &NoOpMetricsCollector,
             )
             .await
             .unwrap();

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -76,7 +76,7 @@ use lance_datafusion::{
     chunker::chunk_concat_stream,
     exec::{LanceExecutionOptions, OneShotExec, execute_plan},
 };
-use lance_select::{NullableRowAddrSet, RowSetOps};
+use lance_select::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use log::{debug, warn};
 use object_store::Error as ObjectStoreError;
 use rangemap::RangeInclusiveMap;
@@ -1706,6 +1706,7 @@ impl BTreeIndex {
         matches: Matches,
         index_reader: LazyIndexReader,
         prebuilt: Option<&Arc<dyn PhysicalExpr>>,
+        track_nulls: bool,
         metrics: &dyn MetricsCollector,
     ) -> Result<NullableRowAddrSet> {
         let subindex = self
@@ -1716,13 +1717,14 @@ impl BTreeIndex {
             // For a large IsIn the predicate is compiled once (see `search`) and
             // reused here, instead of rebuilding the whole IN-list per page.
             Matches::Some(_) => match prebuilt {
-                Some(expr) => subindex.search_prebuilt(expr, metrics),
-                None => subindex.search(query, metrics),
+                Some(expr) => subindex.search_prebuilt(expr, track_nulls, metrics),
+                None => subindex.search(query, track_nulls, metrics),
             },
             Matches::All(_) => Ok(match query {
                 // This means we hit an all-null page so just grab all row ids as true
                 SargableQuery::IsNull() => subindex.all_ignore_nulls(),
-                _ => subindex.all(),
+                _ if track_nulls => subindex.all(),
+                _ => subindex.all_non_null(),
             }),
         }
     }
@@ -2203,7 +2205,7 @@ impl ScalarIndex for BTreeIndex {
         // page with zero nulls is a true Matches::All, while one with nulls needs
         // Matches::Some only to track the null rows; surfacing `null_count` here
         // could refine that classification (see #6802).
-        if options.track_nulls && !matches!(query, SargableQuery::IsNull()) {
+        if options.track_nulls() && !matches!(query, SargableQuery::IsNull()) {
             let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
             for &page_id in self
                 .page_lookup
@@ -2235,6 +2237,7 @@ impl ScalarIndex for BTreeIndex {
                     page_index,
                     lazy_index_reader.clone(),
                     prebuilt.as_ref(),
+                    options.track_nulls(),
                     metrics,
                 )
                 .boxed()
@@ -2250,8 +2253,18 @@ impl ScalarIndex for BTreeIndex {
             .try_collect()
             .await?;
 
-        // Merge matching row IDs
-        let selection = NullableRowAddrSet::union_all(&results);
+        let selection = if options.track_nulls() {
+            NullableRowAddrSet::union_all(&results)
+        } else {
+            let selected_rows = results
+                .iter()
+                .map(NullableRowAddrSet::selected_rows)
+                .collect::<Vec<_>>();
+            NullableRowAddrSet::new(
+                RowAddrTreeMap::union_all(&selected_rows),
+                Default::default(),
+            )
+        };
 
         Ok(SearchResult::Exact(selection))
     }
@@ -5540,7 +5553,11 @@ mod tests {
         // should be read when the searched value is absent.
         let metrics = LocalMetricsCollector::default();
         let result = index
-            .search_with_options(&query, SearchOptions { track_nulls: false }, &metrics)
+            .search_with_options(
+                &query,
+                SearchOptions::default().with_track_nulls(false),
+                &metrics,
+            )
             .await
             .unwrap();
         assert_eq!(result, SearchResult::exact(RowAddrTreeMap::default()));
@@ -5586,6 +5603,57 @@ mod tests {
             }
             _ => panic!("BTree search should return Exact"),
         }
+    }
+
+    /// Regression test: disabling NULL tracking also omits NULL rows from a
+    /// candidate page that contains both matching and NULL values.
+    #[tokio::test]
+    async fn test_search_without_null_tracking_on_mixed_page() {
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::memory()),
+            Path::default(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let data = record_batch!(
+            ("value", Int32, [None, Some(5), Some(7)]),
+            ("_rowid", UInt64, [0, 1, 2])
+        )
+        .unwrap();
+        let schema = data.schema();
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(async { Ok(data) }),
+        ));
+        train_btree_index(stream, test_store.as_ref(), 3, None, None)
+            .await
+            .unwrap();
+
+        let index = BTreeIndex::load(test_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert_eq!(index.page_lookup.null_pages, vec![0]);
+
+        let query = SargableQuery::Equals(ScalarValue::Int32(Some(5)));
+        let result = index
+            .search_with_options(
+                &query,
+                SearchOptions::default().with_track_nulls(false),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        let SearchResult::Exact(row_ids) = result else {
+            panic!("BTree search should be exact");
+        };
+        assert_eq!(row_ids.true_rows(), RowAddrTreeMap::from_iter([1]));
+        assert!(row_ids.null_rows().is_empty());
+
+        let tracked = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let SearchResult::Exact(tracked) = tracked else {
+            panic!("BTree search should be exact");
+        };
+        assert_eq!(tracked.true_rows(), RowAddrTreeMap::from_iter([1]));
+        assert_eq!(tracked.null_rows(), &RowAddrTreeMap::from_iter([0]));
     }
 
     fn sample_lookup_batch() -> RecordBatch {

--- a/rust/lance-index/src/scalar/btree/flat.rs
+++ b/rust/lance-index/src/scalar/btree/flat.rs
@@ -134,6 +134,14 @@ impl FlatIndex {
         NullableRowAddrSet::new(self.all_addrs_map.clone(), Default::default())
     }
 
+    /// Return every non-null row as TRUE without preserving NULL rows.
+    pub fn all_non_null(&self) -> NullableRowAddrSet {
+        NullableRowAddrSet::new(
+            self.all_addrs_map.clone() - &self.null_addrs_map,
+            Default::default(),
+        )
+    }
+
     pub fn remap_batch(batch: RecordBatch, mapping: &RowAddrRemap) -> Result<RecordBatch> {
         let row_ids = batch.column(IDS_COL_IDX).as_primitive::<UInt64Type>();
         let val_idx_and_new_id = row_ids
@@ -176,6 +184,7 @@ impl FlatIndex {
     pub fn search(
         &self,
         query: &dyn AnyQuery,
+        track_nulls: bool,
         metrics: &dyn MetricsCollector,
     ) -> Result<NullableRowAddrSet> {
         metrics.record_comparisons(self.data.num_rows());
@@ -189,10 +198,11 @@ impl FlatIndex {
             SargableQuery::Equals(value) => {
                 if value.is_null() {
                     // if we have x = NULL then the correct SQL behavior is to return all NULLs
-                    return Ok(NullableRowAddrSet::new(
-                        Default::default(),
-                        self.all_addrs_map.clone(),
-                    ));
+                    return Ok(if track_nulls {
+                        NullableRowAddrSet::new(Default::default(), self.all_addrs_map.clone())
+                    } else {
+                        NullableRowAddrSet::empty()
+                    });
                 }
             }
             // x IS NULL we can use pre-computed nulls
@@ -212,19 +222,21 @@ impl FlatIndex {
                 }
                 (Bound::Unbounded, Bound::Included(upper) | Bound::Excluded(upper)) => {
                     if upper.is_null() {
-                        return Ok(NullableRowAddrSet::new(
-                            Default::default(),
-                            self.all_addrs_map.clone(),
-                        ));
+                        return Ok(if track_nulls {
+                            NullableRowAddrSet::new(Default::default(), self.all_addrs_map.clone())
+                        } else {
+                            NullableRowAddrSet::empty()
+                        });
                     }
                 }
                 (Bound::Included(lower) | Bound::Excluded(lower), Bound::Unbounded)
                     if lower.is_null() =>
                 {
-                    return Ok(NullableRowAddrSet::new(
-                        Default::default(),
-                        self.all_addrs_map.clone(),
-                    ));
+                    return Ok(if track_nulls {
+                        NullableRowAddrSet::new(Default::default(), self.all_addrs_map.clone())
+                    } else {
+                        NullableRowAddrSet::empty()
+                    });
                 }
                 _ => {}
             },
@@ -234,7 +246,7 @@ impl FlatIndex {
         // No shortcut possible, need to actually evaluate the query
         let expr = query.to_expr(BTREE_VALUES_COLUMN.to_string());
         let expr = create_physical_expr(&expr, &self.df_schema, &ExecutionProps::default())?;
-        self.eval_expr(&expr)
+        self.eval_expr(&expr, track_nulls)
     }
 
     /// Evaluate a predicate compiled once by the caller. Lets a large IsIn that
@@ -243,20 +255,24 @@ impl FlatIndex {
     pub fn search_prebuilt(
         &self,
         expr: &Arc<dyn PhysicalExpr>,
+        track_nulls: bool,
         metrics: &dyn MetricsCollector,
     ) -> Result<NullableRowAddrSet> {
         metrics.record_comparisons(self.data.num_rows());
-        self.eval_expr(expr)
+        self.eval_expr(expr, track_nulls)
     }
 
-    fn eval_expr(&self, expr: &Arc<dyn PhysicalExpr>) -> Result<NullableRowAddrSet> {
+    fn eval_expr(
+        &self,
+        expr: &Arc<dyn PhysicalExpr>,
+        track_nulls: bool,
+    ) -> Result<NullableRowAddrSet> {
         let predicate = expr.evaluate(&self.data)?;
         let predicate = predicate.into_array(self.data.num_rows())?;
         let predicate = predicate
             .as_any()
             .downcast_ref::<BooleanArray>()
             .expect("Predicate should return boolean array");
-        let nulls = arrow::compute::is_null(&predicate)?;
 
         let matching_ids = arrow_select::filter::filter(self.ids(), predicate)?;
         let matching_ids = matching_ids
@@ -265,6 +281,11 @@ impl FlatIndex {
             .expect("Result of arrow_select::filter::filter did not match input type");
         let selected = RowAddrTreeMap::from_sorted_iter(matching_ids.values().iter().copied())?;
 
+        if !track_nulls {
+            return Ok(NullableRowAddrSet::new(selected, Default::default()));
+        }
+
+        let nulls = arrow::compute::is_null(&predicate)?;
         let null_row_ids = arrow_select::filter::filter(self.ids(), &nulls)?;
         let null_row_ids = null_row_ids
             .as_any()
@@ -364,7 +385,7 @@ mod tests {
 
     async fn check_index(query: &SargableQuery, expected: &[u64]) {
         let index = example_index();
-        let actual = index.search(query, &NoOpMetricsCollector).unwrap();
+        let actual = index.search(query, true, &NoOpMetricsCollector).unwrap();
         let expected =
             NullableRowAddrSet::new(RowAddrTreeMap::from_iter(expected), Default::default());
         assert_eq!(actual, expected);
@@ -537,7 +558,7 @@ mod tests {
         let index = FlatIndex::try_new(batch).unwrap();
 
         let check = |query: SargableQuery, true_ids: &[u64], null_ids: &[u64]| {
-            let actual = index.search(&query, &NoOpMetricsCollector).unwrap();
+            let actual = index.search(&query, true, &NoOpMetricsCollector).unwrap();
             let expected = NullableRowAddrSet::new(
                 RowAddrTreeMap::from_iter(true_ids),
                 RowAddrTreeMap::from_iter(null_ids),

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -1981,7 +1981,7 @@ impl ScalarIndexExpr {
                 let search_result = index
                     .search_with_options(
                         search.query.as_ref(),
-                        SearchOptions { track_nulls },
+                        SearchOptions::default().with_track_nulls(track_nulls),
                         metrics,
                     )
                     .await?;

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -20,7 +20,7 @@ use tokio::try_join;
 
 use super::{
     AnyQuery, BloomFilterQuery, LabelListQuery, MetricsCollector, SargableQuery, ScalarIndex,
-    SearchResult, TextQuery, TokenQuery, label_list::validate_label_list_data_type,
+    SearchOptions, SearchResult, TextQuery, TokenQuery, label_list::validate_label_list_data_type,
 };
 #[cfg(feature = "geo")]
 use super::{GeoQuery, RelationQuery};
@@ -1937,26 +1937,40 @@ impl ScalarIndexExpr {
     ///
     /// TODO: We could potentially try and be smarter about reusing loaded indices for
     /// any situations where the session cache has been disabled.
-    #[async_recursion]
     pub async fn evaluate_nullable(
         &self,
         index_loader: &dyn ScalarIndexLoader,
         metrics: &dyn MetricsCollector,
     ) -> Result<NullableIndexExprResult> {
+        self.evaluate_with_options(index_loader, metrics, true)
+            .await
+    }
+
+    #[async_recursion]
+    async fn evaluate_with_options(
+        &self,
+        index_loader: &dyn ScalarIndexLoader,
+        metrics: &dyn MetricsCollector,
+        track_nulls: bool,
+    ) -> Result<NullableIndexExprResult> {
         match self {
             Self::Not(inner) => {
-                let result = inner.evaluate_nullable(index_loader, metrics).await?;
+                // NOT needs the child's NULL rows to preserve SQL three-valued
+                // logic. Once enabled, keep tracking through the whole subtree.
+                let result = inner
+                    .evaluate_with_options(index_loader, metrics, true)
+                    .await?;
                 Ok(!result)
             }
             Self::And(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_nullable(index_loader, metrics);
-                let rhs_result = rhs.evaluate_nullable(index_loader, metrics);
+                let lhs_result = lhs.evaluate_with_options(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_with_options(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result & rhs_result)
             }
             Self::Or(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_nullable(index_loader, metrics);
-                let rhs_result = rhs.evaluate_nullable(index_loader, metrics);
+                let lhs_result = lhs.evaluate_with_options(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_with_options(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result | rhs_result)
             }
@@ -1964,7 +1978,13 @@ impl ScalarIndexExpr {
                 let index = index_loader
                     .load_index(&search.column, &search.index_name, metrics)
                     .await?;
-                let search_result = index.search(search.query.as_ref(), metrics).await?;
+                let search_result = index
+                    .search_with_options(
+                        search.query.as_ref(),
+                        SearchOptions { track_nulls },
+                        metrics,
+                    )
+                    .await?;
                 let result = search_result_to_nullable(search_result);
                 if index.results_are_row_addresses() {
                     // Translate address-domain results to the row-id domain
@@ -1985,7 +2005,7 @@ impl ScalarIndexExpr {
         metrics: &dyn MetricsCollector,
     ) -> Result<IndexExprResult> {
         Ok(self
-            .evaluate_nullable(index_loader, metrics)
+            .evaluate_with_options(index_loader, metrics, false)
             .await?
             .drop_nulls())
     }

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -38,8 +38,8 @@ use crate::{
     metrics::MetricsCollector,
     registry::IndexPluginRegistry,
     scalar::{
-        AnyQuery, CreatedIndex, IndexStore, RowIdRemapper, ScalarIndex, SearchResult,
-        UpdateCriteria,
+        AnyQuery, CreatedIndex, IndexStore, RowIdRemapper, ScalarIndex, SearchOptions,
+        SearchResult, UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
         registry::{
             BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
@@ -107,9 +107,19 @@ impl ScalarIndex for JsonIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<JsonQuery>().unwrap();
         self.target_index
-            .search(query.target_query.as_ref(), metrics)
+            .search_with_options(query.target_query.as_ref(), options, metrics)
             .await
     }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -229,6 +229,85 @@ async fn test_create_scalar_index(
     dataset.index_statistics(&index_name).await.unwrap();
 }
 
+#[tokio::test]
+async fn test_btree_nullable_filters_match_unindexed_scan() {
+    let test_uri = TempStrDir::default();
+    let num_rows = 10_000u64;
+    let values: Int32Array = (0..num_rows).map(|id| (id % 5 == 0).then_some(7)).collect();
+    let ids = UInt64Array::from_iter_values(0..num_rows);
+    let batch = RecordBatch::try_from_iter(vec![
+        ("value", Arc::new(values) as ArrayRef),
+        ("id", Arc::new(ids) as ArrayRef),
+    ])
+    .unwrap();
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new([Ok(batch)], schema);
+    let mut dataset = Dataset::write(
+        reader,
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 2_500,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert!(dataset.get_fragments().len() > 1);
+
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::BTree,
+            Some("value_btree".to_string()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    for predicate in [
+        "value = 7",
+        "value IN (7, 99)",
+        "NOT (value = 99)",
+        "NOT (value = 7)",
+        "NOT (value = 99 OR value = 7)",
+        "NOT (NOT (value = 7))",
+        "value = 99 OR value = 7",
+    ] {
+        let mut indexed_scan = dataset.scan();
+        indexed_scan
+            .filter(predicate)
+            .unwrap()
+            .project(&["id"])
+            .unwrap();
+        let indexed = indexed_scan.try_into_batch().await.unwrap();
+
+        let mut baseline_scan = dataset.scan();
+        baseline_scan.use_scalar_index(false);
+        baseline_scan
+            .filter(predicate)
+            .unwrap()
+            .project(&["id"])
+            .unwrap();
+        let baseline = baseline_scan.try_into_batch().await.unwrap();
+
+        let sorted_ids = |batch: &RecordBatch| {
+            let mut ids = batch
+                .column(0)
+                .as_primitive::<UInt64Type>()
+                .values()
+                .to_vec();
+            ids.sort_unstable();
+            ids
+        };
+        assert_eq!(
+            sorted_ids(&indexed),
+            sorted_ids(&baseline),
+            "indexed result differs for {predicate}"
+        );
+    }
+}
+
 async fn create_bad_file(data_storage_version: LanceFileVersion) -> Result<Dataset> {
     let test_uri = TempStrDir::default();
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -280,6 +280,11 @@ async fn test_btree_nullable_filters_match_unindexed_scan() {
             .unwrap()
             .project(&["id"])
             .unwrap();
+        let plan = indexed_scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("ScalarIndexQuery") && plan.contains("BTree"),
+            "Expected BTree scalar index query for {predicate}:\n{plan}"
+        );
         let indexed = indexed_scan.try_into_batch().await.unwrap();
 
         let mut baseline_scan = dataset.scan();

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -503,7 +503,7 @@ mod tests {
         let untracked = logical
             .search_with_options(
                 &query,
-                SearchOptions { track_nulls: false },
+                SearchOptions::default().with_track_nulls(false),
                 &NoOpMetricsCollector,
             )
             .await

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -12,7 +12,9 @@ use futures::future::try_join_all;
 use lance_core::deepsize::{Context, DeepSizeOf};
 use lance_core::{Error, Result};
 use lance_index::metrics::MetricsCollector;
-use lance_index::scalar::{AnyQuery, CreatedIndex, ScalarIndex, SearchResult, UpdateCriteria};
+use lance_index::scalar::{
+    AnyQuery, CreatedIndex, ScalarIndex, SearchOptions, SearchResult, UpdateCriteria,
+};
 use lance_index::{Index, IndexType};
 use lance_select::NullableRowAddrSet;
 use lance_table::format::IndexMetadata;
@@ -142,10 +144,20 @@ impl ScalarIndex for LogicalScalarIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let results = try_join_all(
             self.segments
                 .iter()
-                .map(|segment| segment.search(query, metrics)),
+                .map(|segment| segment.search_with_options(query, options, metrics)),
         )
         .await?;
         combine_search_results(results)
@@ -366,11 +378,14 @@ mod tests {
     use datafusion::scalar::ScalarValue;
     use lance_core::utils::address::RowAddress;
     use lance_core::utils::tempfile::TempStrDir;
-    use lance_datagen::array;
+    use lance_datagen::{ArrayGeneratorExt, array};
     use lance_index::IndexType;
     use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::scalar::bitmap::BITMAP_LOOKUP_NAME;
-    use lance_index::scalar::{BuiltinIndexType, SargableQuery, ScalarIndexParams};
+    use lance_index::scalar::{
+        BuiltinIndexType, SargableQuery, ScalarIndexParams, SearchOptions, SearchResult,
+    };
+    use lance_select::{RowAddrTreeMap, RowSetOps};
 
     use crate::Dataset;
     use crate::dataset::WriteParams;
@@ -432,7 +447,10 @@ mod tests {
     async fn test_open_named_scalar_index_uses_all_btree_segments() {
         let test_dir = TempStrDir::default();
         let dataset = lance_datagen::gen_batch()
-            .col("value", array::step::<Int32Type>())
+            .col(
+                "value",
+                array::fill::<Int32Type>(7).with_nulls(&[true, false, true, true]),
+            )
             .into_dataset(
                 test_dir.as_str(),
                 FragmentCount::from(4),
@@ -473,6 +491,24 @@ mod tests {
             logical.calculate_included_frags().await.unwrap(),
             dataset.fragment_bitmap.as_ref().clone()
         );
+
+        let query = SargableQuery::Equals(ScalarValue::Int32(Some(99)));
+        let tracked = logical.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let SearchResult::Exact(tracked) = tracked else {
+            panic!("BTree search should be exact");
+        };
+        assert!(tracked.true_rows().is_empty());
+        assert!(!tracked.null_rows().is_empty());
+
+        let untracked = logical
+            .search_with_options(
+                &query,
+                SearchOptions { track_nulls: false },
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        assert_eq!(untracked, SearchResult::exact(RowAddrTreeMap::default()));
 
         let combined_bitmap = scalar_index_fragment_bitmap(&dataset, "value", "value_btree")
             .await


### PR DESCRIPTION
## Summary

- add execution-time scalar index search options while preserving the existing `ScalarIndex::search` NULL-tracking behavior
- skip BTree NULL-only pages, and avoid cloning Bitmap NULL maps, when the final filter does not need nullable results
- restore NULL tracking inside `NOT` subtrees so SQL three-valued logic remains correct
- forward the option through JSON and multi-segment logical scalar indexes

## Problem

BTree searches currently add every NULL-containing and all-NULL page to non-`IS NULL` queries so expression evaluation can preserve SQL three-valued logic. This is required below `NOT`, but it is unnecessary for a top-level positive filter because the scanner drops NULL results at the end.

On nullable, high-cardinality columns this can turn a selective equality, range, or `IN` lookup into hundreds or thousands of small reads over rows that cannot match.

## Approach

`SearchOptions::default()` keeps NULL tracking enabled, so direct scalar-index callers retain the existing behavior. The top-level filter evaluator explicitly disables tracking, propagates that choice through `AND` / `OR`, and enables it for every `NOT` subtree.

BTree uses the option to avoid adding unrelated NULL pages. Bitmap uses it to avoid copying its NULL row map. Wrappers forward the option to their target/segment indexes.

## Prior art and acknowledgment

This is a fresh implementation of the optimization proposed in #6614 by @wojiaodoubao. Thank you for identifying the NULL-page I/O problem and proposing optional tracking. That PR was closed as stale before merge; this version adapts the design to the current `lance-index-core` trait split and logical scalar-index segments, while keeping the existing direct-search default for compatibility.

The NULL tracking itself was introduced for correctness in #6043 and remains enabled wherever three-valued logic requires it.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-index --lib` (1018 passed, 2 ignored)
- BTree regression test verifies an absent positive lookup loads 0 pages when tracking is disabled, while the existing API still returns NULL rows
- multi-fragment BTree scanner test compares indexed and unindexed results across equality, `IN`, `AND` / `OR`, nested `NOT`, and double `NOT`
- logical multi-segment BTree test verifies the option reaches every physical segment
