### PR TITLE
fix(java): narrow JNI byte slice casts

### DIFF
--- a/java/lance-jni/src/blocking_blob.rs
+++ b/java/lance-jni/src/blocking_blob.rs
@@ -7,14 +7,19 @@ use crate::traits::{FromJString, IntoJava};
 use crate::{JNIEnvExt, block_on};
 use jni::JNIEnv;
 use jni::objects::{JByteArray, JObject, JString, JValueGen};
-use jni::sys::{jbyteArray, jint, jlong};
+use jni::sys::{jbyte, jbyteArray, jint, jlong};
 use lance::dataset::BlobFile;
-use std::mem::transmute;
 use std::sync::Arc;
 
 const BLOB_FILE_CLASS: &str = "org/lance/BlobFile";
 const BLOB_FILE_CTOR_SIG: &str = "()V";
 const NATIVE_BLOB: &str = "nativeBlobHandle";
+
+fn as_jbytes(bytes: &[u8]) -> &[jbyte] {
+    // SAFETY: jbyte is i8; u8 and i8 have identical size and alignment, and
+    // both permit every bit pattern. The returned slice retains the input lifetime.
+    unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len()) }
+}
 
 pub struct BlockingBlobFile {
     pub(crate) inner: BlobFile,
@@ -141,10 +146,7 @@ fn inner_blob_read<'local>(env: &mut JNIEnv<'local>, jblob: JObject) -> Result<J
         block_on(blob.inner.read())?
     };
     let arr = env.new_byte_array(bytes.len() as jint)?;
-    let u8_slice: &[u8] = bytes.as_ref();
-    let i8_slice: &[i8] = unsafe { transmute(u8_slice) };
-
-    env.set_byte_array_region(&arr, 0, i8_slice)?;
+    env.set_byte_array_region(&arr, 0, as_jbytes(bytes.as_ref()))?;
     Ok(arr)
 }
 
@@ -171,10 +173,7 @@ fn inner_blob_read_up_to<'local>(
         block_on(blob.inner.read_up_to(len as usize))?
     };
     let arr = env.new_byte_array(bytes.len() as jint)?;
-    let u8_slice: &[u8] = bytes.as_ref();
-    let i8_slice: &[i8] = unsafe { transmute(u8_slice) };
-
-    env.set_byte_array_region(&arr, 0, i8_slice)?;
+    env.set_byte_array_region(&arr, 0, as_jbytes(bytes.as_ref()))?;
     Ok(arr)
 }
 
@@ -206,10 +205,7 @@ fn inner_blob_read_range<'local>(
         block_on(blob.inner.read_range(offset as u64..end))?
     };
     let arr = env.new_byte_array(bytes.len() as jint)?;
-    let u8_slice: &[u8] = bytes.as_ref();
-    let i8_slice: &[i8] = unsafe { transmute(u8_slice) };
-
-    env.set_byte_array_region(&arr, 0, i8_slice)?;
+    env.set_byte_array_region(&arr, 0, as_jbytes(bytes.as_ref()))?;
     Ok(arr)
 }
 
@@ -263,4 +259,15 @@ fn inner_blob_close(env: &mut JNIEnv, jblob: JObject) -> Result<()> {
     let blob = unsafe { env.take_rust_field::<_, _, BlockingBlobFile>(jblob, NATIVE_BLOB)? };
     block_on(blob.inner.close())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::as_jbytes;
+
+    #[test]
+    fn byte_slice_cast_preserves_bits() {
+        assert_eq!(as_jbytes(&[0, 127, 128, 255]), &[0, 127, -128, -1]);
+        assert!(as_jbytes(&[]).is_empty());
+    }
 }


### PR DESCRIPTION
Blob reads repeatedly used `transmute` to reinterpret Rust byte slices as JNI signed-byte slices. Keep the necessary zero-copy representation cast in one narrowly scoped helper with explicit size, alignment, bit-pattern, and lifetime invariants, and reuse it across all blob read paths.