### PR TITLE
fix(encoding): initialize bitpacking output buffers

### DIFF
--- a/rust/compression/bitpacking/src/lib.rs
+++ b/rust/compression/bitpacking/src/lib.rs
@@ -14,7 +14,7 @@
 // https://github.com/spiraldb/fastlanes/blob/8e0ff374f815d919d0c0ebdccf5ffd9e6dc7d663/LICENSE
 
 use arrayref::{array_mut_ref, array_ref};
-use core::mem::size_of;
+use core::mem::{MaybeUninit, size_of};
 
 mod bitpacker_internal;
 
@@ -55,7 +55,7 @@ macro_rules! pack {
                 // Special case for W=T, we can just copy the input value directly to the packed value.
                 paste!(seq_t!(row in $T {
                     let idx = index(row, $lane);
-                    $packed[<$T>::LANES * row + $lane] = __kernel__!(idx);
+                    $packed[<$T>::LANES * row + $lane].write(__kernel__!(idx));
                 }));
             } else {
                 // A mask of W bits.
@@ -86,7 +86,7 @@ macro_rules! pack {
 
                     #[allow(unused_assignments)]
                     if next_word > curr_word {
-                        $packed[<$T>::LANES * curr_word + $lane] = tmp;
+                        $packed[<$T>::LANES * curr_word + $lane].write(tmp);
                         let remaining_bits: usize = ((row + 1) * $W) % T;
                         // Keep the remaining bits for the next packed value.
                         tmp = src >> $W - remaining_bits;
@@ -200,8 +200,66 @@ pub trait BitPacking: FastLanes {
     unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]);
 }
 
-impl BitPacking for u8 {
-    unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+/// Bitpacking kernels that can initialize previously uninitialized output storage.
+pub trait BitPackingUninit: BitPacking {
+    /// Packs into potentially uninitialized output storage.
+    ///
+    /// # Safety
+    /// The input and output lengths have the same requirements as
+    /// [`Self::unchecked_pack`]. Every output element is initialized on return.
+    unsafe fn unchecked_pack_uninit(width: usize, input: &[Self], output: &mut [MaybeUninit<Self>]);
+
+    /// Unpacks into potentially uninitialized output storage.
+    ///
+    /// # Safety
+    /// The input and output lengths have the same requirements as
+    /// [`Self::unchecked_unpack`]. Every output element is initialized on return.
+    unsafe fn unchecked_unpack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    );
+}
+
+macro_rules! impl_bitpacking_compat {
+    ($ty:ty) => {
+        impl BitPacking for $ty {
+            unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+                let output = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        output.as_mut_ptr().cast::<MaybeUninit<Self>>(),
+                        output.len(),
+                    )
+                };
+                unsafe { <Self as BitPackingUninit>::unchecked_pack_uninit(width, input, output) };
+            }
+
+            unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+                let output = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        output.as_mut_ptr().cast::<MaybeUninit<Self>>(),
+                        output.len(),
+                    )
+                };
+                unsafe {
+                    <Self as BitPackingUninit>::unchecked_unpack_uninit(width, input, output)
+                };
+            }
+        }
+    };
+}
+
+impl_bitpacking_compat!(u8);
+impl_bitpacking_compat!(u16);
+impl_bitpacking_compat!(u32);
+impl_bitpacking_compat!(u64);
+
+impl BitPackingUninit for u8 {
+    unsafe fn unchecked_pack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             output.len(),
@@ -256,7 +314,11 @@ impl BitPacking for u8 {
         }
     }
 
