### PR TITLE
fix(linalg): validate distance input lengths

### DIFF
--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -25,6 +25,31 @@ pub mod l2;
 pub mod l2_u8;
 pub mod norm_l2;
 
+#[inline]
+fn assert_equal_lengths(left_len: usize, right_len: usize) {
+    assert_eq!(
+        left_len, right_len,
+        "distance inputs must have equal lengths: left={left_len}, right={right_len}"
+    );
+}
+
+#[inline]
+fn assert_batch_layout(vector_len: usize, batch_len: usize, dimension: usize) {
+    assert!(
+        dimension > 0,
+        "distance dimension must be greater than zero"
+    );
+    assert_eq!(
+        vector_len, dimension,
+        "distance vector length must match dimension: vector={vector_len}, dimension={dimension}"
+    );
+    assert_eq!(
+        batch_len % dimension,
+        0,
+        "distance batch length must be divisible by dimension: batch={batch_len}, dimension={dimension}"
+    );
+}
+
 /// Number of distances computed per call into a runtime-selected batch kernel.
 ///
 /// Keeping a small output buffer amortizes the `#[target_feature]` call while

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -18,7 +18,6 @@ use arrow_array::{Array, FixedSizeListArray, Float32Array, cast::AsArray, types:
 use arrow_schema::DataType;
 use half::{bf16, f16};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
-use lance_core::assume_eq;
 #[allow(unused_imports)]
 use lance_core::utils::cpu::{SIMD_SUPPORT, SimdSupport};
 use num_traits::{AsPrimitive, Num, real::Real};
@@ -29,6 +28,7 @@ use crate::Result;
     not(all(target_feature = "avx2", target_feature = "fma"))
 ))]
 use crate::distance::{BatchIter, BatchKernel, BatchKind, BatchOperation};
+use crate::distance::{assert_batch_layout, assert_equal_lengths};
 #[cfg(all(
     target_arch = "x86_64",
     not(all(target_feature = "avx2", target_feature = "fma"))
@@ -74,6 +74,7 @@ fn dot_scalar<
 /// Dot product.
 #[inline]
 pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
+    assert_equal_lengths(from.len(), to.len());
     T::dot(from, to)
 }
 
@@ -82,6 +83,7 @@ pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
 /// needed on top of the generic [`dot`].
 #[inline]
 pub fn dot_f32(x: &[f32], y: &[f32]) -> f32 {
+    assert_equal_lengths(x.len(), y.len());
     #[cfg(target_arch = "x86_64")]
     {
         use lance_core::utils::cpu::SimdSupport;
@@ -118,6 +120,7 @@ unsafe fn dot_f32_avx512(x: &[f32], y: &[f32]) -> f32 {
 /// Negative [Dot] distance.
 #[inline]
 pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
+    assert_equal_lengths(from.len(), to.len());
     1.0 - T::dot(from, to)
 }
 
@@ -141,6 +144,7 @@ pub trait Dot: Num {
         batch: &'a [Self],
         dimension: usize,
     ) -> impl Iterator<Item = f32> + 'a {
+        assert_batch_layout(x.len(), batch.len(), dimension);
         batch.chunks_exact(dimension).map(move |y| Self::dot(x, y))
     }
 }
@@ -168,6 +172,7 @@ mod bf16_kernel {
 impl Dot for bf16 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -224,6 +229,7 @@ mod kernel {
 impl Dot for f16 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -260,6 +266,7 @@ impl Dot for f16 {
 impl Dot for f32 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
         // to an AVX2 or AVX-512 inner kernel on capable hosts, or a portable
@@ -273,6 +280,7 @@ impl Dot for f32 {
         batch: &'a [Self],
         dimension: usize,
     ) -> impl Iterator<Item = Self> + 'a {
+        assert_batch_layout(x.len(), batch.len(), dimension);
         // Exactly one arm compiles. Keeping each a tail expression (rather than
         // an early `return` guarded by `cfg`) mirrors `dot_f32_dispatched` and
         // avoids an unreachable tail on AVX2-baseline builds.
@@ -478,6 +486,7 @@ fn dot_f32_scalar(x: &[f32], y: &[f32]) -> f32 {
 impl Dot for f64 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         dot_f64_simd(x, y)
     }
 }
@@ -769,6 +778,7 @@ fn dot_f64_simd_other(x: &[f64], y: &[f64]) -> f32 {
 impl Dot for u8 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         super::dot_u8::dot_u8(x, y) as f32
     }
 }
@@ -779,8 +789,7 @@ pub fn dot_distance_batch<'a, T: Dot>(
     to: &'a [T],
     dimension: usize,
 ) -> Box<dyn Iterator<Item = f32> + 'a> {
