### PR TITLE
fix: make MemWAL HNSW snapshots publication-consistent

### DIFF
--- a/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
@@ -454,7 +454,9 @@ impl VectorSource for VectorStoreSnapshot {
     }
 
     fn row_id(&self, id: u32) -> u64 {
-        assert!(
+        // HNSW only requests ids from its own graph, which is built from this
+        // snapshot's visible prefix. Keep this as a debug-only contract check.
+        debug_assert!(
             (id as usize) < self.visible_len,
             "vector id {id} is outside snapshot length {}",
             self.visible_len
@@ -463,7 +465,7 @@ impl VectorSource for VectorStoreSnapshot {
     }
 
     fn vector(&self, id: u32) -> &[f32] {
-        assert!(
+        debug_assert!(
             (id as usize) < self.visible_len,
             "vector id {id} is outside snapshot length {}",
             self.visible_len

--- a/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
@@ -332,6 +332,19 @@ impl ArrowFixedSizeListVectorStore {
 
     /// Capture a stable visible prefix of the store.
     pub fn snapshot(self: &Arc<Self>) -> VectorStoreSnapshot {
+        self.snapshot_after_visible_len(|| {})
+    }
+
+    fn snapshot_after_visible_len(
+        self: &Arc<Self>,
+        after_visible_len: impl FnOnce(),
+    ) -> VectorStoreSnapshot {
+        // Read the length first. If it observes a newly committed batch, the
+        // Acquire load also makes the preceding committed_batches publication
+        // visible to the later load below. If it observes the old length, the
+        // snapshot remains a valid prefix even if a writer commits meanwhile.
+        let visible_len = self.committed_len();
+        after_visible_len();
         let committed_batches = self.committed_batches.load(Ordering::Acquire);
         let contiguous_values_addr = if committed_batches == 1 {
             // SAFETY: batch slot 0 is initialized before committed_batches is
@@ -342,7 +355,7 @@ impl ArrowFixedSizeListVectorStore {
         };
         VectorStoreSnapshot {
             store: self.clone(),
-            visible_len: self.committed_len(),
+            visible_len,
             contiguous_values_addr,
         }
     }
@@ -441,12 +454,20 @@ impl VectorSource for VectorStoreSnapshot {
     }
 
     fn row_id(&self, id: u32) -> u64 {
-        debug_assert!((id as usize) < self.visible_len);
+        assert!(
+            (id as usize) < self.visible_len,
+            "vector id {id} is outside snapshot length {}",
+            self.visible_len
+        );
         self.store.row_id_at(id)
     }
 
     fn vector(&self, id: u32) -> &[f32] {
-        debug_assert!((id as usize) < self.visible_len);
+        assert!(
+            (id as usize) < self.visible_len,
+            "vector id {id} is outside snapshot length {}",
+            self.visible_len
+        );
         if self.contiguous_values_addr != 0 {
             // SAFETY: this snapshot holds the store Arc, which retains the
             // Arrow batch backing this pointer. The id was checked above.
@@ -470,6 +491,7 @@ fn uninit_boxed_slice<T>(len: usize) -> Box<[MaybeUninit<T>]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Barrier;
 
     fn fsl(values: Vec<f32>, dim: usize) -> Arc<FixedSizeListArray> {
         let values = Arc::new(Float32Array::from(values)) as ArrayRef;
@@ -502,6 +524,36 @@ mod tests {
             compute_f32_distance(snapshot.vector(0), snapshot.vector(1), DistanceType::L2),
             8.0
         );
+    }
+
+    #[test]
+    fn test_snapshot_stays_with_visible_prefix_during_commit() {
+        let store =
+            Arc::new(ArrowFixedSizeListVectorStore::try_new(8, 2, 2, DistanceType::L2).unwrap());
+        store
+            .append_batch(fsl(vec![1.0, 2.0, 3.0, 4.0], 2), 10)
+            .unwrap();
+
+        let visible_len_loaded = Arc::new(Barrier::new(2));
+        let continue_snapshot = Arc::new(Barrier::new(2));
+        let snapshot_store = store.clone();
+        let snapshot_visible_len_loaded = visible_len_loaded.clone();
+        let snapshot_continue = continue_snapshot.clone();
+        let snapshot_thread = std::thread::spawn(move || {
+            snapshot_store.snapshot_after_visible_len(|| {
+                snapshot_visible_len_loaded.wait();
+                snapshot_continue.wait();
+            })
+        });
+
+        visible_len_loaded.wait();
+        store.append_batch(fsl(vec![5.0, 6.0], 2), 12).unwrap();
+        continue_snapshot.wait();
+
+        let snapshot = snapshot_thread.join().unwrap();
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot.row_id(1), 11);
+        assert_eq!(snapshot.vector(1), &[3.0, 4.0]);
     }
 
     /// Build a `FixedSizeList<Float32>` where `None` rows are null at the list


### PR DESCRIPTION
A MemWAL HNSW writer publishes the committed batch count before the committed vector length. Snapshots previously loaded those atomics in the opposite order, so a snapshot racing a second append could retain the first batch's contiguous pointer while exposing the new two-batch length. Accessing a vector from the second batch would then construct a slice beyond the first Arrow allocation.

This makes snapshot acquisition load the visible length first and the batch count second. Observing a new length now synchronizes with the preceding batch publication; observing an old length remains a valid prefix. It also enforces the safe `VectorSource` bounds contract in release builds and adds a barrier-controlled concurrent-commit regression.
