### PR TITLE
fix(select): make row address iterators safe

### DIFF
--- a/rust/lance-select/benches/row_addr_mask.rs
+++ b/rust/lance-select/benches/row_addr_mask.rs
@@ -69,8 +69,7 @@ fn bench_iter_addrs(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
-                // SAFETY: the map only contains Partial selections; no Full entries.
-                let count: u64 = unsafe { map.clone().into_addr_iter() }.count() as u64;
+                let count: u64 = map.clone().into_addr_iter().count() as u64;
                 std::hint::black_box(count);
             });
         });
@@ -121,9 +120,8 @@ fn bench_iter_runs_partial(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
-                // SAFETY: map only contains Partial selections.
                 let mut runs: u64 = 0;
-                for _ in unsafe { map.iter_runs() } {
+                for _ in map.iter_runs() {
                     runs += 1;
                 }
                 std::hint::black_box(runs);
@@ -181,7 +179,7 @@ fn bench_range_to_ranges_round_trip(c: &mut Criterion) {
                 // consumer actually does — e.g. GroupingIterator).
                 let mut ids = RowAddrTreeMap::from(src.clone());
                 ids.mask(&mask);
-                let count = unsafe { ids.into_addr_iter() }.count();
+                let count = ids.into_addr_iter().count();
                 std::hint::black_box(count);
             });
         });