-    assume_eq!(from.len(), dimension);
-    assume_eq!(to.len() % dimension, 0);
+    assert_batch_layout(from.len(), to.len(), dimension);
     Box::new(T::dot_batch(from, to, dimension).map(|d| 1.0 - d))
 }
 
@@ -861,6 +870,20 @@ mod tests {
     };
     use num_traits::{Float, FromPrimitive};
     use proptest::prelude::*;
+
+    #[test]
+    fn test_dot_rejects_mismatched_lengths() {
+        let short = [1.0_f32];
+        let long = [1.0_f32, 2.0];
+
+        assert!(std::panic::catch_unwind(|| dot(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| dot_f32(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| f32::dot(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| dot_distance(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| dot_distance_batch(&short, &long, 2)).is_err());
+        assert!(std::panic::catch_unwind(|| dot_distance_batch(&long, &[1.0_f32; 3], 2)).is_err());
+        assert!(std::panic::catch_unwind(|| dot_distance_batch::<f32>(&[], &[], 0)).is_err());
+    }
 
     #[test]
     fn test_dot_f32_dispatch_matches_scalar() {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -85,28 +85,6 @@ pub fn dot_f32(x: &[f32], y: &[f32]) -> f32 {
     f32::dot(x, y)
 }
 
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx512f")]
-unsafe fn dot_f32_avx512(x: &[f32], y: &[f32]) -> f32 {
-    use std::arch::x86_64::*;
-    debug_assert_eq!(x.len(), y.len());
-    let n = x.len();
-    let mut acc = _mm512_setzero_ps();
-    let mut i = 0usize;
-    while i + 16 <= n {
-        let a = _mm512_loadu_ps(x.as_ptr().add(i));
-        let b = _mm512_loadu_ps(y.as_ptr().add(i));
-        acc = _mm512_fmadd_ps(a, b, acc);
-        i += 16;
-    }
-    let mut sum = _mm512_reduce_add_ps(acc);
-    while i < n {
-        sum += x[i] * y[i];
-        i += 1;
-    }
-    sum
-}
-
 /// Negative [Dot] distance.
 #[inline]
 pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -74,7 +74,6 @@ fn dot_scalar<
 /// Dot product.
 #[inline]
 pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
-    assert_equal_lengths(from.len(), to.len());
     T::dot(from, to)
 }
 
@@ -83,16 +82,7 @@ pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
 /// needed on top of the generic [`dot`].
 #[inline]
 pub fn dot_f32(x: &[f32], y: &[f32]) -> f32 {
-    assert_equal_lengths(x.len(), y.len());
-    #[cfg(target_arch = "x86_64")]
-    {
-        use lance_core::utils::cpu::SimdSupport;
-        if matches!(*SIMD_SUPPORT, SimdSupport::Avx512 | SimdSupport::Avx512FP16) {
-            // SAFETY: guarded by the runtime AVX-512 detection above.
-            return unsafe { dot_f32_avx512(x, y) };
-        }
-    }
-    dot(x, y)
+    f32::dot(x, y)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -120,7 +110,6 @@ unsafe fn dot_f32_avx512(x: &[f32], y: &[f32]) -> f32 {
 /// Negative [Dot] distance.
 #[inline]
 pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
-    assert_equal_lengths(from.len(), to.len());
     1.0 - T::dot(from, to)
 }
 
@@ -326,7 +315,12 @@ impl Dot for f32 {
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
-            batch.chunks_exact(dimension).map(move |y| Self::dot(x, y))
+            // `assert_batch_layout` proves every chunk has the same length as
+            // `x`, so call the private kernel directly instead of repeating
+            // the public `Dot::dot` validation for every vector.
+            batch
+                .chunks_exact(dimension)
+                .map(move |y| dot_f32_dispatched(x, y))
         }
     }
 }
@@ -789,7 +783,6 @@ pub fn dot_distance_batch<'a, T: Dot>(
     to: &'a [T],
     dimension: usize,
 ) -> Box<dyn Iterator<Item = f32> + 'a> {
-    assert_batch_layout(from.len(), to.len(), dimension);
     Box::new(T::dot_batch(from, to, dimension).map(|d| 1.0 - d))
 }
 

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -28,10 +28,12 @@
 
 use std::sync::OnceLock;
 
+use super::assert_equal_lengths;
+
 /// Portable scalar u8 dot product, also used for SIMD tail elements.
 #[inline]
 pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_equal_lengths(a.len(), b.len());
     a.iter()
         .zip(b.iter())
         .map(|(&x, &y)| x as u32 * y as u32)
@@ -146,12 +148,19 @@ fn select_backend() -> DotU8Fn {
 /// Dispatched u8 dot product, selecting the best available SIMD backend.
 #[inline]
 pub fn dot_u8(a: &[u8], b: &[u8]) -> u32 {
+    assert_equal_lengths(a.len(), b.len());
     (DISPATCH.get_or_init(select_backend))(a, b)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_mismatched_lengths() {
+        assert!(std::panic::catch_unwind(|| dot_u8_scalar(&[1, 2], &[1])).is_err());
+        assert!(std::panic::catch_unwind(|| dot_u8(&[1, 2], &[1])).is_err());
+    }
 
     fn fill_random(buf: &mut [u8], seed: &mut u32) {
         for slot in buf.iter_mut() {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -22,7 +22,6 @@ use arrow_array::{
 use arrow_schema::DataType;
 use half::{bf16, f16};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
-use lance_core::assume_eq;
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::utils::cpu::SIMD_SUPPORT;
 // Named tiers are only matched on x86_64, or by the fp16 kernels on the other
@@ -30,6 +29,8 @@ use lance_core::utils::cpu::SIMD_SUPPORT;
 #[cfg(any(feature = "fp16kernels", target_arch = "x86_64"))]
 use lance_core::utils::cpu::SimdSupport;
 use num_traits::{AsPrimitive, Num};
+
+use crate::distance::{assert_batch_layout, assert_equal_lengths};
 
 #[cfg(all(
     target_arch = "x86_64",
@@ -64,12 +65,14 @@ pub trait L2: Num {
         y: &'a [Self],
         dimension: usize,
     ) -> impl Iterator<Item = f32> + 'a {
+        assert_batch_layout(x.len(), y.len(), dimension);
         y.chunks_exact(dimension).map(move |v| Self::l2(x, v))
     }
 }
 
 #[inline]
 pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
+    assert_equal_lengths(from.len(), to.len());
     T::l2(from, to)
 }
 
@@ -82,6 +85,7 @@ pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
 /// index an explicit f32 API.
 #[inline]
 pub fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
+    assert_equal_lengths(x.len(), y.len());
     #[cfg(target_arch = "x86_64")]
     {
         if matches!(*SIMD_SUPPORT, SimdSupport::Avx512 | SimdSupport::Avx512FP16) {
@@ -119,6 +123,7 @@ unsafe fn l2_f32_avx512(x: &[f32], y: &[f32]) -> f32 {
 /// Calculate L2 distance between two uint8 slices.
 #[inline]
 pub fn l2_distance_uint_scalar(key: &[u8], target: &[u8]) -> f32 {
+    assert_equal_lengths(key.len(), target.len());
     key.iter()
         .zip(target.iter())
         .map(|(&x, &y)| (x.abs_diff(y) as u32).pow(2))
@@ -139,6 +144,7 @@ pub fn l2_scalar<
     from: &[T],
     to: &[T],
 ) -> Output {
+    assert_equal_lengths(from.len(), to.len());
     let x_chunks = from.chunks_exact(LANES);
     let y_chunks = to.chunks_exact(LANES);
 
@@ -170,6 +176,7 @@ pub fn l2_scalar<
 impl L2 for u8 {
     #[inline]
     fn l2(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         super::l2_u8::l2_u8(x, y) as f32
     }
 }
@@ -197,6 +204,7 @@ mod bf16_kernel {
 impl L2 for bf16 {
     #[inline]
     fn l2(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -253,6 +261,7 @@ mod kernel {
 impl L2 for f16 {
     #[inline]
     fn l2(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -289,6 +298,7 @@ impl L2 for f16 {
 impl L2 for f32 {
     #[inline]
     fn l2(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
         // to an AVX2 or AVX-512 inner kernel on capable hosts, or a portable
@@ -301,6 +311,7 @@ impl L2 for f32 {
         y: &'a [Self],
         dimension: usize,
     ) -> impl Iterator<Item = Self> + 'a {
+        assert_batch_layout(x.len(), y.len(), dimension);
         // Exactly one arm compiles; see `Dot::dot_batch` for f32.
         #[cfg(all(
             target_arch = "x86_64",
@@ -498,6 +509,7 @@ fn l2_f32_scalar(x: &[f32], y: &[f32]) -> f32 {
 impl L2 for f64 {
     #[inline]
     fn l2(x: &[Self], y: &[Self]) -> f32 {
+        assert_equal_lengths(x.len(), y.len());
         l2_f64_simd(x, y)
     }
 }
@@ -927,6 +939,7 @@ impl L2Prepared {
 /// Compute L2 distance between two vectors.
 #[inline]
 pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
+    assert_equal_lengths(from.len(), to.len());
     l2(from, to)
 }
 
@@ -946,8 +959,7 @@ pub fn l2_distance_batch<'a, T: L2>(
     to: &'a [T],
     dimension: usize,
 ) -> impl Iterator<Item = f32> + 'a {
-    assume_eq!(from.len(), dimension);
-    assume_eq!(to.len() % dimension, 0);
+    assert_batch_layout(from.len(), to.len(), dimension);
 
     T::l2_batch(from, to, dimension)
 }
@@ -1022,6 +1034,22 @@ mod tests {
     use approx::assert_relative_eq;
     use num_traits::ToPrimitive;
     use proptest::prelude::*;
+
+    #[test]
+    fn test_l2_rejects_mismatched_lengths() {
+        let short = [1.0_f32];
+        let long = [1.0_f32, 2.0];
+
+        assert!(std::panic::catch_unwind(|| l2(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_f32(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| f32::l2(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_distance(&short, &long)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_distance_batch(&short, &long, 2)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_distance_batch(&long, &[1.0_f32; 3], 2)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_distance_batch::<f32>(&[], &[], 0)).is_err());
+        assert!(std::panic::catch_unwind(|| l2_distance_uint_scalar(&[1, 2], &[1])).is_err());
+        assert!(std::panic::catch_unwind(|| l2_scalar::<u8, f32, 16>(&[1, 2], &[1])).is_err());
+    }
 
     use crate::test_utils::{
         arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, arbitrary_vector_pair,

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -87,30 +87,6 @@ pub fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
     f32::l2(x, y)
 }
 
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx512f")]
-unsafe fn l2_f32_avx512(x: &[f32], y: &[f32]) -> f32 {
-    use std::arch::x86_64::*;
-    debug_assert_eq!(x.len(), y.len());
-    let n = x.len();
-    let mut acc = _mm512_setzero_ps();
-    let mut i = 0usize;
-    while i + 16 <= n {
-        let a = _mm512_loadu_ps(x.as_ptr().add(i));
-        let b = _mm512_loadu_ps(y.as_ptr().add(i));
-        let diff = _mm512_sub_ps(a, b);
-        acc = _mm512_fmadd_ps(diff, diff, acc);
-        i += 16;
-    }
-    let mut sum = _mm512_reduce_add_ps(acc);
-    while i < n {
-        let diff = x[i] - y[i];
-        sum += diff * diff;
-        i += 1;
-    }
-    sum
-}
-
 /// Calculate L2 distance between two uint8 slices.
 #[inline]
 pub fn l2_distance_uint_scalar(key: &[u8], target: &[u8]) -> f32 {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -72,7 +72,6 @@ pub trait L2: Num {
 
 #[inline]
 pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
-    assert_equal_lengths(from.len(), to.len());
     T::l2(from, to)
 }
 
@@ -85,15 +84,7 @@ pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
 /// index an explicit f32 API.
 #[inline]
 pub fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
-    assert_equal_lengths(x.len(), y.len());
-    #[cfg(target_arch = "x86_64")]
-    {
-        if matches!(*SIMD_SUPPORT, SimdSupport::Avx512 | SimdSupport::Avx512FP16) {
-            // SAFETY: guarded by the runtime AVX-512 detection above.
-            return unsafe { l2_f32_avx512(x, y) };
-        }
-    }
-    l2(x, y)
+    f32::l2(x, y)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -346,7 +337,11 @@ impl L2 for f32 {
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
-            y.chunks_exact(dimension).map(move |v| Self::l2(x, v))
+            // `assert_batch_layout` proves every chunk has the same length as
+            // `x`, so call the private kernel directly instead of repeating
+            // the public `L2::l2` validation for every vector.
+            y.chunks_exact(dimension)
+                .map(move |v| l2_f32_dispatched(x, v))
         }
     }
 }
@@ -939,7 +934,6 @@ impl L2Prepared {
 /// Compute L2 distance between two vectors.
 #[inline]
 pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
-    assert_equal_lengths(from.len(), to.len());
     l2(from, to)
 }
 
@@ -959,8 +953,6 @@ pub fn l2_distance_batch<'a, T: L2>(
     to: &'a [T],
     dimension: usize,
 ) -> impl Iterator<Item = f32> + 'a {
-    assert_batch_layout(from.len(), to.len(), dimension);
-
     T::l2_batch(from, to, dimension)
 }
 

--- a/rust/lance-linalg/src/distance/l2_u8.rs
+++ b/rust/lance-linalg/src/distance/l2_u8.rs
@@ -22,10 +22,12 @@
 
 use std::sync::OnceLock;
 
+use super::assert_equal_lengths;
+
 /// Portable scalar u8 squared L2 distance, also used for SIMD tail elements.
 #[inline]
 pub fn l2_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_equal_lengths(a.len(), b.len());
     a.iter()
         .zip(b.iter())
         .map(|(&x, &y)| (x.abs_diff(y) as u32).pow(2))
@@ -155,12 +157,19 @@ fn select_backend() -> L2U8Fn {
 /// Dispatched u8 squared L2 distance, selecting the best available SIMD backend.
 #[inline]
 pub fn l2_u8(a: &[u8], b: &[u8]) -> u32 {
+    assert_equal_lengths(a.len(), b.len());
     (DISPATCH.get_or_init(select_backend))(a, b)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_mismatched_lengths() {
+        assert!(std::panic::catch_unwind(|| l2_u8_scalar(&[1, 2], &[1])).is_err());
+        assert!(std::panic::catch_unwind(|| l2_u8(&[1, 2], &[1])).is_err());
+    }
 
     fn fill_random(buf: &mut [u8], seed: &mut u32) {
         for slot in buf.iter_mut() {


### PR DESCRIPTION
Several safe distance APIs only used debug assertions before runtime-dispatched SIMD or C kernels that iterate using the first slice length. In optimized builds, a shorter second slice could therefore be read out of bounds. Scalar fallbacks also silently truncated through zip, producing backend-dependent behavior.

This establishes one checked contract across generic dot/L2, direct trait calls, f32 dispatch, fp16/bf16/f64/u8 implementations, scalar helpers, and batch layouts. Invalid lengths now fail before any backend selection or raw load, including optimized builds.