### PR TITLE
fix(python): return a shared background executor

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -135,11 +135,13 @@ static EXECUTOR_INSTALLED: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 static ATFORK_INSTALLED: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
-pub fn rt() -> &'static mut BackgroundExecutor {
+pub fn rt() -> &'static BackgroundExecutor {
     loop {
         let ptr = BACKGROUND_EXECUTOR.load(Ordering::SeqCst);
         if !ptr.is_null() {
-            return unsafe { &mut *ptr };
+            // SAFETY: installed executors are leaked and remain valid for the
+            // process lifetime. BackgroundExecutor uses shared access only.
+            return unsafe { &*ptr };
         }
         if !EXECUTOR_INSTALLED.fetch_or(true, Ordering::SeqCst) {
             break;
@@ -151,7 +153,8 @@ pub fn rt() -> &'static mut BackgroundExecutor {
     }
     let new_ptr = Box::into_raw(Box::new(create_background_executor()));
     BACKGROUND_EXECUTOR.store(new_ptr, Ordering::SeqCst);
-    unsafe { &mut *new_ptr }
+    // SAFETY: the executor is leaked and all of its operations take `&self`.
+    unsafe { &*new_ptr }
 }
 
 /// After a fork() operation, force re-creation of the BackgroundExecutor. Note: this function
@@ -510,4 +513,16 @@ fn ffi_logical_codec_from_pycapsule(obj: Bound<PyAny>) -> PyResult<FFI_LogicalEx
     let codec = unsafe { data.as_ref() };
 
     Ok(codec.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn background_executor_is_a_shared_singleton() {
+        let first: &'static BackgroundExecutor = rt();
+        let second: &'static BackgroundExecutor = rt();
+        assert!(std::ptr::eq(first, second));
+    }
 }


### PR DESCRIPTION
The process-wide background executor was exposed as a mutable static reference even though its API only requires shared access. Repeated callers could therefore obtain aliased `&mut` references to the same executor, violating Rust reference rules. Return a shared reference while preserving the singleton and fork-reinitialization behavior.