@@ -204,8 +202,8 @@ fn bench_range_to_ranges_round_trip_runs(c: &mut Criterion) {
             b.iter(|| {
                 let mut ids = RowAddrTreeMap::from(src.clone());
                 ids.mask(&mask);
-                // SAFETY: only Partial selections in play.
-                let count: u64 = unsafe { ids.iter_runs() }
+                let count: u64 = ids
+                    .iter_runs()
                     .map(|(_, r)| (*r.end() as u64) - (*r.start() as u64) + 1)
                     .sum();
                 std::hint::black_box(count);

--- a/rust/lance-select/src/mask.rs
+++ b/rust/lance-select/src/mask.rs
@@ -649,12 +649,10 @@ impl RowAddrTreeMap {
 
     /// Convert the set into an iterator of row addrs
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// This is unsafe because if any of the inner RowAddrSelection elements
-    /// is not a Partial then the iterator will panic because we don't know
-    /// the size of the bitmap.
-    pub unsafe fn into_addr_iter(self) -> impl Iterator<Item = u64> {
+    /// Panics if any selection is `Full` because the fragment size is unknown.
+    pub fn into_addr_iter(self) -> impl Iterator<Item = u64> {
         self.inner
             .into_iter()
             .flat_map(|(fragment, selection)| match selection {
@@ -675,10 +673,10 @@ impl RowAddrTreeMap {
     /// rather than its individual bits, so dense ranges cost
     /// O(num_containers) (roughly num_rows / 65536) instead of O(num_rows).
     ///
-    /// # Safety
-    /// Same contract as [`Self::into_addr_iter`]: panics if any entry is
-    /// `Full`, since the fragment size is unknown at this layer.
-    pub unsafe fn iter_runs(&self) -> impl Iterator<Item = (u32, RangeInclusive<u32>)> + '_ {
+    /// # Panics
+    ///
+    /// Panics if any selection is `Full` because the fragment size is unknown.
+    pub fn iter_runs(&self) -> impl Iterator<Item = (u32, RangeInclusive<u32>)> + '_ {
         self.inner
             .iter()
             .flat_map(|(&fragment, selection)| match selection {
@@ -1582,9 +1580,7 @@ mod tests {
         let mut mask = RowAddrTreeMap::default();
         mask.insert_fragment(0);
 
-        unsafe {
-            let _ = mask.into_addr_iter().collect::<Vec<u64>>();
-        }
+        let _ = mask.into_addr_iter().collect::<Vec<u64>>();
     }
 
     #[test]
@@ -1596,7 +1592,7 @@ mod tests {
         mask.insert(2 << 32 | 10);
 
         let expected = vec![0u64, 1, 1 << 32 | 5, 2 << 32 | 10];
-        let actual: Vec<u64> = unsafe { mask.into_addr_iter().collect() };
+        let actual: Vec<u64> = mask.into_addr_iter().collect();
         assert_eq!(actual, expected);
     }
 
@@ -1608,8 +1604,7 @@ mod tests {
         mask.insert_range(10..15);
         mask.insert_range((1u64 << 32) + 100..(1u64 << 32) + 103);
 
-        // SAFETY: only Partial entries.
-        let runs: Vec<(u32, RangeInclusive<u32>)> = unsafe { mask.iter_runs().collect() };
+        let runs: Vec<(u32, RangeInclusive<u32>)> = mask.iter_runs().collect();
         assert_eq!(runs, vec![(0, 0..=2), (0, 10..=14), (1, 100..=102)]);
     }
 
@@ -1622,13 +1617,14 @@ mod tests {
         mask.insert_range(20..25);
         mask.insert_range((1u64 << 32)..(1u64 << 32) + 3);
 
-        let from_runs: Vec<u64> = unsafe { mask.iter_runs() }
+        let from_runs: Vec<u64> = mask
+            .iter_runs()
             .flat_map(|(frag, run)| {
                 let frag = u64::from(frag);
                 (*run.start()..=*run.end()).map(move |v| (frag << 32) | u64::from(v))
             })
             .collect();
-        let from_bits: Vec<u64> = unsafe { mask.clone().into_addr_iter() }.collect();
+        let from_bits: Vec<u64> = mask.clone().into_addr_iter().collect();
         assert_eq!(from_runs, from_bits);
     }
 

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -428,9 +428,8 @@ impl RowIdSequence {
                     ids.mask(mask);
                     // Range-aware path: walk the bitmap's runs directly via
                     // iter_runs so the per-row cost collapses to per-run cost.
-                    // SAFETY: built from a u64 range; no Full entries possible.
                     let mut cur: Option<Range<u64>> = None;
-                    for (fragment, run) in unsafe { ids.iter_runs() } {
+                    for (fragment, run) in ids.iter_runs() {
                         let frag = u64::from(fragment);
                         let run_start = (frag << 32) | u64::from(*run.start());
                         let run_end_excl = (frag << 32) | (u64::from(*run.end()) + 1);
@@ -465,19 +464,17 @@ impl RowIdSequence {
                     sorted_holes.sort_unstable();
                     let mut next_holes_iter = sorted_holes.into_iter().peekable();
                     let mut holes_passed = 0;
-                    ranges.extend(GroupingIterator::new(unsafe { ids.into_addr_iter() }.map(
-                        |addr| {
-                            while let Some(next_hole) = next_holes_iter.peek() {
-                                if *next_hole < addr {
-                                    next_holes_iter.next();
-                                    holes_passed += 1;
-                                } else {
-                                    break;
-                                }
+                    ranges.extend(GroupingIterator::new(ids.into_addr_iter().map(|addr| {
+                        while let Some(next_hole) = next_holes_iter.peek() {
+                            if *next_hole < addr {
+                                next_holes_iter.next();
+                                holes_passed += 1;
+                            } else {
+                                break;
                             }
-                            addr - range.start + offset_start - holes_passed
-                        },
-                    )));
+                        }
+                        addr - range.start + offset_start - holes_passed
+                    })));
                 }
                 U64Segment::RangeWithBitmap { range, bitmap } => {
                     let mut ids = RowAddrTreeMap::from(range.clone());
@@ -492,18 +489,16 @@ impl RowIdSequence {
                     let mut bitmap_iter = bitmap.iter();
                     let mut bitmap_iter_pos = 0;
                     let mut holes_passed = 0;
-                    ranges.extend(GroupingIterator::new(unsafe { ids.into_addr_iter() }.map(
-                        |addr| {
-                            let position_in_range = addr - range.start;
-                            while bitmap_iter_pos < position_in_range {
-                                if !bitmap_iter.next().unwrap() {
-                                    holes_passed += 1;
-                                }
-                                bitmap_iter_pos += 1;
+                    ranges.extend(GroupingIterator::new(ids.into_addr_iter().map(|addr| {
+                        let position_in_range = addr - range.start;
+                        while bitmap_iter_pos < position_in_range {
+                            if !bitmap_iter.next().unwrap() {
+                                holes_passed += 1;
                             }
-                            offset_start + position_in_range - holes_passed
-                        },
-                    )));
+                            bitmap_iter_pos += 1;
+                        }
+                        offset_start + position_in_range - holes_passed
+                    })));
                 }
                 U64Segment::SortedArray(array) | U64Segment::Array(array) => {
                     // TODO: Could probably optimize the sorted array case to be O(N) instead of O(N log N)


### PR DESCRIPTION
`RowAddrTreeMap` iterators were declared unsafe only because they panic when a `Full` fragment has no known size. Panicking is not an unsafe operation and callers had no memory-safety invariant to uphold. Expose ordinary safe iterators, document the panic contract, and remove the unnecessary unsafe blocks from consumers.