### PR TITLE
perf(filtered-read): prune non-candidate fragment metadata

### DIFF
--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -113,6 +113,42 @@ impl EvaluatedIndex {
             std::mem::take(&mut self.index_result.lower).also_block(block_list.clone());
         self
     }
+
+    /// Whether planning can require full metadata from `fragment`.
+    ///
+    /// The upper mask contains every row that might match. For address-style row ids its high
+    /// 32 bits identify the fragment directly. Stable row ids need the fragment's row-id
+    /// sequence to make the same decision, but this still avoids opening deletion metadata,
+    /// row counts, and data files for non-candidate fragments.
+    async fn needs_fragment_metadata(
+        &self,
+        dataset: &Dataset,
+        fragment: &Fragment,
+        only_indexed_fragments: bool,
+    ) -> Result<bool> {
+        let fragment_id = fragment.id as u32;
+        if !self.applicable_fragments.contains(fragment_id) {
+            return Ok(!only_indexed_fragments);
+        }
+        let Some(candidate_rows) = self.index_result.upper.allow_list() else {
+            // A block-list may select rows from every fragment.
+            return Ok(true);
+        };
+        if candidate_rows.iter().next().is_none() {
+            return Ok(false);
+        }
+        if dataset.manifest.uses_stable_row_ids() {
+            let row_ids = load_row_id_sequence(dataset, fragment).await?;
+            return Ok(!row_ids
+                .mask_to_offset_ranges(&self.index_result.upper)
+                .is_empty());
+        }
+        Ok(match candidate_rows.get(&fragment_id) {
+            Some(RowAddrSelection::Full) => true,
+            Some(RowAddrSelection::Partial(rows)) => !rows.is_empty(),
+            None => false,
+        })
+    }
 }
 
 /// A fragment along with ranges of row offsets to read