-    unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+    unsafe fn unchecked_unpack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             input.len(),
@@ -273,7 +335,7 @@ impl BitPacking for u8 {
         match width {
             0 => {
                 // A zero-width packed chunk implies all zeros.
-                output.fill(0);
+                output.fill(MaybeUninit::new(0));
             }
             1 => unpack_8_1(
                 array_ref![input, 0, 1024 / 8],
@@ -313,8 +375,12 @@ impl BitPacking for u8 {
     }
 }
 
-impl BitPacking for u16 {
-    unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+impl BitPackingUninit for u16 {
+    unsafe fn unchecked_pack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             output.len(),
@@ -402,7 +468,11 @@ impl BitPacking for u16 {
         }
     }
 
-    unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+    unsafe fn unchecked_unpack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             input.len(),
@@ -418,7 +488,7 @@ impl BitPacking for u16 {
 
         match width {
             0 => {
-                output.fill(0);
+                output.fill(MaybeUninit::new(0));
             }
             1 => unpack_16_1(
                 array_ref![input, 0, 1024 / 16],
@@ -491,8 +561,12 @@ impl BitPacking for u16 {
     }
 }
 
-impl BitPacking for u32 {
-    unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+impl BitPackingUninit for u32 {
+    unsafe fn unchecked_pack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             output.len(),
@@ -646,7 +720,11 @@ impl BitPacking for u32 {
         }
     }
 
-    unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+    unsafe fn unchecked_unpack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             input.len(),
@@ -662,7 +740,7 @@ impl BitPacking for u32 {
 
         match width {
             0 => {
-                output.fill(0);
+                output.fill(MaybeUninit::new(0));
             }
             1 => unpack_32_1(
                 array_ref![input, 0, 1024 / 32],
@@ -801,8 +879,12 @@ impl BitPacking for u32 {
     }
 }
 
-impl BitPacking for u64 {
-    unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+impl BitPackingUninit for u64 {
+    unsafe fn unchecked_pack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             output.len(),
@@ -1087,7 +1169,11 @@ impl BitPacking for u64 {
         }
     }
 
-    unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+    unsafe fn unchecked_unpack_uninit(
+        width: usize,
+        input: &[Self],
+        output: &mut [MaybeUninit<Self>],
+    ) {
         let packed_len = 128 * width / size_of::<Self>();
         debug_assert_eq!(
             input.len(),
@@ -1103,7 +1189,7 @@ impl BitPacking for u64 {
 
         match width {
             0 => {
-                output.fill(0);
+                output.fill(MaybeUninit::new(0));
             }
             1 => unpack_64_1(
                 array_ref![input, 0, 1024 / 64],
@@ -1375,10 +1461,10 @@ impl BitPacking for u64 {
 
 macro_rules! unpack_8 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u8; 1024 * $bits / u8::T], output: &mut [u8; 1024]) {
+        fn $name(input: &[u8; 1024 * $bits / u8::T], output: &mut [MaybeUninit<u8>; 1024]) {
             for lane in 0..u8::LANES {
                 unpack!(u8, $bits, input, lane, |$idx, $elem| {
-                    output[$idx] = $elem;
+                    output[$idx].write($elem);
                 });
             }
         }
@@ -1396,7 +1482,7 @@ unpack_8!(unpack_8_8, 8);
 
 macro_rules! pack_8 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u8; 1024], output: &mut [u8; 1024 * $bits / u8::T]) {
+        fn $name(input: &[u8; 1024], output: &mut [MaybeUninit<u8>; 1024 * $bits / u8::T]) {
             for lane in 0..u8::LANES {
                 pack!(u8, $bits, output, lane, |$idx| { input[$idx] });
             }
@@ -1414,10 +1500,10 @@ pack_8!(pack_8_8, 8);
 
 macro_rules! unpack_16 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u16; 1024 * $bits / u16::T], output: &mut [u16; 1024]) {
+        fn $name(input: &[u16; 1024 * $bits / u16::T], output: &mut [MaybeUninit<u16>; 1024]) {
             for lane in 0..u16::LANES {
                 unpack!(u16, $bits, input, lane, |$idx, $elem| {
-                    output[$idx] = $elem;
+                    output[$idx].write($elem);
                 });
             }
         }
@@ -1443,7 +1529,7 @@ unpack_16!(unpack_16_16, 16);
 
 macro_rules! pack_16 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u16; 1024], output: &mut [u16; 1024 * $bits / u16::T]) {
+        fn $name(input: &[u16; 1024], output: &mut [MaybeUninit<u16>; 1024 * $bits / u16::T]) {
             for lane in 0..u16::LANES {
                 pack!(u16, $bits, output, lane, |$idx| { input[$idx] });
             }
@@ -1470,10 +1556,10 @@ pack_16!(pack_16_16, 16);
 
 macro_rules! unpack_32 {
     ($name:ident, $bit_width:expr) => {
-        fn $name(input: &[u32; 1024 * $bit_width / u32::T], output: &mut [u32; 1024]) {
+        fn $name(input: &[u32; 1024 * $bit_width / u32::T], output: &mut [MaybeUninit<u32>; 1024]) {
             for lane in 0..u32::LANES {
                 unpack!(u32, $bit_width, input, lane, |$idx, $elem| {
-                    output[$idx] = $elem
+                    output[$idx].write($elem);
                 });
             }
         }
@@ -1515,7 +1601,10 @@ unpack_32!(unpack_32_32, 32);
 
 macro_rules! pack_32 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u32; 1024], output: &mut [u32; 1024 * $bits / u32::BITS as usize]) {
+        fn $name(
+            input: &[u32; 1024],
+            output: &mut [MaybeUninit<u32>; 1024 * $bits / u32::BITS as usize],
+        ) {
             for lane in 0..u32::LANES {
                 pack!(u32, $bits, output, lane, |$idx| { input[$idx] });
             }
@@ -1558,10 +1647,10 @@ pack_32!(pack_32_32, 32);
 
 macro_rules! unpack_64 {
     ($name:ident, $bit_width:expr) => {
-        fn $name(input: &[u64; 1024 * $bit_width / u64::T], output: &mut [u64; 1024]) {
+        fn $name(input: &[u64; 1024 * $bit_width / u64::T], output: &mut [MaybeUninit<u64>; 1024]) {
             for lane in 0..u64::LANES {
                 unpack!(u64, $bit_width, input, lane, |$idx, $elem| {
-                    output[$idx] = $elem
+                    output[$idx].write($elem);
                 });
             }
         }
@@ -1636,7 +1725,10 @@ unpack_64!(unpack_64_64, 64);
 
 macro_rules! pack_64 {
     ($name:ident, $bits:expr) => {
-        fn $name(input: &[u64; 1024], output: &mut [u64; 1024 * $bits / u64::BITS as usize]) {
+        fn $name(
+            input: &[u64; 1024],
+            output: &mut [MaybeUninit<u64>; 1024 * $bits / u64::BITS as usize],
+        ) {
             for lane in 0..u64::LANES {
                 pack!(u64, $bits, output, lane, |$idx| { input[$idx] });
             }
@@ -1842,13 +1934,16 @@ mod test {
             *value = (rng.next() % (1 << bit_width)) as u8;
         }
 
-        let mut packed = vec![0; 1024 * bit_width / 8];
+        let mut packed = vec![MaybeUninit::uninit(); 1024 * bit_width / 8];
         for lane in 0..u8::LANES {
             // Always loop over lanes first. This is what the compiler vectorizes.
             pack!(u8, bit_width, packed, lane, |$pos| {
                 values[$pos]
             });
         }
+        // The pack kernel writes every element of the packed output.
+        let packed =
+            unsafe { core::slice::from_raw_parts(packed.as_ptr().cast::<u8>(), packed.len()) };
 
         let mut unpacked: [u8; 1024] = [0; 1024];
         for lane in 0..u8::LANES {
@@ -1868,13 +1963,16 @@ mod test {
             *value = (rng.next() % (1 << bit_width)) as u16;
         }
 
-        let mut packed = vec![0; 1024 * bit_width / 16];
+        let mut packed = vec![MaybeUninit::uninit(); 1024 * bit_width / 16];
         for lane in 0..u16::LANES {
             // Always loop over lanes first. This is what the compiler vectorizes.
             pack!(u16, bit_width, packed, lane, |$pos| {
                 values[$pos]
             });
         }
+        // The pack kernel writes every element of the packed output.
+        let packed =
+            unsafe { core::slice::from_raw_parts(packed.as_ptr().cast::<u16>(), packed.len()) };
 
         let mut unpacked: [u16; 1024] = [0; 1024];
         for lane in 0..u16::LANES {
@@ -1894,13 +1992,16 @@ mod test {
             *value = (rng.next() % (1 << bit_width)) as u32;
         }
 
-        let mut packed = vec![0; 1024 * bit_width / 32];
+        let mut packed = vec![MaybeUninit::uninit(); 1024 * bit_width / 32];
         for lane in 0..u32::LANES {
             // Always loop over lanes first. This is what the compiler vectorizes.
             pack!(u32, bit_width, packed, lane, |$pos| {
                 values[$pos]
             });
         }
+        // The pack kernel writes every element of the packed output.
+        let packed =
+            unsafe { core::slice::from_raw_parts(packed.as_ptr().cast::<u32>(), packed.len()) };
 
         let mut unpacked: [u32; 1024] = [0; 1024];
         for lane in 0..u32::LANES {
@@ -1926,13 +2027,16 @@ mod test {
             }
         }
 
-        let mut packed = vec![0; 1024 * bit_width / 64];
+        let mut packed = vec![MaybeUninit::uninit(); 1024 * bit_width / 64];
         for lane in 0..u64::LANES {
             // Always loop over lanes first. This is what the compiler vectorizes.
             pack!(u64, bit_width, packed, lane, |$pos| {
                 values[$pos]
             });
         }
+        // The pack kernel writes every element of the packed output.
+        let packed =
+            unsafe { core::slice::from_raw_parts(packed.as_ptr().cast::<u64>(), packed.len()) };
 
         let mut unpacked: [u64; 1024] = [0; 1024];
         for lane in 0..u64::LANES {

--- a/rust/compression/bitpacking/src/lib.rs
+++ b/rust/compression/bitpacking/src/lib.rs
@@ -206,14 +206,14 @@ pub trait BitPackingUninit: BitPacking {
     ///
     /// # Safety
     /// The input and output lengths have the same requirements as
-    /// [`Self::unchecked_pack`]. Every output element is initialized on return.
+    /// [`BitPacking::unchecked_pack`]. Every output element is initialized on return.
     unsafe fn unchecked_pack_uninit(width: usize, input: &[Self], output: &mut [MaybeUninit<Self>]);
 
     /// Unpacks into potentially uninitialized output storage.
     ///
     /// # Safety
     /// The input and output lengths have the same requirements as
-    /// [`Self::unchecked_unpack`]. Every output element is initialized on return.
+    /// [`BitPacking::unchecked_unpack`]. Every output element is initialized on return.
     unsafe fn unchecked_unpack_uninit(
         width: usize,
         input: &[Self],

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -110,8 +110,8 @@ impl InlineBitpacking {
             let bit_width = bit_widths_array.value(i) as usize;
             output.push(T::from_usize(bit_width).unwrap());
             let output_len = output.len();
+            output.resize(output_len + *packed_chunk_size, T::from_usize(0).unwrap());
             unsafe {
-                output.set_len(output_len + *packed_chunk_size);
                 BitPacking::unchecked_pack(
                     bit_width,
                     &data_buffer[start_elem..][..ELEMS_PER_CHUNK as usize],
@@ -137,8 +137,11 @@ impl InlineBitpacking {
         let bit_width = bit_widths_array.value(bit_widths_array.len() - 1) as usize;
         output.push(T::from_usize(bit_width).unwrap());
         let output_len = output.len();
+        output.resize(
+            output_len + packed_chunk_sizes[bit_widths_array.len() - 1],
+            T::from_usize(0).unwrap(),
+        );
         unsafe {
-            output.set_len(output_len + packed_chunk_sizes[bit_widths_array.len() - 1]);
             BitPacking::unchecked_pack(
                 bit_width,
                 &last_chunk,
@@ -368,12 +371,7 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
     let last_chunk_is_runt = data_buffer.len() % ELEMS_PER_CHUNK as usize != 0;
     let words_per_chunk = (ELEMS_PER_CHUNK as usize * compressed_bits_per_value)
         .div_ceil(data.bits_per_value as usize);
-    #[allow(clippy::uninit_vec)]
-    let mut output: Vec<T> = Vec::with_capacity(num_chunks * words_per_chunk);
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        output.set_len(num_chunks * words_per_chunk);
-    }
+    let mut output: Vec<T> = vec![T::from_usize(0).unwrap(); num_chunks * words_per_chunk];
 
     let num_whole_chunks = if last_chunk_is_runt {
         num_chunks - 1
@@ -401,10 +399,7 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
     }
 
     let last_chunk_start = num_whole_chunks * ELEMS_PER_CHUNK as usize;
-    // Safety: output ensures to have those values.
-    unsafe {
-        output.set_len(num_whole_chunks * words_per_chunk);
-    }
+    output.truncate(num_whole_chunks * words_per_chunk);
     let remaining_items = data_buffer.len() - last_chunk_start;
 
     let uncompressed_bits = data.bits_per_value as usize;
@@ -419,9 +414,8 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
         let mut last_chunk: Vec<T> = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
         last_chunk[..remaining_items].copy_from_slice(&data_buffer[last_chunk_start..]);
         let start = output.len();
+        output.resize(start + words_per_chunk, T::from_usize(0).unwrap());
         unsafe {
-            // Capacity reserves a full chunk for each block; extend the visible length and fill it immediately.
-            output.set_len(start + words_per_chunk);
             BitPacking::unchecked_pack(
                 compressed_bits_per_value,
                 &last_chunk,
@@ -457,13 +451,10 @@ fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
     let tail_is_raw = tail_values > 0 && compressed_words.len() == expected_new_len;
 
     let extra_tail_capacity = ELEMS_PER_CHUNK as usize;
-    #[allow(clippy::uninit_vec)]
     let mut decompressed: Vec<T> =
         Vec::with_capacity(num_values.saturating_add(extra_tail_capacity));
     let chunk_value_len = num_whole_chunks * ELEMS_PER_CHUNK as usize;
-    unsafe {
-        decompressed.set_len(chunk_value_len);
-    }
+    decompressed.resize(chunk_value_len, T::from_usize(0).unwrap());
 
     for chunk_idx in 0..num_whole_chunks {
         let input_start = chunk_idx * words_per_chunk;
@@ -488,9 +479,10 @@ fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
         } else {
             let tail_start = expected_full_words;
             let output_start = decompressed.len();
-            unsafe {
-                decompressed.set_len(output_start + ELEMS_PER_CHUNK as usize);
-            }
+            decompressed.resize(
+                output_start + ELEMS_PER_CHUNK as usize,
+                T::from_usize(0).unwrap(),
+            );
             unsafe {
                 BitPacking::unchecked_unpack(
                     compressed_bits_per_value,

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -18,7 +18,7 @@
 use arrow_array::types::UInt64Type;
 use arrow_array::{Array, PrimitiveArray};
 use arrow_buffer::ArrowNativeType;
-use lance_bitpacking::BitPacking;
+use lance_bitpacking::BitPackingUninit;
 
 use lance_core::{Error, Result};
 
@@ -70,7 +70,7 @@ impl InlineBitpacking {
     /// Each chunk can have a different bit width
     ///
     /// Each chunk has the compressed bit width stored inline in the chunk itself.
-    fn bitpack_chunked<T: ArrowNativeType + BitPacking>(
+    fn bitpack_chunked<T: ArrowNativeType + BitPackingUninit>(
         data: FixedWidthDataBlock,
     ) -> MiniBlockCompressed {
         debug_assert!(data.num_values > 0);
@@ -110,13 +110,14 @@ impl InlineBitpacking {
             let bit_width = bit_widths_array.value(i) as usize;
             output.push(T::from_usize(bit_width).unwrap());
             let output_len = output.len();
-            output.resize(output_len + *packed_chunk_size, T::from_usize(0).unwrap());
             unsafe {
-                BitPacking::unchecked_pack(
+                BitPackingUninit::unchecked_pack_uninit(
                     bit_width,
                     &data_buffer[start_elem..][..ELEMS_PER_CHUNK as usize],
-                    &mut output[output_len..][..*packed_chunk_size],
+                    &mut output.spare_capacity_mut()[..*packed_chunk_size],
                 );
+                // The bitpacking kernel initialized every reserved output word.
+                output.set_len(output_len + *packed_chunk_size);
             }
             chunks.push(MiniBlockChunk {
                 buffer_sizes: vec![((1 + *packed_chunk_size) * std::mem::size_of::<T>()) as u32],
@@ -137,16 +138,15 @@ impl InlineBitpacking {
         let bit_width = bit_widths_array.value(bit_widths_array.len() - 1) as usize;
         output.push(T::from_usize(bit_width).unwrap());
         let output_len = output.len();
-        output.resize(
-            output_len + packed_chunk_sizes[bit_widths_array.len() - 1],
-            T::from_usize(0).unwrap(),
-        );
+        let packed_chunk_size = packed_chunk_sizes[bit_widths_array.len() - 1];
         unsafe {
-            BitPacking::unchecked_pack(
+            BitPackingUninit::unchecked_pack_uninit(
                 bit_width,
                 &last_chunk,
-                &mut output[output_len..][..packed_chunk_sizes[bit_widths_array.len() - 1]],
+                &mut output.spare_capacity_mut()[..packed_chunk_size],
             );
+            // The bitpacking kernel initialized every reserved output word.
+            output.set_len(output_len + packed_chunk_size);
         }
         chunks.push(MiniBlockChunk {
             buffer_sizes: vec![
@@ -184,7 +184,7 @@ impl InlineBitpacking {
         )
     }
 
-    fn unchunk<T: ArrowNativeType + BitPacking + Pod>(
+    fn unchunk<T: ArrowNativeType + BitPackingUninit + Pod>(
         data: LanceBuffer,
         num_values: u64,
     ) -> Result<DataBlock> {
@@ -260,9 +260,15 @@ impl InlineBitpacking {
             ));
         }
 
-        let mut decompressed = vec![T::default(); ELEMS_PER_CHUNK as usize];
+        let mut decompressed = Vec::with_capacity(ELEMS_PER_CHUNK as usize);
         unsafe {
-            BitPacking::unchecked_unpack(bit_width_value, chunk, &mut decompressed);
+            BitPackingUninit::unchecked_unpack_uninit(
+                bit_width_value,
+                chunk,
+                &mut decompressed.spare_capacity_mut()[..ELEMS_PER_CHUNK as usize],
+            );
+            // The bitpacking kernel initialized all 1024 decoded values.
+            decompressed.set_len(ELEMS_PER_CHUNK as usize);
         }
 
         decompressed.truncate(num_values as usize);
@@ -360,7 +366,7 @@ impl BlockDecompressor for InlineBitpacking {
 /// Each chunk of 1024 values is packed with a constant bit width. For the tail we compare the
 /// cost of padding and packing against storing the raw values: if padding yields a smaller
 /// representation we pack; otherwise we append the raw tail.
-fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
+fn bitpack_out_of_line<T: ArrowNativeType + BitPackingUninit>(
     data: FixedWidthDataBlock,
     compressed_bits_per_value: usize,
 ) -> LanceBuffer {
@@ -371,7 +377,7 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
     let last_chunk_is_runt = data_buffer.len() % ELEMS_PER_CHUNK as usize != 0;
     let words_per_chunk = (ELEMS_PER_CHUNK as usize * compressed_bits_per_value)
         .div_ceil(data.bits_per_value as usize);
-    let mut output: Vec<T> = vec![T::from_usize(0).unwrap(); num_chunks * words_per_chunk];
+    let mut output: Vec<T> = Vec::with_capacity(num_chunks * words_per_chunk);
 
     let num_whole_chunks = if last_chunk_is_runt {
         num_chunks - 1
@@ -383,14 +389,15 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
     for i in 0..num_whole_chunks {
         let input_start = i * ELEMS_PER_CHUNK as usize;
         let input_end = input_start + ELEMS_PER_CHUNK as usize;
-        let output_start = i * words_per_chunk;
-        let output_end = output_start + words_per_chunk;
+        let output_start = output.len();
         unsafe {
-            BitPacking::unchecked_pack(
+            BitPackingUninit::unchecked_pack_uninit(
                 compressed_bits_per_value,
                 &data_buffer[input_start..input_end],
-                &mut output[output_start..output_end],
+                &mut output.spare_capacity_mut()[..words_per_chunk],
             );
+            // The bitpacking kernel initialized this complete packed chunk.
+            output.set_len(output_start + words_per_chunk);
         }
     }
 
@@ -399,7 +406,6 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
     }
 
     let last_chunk_start = num_whole_chunks * ELEMS_PER_CHUNK as usize;
-    output.truncate(num_whole_chunks * words_per_chunk);
     let remaining_items = data_buffer.len() - last_chunk_start;
 
     let uncompressed_bits = data.bits_per_value as usize;
@@ -414,13 +420,14 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
         let mut last_chunk: Vec<T> = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
         last_chunk[..remaining_items].copy_from_slice(&data_buffer[last_chunk_start..]);
         let start = output.len();
-        output.resize(start + words_per_chunk, T::from_usize(0).unwrap());
         unsafe {
-            BitPacking::unchecked_pack(
+            BitPackingUninit::unchecked_pack_uninit(
                 compressed_bits_per_value,
                 &last_chunk,
-                &mut output[start..start + words_per_chunk],
+                &mut output.spare_capacity_mut()[..words_per_chunk],
             );
+            // The bitpacking kernel initialized the padded tail chunk.
+            output.set_len(start + words_per_chunk);
         }
     } else {
         // Padding would waste space; append tail values as-is.
@@ -435,7 +442,7 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
 /// The compressed bit width is provided while the uncompressed width comes from `T`.
 /// Depending on the encoding decision the final chunk may be fully packed (with padding)
 /// or stored as raw tail values. We infer the layout from the buffer length.
-fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
+fn unpack_out_of_line<T: ArrowNativeType + BitPackingUninit>(
     data: FixedWidthDataBlock,
     num_values: usize,
     compressed_bits_per_value: usize,
@@ -453,20 +460,19 @@ fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
     let extra_tail_capacity = ELEMS_PER_CHUNK as usize;
     let mut decompressed: Vec<T> =
         Vec::with_capacity(num_values.saturating_add(extra_tail_capacity));
-    let chunk_value_len = num_whole_chunks * ELEMS_PER_CHUNK as usize;
-    decompressed.resize(chunk_value_len, T::from_usize(0).unwrap());
 
     for chunk_idx in 0..num_whole_chunks {
         let input_start = chunk_idx * words_per_chunk;
         let input_end = input_start + words_per_chunk;
-        let output_start = chunk_idx * ELEMS_PER_CHUNK as usize;
-        let output_end = output_start + ELEMS_PER_CHUNK as usize;
+        let output_start = decompressed.len();
         unsafe {
-            BitPacking::unchecked_unpack(
+            BitPackingUninit::unchecked_unpack_uninit(
                 compressed_bits_per_value,
                 &compressed_words[input_start..input_end],
-                &mut decompressed[output_start..output_end],
+                &mut decompressed.spare_capacity_mut()[..ELEMS_PER_CHUNK as usize],
             );
+            // The bitpacking kernel initialized this complete decoded chunk.
+            decompressed.set_len(output_start + ELEMS_PER_CHUNK as usize);
         }
     }
 
@@ -479,16 +485,14 @@ fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
         } else {
             let tail_start = expected_full_words;
             let output_start = decompressed.len();
-            decompressed.resize(
-                output_start + ELEMS_PER_CHUNK as usize,
-                T::from_usize(0).unwrap(),
-            );
             unsafe {
-                BitPacking::unchecked_unpack(
+                BitPackingUninit::unchecked_unpack_uninit(
                     compressed_bits_per_value,
                     &compressed_words[tail_start..tail_start + words_per_chunk],
-                    &mut decompressed[output_start..output_start + ELEMS_PER_CHUNK as usize],
+                    &mut decompressed.spare_capacity_mut()[..ELEMS_PER_CHUNK as usize],
                 );
+                // The kernel initialized a full chunk; only the requested tail stays visible.
+                decompressed.set_len(output_start + ELEMS_PER_CHUNK as usize);
             }
             decompressed.truncate(output_start + tail_values);
         }
@@ -611,7 +615,7 @@ mod test {
     use arrow_buffer::ArrowNativeType;
     use arrow_schema::DataType;
     use bytemuck::Pod;
-    use lance_bitpacking::BitPacking;
+    use lance_bitpacking::{BitPacking, BitPackingUninit};
     use rstest::rstest;
 
     use super::{ELEMS_PER_CHUNK, InlineBitpacking, bitpack_out_of_line, unpack_out_of_line};
@@ -664,7 +668,7 @@ mod test {
 
     fn roundtrip_unchunk<T>(values: &[T], bit_width: usize)
     where
-        T: ArrowNativeType + BitPacking + Pod,
+        T: ArrowNativeType + BitPackingUninit + Pod,
     {
         assert!(values.len() <= ELEMS_PER_CHUNK as usize);
         let num_values = values.len() as u64;
@@ -692,7 +696,7 @@ mod test {
 
     fn assert_corrupt_unchunk<T>(data: LanceBuffer, num_values: u64, expected_message: &str)
     where
-        T: ArrowNativeType + BitPacking + Pod,
+        T: ArrowNativeType + BitPackingUninit + Pod,
     {
         let err = InlineBitpacking::unchunk::<T>(data, num_values).unwrap_err();
         assert!(matches!(err, lance_core::Error::CorruptFile { .. }));


### PR DESCRIPTION
Bitpacking pack and unpack paths extended vectors with `set_len` before their elements were initialized, then passed safe mutable slices over those elements to the kernels. Initialize each output range before packing or unpacking, while retaining the existing buffer sizing and tail layout decisions.