### PR TITLE
fix(index): initialize BQ distance buffers

### DIFF
--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -931,20 +931,14 @@ impl<'a> RabitDistCalculator<'a> {
     /// Fill `dists[0..n]` with exact per-row binary distances computed
     /// directly from the f32 dist table — the fallback when the quantized
     /// reconstruction scale would be non-finite ([`DistTableDequant::Exact`]).
-    #[allow(clippy::uninit_vec)]
     fn fill_exact_binary_distances(&self, n: usize, code_len: usize, dists: &mut Vec<f32>) {
         dists.clear();
-        dists.reserve(n);
-        // SAFETY: the loop initializes every element in [0, n).
-        unsafe {
-            dists.set_len(n);
-        }
+        dists.resize(n, 0.0);
         dists.iter_mut().enumerate().for_each(|(id, dist)| {
             *dist = compute_single_rq_distance(self.codes, id, n, code_len, &self.dist_table);
         });
     }
 
-    #[allow(clippy::uninit_vec)]
     fn binary_distances_with_scratch(
         &self,
         n: usize,
@@ -978,11 +972,7 @@ impl<'a> RabitDistCalculator<'a> {
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
-        quantized_dists.reserve(simd_len);
-        // SAFETY: sum_4bit_dist_table overwrites each element in the SIMD batch range.
-        unsafe {
-            quantized_dists.set_len(simd_len);
-        }
+        quantized_dists.resize(simd_len, 0);
         simd::dist_table::sum_4bit_dist_table(
             simd_len,
             code_len,
@@ -995,12 +985,7 @@ impl<'a> RabitDistCalculator<'a> {
         let num_tables = quantized_dists_table.len() / SEGMENT_NUM_CODES;
         let sum_min = num_tables as f32 * qmin;
         dists.clear();
-        dists.reserve(n);
-        // SAFETY: the SIMD section below writes [0, simd_len), and the
-        // remainder section writes [simd_len, n).
-        unsafe {
-            dists.set_len(n);
-        }
+        dists.resize(n, 0.0);
         let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
         simd_dists
             .iter_mut()
@@ -1024,7 +1009,6 @@ impl<'a> RabitDistCalculator<'a> {
         simd_len
     }
 
-    #[allow(clippy::uninit_vec)]
     fn binary_distances_hacc_with_scratch(
         &self,
         n: usize,
@@ -1048,11 +1032,7 @@ impl<'a> RabitDistCalculator<'a> {
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
-        quantized_dists.reserve(simd_len);
-        // SAFETY: sum_4bit_hacc_dist_table overwrites each element in the batch range.
-        unsafe {
-            quantized_dists.set_len(simd_len);
-        }
+        quantized_dists.resize(simd_len, 0);
         simd::dist_table::sum_4bit_hacc_dist_table(
             simd_len,
             code_len,
@@ -1065,12 +1045,7 @@ impl<'a> RabitDistCalculator<'a> {
         let num_tables = quantized_dist_table.len() / SEGMENT_NUM_CODES;
         let sum_min = num_tables as f32 * qmin;
         dists.clear();
-        dists.reserve(n);
-        // SAFETY: the batch section writes [0, simd_len), and the
-        // remainder section writes [simd_len, n).
-        unsafe {
-            dists.set_len(n);
-        }
+        dists.resize(n, 0.0);
         let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
         simd_dists
             .iter_mut()
@@ -1102,7 +1077,6 @@ impl<'a> RabitDistCalculator<'a> {
         }
     }
 
-    #[allow(clippy::uninit_vec)]
     fn one_bit_distances_with_scratch(
         &self,
         n: usize,
@@ -1131,7 +1105,6 @@ impl<'a> RabitDistCalculator<'a> {
         });
     }
 
-    #[allow(clippy::uninit_vec)]
     fn apply_raw_query_multi_bit_distances(
         &self,
         simd_len: usize,
@@ -1164,11 +1137,7 @@ impl<'a> RabitDistCalculator<'a> {
                         quantized_dists_table,
                     );
                     quantized_dists.clear();
-                    quantized_dists.reserve(fastscan_len);
-                    // SAFETY: sum_4bit_dist_table overwrites each element in the SIMD batch range.
-                    unsafe {
-                        quantized_dists.set_len(fastscan_len);
-                    }
+                    quantized_dists.resize(fastscan_len, 0);
                     simd::dist_table::sum_4bit_dist_table(
                         fastscan_len,
                         fastscan_code_len,
@@ -1827,7 +1796,6 @@ impl DistCalculator for RabitDistCalculator<'_> {
     }
 
     #[inline(always)]
-    #[allow(clippy::uninit_vec)]
     fn distance_all_with_scratch(
         &self,
         _: usize,

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -933,10 +933,21 @@ impl<'a> RabitDistCalculator<'a> {
     /// reconstruction scale would be non-finite ([`DistTableDequant::Exact`]).
     fn fill_exact_binary_distances(&self, n: usize, code_len: usize, dists: &mut Vec<f32>) {
         dists.clear();
-        dists.resize(n, 0.0);
-        dists.iter_mut().enumerate().for_each(|(id, dist)| {
-            *dist = compute_single_rq_distance(self.codes, id, n, code_len, &self.dist_table);
-        });
+        dists.reserve(n);
+        dists.spare_capacity_mut()[..n]
+            .iter_mut()
+            .enumerate()
+            .for_each(|(id, dist)| {
+                dist.write(compute_single_rq_distance(
+                    self.codes,
+                    id,
+                    n,
+                    code_len,
+                    &self.dist_table,
+                ));
+            });
+        // Every reserved slot was initialized above.
+        unsafe { dists.set_len(n) };
     }
 
     fn binary_distances_with_scratch(
@@ -972,40 +983,48 @@ impl<'a> RabitDistCalculator<'a> {
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
-        quantized_dists.resize(simd_len, 0);
-        simd::dist_table::sum_4bit_dist_table(
-            simd_len,
-            code_len,
-            self.codes,
-            quantized_dists_table,
-            quantized_dists,
-        );
+        quantized_dists.reserve(simd_len);
+        unsafe {
+            // Storage construction proves the code and table layouts, and the
+            // reserved output has exactly one slot per SIMD row.
+            simd::dist_table::sum_4bit_dist_table_uninit(
+                simd_len,
+                code_len,
+                self.codes,
+                quantized_dists_table,
+                &mut quantized_dists.spare_capacity_mut()[..simd_len],
+            );
+            // The distance-table kernel initialized every SIMD output slot.
+            quantized_dists.set_len(simd_len);
+        }
 
         let range = (qmax - qmin) / 255.0;
         let num_tables = quantized_dists_table.len() / SEGMENT_NUM_CODES;
         let sum_min = num_tables as f32 * qmin;
         dists.clear();
-        dists.resize(n, 0.0);
-        let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
-        simd_dists
+        dists.reserve(n);
+        let uninit_dists = &mut dists.spare_capacity_mut()[..n];
+        uninit_dists[..simd_len]
             .iter_mut()
             .zip(quantized_dists.iter())
             .for_each(|(dist, q_dist)| {
-                *dist = (*q_dist as f32) * range + sum_min;
+                dist.write((*q_dist as f32) * range + sum_min);
             });
 
-        remainder_dists
+        uninit_dists[simd_len..]
             .iter_mut()
             .enumerate()
             .for_each(|(id, dist)| {
-                *dist = compute_single_rq_distance(
+                dist.write(compute_single_rq_distance(
                     self.codes,
                     simd_len + id,
                     n,
                     code_len,
                     &self.dist_table,
-                );
+                ));
             });
+        // Both the SIMD reconstruction and scalar remainder initialized their slots.
+        unsafe { dists.set_len(n) };
         simd_len
     }
 
@@ -1032,40 +1051,48 @@ impl<'a> RabitDistCalculator<'a> {
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
-        quantized_dists.resize(simd_len, 0);
-        simd::dist_table::sum_4bit_hacc_dist_table(
-            simd_len,
-            code_len,
-            self.codes,
-            hacc_dist_table,
-            quantized_dists,
-        );
+        quantized_dists.reserve(simd_len);
+        unsafe {
+            // Storage construction proves the code and table layouts, and the
+            // reserved output has exactly one slot per SIMD row.
+            simd::dist_table::sum_4bit_hacc_dist_table_uninit(
+                simd_len,
+                code_len,
+                self.codes,
+                hacc_dist_table,
+                &mut quantized_dists.spare_capacity_mut()[..simd_len],
+            );
+            // The high-accuracy kernel initialized every SIMD output slot.
+            quantized_dists.set_len(simd_len);
+        }
 
         let range = (qmax - qmin) / u16::MAX as f32;
         let num_tables = quantized_dist_table.len() / SEGMENT_NUM_CODES;
         let sum_min = num_tables as f32 * qmin;
         dists.clear();
-        dists.resize(n, 0.0);
-        let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
-        simd_dists
+        dists.reserve(n);
+        let uninit_dists = &mut dists.spare_capacity_mut()[..n];
+        uninit_dists[..simd_len]
             .iter_mut()
             .zip(quantized_dists.iter())
             .for_each(|(dist, q_dist)| {
-                *dist = (*q_dist as f32) * range + sum_min;
+                dist.write((*q_dist as f32) * range + sum_min);
             });
 
-        remainder_dists
+        uninit_dists[simd_len..]
             .iter_mut()
             .enumerate()
             .for_each(|(id, dist)| {
-                *dist = compute_single_rq_distance(
+                dist.write(compute_single_rq_distance(
                     self.codes,
                     simd_len + id,
                     n,
                     code_len,
                     &self.dist_table,
-                );
+                ));
             });
+        // Both the SIMD reconstruction and scalar remainder initialized their slots.
+        unsafe { dists.set_len(n) };
         simd_len
     }
 
@@ -1137,14 +1164,20 @@ impl<'a> RabitDistCalculator<'a> {
                         quantized_dists_table,
                     );
                     quantized_dists.clear();
-                    quantized_dists.resize(fastscan_len, 0);
-                    simd::dist_table::sum_4bit_dist_table(
-                        fastscan_len,
-                        fastscan_code_len,
-                        packed_ex_codes,
-                        quantized_dists_table,
-                        quantized_dists,
-                    );
+                    quantized_dists.reserve(fastscan_len);
+                    unsafe {
+                        // The packed ex-code layout and table size are fixed at
+                        // construction, and the output reserves one slot per row.
+                        simd::dist_table::sum_4bit_dist_table_uninit(
+                            fastscan_len,
+                            fastscan_code_len,
+                            packed_ex_codes,
+                            quantized_dists_table,
+                            &mut quantized_dists.spare_capacity_mut()[..fastscan_len],
+                        );
+                        // The distance-table kernel initialized every fast-scan slot.
+                        quantized_dists.set_len(fastscan_len);
+                    }
 
                     let range = (qmax - qmin) / quantization_max;
                     let num_tables = quantized_dists_table.len() / SEGMENT_NUM_CODES;

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -365,7 +365,7 @@ fn sum_4bit_hacc_dist_table_avx2(
                     );
                 }
             } else {
-                let mut chunk_dists = [0u32; BATCH_SIZE];
+                let mut chunk_dists = [MaybeUninit::<u32>::uninit(); BATCH_SIZE];
                 unsafe {
                     sum_hacc_dist_table_32bytes_batch_avx2(
                         &batch_codes[code_range],
@@ -373,6 +373,10 @@ fn sum_4bit_hacc_dist_table_avx2(
                         &mut chunk_dists,
                     );
                 }
+                // The kernel above initializes every temporary output slot.
+                let chunk_dists = unsafe {
+                    std::slice::from_raw_parts(chunk_dists.as_ptr().cast::<u32>(), BATCH_SIZE)
+                };
                 // The first code chunk initialized every output slot.
                 let batch_dists = unsafe {
                     std::slice::from_raw_parts_mut(

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -5,6 +5,7 @@
 use std::arch::aarch64::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+use std::mem::MaybeUninit;
 
 #[allow(unused_imports)]
 use lance_core::utils::cpu::{SIMD_SUPPORT, SimdSupport};
@@ -34,7 +35,38 @@ pub fn sum_4bit_dist_table(
     dist_table: &[u8],
     dists: &mut [u16],
 ) {
+    assert!(n.is_multiple_of(BATCH_SIZE));
+    assert!(dists.len() >= n);
+    assert!(codes.len() >= n * code_len);
+    assert!(dist_table.len() >= BATCH_SIZE * code_len);
+    // A `u16` slice is also a valid `MaybeUninit<u16>` slice. The dispatched
+    // kernels overwrite every output slot.
+    let dists = unsafe {
+        std::slice::from_raw_parts_mut(dists.as_mut_ptr().cast::<MaybeUninit<u16>>(), dists.len())
+    };
+    unsafe { sum_4bit_dist_table_uninit(n, code_len, codes, dist_table, dists) };
+}
+
+/// Sum a 4-bit distance table into potentially uninitialized output storage.
+///
+/// Every element in `dists[..n]` is initialized before this function returns.
+///
+/// # Safety
+///
+/// `n` must be a multiple of [`BATCH_SIZE`], `codes` must contain at least
+/// `n * code_len` bytes, `dist_table` must contain at least
+/// `BATCH_SIZE * code_len` bytes, and `dists` must contain at least `n` slots.
+#[inline]
+pub unsafe fn sum_4bit_dist_table_uninit(
+    n: usize,
+    code_len: usize,
+    codes: &[u8],
+    dist_table: &[u8],
+    dists: &mut [MaybeUninit<u16>],
+) {
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
+    debug_assert!(dists.len() >= n);
+    debug_assert!(codes.len() >= n * code_len);
 
     match *SIMD_SUPPORT {
         #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
@@ -48,7 +80,7 @@ pub fn sum_4bit_dist_table(
                         codes.as_ptr(),
                         codes.len(),
                         dist_table.as_ptr(),
-                        dists[i..i + BATCH_SIZE].as_mut_ptr(),
+                        dists[i..i + BATCH_SIZE].as_mut_ptr().cast::<u16>(),
                     )
                 }
             }
@@ -77,7 +109,13 @@ pub fn sum_4bit_dist_table(
         // the AVX2 inner uses `_mm256_shuffle_epi8` / `_mm256_and_si256` /
         // `_mm256_srli_epi16` / `_mm256_add_epi16` integer ops which
         // neither AVX nor AVX+FMA provides. Scalar is the correct route.
-        _ => sum_4bit_dist_table_scalar(code_len, codes, dist_table, dists),
+        _ => {
+            dists[..n].fill(MaybeUninit::new(0));
+            // Every slot was initialized immediately above.
+            let dists =
+                unsafe { std::slice::from_raw_parts_mut(dists.as_mut_ptr().cast::<u16>(), n) };
+            sum_4bit_dist_table_scalar(code_len, &codes[..n * code_len], dist_table, dists);
+        }
     }
 }
 
@@ -164,6 +202,35 @@ pub fn sum_4bit_hacc_dist_table(
     hacc_dist_table: &[u8],
     dists: &mut [u32],
 ) {
+    assert!(n.is_multiple_of(BATCH_SIZE));
+    assert!(dists.len() >= n);
+    assert!(codes.len() >= n * code_len);
+    assert!(hacc_dist_table.len() >= code_len * 64);
+    // A `u32` slice is also a valid `MaybeUninit<u32>` slice. The dispatched
+    // kernels overwrite every output slot.
+    let dists = unsafe {
+        std::slice::from_raw_parts_mut(dists.as_mut_ptr().cast::<MaybeUninit<u32>>(), dists.len())
+    };
+    unsafe { sum_4bit_hacc_dist_table_uninit(n, code_len, codes, hacc_dist_table, dists) };
+}
+
+/// Sum a high-accuracy 4-bit distance table into uninitialized output storage.
+///
+/// Every element in `dists[..n]` is initialized before this function returns.
+///
+/// # Safety
+///
+/// `n` must be a multiple of [`BATCH_SIZE`], `codes` must contain at least
+/// `n * code_len` bytes, `hacc_dist_table` must contain at least
+/// `code_len * 64` bytes, and `dists` must contain at least `n` slots.
+#[inline]
+pub unsafe fn sum_4bit_hacc_dist_table_uninit(
+    n: usize,
+    code_len: usize,
+    codes: &[u8],
+    hacc_dist_table: &[u8],
+    dists: &mut [MaybeUninit<u32>],
+) {
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
     debug_assert!(dists.len() >= n);
     debug_assert!(codes.len() >= n * code_len);
@@ -176,7 +243,18 @@ pub fn sum_4bit_hacc_dist_table(
         {
             sum_4bit_hacc_dist_table_avx2(n, code_len, codes, hacc_dist_table, dists);
         }
-        _ => sum_4bit_hacc_dist_table_scalar(code_len, codes, hacc_dist_table, dists),
+        _ => {
+            dists[..n].fill(MaybeUninit::new(0));
+            // Every slot was initialized immediately above.
+            let dists =
+                unsafe { std::slice::from_raw_parts_mut(dists.as_mut_ptr().cast::<u32>(), n) };
+            sum_4bit_hacc_dist_table_scalar(
+                code_len,
+                &codes[..n * code_len],
+                hacc_dist_table,
+                dists,
+            );
+        }
     }
 }
 
@@ -261,20 +339,24 @@ fn sum_4bit_hacc_dist_table_avx2(
     code_len: usize,
     codes: &[u8],
     hacc_dist_table: &[u8],
-    dists: &mut [u32],
+    dists: &mut [MaybeUninit<u32>],
 ) {
     const SAFE_CODE_LEN: usize = 128;
 
     for i in (0..n).step_by(BATCH_SIZE) {
         let batch_codes = &codes[i * code_len..(i + BATCH_SIZE) * code_len];
         let batch_dists = &mut dists[i..i + BATCH_SIZE];
-        batch_dists.fill(0);
+
+        if code_len == 0 {
+            batch_dists.fill(MaybeUninit::new(0));
+            continue;
+        }
 
         for code_start in (0..code_len).step_by(SAFE_CODE_LEN) {
             let code_end = (code_start + SAFE_CODE_LEN).min(code_len);
             let code_range = code_start * BATCH_SIZE..code_end * BATCH_SIZE;
             let table_range = code_start * 64..code_end * 64;
-            if code_start == 0 && code_end == code_len {
+            if code_start == 0 {
                 unsafe {
                     sum_hacc_dist_table_32bytes_batch_avx2(
                         &batch_codes[code_range],
@@ -291,6 +373,13 @@ fn sum_4bit_hacc_dist_table_avx2(
                         &mut chunk_dists,
                     );
                 }
+                // The first code chunk initialized every output slot.
+                let batch_dists = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        batch_dists.as_mut_ptr().cast::<u32>(),
+                        BATCH_SIZE,
+                    )
+                };
                 batch_dists
                     .iter_mut()
                     .zip(chunk_dists.iter())
@@ -307,7 +396,7 @@ fn sum_4bit_hacc_dist_table_avx2(
 unsafe fn sum_hacc_dist_table_32bytes_batch_avx2(
     codes: &[u8],
     hacc_dist_table: &[u8],
-    dists: &mut [u32],
+    dists: &mut [MaybeUninit<u32>],
 ) {
     let low_mask = _mm256_set1_epi8(0x0f);
     let mut low_accu0 = _mm256_setzero_si256();
@@ -389,7 +478,11 @@ unsafe fn sum_hacc_dist_table_32bytes_batch_avx2(
 #[target_feature(enable = "avx2")]
 #[inline]
 #[allow(unused)]
-unsafe fn sum_dist_table_32bytes_batch_avx2(codes: &[u8], dist_table: &[u8], dists: &mut [u16]) {
+unsafe fn sum_dist_table_32bytes_batch_avx2(
+    codes: &[u8],
+    dist_table: &[u8],
+    dists: &mut [MaybeUninit<u16>],
+) {
     let mut c = _mm256_undefined_si256();
     let mut lo = _mm256_undefined_si256();
     let mut hi = _mm256_undefined_si256();
@@ -461,7 +554,11 @@ unsafe fn sum_dist_table_32bytes_batch_avx2(codes: &[u8], dist_table: &[u8], dis
 
 #[cfg(target_arch = "aarch64")]
 #[inline]
-unsafe fn sum_dist_table_32bytes_batch_neon(codes: &[u8], dist_table: &[u8], dists: &mut [u16]) {
+unsafe fn sum_dist_table_32bytes_batch_neon(
+    codes: &[u8],
+    dist_table: &[u8],
+    dists: &mut [MaybeUninit<u16>],
+) {
     let low_mask = vdupq_n_u8(0x0f);
 
     // 8 accumulators: 4 per 128-bit "lane" (lo = bytes 0..16, hi = bytes 16..32 of each block)
@@ -517,8 +614,8 @@ unsafe fn sum_dist_table_32bytes_batch_neon(codes: &[u8], dist_table: &[u8], dis
     // This is the NEON equivalent of AVX2's permute2f128 + blend + add
     let dis0_even = vaddq_u16(accu0_lo, accu0_hi);
     let dis0_odd = vaddq_u16(accu1_lo, accu1_hi);
-    vst1q_u16(dists.as_mut_ptr(), dis0_even);
-    vst1q_u16(dists.as_mut_ptr().add(8), dis0_odd);
+    vst1q_u16(dists.as_mut_ptr().cast::<u16>(), dis0_even);
+    vst1q_u16(dists.as_mut_ptr().add(8).cast::<u16>(), dis0_odd);
 
     // Same for hi-nibble accumulators (vectors 16..31)
     accu2_lo = vsubq_u16(accu2_lo, vshlq_n_u16::<8>(accu3_lo));
@@ -526,8 +623,8 @@ unsafe fn sum_dist_table_32bytes_batch_neon(codes: &[u8], dist_table: &[u8], dis
 
     let dis1_even = vaddq_u16(accu2_lo, accu2_hi);
     let dis1_odd = vaddq_u16(accu3_lo, accu3_hi);
-    vst1q_u16(dists.as_mut_ptr().add(16), dis1_even);
-    vst1q_u16(dists.as_mut_ptr().add(24), dis1_odd);
+    vst1q_u16(dists.as_mut_ptr().add(16).cast::<u16>(), dis1_even);
+    vst1q_u16(dists.as_mut_ptr().add(24).cast::<u16>(), dis1_odd);
 }
 
 // We implement the AVX512 version in C because AVX512 is not stable yet in Rust,


### PR DESCRIPTION
BQ distance calculation grew scratch vectors with `set_len` before their elements were initialized, then exposed those elements through safe mutable slices and iterators. Initialize each output range with `resize` before SIMD and scalar writers reuse it, preserving scratch allocation reuse without creating references to uninitialized values.