@@ -2159,20 +2195,54 @@ impl FilteredReadExec {
                     .unwrap_or_else(|| dataset.fragments().clone());
 
                 let with_deleted_rows = options.with_deleted_rows;
+                // A range before filtering is expressed in dataset/fragment order. Planning it
+                // needs every preceding fragment's logical row count, including fragments that
+                // the index later eliminates. Without that range, discard covered non-candidate
+                // fragments before opening their full metadata.
+                let needs_fragment_offsets = options.scan_range_before_filter.is_some();
+                let only_indexed_fragments = options.only_indexed_fragments;
                 let frag_futs = fragments
                     .iter()
-                    .map(|frag| {
-                        Result::Ok(FilteredReadStream::load_fragment(
-                            dataset.clone(),
-                            frag.clone(),
-                            with_deleted_rows,
-                        ))
+                    .map(|fragment| {
+                        let dataset = dataset.clone();
+                        let evaluated_index = evaluated_index.clone();
+                        let fragment = fragment.clone();
+                        async move {
+                            let needs_metadata = if needs_fragment_offsets {
+                                true
+                            } else if let Some(index) = evaluated_index {
+                                index
+                                    .needs_fragment_metadata(
+                                        dataset.as_ref(),
+                                        &fragment,
+                                        only_indexed_fragments,
+                                    )
+                                    .await?
+                            } else {
+                                !only_indexed_fragments
+                            };
+                            if needs_metadata {
+                                Ok::<_, Error>(Some(
+                                    FilteredReadStream::load_fragment(
+                                        dataset,
+                                        fragment,
+                                        with_deleted_rows,
+                                    )
+                                    .await?,
+                                ))
+                            } else {
+                                Ok::<_, Error>(None)
+                            }
+                        }
                     })
                     .collect::<Vec<_>>();
                 let loaded_fragments = futures::stream::iter(frag_futs)
-                    .try_buffered(io_parallelism)
-                    .try_collect::<Vec<_>>()
-                    .await?;
+                    .buffered(io_parallelism)
+                    .try_collect::<Vec<Option<_>>>()
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
 
                 // Plan the scan; the metadata loaded here drops when planning
                 // finishes — stream construction rebuilds I/O-free handles
@@ -3443,6 +3513,227 @@ mod tests {
         Arc::new(UInt32Array::from_iter_values(
             ranges.into_iter().flat_map(|r| r.into_iter()),
         ))
+    }
+
+    async fn metadata_pruning_dataset(uses_stable_row_ids: bool) -> (TempStrDir, Arc<Dataset>) {
+        let tmp_path = TempStrDir::default();
+        let dataset = Arc::new(
+            gen_batch()
+                .col("value", array::step::<UInt32Type>())
+                .into_dataset_with_params(
+                    tmp_path.as_str(),
+                    FragmentCount::from(4),
+                    FragmentRowCount::from(10),
+                    Some(WriteParams {
+                        max_rows_per_file: 10,
+                        enable_stable_row_ids: uses_stable_row_ids,
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .unwrap(),
+        );
+        assert_eq!(
+            dataset.manifest().uses_stable_row_ids(),
+            uses_stable_row_ids
+        );
+        (tmp_path, dataset)
+    }
+
+    fn index_result_input(
+        result: IndexExprResult,
+        fragments: &[Fragment],
+    ) -> Arc<dyn ExecutionPlan> {
+        let covered: RoaringBitmap = fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .collect();
+        index_result_input_with_coverage(result, &covered)
+    }
+
+    fn index_result_input_with_coverage(
+        result: IndexExprResult,
+        covered: &RoaringBitmap,
+    ) -> Arc<dyn ExecutionPlan> {
+        let batch = result
+            .serialize(covered, IndexExprResultWireFormat::default())
+            .unwrap();
+        let schema = batch.schema();
+        let index_stream = futures::stream::once(async move { Ok(batch) });
+        Arc::new(OneShotExec::new(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            index_stream,
+        ))))
+    }
+
+    /// An exact empty index result should finish without opening metadata for any covered
+    /// fragment. The invalid file paths are sentinels that make an attempted open fail, turning
+    /// the metadata-I/O behavior into a deterministic regression assertion.
+    #[rstest]
+    #[case::address(false)]
+    #[case::stable(true)]
+    #[tokio::test]
+    async fn test_exact_empty_index_skips_fragment_metadata(#[case] uses_stable_row_ids: bool) {
+        let (_tmp_path, dataset) = metadata_pruning_dataset(uses_stable_row_ids).await;
+
+        let mut fragments = dataset.fragments().as_ref().clone();
+        for fragment in &mut fragments {
+            fragment.physical_rows = None;
+            fragment.files[0].path = "must-not-open.lance".to_string();
+            if uses_stable_row_ids {
+                fragment.row_id_meta = None;
+            }
+        }
+        let index_input = index_result_input(
+            IndexExprResult::exact(RowAddrMask::allow_nothing()),
+            &fragments,
+        );
+
+        let options =
+            FilteredReadOptions::basic_full_read(&dataset).with_fragments(Arc::new(fragments));
+        let plan = FilteredReadExec::try_new(dataset, options, Some(index_input)).unwrap();
+        let batches = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(batches.is_empty());
+    }
+
+    /// A sparse non-empty result should only open full metadata for candidate fragments. Stable
+    /// row ids still need the inline row-id sequence to route candidates, but must not open the
+    /// data file or deletion metadata of non-candidate fragments.
+    #[rstest]
+    #[case::address(false)]
+    #[case::stable(true)]
+    #[tokio::test]
+    async fn test_sparse_index_skips_non_candidate_fragment_metadata(
+        #[case] uses_stable_row_ids: bool,
+    ) {
+        let (_tmp_path, dataset) = metadata_pruning_dataset(uses_stable_row_ids).await;
+
+        let mut fragments = dataset.fragments().as_ref().clone();
+        for fragment in fragments.iter_mut().skip(1) {
+            fragment.physical_rows = None;
+            fragment.files[0].path = "must-not-open.lance".to_string();
+        }
+        // The initial stable row ids are 0..40, so row id 3 and address (0, 3) select the same
+        // physical row in their respective modes.
+        let candidate = if uses_stable_row_ids {
+            3
+        } else {
+            RowAddress::new_from_parts(0, 3).into()
+        };
+        let candidates = RowAddrTreeMap::from_iter([candidate]);
+        let index_input = index_result_input(
+            IndexExprResult::exact(RowAddrMask::from_allowed(candidates)),
+            &fragments,
+        );
+
+        let options =
+            FilteredReadOptions::basic_full_read(&dataset).with_fragments(Arc::new(fragments));
+        let plan = FilteredReadExec::try_new(dataset, options, Some(index_input)).unwrap();
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+
+        assert_eq!(batch["value"].as_primitive::<UInt32Type>().values(), &[3]);
+    }
+
+    /// Pruning must use the upper bound of an inexact result. The lower bound alone contains row
+    /// 3, while row 13 is only a possible match in the upper bound and must still be read.
+    #[rstest]
+    #[case::address(false)]
+    #[case::stable(true)]
+    #[tokio::test]
+    async fn test_refined_index_prunes_from_upper_bound(#[case] uses_stable_row_ids: bool) {
+        let (_tmp_path, dataset) = metadata_pruning_dataset(uses_stable_row_ids).await;
+
+        let mut fragments = dataset.fragments().as_ref().clone();
+        for fragment in fragments.iter_mut().skip(2) {
+            fragment.physical_rows = None;
+            fragment.files[0].path = "must-not-open.lance".to_string();
+        }
+        let candidate = |fragment_id, offset, stable_row_id| {
+            if uses_stable_row_ids {
+                stable_row_id
+            } else {
+                RowAddress::new_from_parts(fragment_id, offset).into()
+            }
+        };
+        let definite_row = candidate(0, 3, 3);
+        let possible_row = candidate(1, 3, 13);
+        let result = IndexExprResult::new(
+            RowAddrMask::from_allowed(RowAddrTreeMap::from_iter([definite_row])),
+            RowAddrMask::from_allowed(RowAddrTreeMap::from_iter([definite_row, possible_row])),
+        );
+        let index_input = index_result_input(result, &fragments);
+
+        let options =
+            FilteredReadOptions::basic_full_read(&dataset).with_fragments(Arc::new(fragments));
+        let plan = FilteredReadExec::try_new(dataset, options, Some(index_input)).unwrap();
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+
+        assert_eq!(
+            batch["value"].as_primitive::<UInt32Type>().values(),
+            &[3, 13]
+        );
+    }
+
+    /// An empty result only eliminates fragments covered by the index. Uncovered fragments must
+    /// still be scanned for a complete query, while fast search intentionally omits them.
+    #[rstest]
+    #[case::address_complete(false, false)]
+    #[case::address_fast(false, true)]
+    #[case::stable_complete(true, false)]
+    #[case::stable_fast(true, true)]
+    #[tokio::test]
+    async fn test_empty_index_preserves_uncovered_fragments(
+        #[case] uses_stable_row_ids: bool,
+        #[case] only_indexed_fragments: bool,
+    ) {
+        let (_tmp_path, dataset) = metadata_pruning_dataset(uses_stable_row_ids).await;
+
+        let mut fragments = dataset.fragments().as_ref().clone();
+        let covered: RoaringBitmap = fragments
+            .iter()
+            .take(3)
+            .map(|fragment| fragment.id as u32)
+            .collect();
+        for fragment in fragments.iter_mut().take(3) {
+            fragment.physical_rows = None;
+            fragment.files[0].path = "must-not-open.lance".to_string();
+            if uses_stable_row_ids {
+                fragment.row_id_meta = None;
+            }
+        }
+        let index_input = index_result_input_with_coverage(
+            IndexExprResult::exact(RowAddrMask::allow_nothing()),
+            &covered,
+        );
+
+        let mut options =
+            FilteredReadOptions::basic_full_read(&dataset).with_fragments(Arc::new(fragments));
+        if only_indexed_fragments {
+            options = options.with_only_indexed_fragments();
+        }
+        let plan = FilteredReadExec::try_new(dataset, options, Some(index_input)).unwrap();
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+
+        let expected = if only_indexed_fragments {
+            UInt32Array::from(Vec::<u32>::new())
+        } else {
+            UInt32Array::from((30..40).collect::<Vec<_>>())
+        };
+        assert_eq!(batch["value"].as_ref(), &expected);
     }
 
     /// Take-shaped masked reads consolidate their tiny per-fragment batches;

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -81,9 +81,13 @@ pub struct EvaluatedIndex {
     applicable_fragments: RoaringBitmap,
 }
 
+// Keep common selective and dense masks single-pass without allowing highly fragmented stable-ID
+// masks to retain unbounded request-scoped range storage before final planning.
+const MAX_RETAINED_STABLE_INDEX_RANGE_BYTES: usize = 16 * 1024 * 1024;
+
 struct StableIndexRouting {
     row_id_sequence: Arc<RowIdSequence>,
-    upper_ranges: Vec<Range<u64>>,
+    upper_ranges: Option<Vec<Range<u64>>>,
 }
 
 enum FragmentMetadataLoad {
@@ -93,6 +97,23 @@ enum FragmentMetadataLoad {
 }
 
 impl EvaluatedIndex {
+    fn retain_stable_index_ranges(
+        upper_ranges: Vec<Range<u64>>,
+        retained_range_bytes: &AtomicUsize,
+    ) -> Option<Vec<Range<u64>>> {
+        let allocated_bytes = upper_ranges
+            .capacity()
+            .saturating_mul(std::mem::size_of::<Range<u64>>());
+        retained_range_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |retained_bytes| {
+                retained_bytes
+                    .checked_add(allocated_bytes)
+                    .filter(|new_total| *new_total <= MAX_RETAINED_STABLE_INDEX_RANGE_BYTES)
+            })
+            .ok()
+            .map(|_| upper_ranges)
+    }
+
     /// Get the row id mask representing which rows matched the index filter.
     pub fn index_result(&self) -> &IndexExprResult {
         &self.index_result
@@ -136,6 +157,7 @@ impl EvaluatedIndex {
         dataset: &Dataset,
         fragment: &Fragment,
         only_indexed_fragments: bool,
+        retained_range_bytes: &AtomicUsize,
     ) -> Result<FragmentMetadataLoad> {
         let fragment_id = fragment.id as u32;
         if !self.applicable_fragments.contains(fragment_id) {
@@ -160,7 +182,10 @@ impl EvaluatedIndex {
             } else {
                 FragmentMetadataLoad::LoadWithStableRouting(StableIndexRouting {
                     row_id_sequence,
-                    upper_ranges,
+                    upper_ranges: Self::retain_stable_index_ranges(
+                        upper_ranges,
+                        retained_range_bytes,
+                    ),
                 })
             });
         }
@@ -709,7 +734,7 @@ impl FilteredReadStream {
             if dataset.manifest.uses_stable_row_ids() {
                 let (row_id_sequence, index_upper_ranges) =
                     if let Some(routing) = stable_index_routing {
-                        (routing.row_id_sequence, Some(routing.upper_ranges))
+                        (routing.row_id_sequence, routing.upper_ranges)
                     } else {
                         (load_row_id_sequence(dataset.as_ref(), &frag).await?, None)
                     };
@@ -746,7 +771,7 @@ impl FilteredReadStream {
     // Returns: FilteredReadInternalPlan
     #[instrument(name = "plan_scan", skip_all)]
     fn plan_scan(
-        fragments: &[LoadedFragment],
+        mut fragments: Vec<LoadedFragment>,
         evaluated_index: &Option<Arc<EvaluatedIndex>>,
         options: &FilteredReadOptions,
     ) -> FilteredReadInternalPlan {
@@ -793,7 +818,7 @@ impl FilteredReadStream {
             num_logical_rows,
             num_physical_rows,
             deletion_vector,
-        } in fragments.iter()
+        } in fragments.iter_mut()
         {
             if let Some(range_before_filter) = &options.scan_range_before_filter
                 && range_offset >= range_before_filter.end
@@ -807,11 +832,11 @@ impl FilteredReadStream {
             if let Some(range_before_filter) = &options.scan_range_before_filter {
                 let range_start = range_offset;
                 let range_end = if options.with_deleted_rows {
-                    range_offset += num_physical_rows;
-                    range_start + num_physical_rows
+                    range_offset += *num_physical_rows;
+                    range_start + *num_physical_rows
                 } else {
-                    range_offset += num_logical_rows;
-                    range_start + num_logical_rows
+                    range_offset += *num_logical_rows;
+                    range_start + *num_logical_rows
                 };
                 to_read = Self::trim_ranges(to_read, range_start..range_end, range_before_filter);
                 if to_read.is_empty() {
@@ -824,7 +849,7 @@ impl FilteredReadStream {
                 evaluated_index,
                 fragment,
                 row_id_sequence,
-                index_upper_ranges.as_deref(),
+                index_upper_ranges.take(),
                 to_read,
                 &mut to_skip,
                 &mut to_take,
@@ -958,7 +983,7 @@ impl FilteredReadStream {
         evaluated_index: &Option<Arc<EvaluatedIndex>>,
         fragment: &FileFragment,
         row_id_sequence: &Arc<RowIdSequence>,
-        index_upper_ranges: Option<&[Range<u64>]>,
+        index_upper_ranges: Option<Vec<Range<u64>>>,
         to_read: Vec<Range<u64>>,
         to_skip: &mut u64,
         to_take: &mut u64,
@@ -1072,7 +1097,7 @@ impl FilteredReadStream {
         physical_ranges.truncate(write_idx);
     }
 
-    /// Intersect two sets of sorted ranges
+    /// Intersect two sets of sorted ranges.
     fn intersect_ranges(ranges1: &[Range<u64>], ranges2: &[Range<u64>]) -> Vec<Range<u64>> {
         let mut result = Vec::new();
         let mut i = 0;
@@ -1105,16 +1130,13 @@ impl FilteredReadStream {
         to_read: &[Range<u64>],
         row_id_sequence: &RowIdSequence,
         index_mask: &RowAddrMask,
-        precomputed_ranges: Option<&[Range<u64>]>,
+        precomputed_ranges: Option<Vec<Range<u64>>>,
     ) -> Vec<Range<u64>> {
-        let computed_ranges;
-        let index_ranges = if let Some(precomputed_ranges) = precomputed_ranges {
-            precomputed_ranges
-        } else {
-            computed_ranges = row_id_sequence.mask_to_offset_ranges(index_mask);
-            &computed_ranges
-        };
-        Self::intersect_ranges(to_read, index_ranges)
+        // Taking routed ranges fragment-by-fragment drops each input as its final intersection is
+        // produced instead of retaining every routed range vector alongside the completed plan.
+        let index_ranges =
+            precomputed_ranges.unwrap_or_else(|| row_id_sequence.mask_to_offset_ranges(index_mask));
+        Self::intersect_ranges(to_read, &index_ranges)
     }
 
     /// Apply skip and take to ranges and update the counters
@@ -2266,11 +2288,13 @@ impl FilteredReadExec {
                 // fragments before opening their full metadata.
                 let needs_fragment_offsets = options.scan_range_before_filter.is_some();
                 let only_indexed_fragments = options.only_indexed_fragments;
+                let retained_range_bytes = Arc::new(AtomicUsize::new(0));
                 let frag_futs = fragments
                     .iter()
                     .map(|fragment| {
                         let dataset = dataset.clone();
                         let evaluated_index = evaluated_index.clone();
+                        let retained_range_bytes = retained_range_bytes.clone();
                         let fragment = fragment.clone();
                         async move {
                             let metadata_load = if needs_fragment_offsets {
@@ -2281,6 +2305,7 @@ impl FilteredReadExec {
                                         dataset.as_ref(),
                                         &fragment,
                                         only_indexed_fragments,
+                                        retained_range_bytes.as_ref(),
                                     )
                                     .await?
                             } else if only_indexed_fragments {
@@ -2324,7 +2349,7 @@ impl FilteredReadExec {
                 // finishes — stream construction rebuilds I/O-free handles
                 // from the manifest descriptors
                 Ok(FilteredReadStream::plan_scan(
-                    &loaded_fragments,
+                    loaded_fragments,
                     &evaluated_index,
                     options,
                 ))
@@ -3335,6 +3360,32 @@ mod tests {
                 self.count.fetch_add(1, Ordering::Relaxed);
             }
         }
+    }
+
+    #[test]
+    fn test_stable_index_range_retention_is_bounded() {
+        let ranges = vec![0..1];
+        let range_bytes = ranges.capacity() * std::mem::size_of::<Range<u64>>();
+        let retained_range_bytes = AtomicUsize::new(
+            MAX_RETAINED_STABLE_INDEX_RANGE_BYTES
+                .checked_sub(range_bytes)
+                .unwrap(),
+        );
+
+        assert!(
+            EvaluatedIndex::retain_stable_index_ranges(ranges, &retained_range_bytes).is_some()
+        );
+        assert_eq!(
+            retained_range_bytes.load(Ordering::Relaxed),
+            MAX_RETAINED_STABLE_INDEX_RANGE_BYTES
+        );
+        assert!(
+            EvaluatedIndex::retain_stable_index_ranges(vec![1..2], &retained_range_bytes).is_none()
+        );
+        assert_eq!(
+            retained_range_bytes.load(Ordering::Relaxed),
+            MAX_RETAINED_STABLE_INDEX_RANGE_BYTES
+        );
     }
 
     struct TestFixture {

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -81,6 +81,17 @@ pub struct EvaluatedIndex {
     applicable_fragments: RoaringBitmap,
 }
 
+struct StableIndexRouting {
+    row_id_sequence: Arc<RowIdSequence>,
+    upper_ranges: Vec<Range<u64>>,
+}
+
+enum FragmentMetadataLoad {
+    Skip,
+    Load,
+    LoadWithStableRouting(StableIndexRouting),
+}
+
 impl EvaluatedIndex {
     /// Get the row id mask representing which rows matched the index filter.
     pub fn index_result(&self) -> &IndexExprResult {
@@ -114,39 +125,49 @@ impl EvaluatedIndex {
         self
     }
 
-    /// Whether planning can require full metadata from `fragment`.
+    /// Decide whether planning needs full metadata from `fragment`.
     ///
     /// The upper mask contains every row that might match. For address-style row ids its high
     /// 32 bits identify the fragment directly. Stable row ids need the fragment's row-id
     /// sequence to make the same decision, but this still avoids opening deletion metadata,
     /// row counts, and data files for non-candidate fragments.
-    async fn needs_fragment_metadata(
+    async fn fragment_metadata_load(
         &self,
         dataset: &Dataset,
         fragment: &Fragment,
         only_indexed_fragments: bool,
-    ) -> Result<bool> {
+    ) -> Result<FragmentMetadataLoad> {
         let fragment_id = fragment.id as u32;
         if !self.applicable_fragments.contains(fragment_id) {
-            return Ok(!only_indexed_fragments);
+            return Ok(if only_indexed_fragments {
+                FragmentMetadataLoad::Skip
+            } else {
+                FragmentMetadataLoad::Load
+            });
         }
         let Some(candidate_rows) = self.index_result.upper.allow_list() else {
             // A block-list may select rows from every fragment.
-            return Ok(true);
+            return Ok(FragmentMetadataLoad::Load);
         };
         if candidate_rows.iter().next().is_none() {
-            return Ok(false);
+            return Ok(FragmentMetadataLoad::Skip);
         }
         if dataset.manifest.uses_stable_row_ids() {
-            let row_ids = load_row_id_sequence(dataset, fragment).await?;
-            return Ok(!row_ids
-                .mask_to_offset_ranges(&self.index_result.upper)
-                .is_empty());
+            let row_id_sequence = load_row_id_sequence(dataset, fragment).await?;
+            let upper_ranges = row_id_sequence.mask_to_offset_ranges(&self.index_result.upper);
+            return Ok(if upper_ranges.is_empty() {
+                FragmentMetadataLoad::Skip
+            } else {
+                FragmentMetadataLoad::LoadWithStableRouting(StableIndexRouting {
+                    row_id_sequence,
+                    upper_ranges,
+                })
+            });
         }
         Ok(match candidate_rows.get(&fragment_id) {
-            Some(RowAddrSelection::Full) => true,
-            Some(RowAddrSelection::Partial(rows)) => !rows.is_empty(),
-            None => false,
+            Some(RowAddrSelection::Full) => FragmentMetadataLoad::Load,
+            Some(RowAddrSelection::Partial(rows)) if !rows.is_empty() => FragmentMetadataLoad::Load,
+            Some(RowAddrSelection::Partial(_)) | None => FragmentMetadataLoad::Skip,
         })
     }
 }
@@ -186,6 +207,9 @@ impl ScopedFragmentRead {
 #[derive(Debug, Clone)]
 struct LoadedFragment {
     row_id_sequence: Arc<RowIdSequence>,
+    /// Stable row-ID upper ranges computed while routing index candidates.
+    /// Reusing them avoids mapping the same mask again during final planning.
+    index_upper_ranges: Option<Vec<Range<u64>>>,
     deletion_vector: Option<Arc<DeletionVector>>,
     fragment: Arc<FileFragment>,
     // The number of physical rows in the fragment
@@ -641,6 +665,7 @@ impl FilteredReadStream {
                     dataset.clone(),
                     frag.clone(),
                     options.with_deleted_rows,
+                    None,
                 ))
             })
             .collect::<Vec<_>>();
@@ -670,6 +695,7 @@ impl FilteredReadStream {
         dataset: Arc<Dataset>,
         frag: Fragment,
         include_deleted_rows: bool,
+        stable_index_routing: Option<StableIndexRouting>,
     ) -> Result<LoadedFragment> {
         let file_fragment = FileFragment::new(dataset.clone(), frag.clone());
         let deletion_vector = if include_deleted_rows {
@@ -679,19 +705,27 @@ impl FilteredReadStream {
         };
 
         let num_physical_rows = file_fragment.physical_rows().await? as u64;
-        let (row_id_sequence, num_logical_rows) = if dataset.manifest.uses_stable_row_ids() {
-            let row_id_sequence = load_row_id_sequence(dataset.as_ref(), &frag).await?;
-            let num_logical_rows = row_id_sequence.len();
-            (row_id_sequence, num_logical_rows)
-        } else {
-            let row_ids_start = frag.id << 32;
-            let row_ids_end = row_ids_start + num_physical_rows;
-            let num_logical_rows = file_fragment.count_rows(None).await? as u64;
-            let addrs_as_ids = Arc::new(RowIdSequence::from(row_ids_start..row_ids_end));
-            (addrs_as_ids, num_logical_rows)
-        };
+        let (row_id_sequence, num_logical_rows, index_upper_ranges) =
+            if dataset.manifest.uses_stable_row_ids() {
+                let (row_id_sequence, index_upper_ranges) =
+                    if let Some(routing) = stable_index_routing {
+                        (routing.row_id_sequence, Some(routing.upper_ranges))
+                    } else {
+                        (load_row_id_sequence(dataset.as_ref(), &frag).await?, None)
+                    };
+                let num_logical_rows = row_id_sequence.len();
+                (row_id_sequence, num_logical_rows, index_upper_ranges)
+            } else {
+                debug_assert!(stable_index_routing.is_none());
+                let row_ids_start = frag.id << 32;
+                let row_ids_end = row_ids_start + num_physical_rows;
+                let num_logical_rows = file_fragment.count_rows(None).await? as u64;
+                let addrs_as_ids = Arc::new(RowIdSequence::from(row_ids_start..row_ids_end));
+                (addrs_as_ids, num_logical_rows, None)
+            };
         Ok(LoadedFragment {
             row_id_sequence,
+            index_upper_ranges,
             fragment: Arc::new(file_fragment),
             num_physical_rows,
             num_logical_rows,
@@ -754,6 +788,7 @@ impl FilteredReadStream {
         let mut range_offset = 0;
         for LoadedFragment {
             row_id_sequence,
+            index_upper_ranges,
             fragment,
             num_logical_rows,
             num_physical_rows,
@@ -789,6 +824,7 @@ impl FilteredReadStream {
                 evaluated_index,
                 fragment,
                 row_id_sequence,
+                index_upper_ranges.as_deref(),
                 to_read,
                 &mut to_skip,
                 &mut to_take,
@@ -922,6 +958,7 @@ impl FilteredReadStream {
         evaluated_index: &Option<Arc<EvaluatedIndex>>,
         fragment: &FileFragment,
         row_id_sequence: &Arc<RowIdSequence>,
+        index_upper_ranges: Option<&[Range<u64>]>,
         to_read: Vec<Range<u64>>,
         to_skip: &mut u64,
         to_take: &mut u64,
@@ -938,8 +975,12 @@ impl FilteredReadStream {
                 let index_result = &evaluated_index.index_result;
                 if index_result.is_exact() {
                     // lower == upper; either side gives the precise answer.
-                    let valid_ranges = row_id_sequence.mask_to_offset_ranges(&index_result.upper);
-                    let mut matched_ranges = Self::intersect_ranges(&to_read, &valid_ranges);
+                    let mut matched_ranges = Self::intersect_index_ranges(
+                        &to_read,
+                        row_id_sequence,
+                        &index_result.upper,
+                        index_upper_ranges,
+                    );
                     fragments_to_read.insert(fragment_id, matched_ranges.clone());
 
                     Self::apply_skip_take_to_ranges(&mut matched_ranges, to_skip, to_take);
@@ -947,8 +988,12 @@ impl FilteredReadStream {
                 } else if index_result.is_at_least() {
                     // upper is universe; lower is the guaranteed-match set
                     // used for the skip/take push-down path.
-                    let valid_ranges = row_id_sequence.mask_to_offset_ranges(&index_result.lower);
-                    let mut guaranteed_ranges = Self::intersect_ranges(&to_read, &valid_ranges);
+                    let mut guaranteed_ranges = Self::intersect_index_ranges(
+                        &to_read,
+                        row_id_sequence,
+                        &index_result.lower,
+                        None,
+                    );
                     fragments_to_read.insert(fragment_id, guaranteed_ranges.clone());
 
                     Self::apply_skip_take_to_ranges(&mut guaranteed_ranges, to_skip, to_take);
@@ -966,8 +1011,12 @@ impl FilteredReadStream {
                     // `lower` portion would also be visible up at the
                     // `can_skip_recheck` block — both are deferred. See
                     // TODO(refined-pushdown).
-                    let valid_ranges = row_id_sequence.mask_to_offset_ranges(&index_result.upper);
-                    let matched_ranges = Self::intersect_ranges(&to_read, &valid_ranges);
+                    let matched_ranges = Self::intersect_index_ranges(
+                        &to_read,
+                        row_id_sequence,
+                        &index_result.upper,
+                        index_upper_ranges,
+                    );
                     fragments_to_read.insert(fragment_id, matched_ranges);
                 }
             } else {
@@ -1050,6 +1099,22 @@ impl FilteredReadStream {
         }
 
         result
+    }
+
+    fn intersect_index_ranges(
+        to_read: &[Range<u64>],
+        row_id_sequence: &RowIdSequence,
+        index_mask: &RowAddrMask,
+        precomputed_ranges: Option<&[Range<u64>]>,
+    ) -> Vec<Range<u64>> {
+        let computed_ranges;
+        let index_ranges = if let Some(precomputed_ranges) = precomputed_ranges {
+            precomputed_ranges
+        } else {
+            computed_ranges = row_id_sequence.mask_to_offset_ranges(index_mask);
+            &computed_ranges
+        };
+        Self::intersect_ranges(to_read, index_ranges)
     }
 
     /// Apply skip and take to ranges and update the counters
@@ -2208,30 +2273,41 @@ impl FilteredReadExec {
                         let evaluated_index = evaluated_index.clone();
                         let fragment = fragment.clone();
                         async move {
-                            let needs_metadata = if needs_fragment_offsets {
-                                true
+                            let metadata_load = if needs_fragment_offsets {
+                                FragmentMetadataLoad::Load
                             } else if let Some(index) = evaluated_index {
                                 index
-                                    .needs_fragment_metadata(
+                                    .fragment_metadata_load(
                                         dataset.as_ref(),
                                         &fragment,
                                         only_indexed_fragments,
                                     )
                                     .await?
+                            } else if only_indexed_fragments {
+                                FragmentMetadataLoad::Skip
                             } else {
-                                !only_indexed_fragments
+                                FragmentMetadataLoad::Load
                             };
-                            if needs_metadata {
-                                Ok::<_, Error>(Some(
+                            match metadata_load {
+                                FragmentMetadataLoad::Skip => Ok::<_, Error>(None),
+                                FragmentMetadataLoad::Load => Ok(Some(
                                     FilteredReadStream::load_fragment(
                                         dataset,
                                         fragment,
                                         with_deleted_rows,
+                                        None,
                                     )
                                     .await?,
-                                ))
-                            } else {
-                                Ok::<_, Error>(None)
+                                )),
+                                FragmentMetadataLoad::LoadWithStableRouting(routing) => Ok(Some(
+                                    FilteredReadStream::load_fragment(
+                                        dataset,
+                                        fragment,
+                                        with_deleted_rows,
+                                        Some(routing),
+                                    )
+                                    .await?,
+                                )),
                             }
                         }
                     })
@@ -3202,6 +3278,7 @@ impl ExecutionPlan for FilteredReadExec {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::index::DatasetIndexExt;
     use arrow::{
@@ -3225,6 +3302,10 @@ mod tests {
     use lance_select::result::IndexExprResultWireFormat;
     use lance_select::{RowAddrMask, RowAddrTreeMap};
     use rstest::rstest;
+    use tracing_subscriber::{
+        Layer,
+        layer::{Context, SubscriberExt},
+    };
 
     use crate::{
         dataset::{InsertBuilder, WriteDestination, WriteMode, WriteParams},
@@ -3234,6 +3315,27 @@ mod tests {
     };
 
     use super::*;
+
+    #[derive(Clone, Default)]
+    struct MaskToOffsetRangesCounter {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl<S> Layer<S> for MaskToOffsetRangesCounter
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &tracing::span::Id,
+            _ctx: Context<'_, S>,
+        ) {
+            if attrs.metadata().name() == "mask_to_offset_ranges" {
+                self.count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 
     struct TestFixture {
         _tmp_path: TempStrDir,
@@ -3640,6 +3742,37 @@ mod tests {
         let batch = concat_batches(&schema, &batches).unwrap();
 
         assert_eq!(batch["value"].as_primitive::<UInt32Type>().values(), &[3]);
+    }
+
+    /// Dense stable-ID masks route every fragment. Carry the ranges computed during routing into
+    /// final planning so this case does not map the same IDs to offsets twice.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_dense_stable_index_reuses_routing_ranges() {
+        let (_tmp_path, dataset) = metadata_pruning_dataset(true).await;
+        let fragments = dataset.fragments().as_ref().clone();
+        let index_input = index_result_input(
+            IndexExprResult::exact(RowAddrMask::from_allowed(RowAddrTreeMap::from(0_u64..40))),
+            &fragments,
+        );
+        let options = FilteredReadOptions::basic_full_read(&dataset);
+        let read = FilteredReadExec::try_new(dataset, options, Some(index_input)).unwrap();
+        let counter = MaskToOffsetRangesCounter::default();
+        let subscriber = tracing_subscriber::registry().with(counter.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let plan = read
+            .get_or_create_plan(Arc::new(TaskContext::default()))
+            .await
+            .unwrap();
+
+        assert_eq!(counter.count.load(Ordering::Relaxed), 4);
+        assert_eq!(plan.rows.iter().count(), 4);
+        for (_, selection) in plan.rows.iter() {
+            let RowAddrSelection::Partial(offsets) = selection else {
+                panic!("dense stable-ID plan should contain explicit offsets");
+            };
+            assert_eq!(offsets.iter().collect_vec(), (0..10).collect_vec());
+        }
     }
 
     /// Pruning must use the upper bound of an inexact result. The lower bound alone contains row

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -104,14 +104,21 @@ impl EvaluatedIndex {
         let allocated_bytes = upper_ranges
             .capacity()
             .saturating_mul(std::mem::size_of::<Range<u64>>());
-        retained_range_bytes
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |retained_bytes| {
-                retained_bytes
-                    .checked_add(allocated_bytes)
-                    .filter(|new_total| *new_total <= MAX_RETAINED_STABLE_INDEX_RANGE_BYTES)
-            })
-            .ok()
-            .map(|_| upper_ranges)
+        let mut retained_bytes = retained_range_bytes.load(Ordering::Relaxed);
+        loop {
+            let new_total = retained_bytes
+                .checked_add(allocated_bytes)
+                .filter(|new_total| *new_total <= MAX_RETAINED_STABLE_INDEX_RANGE_BYTES)?;
+            match retained_range_bytes.compare_exchange_weak(
+                retained_bytes,
+                new_total,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(upper_ranges),
+                Err(actual) => retained_bytes = actual,
+            }
+        }
     }
 
     /// Get the row id mask representing which rows matched the index filter.


### PR DESCRIPTION
## Problem

After a scalar index returns its row-ID mask, `FilteredReadExec::get_or_create_plan_impl` still loads deletion vectors, row counts, and row-ID metadata for every fragment before applying that mask. An exact index miss therefore performs an O(fragment count) metadata pass even though no fragment can contribute a row.

This is a follow-up to #7792. That PR removed the second all-fragment metadata load during stream construction; the first planning-time pass remained. Related to #4189, which tracks broader filtered-read planning costs.

## Change

Use the index result's upper bound to decide whether a fragment can contribute before loading its full metadata:

- skip every covered fragment for an exact empty allow-list;
- use the fragment portion of address-style row IDs for direct pruning;
- for non-empty stable row-ID masks, use each fragment's row-ID sequence to route candidates, then load deletion vectors and row counts only for candidate fragments;
- carry the routed stable row-ID sequence and upper offset ranges into final planning, so exact and refined/at-most results do not map the same IDs twice;
- cap retained stable-ID range payload at 16 MiB per plan and drain retained vectors fragment-by-fragment; over-budget fragments reuse the loaded row-ID sequence but recompute ranges during final planning;
- keep uncovered fragments unless `only_indexed_fragments` is enabled;
- conservatively keep block-list upper bounds and every fragment needed to calculate a pre-filter scan range.

Candidate fragments still load and apply their deletion vectors, so stale deleted index hits remain excluded. Pruning uses the upper bound of refined index results to avoid false negatives.

## Benchmark

Lower is better for every metric below.

| Scenario / metric | Baseline (`e958adfdf`) | This PR (`150e000f0`) | Benefit |
| --- | ---: | ---: | ---: |
| Exact-empty plan latency | 1,630.20 ms/query | 5.14 ms/query | 316.9x speedup |
| Indexed zero-hit query latency | 2,067.66 ms/query | 84.73 ms/query | 24.4x speedup |
| Indexed one-hit query latency | 2,081.91 ms/query | 163.69 ms/query | 12.7x speedup |
| Exact-empty plan S3 reads | 2,600 reads/query | 0 reads/query | 2,600 reads/query eliminated |
| Indexed zero-hit S3 reads | 2,603 reads/query | 3 reads/query | 867.7x fewer reads |
| Indexed one-hit S3 reads | 2,606 reads/query | 7 reads/query | 372.3x fewer reads |

The review follow-up also measures cache-hot dense stable-row-ID planning, where all 5,200 physical row IDs route to all 2,600 fragments:

| Scenario / metric | Before follow-up (`824551d44`) | This PR (`150e000f0`) | Benefit |
| --- | ---: | ---: | ---: |
| Dense stable-ID plan latency | 9.17 ms/plan | 7.86 ms/plan | 1.17x speedup |

The main-branch control was 7.13 ms/plan. The current implementation is 0.72 ms/plan (1.10x) above that control because it performs the stable-ID routing pass needed for pruning, but it no longer repeats the same mapping during final planning. All cache-hot measured plans performed 0 S3 reads.

Environment and methodology:

- AWS `m7i.4xlarge` in `us-east-1a`, reading S3 in the same region.
- One dataset with 2,600 stable-row-ID fragments, 2 rows per fragment, one real deletion vector per fragment, 14 payload columns, and BTree indices on `org_id` and `repo_id`.
- Separate main, pre-follow-up, and current PR binaries built with Rust 1.97.1, `release-with-debug`, `--no-default-features --features aws`; their SHA256 hashes were checked before measurement.
- Three serialized trials per case; base/PR order alternated by trial. Each trial used a new process and fresh Lance `Session`; the table reports medians.
- Dataset-open time and I/O were excluded. Query/planning I/O uses incremental `IOTracker` statistics after open.
- The dense case used three processes per revision. Each process ran one excluded S3 warm-up plan followed by 21 measured plans; the table reports the median of the three process medians. Index-result serialization and exec construction were outside the timed region.
- This measures the metadata path against real S3, not the Plan Executor persistent-disk cache.

Measured bytes followed the same pattern: exact-empty planning dropped from 1,814,800 B/query to 0 B/query; the zero-hit query dropped from 1,882,874 B/query to 68,074 B/query; the one-hit query dropped from 1,965,927 B/query to 151,825 B/query.

## Correctness and limitations

The regression coverage includes stable and address-style row IDs, exact-empty and sparse non-empty masks, refined upper bounds, partially indexed datasets, and `only_indexed_fragments` behavior. A deterministic dense stable-ID test counts `mask_to_offset_ranges` spans: four candidate fragments must produce exactly four mappings; the pre-follow-up implementation produced eight. A separate boundary test verifies that retained range payload cannot exceed the per-plan budget.

For a non-empty stable row-ID mask, this change still visits each covered fragment's row-ID sequence to discover candidate fragments. The benchmark fixture stores those sequences inline, so it removes the S3 deletion-vector/row-count reads but not the O(fragment count) routing walk. Datasets with external row-ID metadata can still perform O(fragment count) row-ID metadata reads. Eliminating that remaining cost requires carrying physical candidate-fragment information from scalar-index execution or persisted row-ID routing metadata.

## Validation

- `cargo fmt --all`
- `cargo test -p lance io::exec::filtered_read::tests -- --test-threads=1` (75 passed)
- `cargo clippy --all --tests --benches -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo +nightly-2026-07-13 check -p lance --tests`
- AWS S3 benchmark described above
