### PR TITLE
fix(linalg): validate slice lengths before SIMD loads

### DIFF
--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -148,6 +148,11 @@ fn gather_scalar_x86(slice: &[f32], indices: &[i32; 8]) -> f32x8 {
 
 impl From<&[f32]> for f32x8 {
     fn from(value: &[f32]) -> Self {
+        assert!(
+            value.len() >= 8,
+            "f32x8 requires at least 8 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -528,6 +533,11 @@ impl std::fmt::Debug for f32x16 {
 
 impl From<&[f32]> for f32x16 {
     fn from(value: &[f32]) -> Self {
+        assert!(
+            value.len() >= 16,
+            "f32x16 requires at least 16 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -934,6 +944,12 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn test_slice_conversion_rejects_short_input() {
+        assert!(std::panic::catch_unwind(|| f32x8::from(&[0.0; 7][..])).is_err());
+        assert!(std::panic::catch_unwind(|| f32x16::from(&[0.0; 15][..])).is_err());
+    }
 
     #[test]
     fn test_basic_ops() {

--- a/rust/lance-linalg/src/simd/f64.rs
+++ b/rust/lance-linalg/src/simd/f64.rs
@@ -45,6 +45,11 @@ impl std::fmt::Debug for f64x4 {
 
 impl From<&[f64]> for f64x4 {
     fn from(value: &[f64]) -> Self {
+        assert!(
+            value.len() >= 4,
+            "f64x4 requires at least 4 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -389,6 +394,11 @@ impl std::fmt::Debug for f64x8 {
 
 impl From<&[f64]> for f64x8 {
     fn from(value: &[f64]) -> Self {
+        assert!(
+            value.len() >= 8,
+            "f64x8 requires at least 8 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -733,6 +743,12 @@ impl SubAssign for f64x8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_slice_conversion_rejects_short_input() {
+        assert!(std::panic::catch_unwind(|| f64x4::from(&[0.0; 3][..])).is_err());
+        assert!(std::panic::catch_unwind(|| f64x8::from(&[0.0; 7][..])).is_err());
+    }
 
     #[test]
     fn test_f64x4_basic_ops() {

--- a/rust/lance-linalg/src/simd/i32.rs
+++ b/rust/lance-linalg/src/simd/i32.rs
@@ -42,6 +42,11 @@ impl std::fmt::Debug for i32x8 {
 
 impl From<&[i32]> for i32x8 {
     fn from(value: &[i32]) -> Self {
+        assert!(
+            value.len() >= 8,
+            "i32x8 requires at least 8 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -318,4 +323,11 @@ impl Mul for i32x8 {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slice_conversion_rejects_short_input() {
+        assert!(std::panic::catch_unwind(|| i32x8::from(&[0; 7][..])).is_err());
+    }
+}

--- a/rust/lance-linalg/src/simd/u8.rs
+++ b/rust/lance-linalg/src/simd/u8.rs
@@ -85,6 +85,11 @@ impl std::fmt::Debug for u8x16 {
 
 impl From<&[u8]> for u8x16 {
     fn from(value: &[u8]) -> Self {
+        assert!(
+            value.len() >= 16,
+            "u8x16 requires at least 16 values, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -402,6 +407,11 @@ impl SubAssign for u8x16 {
 mod tests {
 
     use super::*;
+
+    #[test]
+    fn test_slice_conversion_rejects_short_input() {
+        assert!(std::panic::catch_unwind(|| u8x16::from(&[0; 15][..])).is_err());
+    }
 
     #[test]
     fn test_basic_u8x16_ops() {


### PR DESCRIPTION
The safe From<&[T]> implementations for fixed-width SIMD vectors unconditionally loaded 4, 8, or 16 lanes from the slice pointer. A caller could pass a shorter slice through safe Rust and trigger an out-of-bounds read.

This validates the minimum lane count before every raw load while preserving the existing conversion API and support for longer slices. Regressions cover every affected scalar type in debug and optimized builds.